### PR TITLE
fix(claude-config): stop audit-pass asking the model to test a substituted placeholder

### DIFF
--- a/plugins/claude-config/.claude-plugin/plugin.json
+++ b/plugins/claude-config/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "claude-config",
-  "version": "0.35.3",
+  "version": "0.35.4",
   "description": "Eight configuration-health skills (plus setup) for a repo's Claude Code configuration: audit (settings.json / .mcp.json / hooks / plugins / permissions drift), audit-automation-gaps (evidence-gated verdicts on automation gaps), audit-permission-grants (allow-rule / allowed-tools grants for auto-mode durability and portability), audit-permission-state (which settings scopes exist and what rules each one holds — managed policy, user-global, project, local, and the pre-v2.1.211 start-directory copy), audit-instructions (locally-owned instruction surfaces vs current model capability — proposes removals/rewrites of instructions the model no longer needs, and detects cross-surface instruction conflicts), audit-prompting-postures (the additive lane — posture guidance the prompting guide says a component's purpose needs but the component does not carry), audit-pass (one coordinated, ordered, resumable pass over a named target — three-scope inventory, run-time-derived exclusion set, stable finding identity, suppression memory, resume, one human gate — delegating every check to the plugin that owns it), and unhobble (the empirical bare-baseline experiment: reversibly strip a repo's standing instructions, log real stumbles against the current model, re-add only what evidence earns).",
   "author": {
     "name": "Melodic Software",

--- a/plugins/claude-config/CHANGELOG.md
+++ b/plugins/claude-config/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to the `claude-config` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+<<<<<<< HEAD
 ## [0.35.3]
 
 ### Fixed
@@ -40,6 +41,36 @@ All notable changes to the `claude-config` plugin are documented here. Format fo
   #2282 records.
 - Rows **A7b** (no inert-grant check) and **A12** (`~user` username leak unflagged) are **not**
   fixed here; both still reproduce at HEAD and are tracked separately.
+=======
+## [0.35.4]
+
+### Fixed
+
+- **`audit-pass` no longer asks the model to evaluate a placeholder it never sees.** Its default
+  `target` read "`${CLAUDE_PROJECT_DIR}` when set, else `git rev-parse --show-toplevel`". That
+  placeholder is substituted inline in skill content before the file reaches the model, so the literal
+  token is never visible and "when set" is a test about a value that has already been resolved. The
+  default is now stated in prose — the project root Claude Code resolved for this session, else
+  `git rev-parse --show-toplevel` — with the prohibition itself written out so the shape does not come
+  back. **This was a contradiction inside one plugin**: #2250 landed exactly this prohibition in
+  `audit-prompting-postures` while `audit-pass` kept the shape, so two sibling skills disagreed about
+  the same placeholder.
+- **Both instances, not just the filed one.** The report named `SKILL.md:42-43`; the same unevaluable
+  condition also sat in the non-git refusal ("with no explicit `target` and no
+  `${CLAUDE_PROJECT_DIR}`"), where it governs the diagnostic path that refusal exists to produce.
+  Fixing only the cited line would have left the contradiction half-standing while reading as closed.
+- **The `{id}` derivation is stated, so a report cannot be written where the next run will not look.**
+  The skill said `${CLAUDE_PLUGIN_DATA}` resolves to `~/.claude/plugins/data/{id}/` and never said how
+  `{id}` is formed. Now quoted: the plugin identifier with characters outside `a-z`, `A-Z`, `0-9`, `_`
+  and `-` replaced by `-`, with the plugins reference's own worked example
+  (`formatter@my-marketplace` → `formatter-my-marketplace`). A wrong derivation is also how `--resume`
+  loses a partial.
+- **`${CLAUDE_PLUGIN_DATA}` is recorded as absent from the Bash tool's environment.** The export is
+  documented for "hook processes and … MCP and LSP server subprocesses"; the Bash tool is none of
+  those, so `echo "$CLAUDE_PLUGIN_DATA"` in a Bash call returns an empty string even though the token
+  substitutes correctly in skill content. Nothing in the skill said so, which invites exactly that
+  shell expansion.
+>>>>>>> 644de273 (fix(claude-config): stop audit-pass asking the model to test a substituted placeholder)
 
 ## [0.35.2]
 

--- a/plugins/claude-config/CHANGELOG.md
+++ b/plugins/claude-config/CHANGELOG.md
@@ -3,7 +3,35 @@
 All notable changes to the `claude-config` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
-<<<<<<< HEAD
+## [0.35.4]
+
+### Fixed
+
+- **`audit-pass` no longer asks the model to evaluate a placeholder it never sees.** Its default
+  `target` read "`${CLAUDE_PROJECT_DIR}` when set, else `git rev-parse --show-toplevel`". That
+  placeholder is substituted inline in skill content before the file reaches the model, so the literal
+  token is never visible and "when set" is a test about a value that has already been resolved. The
+  default is now stated in prose — the project root Claude Code resolved for this session, else
+  `git rev-parse --show-toplevel` — with the prohibition itself written out so the shape does not come
+  back. **This was a contradiction inside one plugin**: #2250 landed exactly this prohibition in
+  `audit-prompting-postures` while `audit-pass` kept the shape, so two sibling skills disagreed about
+  the same placeholder.
+- **Both instances, not just the filed one.** The report named `SKILL.md:42-43`; the same unevaluable
+  condition also sat in the non-git refusal ("with no explicit `target` and no
+  `${CLAUDE_PROJECT_DIR}`"), where it governs the diagnostic path that refusal exists to produce.
+  Fixing only the cited line would have left the contradiction half-standing while reading as closed.
+- **The `{id}` derivation is stated, so a report cannot be written where the next run will not look.**
+  The skill said `${CLAUDE_PLUGIN_DATA}` resolves to `~/.claude/plugins/data/{id}/` and never said how
+  `{id}` is formed. Now quoted: the plugin identifier with characters outside `a-z`, `A-Z`, `0-9`, `_`
+  and `-` replaced by `-`, with the plugins reference's own worked example
+  (`formatter@my-marketplace` → `formatter-my-marketplace`). A wrong derivation is also how `--resume`
+  loses a partial.
+- **`${CLAUDE_PLUGIN_DATA}` is recorded as absent from the Bash tool's environment.** The export is
+  documented for "hook processes and … MCP and LSP server subprocesses"; the Bash tool is none of
+  those, so `echo "$CLAUDE_PLUGIN_DATA"` in a Bash call returns an empty string even though the token
+  substitutes correctly in skill content. Nothing in the skill said so, which invites exactly that
+  shell expansion.
+
 ## [0.35.3]
 
 ### Fixed
@@ -41,36 +69,6 @@ All notable changes to the `claude-config` plugin are documented here. Format fo
   #2282 records.
 - Rows **A7b** (no inert-grant check) and **A12** (`~user` username leak unflagged) are **not**
   fixed here; both still reproduce at HEAD and are tracked separately.
-=======
-## [0.35.4]
-
-### Fixed
-
-- **`audit-pass` no longer asks the model to evaluate a placeholder it never sees.** Its default
-  `target` read "`${CLAUDE_PROJECT_DIR}` when set, else `git rev-parse --show-toplevel`". That
-  placeholder is substituted inline in skill content before the file reaches the model, so the literal
-  token is never visible and "when set" is a test about a value that has already been resolved. The
-  default is now stated in prose — the project root Claude Code resolved for this session, else
-  `git rev-parse --show-toplevel` — with the prohibition itself written out so the shape does not come
-  back. **This was a contradiction inside one plugin**: #2250 landed exactly this prohibition in
-  `audit-prompting-postures` while `audit-pass` kept the shape, so two sibling skills disagreed about
-  the same placeholder.
-- **Both instances, not just the filed one.** The report named `SKILL.md:42-43`; the same unevaluable
-  condition also sat in the non-git refusal ("with no explicit `target` and no
-  `${CLAUDE_PROJECT_DIR}`"), where it governs the diagnostic path that refusal exists to produce.
-  Fixing only the cited line would have left the contradiction half-standing while reading as closed.
-- **The `{id}` derivation is stated, so a report cannot be written where the next run will not look.**
-  The skill said `${CLAUDE_PLUGIN_DATA}` resolves to `~/.claude/plugins/data/{id}/` and never said how
-  `{id}` is formed. Now quoted: the plugin identifier with characters outside `a-z`, `A-Z`, `0-9`, `_`
-  and `-` replaced by `-`, with the plugins reference's own worked example
-  (`formatter@my-marketplace` → `formatter-my-marketplace`). A wrong derivation is also how `--resume`
-  loses a partial.
-- **`${CLAUDE_PLUGIN_DATA}` is recorded as absent from the Bash tool's environment.** The export is
-  documented for "hook processes and … MCP and LSP server subprocesses"; the Bash tool is none of
-  those, so `echo "$CLAUDE_PLUGIN_DATA"` in a Bash call returns an empty string even though the token
-  substitutes correctly in skill content. Nothing in the skill said so, which invites exactly that
-  shell expansion.
->>>>>>> 644de273 (fix(claude-config): stop audit-pass asking the model to test a substituted placeholder)
 
 ## [0.35.2]
 

--- a/plugins/claude-config/skills/audit-pass/SKILL.md
+++ b/plugins/claude-config/skills/audit-pass/SKILL.md
@@ -39,9 +39,17 @@ Bare invocation reads and reports. `--fix` is the only mutation path, and it is 
 
 Parse `$ARGUMENTS`:
 
-- **`target`** — the git repository to audit. Default: `${CLAUDE_PROJECT_DIR}` when set, else
-  `git rev-parse --show-toplevel`. Never the working directory — a run launched from a subdirectory
-  must key and scan identically to one launched from the root.
+- **`target`** — the git repository to audit. Default: the project root Claude Code resolved for this
+  session; where no such root is available, `git rev-parse --show-toplevel`. Never the working
+  directory — a run launched from a subdirectory must key and scan identically to one launched from
+  the root.
+
+  **Do not express this as a condition over `${CLAUDE_PROJECT_DIR}` "when set".** That placeholder is
+  substituted inline in skill content before this file reaches you, so the literal token is never
+  visible and the test is not yours to make — you would be deciding "is it set?" about a value that
+  has already been resolved. Work from what you can observe: the resolved path, or a command you run.
+  The sibling `audit-prompting-postures` states this same rule where it derives its report path, and
+  the two skills contradicted each other on it until this was fixed.
 
   **`target` must resolve to the active project root, and a path that does not is refused.** The
   delegated interfaces accept no target: `audit-instructions` takes a surface scope and inventories
@@ -63,7 +71,7 @@ Parse `$ARGUMENTS`:
   before Phase 0 does any work, naming the path and the reason, writing nothing.
 
   **Name the directory, not an empty string.** In the case this refusal is *for*, the default
-  resolution above produces nothing: with no explicit `target` and no `${CLAUDE_PROJECT_DIR}`,
+  resolution above produces nothing: with no explicit `target` and no session-resolved project root,
   `git rev-parse --show-toplevel` fails outside a repository and there is no resolved root to report.
   So for the diagnostic only, fall back to the current directory and name **that** — a refusal that
   cannot say which path it refused is barely better than a silent one. The fallback is for the message;

--- a/plugins/claude-config/skills/audit-pass/reference/report-location-and-schema.md
+++ b/plugins/claude-config/skills/audit-pass/reference/report-location-and-schema.md
@@ -19,8 +19,24 @@ held.
 - The report goes under `${CLAUDE_PLUGIN_DATA}` at `runs/<state-key>/<run-id>/findings.json`, which
   survives plugin updates. **State its location precisely, because a whole target class turns on it:**
   that directory resolves to `~/.claude/plugins/data/{id}/`
-  ([plugins reference](https://code.claude.com/docs/en/plugins-reference), verified 2026-08-11), and no
-  documented setting relocates it. It is therefore **outside** a target below `~` and **inside** any
+  ([plugins reference](https://code.claude.com/docs/en/plugins-reference), verified 2026-08-12), and no
+  documented setting relocates it.
+
+  **`{id}` is derived, and deriving it wrong loses the report.** Same page, verbatim: `{id}` is *"the
+  plugin identifier with characters outside `a-z`, `A-Z`, `0-9`, `_`, and `-` replaced by `-`"*, with
+  the worked example that a plugin installed as `formatter@my-marketplace` lands in
+  `~/.claude/plugins/data/formatter-my-marketplace/` — the `@` becomes `-`. A wrong derivation writes
+  the report where the next run will not look for it, which is also how `--resume` loses a partial.
+
+  **`${CLAUDE_PLUGIN_DATA}` is not in the Bash tool's environment — do not try to expand it from a
+  shell.** The same page scopes the export precisely: *"All three are exported as environment variables
+  to hook processes and to MCP and LSP server subprocesses."* The Bash tool is none of those. The token
+  does substitute in **skill content**, which is how a resolved path reaches you in this file, but
+  `echo "$CLAUDE_PLUGIN_DATA"` inside a Bash call yields an empty string. Use the path already
+  substituted into the text you are reading, or rebuild it from `~/.claude/plugins/data/` plus the
+  mangled identifier above.
+
+  It is therefore **outside** a target below `~` and **inside** any
   target at or above it. The default path is *usually* outside the scan set and is **not
   unconditionally** outside it — a dotfiles repository, or `~` itself, is a target where containment
   holds by construction, and the older unconditional claim was false there.


### PR DESCRIPTION
Refs #2280 — takes rows F9 and F8. Rows F3, F5, F12 and F13 are **not** taken; see `## Related`.

No linked issue closes here on purpose: #2280 carries six rows and this PR takes two, so a closing keyword would auto-close four live rows.

## Summary

**F9 — `audit-pass` asked the model to evaluate a placeholder it never sees.** The default `target` read:

```
- **`target`** — the git repository to audit. Default: `${CLAUDE_PROJECT_DIR}` when set, else
  `git rev-parse --show-toplevel`.
```

`${CLAUDE_PROJECT_DIR}` substitutes inline in skill content before the file reaches the model (plugins reference: *"Skill and agent content | Anywhere the placeholder appears"*), so the literal token is never visible and "when set" is a test about a value that has already been resolved. It is now prose — *the project root Claude Code resolved for this session; where no such root is available, `git rev-parse --show-toplevel`* — with the prohibition itself written out so the shape does not come back.

**This is a contradiction inside one plugin, and one this batch created.** #2250 landed exactly this prohibition in `audit-prompting-postures`, where it still reads *"Do not express the path as a condition over `${CLAUDE_PROJECT_DIR}` 'when set'"*, while `audit-pass` kept the shape. Two sibling skills disagreed about the same placeholder. Fixed rather than documented.

**Both instances, not just the filed one.** #2280 cites `SKILL.md:42-43`. The same unevaluable condition also sat in the non-git refusal at `:66` — *"with no explicit `target` and no `${CLAUDE_PROJECT_DIR}`"* — where it governs the diagnostic path that refusal exists to produce. That second one was not in the issue; I found it during pre-flight and recorded it on #2280 before writing this. **Fixing only the cited line would have left the contradiction half-standing while reading as closed.**

**F8 — two facts the skill depended on and never stated.**

- **How `{id}` is derived.** The skill said `${CLAUDE_PLUGIN_DATA}` resolves to `~/.claude/plugins/data/{id}/` and never said how `{id}` is formed. Now quoted verbatim: *"the plugin identifier with characters outside `a-z`, `A-Z`, `0-9`, `_`, and `-` replaced by `-`"*, with the page's own worked example — `formatter@my-marketplace` → `~/.claude/plugins/data/formatter-my-marketplace/`. A wrong derivation writes the report where the next run will not look, which is also how `--resume` loses a partial.
- **`${CLAUDE_PLUGIN_DATA}` is not in the Bash tool's environment.** The export is scoped: *"All three are exported as environment variables to hook processes and to MCP and LSP server subprocesses."* The Bash tool is none of those, so `echo "$CLAUDE_PLUGIN_DATA"` in a Bash call returns an empty string even though the token substitutes correctly in skill content. Nothing in the skill said so, which invites exactly that shell expansion.

Both doc quotes were re-fetched as raw markdown (`curl …/docs/en/plugins-reference.md`) on 2026-08-12 and grepped — lines 672 and 709 — not recalled.

## Test plan

Prose-only change to model-facing instructions; there is no behavioral test to write, and I am not inventing one. What is verifiable is that the shape is gone and the surfaces agree:

```
$ grep -n 'CLAUDE_PROJECT_DIR' plugins/claude-config/skills/audit-pass/SKILL.md
47:  **Do not express this as a condition over `${CLAUDE_PROJECT_DIR}` "when set".** That placeholder is
```

One hit, and it is the prohibition itself — both conditional uses are gone. Before this change the same grep returned `:42` and `:66`, the two instances.

Repo gates:

```
$ npx markdownlint-cli2 plugins/claude-config/CHANGELOG.md "plugins/claude-config/skills/audit-pass/**/*.md"
Linting: 11 files
Summary: 0 issues in 0 files

$ CHECK_SKILL_SKILLS_ROOT=plugins/claude-config/skills bash plugins/skill-quality/scripts/check-skill.sh audit-pass
CHECK-SKILL audit-pass: PASS — 0 errors, 2 warning(s)

$ bash scripts/check-changelog-parity.sh --check-order
All 76 changelog(s) read newest-first with no duplicate versions.

$ bash scripts/check-changelog-parity.sh --check-bump origin/main
Every plugin whose version changed vs origin/main has a '## [<version>]' CHANGELOG.md entry.
```

Both `check-skill.sh` warnings are pre-existing on `audit-pass` (a stale fresh-eyes-exempt directive at `SKILL.md:367`, and no `metadata.category`); neither is introduced here.

## Related

- **#2280** — the owning issue. This PR takes **F9** (both instances) and **F8**. Deliberately **not** taken, so the issue stays open:
  - **F3** — build `scripts/resolve-run-paths.sh` and `scripts/lease.sh`. The issue itself marks this a "deferred shape".
  - **F5** — the lease was specified and not written. **`SELF_REPORTED`**: the non-write is a runtime observation from the one session that ran the component, and nothing in this repository can confirm or refute it. Building a lease implementation on an unreproducible observation is the mistake this batch's re-verification discipline exists to prevent.
  - **F12 / F13** — the `--resume` partial dependency and the unbounded intra-lane fan-out. Both re-verified present at HEAD; both are consequences of F3/F5's missing mechanism rather than independent prose fixes.
  - Pre-flight evidence for every row is recorded in [this comment on #2280](https://github.com/melodic-software/claude-code-plugins/issues/2280#issuecomment-5262199272), including the second F9 instance.
- **#2250** (closed) — landed the `${CLAUDE_PROJECT_DIR}`-"when set" prohibition in `audit-prompting-postures`. The drift this PR removes is the sibling it did not sweep.
- **#2228 / #2229 / #2230 / #2231** (closed) — fixed the containment premise, the flag-gated exclusion machinery, the eval suite, and the non-git target gate. F8's first fact (that the directory resolves to `~/.claude/plugins/data/{id}/`) landed in #2229/#2230; the derivation and the Bash-environment fact are what they left standing.
- **#1568** (open) — owns the `${CLAUDE_*}` substitution-scope question empirically. This PR does **not** depend on it: `SKILL.md` is unambiguously skill content, which both the plugins reference and the skills page agree substitutes, and no claim here rests on bundled spoke files.
- **#1430** (open) — cross-epoch carry-forward, adjacent to F3's observation from the other side.
- **#2382** — open, and also bumps `claude-config`. It claims **0.35.3**; this PR takes **0.35.4** to avoid a manifest collision, since #2382 is green and ready first. Whichever merges second needs no rebase for the version, only for the CHANGELOG ordering if both land.

Inbox item: `20260811-020411-claude-config-audit-pass-report-path-inside-scan-set`.
Ledger: `.work/handoff-inbox-batch-4/ledgers/I8-audit-pass-report-path.md` § F9, F8.
