### PR TITLE
fix(claude-config): tighten permission-rule-check P1/P2 precision

### DIFF
--- a/plugins/claude-config/.claude-plugin/plugin.json
+++ b/plugins/claude-config/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "claude-config",
-  "version": "0.35.2",
+  "version": "0.35.3",
   "description": "Eight configuration-health skills (plus setup) for a repo's Claude Code configuration: audit (settings.json / .mcp.json / hooks / plugins / permissions drift), audit-automation-gaps (evidence-gated verdicts on automation gaps), audit-permission-grants (allow-rule / allowed-tools grants for auto-mode durability and portability), audit-permission-state (which settings scopes exist and what rules each one holds — managed policy, user-global, project, local, and the pre-v2.1.211 start-directory copy), audit-instructions (locally-owned instruction surfaces vs current model capability — proposes removals/rewrites of instructions the model no longer needs, and detects cross-surface instruction conflicts), audit-prompting-postures (the additive lane — posture guidance the prompting guide says a component's purpose needs but the component does not carry), audit-pass (one coordinated, ordered, resumable pass over a named target — three-scope inventory, run-time-derived exclusion set, stable finding identity, suppression memory, resume, one human gate — delegating every check to the plugin that owns it), and unhobble (the empirical bare-baseline experiment: reversibly strip a repo's standing instructions, log real stumbles against the current model, re-add only what evidence earns).",
   "author": {
     "name": "Melodic Software",

--- a/plugins/claude-config/CHANGELOG.md
+++ b/plugins/claude-config/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to the `claude-config` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.35.3]
+
+### Fixed
+
+- **`audit-permission-grants` permission-rule-check P2/P1 precision (#2282, rows A2/A3/A19).**
+  `//Users` portable root anchors are no longer flagged; P2 findings report the full offending
+  rule instead of an eight-character fragment; `Bash(npm view … version*)` is no longer treated
+  as a bare package-manager wildcard when only the last token carries a trailing `*`.
+
 ## [0.35.2]
 
 ### Fixed

--- a/plugins/claude-config/CHANGELOG.md
+++ b/plugins/claude-config/CHANGELOG.md
@@ -7,10 +7,39 @@ All notable changes to the `claude-config` plugin are documented here. Format fo
 
 ### Fixed
 
-- **`audit-permission-grants` permission-rule-check P2/P1 precision (#2282, rows A2/A3/A19).**
-  `//Users` portable root anchors are no longer flagged; P2 findings report the full offending
-  rule instead of an eight-character fragment; `Bash(npm view … version*)` is no longer treated
-  as a bare package-manager wildcard when only the last token carries a trailing `*`.
+- **`criteria.md` no longer calls `//…` a portable anchor — the detector was right and the
+  document was wrong.** Its P2 "How to check" grouped `${CLAUDE_PROJECT_DIR}/…`, `~/…` and `//…`
+  as forms that "expand or are portable anchors", while the detector flagged `//Users/…` anyway;
+  the two shipped files disagreed, so a maintainer reading `criteria.md` could not predict the
+  detector. **The corrected mechanism is the opposite of the one originally filed:** `//` is the
+  *absolute* anchor, not a portable one. The permissions page's pattern table gives `//path` =
+  "Absolute path from filesystem root" with `Read(//Users/alice/secrets/**)` resolving to
+  `/Users/alice/secrets/**`, and the same page says "Use `//Users/alice/file` for absolute
+  paths." So `//Users/<name>/…` is the canonical *spelling* of a hardcoded user home rather than
+  an exception to one, and it leaks the username exactly as `/Users/<name>/…` does — which is
+  the whole of P2's finding. `~/…` is portable because its home segment is supplied per user;
+  `//…` supplies nothing. The exemption was therefore removed from the document instead of added
+  to the detector: exempting it would have made an `error`-tier username-leak check blind to the
+  documentation's own literal example of the leak.
+- **P2 findings report the full offending rule** rather than an eight-character path fragment
+  (`/Users/k`) an operator could not map back to any particular rule. This is the intent the file
+  already stated for P1 and had never applied to P2.
+- **P2 reads every tool's rules, not five names.** While adding that full-rule capture the tool
+  name was briefly enumerated as `(Read|Edit|Write|Bash|PowerShell)`, which silently stopped
+  flagging a hardcoded machine path in a `WebFetch(...)`, `Glob(...)`, `NotebookEdit(...)`,
+  `mcp__server__tool(...)` or `Agent(...)` rule — `Agent` most clearly wrong, since this script
+  ships a dedicated `scan_agent()`. It now uses the same open tool-name grammar as
+  `CCPERM_TOOL_TOKEN_ERE`. Narrowing an `error`-tier check's reach is not a reporting-format
+  change; four regression cases pin it.
+- **`Bash(npm view ctx7 version*)` is no longer flagged as a bare package-manager wildcard.** The
+  P1 runner alternative let the required `*` sit arbitrarily far past the manager name, so a
+  fully-pinned subcommand carrying a trailing `*` matched. The `*` must now be preceded by a
+  separator, which keeps `Bash(npm *)`, `Bash(npm:*)`, `Bash(npx *)` and `Bash(pnpm dlx *)`
+  matching and leaves `Bash(npm test)` clean. That pattern moved into
+  `lib/permission-patterns.sh` under #2260, so the fix lands there rather than at the anchors
+  #2282 records.
+- Rows **A7b** (no inert-grant check) and **A12** (`~user` username leak unflagged) are **not**
+  fixed here; both still reproduce at HEAD and are tracked separately.
 
 ## [0.35.2]
 

--- a/plugins/claude-config/CHANGELOG.md
+++ b/plugins/claude-config/CHANGELOG.md
@@ -13,8 +13,8 @@ All notable changes to the `claude-config` plugin are documented here. Format fo
   the two shipped files disagreed, so a maintainer reading `criteria.md` could not predict the
   detector. **The corrected mechanism is the opposite of the one originally filed:** `//` is the
   *absolute* anchor, not a portable one. The permissions page's pattern table gives `//path` =
-  "Absolute path from filesystem root" with `Read(//Users/alice/secrets/**)` resolving to
-  `/Users/alice/secrets/**`, and the same page says "Use `//Users/alice/file` for absolute
+  "Absolute path from filesystem root" with `Read(//Users/<name>/secrets/**)` resolving to
+  `/Users/<name>/secrets/**`, and the same page says "Use `//Users/<name>/file` for absolute
   paths." So `//Users/<name>/…` is the canonical *spelling* of a hardcoded user home rather than
   an exception to one, and it leaks the username exactly as `/Users/<name>/…` does — which is
   the whole of P2's finding. `~/…` is portable because its home segment is supplied per user;

--- a/plugins/claude-config/lib/permission-patterns.sh
+++ b/plugins/claude-config/lib/permission-patterns.sh
@@ -57,7 +57,7 @@ CCPERM_SCRIPT_BODY='py|sh|rb|js|ts|mjs|cjs|pl|php'
 # driver reports the full offending rule, not a substring truncated at the *.
 CCPERM_P1_ERE="(Bash|PowerShell)\\(\\*\\)"
 CCPERM_P1_ERE="${CCPERM_P1_ERE}|(Bash|PowerShell)\\([\"' ]*([^)\"' ]*[/\\\\])?(${CCPERM_INTERP_BODY})([\"' :][^)]*)?\\*[^)]*\\)"
-CCPERM_P1_ERE="${CCPERM_P1_ERE}|(Bash|PowerShell)\\([\"' ]*(${CCPERM_RUNNER_BODY})([\"' :][^)]*)?\\*[^)]*\\)"
+CCPERM_P1_ERE="${CCPERM_P1_ERE}|(Bash|PowerShell)\\([\"' ]*(${CCPERM_RUNNER_BODY})([\"' :][^)]*)?([\"' :])\\*[^)]*\\)"
 CCPERM_P1_ERE="${CCPERM_P1_ERE}|(Bash|PowerShell)\\([\"' ]*\\*[^)]*\\.(${CCPERM_SCRIPT_BODY})[^)]*\\)"
 
 # Splits rule text into top-level `Tool` / `Tool(...)` tokens. The greedy

--- a/plugins/claude-config/skills/audit-permission-grants/reference/criteria.md
+++ b/plugins/claude-config/skills/audit-permission-grants/reference/criteria.md
@@ -76,12 +76,12 @@ genuinely expand per machine and per user — while only concrete usernames matc
 **`//…` is flagged, and this line used to say the opposite.** It previously grouped `//…` with the two
 expanding forms as a "portable anchor". It is not one: `//` is the *absolute* anchor.
 <https://code.claude.com/docs/en/permissions>, § Read and Edit, fetched 2026-08-12, gives the pattern
-table row `` `//path` | Absolute path from filesystem root | `Read(//Users/alice/secrets/**)` |
-`/Users/alice/secrets/**` ``, and the same page states: *"A pattern like `/Users/alice/file` isn't an
+table row `` `//path` | Absolute path from filesystem root | `Read(//Users/<name>/secrets/**)` |
+`/Users/<name>/secrets/**` ``, and the same page states: *"A pattern like `/Users/<name>/file` isn't an
 absolute path. The single leading slash anchors at the settings source, not the filesystem root. **Use
-`//Users/alice/file` for absolute paths.**"* So `//Users/alice/…` resolves to a concrete user home and
+`//Users/<name>/file` for absolute paths.**"* So `//Users/<name>/…` resolves to a concrete user home and
 carries the username — it is the canonical *spelling* of the defect P2 exists to catch, not an
-exception to it. Contrast `~/…`, whose own doc row (`Read(~/Documents/*.pdf)` → `/Users/alice/Documents/*.pdf`)
+exception to it. Contrast `~/…`, whose own doc row (`Read(~/Documents/*.pdf)` → `/Users/<name>/Documents/*.pdf`)
 shows the home segment being supplied per user, which is what makes it portable.
 
 Exempting `//` would have made this check blind to the documentation's own literal example of a

--- a/plugins/claude-config/skills/audit-permission-grants/reference/criteria.md
+++ b/plugins/claude-config/skills/audit-permission-grants/reference/criteria.md
@@ -70,8 +70,23 @@ the same. See convention anti-pattern 1.
 **What**: An entry containing a concrete user-home absolute path — `/c/Users/<name>/…` (POSIX-normalized
 Windows), `/home/<name>/…`, `/Users/<name>/…`, or `C:\Users\<name>\…`.
 
-**How to check**: run the detector. `${CLAUDE_PROJECT_DIR}/…`, `~/…`, and `//…` forms are not flagged
-(they expand or are portable anchors); only concrete usernames match.
+**How to check**: run the detector. `${CLAUDE_PROJECT_DIR}/…` and `~/…` forms are not flagged — those
+genuinely expand per machine and per user — while only concrete usernames match.
+
+**`//…` is flagged, and this line used to say the opposite.** It previously grouped `//…` with the two
+expanding forms as a "portable anchor". It is not one: `//` is the *absolute* anchor.
+<https://code.claude.com/docs/en/permissions>, § Read and Edit, fetched 2026-08-12, gives the pattern
+table row `` `//path` | Absolute path from filesystem root | `Read(//Users/alice/secrets/**)` |
+`/Users/alice/secrets/**` ``, and the same page states: *"A pattern like `/Users/alice/file` isn't an
+absolute path. The single leading slash anchors at the settings source, not the filesystem root. **Use
+`//Users/alice/file` for absolute paths.**"* So `//Users/alice/…` resolves to a concrete user home and
+carries the username — it is the canonical *spelling* of the defect P2 exists to catch, not an
+exception to it. Contrast `~/…`, whose own doc row (`Read(~/Documents/*.pdf)` → `/Users/alice/Documents/*.pdf`)
+shows the home segment being supplied per user, which is what makes it portable.
+
+Exempting `//` would have made this check blind to the documentation's own literal example of a
+hardcoded path, in the check graded `error`. The detector's behavior was right and this file was
+wrong; the file moved.
 
 **Why**: the rule names a concrete user home, so it breaks on any other machine or username — and after
 a skill migrates into a plugin, since the install path changes — and it leaks a username into version

--- a/plugins/claude-config/skills/audit-permission-grants/scripts/permission-rule-check.sh
+++ b/plugins/claude-config/skills/audit-permission-grants/scripts/permission-rule-check.sh
@@ -180,7 +180,7 @@ scan_rule() {
     [[ -z "$m" ]] && continue
     # No `//…` carve-out. `//` is the ABSOLUTE anchor, not a portable one: the
     # permissions page's own row is `//path` = "Absolute path from filesystem
-    # root", with `Read(//Users/alice/secrets/**)` -> `/Users/alice/secrets/**`.
+    # root", with `Read(//Users/<name>/secrets/**)` -> `/Users/<name>/secrets/**`.
     # So `//Users/<name>/…` names a concrete user home and leaks the username,
     # exactly like `/Users/<name>/…`. `~/…` and `${CLAUDE_PROJECT_DIR}/…` are the
     # genuinely portable forms and are already excluded by `_seg` above.

--- a/plugins/claude-config/skills/audit-permission-grants/scripts/permission-rule-check.sh
+++ b/plugins/claude-config/skills/audit-permission-grants/scripts/permission-rule-check.sh
@@ -150,9 +150,8 @@ _sl='/'
 # shellcheck disable=SC1003  # _bs is a literal single backslash, not an escape
 _bs='\'
 _seg="[^${_sl}${_bs}*<>\${}~ ]"
-P2_ERE="${_sl}Users${_sl}${_seg}"                                    # macOS + POSIX-normalized Windows (/c/Users/…)
-P2_ERE="${P2_ERE}|${_sl}home${_sl}${_seg}"                           # Linux
-P2_ERE="${P2_ERE}|[A-Za-z]:[${_sl}${_bs}]Users[${_sl}${_bs}]${_seg}" # raw Windows drive
+_p2_path="${_sl}Users${_sl}${_seg}|${_sl}home${_sl}${_seg}|[A-Za-z]:[${_sl}${_bs}]Users[${_sl}${_bs}]${_seg}"
+P2_RULE_ERE="(Read|Edit|Write|Bash|PowerShell)\\([^)]*(${_p2_path})[^)]*\\)"
 
 findings=()
 
@@ -168,8 +167,11 @@ scan_rule() {
     [[ -n "$m" ]] && emit warning P1 "$src" "'$m' is an interpreter/runner-led grant, not the portable bare-name pattern; Claude Code drops the broad forms of this shape (blanket, package-manager runners, and wildcarded/globbed-target interpreters) on entering auto mode. Expose the guarded script as a bare PATH command and allow that, e.g. Bash(babysit_merge.sh:*)."
   done < <(printf '%s\n' "$text" | grep -oE "$P1_ERE" 2>/dev/null | sort -u)
   while IFS= read -r m; do
-    [[ -n "$m" ]] && emit error P2 "$src" "hardcoded machine path in '$m' — the rule names a concrete user home, so it breaks on other machines and usernames and leaks a username into source control. Portable forms: \${CLAUDE_SKILL_DIR} for a skill's own bundled script (substituted in allowed-tools Bash rules), a bare-name command on PATH, or the ~/ home anchor for Read/Edit rules."
-  done < <(printf '%s\n' "$text" | grep -oE "$P2_ERE" 2>/dev/null | sort -u)
+    [[ -z "$m" ]] && continue
+    # `//…` is a portable root anchor (criteria.md); only concrete `/Users/…` paths flag.
+    [[ "$m" == *"(//"* ]] && continue
+    emit error P2 "$src" "hardcoded machine path in '$m' — the rule names a concrete user home, so it breaks on other machines and usernames and leaks a username into source control. Portable forms: \${CLAUDE_SKILL_DIR} for a skill's own bundled script (substituted in allowed-tools Bash rules), a bare-name command on PATH, or the ~/ home anchor for Read/Edit rules."
+  done < <(printf '%s\n' "$text" | grep -oE "$P2_RULE_ERE" 2>/dev/null | sort -u)
 }
 
 top_level_tokens() {

--- a/plugins/claude-config/skills/audit-permission-grants/scripts/permission-rule-check.sh
+++ b/plugins/claude-config/skills/audit-permission-grants/scripts/permission-rule-check.sh
@@ -151,7 +151,17 @@ _sl='/'
 _bs='\'
 _seg="[^${_sl}${_bs}*<>\${}~ ]"
 _p2_path="${_sl}Users${_sl}${_seg}|${_sl}home${_sl}${_seg}|[A-Za-z]:[${_sl}${_bs}]Users[${_sl}${_bs}]${_seg}"
-P2_RULE_ERE="(Read|Edit|Write|Bash|PowerShell)\\([^)]*(${_p2_path})[^)]*\\)"
+# Capture the WHOLE `Tool(...)` spec so a finding reports the offending rule rather
+# than an eight-character path fragment — the intent already stated for P1 above.
+#
+# The tool name is the OPEN grammar, not an enumerated list. `(Read|Edit|Write|Bash
+# |PowerShell)` would silently stop flagging a hardcoded path in a `WebFetch(...)`,
+# `Glob(...)`, `NotebookEdit(...)`, `mcp__server__tool(...)` or `Agent(...)` rule —
+# and this file has a dedicated `scan_agent()`, so `Agent` is unambiguously in
+# scope. Narrowing an `error`-tier check's reach is not a reporting-format change.
+# The leading `[A-Za-z_][A-Za-z0-9_]*` is `CCPERM_TOOL_TOKEN_ERE`'s own tool-name
+# grammar, kept consistent with the library #2260 extracted.
+P2_RULE_ERE="[A-Za-z_][A-Za-z0-9_]*\\([^)]*(${_p2_path})[^)]*\\)"
 
 findings=()
 
@@ -168,8 +178,12 @@ scan_rule() {
   done < <(printf '%s\n' "$text" | grep -oE "$P1_ERE" 2>/dev/null | sort -u)
   while IFS= read -r m; do
     [[ -z "$m" ]] && continue
-    # `//…` is a portable root anchor (criteria.md); only concrete `/Users/…` paths flag.
-    [[ "$m" == *"(//"* ]] && continue
+    # No `//…` carve-out. `//` is the ABSOLUTE anchor, not a portable one: the
+    # permissions page's own row is `//path` = "Absolute path from filesystem
+    # root", with `Read(//Users/alice/secrets/**)` -> `/Users/alice/secrets/**`.
+    # So `//Users/<name>/…` names a concrete user home and leaks the username,
+    # exactly like `/Users/<name>/…`. `~/…` and `${CLAUDE_PROJECT_DIR}/…` are the
+    # genuinely portable forms and are already excluded by `_seg` above.
     emit error P2 "$src" "hardcoded machine path in '$m' — the rule names a concrete user home, so it breaks on other machines and usernames and leaks a username into source control. Portable forms: \${CLAUDE_SKILL_DIR} for a skill's own bundled script (substituted in allowed-tools Bash rules), a bare-name command on PATH, or the ~/ home anchor for Read/Edit rules."
   done < <(printf '%s\n' "$text" | grep -oE "$P2_RULE_ERE" 2>/dev/null | sort -u)
 }

--- a/plugins/claude-config/skills/audit-permission-grants/scripts/permission-rule-check.test.sh
+++ b/plugins/claude-config/skills/audit-permission-grants/scripts/permission-rule-check.test.sh
@@ -353,6 +353,22 @@ rc=0
 PERMISSION_HYGIENE_FIXTURE_DIR="$TEST_TMPDIR/does-not-exist" bash "$SCRIPT" --count >/dev/null 2>&1 || rc=$?
 assert_exit "--count refuses a nonexistent root too" 2 "$rc"
 
+# --- Case 8b: #2282 P2 // exemption, full-rule reporting; P1 pinned npm view ----
+D8B="$TEST_TMPDIR/issue-2282"
+mkdir -p "$D8B/.claude"
+jq -n --arg posix "Bash(${POSIX_MP}:*)" \
+  '{permissions:{allow:[
+    "Read(//Users/alice/secrets/**)",
+    "Bash(npm view ctx7 version*)",
+    $posix
+  ]}}' >"$D8B/.claude/settings.json"
+OUT_2282=$(run "$D8B")
+assert_not_contains "//Users portable root anchor is not flagged" "$OUT_2282" "//Users"
+assert_not_contains "//Users portable root anchor is not flagged" "$OUT_2282" "alice/secrets"
+assert_contains "P2 reports the full offending Bash rule" "$OUT_2282" "Bash(${POSIX_MP}:*)"
+assert_not_contains "fully-pinned npm view rule is not flagged as P1" "$OUT_2282" "npm view ctx7 version"
+assert_eq "only the real machine-path rule is flagged" "1" "$(run "$D8B" --count)"
+
 # --- Case 9: missing jq exits 2 ---------------------------------------------
 real_bash=$(command -v bash)
 empty_path_dir="$TEST_TMPDIR/empty-path"

--- a/plugins/claude-config/skills/audit-permission-grants/scripts/permission-rule-check.test.sh
+++ b/plugins/claude-config/skills/audit-permission-grants/scripts/permission-rule-check.test.sh
@@ -66,6 +66,13 @@ POSIX_MP="${SL}c${SL}Users${SL}alice${SL}.agents${SL}skills${SL}merge${SL}x.sh"
 WIN_MP="C:${BS}Users${BS}bob${BS}x.sh"
 READ_MP="${SL}c${SL}Users${SL}carol${SL}notes.md"
 EDIT_MP="${SL}Users${SL}dave${SL}src${SL}**"
+# #2282 rows: `//` absolute anchor, tool-reach, and prefix-laundering fixtures.
+ABS_MP="${SL}${SL}Users${SL}erin${SL}secrets${SL}**"
+LAUNDER_MP="${SL}${SL}opt${SL}data${SL}..${SL}Users${SL}frank${SL}secrets"
+WF_MP="${SL}Users${SL}grace${SL}x"
+GLOB_MP="${SL}home${SL}heidi${SL}**"
+NB_MP="${SL}Users${SL}ivan${SL}nb.ipynb"
+MCP_MP="${SL}Users${SL}judy${SL}x"
 
 # --- Case 1: --help ----------------------------------------------------------
 rc=0
@@ -356,22 +363,18 @@ assert_exit "--count refuses a nonexistent root too" 2 "$rc"
 # --- Case 8b: #2282 — full-rule reporting, `//` is NOT exempt, P1 pinned npm view
 #
 # `//` is the ABSOLUTE anchor, not a portable one. permissions.md's own table row is
-# `//path` = "Absolute path from filesystem root", with `Read(//Users/alice/secrets/**)`
-# resolving to `/Users/alice/secrets/**`, and the same page says "Use
-# `//Users/alice/file` for absolute paths." The docs' literal example names a concrete
+# `//path` = "Absolute path from filesystem root", with `Read(//Users/<name>/secrets/**)`
+# resolving to `/Users/<name>/secrets/**`, and the same page says "Use
+# `//Users/<name>/file` for absolute paths." The docs' literal example names a concrete
 # user home and leaks `alice`. An earlier revision of this suite asserted the opposite,
 # which would have taught an `error`-tier username-leak check to ignore the canonical
 # spelling of the leak.
 D8B="$TEST_TMPDIR/issue-2282"
 mkdir -p "$D8B/.claude"
-jq -n --arg posix "Bash(${POSIX_MP}:*)" \
-  '{permissions:{allow:[
-    "Read(//Users/alice/secrets/**)",
-    "Bash(npm view ctx7 version*)",
-    $posix
-  ]}}' >"$D8B/.claude/settings.json"
+jq -n --arg posix "Bash(${POSIX_MP}:*)" --arg abs "Read(${ABS_MP})" \
+  '{permissions:{allow:[$abs, "Bash(npm view ctx7 version*)", $posix]}}' >"$D8B/.claude/settings.json"
 OUT_2282=$(run "$D8B")
-assert_contains "// absolute anchor IS flagged — it names a concrete user home" "$OUT_2282" "Read(//Users/alice/secrets/**)"
+assert_contains "// absolute anchor IS flagged — it names a concrete user home" "$OUT_2282" "Read(${ABS_MP})"
 assert_contains "P2 reports the full offending Bash rule" "$OUT_2282" "Bash(${POSIX_MP}:*)"
 assert_not_contains "fully-pinned npm view rule is not flagged as P1" "$OUT_2282" "npm view ctx7 version"
 assert_eq "both machine-path rules flagged, npm view not" "2" "$(run "$D8B" --count)"
@@ -381,10 +384,7 @@ assert_eq "both machine-path rules flagged, npm view not" "2" "$(run "$D8B" --co
 # user/project segment at resolution time; `//` does not.
 D8C="$TEST_TMPDIR/issue-2282-portable"
 mkdir -p "$D8C/.claude"
-jq -n '{permissions:{allow:[
-    "Read(~/Documents/*.pdf)",
-    "Bash(${CLAUDE_PROJECT_DIR}/scripts/x.sh:*)"
-  ]}}' >"$D8C/.claude/settings.json"
+jq -n '{permissions:{allow:["Read(~/Documents/*.pdf)","Bash(${CLAUDE_PROJECT_DIR}/scripts/x.sh:*)"]}}' >"$D8C/.claude/settings.json"
 assert_eq "portable anchors produce no P2 finding" "0" "$(run "$D8C" --count)"
 
 # --- Case 8d: P2 reach is the open tool grammar, not five hardcoded names ------
@@ -394,24 +394,19 @@ assert_eq "portable anchors produce no P2 finding" "0" "$(run "$D8C" --count)"
 # scan_agent(). Each rule below must produce its own P2 finding.
 D8D="$TEST_TMPDIR/issue-2282-tools"
 mkdir -p "$D8D/.claude"
-jq -n '{permissions:{allow:[
-    "WebFetch(/Users/kyle/x)",
-    "Glob(/home/bob/**)",
-    "NotebookEdit(/Users/kyle/nb.ipynb)",
-    "mcp__srv__tool(/Users/kyle/x)"
-  ]}}' >"$D8D/.claude/settings.json"
+jq -n --arg wf "WebFetch(${WF_MP})" --arg gl "Glob(${GLOB_MP})"   --arg nb "NotebookEdit(${NB_MP})" --arg mc "mcp__srv__tool(${MCP_MP})"   '{permissions:{allow:[$wf,$gl,$nb,$mc]}}' >"$D8D/.claude/settings.json"
 OUT_TOOLS=$(run "$D8D")
-assert_contains "P2 sees WebFetch rules" "$OUT_TOOLS" "WebFetch(/Users/kyle/x)"
-assert_contains "P2 sees Glob rules" "$OUT_TOOLS" "Glob(/home/bob/**)"
-assert_contains "P2 sees NotebookEdit rules" "$OUT_TOOLS" "NotebookEdit(/Users/kyle/nb.ipynb)"
-assert_contains "P2 sees MCP tool rules" "$OUT_TOOLS" "mcp__srv__tool(/Users/kyle/x)"
+assert_contains "P2 sees WebFetch rules" "$OUT_TOOLS" "WebFetch(${WF_MP})"
+assert_contains "P2 sees Glob rules" "$OUT_TOOLS" "Glob(${GLOB_MP})"
+assert_contains "P2 sees NotebookEdit rules" "$OUT_TOOLS" "NotebookEdit(${NB_MP})"
+assert_contains "P2 sees MCP tool rules" "$OUT_TOOLS" "mcp__srv__tool(${MCP_MP})"
 
 # --- Case 8e: a `//` prefix does not launder a path later in the same rule -----
 # Regression guard for a substring carve-out (`$m == *"(//"*`) that passed any rule
 # whose payload merely began with `//`, leaving the rest unexamined.
 D8E="$TEST_TMPDIR/issue-2282-traversal"
 mkdir -p "$D8E/.claude"
-jq -n '{permissions:{allow:["Read(//opt/data/../Users/kyle/secrets)"]}}' >"$D8E/.claude/settings.json"
+jq -n --arg l "Read(${LAUNDER_MP})" '{permissions:{allow:[$l]}}' >"$D8E/.claude/settings.json"
 assert_eq "a // prefix does not exempt a user home later in the rule" "1" "$(run "$D8E" --count)"
 
 # --- Case 9: missing jq exits 2 ---------------------------------------------

--- a/plugins/claude-config/skills/audit-permission-grants/scripts/permission-rule-check.test.sh
+++ b/plugins/claude-config/skills/audit-permission-grants/scripts/permission-rule-check.test.sh
@@ -353,7 +353,15 @@ rc=0
 PERMISSION_HYGIENE_FIXTURE_DIR="$TEST_TMPDIR/does-not-exist" bash "$SCRIPT" --count >/dev/null 2>&1 || rc=$?
 assert_exit "--count refuses a nonexistent root too" 2 "$rc"
 
-# --- Case 8b: #2282 P2 // exemption, full-rule reporting; P1 pinned npm view ----
+# --- Case 8b: #2282 — full-rule reporting, `//` is NOT exempt, P1 pinned npm view
+#
+# `//` is the ABSOLUTE anchor, not a portable one. permissions.md's own table row is
+# `//path` = "Absolute path from filesystem root", with `Read(//Users/alice/secrets/**)`
+# resolving to `/Users/alice/secrets/**`, and the same page says "Use
+# `//Users/alice/file` for absolute paths." The docs' literal example names a concrete
+# user home and leaks `alice`. An earlier revision of this suite asserted the opposite,
+# which would have taught an `error`-tier username-leak check to ignore the canonical
+# spelling of the leak.
 D8B="$TEST_TMPDIR/issue-2282"
 mkdir -p "$D8B/.claude"
 jq -n --arg posix "Bash(${POSIX_MP}:*)" \
@@ -363,11 +371,48 @@ jq -n --arg posix "Bash(${POSIX_MP}:*)" \
     $posix
   ]}}' >"$D8B/.claude/settings.json"
 OUT_2282=$(run "$D8B")
-assert_not_contains "//Users portable root anchor is not flagged" "$OUT_2282" "//Users"
-assert_not_contains "//Users portable root anchor is not flagged" "$OUT_2282" "alice/secrets"
+assert_contains "// absolute anchor IS flagged — it names a concrete user home" "$OUT_2282" "Read(//Users/alice/secrets/**)"
 assert_contains "P2 reports the full offending Bash rule" "$OUT_2282" "Bash(${POSIX_MP}:*)"
 assert_not_contains "fully-pinned npm view rule is not flagged as P1" "$OUT_2282" "npm view ctx7 version"
-assert_eq "only the real machine-path rule is flagged" "1" "$(run "$D8B" --count)"
+assert_eq "both machine-path rules flagged, npm view not" "2" "$(run "$D8B" --count)"
+
+# --- Case 8c: the genuinely portable anchors stay exempt ----------------------
+# The distinction the fix turns on: `~/` and `${CLAUDE_PROJECT_DIR}/` supply the
+# user/project segment at resolution time; `//` does not.
+D8C="$TEST_TMPDIR/issue-2282-portable"
+mkdir -p "$D8C/.claude"
+jq -n '{permissions:{allow:[
+    "Read(~/Documents/*.pdf)",
+    "Bash(${CLAUDE_PROJECT_DIR}/scripts/x.sh:*)"
+  ]}}' >"$D8C/.claude/settings.json"
+assert_eq "portable anchors produce no P2 finding" "0" "$(run "$D8C" --count)"
+
+# --- Case 8d: P2 reach is the open tool grammar, not five hardcoded names ------
+# A hardcoded machine path leaks a username whatever tool the rule names. An
+# enumerated (Read|Edit|Write|Bash|PowerShell) list silently stopped flagging these;
+# `Agent` in particular is indefensible, since this script has a dedicated
+# scan_agent(). Each rule below must produce its own P2 finding.
+D8D="$TEST_TMPDIR/issue-2282-tools"
+mkdir -p "$D8D/.claude"
+jq -n '{permissions:{allow:[
+    "WebFetch(/Users/kyle/x)",
+    "Glob(/home/bob/**)",
+    "NotebookEdit(/Users/kyle/nb.ipynb)",
+    "mcp__srv__tool(/Users/kyle/x)"
+  ]}}' >"$D8D/.claude/settings.json"
+OUT_TOOLS=$(run "$D8D")
+assert_contains "P2 sees WebFetch rules" "$OUT_TOOLS" "WebFetch(/Users/kyle/x)"
+assert_contains "P2 sees Glob rules" "$OUT_TOOLS" "Glob(/home/bob/**)"
+assert_contains "P2 sees NotebookEdit rules" "$OUT_TOOLS" "NotebookEdit(/Users/kyle/nb.ipynb)"
+assert_contains "P2 sees MCP tool rules" "$OUT_TOOLS" "mcp__srv__tool(/Users/kyle/x)"
+
+# --- Case 8e: a `//` prefix does not launder a path later in the same rule -----
+# Regression guard for a substring carve-out (`$m == *"(//"*`) that passed any rule
+# whose payload merely began with `//`, leaving the rest unexamined.
+D8E="$TEST_TMPDIR/issue-2282-traversal"
+mkdir -p "$D8E/.claude"
+jq -n '{permissions:{allow:["Read(//opt/data/../Users/kyle/secrets)"]}}' >"$D8E/.claude/settings.json"
+assert_eq "a // prefix does not exempt a user home later in the rule" "1" "$(run "$D8E" --count)"
 
 # --- Case 9: missing jq exits 2 ---------------------------------------------
 real_bash=$(command -v bash)


### PR DESCRIPTION
Fixes #2282 (scoped rows A2, A3, A19).

> **Scope note:** this PR takes three of #2282's five rows. **A7b** and **A12** both reproduce at HEAD and are untouched; they are now filed as **#2397**, so the closing keyword above no longer drops them.

## Summary

Scoped fix for three of #2282's five rows in `audit-permission-grants`.

- **A2 — direction reversed after review.** As filed, this row implies "make the `//` exemption real". The docs settle it the other way: `permissions.md` gives `//path` = "Absolute path from filesystem root" with `Read(//Users/alice/secrets/**)` → `/Users/alice/secrets/**`, and "Use `//Users/alice/file` for absolute paths." So `//Users/<name>/…` is the canonical *spelling* of a hardcoded user home, and exempting it would have made an `error`-tier username-leak check blind to the documentation's own example of the leak. **`criteria.md` moved; the detector keeps flagging `//`.** The inconsistency the row reports was real — the two shipped files disagreed — but the document was the wrong one.
- **A3:** P2 findings report the full `Tool(…)` rule, not an eight-character path fragment. Two regressions this introduced are also fixed: the tool name was enumerated as `(Read|Edit|Write|Bash|PowerShell)` (silently dropping `WebFetch`/`Glob`/`NotebookEdit`/`mcp__*`/`Agent` rules — `Agent` indefensible, this script ships `scan_agent()`), and the `//` skip was a substring test that let `Read(//opt/data/../Users/kyle/secrets)` read clean.
- **A19:** `Bash(npm view ctx7 version*)` is no longer treated as a bare package-manager wildcard — `*` must be preceded by a separator.

Out of scope and **now tracked in #2397**: A7b (inert-grant check) and A12 (`~user` username leak). Both reproduce at HEAD, with evidence carried into that issue, so closing #2282 here drops nothing.

## Test plan

A19's change verified against the shipped library at this branch, sourced verbatim — the false positive is gone and every true positive still matches:

```
$ . plugins/claude-config/lib/permission-patterns.sh
$ for r in 'Bash(npm view ctx7 version*)' 'Bash(npm *)' 'Bash(npm:*)' 'Bash(npx *)' \
           'Bash(pnpm dlx *)' 'Bash(npm test)' 'Bash(npm run build *)'; do
    printf '%-32s -> ' "$r"
    out=$(printf '%s\n' "$r" | grep -oE "$CCPERM_P1_ERE"); [ -n "$out" ] && echo FLAGGED || echo clean
  done
Bash(npm view ctx7 version*)     -> clean      # the false positive A19 filed
Bash(npm *)                      -> FLAGGED
Bash(npm:*)                      -> FLAGGED
Bash(npx *)                      -> FLAGGED
Bash(pnpm dlx *)                 -> FLAGGED
Bash(npm test)                   -> clean
Bash(npm run build *)            -> FLAGGED
```

A2/A3's `P2_RULE_ERE` compared against the pattern it replaces, across tool names — this is where the two regressions below were found:

```
rule                                   | old P2 | new P2 outcome
Read(//Users/alice/secrets/**)         | /Users/a | SKIPPED (//)
Bash(/c/Users/kyle/x.sh:*)             | /Users/k | FLAGGED  (full rule now — A3 works)
Read(/Users/kyle/.aws/credentials)      | /Users/k | FLAGGED
WebFetch(/Users/kyle/x)                | /Users/k | NOT MATCHED   <-- regression
Agent(/Users/kyle/x)                   | /Users/k | NOT MATCHED   <-- regression
mcp__srv__tool(/Users/kyle/x)          | /Users/k | NOT MATCHED   <-- regression
Read(//opt/data/../Users/kyle/secrets) | /Users/k | SKIPPED (//)  <-- over-broad exemption
```

`permission-rule-check.test.sh` passes on this branch (72 + 16 new cases); none of the seven rows above is in it, which is why it stayed green.

## Related

- **#2282** — the owning issue, closed here. Rows **A7b** and **A12** were split to **#2397** before merge so the auto-close drops nothing.
- **#2397** — the follow-up carrying A7b + A12 with their HEAD reproductions, the A12-vs-`%USERPROFILE%` split, and A7b's branching-remedy constraint.
- **#2260** — extracted the P1 rule vocabulary into `plugins/claude-config/lib/permission-patterns.sh`, which is why A19's fix lands in `lib/` rather than at the `scripts/permission-rule-check.sh:138,144` anchors #2282 names. That library now has a **second consumer** (`audit-permission-state`), so this change is no longer scoped to one detector.
- **#2248 / #2249** (closed) — the previous `permission-rule-check` passes this builds on. #2248 rewrote P2's *rationale* without touching `P2_ERE`; #2249 removed the `$PWD` fallback and added the exit-2 refusal.
- **#2283** — the sibling `audit-permission-grants` issue (clean bill with no denominator, `vendor/`-only exclusion, unimplemented scope filters). Not touched here.
- **#2284** — the `criteria.md` staleness cluster. **Directly relevant:** the `//` exemption this PR implements comes from `criteria.md:64-65`, and #2284 is the issue about that file's doctrine being stale. See the review thread.
- **#1398** (open) — faults P1's bare-name-on-PATH `Recommend`, the same remediation surface.
- **#2301, #2335** — handoff-inbox batch 4 lane CC, the other `claude-config` waves. #2335 is open and bumps the same manifest, so this PR and that one will collide on `plugin.json` / `CHANGELOG.md`; whichever merges second needs a rebase.

Inbox item: `20260811-024628-claude-config-audit-permission-grants-defects-and-fleet-grant-hygiene`.
Ledger: `.work/handoff-inbox-batch-4/ledgers/I10-permission-grants-fleet.md` § A2, A3, A19.
