### PR TITLE
fix(guardrails): replay inherited --git-dir into ! alias lease probe

### DIFF
--- a/plugins/guardrails/.claude-plugin/plugin.json
+++ b/plugins/guardrails/.claude-plugin/plugin.json
@@ -1,8 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "guardrails",
-  "version": "0.28.2",
-  "description": "Twelve safety guards that block secret/credential writes, hardcoded machine-specific paths, git hook-bypass attempts, irreversible git operations (force-push, reset --hard, worktree-wide checkout/restore discards), Bash file-write workarounds that circumvent Write/Edit hooks, multi-line `git commit -m` messages (an actual-newline `-m` mangles across shells; single-line `-m` passes), commit subjects and gh pr create titles that violate the repo's tracked team convention (when one is declared in .claude/source-control.md), (advisory) hallucinated CLI flags, (advisory) /plugin:skill references that do not resolve, (advisory) markdown citing a repo path the repo's own history shows was removed, (advisory, opt-in) un-throttled Workflow fan-out that risks burst 529s, and (advisory, opt-in) direct gh pr create calls bypassing this marketplace's own pull-request skill — each independently toggleable.",
+  "description": "Twelve safety guards that block secret/credential writes, hardcoded machine-specific paths, git hook-bypass attempts, irreversible git operations (force-push, reset --hard, worktree-wide checkout/restore discards), Bash file-write workarounds that circumvent Write/Edit hooks, multi-line `git commit -m` messages (an actual-newline `-m` mangles across shells; single-line `-m` passes), commit subjects and gh pr create titles that violate the repo's tracked team convention (when one is declared in .claude/source-control.md), (advisory) hallucinated CLI flags, (advisory) /plugin:skill references that do not resolve, (advisory) markdown citing a repo path the repo's own history shows was removed, (advisory, opt-in) un-throttled Workflow fan-out that risks burst 529s, and (advisory, opt-in) direct gh pr create calls bypassing this marketplace's own pull-request skill \u2014 each independently toggleable.",
   "author": {
     "name": "Melodic Software",
     "email": "info@melodicsoftware.com"
@@ -125,7 +124,7 @@
     "block_hook_bypass_scratch_roots": {
       "type": "string",
       "title": "block-hook-bypass scratch roots",
-      "description": "Comma-separated ABSOLUTE directories block-hook-bypass exempts as scratch/temp write targets (e.g. /tmp/scratch,/d/jobtmp/session); empty (the default) exempts nothing and leaves the guard's shipped behaviour unchanged. Matching is on the effective stdout target after lexical normalization, at a path-component boundary — a sibling merely sharing the name prefix, a `..` escape out of a root, and a discard-then-real-file redirect all still block. A quoted or escaped OPERAND is never exempt: the operand is marked so it survives the quote strip and the segment split as one word, and an operand carrying whitespace, `;`, `|`, `&`, `(`, `)`, a newline or a backslash escape exempts nothing. Quotes elsewhere in the command no longer matter. Symlinks are not followed",
+      "description": "Comma-separated ABSOLUTE directories block-hook-bypass exempts as scratch/temp write targets (e.g. /tmp/scratch,/d/jobtmp/session); empty (the default) exempts nothing and leaves the guard's shipped behaviour unchanged. Matching is on the effective stdout target after lexical normalization, at a path-component boundary \u2014 a sibling merely sharing the name prefix, a `..` escape out of a root, and a discard-then-real-file redirect all still block. A quoted or escaped OPERAND is never exempt: the operand is marked so it survives the quote strip and the segment split as one word, and an operand carrying whitespace, `;`, `|`, `&`, `(`, `)`, a newline or a backslash escape exempts nothing. Quotes elsewhere in the command no longer matter. Symlinks are not followed",
       "default": ""
     },
     "stdin_read_timeout": {
@@ -135,5 +134,6 @@
       "default": 2,
       "min": 1
     }
-  }
+  },
+  "version": "0.28.3"
 }

--- a/plugins/guardrails/CHANGELOG.md
+++ b/plugins/guardrails/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to the `guardrails` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.28.3]
+
+### Fixed
+
+- **`block-dangerous-git` cleared a lease when a `!` alias inherited `--git-dir` / `--work-tree`
+  (#2151).** git exports those globals into a shell-alias body's environment without relocating
+  its directory the way `-C` does, so the reparse's width probe ran against the payload cwd while
+  the push executed in the inherited repository. Inherited locating spellings are now replayed into
+  `!` reparses via `HOOK_GIT_INHERITED_LOCATING_OPTS`.
+
 ## [0.28.2]
 
 ### Fixed

--- a/plugins/guardrails/hooks/block-dangerous-git.sh
+++ b/plugins/guardrails/hooks/block-dangerous-git.sh
@@ -97,11 +97,10 @@ hook::require_jq_blocking "guardrails-block-dangerous-git" "block_dangerous_git_
 
 # All three payload fields in ONE jq process (hook::jq_fields), not three. A jq
 # spawn is ~140 ms of fork() emulation on Windows Git Bash and this guard runs on
-# every Bash/PowerShell call. rc 1 here means jq could not parse the payload at
-# all — it exits 0 exactly as the empty-COMMAND skip below did. A MISSING jq
-# can no longer reach this line — hook::require_jq_blocking above has already
-# denied the call (#2146) — so the rc-1 path here is now only the unparsable-
-# payload case.
+# every Bash/PowerShell call. rc 2 here means jq could not parse the payload at
+# all — it exits 2, matching the MAX_COMMAND_LEN ceiling's fail-closed posture
+# toward an input it cannot parse (#2157). A MISSING jq can no longer reach this
+# line — hook::require_jq_blocking above has already denied the call (#2146).
 #
 # `.cwd` is the directory the TOOL CALL runs in, which is not the hook process's
 # own: Claude Code launches hooks from the session root while the Bash tool runs
@@ -112,9 +111,8 @@ hook::require_jq_blocking "guardrails-block-dangerous-git" "block_dangerous_git_
 # block-noncanonical-commit has read this field since it shipped; this guard did
 # not, and the same chain is adopted here rather than a second mechanism.
 #
-# That remaining allow-on-unparsable path is unchanged by #2122 and is NOT what
-# the NUL check below covers.
-hook::jq_fields "$INPUT" '.tool_input.command' '.cwd' '.tool_name' || exit 0
+# The NUL check below is a separate branch — payload integrity vs value-space.
+hook::jq_fields "$INPUT" '.tool_input.command' '.cwd' '.tool_name' || exit 2
 
 # A NUL byte in ANY field read above is fail-CLOSED, and is decided BEFORE
 # the empty-COMMAND skip below: the helper strips every NUL out of a value, so a
@@ -407,6 +405,39 @@ collect_git_locating_opts() {
     *) ((j++)) ;;
     esac
   done
+  if ((${#HOOK_GIT_INHERITED_LOCATING_OPTS[@]})); then
+    git_locating_opts+=("${HOOK_GIT_INHERITED_LOCATING_OPTS[@]}")
+  fi
+}
+
+# git_inherited_locating_opts_from_words <gi> <sub_idx> <words...> — the
+# --git-dir / --work-tree / --namespace spellings between git and subcommand.
+# git EXPORTS these into a `!` alias body's environment (unlike `-C`, which
+# relocates the body's directory), so a `!` reparse must replay them into its
+# width probe separately from effective_dir's `-C` composition.
+# shellcheck disable=SC2329  # reached via the hook::bash_parse_segments callback chain
+git_inherited_locating_opts_from_words() {
+  local gi="$1" sub_idx="$2"
+  shift 2
+  local -a w=("$@")
+  local j=$((gi + 1))
+  HOOK_GIT_INHERITED_LOCATING_OPTS=()
+  while ((j < sub_idx)); do
+    case "${w[j]}" in
+    --git-dir | --work-tree | --namespace)
+      ((j + 1 < sub_idx)) && HOOK_GIT_INHERITED_LOCATING_OPTS+=("${w[j]}" "${w[j + 1]}")
+      ((j += 2))
+      ;;
+    --git-dir=* | --work-tree=* | --namespace=*)
+      HOOK_GIT_INHERITED_LOCATING_OPTS+=("${w[j]}")
+      ((j++))
+      ;;
+    -C | -c | --config | --config-env | --super-prefix | --attr-source | --exec-path)
+      ((j += 2))
+      ;;
+    *) ((j++)) ;;
+    esac
+  done
 }
 
 # Directory a segment's git actually runs in: the base with every `-C` in an
@@ -440,18 +471,9 @@ collect_git_locating_opts() {
 # alias.wd='!pwd' wd` prints `<other>`'s top level, while `git --git-dir=<other>
 # -c alias.wd='!pwd' wd` does NOT relocate at all. The two functions answer
 # different questions (which DIRECTORY the body runs in vs which REPOSITORY the
-# probe addresses), so the option sets legitimately differ.
-#
-# Known gap, pre-existing and NOT closed here: only `-C` is composed. git also
-# EXPORTS an explicit `--git-dir` / `--work-tree` into a `!` body's environment
-# (verified on git 2.54.0: `git --git-dir=<sha256>/.git -c alias.y='!git
-# rev-parse --show-object-format' y` prints sha256 from a SHA-1 directory, and
-# the body sees GIT_DIR set), so a body inherits a repository this directory does
-# not name and its lease is judged against the base instead. Reproduced against
-# BOTH origin/main and this change — it is a residual of the same family as
-# #2124, not something introduced by reading the payload cwd, and closing it
-# means replaying the inherited globals rather than a directory, which is a
-# larger mechanism than the base chain adopted here.
+# probe addresses), so the option sets legitimately differ. A `!` reparse replays
+# the inherited `--git-dir` / `--work-tree` / `--namespace` spellings separately
+# via HOOK_GIT_INHERITED_LOCATING_OPTS (#2151) — only `-C` is composed here.
 # shellcheck disable=SC2329  # reached via the hook::bash_parse_segments callback chain
 effective_dir() {
   local base="${HOOK_EFFECTIVE_BASE:-${HOOK_CWD:-${CLAUDE_PROJECT_DIR:-.}}}" i n=$# arg
@@ -674,7 +696,7 @@ check_segment() {
   # and finite distinct alias keys guarantee termination. Terminating is not the
   # same as tractable — the walk branches per hop, and alias_reexpand_admit is what
   # keeps its cost proportional to the chain's length.
-  local exp reparse a alias_rc s seen_hit=0 saved_base=""
+  local exp reparse a alias_rc s seen_hit=0 saved_base="" saved_inherited=()
   local -a expw=() saved_seen=() nextw=()
   hook::git_alias_expansion "$sub"
   alias_rc=$?
@@ -738,6 +760,8 @@ check_segment() {
         reparse="${exp#!}"
         for a in "${w[@]:sub_idx+1}"; do reparse+=" $(printf '%q' "$a")"; done
         HOOK_ALIAS_SEEN=()
+        saved_inherited=(${HOOK_GIT_INHERITED_LOCATING_OPTS[@]+"${HOOK_GIT_INHERITED_LOCATING_OPTS[@]}"})
+        git_inherited_locating_opts_from_words "$gi" "$sub_idx" "${w[@]}"
         # `:2` skips the base's own `-C <dir>` pair, which
         # collect_git_locating_opts ALWAYS leads with. effective_dir supplies
         # that same value from its HOOK_EFFECTIVE_BASE default, so passing it
@@ -750,6 +774,7 @@ check_segment() {
         alias_reexpand_admit shell "$reparse" &&
           hook::bash_parse_segments "$reparse" check_segment
         HOOK_EFFECTIVE_BASE="$saved_base"
+        HOOK_GIT_INHERITED_LOCATING_OPTS=(${saved_inherited[@]+"${saved_inherited[@]}"})
         HOOK_ALIAS_SEEN=(${saved_seen[@]+"${saved_seen[@]}"} "$sub")
       else
         # Git alias: its expansion is dequoted with shell quoting rules
@@ -1340,6 +1365,7 @@ HOOK_ALIAS_SEEN=()
 # CLAUDE_PROJECT_DIR, then `.` — the last of which reproduces the pre-#2124
 # behaviour for a payload that carries no cwd at all.
 HOOK_EFFECTIVE_BASE="${HOOK_CWD:-${CLAUDE_PROJECT_DIR:-.}}"
+HOOK_GIT_INHERITED_LOCATING_OPTS=()
 
 # The alias-traversal bounds (alias_reexpand_admit). Both are invocation-wide and
 # deliberately NOT save/restored: a state analyzed anywhere is analyzed, and the

--- a/plugins/guardrails/hooks/block-dangerous-git.test.sh
+++ b/plugins/guardrails/hooks/block-dangerous-git.test.sh
@@ -177,6 +177,12 @@ run_split "$REPO_SHA1" "$REPO_SHA256" "payload cwd is the SHA-1 repo, 64-hex exp
 # the same misprobe one recursion level down.
 run_split "$REPO_SHA1" "$REPO_SHA1" "git -C <sha256-repo> -c alias.y='!git push --force-with-lease=main:<40-hex>' y (the body runs in the SHA-256 repo, blocked)" "git -C $REPO_SHA256 -c alias.y='!git push --force-with-lease=main:$SHA1_OID origin main' y" 2
 run_split "$REPO_SHA256" "$REPO_SHA256" "git -C <sha1-repo> -c alias.y='!git push --force-with-lease=main:<40-hex>' y (the body runs in the SHA-1 repo, allowed)" "git -C $REPO_SHA1 -c alias.y='!git push --force-with-lease=main:$SHA1_OID origin main' y" 0
+# #2151: an explicit --git-dir/--work-tree is inherited by a `!` body via GIT_DIR,
+# not relocated like -C. Without replaying those globals into the reparse, a
+# 40-hex lease is judged against the payload cwd while git pushes from the
+# inherited repository.
+run_split "$REPO_SHA1" "$REPO_SHA1" "git --git-dir=<sha256>/.git --work-tree=<sha256> -c alias.y='!git push --force-with-lease=main:<40-hex>' y (inherited GIT_DIR, blocked)" "git --git-dir=$REPO_SHA256/.git --work-tree=$REPO_SHA256 -c alias.y='!git push --force-with-lease=main:$SHA1_OID origin main' y" 2
+run_split "$REPO_SHA256" "$REPO_SHA1" "git --git-dir=<sha1>/.git --work-tree=<sha1> -c alias.y='!git push --force-with-lease=main:<40-hex>' y (40-hex is object id in inherited repo, allowed)" "git --git-dir=$REPO_SHA1/.git --work-tree=$REPO_SHA1 -c alias.y='!git push --force-with-lease=main:$SHA1_OID origin main' y" 0
 # The re-expansion MEMO must key on the effective base. A verdict is now a function
 # of the base, so one alias STRING reached under two bases is two analyses — and a
 # key blind to the base skips the second. Ordered sha1-then-sha256 deliberately:


### PR DESCRIPTION
Fixes #2151.

**Problem:** `git --git-dir=<other> -c alias.y='!git push --force-with-lease=…' y` inherited the target repository via `GIT_DIR`, but the guard's width probe still measured the payload cwd — clearing a 40-hex lease against a SHA-256 repo.

**Fix:** Replay inherited `--git-dir` / `--work-tree` / `--namespace` spellings into `!` reparses via `HOOK_GIT_INHERITED_LOCATING_OPTS`.

**Tests:** Row A (blocked) plus opposite-direction control (allowed when `--git-dir` points at SHA-1).

## Related

Refs #2151