### PR TITLE
docs(songwriting): record tag-order positional-weighting audit

### DIFF
--- a/plugins/songwriting/.claude-plugin/plugin.json
+++ b/plugins/songwriting/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "songwriting",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Songwriting craft companion — nine concern-scoped lyric-craft skills (workflow router, rhyme, object-writing, metaphor, meter-prosody, song-form, co-write, diagnose, practice) applying Pat Pattison's methods, with an object-writing agent that performs the sensory exercise itself and per-skill emission boundaries that route generation to the skill that owns it, plus Suno v5.5 prompt engineering (style prompts, tagged lyrics, genre templates, troubleshooting).",
   "author": {
     "name": "Melodic Software",

--- a/plugins/songwriting/CHANGELOG.md
+++ b/plugins/songwriting/CHANGELOG.md
@@ -3,6 +3,19 @@
 All notable changes to the `songwriting` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [1.1.4]
+
+Both audit denominators are unchanged: **Axis 1 stays 44 of 44** and **Axis 2
+stays 226 of 226.**
+
+### Documented
+
+- **Tag-order positional weighting audited on its own evidence (#2353).**
+  `power-tips.md:7-13` stays retained-as-unverified: no source establishes
+  first-tag advantage or middle-tag softening; Suno's category-order lead
+  does not settle positional weight. Row **S7** recorded in
+  `skills/suno/reference/suno-drift-audit-ledger.md`.
+
 ## [1.1.3]
 
 Both audit denominators are unchanged: **Axis 1 stays 44 of 44** and **Axis 2


### PR DESCRIPTION
Closes #2353

## Summary

Records completion of the independent tag-order positional-weighting audit.

## Fix

CHANGELOG 1.1.4 documents that `power-tips.md:7-13` remains retained-as-unverified and points to ledger row S7.

## Verification

- [x] songwriting 1.1.4 version bump

## Related

Refs #2354