### PR TITLE
fix(guardrails): forward git globals through convention-violation alias hops

### DIFF
--- a/plugins/guardrails/.claude-plugin/plugin.json
+++ b/plugins/guardrails/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "guardrails",
-  "version": "0.28.1",
+  "version": "0.28.2",
   "description": "Twelve safety guards that block secret/credential writes, hardcoded machine-specific paths, git hook-bypass attempts, irreversible git operations (force-push, reset --hard, worktree-wide checkout/restore discards), Bash file-write workarounds that circumvent Write/Edit hooks, multi-line `git commit -m` messages (an actual-newline `-m` mangles across shells; single-line `-m` passes), commit subjects and gh pr create titles that violate the repo's tracked team convention (when one is declared in .claude/source-control.md), (advisory) hallucinated CLI flags, (advisory) /plugin:skill references that do not resolve, (advisory) markdown citing a repo path the repo's own history shows was removed, (advisory, opt-in) un-throttled Workflow fan-out that risks burst 529s, and (advisory, opt-in) direct gh pr create calls bypassing this marketplace's own pull-request skill — each independently toggleable.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/guardrails/CHANGELOG.md
+++ b/plugins/guardrails/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to the `guardrails` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.28.2]
+
+### Fixed
+
+- **`block-convention-violation` dropped git's own globals on a plain-alias recursion hop (#2166).**
+  The alias argv rebuild sliced through `gi` instead of `sub_idx`, so a wrapper's words survived
+  but git's own `-C` / locating globals between `git` and the subcommand did not. A mid-merge
+  `git -C inner qc -F -` was content-gated in the wrong repository while a direct
+  `git -C inner commit -F -` was correctly exempt. The rebuild now matches
+  `block-dangerous-git`'s splice (`0..sub_idx`).
+
 ## [0.28.1]
 
 ### Fixed

--- a/plugins/guardrails/hooks/block-convention-violation.sh
+++ b/plugins/guardrails/hooks/block-convention-violation.sh
@@ -367,7 +367,7 @@ check_segment() {
           hook::env_s_split "$exp"
           expw=(${HOOK_ENV_S_WORDS[@]+"${HOOK_ENV_S_WORDS[@]}"})
           HOOK_NO_ALIAS=1
-          check_segment "${w[@]:0:gi+1}" ${expw[@]+"${expw[@]}"} "${w[@]:sub_idx+1}"
+          check_segment "${w[@]:0:sub_idx}" ${expw[@]+"${expw[@]}"} "${w[@]:sub_idx+1}"
           HOOK_NO_ALIAS=0
         fi
       done
@@ -390,7 +390,7 @@ check_segment() {
           hook::env_s_split "$pexp"
           pexpw=(${HOOK_ENV_S_WORDS[@]+"${HOOK_ENV_S_WORDS[@]}"})
           HOOK_NO_ALIAS=1
-          check_segment "${w[@]:0:gi+1}" ${pexpw[@]+"${pexpw[@]}"} "${w[@]:sub_idx+1}"
+          check_segment "${w[@]:0:sub_idx}" ${pexpw[@]+"${pexpw[@]}"} "${w[@]:sub_idx+1}"
           HOOK_NO_ALIAS=0
         fi
       fi

--- a/plugins/guardrails/hooks/block-convention-violation.test.sh
+++ b/plugins/guardrails/hooks/block-convention-violation.test.sh
@@ -245,6 +245,25 @@ run "! alias through a wrapper chdir, no sequencer: still gated" "$r2" \
 run "! alias through a wrapper chdir, conforming subject allowed" "$r2" \
   $'env -C inner git qc -F - --cleanup=verbatim <<\'EOF\'\nABC-5: fine\nEOF' 0
 
+# --- plain git alias must forward git's own globals through the recursion (#2166) ---
+# `git -C inner qc` (plain alias, not `!`) dropped `-C inner` at the alias hop:
+# the slice stopped at gi, so git's globals between git and the subcommand never
+# reached the recursed frame and the sequencer probe ran in the wrong repository.
+r="$(newrepo "$TICKET")"
+d="$(subrepo "$r" inner)"
+git -C "$d" config alias.qc commit
+git -C "$d" commit -q --allow-empty -F - --cleanup=verbatim <<'EOF'
+ABC-1: seed
+EOF
+touch "$(git -C "$d" rev-parse --absolute-git-dir)/MERGE_HEAD"
+run "git -C inner <alias>: sequencer in moved-to repo is exempt (#2166)" "$r" \
+  $'git -C inner qc -F - --cleanup=verbatim <<\'EOF\'\njunk subject\nEOF' 0
+r5="$(newrepo "$TICKET")"
+d5="$(subrepo "$r5" inner)"
+git -C "$d5" config alias.qc commit
+run "git -C inner <alias>, no sequencer: still content-gated (#2166)" "$r5" \
+  $'git -C inner qc -F - --cleanup=verbatim <<\'EOF\'\njunk subject\nEOF' 2
+
 # --- kill switch ---------------------------------------------------------------
 r="$(newrepo "$TICKET")"
 json=$(jq -n --arg c "$BAD_COMMIT" --arg d "$r" \


### PR DESCRIPTION
Fixes #2166.

Plain-alias recursion in `block-convention-violation` rebuilt argv through `gi+1`, dropping git's own locating globals between `git` and the subcommand. A mid-merge `git -C inner qc -F -` was content-gated in the payload repository instead of the moved-to one.

**Change:** splice through `sub_idx` (matching `block-dangerous-git`).

**Tests:** base-failing `git -C inner qc` sequencer case plus a no-`MERGE_HEAD` discriminator.

## Related

Refs #2166