### PR TITLE
fix(discovery): researcher must not assume skills preload succeeded

### DIFF
--- a/plugins/discovery/.claude-plugin/plugin.json
+++ b/plugins/discovery/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "discovery",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "description": "Structured discovery before changes: explore the local codebase and run disciplined multi-source external research, both dispatching a purpose-built subagent by default so the reading stays out of the main conversation — with source tiers, falsification, recency gates, and a corpus-coverage ledger — persisting EXPLORE.md / RESEARCH.md index-plus-sidecar handoff artifacts.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/discovery/CHANGELOG.md
+++ b/plugins/discovery/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog — discovery plugin
 
+## [0.15.2]
+
+### Fixed
+
+- **`researcher` no longer assumes `skills:` preload succeeded.** The agent
+  body now requires confirming the preload-liveness sentinel or Reading the
+  skill before research, and mandates echoing `preload_token` — matching the
+  parent contract that treats a missing token as a failed dispatch. (#2338)
+
 ## [0.15.1]
 
 ### Fixed

--- a/plugins/discovery/agents/researcher.md
+++ b/plugins/discovery/agents/researcher.md
@@ -13,10 +13,21 @@ volume of external research — queries, fetched pages, extraction output — ne
 orchestrator's context window. You start with no conversation history by design. Everything you
 need arrives in your dispatch prompt.
 
-The `/discovery:research` skill is preloaded into your context at startup. It is the contract you
-run, not a suggestion: its mandatory disciplines, phase structure, and outcome gate are your
-procedure. It names a sibling discipline file for the tier tables, recipes, and calibration — Read
-that file at the phase that needs it rather than up front.
+You are bound by the `/discovery:research` discipline — its mandatory phases,
+outcome gate, and tier rules are your procedure, not a suggestion. Agent
+`skills:` preload **may not inject the skill body** (a failed preload is
+skipped silently in the harness debug log). Before any research work, confirm
+the preload-liveness sentinel is already in your context:
+
+```text
+discovery-research-preload-4c1f9a
+```
+
+If you do not see it verbatim, **Read**
+`${CLAUDE_PLUGIN_ROOT}/skills/research/SKILL.md` and the discipline file it
+names at the phase that needs it rather than up front. Echo the sentinel
+verbatim as `preload_token` in your return payload — a missing or mismatched
+token is a hard failure for the parent.
 
 ## Your dispatch prompt must carry these; refuse to guess any of them
 


### PR DESCRIPTION
Closes #2338

## Summary

The researcher agent no longer assumes agent `skills:` preload injected the research discipline.

## Fix

Requires confirming the preload-liveness sentinel or Reading the skill before work, and mandates `preload_token` in the return payload.

## Verification

- [x] discovery 0.15.2 version bump and CHANGELOG entry

## Related

N/A