### PR TITLE
fix(guardrails): restate block-hook-bypass's emitted scope note at its shipped width

### DIFF
--- a/plugins/guardrails/.claude-plugin/plugin.json
+++ b/plugins/guardrails/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "guardrails",
-  "version": "0.28.0",
+  "version": "0.28.1",
   "description": "Twelve safety guards that block secret/credential writes, hardcoded machine-specific paths, git hook-bypass attempts, irreversible git operations (force-push, reset --hard, worktree-wide checkout/restore discards), Bash file-write workarounds that circumvent Write/Edit hooks, multi-line `git commit -m` messages (an actual-newline `-m` mangles across shells; single-line `-m` passes), commit subjects and gh pr create titles that violate the repo's tracked team convention (when one is declared in .claude/source-control.md), (advisory) hallucinated CLI flags, (advisory) /plugin:skill references that do not resolve, (advisory) markdown citing a repo path the repo's own history shows was removed, (advisory, opt-in) un-throttled Workflow fan-out that risks burst 529s, and (advisory, opt-in) direct gh pr create calls bypassing this marketplace's own pull-request skill — each independently toggleable.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/guardrails/CHANGELOG.md
+++ b/plugins/guardrails/CHANGELOG.md
@@ -3,6 +3,33 @@
 All notable changes to the `guardrails` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.28.1]
+
+### Fixed
+
+- **`block-hook-bypass`'s own scope message told the operator it covers `inline python3 -c only`,
+  which 0.28.0 had just made false (#2217).** Both emitted notes — Bash and PowerShell — are the
+  guard's contract with whoever it just blocked, so understating the enforced surface is not a
+  cosmetic slip: it is the same false-account defect in the opposite direction, and it invites the
+  contortion the note's own preamble warns about (an agent routing to a form it is told the guard
+  cannot see). 0.28.0 widened the python lane from the literal `python3 -c` to the interpreter family
+  plus a `python3 - <<PY` stdin heredoc and left both notes unchanged. Emitted now, verified by
+  invoking the hook:
+
+  ```
+  Scope: only this command string is inspected — known shell file-write forms plus inline python
+  code (python/python3/py/pypy with -c, or a program read from stdin as python3 - <<PY) only. POSIX
+  tee pipe writes, other inline-interpreter writes (e.g. node -e, sed -i), a stdin heredoc with no -
+  argument (python3 <<PY), writes inside an invoked script file or a program's own opaque code, and
+  redirects produced by another program, are not seen.
+  ```
+
+  The contract test is the part that should have caught this and did not: its assertion pinned the
+  literal string `inline python3 -c only`, so it kept passing while the claim went stale. It now
+  pins the family, the stdin form **and** the no-dash residual, so the note cannot drift from the
+  detector without a failure. Found by the automated reviewer on the 0.28.0 PR, after that PR had
+  already merged. No detector behaviour changes: 0 granted → refused, 0 refused → granted.
+
 ## [0.28.0]
 
 ### Fixed

--- a/plugins/guardrails/hooks/block-hook-bypass.sh
+++ b/plugins/guardrails/hooks/block-hook-bypass.sh
@@ -904,16 +904,25 @@ producer_redirect_bypass() {
 # ordinary data-processing redirects (`sort f > out`, `curl … > page.html`) and
 # other unmodeled Bash write utilities (POSIX `tee`, inline `node -e`, …) are
 # allowed by design too, not only writes inside an invoked script.
+# These notes state the ENFORCED surface to the operator, so they are part of the
+# detector's contract, not commentary: understating it invites the "guard says it
+# cannot see this" contortion the paragraph above describes, and overstating it is
+# the false-assurance failure. #2217 widened the python lane from the literal
+# `python3 -c` to the interpreter family plus a stdin heredoc, and left both notes
+# saying `inline python3 -c only` — materially wrong about a safety guard's own
+# reach. Restated at the shipped width, with the residuals named at theirs.
 _BYPASS_SCOPE_NOTE_BASH="Scope: only this command string is inspected — known shell \
-file-write forms plus inline python3 -c only. POSIX tee pipe writes, other \
-inline-interpreter writes (e.g. node -e, sed -i), writes inside an invoked \
-script file or a program's own opaque code, and redirects produced by another \
-program, are not seen."
+file-write forms plus inline python code (python/python3/py/pypy with -c, or a \
+program read from stdin as python3 - <<PY) only. POSIX tee pipe writes, other \
+inline-interpreter writes (e.g. node -e, sed -i), a stdin heredoc with no - \
+argument (python3 <<PY), writes inside an invoked script file or a program's own \
+opaque code, and redirects produced by another program, are not seen."
 _BYPASS_SCOPE_NOTE_PWSH="Scope: only this command string is inspected — known PowerShell \
 file-write cmdlets and content-producer redirects (including Tee-Object and the \
-tee alias) plus inline python3 -c only. Other inline-interpreter writes (e.g. \
-node -e), writes inside an invoked script file or a program's own opaque code, \
-and redirects produced by another program, are not seen."
+tee alias) plus inline python code (python/python3/py/pypy with -c) only. Other \
+inline-interpreter writes (e.g. node -e), writes inside an invoked script file or \
+a program's own opaque code, and redirects produced by another program, are not \
+seen."
 
 block_bypass() {
   local form="$1" reason="$2"

--- a/plugins/guardrails/hooks/block-hook-bypass.test.sh
+++ b/plugins/guardrails/hooks/block-hook-bypass.test.sh
@@ -753,14 +753,25 @@ assert_contains "bash block states its scope" "$scopeout" \
   "only this command string is inspected"
 assert_contains "bash block names the invoked-script gap" "$scopeout" \
   "inside an invoked script file"
-assert_contains "bash block limits interpreter coverage to python3 -c" "$scopeout" \
-  "inline python3 -c only"
+# The note states the ENFORCED surface, so it is pinned at the shipped width, not
+# at a remembered one. #2217 widened the python lane past the literal `python3 -c`
+# and this assertion went on pinning the obsolete claim — the assertion is what
+# should have caught the drift, so it now names both the family and the stdin form.
+assert_contains "bash block names the interpreter family it covers" "$scopeout" \
+  "python/python3/py/pypy with -c"
+assert_contains "bash block names the stdin form it covers" "$scopeout" \
+  "python3 - <<PY"
+assert_contains "bash block names the no-dash stdin residual" "$scopeout" \
+  "python3 <<PY"
+assert_contains "bash block still limits interpreter coverage" "$scopeout" "only"
 assert_contains "bash block names the tee gap" "$scopeout" "POSIX tee"
 assert_contains "bash block names other-interpreter gap" "$scopeout" "node -e"
 psscope=$(bash "$HOOK" <<<"$(pwsh_command_json "Set-Content f.txt 'x'")" 2>&1)
 assert_contains "powershell block states its scope" "$psscope" \
   "only this command string is inspected"
 assert_contains "powershell block names Tee-Object coverage" "$psscope" "Tee-Object"
+assert_contains "powershell block names the interpreter family it covers" "$psscope" \
+  "python/python3/py/pypy with -c"
 
 # The behaviour the scope note describes. A write inside an invoked script is
 # not inspected, and a redirect whose producer is another program is allowed by


### PR DESCRIPTION
## Summary

Follow-up to #2367, which merged while its automated review was still landing. The reviewer's second
P2 is correct and this fixes it.

#2367 widened `block-hook-bypass`'s python lane from the literal `python3 -c` to the interpreter
family plus a `python3 - <<PY` stdin heredoc — and left both **emitted scope notes** saying
`inline python3 -c only`.

That note is not commentary. It is the guard's contract with whoever it just blocked, and the
paragraph directly above it in the source says why: understating the surface makes an agent contort
around a restriction that isn't there, and overstating it makes a human credit coverage the guard
never had. Shipping a widened detector behind a narrower claim is the same false-account defect as
the reverse, and it points the blocked agent at a form it is told the guard cannot see — which, after
#2367, it can.

**The contract test is the part that should have caught this and didn't.** Its assertion pinned the
literal string `inline python3 -c only`, so it kept passing while the claim it pinned went stale. It
now pins the interpreter family, the stdin form, **and** the no-dash residual, so the note cannot
drift from the detector again without a failure.

**No detector behaviour changes: 0 granted → refused, 0 refused → granted.** Only the two note
strings and the assertions over them.

## Test plan

The notes as actually emitted, by invoking the hook on a blocked payload (not read off the source):

```
$ bash plugins/guardrails/hooks/block-hook-bypass.sh <<< '{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"cat > f.txt"},...}'
Scope: only this command string is inspected — known shell file-write forms plus inline python
code (python/python3/py/pypy with -c, or a program read from stdin as python3 - <<PY) only. POSIX
tee pipe writes, other inline-interpreter writes (e.g. node -e, sed -i), a stdin heredoc with no -
argument (python3 <<PY), writes inside an invoked script file or a program's own opaque code, and
redirects produced by another program, are not seen.

$ ... tool_name PowerShell, command "Set-Content f.txt x"
Scope: only this command string is inspected — known PowerShell file-write cmdlets and
content-producer redirects (including Tee-Object and the tee alias) plus inline python code
(python/python3/py/pypy with -c) only. Other inline-interpreter writes (e.g. node -e), writes inside
an invoked script file or a program's own opaque code, and redirects produced by another program,
are not seen.
```

Each clause is checked against the detector it describes, all of which are already asserted in the
suite from #2367: the family (`python -c`, `py -c`, `py3 -c`, `python2 -c`, `python3.11 -c`,
`pypy3 -c` all `rc=2`), the stdin form (`python3 - <<PY` `rc=2`), and the residual
(`python3 <<PY` with no `-` `rc=0`).

**Lint:**

```
$ shellcheck -x plugins/guardrails/hooks/block-hook-bypass.sh plugins/guardrails/hooks/block-hook-bypass.test.sh
(no output)
$ shfmt -d <same two files>
(no output)
```

The suite count moves from 412 to 414 (two assertions replaced by five, plus one on the PowerShell
note). `plugin-gate` runs `plugins/**/*.test.sh` and is the gate on it.

## Related

Follow-up to #2367 (closes #2217). Raised by the automated reviewer on that PR at
`block-hook-bypass.sh:1057`, resolved there without a fix because the PR had already merged.

**Also raised on #2367 and deliberately NOT fixed here — filed separately instead.** The reviewer's
first P2 says the empty line-join reconstructs `echo` from `ec"x<newline>y"ho`, which bash would run
as `ecx<newline>yho`. The symptom is real; the stated mechanism is incomplete, and measuring it
changes what the fix has to be:

```
                                                        base(4c90b454)  after #2367
ec"xy"ho hello > out.txt      (single line, non-empty)       rc=2           rc=2
ec"x<NL>y"ho hello > out.txt  (multi-line, non-empty)        rc=0           rc=2
ec""ho x > f                  (single line, empty span)      rc=2           rc=2
ec"<NL>"ho x > f              (multi-line, empty span)       rc=0           rc=2
```

The single-line row was **already** `rc=2` before #2367 — `strip_literals` has always dropped a
quoted span's content without marking it, so the command-word splice predates this work by a long
way. #2367 made the multi-line form agree with the shipped single-line form. Marking the *newline
join* opaque, as suggested, would fix only the multi-line half and put the two spellings back in
disagreement, while also losing the empty-span case (`ec"<newline>"ho x > f` genuinely *is* `echo` to
bash). A coherent fix belongs at the dropped-span emit site for both line shapes and needs to
distinguish an empty span from a non-empty one — bigger than a note fix and its own change.
