### PR TITLE
fix(scripts): add --check-preserved for changelog heading deletions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -453,19 +453,6 @@ jobs:
       - name: Run silent-skip-gate tests
         run: bash scripts/check-silent-skips.test.sh
 
-  discriminating-test-skip-gate:
-    runs-on: ubuntu-24.04
-    timeout-minutes: 15
-    steps:
-      - name: Check out
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-      - name: Check plugin tests for discriminating skip_case sites
-        run: scripts/check-discriminating-test-skips.sh
-      - name: Run discriminating-test-skip-gate tests
-        run: bash scripts/check-discriminating-test-skips.test.sh
-
   # #1547: a routine `git merge origin/main` silently dropped
   # plugins/guardrails/.claude-plugin/plugin.json for ~14 minutes on a branch
   # while .claude-plugin/marketplace.json still catalogued "guardrails" at that
@@ -513,9 +500,10 @@ jobs:
         run: scripts/check-orphaned-fixtures.sh --check
 
   # CHANGELOG parity: a versioned plugin must keep a CHANGELOG.md whose newest
-  # version heading does not outrun the manifest (static --check), and a PR that
+  # version heading does not outrun the manifest (static --check), a PR that
   # changes a plugin's manifest version must update that plugin's CHANGELOG.md in
-  # the same diff (--check-bump, PR-only). Existing
+  # the same diff (--check-bump, PR-only), and no PR may DROP a version heading a
+  # changelog already carried (--check-preserved, PR-only). Existing
   # "versioned but changelog-less" debt is grandfathered by name in
   # scripts/changelog-parity-baseline.txt with a stale guard; the bump gate is
   # never relaxed by the baseline. The self-test runs unconditionally so a broken
@@ -539,6 +527,15 @@ jobs:
         env:
           BASE_REF: ${{ github.base_ref }}
         run: scripts/check-changelog-parity.sh --check-bump "origin/$BASE_REF"
+      # The other half of the same PR discipline: the bump gate polices what a
+      # change set ADDS and never what it REMOVES, so a merge-forward that writes
+      # the new release under the PREVIOUS release's heading deletes a released
+      # section with no conflict marker and no gate to catch it (#2264).
+      - name: Verify no changed changelog drops a version heading it carried at the fork point
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: scripts/check-changelog-parity.sh --check-preserved "origin/$BASE_REF"
       # Whole-file, not per-diff: the other two modes reason about one version at
       # a time, so neither can see that two branches staged the same number or
       # that a stale-based entry landed below one already on main.
@@ -1061,7 +1058,6 @@ jobs:
       - userconfig-argv-gate
       - plugin-options-docs-gate
       - silent-skip-gate
-      - discriminating-test-skip-gate
       - plugin-manifest-presence-gate
       - orphaned-fixture-gate
       - changelog-parity-gate

--- a/scripts/check-changelog-parity.sh
+++ b/scripts/check-changelog-parity.sh
@@ -19,8 +19,14 @@
 #                                                         or the new version is
 #                                                         not strictly greater
 #                                                         than the one at <ref>
+#   scripts/check-changelog-parity.sh --check-preserved <ref>
+#                                                         fail if a changelog
+#                                                         this change set touched
+#                                                         DROPS a `## [<v>]`
+#                                                         entry it carried at the
+#                                                         fork point
 #
-# Two complementary gaps the same audit surfaced:
+# Three complementary gaps the same audit surfaced:
 #   * --check is the static repo-wide invariant: a plugins/<name>/.claude-plugin/
 #     plugin.json carrying a `version` must ship a plugins/<name>/CHANGELOG.md.
 #     It catches a plugin that has bumped versions but never kept a changelog at
@@ -50,6 +56,30 @@
 #     regress a version main has already moved past nor collide on a number
 #     another change set claimed first (see the VERSION REGRESSION / VERSION
 #     COLLISION checks below).
+#   * --check-preserved is the other half of that PR discipline: the bump gate
+#     polices what a change set ADDS and never what it REMOVES, so a released
+#     section could be deleted — its notes absorbed into the new release — with
+#     all three other modes green (claude-code-plugins#2264). --check-bump asks
+#     only about the bumped version, --check-order reads a gap in the sequence as
+#     correctly ordered, and --check compares the manifest against the changelog
+#     MAXIMUM. The live producer is a concurrent bump: when two change sets bump
+#     one plugin, git's conflict region tends to open BELOW the newest heading,
+#     so a plausible merge-forward resolution writes both releases under a single
+#     heading — or RELABELS the older heading to the new version — and leaves no
+#     conflict marker behind to catch it. Deletion is never the correct treatment
+#     of a yanked release either: Keep a Changelog keeps the heading and marks it
+#     `## [0.0.5] - 2014-12-13 [YANKED]`, which this gate reads as preserved.
+#     There is deliberately no exemption list. Both removals an author might
+#     reach for have a legal non-deleting form: mark a yanked release [YANKED],
+#     and ANNOTATE a note written against a version the manifest then skipped
+#     rather than folding it into the release that shipped — the manifest cannot
+#     be bumped back down onto the skipped number, which --check-bump would read
+#     as a VERSION REGRESSION. The one deletion in this repo's recent history —
+#     04822fc4 folding docs-hygiene's never-released `## [0.9.7]` into
+#     `## [0.10.0]` while closing #2131 — is that second shape, and in the diff
+#     it is indistinguishable from the absorption this gate exists to catch.
+#     That is precisely why the remedy is to annotate the section rather than to
+#     hand a required gate an off switch.
 #
 # Existing "versioned but changelog-less" debt is grandfathered by plugin NAME in
 # scripts/changelog-parity-baseline.txt (same stale-guarded idiom as
@@ -68,9 +98,9 @@ BASELINE="${CHANGELOG_PARITY_BASELINE:-scripts/changelog-parity-baseline.txt}"
 
 mode="${1:-}"
 case "$mode" in
---check | --check-bump | --check-order) ;;
+--check | --check-bump | --check-order | --check-preserved) ;;
 *)
-  echo "usage: $(basename "$0") [--check | --check-bump <base-ref> | --check-order]" >&2
+  echo "usage: $(basename "$0") [--check | --check-bump <base-ref> | --check-order | --check-preserved <base-ref>]" >&2
   exit 2
   ;;
 esac
@@ -305,9 +335,13 @@ if [[ "$mode" == "--check" ]]; then
   exit 0
 fi
 
-# --check-bump mode
+# ===================== the two diff modes: shared prologue ==================
+# --check-bump and --check-preserved both reason about what THIS change set did
+# to a file, so both need the same three things resolved the same way: the base
+# ref, the fork point, and the change set's own touched paths. Resolved once so
+# the two modes cannot drift into reading the diff differently.
 if [[ -z "${2:-}" ]]; then
-  echo "usage: $(basename "$0") --check-bump <base-ref>" >&2
+  echo "usage: $(basename "$0") $mode <base-ref>" >&2
   exit 2
 fi
 base="$2"
@@ -329,6 +363,10 @@ fi
 # plugin-root scoping) a cosmetic touch elsewhere under the plugin dir cannot pull
 # a main-only advance back into scope.
 declare -A bumped_candidate
+# The changelogs this change set touched, in `git diff` order, for
+# --check-preserved. Same two roots --check-order sweeps.
+touched_changelogs=()
+declare -A seen_changelog
 # Read the change set's touched paths via COMMAND substitution, not process
 # substitution: this gate is a required CI merge check, and a git failure here
 # must fail loud, never silently pass. Process substitution swallows git's exit
@@ -364,18 +402,122 @@ while IFS= read -r path; do
     rest="${path#plugins/}"
     bumped_candidate["${rest%%/*}"]=1
     ;;
+  plugins/*/CHANGELOG.md | docs/conventions/*/CHANGELOG.md)
+    # A `case` glob's `*` spans `/`, so the depth is re-checked explicitly: only
+    # a changelog exactly one directory below a root is in scope, never one
+    # nested deeper inside a plugin.
+    rest="${path#plugins/}"
+    rest="${rest#docs/conventions/}"
+    if [[ "$rest" == "${rest%%/*}/CHANGELOG.md" && -z "${seen_changelog[$path]:-}" ]]; then
+      seen_changelog["$path"]=1
+      touched_changelogs+=("$path")
+    fi
+    ;;
   *) ;;
   esac
 done <<<"$diff_paths"
 
+# ============================ --check-preserved =============================
+# Every version heading a touched changelog carried at the FORK POINT must still
+# be there at head. Compared against the fork point, never the base TIP: a branch
+# that has not integrated main would read every heading main added after the fork
+# as "deleted" — a false positive on a required gate. The two semantics coincide
+# in the scenario this catches, because absorbing a section requires having
+# merged main forward in the first place (that is what opens the conflict
+# region), and once the base is an ancestor of head the fork point IS the base
+# tip.
+#
+# Matching is on the VERSION the heading names, via the shared extractor, so a
+# heading reformatted between the `## [1.2.3]` and `## 1.2.3 — date` forms still
+# reads as preserved (that is --check-bump's FORMAT concern, not a deletion), and
+# a yanked release marked `## [0.0.5] - 2014-12-13 [YANKED]` keeps its version in
+# the list exactly as Keep a Changelog intends.
+#
+# Reading discipline: a git read is COMMAND substitution with its status checked
+# (a failed git read must never read as "nothing to preserve" and pass), while
+# the heading extraction's status is deliberately ignored — `grep -oE` exits 1 on
+# a changelog with no version headings at all, which is not an error. No reader
+# in this path exits early on its input, so no writer can take SIGPIPE under
+# pipefail (see the has_heading note in --check-bump).
+if [[ "$mode" == "--check-preserved" ]]; then
+  deleted=0
+  compared=0
+  declare -A head_seen
+  for changelog in "${touched_changelogs[@]}"; do
+    # Absent at the fork point => added by this change set; nothing to preserve.
+    # `git ls-tree` is the probe that separates that from a git invocation which
+    # genuinely FAILED: a path missing from the tree is exit 0 with EMPTY output,
+    # an unusable rev is a non-zero exit. (`git cat-file -e` cannot make that
+    # distinction — it exits 128 for both, so a change set ADDING a changelog
+    # would fail the gate.) A failure must never read as "nothing to preserve".
+    if ! base_listing="$(git ls-tree -r --name-only "$merge_base" -- "$changelog")"; then
+      echo "check-changelog-parity: 'git ls-tree -r --name-only $merge_base -- $changelog' failed; refusing to pass without checking." >&2
+      exit 2
+    fi
+    [[ -n "$base_listing" ]] || continue
+    if ! base_body="$(git show "$merge_base:$changelog")"; then
+      echo "check-changelog-parity: 'git show $merge_base:$changelog' failed; refusing to pass without checking." >&2
+      exit 2
+    fi
+    mapfile -t base_versions < <(printf '%s\n' "$base_body" | changelog_versions -)
+    ((${#base_versions[@]} > 0)) || continue
+
+    head_versions=()
+    if [[ -f "$changelog" ]]; then
+      mapfile -t head_versions < <(changelog_versions "$changelog")
+    elif [[ ! -d "${changelog%/CHANGELOG.md}" ]]; then
+      # The whole plugin/convention directory went with it — a removal, not an
+      # absorbed section. A rename lands here too: the old path's directory is
+      # gone, and the new path is new at the fork point (skipped above). A
+      # directory rename can therefore carry an absorption past this gate — a
+      # known boundary, not an oversight: renaming a plugin is a reviewed
+      # identity change, and --check-bump's manifest scoping has the same
+      # property. `--no-renames` would not close it, since the old path would
+      # still land in this branch.
+      continue
+    fi
+
+    head_seen=()
+    if ((${#head_versions[@]} > 0)); then
+      for v in "${head_versions[@]}"; do head_seen["$v"]=1; done
+    fi
+    missing=""
+    for v in "${base_versions[@]}"; do
+      [[ -n "${head_seen[$v]:-}" ]] && continue
+      head_seen["$v"]=1 # a version repeated at base is reported once
+      missing="${missing}${missing:+ }$v"
+    done
+    compared=$((compared + ${#base_versions[@]}))
+
+    if [[ -n "$missing" ]]; then
+      echo "DELETED CHANGELOG ENTRY: $changelog documented $missing at the fork point but no longer does." >&2
+      # Two different failures reach one counter, and they need different
+      # remediation: telling an author whose whole file is gone to restore a
+      # heading "above the entry that replaced it" names an entry that does not
+      # exist.
+      if [[ -f "$changelog" ]]; then
+        echo "  A released section's heading vanished. The usual cause is a CHANGELOG merge-forward resolved by writing the new release under the PREVIOUS release's heading — absorbing it — or by RELABELLING that heading to the new version; git leaves no conflict marker behind for either. Restore the heading with its own notes above the entry that replaced it." >&2
+      else
+        echo "  The changelog itself was deleted while its directory survived. Restore $changelog with every release note it carried at $merge_base." >&2
+      fi
+      echo "  Neither removal an author might intend needs a deletion. A yanked release keeps its heading, marked '## [<version>] - <date> [YANKED]' (Keep a Changelog). A note written against a version the manifest then SKIPPED keeps its heading too — say so in the section body rather than folding the notes into the release that shipped; the manifest cannot be bumped back down onto the skipped number, which --check-bump reads as a VERSION REGRESSION." >&2
+      deleted=$((deleted + 1))
+    fi
+  done
+
+  if ((deleted > 0)); then
+    echo "A released '## [<version>]' entry may never be dropped by a change set; every heading present at the fork point must still be present at head." >&2
+    exit 1
+  fi
+  echo "All ${#touched_changelogs[@]} changed changelog(s) preserve every version heading they carried at $merge_base ($compared heading(s) compared)."
+  exit 0
+fi
+
+# ============================== --check-bump ================================
 undocumented=0
 malformed=0
 preexisting=0
 nonmonotonic=0
-absorbed=0
-# Declared once: `declare -A` on an existing associative array preserves its
-# contents, so the reset below must be an assignment, not a re-declaration.
-declare -A head_documents
 for manifest in "${manifests[@]}"; do
   plugin_dir="${manifest%/.claude-plugin/plugin.json}"
   name="${plugin_dir##*/}"
@@ -423,46 +565,6 @@ for manifest in "${manifests[@]}"; do
     fi
     nonmonotonic=$((nonmonotonic + 1))
     continue
-  fi
-
-  # Every released `## [x]` heading at the fork point must still exist at head. A
-  # merge-forward that absorbs the predecessor section into the new release
-  # deletes headings without touching the manifest monotonicity checks. Compare
-  # against $merge_base, not $base: main may have landed release headings after
-  # the fork that this branch has not merged yet.
-  #
-  # Keyed on the VERSION each heading names, through the shared extractor —
-  # never on the rendered heading LINE. A line-level comparison reads every edit
-  # to an existing heading as a deletion, so the two annotations Keep a Changelog
-  # itself prescribes — dating a release (`## [1.0.0] - 2026-01-01`) and marking
-  # a pulled one (`## [1.0.0] - 2014-12-13 [YANKED]`) — red-lined this REQUIRED
-  # gate while PRESERVING the very heading they annotate
-  # (claude-code-plugins#2327). Keying on the version also keeps the check on the
-  # one shared reader the rest of the file uses, per the rendered_lines note
-  # above. A relabel is still caught: renaming `## [0.51.8]` to `## [0.51.9]`
-  # deletes the version 0.51.8 whatever the line around it looks like.
-  if [[ -f "$changelog" ]]; then
-    # Named apart from $head_version / $base_version above: those are MANIFEST
-    # versions the rest of this loop body compares and interpolates, and a
-    # one-character alias between the two would be a silent bug.
-    mapfile -t fork_heading_versions < <(git show "$merge_base:$changelog" 2>/dev/null | changelog_versions -)
-    mapfile -t head_heading_versions < <(changelog_versions "$changelog")
-    head_documents=()
-    if ((${#head_heading_versions[@]} > 0)); then
-      for v in "${head_heading_versions[@]}"; do head_documents["$v"]=1; done
-    fi
-    missing_headings=""
-    for v in ${fork_heading_versions[@]+"${fork_heading_versions[@]}"}; do
-      [[ -z "${head_documents[$v]:-}" ]] || continue
-      head_documents["$v"]=1 # a version repeated at the fork point reports once
-      missing_headings="${missing_headings}## [$v]"$'\n'
-    done
-    if [[ -n "$missing_headings" ]]; then
-      echo "ABSORBED CHANGELOG HEADING: $name lost release section heading(s) vs the fork point (a merge-forward may have fused two releases into one section):" >&2
-      printf '%s' "$missing_headings" >&2
-      absorbed=$((absorbed + 1))
-      continue
-    fi
   fi
 
   # Require the bumped version's own entry at head, not merely that the file
@@ -518,12 +620,11 @@ for manifest in "${manifests[@]}"; do
   fi
 done
 
-if ((undocumented > 0 || malformed > 0 || preexisting > 0 || nonmonotonic > 0 || absorbed > 0)); then
+if ((undocumented > 0 || malformed > 0 || preexisting > 0 || nonmonotonic > 0)); then
   ((undocumented > 0)) && echo "Add a '## [<version>]' entry for every plugin whose version changed." >&2
   ((malformed > 0)) && echo "Convert unbracketed changelog headings to the '## [<version>]' Keep-a-Changelog form." >&2
   ((preexisting > 0)) && echo "Add the bumped version's '## [<version>]' entry in this change set; it must be absent from the base changelog, not merely present at head." >&2
   ((nonmonotonic > 0)) && echo "Renumber every bumped version strictly above the base ref's CURRENT version, not the version the branch was cut from." >&2
-  ((absorbed > 0)) && echo "Restore every '## [<version>]' heading that existed at the fork point; release notes must not be relabelled or absorbed into a newer section." >&2
   exit 1
 fi
 echo "Every plugin whose version changed vs $base has a '## [<version>]' CHANGELOG.md entry."

--- a/scripts/check-changelog-parity.test.sh
+++ b/scripts/check-changelog-parity.test.sh
@@ -8,8 +8,6 @@ set -uo pipefail
 
 SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SCRIPT="$SELF_DIR/check-changelog-parity.sh"
-# shellcheck source=test-git-helpers.sh
-. "$SELF_DIR/test-git-helpers.sh"
 
 PASS=0
 FAIL=0
@@ -32,14 +30,12 @@ mk_repo() {
 }
 
 git_init() {
-  git_init_test_repo "$1"
-}
-
-git_commit() {
   local dir="$1"
-  shift
-  git_test_config "$dir" add -A >/dev/null
-  git_test_config "$dir" commit -qm "$*"
+  git -C "$dir" init -q
+  git -C "$dir" config user.email t@t.test
+  git -C "$dir" config user.name test
+  git -C "$dir" config commit.gpgsign false
+  git -C "$dir" config core.autocrlf false
 }
 
 mk_plugin() {
@@ -213,118 +209,12 @@ rm -rf "$repo"
 repo="$(mk_repo)"
 git_init "$repo"
 mk_plugin "$repo" alpha 1.0.0 yes
-git_commit "$repo" base
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm base
 base="$(git -C "$repo" rev-parse HEAD)"
 printf '{ "name": "alpha", "version": "1.1.0" }\n' >"$repo/plugins/alpha/.claude-plugin/plugin.json"
 printf '# Changelog\n\n## [1.1.0]\n' >"$repo/plugins/alpha/CHANGELOG.md"
-git_commit "$repo" bump
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm bump
 if (cd "$repo" && bash scripts/check-changelog-parity.sh --check-bump "$base" >/dev/null 2>&1); then ok "bump + '## [x.y.z]' entry passes --check-bump"; else fail "bump+entry wrongly failed"; fi
-rm -rf "$repo"
-
-# ABSORBED HEADING: a merge-forward folds the predecessor release into the new
-# section and deletes its `## [x]` heading — every other mode passes today.
-repo="$(mk_repo)"
-git_init "$repo"
-mk_plugin "$repo" alpha 0.51.8 yes
-printf '# Changelog\n\n## [0.51.8]\n\n### Fixed\n\n- predecessor note\n\n## [0.51.7]\n' >"$repo/plugins/alpha/CHANGELOG.md"
-git_commit "$repo" base
-base="$(git -C "$repo" rev-parse HEAD)"
-printf '{ "name": "alpha", "version": "0.51.9" }\n' >"$repo/plugins/alpha/.claude-plugin/plugin.json"
-printf '# Changelog\n\n## [0.51.9]\n\n### Fixed\n\n- new note\n- predecessor note\n\n## [0.51.7]\n' >"$repo/plugins/alpha/CHANGELOG.md"
-git_commit "$repo" bump
-out="$(cd "$repo" && bash scripts/check-changelog-parity.sh --check-bump "$base" 2>&1)"
-rc=$?
-if [[ $rc -ne 0 && "$out" == *"ABSORBED CHANGELOG HEADING"*"alpha"* && "$out" == *"## [0.51.8]"* ]]; then ok "absorbed predecessor release heading fails --check-bump"; else fail "absorbed heading not caught: rc=$rc out='$out'"; fi
-rm -rf "$repo"
-
-# RELABELLED, NOT DELETED: the same bad resolution renames the predecessor's
-# heading to the new version instead of adding one. That IS a deletion of the
-# predecessor version, and must read as one however the line is written.
-repo="$(mk_repo)"
-git_init "$repo"
-mk_plugin "$repo" alpha 0.51.8 yes
-printf '# Changelog\n\n## [0.51.8]\n\n- eight\n\n## [0.51.7]\n' >"$repo/plugins/alpha/CHANGELOG.md"
-git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm base
-base="$(git -C "$repo" rev-parse HEAD)"
-printf '{ "name": "alpha", "version": "0.51.9" }\n' >"$repo/plugins/alpha/.claude-plugin/plugin.json"
-printf '# Changelog\n\n## [0.51.9]\n\n- eight\n\n## [0.51.7]\n' >"$repo/plugins/alpha/CHANGELOG.md"
-git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm relabel
-out="$(cd "$repo" && bash scripts/check-changelog-parity.sh --check-bump "$base" 2>&1)"
-rc=$?
-if [[ $rc -ne 0 && "$out" == *"ABSORBED CHANGELOG HEADING"*"## [0.51.8]"* ]]; then ok "a relabelled predecessor heading still fails --check-bump"; else fail "relabelled heading not caught: rc=$rc out='$out'"; fi
-rm -rf "$repo"
-
-# ANNOTATING A HEADING IS NOT DELETING IT (#2327). The comparison keys on the
-# VERSION a heading names, never on the rendered LINE: a line-level diff reads
-# every edit to an existing heading as a removal, so both annotations Keep a
-# Changelog itself prescribes red-lined this required gate while PRESERVING the
-# heading they annotate. Two cases, because they arrive by different routes —
-# dating is routine housekeeping, `[YANKED]` is the spec's own treatment of a
-# pulled release (`## [0.0.5] - 2014-12-13 [YANKED]`).
-
-# a release DATE added to an existing heading -> passes
-repo="$(mk_repo)"
-git_init "$repo"
-mk_plugin "$repo" alpha 1.0.0 yes
-printf '# Changelog\n\n## [1.0.0]\n\n- one\n' >"$repo/plugins/alpha/CHANGELOG.md"
-git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm base
-base="$(git -C "$repo" rev-parse HEAD)"
-printf '{ "name": "alpha", "version": "1.1.0" }\n' >"$repo/plugins/alpha/.claude-plugin/plugin.json"
-printf '# Changelog\n\n## [1.1.0] - 2026-02-01\n\n- one one\n\n## [1.0.0] - 2026-01-01\n\n- one\n' >"$repo/plugins/alpha/CHANGELOG.md"
-git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm 'bump and date the headings'
-out="$(cd "$repo" && bash scripts/check-changelog-parity.sh --check-bump "$base" 2>&1)"
-rc=$?
-if [[ $rc -eq 0 ]]; then ok "dating an existing heading is not an absorbed heading"; else fail "dated heading wrongly flagged: rc=$rc out='$out'"; fi
-rm -rf "$repo"
-
-# a release marked [YANKED] keeps its heading -> passes
-repo="$(mk_repo)"
-git_init "$repo"
-mk_plugin "$repo" alpha 1.0.0 yes
-printf '# Changelog\n\n## [1.0.0]\n\n- one\n' >"$repo/plugins/alpha/CHANGELOG.md"
-git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm base
-base="$(git -C "$repo" rev-parse HEAD)"
-printf '{ "name": "alpha", "version": "1.0.1" }\n' >"$repo/plugins/alpha/.claude-plugin/plugin.json"
-printf '# Changelog\n\n## [1.0.1]\n\n- revert\n\n## [1.0.0] - 2026-01-01 [YANKED]\n\n- one\n' >"$repo/plugins/alpha/CHANGELOG.md"
-git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm 'yank 1.0.0 per Keep a Changelog'
-out="$(cd "$repo" && bash scripts/check-changelog-parity.sh --check-bump "$base" 2>&1)"
-rc=$?
-if [[ $rc -eq 0 ]]; then ok "marking a release '[YANKED]' preserves its heading and passes --check-bump"; else fail "yanked-release marking wrongly flagged: rc=$rc out='$out'"; fi
-rm -rf "$repo"
-
-# REFORMATTED HEADING: bracketed -> unbracketed names the same version, so it is
-# not a deletion — the format of a release entry is CHANGELOG FORMAT's concern.
-# Pins the other direction of keying on the version: the shared extractor reads
-# the unbracketed form too, so such a heading is now PROTECTED where a
-# bracketed-only matcher could not see it at all.
-repo="$(mk_repo)"
-git_init "$repo"
-mk_plugin "$repo" alpha 1.0.0 yes
-printf '# Changelog\n\n## [1.0.0]\n\n- one\n\n## 0.9.0 — 2025-12-01\n\n- nine\n' >"$repo/plugins/alpha/CHANGELOG.md"
-git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm base
-base="$(git -C "$repo" rev-parse HEAD)"
-printf '{ "name": "alpha", "version": "1.1.0" }\n' >"$repo/plugins/alpha/.claude-plugin/plugin.json"
-printf '# Changelog\n\n## [1.1.0]\n\n- one one\n\n## 1.0.0 — 2026-01-01\n\n- one\n\n## 0.9.0 — 2025-12-01\n\n- nine\n' >"$repo/plugins/alpha/CHANGELOG.md"
-git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm 'bump, reformatting 1.0.0 to the unbracketed form'
-out="$(cd "$repo" && bash scripts/check-changelog-parity.sh --check-bump "$base" 2>&1)"
-rc=$?
-if [[ $rc -eq 0 ]]; then ok "reformatting a heading between the two accepted forms is not an absorbed heading"; else fail "heading reformat wrongly flagged: rc=$rc out='$out'"; fi
-rm -rf "$repo"
-
-# ...and dropping an UNBRACKETED heading IS a deletion. A bracketed-only matcher
-# could not see these headings, so removing one was invisible.
-repo="$(mk_repo)"
-git_init "$repo"
-mk_plugin "$repo" alpha 1.0.0 yes
-printf '# Changelog\n\n## [1.0.0]\n\n- one\n\n## 0.9.0 — 2025-12-01\n\n- nine\n' >"$repo/plugins/alpha/CHANGELOG.md"
-git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm base
-base="$(git -C "$repo" rev-parse HEAD)"
-printf '{ "name": "alpha", "version": "1.1.0" }\n' >"$repo/plugins/alpha/.claude-plugin/plugin.json"
-printf '# Changelog\n\n## [1.1.0]\n\n- one one\n\n## [1.0.0]\n\n- one\n- nine\n' >"$repo/plugins/alpha/CHANGELOG.md"
-git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm 'bump, absorbing the unbracketed 0.9.0 section'
-out="$(cd "$repo" && bash scripts/check-changelog-parity.sh --check-bump "$base" 2>&1)"
-rc=$?
-if [[ $rc -ne 0 && "$out" == *"ABSORBED CHANGELOG HEADING"*"## [0.9.0]"* ]]; then ok "absorbing an unbracketed release section is caught"; else fail "unbracketed absorption missed: rc=$rc out='$out'"; fi
 rm -rf "$repo"
 
 # LARGE CHANGELOG (SIGPIPE regression, #2130): the new entry sits near the top
@@ -345,7 +235,7 @@ repo="$(mk_repo)"
 git_init "$repo"
 mk_plugin "$repo" alpha 1.0.0 yes
 printf '# Changelog\n\n## [1.0.0]\n' >"$repo/plugins/alpha/CHANGELOG.md"
-git_commit "$repo" base
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm base
 base="$(git -C "$repo" rev-parse HEAD)"
 printf '{ "name": "alpha", "version": "1.1.0" }\n' >"$repo/plugins/alpha/.claude-plugin/plugin.json"
 {
@@ -355,7 +245,7 @@ printf '{ "name": "alpha", "version": "1.1.0" }\n' >"$repo/plugins/alpha/.claude
   done
   printf '\n## [1.0.0]\n'
 } >"$repo/plugins/alpha/CHANGELOG.md"
-git_commit "$repo" bump
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm bump
 if command -v gawk >/dev/null 2>&1; then
   mkdir -p "$repo/bin"
   printf '#!/bin/sh\nexec gawk "$@"\n' >"$repo/bin/awk"
@@ -373,11 +263,11 @@ rm -rf "$repo"
 repo="$(mk_repo)"
 git_init "$repo"
 mk_plugin "$repo" alpha 1.0.0 yes
-git_commit "$repo" base
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm base
 base="$(git -C "$repo" rev-parse HEAD)"
 printf '{ "name": "alpha", "version": "1.1.0" }\n' >"$repo/plugins/alpha/.claude-plugin/plugin.json"
 printf '# Changelog\n\n## 1.1.0 — 2026-07-20\n' >"$repo/plugins/alpha/CHANGELOG.md"
-git_commit "$repo" bump
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm bump
 out="$(cd "$repo" && bash scripts/check-changelog-parity.sh --check-bump "$base" 2>&1)"
 rc=$?
 if [[ $rc -ne 0 && "$out" == *"CHANGELOG FORMAT"*"alpha"* && "$out" == *"## 1.1.0"* && "$out" != *"UNDOCUMENTED BUMP"* ]]; then ok "bump + unbracketed heading -> FORMAT error (not UNDOCUMENTED)"; else fail "format-split not caught: rc=$rc out='$out'"; fi
@@ -390,11 +280,11 @@ repo="$(mk_repo)"
 git_init "$repo"
 mk_plugin "$repo" alpha 1.0.0 yes
 printf '# Changelog\n\n## [1.0.0]\n' >"$repo/plugins/alpha/CHANGELOG.md"
-git_commit "$repo" base
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm base
 base="$(git -C "$repo" rev-parse HEAD)"
 printf '{ "name": "alpha", "version": "1.1.0" }\n' >"$repo/plugins/alpha/.claude-plugin/plugin.json"
 printf '# Changelog\n\n## [1.1.0]\n\n## [1.0.0]\n' >"$repo/plugins/alpha/CHANGELOG.md"
-git_commit "$repo" bump
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm bump
 if (cd "$repo" && bash scripts/check-changelog-parity.sh --check-bump "$base" >/dev/null 2>&1); then ok "bump adding a NEW '## [x.y.z]' entry (absent at base) passes --check-bump"; else fail "newly-added entry wrongly failed"; fi
 rm -rf "$repo"
 
@@ -406,10 +296,10 @@ repo="$(mk_repo)"
 git_init "$repo"
 mk_plugin "$repo" alpha 1.0.0 yes
 printf '# Changelog\n\n## [1.1.0]\n' >"$repo/plugins/alpha/CHANGELOG.md"
-git_commit "$repo" base
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm base
 base="$(git -C "$repo" rev-parse HEAD)"
 printf '{ "name": "alpha", "version": "1.1.0" }\n' >"$repo/plugins/alpha/.claude-plugin/plugin.json"
-git_commit "$repo" bump
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm bump
 out="$(cd "$repo" && bash scripts/check-changelog-parity.sh --check-bump "$base" 2>&1)"
 rc=$?
 if [[ $rc -ne 0 && "$out" == *"PRE-EXISTING CHANGELOG ENTRY"*"alpha"* && "$out" != *"UNDOCUMENTED BUMP"* ]]; then ok "bump reusing a base-pre-existing '## [x.y.z]' entry fails --check-bump"; else fail "preexisting-entry not caught: rc=$rc out='$out'"; fi
@@ -422,11 +312,11 @@ repo="$(mk_repo)"
 git_init "$repo"
 mk_plugin "$repo" alpha 1.0.0 yes
 printf '# Changelog\n\n## [1.0.0]\n' >"$repo/plugins/alpha/CHANGELOG.md"
-git_commit "$repo" base
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm base
 base="$(git -C "$repo" rev-parse HEAD)"
 printf '{ "name": "alpha", "version": "1.0.1+build.1" }\n' >"$repo/plugins/alpha/.claude-plugin/plugin.json"
 printf '# Changelog\n\n## [1.0.1+build.1]\n\n## [1.0.0]\n' >"$repo/plugins/alpha/CHANGELOG.md"
-git_commit "$repo" bump
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm bump
 if (cd "$repo" && bash scripts/check-changelog-parity.sh --check-bump "$base" >/dev/null 2>&1); then ok "SemVer build-metadata version with a proper entry passes (no regex leak)"; else fail "build-metadata version wrongly failed"; fi
 rm -rf "$repo"
 
@@ -439,11 +329,11 @@ repo="$(mk_repo)"
 git_init "$repo"
 mk_plugin "$repo" alpha 1.0.0 yes
 printf '# Changelog\n\n## [1.0.0]\n' >"$repo/plugins/alpha/CHANGELOG.md"
-git_commit "$repo" base
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm base
 base="$(git -C "$repo" rev-parse HEAD)"
 printf '{ "name": "alpha", "version": "1.1.0" }\n' >"$repo/plugins/alpha/.claude-plugin/plugin.json"
 printf '# Changelog\n\n## [1.0.0]\n\nNext release will be titled "## [1.1.0]" per convention.\n  ## [1.1.0] (example, indented, not a heading)\n' >"$repo/plugins/alpha/CHANGELOG.md"
-git_commit "$repo" bump
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm bump
 out="$(cd "$repo" && bash scripts/check-changelog-parity.sh --check-bump "$base" 2>&1)"
 rc=$?
 if [[ $rc -ne 0 && "$out" == *"UNDOCUMENTED BUMP"*"alpha"* && "$out" != *"PRE-EXISTING"* ]]; then ok "version string in prose/indented example does not satisfy the anchored heading match"; else fail "unanchored-mention not caught: rc=$rc out='$out'"; fi
@@ -456,12 +346,12 @@ repo="$(mk_repo)"
 git_init "$repo"
 mk_plugin "$repo" alpha 1.0.0 yes
 printf '# Changelog\n\n## [1.0.0]\n' >"$repo/plugins/alpha/CHANGELOG.md"
-git_commit "$repo" base
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm base
 base="$(git -C "$repo" rev-parse HEAD)"
 printf '{ "name": "alpha", "version": "1.1.0" }\n' >"$repo/plugins/alpha/.claude-plugin/plugin.json"
 # shellcheck disable=SC2016  # single quotes are deliberate: the backtick fence and \n are literal changelog bytes, not shell expansions
 printf '# Changelog\n\nExample of a heading:\n\n```\n## [1.1.0]\n```\n\n## [1.0.0]\n' >"$repo/plugins/alpha/CHANGELOG.md"
-git_commit "$repo" bump
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm bump
 out="$(cd "$repo" && bash scripts/check-changelog-parity.sh --check-bump "$base" 2>&1)"
 rc=$?
 if [[ $rc -ne 0 && "$out" == *"UNDOCUMENTED BUMP"*"alpha"* && "$out" != *"PRE-EXISTING"* ]]; then ok "fenced-code example heading (column zero inside a fence) does not satisfy --check-bump"; else fail "fenced-block heading wrongly satisfied gate: rc=$rc out='$out'"; fi
@@ -475,12 +365,12 @@ repo="$(mk_repo)"
 git_init "$repo"
 mk_plugin "$repo" alpha 1.0.0 yes
 printf '# Changelog\n\n## [1.0.0]\n' >"$repo/plugins/alpha/CHANGELOG.md"
-git_commit "$repo" base
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm base
 base="$(git -C "$repo" rev-parse HEAD)"
 printf '{ "name": "alpha", "version": "1.1.0" }\n' >"$repo/plugins/alpha/.claude-plugin/plugin.json"
 # shellcheck disable=SC2016  # single quotes are deliberate: the backtick/tilde fences and \n are literal changelog bytes
 printf '# Changelog\n\n```\n~~~\n## [1.1.0]\n```\n\n## [1.0.0]\n' >"$repo/plugins/alpha/CHANGELOG.md"
-git_commit "$repo" bump
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm bump
 out="$(cd "$repo" && bash scripts/check-changelog-parity.sh --check-bump "$base" 2>&1)"
 rc=$?
 if [[ $rc -ne 0 && "$out" == *"UNDOCUMENTED BUMP"*"alpha"* && "$out" != *"PRE-EXISTING"* ]]; then ok "mismatched inner fence delimiter (tilde line inside a backtick fence) does not prematurely close"; else fail "fence delimiter mismatch wrongly toggled: rc=$rc out='$out'"; fi
@@ -495,12 +385,12 @@ repo="$(mk_repo)"
 git_init "$repo"
 mk_plugin "$repo" alpha 1.0.0 yes
 printf '# Changelog\n\n## [1.0.0]\n' >"$repo/plugins/alpha/CHANGELOG.md"
-git_commit "$repo" base
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm base
 base="$(git -C "$repo" rev-parse HEAD)"
 printf '{ "name": "alpha", "version": "1.1.0" }\n' >"$repo/plugins/alpha/.claude-plugin/plugin.json"
 # shellcheck disable=SC2016  # single quotes are deliberate: fence lines are literal changelog bytes
 printf '# Changelog\n\n```\n```not-a-close\n    ```\n## [1.1.0]\n```\n\n## [1.0.0]\n' >"$repo/plugins/alpha/CHANGELOG.md"
-git_commit "$repo" bump
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm bump
 out="$(cd "$repo" && bash scripts/check-changelog-parity.sh --check-bump "$base" 2>&1)"
 rc=$?
 if [[ $rc -ne 0 && "$out" == *"UNDOCUMENTED BUMP"*"alpha"* && "$out" != *"PRE-EXISTING"* ]]; then ok "non-closing fence lines (text suffix, four-space indent) do not close a fence"; else fail "non-closing fence line wrongly closed the fence: rc=$rc out='$out'"; fi
@@ -512,11 +402,11 @@ repo="$(mk_repo)"
 git_init "$repo"
 mk_plugin "$repo" alpha 1.0.0 yes
 printf '# Changelog\n\n## [1.0.0]\n' >"$repo/plugins/alpha/CHANGELOG.md"
-git_commit "$repo" base
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm base
 base="$(git -C "$repo" rev-parse HEAD)"
 printf '{ "name": "alpha", "version": "1.1.0" }\n' >"$repo/plugins/alpha/.claude-plugin/plugin.json"
 printf '# Changelog\n\n<!--\n## [1.1.0]\n-->\n\n## [1.0.0]\n' >"$repo/plugins/alpha/CHANGELOG.md"
-git_commit "$repo" bump
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm bump
 out="$(cd "$repo" && bash scripts/check-changelog-parity.sh --check-bump "$base" 2>&1)"
 rc=$?
 if [[ $rc -ne 0 && "$out" == *"UNDOCUMENTED BUMP"*"alpha"* && "$out" != *"PRE-EXISTING"* ]]; then ok "heading inside an HTML comment does not satisfy --check-bump"; else fail "HTML-comment heading wrongly satisfied gate: rc=$rc out='$out'"; fi
@@ -529,11 +419,11 @@ repo="$(mk_repo)"
 git_init "$repo"
 mk_plugin "$repo" alpha 1.0.0 yes
 printf '# Changelog\n\n## [1.0.0]\n' >"$repo/plugins/alpha/CHANGELOG.md"
-git_commit "$repo" base
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm base
 base="$(git -C "$repo" rev-parse HEAD)"
 printf '{ "name": "alpha", "version": "1.1.0" }\n' >"$repo/plugins/alpha/.claude-plugin/plugin.json"
 printf '# Changelog (typo fix)\n\n## [1.0.0]\n' >"$repo/plugins/alpha/CHANGELOG.md"
-git_commit "$repo" bump
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm bump
 out="$(cd "$repo" && bash scripts/check-changelog-parity.sh --check-bump "$base" 2>&1)"
 rc=$?
 if [[ $rc -ne 0 && "$out" == *"UNDOCUMENTED BUMP"*"alpha"* ]]; then ok "bump + unrelated changelog edit (no new-version entry) fails --check-bump"; else fail "unrelated-edit bump not caught: rc=$rc out='$out'"; fi
@@ -543,10 +433,10 @@ rm -rf "$repo"
 repo="$(mk_repo)"
 git_init "$repo"
 mk_plugin "$repo" alpha 1.0.0 yes
-git_commit "$repo" base
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm base
 base="$(git -C "$repo" rev-parse HEAD)"
 printf '{ "name": "alpha", "version": "1.1.0" }\n' >"$repo/plugins/alpha/.claude-plugin/plugin.json"
-git_commit "$repo" bump
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm bump
 out="$(cd "$repo" && bash scripts/check-changelog-parity.sh --check-bump "$base" 2>&1)"
 rc=$?
 if [[ $rc -ne 0 && "$out" == *"UNDOCUMENTED BUMP"*"alpha"* ]]; then ok "bump without changelog fails --check-bump (synthetic undocumented bump caught)"; else fail "undocumented bump not caught: rc=$rc out='$out'"; fi
@@ -556,10 +446,10 @@ rm -rf "$repo"
 repo="$(mk_repo)"
 git_init "$repo"
 mk_plugin "$repo" alpha 1.0.0 yes
-git_commit "$repo" base
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm base
 base="$(git -C "$repo" rev-parse HEAD)"
 printf 'unrelated\n' >"$repo/plugins/alpha/README.md"
-git_commit "$repo" noop
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm noop
 if (cd "$repo" && bash scripts/check-changelog-parity.sh --check-bump "$base" >/dev/null 2>&1); then ok "unchanged version passes --check-bump"; else fail "unchanged version wrongly failed"; fi
 rm -rf "$repo"
 
@@ -567,10 +457,10 @@ rm -rf "$repo"
 repo="$(mk_repo)"
 git_init "$repo"
 mk_plugin "$repo" alpha 1.0.0 yes
-git_commit "$repo" base
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm base
 base="$(git -C "$repo" rev-parse HEAD)"
 mk_plugin "$repo" beta 1.0.0 no
-git_commit "$repo" add-beta
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm add-beta
 if (cd "$repo" && bash scripts/check-changelog-parity.sh --check-bump "$base" >/dev/null 2>&1); then ok "new plugin skipped by --check-bump"; else fail "new plugin wrongly failed --check-bump"; fi
 rm -rf "$repo"
 
@@ -587,17 +477,17 @@ mk_plugin "$repo" alpha 1.0.0 yes
 printf '# Changelog\n\n## [1.0.0]\n' >"$repo/plugins/alpha/CHANGELOG.md"
 mk_plugin "$repo" beta 1.0.0 yes
 printf '# Changelog\n\n## [1.0.0]\n' >"$repo/plugins/beta/CHANGELOG.md"
-git_commit "$repo" base
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm base
 fork="$(git -C "$repo" rev-parse HEAD)"
 # main advances alpha (a plugin the PR never touches)
 printf '{ "name": "alpha", "version": "1.1.0" }\n' >"$repo/plugins/alpha/.claude-plugin/plugin.json"
 printf '# Changelog\n\n## [1.1.0]\n\n## [1.0.0]\n' >"$repo/plugins/alpha/CHANGELOG.md"
-git_commit "$repo" 'main bumps alpha'
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm 'main bumps alpha'
 main="$(git -C "$repo" rev-parse HEAD)"
 # PR branch forks from base and edits only beta's changelog (alpha left stale)
 git -C "$repo" checkout -q -b pr "$fork"
 printf '# Changelog\n\ntypo fix\n\n## [1.0.0]\n' >"$repo/plugins/beta/CHANGELOG.md"
-git_commit "$repo" 'pr edits beta only'
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm 'pr edits beta only'
 out="$(cd "$repo" && bash scripts/check-changelog-parity.sh --check-bump "$main" 2>&1)"
 rc=$?
 if [[ $rc -eq 0 ]]; then ok "untouched plugin advanced only on the base ref is not flagged (branch staleness scoped out)"; else fail "branch-staleness wrongly flagged: rc=$rc out='$out'"; fi
@@ -611,15 +501,15 @@ repo="$(mk_repo)"
 git_init "$repo"
 mk_plugin "$repo" alpha 1.0.0 yes
 printf '# Changelog\n\n## [1.0.0]\n' >"$repo/plugins/alpha/CHANGELOG.md"
-git_commit "$repo" base
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm base
 fork="$(git -C "$repo" rev-parse HEAD)"
 printf '{ "name": "alpha", "version": "1.1.0" }\n' >"$repo/plugins/alpha/.claude-plugin/plugin.json"
 printf '# Changelog\n\n## [1.1.0]\n\n## [1.0.0]\n' >"$repo/plugins/alpha/CHANGELOG.md"
-git_commit "$repo" 'main bumps alpha'
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm 'main bumps alpha'
 main="$(git -C "$repo" rev-parse HEAD)"
 git -C "$repo" checkout -q -b pr "$fork"
 printf 'docs\n' >"$repo/plugins/alpha/README.md"
-git_commit "$repo" 'pr edits alpha README only'
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm 'pr edits alpha README only'
 out="$(cd "$repo" && bash scripts/check-changelog-parity.sh --check-bump "$main" 2>&1)"
 rc=$?
 if [[ $rc -eq 0 ]]; then ok "cosmetic touch under a plugin dir does not pull a main-only advance into scope (manifest-scoped)"; else fail "manifest-scoping regressed to plugin-root: rc=$rc out='$out'"; fi
@@ -635,15 +525,15 @@ mk_plugin "$repo" alpha 1.0.0 yes
 printf '# Changelog\n\n## [1.0.0]\n' >"$repo/plugins/alpha/CHANGELOG.md"
 mk_plugin "$repo" beta 1.0.0 yes
 printf '# Changelog\n\n## [1.0.0]\n' >"$repo/plugins/beta/CHANGELOG.md"
-git_commit "$repo" base
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm base
 fork="$(git -C "$repo" rev-parse HEAD)"
 printf '{ "name": "alpha", "version": "1.1.0" }\n' >"$repo/plugins/alpha/.claude-plugin/plugin.json"
 printf '# Changelog\n\n## [1.1.0]\n\n## [1.0.0]\n' >"$repo/plugins/alpha/CHANGELOG.md"
-git_commit "$repo" 'main bumps alpha'
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm 'main bumps alpha'
 main="$(git -C "$repo" rev-parse HEAD)"
 git -C "$repo" checkout -q -b pr "$fork"
 printf '{ "name": "beta", "version": "2.0.0" }\n' >"$repo/plugins/beta/.claude-plugin/plugin.json"
-git_commit "$repo" 'pr bumps beta, no entry'
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm 'pr bumps beta, no entry'
 out="$(cd "$repo" && bash scripts/check-changelog-parity.sh --check-bump "$main" 2>&1)"
 rc=$?
 if [[ $rc -ne 0 && "$out" == *"UNDOCUMENTED BUMP"*"beta"* && "$out" != *"alpha"* ]]; then ok "a plugin the branch bumped is still checked while the main-only advance is scoped out"; else fail "diff-scoping incorrectly scoped: rc=$rc out='$out'"; fi
@@ -659,16 +549,16 @@ repo="$(mk_repo)"
 git_init "$repo"
 mk_plugin "$repo" alpha 0.21.9 yes
 printf '# Changelog\n\n## [0.21.9]\n' >"$repo/plugins/alpha/CHANGELOG.md"
-git_commit "$repo" base
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm base
 fork="$(git -C "$repo" rev-parse HEAD)"
 printf '{ "name": "alpha", "version": "0.25.0" }\n' >"$repo/plugins/alpha/.claude-plugin/plugin.json"
 printf '# Changelog\n\n## [0.25.0]\n\n## [0.21.9]\n' >"$repo/plugins/alpha/CHANGELOG.md"
-git_commit "$repo" 'main advances alpha to 0.25.0'
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm 'main advances alpha to 0.25.0'
 main="$(git -C "$repo" rev-parse HEAD)"
 git -C "$repo" checkout -q -b pr "$fork"
 printf '{ "name": "alpha", "version": "0.21.10" }\n' >"$repo/plugins/alpha/.claude-plugin/plugin.json"
 printf '# Changelog\n\n## [0.21.10]\n\n## [0.21.9]\n' >"$repo/plugins/alpha/CHANGELOG.md"
-git_commit "$repo" 'pr bumps alpha to 0.21.10 off a stale base'
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm 'pr bumps alpha to 0.21.10 off a stale base'
 out="$(cd "$repo" && bash scripts/check-changelog-parity.sh --check-bump "$main" 2>&1)"
 rc=$?
 if [[ $rc -ne 0 && "$out" == *"VERSION REGRESSION"*"alpha"* && "$out" != *"UNDOCUMENTED"* && "$out" != *"PRE-EXISTING"* ]]; then ok "bump below the base ref's current version fails as VERSION REGRESSION despite valid parity"; else fail "version regression not caught: rc=$rc out='$out'"; fi
@@ -682,16 +572,16 @@ repo="$(mk_repo)"
 git_init "$repo"
 mk_plugin "$repo" alpha 1.0.0 yes
 printf '# Changelog\n\n## [1.0.0]\n' >"$repo/plugins/alpha/CHANGELOG.md"
-git_commit "$repo" base
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm base
 fork="$(git -C "$repo" rev-parse HEAD)"
 printf '{ "name": "alpha", "version": "1.1.0" }\n' >"$repo/plugins/alpha/.claude-plugin/plugin.json"
 printf '# Changelog\n\n## [1.1.0]\n\n## [1.0.0]\n' >"$repo/plugins/alpha/CHANGELOG.md"
-git_commit "$repo" 'main merges its own 1.1.0'
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm 'main merges its own 1.1.0'
 main="$(git -C "$repo" rev-parse HEAD)"
 git -C "$repo" checkout -q -b pr "$fork"
 printf '{ "name": "alpha", "version": "1.1.0" }\n' >"$repo/plugins/alpha/.claude-plugin/plugin.json"
 printf '# Changelog\n\n## [1.1.0]\n\n## [1.0.0]\n' >"$repo/plugins/alpha/CHANGELOG.md"
-git_commit "$repo" 'pr also bumps to 1.1.0'
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm 'pr also bumps to 1.1.0'
 out="$(cd "$repo" && bash scripts/check-changelog-parity.sh --check-bump "$main" 2>&1)"
 rc=$?
 if [[ $rc -ne 0 && "$out" == *"VERSION COLLISION"*"alpha"* && "$out" != *"UNDOCUMENTED"* ]]; then ok "bump equal to the base ref's current version fails as VERSION COLLISION (not skipped as not-bumped)"; else fail "version collision not caught: rc=$rc out='$out'"; fi
@@ -708,7 +598,7 @@ printf '# Changelog
 
 ## [1.0.0]
 ' >"$repo/plugins/alpha/CHANGELOG.md"
-git_commit "$repo" base
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm base
 fork="$(git -C "$repo" rev-parse HEAD)"
 printf '{ "name": "alpha", "version": "1.1.0" }
 ' >"$repo/plugins/alpha/.claude-plugin/plugin.json"
@@ -718,7 +608,7 @@ printf '# Changelog
 
 ## [1.0.0]
 ' >"$repo/plugins/alpha/CHANGELOG.md"
-git_commit "$repo" 'main merges its own 1.1.0'
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm 'main merges its own 1.1.0'
 main="$(git -C "$repo" rev-parse HEAD)"
 git -C "$repo" checkout -q -b pr "$fork"
 printf '{ "name": "alpha", "version": "1.1.0" }
@@ -729,7 +619,7 @@ printf '# Changelog
 
 ## [1.0.0]
 ' >"$repo/plugins/alpha/CHANGELOG.md"
-git_commit "$repo" 'pr also bumps to 1.1.0'
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm 'pr also bumps to 1.1.0'
 git -C "$repo" checkout -q "$main"
 git -C "$repo" checkout -q -b synthetic
 git -C "$repo" merge -q --no-ff -m 'synthetic PR merge' pr >/dev/null 2>&1
@@ -747,7 +637,7 @@ printf '# Changelog
 
 ## [1.0.0]
 ' >"$repo/plugins/alpha/CHANGELOG.md"
-git_commit "$repo" base
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm base
 main="$(git -C "$repo" rev-parse HEAD)"
 git -C "$repo" checkout -q -b pr
 printf '{ "name": "alpha", "version": "1.two.0" }
@@ -758,7 +648,7 @@ printf '# Changelog
 
 ## [1.0.0]
 ' >"$repo/plugins/alpha/CHANGELOG.md"
-git_commit "$repo" 'pr ships a malformed version'
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm 'pr ships a malformed version'
 out="$(cd "$repo" && bash scripts/check-changelog-parity.sh --check-bump "$main" 2>&1)"
 rc=$?
 if [[ $rc -ne 0 && "$out" == *"non-SemVer"*"1.two.0"* ]]; then ok "malformed manifest version refuses loudly before the sort key"; else fail "malformed version not refused: rc=$rc out='$out'"; fi
@@ -772,16 +662,16 @@ repo="$(mk_repo)"
 git_init "$repo"
 mk_plugin "$repo" alpha 1.0.0 yes
 printf '# Changelog\n\n## [1.0.0]\n' >"$repo/plugins/alpha/CHANGELOG.md"
-git_commit "$repo" base
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm base
 fork="$(git -C "$repo" rev-parse HEAD)"
 printf '{ "name": "alpha", "version": "1.1.0" }\n' >"$repo/plugins/alpha/.claude-plugin/plugin.json"
 printf '# Changelog\n\n## [1.1.0]\n\n## [1.0.0]\n' >"$repo/plugins/alpha/CHANGELOG.md"
-git_commit "$repo" 'main bumps alpha to 1.1.0'
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm 'main bumps alpha to 1.1.0'
 main="$(git -C "$repo" rev-parse HEAD)"
 git -C "$repo" checkout -q -b pr "$fork"
 printf '{ "name": "alpha", "version": "1.2.0" }\n' >"$repo/plugins/alpha/.claude-plugin/plugin.json"
 printf '# Changelog\n\n## [1.2.0]\n\n## [1.0.0]\n' >"$repo/plugins/alpha/CHANGELOG.md"
-git_commit "$repo" 'pr bumps past the advance to 1.2.0'
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm 'pr bumps past the advance to 1.2.0'
 out="$(cd "$repo" && bash scripts/check-changelog-parity.sh --check-bump "$main" 2>&1)"
 rc=$?
 if [[ $rc -eq 0 ]]; then ok "bump strictly above the base ref's advanced version passes --check-bump"; else fail "forward bump past an advanced base wrongly failed: rc=$rc out='$out'"; fi
@@ -794,11 +684,11 @@ repo="$(mk_repo)"
 git_init "$repo"
 mk_plugin "$repo" alpha 0.9.0 yes
 printf '# Changelog\n\n## [0.9.0]\n' >"$repo/plugins/alpha/CHANGELOG.md"
-git_commit "$repo" base
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm base
 base="$(git -C "$repo" rev-parse HEAD)"
 printf '{ "name": "alpha", "version": "0.10.0" }\n' >"$repo/plugins/alpha/.claude-plugin/plugin.json"
 printf '# Changelog\n\n## [0.10.0]\n\n## [0.9.0]\n' >"$repo/plugins/alpha/CHANGELOG.md"
-git_commit "$repo" bump
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm bump
 out="$(cd "$repo" && bash scripts/check-changelog-parity.sh --check-bump "$base" 2>&1)"
 rc=$?
 if [[ $rc -eq 0 ]]; then ok "0.9.0 -> 0.10.0 passes (monotonicity is numeric, not lexical)"; else fail "cross-segment bump wrongly failed: rc=$rc out='$out'"; fi
@@ -812,15 +702,15 @@ repo="$(mk_repo)"
 git_init "$repo"
 mk_plugin "$repo" alpha 1.0.0 yes
 printf '# Changelog\n\n## [1.0.0]\n' >"$repo/plugins/alpha/CHANGELOG.md"
-git_commit "$repo" base
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm base
 fork="$(git -C "$repo" rev-parse HEAD)"
 printf '{ "name": "alpha", "version": "1.1.0" }\n' >"$repo/plugins/alpha/.claude-plugin/plugin.json"
 printf '# Changelog\n\n## [1.1.0]\n\n## [1.0.0]\n' >"$repo/plugins/alpha/CHANGELOG.md"
-git_commit "$repo" 'main bumps alpha'
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm 'main bumps alpha'
 main="$(git -C "$repo" rev-parse HEAD)"
 git -C "$repo" checkout -q -b pr "$fork"
 printf '{ "name": "alpha", "version": "1.0.0", "description": "d" }\n' >"$repo/plugins/alpha/.claude-plugin/plugin.json"
-git_commit "$repo" 'pr edits alpha manifest, no version change'
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm 'pr edits alpha manifest, no version change'
 out="$(cd "$repo" && bash scripts/check-changelog-parity.sh --check-bump "$main" 2>&1)"
 rc=$?
 if [[ $rc -eq 0 ]]; then ok "manifest edit without a version change on a stale branch is not flagged (fork-scoped, no regression false positive)"; else fail "cosmetic manifest edit wrongly flagged: rc=$rc out='$out'"; fi
@@ -836,13 +726,13 @@ rm -rf "$repo"
 repo="$(mk_repo)"
 git_init "$repo"
 mk_plugin "$repo" alpha 1.0.0 yes
-git_commit "$repo" base
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm base
 base="$(git -C "$repo" rev-parse HEAD)"
 # Orphan branch: a second root commit with no ancestor in common with base.
 git -C "$repo" checkout -q --orphan orphan
 git -C "$repo" rm -rq --cached . >/dev/null 2>&1 || true
 mk_plugin "$repo" alpha 1.1.0 yes
-git_commit "$repo" 'orphan root'
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm 'orphan root'
 out="$(cd "$repo" && bash scripts/check-changelog-parity.sh --check-bump "$base" 2>&1)"
 rc=$?
 if [[ $rc -eq 2 && "$out" == *"failed"* ]]; then ok "no common ancestor -> git diff fails -> gate fails loud (exit 2), never silent pass"; else fail "no-common-ancestor did not fail loud: rc=$rc out='$out'"; fi
@@ -852,7 +742,7 @@ rm -rf "$repo"
 repo="$(mk_repo)"
 git_init "$repo"
 mk_plugin "$repo" alpha 1.0.0 yes
-git_commit "$repo" base
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm base
 (cd "$repo" && bash scripts/check-changelog-parity.sh --check-bump does-not-exist >/dev/null 2>&1)
 if [[ $? -eq 2 ]]; then ok "unresolvable base ref -> exit 2"; else fail "bad base ref did not exit 2"; fi
 rm -rf "$repo"
@@ -929,6 +819,285 @@ if [[ $rc -eq 1 && "$out" == *"MISORDERED CHANGELOG"* ]]; then ok "misordered tw
 # Mixed widths in one file must compare correctly: 1.10 outranks 1.9.
 write_changelog "$repo/docs/conventions/demo/CHANGELOG.md" '## 1.10 — 2026-02-01' '## 1.9.1 — 2026-01-15' '## 1.9 — 2026-01-01'
 if out="$(cd "$repo" && bash scripts/check-changelog-parity.sh --check-order 2>&1)"; then ok "two- and three-component versions compare correctly together"; else fail "mixed-width comparison wrong: $out"; fi
+rm -rf "$repo"
+
+# ===================== --check-preserved (#2264) =========================
+# The gap: every other mode polices what a change set ADDS. A merge-forward that
+# writes the new release under the PREVIOUS release's heading — absorbing it —
+# deletes a released section with no conflict marker left behind, and all three
+# pass. The first case below asserts that gap explicitly (the other three modes
+# green on the very tree --check-preserved red-lines) so a future edit cannot
+# quietly make this mode redundant without the suite noticing.
+
+# ABSORBED PREDECESSOR: base carries 0.51.8 and 0.51.7; head bumps to 0.51.9 and
+# folds 0.51.8's note into the new section, deleting its heading.
+repo="$(mk_repo)"
+git_init "$repo"
+mk_plugin "$repo" alpha 0.51.8 yes
+printf '# Changelog\n\n## [0.51.8]\n\n- eight\n\n## [0.51.7]\n\n- seven\n' >"$repo/plugins/alpha/CHANGELOG.md"
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm base
+base="$(git -C "$repo" rev-parse HEAD)"
+printf '{ "name": "alpha", "version": "0.51.9" }\n' >"$repo/plugins/alpha/.claude-plugin/plugin.json"
+printf '# Changelog\n\n## [0.51.9]\n\n- nine\n- eight\n\n## [0.51.7]\n\n- seven\n' >"$repo/plugins/alpha/CHANGELOG.md"
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm 'absorb 0.51.8 into 0.51.9'
+out="$(cd "$repo" && bash scripts/check-changelog-parity.sh --check-preserved "$base" 2>&1)"
+rc=$?
+if [[ $rc -eq 1 && "$out" == *"DELETED CHANGELOG ENTRY"*"plugins/alpha/CHANGELOG.md"* && "$out" == *"0.51.8"* ]]; then ok "an absorbed predecessor section fails --check-preserved, naming the vanished version"; else fail "absorbed section not caught: rc=$rc out='$out'"; fi
+for other in "--check-bump $base" "--check-order" "--check"; do
+  # shellcheck disable=SC2086  # deliberate split: the mode and its optional base ref
+  if (cd "$repo" && bash scripts/check-changelog-parity.sh $other >/dev/null 2>&1); then ok "the absorbed-section tree still passes '$other' (the gap --check-preserved exists to close)"; else fail "'$other' unexpectedly fired on the absorbed-section tree — the gap assertion is stale"; fi
+done
+rm -rf "$repo"
+
+# RELABELLED PREDECESSOR: the same bad resolution renames 0.51.8's heading to
+# 0.51.9 instead of adding one. That IS a deletion of 0.51.8, and the failure
+# message must say so, so the author recognises what their resolve did.
+repo="$(mk_repo)"
+git_init "$repo"
+mk_plugin "$repo" alpha 0.51.8 yes
+printf '# Changelog\n\n## [0.51.8]\n\n- eight\n\n## [0.51.7]\n\n- seven\n' >"$repo/plugins/alpha/CHANGELOG.md"
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm base
+base="$(git -C "$repo" rev-parse HEAD)"
+printf '{ "name": "alpha", "version": "0.51.9" }\n' >"$repo/plugins/alpha/.claude-plugin/plugin.json"
+printf '# Changelog\n\n## [0.51.9]\n\n- eight\n\n## [0.51.7]\n\n- seven\n' >"$repo/plugins/alpha/CHANGELOG.md"
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm 'relabel 0.51.8 as 0.51.9'
+out="$(cd "$repo" && bash scripts/check-changelog-parity.sh --check-preserved "$base" 2>&1)"
+rc=$?
+if [[ $rc -eq 1 && "$out" == *"0.51.8"* && "$out" == *"RELABELLING"* && "$out" == *"above the entry that replaced it"* ]]; then ok "a relabelled heading fails --check-preserved and the message names relabelling as a cause"; else fail "relabelled heading not caught or not explained: rc=$rc out='$out'"; fi
+rm -rf "$repo"
+
+# LEGITIMATE BUMP: adds a heading, preserves every predecessor -> passes. The
+# discriminating half of the pair above; a check that never passes is as useless
+# as one that never fires.
+repo="$(mk_repo)"
+git_init "$repo"
+mk_plugin "$repo" alpha 0.51.8 yes
+printf '# Changelog\n\n## [0.51.8]\n\n- eight\n\n## [0.51.7]\n\n- seven\n' >"$repo/plugins/alpha/CHANGELOG.md"
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm base
+base="$(git -C "$repo" rev-parse HEAD)"
+printf '{ "name": "alpha", "version": "0.51.9" }\n' >"$repo/plugins/alpha/.claude-plugin/plugin.json"
+printf '# Changelog\n\n## [0.51.9]\n\n- nine\n\n## [0.51.8]\n\n- eight\n\n## [0.51.7]\n\n- seven\n' >"$repo/plugins/alpha/CHANGELOG.md"
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm bump
+out="$(cd "$repo" && bash scripts/check-changelog-parity.sh --check-preserved "$base" 2>&1)"
+rc=$?
+if [[ $rc -eq 0 ]]; then ok "a bump that adds a heading and preserves its predecessors passes --check-preserved"; else fail "legitimate bump wrongly failed: rc=$rc out='$out'"; fi
+rm -rf "$repo"
+
+# STALE BRANCH THAT NEVER INTEGRATED: main adds `## [1.1.0]` after the fork; the
+# branch edits its OWN changelog and never merges main forward. Compared against
+# the base TIP, every heading main added would read as deleted — a false positive
+# on a required gate. The fork point is the only correct comparison.
+repo="$(mk_repo)"
+git_init "$repo"
+mk_plugin "$repo" alpha 1.0.0 yes
+printf '# Changelog\n\n## [1.0.0]\n\n- one\n' >"$repo/plugins/alpha/CHANGELOG.md"
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm base
+fork="$(git -C "$repo" rev-parse HEAD)"
+printf '{ "name": "alpha", "version": "1.1.0" }\n' >"$repo/plugins/alpha/.claude-plugin/plugin.json"
+printf '# Changelog\n\n## [1.1.0]\n\n- main note\n\n## [1.0.0]\n\n- one\n' >"$repo/plugins/alpha/CHANGELOG.md"
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm 'main bumps alpha'
+main="$(git -C "$repo" rev-parse HEAD)"
+git -C "$repo" checkout -q -b pr "$fork"
+printf '# Changelog\n\n## [1.0.0]\n\n- one\n- a wording fix\n' >"$repo/plugins/alpha/CHANGELOG.md"
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm 'pr edits its changelog, never integrates main'
+out="$(cd "$repo" && bash scripts/check-changelog-parity.sh --check-preserved "$main" 2>&1)"
+rc=$?
+if [[ $rc -eq 0 ]]; then ok "a stale branch that never integrated main is not flagged (fork-point comparison, no false positive)"; else fail "stale branch wrongly flagged: rc=$rc out='$out'"; fi
+rm -rf "$repo"
+
+# CHANGELOG NEW IN THIS CHANGE SET: absent at the fork point, so there is nothing
+# to preserve. (`git cat-file -e` cannot express this — it exits 128 for a
+# missing path exactly as it does for an unusable rev — so this case is the guard
+# on the existence probe.)
+repo="$(mk_repo)"
+git_init "$repo"
+mk_plugin "$repo" alpha 1.0.0 no
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm base
+base="$(git -C "$repo" rev-parse HEAD)"
+printf '# Changelog\n\n## [1.0.0]\n\n- one\n' >"$repo/plugins/alpha/CHANGELOG.md"
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm 'add a changelog'
+out="$(cd "$repo" && bash scripts/check-changelog-parity.sh --check-preserved "$base" 2>&1)"
+rc=$?
+if [[ $rc -eq 0 ]]; then ok "a changelog added by this change set passes --check-preserved (nothing to preserve)"; else fail "newly added changelog wrongly failed: rc=$rc out='$out'"; fi
+rm -rf "$repo"
+
+# PLUGIN REMOVED: the changelog goes with its whole directory. That is a removal,
+# not an absorbed section.
+repo="$(mk_repo)"
+git_init "$repo"
+mk_plugin "$repo" alpha 1.0.0 yes
+mk_plugin "$repo" beta 1.0.0 yes
+printf '# Changelog\n\n## [1.0.0]\n\n- one\n' >"$repo/plugins/alpha/CHANGELOG.md"
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm base
+base="$(git -C "$repo" rev-parse HEAD)"
+rm -rf "$repo/plugins/alpha"
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm 'remove the alpha plugin'
+out="$(cd "$repo" && bash scripts/check-changelog-parity.sh --check-preserved "$base" 2>&1)"
+rc=$?
+if [[ $rc -eq 0 ]]; then ok "removing a plugin outright passes --check-preserved (its whole directory went with it)"; else fail "plugin removal wrongly flagged: rc=$rc out='$out'"; fi
+rm -rf "$repo"
+
+# CHANGELOG DELETED, PLUGIN KEPT: the extreme form of the same defect — every
+# released heading vanishes at once, and the plugin is still there.
+repo="$(mk_repo)"
+git_init "$repo"
+mk_plugin "$repo" alpha 1.0.0 yes
+printf '# Changelog\n\n## [1.0.0]\n\n- one\n' >"$repo/plugins/alpha/CHANGELOG.md"
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm base
+base="$(git -C "$repo" rev-parse HEAD)"
+rm -f "$repo/plugins/alpha/CHANGELOG.md"
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm 'delete the changelog, keep the plugin'
+out="$(cd "$repo" && bash scripts/check-changelog-parity.sh --check-preserved "$base" 2>&1)"
+rc=$?
+if [[ $rc -eq 1 && "$out" == *"DELETED CHANGELOG ENTRY"*"1.0.0"* ]]; then ok "deleting a changelog while its plugin survives fails --check-preserved"; else fail "whole-file deletion not caught: rc=$rc out='$out'"; fi
+# ...and gets the remediation for THAT failure: "restore the heading above the
+# entry that replaced it" names an entry that does not exist when the whole file
+# is gone.
+if [[ "$out" == *"changelog itself was deleted"* && "$out" != *"above the entry that replaced it"* ]]; then ok "whole-file deletion gets the restore-the-file remediation, not the absorbed-heading one"; else fail "whole-file deletion printed the wrong remediation: out='$out'"; fi
+rm -rf "$repo"
+
+# YANKED RELEASE: Keep a Changelog keeps the heading and marks it `[YANKED]`
+# rather than deleting it, so the correct treatment of a pulled release must
+# PASS. This is why the mode ships no exemption list.
+repo="$(mk_repo)"
+git_init "$repo"
+mk_plugin "$repo" alpha 1.0.0 yes
+printf '# Changelog\n\n## [1.0.0]\n\n- one\n' >"$repo/plugins/alpha/CHANGELOG.md"
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm base
+base="$(git -C "$repo" rev-parse HEAD)"
+printf '{ "name": "alpha", "version": "1.0.1" }\n' >"$repo/plugins/alpha/.claude-plugin/plugin.json"
+printf '# Changelog\n\n## [1.0.1]\n\n- revert\n\n## [1.0.0] - 2026-01-01 [YANKED]\n\n- one\n' >"$repo/plugins/alpha/CHANGELOG.md"
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm 'yank 1.0.0'
+out="$(cd "$repo" && bash scripts/check-changelog-parity.sh --check-preserved "$base" 2>&1)"
+rc=$?
+if [[ $rc -eq 0 ]]; then ok "marking a release '[YANKED]' preserves its heading and passes --check-preserved"; else fail "yanked-release marking wrongly failed: rc=$rc out='$out'"; fi
+rm -rf "$repo"
+
+# REFORMATTED HEADING: bracketed -> unbracketed names the same version. Matching
+# is on the VERSION, so a format change is not a deletion (--check-bump owns the
+# format concern).
+repo="$(mk_repo)"
+git_init "$repo"
+mk_plugin "$repo" alpha 1.0.0 yes
+printf '# Changelog\n\n## [1.0.0]\n\n- one\n' >"$repo/plugins/alpha/CHANGELOG.md"
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm base
+base="$(git -C "$repo" rev-parse HEAD)"
+printf '# Changelog\n\n## 1.0.0 — 2026-01-01\n\n- one\n' >"$repo/plugins/alpha/CHANGELOG.md"
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm 'reformat the heading'
+out="$(cd "$repo" && bash scripts/check-changelog-parity.sh --check-preserved "$base" 2>&1)"
+rc=$?
+if [[ $rc -eq 0 ]]; then ok "reformatting a heading to another accepted form is not a deletion"; else fail "heading reformat wrongly flagged: rc=$rc out='$out'"; fi
+rm -rf "$repo"
+
+# HEADINGLESS CHANGELOG: the shared extractor's `grep -oE` exits 1 when a file
+# declares no version heading at all. Under pipefail that status must NOT be read
+# as a failed check — a false positive on every prose-only changelog.
+repo="$(mk_repo)"
+git_init "$repo"
+mk_plugin "$repo" alpha 1.0.0 yes
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm base
+base="$(git -C "$repo" rev-parse HEAD)"
+printf '# Changelog\n\nNothing released yet.\n' >"$repo/plugins/alpha/CHANGELOG.md"
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm 'edit a headingless changelog'
+out="$(cd "$repo" && bash scripts/check-changelog-parity.sh --check-preserved "$base" 2>&1)"
+rc=$?
+if [[ $rc -eq 0 ]]; then ok "a changelog with no version headings passes --check-preserved (grep's no-match status is not an error)"; else fail "headingless changelog wrongly failed: rc=$rc out='$out'"; fi
+rm -rf "$repo"
+
+# FENCED EXAMPLE HEADING: what looks like a heading inside a code fence is not
+# one, so removing it is not a deletion. The shared extractor owns this.
+repo="$(mk_repo)"
+git_init "$repo"
+mk_plugin "$repo" alpha 1.0.0 yes
+printf '# Changelog\n\n## [1.0.0]\n\n~~~\n## [9.9.9]\n~~~\n' >"$repo/plugins/alpha/CHANGELOG.md"
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm base
+base="$(git -C "$repo" rev-parse HEAD)"
+printf '# Changelog\n\n## [1.0.0]\n\n- one\n' >"$repo/plugins/alpha/CHANGELOG.md"
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm 'drop the fenced example'
+out="$(cd "$repo" && bash scripts/check-changelog-parity.sh --check-preserved "$base" 2>&1)"
+rc=$?
+if [[ $rc -eq 0 ]]; then ok "removing a fenced example heading is not a deletion"; else fail "fenced example wrongly counted as a released heading: rc=$rc out='$out'"; fi
+rm -rf "$repo"
+
+# CONVENTION CHANGELOG: unversioned by any manifest, so --check and --check-bump
+# never look at it. Absorption is just as possible there, and --check-preserved
+# sweeps the same two roots --check-order does.
+repo="$(mk_repo)"
+git_init "$repo"
+mk_plugin "$repo" alpha 1.0.0 yes
+mkdir -p "$repo/docs/conventions/demo"
+printf '# Changelog\n\n## 2.0.0 — 2026-01-02\n\n- two\n\n## 1.0.0 — 2026-01-01\n\n- one\n' >"$repo/docs/conventions/demo/CHANGELOG.md"
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm base
+base="$(git -C "$repo" rev-parse HEAD)"
+printf '# Changelog\n\n## 3.0.0 — 2026-01-03\n\n- three\n- two\n\n## 1.0.0 — 2026-01-01\n\n- one\n' >"$repo/docs/conventions/demo/CHANGELOG.md"
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm 'absorb 2.0.0 into 3.0.0'
+out="$(cd "$repo" && bash scripts/check-changelog-parity.sh --check-preserved "$base" 2>&1)"
+rc=$?
+if [[ $rc -eq 1 && "$out" == *"docs/conventions/demo/CHANGELOG.md"* && "$out" == *"2.0.0"* ]]; then ok "convention changelogs are in --check-preserved scope"; else fail "convention changelog absorption missed: rc=$rc out='$out'"; fi
+rm -rf "$repo"
+
+# LARGE CHANGELOG under gawk (the #2130 shape, applied to this mode): the heading
+# lists are read through the same rendered_lines writer, so no reader in this
+# path may exit before EOF. Forced gawk for the same reason as the --check-bump
+# fixture above — mawk survives a closed pipe and would prove nothing.
+repo="$(mk_repo)"
+git_init "$repo"
+mk_plugin "$repo" alpha 1.0.0 yes
+{
+  printf '# Changelog\n\n## [1.0.0]\n\n'
+  for ((i = 0; i < 4000; i++)); do
+    printf '%s\n' '- a release note line padding the file well past any pipe or stdio buffer'
+  done
+  printf '\n## [0.9.0]\n'
+} >"$repo/plugins/alpha/CHANGELOG.md"
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm base
+base="$(git -C "$repo" rev-parse HEAD)"
+printf '{ "name": "alpha", "version": "1.1.0" }\n' >"$repo/plugins/alpha/.claude-plugin/plugin.json"
+{
+  printf '# Changelog\n\n## [1.1.0]\n\n- one one\n\n## [1.0.0]\n\n'
+  for ((i = 0; i < 4000; i++)); do
+    printf '%s\n' '- a release note line padding the file well past any pipe or stdio buffer'
+  done
+  printf '\n## [0.9.0]\n'
+} >"$repo/plugins/alpha/CHANGELOG.md"
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm bump
+if command -v gawk >/dev/null 2>&1; then
+  mkdir -p "$repo/bin"
+  printf '#!/bin/sh\nexec gawk "$@"\n' >"$repo/bin/awk"
+  chmod +x "$repo/bin/awk"
+  out="$(cd "$repo" && PATH="$repo/bin:$PATH" bash scripts/check-changelog-parity.sh --check-preserved "$base" 2>&1)"
+  rc=$?
+  if [[ $rc -eq 0 ]]; then ok "a large changelog passes --check-preserved under gawk (no early-exiting reader, no SIGPIPE misread)"; else fail "large-changelog preservation wrongly failed under gawk: rc=$rc out='$out'"; fi
+else
+  echo "SKIP: the SIGPIPE fixture requires gawk; under mawk a closed pipe is survivable, so this case cannot distinguish fixed from unfixed." >&2
+fi
+rm -rf "$repo"
+
+# NO COMMON ANCESTOR: same fail-loud discipline as --check-bump — a git read that
+# could not be computed must never read as "nothing was deleted" and pass.
+repo="$(mk_repo)"
+git_init "$repo"
+mk_plugin "$repo" alpha 1.0.0 yes
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm base
+base="$(git -C "$repo" rev-parse HEAD)"
+git -C "$repo" checkout -q --orphan orphan
+git -C "$repo" rm -rq --cached . >/dev/null 2>&1 || true
+mk_plugin "$repo" alpha 1.1.0 yes
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm 'orphan root'
+out="$(cd "$repo" && bash scripts/check-changelog-parity.sh --check-preserved "$base" 2>&1)"
+rc=$?
+if [[ $rc -eq 2 && "$out" == *"failed"* ]]; then ok "--check-preserved fails loud (exit 2) when the diff cannot be computed"; else fail "--check-preserved did not fail loud on a missing common ancestor: rc=$rc out='$out'"; fi
+rm -rf "$repo"
+
+# usage errors mirror --check-bump's
+repo="$(mk_repo)"
+git_init "$repo"
+mk_plugin "$repo" alpha 1.0.0 yes
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm base
+(cd "$repo" && bash scripts/check-changelog-parity.sh --check-preserved >/dev/null 2>&1)
+if [[ $? -eq 2 ]]; then ok "--check-preserved without a base ref -> exit 2"; else fail "--check-preserved missing base ref did not exit 2"; fi
+(cd "$repo" && bash scripts/check-changelog-parity.sh --check-preserved does-not-exist >/dev/null 2>&1)
+if [[ $? -eq 2 ]]; then ok "--check-preserved with an unresolvable base ref -> exit 2"; else fail "--check-preserved bad base ref did not exit 2"; fi
 rm -rf "$repo"
 
 printf '\nPASS=%d FAIL=%d\n' "$PASS" "$FAIL"


### PR DESCRIPTION
Fixes #2342

## Summary

- Add `--check-preserved <ref>` mode that checks every **touched** changelog (plugin and convention) for dropped version headings vs the fork point.
- Replace the in-loop absorbed-heading check inside `--check-bump` (which only ran for bumped plugins) with this dedicated mode.
- Wire `--check-preserved` into the CI `changelog-parity-gate` job as an additional PR-only step.
- Uses `git ls-tree` + command-substitution `git show` (fail-loud on git errors).

## Test plan

- [x] `bash scripts/check-changelog-parity.test.sh` (76/0)
- Covers: changelog-only absorption, convention changelogs, relabelling, [YANKED], heading reformat, stale-branch false-positive guard, whole-file deletion, SIGPIPE/gawk fixture

## Related

- #2264 / #2290 — motivating absorption defect
- #2327 / #2341 — false-positive fixes for heading annotations
- #2324 — git fail-open hardening (overlapping fix, landed separately in PR #2369)