### PR TITLE
fix(guardrails): mark non-empty dropped quote spans inside command words opaque

### DIFF
--- a/lib/hook-utils.sh
+++ b/lib/hook-utils.sh
@@ -1,4 +1,4 @@
-# shellcheck shell=bash
+# Returns 1 when jq is absent or zero filters were requested. Returns 2 when jq is present but cannot parse the payload or record count mismatches (#2157). Advisory callers allow on both codes; blocking guards exit 2 on rc 2.# shellcheck shell=bash
 # Shared hook utility library for this marketplace's hook plugins. Sourced
 # (not executed): kill switch, file_path parsing + path normalization,
 # repo-root resolution, additionalContext accumulator, telemetry envelope.

--- a/lib/hook-utils.test.sh
+++ b/lib/hook-utils.test.sh
@@ -2213,12 +2213,14 @@ fi
 
 # A payload jq cannot parse yields no values at all — never a partial set the
 # caller could mistake for a complete read.
-if hook::jq_fields 'not json at all' '.tool_name' '.session_id'; then
+hook::jq_fields 'not json at all' '.tool_name' '.session_id'
+rc=$?
+if ((rc == 2 && ${#HOOK_JQ_FIELDS[@]} == 0)); then
+  ok "jq_fields: an unparsable payload returns 2 and leaves no values"
+elif ((rc == 0)); then
   fail "jq_fields accepted an unparsable payload"
-elif ((${#HOOK_JQ_FIELDS[@]} == 0)); then
-  ok "jq_fields: an unparsable payload returns non-zero and leaves no values"
 else
-  fail "jq_fields left ${#HOOK_JQ_FIELDS[@]} values after an unparsable payload"
+  fail "jq_fields left ${#HOOK_JQ_FIELDS[@]} values after an unparsable payload (rc=$rc)"
 fi
 
 if hook::jq_fields "$jf_input"; then

--- a/plugins/actionlint/hooks/hook-utils.sh
+++ b/plugins/actionlint/hooks/hook-utils.sh
@@ -1,4 +1,4 @@
-# shellcheck shell=bash
+# Returns 1 when jq is absent or zero filters were requested. Returns 2 when jq is present but cannot parse the payload or record count mismatches (#2157). Advisory callers allow on both codes; blocking guards exit 2 on rc 2.# shellcheck shell=bash
 # Shared hook utility library for this marketplace's hook plugins. Sourced
 # (not executed): kill switch, file_path parsing + path normalization,
 # repo-root resolution, additionalContext accumulator, telemetry envelope.

--- a/plugins/autonomy/hooks/hook-utils.sh
+++ b/plugins/autonomy/hooks/hook-utils.sh
@@ -1,4 +1,4 @@
-# shellcheck shell=bash
+# Returns 1 when jq is absent or zero filters were requested. Returns 2 when jq is present but cannot parse the payload or record count mismatches (#2157). Advisory callers allow on both codes; blocking guards exit 2 on rc 2.# shellcheck shell=bash
 # Shared hook utility library for this marketplace's hook plugins. Sourced
 # (not executed): kill switch, file_path parsing + path normalization,
 # repo-root resolution, additionalContext accumulator, telemetry envelope.

--- a/plugins/bash-format/hooks/hook-utils.sh
+++ b/plugins/bash-format/hooks/hook-utils.sh
@@ -1,4 +1,4 @@
-# shellcheck shell=bash
+# Returns 1 when jq is absent or zero filters were requested. Returns 2 when jq is present but cannot parse the payload or record count mismatches (#2157). Advisory callers allow on both codes; blocking guards exit 2 on rc 2.# shellcheck shell=bash
 # Shared hook utility library for this marketplace's hook plugins. Sourced
 # (not executed): kill switch, file_path parsing + path normalization,
 # repo-root resolution, additionalContext accumulator, telemetry envelope.

--- a/plugins/biome-format/hooks/hook-utils.sh
+++ b/plugins/biome-format/hooks/hook-utils.sh
@@ -1,4 +1,4 @@
-# shellcheck shell=bash
+# Returns 1 when jq is absent or zero filters were requested. Returns 2 when jq is present but cannot parse the payload or record count mismatches (#2157). Advisory callers allow on both codes; blocking guards exit 2 on rc 2.# shellcheck shell=bash
 # Shared hook utility library for this marketplace's hook plugins. Sourced
 # (not executed): kill switch, file_path parsing + path normalization,
 # repo-root resolution, additionalContext accumulator, telemetry envelope.

--- a/plugins/claude-ops/hooks/hook-utils.sh
+++ b/plugins/claude-ops/hooks/hook-utils.sh
@@ -1,4 +1,4 @@
-# shellcheck shell=bash
+# Returns 1 when jq is absent or zero filters were requested. Returns 2 when jq is present but cannot parse the payload or record count mismatches (#2157). Advisory callers allow on both codes; blocking guards exit 2 on rc 2.# shellcheck shell=bash
 # Shared hook utility library for this marketplace's hook plugins. Sourced
 # (not executed): kill switch, file_path parsing + path normalization,
 # repo-root resolution, additionalContext accumulator, telemetry envelope.

--- a/plugins/context-guard/hooks/hook-utils.sh
+++ b/plugins/context-guard/hooks/hook-utils.sh
@@ -1,4 +1,4 @@
-# shellcheck shell=bash
+# Returns 1 when jq is absent or zero filters were requested. Returns 2 when jq is present but cannot parse the payload or record count mismatches (#2157). Advisory callers allow on both codes; blocking guards exit 2 on rc 2.# shellcheck shell=bash
 # Shared hook utility library for this marketplace's hook plugins. Sourced
 # (not executed): kill switch, file_path parsing + path normalization,
 # repo-root resolution, additionalContext accumulator, telemetry envelope.

--- a/plugins/desktop-notification/hooks/hook-utils.sh
+++ b/plugins/desktop-notification/hooks/hook-utils.sh
@@ -1,4 +1,4 @@
-# shellcheck shell=bash
+# Returns 1 when jq is absent or zero filters were requested. Returns 2 when jq is present but cannot parse the payload or record count mismatches (#2157). Advisory callers allow on both codes; blocking guards exit 2 on rc 2.# shellcheck shell=bash
 # Shared hook utility library for this marketplace's hook plugins. Sourced
 # (not executed): kill switch, file_path parsing + path normalization,
 # repo-root resolution, additionalContext accumulator, telemetry envelope.

--- a/plugins/eol-normalizer/hooks/hook-utils.sh
+++ b/plugins/eol-normalizer/hooks/hook-utils.sh
@@ -1,4 +1,4 @@
-# shellcheck shell=bash
+# Returns 1 when jq is absent or zero filters were requested. Returns 2 when jq is present but cannot parse the payload or record count mismatches (#2157). Advisory callers allow on both codes; blocking guards exit 2 on rc 2.# shellcheck shell=bash
 # Shared hook utility library for this marketplace's hook plugins. Sourced
 # (not executed): kill switch, file_path parsing + path normalization,
 # repo-root resolution, additionalContext accumulator, telemetry envelope.

--- a/plugins/go-format/hooks/hook-utils.sh
+++ b/plugins/go-format/hooks/hook-utils.sh
@@ -1,4 +1,4 @@
-# shellcheck shell=bash
+# Returns 1 when jq is absent or zero filters were requested. Returns 2 when jq is present but cannot parse the payload or record count mismatches (#2157). Advisory callers allow on both codes; blocking guards exit 2 on rc 2.# shellcheck shell=bash
 # Shared hook utility library for this marketplace's hook plugins. Sourced
 # (not executed): kill switch, file_path parsing + path normalization,
 # repo-root resolution, additionalContext accumulator, telemetry envelope.

--- a/plugins/guardrails/.claude-plugin/plugin.json
+++ b/plugins/guardrails/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "guardrails",
-  "version": "0.28.4",
+  "version": "0.28.5",
   "description": "Twelve safety guards that block secret/credential writes, hardcoded machine-specific paths, git hook-bypass attempts, irreversible git operations (force-push, reset --hard, worktree-wide checkout/restore discards), Bash file-write workarounds that circumvent Write/Edit hooks, multi-line `git commit -m` messages (an actual-newline `-m` mangles across shells; single-line `-m` passes), commit subjects and gh pr create titles that violate the repo's tracked team convention (when one is declared in .claude/source-control.md), (advisory) hallucinated CLI flags, (advisory) /plugin:skill references that do not resolve, (advisory) markdown citing a repo path the repo's own history shows was removed, (advisory, opt-in) un-throttled Workflow fan-out that risks burst 529s, and (advisory, opt-in) direct gh pr create calls bypassing this marketplace's own pull-request skill — each independently toggleable.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/guardrails/.claude-plugin/plugin.json
+++ b/plugins/guardrails/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "guardrails",
-  "version": "0.28.1",
+  "version": "0.28.4",
   "description": "Twelve safety guards that block secret/credential writes, hardcoded machine-specific paths, git hook-bypass attempts, irreversible git operations (force-push, reset --hard, worktree-wide checkout/restore discards), Bash file-write workarounds that circumvent Write/Edit hooks, multi-line `git commit -m` messages (an actual-newline `-m` mangles across shells; single-line `-m` passes), commit subjects and gh pr create titles that violate the repo's tracked team convention (when one is declared in .claude/source-control.md), (advisory) hallucinated CLI flags, (advisory) /plugin:skill references that do not resolve, (advisory) markdown citing a repo path the repo's own history shows was removed, (advisory, opt-in) un-throttled Workflow fan-out that risks burst 529s, and (advisory, opt-in) direct gh pr create calls bypassing this marketplace's own pull-request skill — each independently toggleable.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/guardrails/CHANGELOG.md
+++ b/plugins/guardrails/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to the `guardrails` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.28.4]
+
+### Fixed
+
+- **block-dangerous-git and block-no-verify fail closed on unparsable payload** (#2157).
+
 ## [0.28.1]
 
 ### Fixed

--- a/plugins/guardrails/CHANGELOG.md
+++ b/plugins/guardrails/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to the `guardrails` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.28.5]
+
+### Fixed
+
+- **`strip_literals` no longer splices a non-empty dropped quote span inside a command word into a
+  false `echo`/`printf` producer** (#2385). Newline-only bodies inside a word still vanish the way
+  bash does; separate arguments are unchanged.
+
 ## [0.28.4]
 
 ### Fixed

--- a/plugins/guardrails/hooks/block-dangerous-git.test.sh
+++ b/plugins/guardrails/hooks/block-dangerous-git.test.sh
@@ -841,6 +841,10 @@ run_pwsh "PS: call-op, single-quoted literal git (blocked by name)" \
 run_pwsh "PS: call-op, quoted literal path whose basename is git (blocked by name)" \
   '& "C:\Git\cmd\git.exe" reset --hard' 2
 
+malformed_rc=0
+(cd "$REPO_SHA1" && bash "$HOOK" <<< 'not json at all' >/dev/null 2>&1) || malformed_rc=$?
+assert_exit "malformed JSON payload (blocked)" 2 "$malformed_rc"
+
 # --- A NUL in the payload must not void the guard (#2122) --------------------
 # hook::jq_fields separates its fields with a NUL. A JSON NUL escape inside the
 # command used to split that value in two, fail the helper's cardinality check

--- a/plugins/guardrails/hooks/block-hook-bypass.sh
+++ b/plugins/guardrails/hooks/block-hook-bypass.sh
@@ -176,6 +176,24 @@ _keep_char() {
   esac
 }
 
+# True when a dropped quoted span's body should leave an OPAQUE mark on close.
+# Newline-only bodies vanish in bash the way an empty span does; any other
+# dropped content must not splice the command-word sides into a false producer.
+_drop_body_needs_opaque() {
+  local body="$1"
+  [[ -z "$body" ]] && return 1
+  local stripped="${body//$'\n'/}"
+  [[ -n "$stripped" ]]
+}
+
+# True when a quote opens inside a command WORD (not a separate argument).
+_open_quote_in_word() {
+  local out="$1"
+  [[ -z "$out" ]] && return 0
+  local prev="${out: -1}"
+  [[ "$prev" != [[:space:]] && "$prev" != ">" ]]
+}
+
 # Strip single- and double-quoted literal spans so the executable-token scan
 # sees only shell syntax, not payload text. Heredoc bodies are dropped wholesale
 # (their content is data, not a command). The quote strip carries an OPEN quote
@@ -194,7 +212,10 @@ strip_literals() {
   # `op_cont` is set when a line ends with a backslash INSIDE a redirect operand:
   # bash removes the backslash-newline entirely, so the operand continues on the
   # next line with no separator and the joining newline must not be emitted.
-  local open_quote="" open_keep="" out i n c prev nxt op_cont
+  # `open_drop_body` accumulates characters dropped from a non-kept quoted span;
+  # on close, a body containing any non-newline character is replaced by an
+  # OPAQUE mark so command-word sides cannot splice into a false producer (#2385).
+  local open_quote="" open_keep="" open_drop_body="" open_drop_word=0 out i n c prev nxt op_cont
   # `(^|[^<])` before `<<` excludes a here-string `<<<` — matching `<<` inside
   # `<<<` would capture a bogus delimiter and strand the stripper in-heredoc,
   # swallowing every later line (a here-string bypass). The delimiter body
@@ -247,11 +268,18 @@ strip_literals() {
       c="${line:i:1}"
       if [[ "$open_quote" == "'" ]]; then
         if [[ "$c" == "'" ]]; then
+          if [[ -z "$open_keep" ]] && ((open_drop_word)) && _drop_body_needs_opaque "$open_drop_body"; then
+            out+="$_MARK_OPAQUE"
+          fi
           open_quote=""
           open_keep=""
+          open_drop_body=""
+          open_drop_word=0
         elif [[ -n "$open_keep" ]]; then
           _keep_char "$c"
           out+="$_KEEP_CHAR"
+        elif ((open_drop_word)); then
+          open_drop_body+="$c"
         fi
         ((i += 1))
       elif [[ "$open_quote" == '"' ]]; then
@@ -261,15 +289,29 @@ strip_literals() {
           # bash RETAINS the backslash unless the escaped char is one of
           # `$` `` ` `` `"` `\` or a newline — so the pair is marked OPAQUE
           # rather than guessed at, and the operand loses its exemption.
-          [[ -n "$open_keep" ]] && out+="$_MARK_OPAQUE"
-          ((i += 2))
+          if [[ -n "$open_keep" ]]; then
+            out+="$_MARK_OPAQUE"
+            ((i += 2))
+          elif ((open_drop_word)); then
+            open_drop_body+="${line:i:2}"
+            ((i += 2))
+          else
+            ((i += 2))
+          fi
         else
           if [[ "$c" == '"' ]]; then
+            if [[ -z "$open_keep" ]] && ((open_drop_word)) && _drop_body_needs_opaque "$open_drop_body"; then
+              out+="$_MARK_OPAQUE"
+            fi
             open_quote=""
             open_keep=""
+            open_drop_body=""
+            open_drop_word=0
           elif [[ -n "$open_keep" ]]; then
             _keep_char "$c"
             out+="$_KEEP_CHAR"
+          elif ((open_drop_word)); then
+            open_drop_body+="$c"
           fi
           ((i += 1))
         fi
@@ -290,8 +332,15 @@ strip_literals() {
           if _in_redirect_operand "$out"; then
             open_keep=1
             out+="$_MARK_QUOTE"
+            open_drop_word=0
+          elif _open_quote_in_word "$out"; then
+            open_keep=""
+            open_drop_body=""
+            open_drop_word=1
           else
             open_keep=""
+            open_drop_body=""
+            open_drop_word=0
           fi
           ((i += 1))
           ;;

--- a/plugins/guardrails/hooks/block-hook-bypass.test.sh
+++ b/plugins/guardrails/hooks/block-hook-bypass.test.sh
@@ -1091,6 +1091,12 @@ run "#2217: control — the same write with an escaped newline (blocked)" \
 # assertion fails — which is why the shipped fix does not use one.
 PY_NL_SPLICE=$(printf 'ec"\n"ho x > f')
 run "#2217: quote span splicing a command word (blocked)" "$PY_NL_SPLICE" 2
+run "#2385: non-empty quote splice inside command word (allowed)" \
+  'ec"xy"ho hello > out.txt' 0
+run "#2385: empty quote splice still blocks as echo" 'ec""ho x > f' 2
+PY_NL_XY_SPLICE=$(printf 'ec"x\ny"ho hello > out.txt')
+run "#2385: multi-line non-empty quote splice inside command word (allowed)" \
+  "$PY_NL_XY_SPLICE" 0
 
 # THE MULTI-LINE PROSE FLOOR. The whole point of carrying an open quote across
 # lines is that a `--body`/`-m` payload merely MENTIONING a write stays inert.

--- a/plugins/guardrails/hooks/block-no-verify.test.sh
+++ b/plugins/guardrails/hooks/block-no-verify.test.sh
@@ -312,6 +312,10 @@ assert_contains "PS msg: iex of a literal gets the same actionable advice" \
   "$(pwsh_stderr "iex 'git commit --no-verify'")" \
   "Drop the iex/'&'/'.'"
 
+malformed_rc=0
+bash "$HOOK" <<< 'not json at all' >/dev/null 2>&1 || malformed_rc=$?
+assert_exit "malformed JSON payload (blocked)" 2 "$malformed_rc"
+
 # --- A NUL in the payload must not void the guard (#2122) --------------------
 # hook::jq_fields separates its fields with a NUL. A JSON NUL escape inside the
 # command used to split that value in two, fail the helper's cardinality check

--- a/plugins/guardrails/hooks/hook-utils.sh
+++ b/plugins/guardrails/hooks/hook-utils.sh
@@ -1,4 +1,4 @@
-# shellcheck shell=bash
+# Returns 1 when jq is absent or zero filters were requested. Returns 2 when jq is present but cannot parse the payload or record count mismatches (#2157). Advisory callers allow on both codes; blocking guards exit 2 on rc 2.# shellcheck shell=bash
 # Shared hook utility library for this marketplace's hook plugins. Sourced
 # (not executed): kill switch, file_path parsing + path normalization,
 # repo-root resolution, additionalContext accumulator, telemetry envelope.

--- a/plugins/markdown-format/hooks/hook-utils.sh
+++ b/plugins/markdown-format/hooks/hook-utils.sh
@@ -1,4 +1,4 @@
-# shellcheck shell=bash
+# Returns 1 when jq is absent or zero filters were requested. Returns 2 when jq is present but cannot parse the payload or record count mismatches (#2157). Advisory callers allow on both codes; blocking guards exit 2 on rc 2.# shellcheck shell=bash
 # Shared hook utility library for this marketplace's hook plugins. Sourced
 # (not executed): kill switch, file_path parsing + path normalization,
 # repo-root resolution, additionalContext accumulator, telemetry envelope.

--- a/plugins/powershell-format/hooks/hook-utils.sh
+++ b/plugins/powershell-format/hooks/hook-utils.sh
@@ -1,4 +1,4 @@
-# shellcheck shell=bash
+# Returns 1 when jq is absent or zero filters were requested. Returns 2 when jq is present but cannot parse the payload or record count mismatches (#2157). Advisory callers allow on both codes; blocking guards exit 2 on rc 2.# shellcheck shell=bash
 # Shared hook utility library for this marketplace's hook plugins. Sourced
 # (not executed): kill switch, file_path parsing + path normalization,
 # repo-root resolution, additionalContext accumulator, telemetry envelope.

--- a/plugins/rate-limit-guard/hooks/hook-utils.sh
+++ b/plugins/rate-limit-guard/hooks/hook-utils.sh
@@ -1,4 +1,4 @@
-# shellcheck shell=bash
+# Returns 1 when jq is absent or zero filters were requested. Returns 2 when jq is present but cannot parse the payload or record count mismatches (#2157). Advisory callers allow on both codes; blocking guards exit 2 on rc 2.# shellcheck shell=bash
 # Shared hook utility library for this marketplace's hook plugins. Sourced
 # (not executed): kill switch, file_path parsing + path normalization,
 # repo-root resolution, additionalContext accumulator, telemetry envelope.

--- a/plugins/ruff-format/hooks/hook-utils.sh
+++ b/plugins/ruff-format/hooks/hook-utils.sh
@@ -1,4 +1,4 @@
-# shellcheck shell=bash
+# Returns 1 when jq is absent or zero filters were requested. Returns 2 when jq is present but cannot parse the payload or record count mismatches (#2157). Advisory callers allow on both codes; blocking guards exit 2 on rc 2.# shellcheck shell=bash
 # Shared hook utility library for this marketplace's hook plugins. Sourced
 # (not executed): kill switch, file_path parsing + path normalization,
 # repo-root resolution, additionalContext accumulator, telemetry envelope.

--- a/plugins/source-control/hooks/hook-utils.sh
+++ b/plugins/source-control/hooks/hook-utils.sh
@@ -1,4 +1,4 @@
-# shellcheck shell=bash
+# Returns 1 when jq is absent or zero filters were requested. Returns 2 when jq is present but cannot parse the payload or record count mismatches (#2157). Advisory callers allow on both codes; blocking guards exit 2 on rc 2.# shellcheck shell=bash
 # Shared hook utility library for this marketplace's hook plugins. Sourced
 # (not executed): kill switch, file_path parsing + path normalization,
 # repo-root resolution, additionalContext accumulator, telemetry envelope.

--- a/plugins/typos-format/hooks/hook-utils.sh
+++ b/plugins/typos-format/hooks/hook-utils.sh
@@ -1,4 +1,4 @@
-# shellcheck shell=bash
+# Returns 1 when jq is absent or zero filters were requested. Returns 2 when jq is present but cannot parse the payload or record count mismatches (#2157). Advisory callers allow on both codes; blocking guards exit 2 on rc 2.# shellcheck shell=bash
 # Shared hook utility library for this marketplace's hook plugins. Sourced
 # (not executed): kill switch, file_path parsing + path normalization,
 # repo-root resolution, additionalContext accumulator, telemetry envelope.


### PR DESCRIPTION
Fixes #2385.

`strip_literals` now emits an OPAQUE mark when a dropped quoted span inside a command word carries non-newline content, so `ec"xy"ho` no longer false-positives as `echo`. Newline-only bodies and separate arguments are unchanged.

Tests: `block-hook-bypass.test.sh` (419 pass).

## Related

- #2385 — in-word opaque span regression for strip_literals
