### PR TITLE
fix(claude-config): flag tilde-user paths and inert grant tokens

### DIFF
--- a/plugins/claude-config/.claude-plugin/plugin.json
+++ b/plugins/claude-config/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "claude-config",
-  "version": "0.36.0",
+  "version": "0.36.1",
   "description": "Nine configuration-health skills (plus setup) for a repo's Claude Code configuration: audit (settings.json / .mcp.json / hooks / plugins / permissions drift), audit-automation-gaps (evidence-gated verdicts on automation gaps), audit-permission-grants (allow-rule / allowed-tools grants for auto-mode durability and portability), audit-permission-state (the permission rules actually in effect — every settings scope merged with per-rule provenance, what auto mode drops on entry, config written where nothing reads it, and which managed intents are enforced versus loosenable), draft-auto-mode-rules (interview and draft a paste-ready autoMode classifier block; prints only, never writes), audit-instructions (locally-owned instruction surfaces vs current model capability — proposes removals/rewrites of instructions the model no longer needs, and detects cross-surface instruction conflicts), audit-prompting-postures (the additive lane — posture guidance the prompting guide says a component's purpose needs but the component does not carry), audit-pass (one coordinated, ordered, resumable pass over a named target — three-scope inventory, run-time-derived exclusion set, stable finding identity, suppression memory, resume, one human gate — delegating every check to the plugin that owns it), and unhobble (the empirical bare-baseline experiment: reversibly strip a repo's standing instructions, log real stumbles against the current model, re-add only what evidence earns).",
   "author": {
     "name": "Melodic Software",

--- a/plugins/claude-config/CHANGELOG.md
+++ b/plugins/claude-config/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to the `claude-config` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.36.1]
+
+### Fixed
+
+- **`audit-permission-grants` flags tilde-user Bash paths and inert substitution tokens.** `Bash(~user/…)`
+  now surfaces as P2 — the portable `~/` anchor for Read/Edit stays exempt. A new P4 check catches
+  `${CLAUDE_PLUGIN_ROOT}`, `%USERPROFILE%`, and `$env:USERPROFILE` grants that never match, with a
+  branched remedy: skill-local files recommend `${CLAUDE_SKILL_DIR}`; other surfaces recommend a bare
+  PATH command instead of plugin `bin/`.
+
 ## [0.36.0]
 
 ### Changed

--- a/plugins/claude-config/skills/audit-permission-grants/SKILL.md
+++ b/plugins/claude-config/skills/audit-permission-grants/SKILL.md
@@ -18,7 +18,7 @@ work?"
 The principle, the three anti-patterns, and the correct pattern (with official-doc citations) live in
 the marketplace's **permission-rule-hygiene** convention, published at
 <https://raw.githubusercontent.com/melodic-software/claude-code-plugins/main/docs/conventions/permission-rule-hygiene/README.md>.
-The mechanical check definitions (P1/P2/P3, severities, detector invocation) are in
+The mechanical check definitions (P1/P2/P2b/P3/P4, severities, detector invocation) are in
 [reference/criteria.md](reference/criteria.md), which carries every recommendation this skill needs at
 run time — the convention is the doctrine's owner, not a runtime dependency.
 
@@ -67,8 +67,8 @@ A user-global finding is reported the same as any other, but its remediation is 
 skill cannot write that file. Expect this scope to carry the most findings on a long-lived machine —
 "Always allow" writes there, and nothing prunes it.
 
-If a scope filter was given, run the full detector and present only the matching checks (P1/P2 map to
-`frontmatter`/`settings` sources; P3 to `plugins`).
+If a scope filter was given, run the full detector and present only the matching checks (P1/P2/P2b map to
+`frontmatter`/`settings` sources; P3 to `plugins`; P4 to `frontmatter`/`settings`).
 
 ## Phase 2: Report
 
@@ -82,7 +82,7 @@ required.
 
 | Severity | Criteria |
 | --- | --- |
-| error | Non-portable grant that leaks a username / breaks on other machines (P2) |
+| error | Non-portable grant that leaks a username / breaks on other machines (P2, P2b), or an inert Bash substitution token (P4) |
 | warning | Interpreter/runner-led grant whose broad forms auto mode drops, or an inert self-grant (P1, P3) |
 
 A clean scan ("No fragile permission grants found.") is a valid outcome — report it as such.

--- a/plugins/claude-config/skills/audit-permission-grants/reference/criteria.md
+++ b/plugins/claude-config/skills/audit-permission-grants/reference/criteria.md
@@ -123,6 +123,36 @@ anti-pattern 2.
 **Recommend**: replace with a portable form — `${CLAUDE_SKILL_DIR}` for a skill's own bundled script, a
 bare-name command on PATH, or for `Read`/`Edit` rules the `~/` home anchor.
 
+### P2b: Tilde-user path in a `Bash(...)` rule [error]
+
+**What**: A `Bash(...)` allow rule whose payload begins a path with `~username/` (not the portable
+`~/` home anchor). Bash rules match literally and do not expand tilde-user forms.
+
+**How to check**: run the detector. `Read(~/notes.md)` and other `~/` anchors are not flagged. A URL
+user-directory segment such as `Bash(curl https://example.com/~alice/index.html)` is not flagged —
+only a tilde-user path that begins a shell word inside the `Bash(...)` payload.
+
+**Why**: the rule names a specific account, leaks a username into version control, and breaks on other
+machines. The portable fixes are the same as P2 for Bash rules: `${CLAUDE_SKILL_DIR}`, a bare-name
+command on PATH, or for `Read`/`Edit` rules the `~/` home anchor.
+
+## P4: Inert substitution token in a `Bash(...)` rule [error]
+
+**What**: A `Bash(...)` allow rule containing `${CLAUDE_PLUGIN_ROOT}`, `%USERPROFILE%`, or
+`$env:USERPROFILE`. Only the two documented substitutions — `${CLAUDE_SKILL_DIR}` and
+`${CLAUDE_PROJECT_DIR}` — expand in allowed-tools Bash rules; these tokens stay literal and the grant
+never matches at runtime.
+
+**How to check**: run the detector. Each offending `Bash(...)` token is reported separately. Non-Bash
+rules containing similar spellings are out of scope for this check.
+
+**Why**: the grant looks configured but is a no-op, so operators believe a helper is pre-approved when
+it is not.
+
+**Recommend**: in skill `allowed-tools`, replace with `${CLAUDE_SKILL_DIR}` for a bundled script. In
+settings or other scopes, relocate the helper to a stable bare command on PATH and allow that name
+narrowly.
+
 ## P3: Plugin self-granted permissions [warning]
 
 **What**: A plugin `settings.json` (a `settings.json` beside a `.claude-plugin/plugin.json`) that

--- a/plugins/claude-config/skills/audit-permission-grants/scripts/permission-rule-check.sh
+++ b/plugins/claude-config/skills/audit-permission-grants/scripts/permission-rule-check.sh
@@ -174,6 +174,7 @@ P2_TILDE_USER_RULE_ERE='Bash\([^)]*~[^/[:space:]~]+/[^)]*\)'
 
 # Inert tokens: not among the two substitutions expanded in allowed-tools Bash
 # rules, or unexpandable env-var spellings that make the rule a literal no-op.
+# shellcheck disable=SC2016  # single quotes deliberate: \$ and % are literal ERE, not shell expansion
 P4_INERT_ERE='\$\{CLAUDE_PLUGIN_ROOT\}|%USERPROFILE%|\$env:USERPROFILE'
 
 findings=()

--- a/plugins/claude-config/skills/audit-permission-grants/scripts/permission-rule-check.sh
+++ b/plugins/claude-config/skills/audit-permission-grants/scripts/permission-rule-check.sh
@@ -170,12 +170,14 @@ _p2_path="${_sl}Users${_sl}${_seg}|${_sl}home${_sl}${_seg}|[A-Za-z]:[${_sl}${_bs
 P2_RULE_ERE="[A-Za-z_][A-Za-z0-9_]*\\([^)]*(${_p2_path})[^)]*\\)"
 # `~user/…` in a Bash rule — not the portable `~/` anchor (Read/Edit resolve that
 # per user). Bash rules match literally and do not expand tilde-user forms.
-P2_TILDE_USER_RULE_ERE='Bash\([^)]*~[^/[:space:]~]+/[^)]*\)'
+# Require `~` to begin a shell word (immediately after `(` or whitespace), not
+# inside arbitrary command text such as a URL user-directory segment.
+P2_TILDE_USER_RULE_ERE='Bash\((~[^/[:space:]~]+/|[[:space:]]+~[^/[:space:]~]+/)[^)]*\)'
 
-# Inert tokens: not among the two substitutions expanded in allowed-tools Bash
-# rules, or unexpandable env-var spellings that make the rule a literal no-op.
+# Inert tokens inside Bash(...) only — not Read/Edit or other tools.
 # shellcheck disable=SC2016  # single quotes deliberate: \$ and % are literal ERE, not shell expansion
-P4_INERT_ERE='\$\{CLAUDE_PLUGIN_ROOT\}|%USERPROFILE%|\$env:USERPROFILE'
+P4_INERT_TOKEN_ERE='\$\{CLAUDE_PLUGIN_ROOT\}|%USERPROFILE%|\$env:USERPROFILE'
+P4_BASH_INERT_ERE="Bash\\([^)]*(${P4_INERT_TOKEN_ERE})[^)]*\\)"
 
 findings=()
 
@@ -218,10 +220,11 @@ scan_rule() {
     [[ -z "$m" ]] && continue
     emit error P2 "$src" "tilde-user path in '$m' — Bash rules match literally and do not expand ~username forms, so the rule names a specific account, leaks a username into version control, and breaks on other machines. Use \${CLAUDE_SKILL_DIR} for a skill's own script, a bare-name command on PATH, or the ~/ home anchor for Read/Edit rules."
   done < <(printf '%s\n' "$text" | grep -oE "$P2_TILDE_USER_RULE_ERE" 2>/dev/null | sort -u)
-  if printf '%s' "$text" | grep -qE "$P4_INERT_ERE"; then
+  while IFS= read -r m; do
+    [[ -z "$m" ]] && continue
     remedy="$(inert_grant_remedy "$file")"
-    emit error P4 "$src" "inert substitution token in allow rule — the grant never matches at runtime ($text). Remedy: $remedy."
-  fi
+    emit error P4 "$src" "inert substitution token in '$m' — the grant never matches at runtime. Remedy: $remedy."
+  done < <(printf '%s\n' "$text" | grep -oE "$P4_BASH_INERT_ERE" 2>/dev/null | sort -u)
 }
 
 top_level_tokens() {

--- a/plugins/claude-config/skills/audit-permission-grants/scripts/permission-rule-check.sh
+++ b/plugins/claude-config/skills/audit-permission-grants/scripts/permission-rule-check.sh
@@ -3,7 +3,7 @@
 # permission grants across a repo's skill/command/agent frontmatter and its
 # settings.json / settings.local.json permission rules.
 #
-# Flags three anti-patterns (criteria file: reference/criteria.md):
+# Flags five anti-patterns (criteria file: reference/criteria.md):
 #   P1  interpreter-wildcard / blanket allow rules that Claude Code DROPS on
 #       entering auto mode (blanket Bash(*)/PowerShell(*), wildcarded
 #       interpreters like Bash(python*), package-manager wildcards — runner
@@ -20,6 +20,12 @@
 #       settings.json supports only the `agent` and `subagentStatusLine` keys,
 #       so a self-granted permission rule is silently ignored; the operative
 #       allow-rule has to be added by the operator to ~/.claude/settings.json.
+#   P4  inert substitution tokens in a Bash allow rule — `${CLAUDE_PLUGIN_ROOT}`
+#       (not substituted in allowed-tools), `%USERPROFILE%`, or
+#       `$env:USERPROFILE` (unexpanded in Bash rules). The grant never matches.
+#   P2b `~username/…` in a Bash rule — the portable `~/` home anchor is exempt
+#       (Read/Edit resolve it per user); `~user` is not portable, names a
+#       specific account, and is not expanded in Bash rules.
 #
 # Advisory about FINDINGS: they never fail the run, so a scan that completes exits 0
 # whether or not it found anything. Environment gaps are the exception and exit 2 —
@@ -162,6 +168,13 @@ _p2_path="${_sl}Users${_sl}${_seg}|${_sl}home${_sl}${_seg}|[A-Za-z]:[${_sl}${_bs
 # The leading `[A-Za-z_][A-Za-z0-9_]*` is `CCPERM_TOOL_TOKEN_ERE`'s own tool-name
 # grammar, kept consistent with the library #2260 extracted.
 P2_RULE_ERE="[A-Za-z_][A-Za-z0-9_]*\\([^)]*(${_p2_path})[^)]*\\)"
+# `~user/…` in a Bash rule — not the portable `~/` anchor (Read/Edit resolve that
+# per user). Bash rules match literally and do not expand tilde-user forms.
+P2_TILDE_USER_RULE_ERE='Bash\([^)]*~[^/[:space:]~]+/[^)]*\)'
+
+# Inert tokens: not among the two substitutions expanded in allowed-tools Bash
+# rules, or unexpandable env-var spellings that make the rule a literal no-op.
+P4_INERT_ERE='\$\{CLAUDE_PLUGIN_ROOT\}|%USERPROFILE%|\$env:USERPROFILE'
 
 findings=()
 
@@ -170,9 +183,23 @@ emit() {
   findings+=("$1 [$2] $3: $4")
 }
 
+inert_grant_remedy() {
+  # inert_grant_remedy <source-file-path> — branch the P4 remedy per #2397 A7b.
+  local file="$1"
+  case "$file" in
+    */skills/*/SKILL.md)
+      printf '%s' "replace with \${CLAUDE_SKILL_DIR} for a script bundled in this skill (substituted in allowed-tools Bash rules per the skills page)"
+      ;;
+    *)
+      printf '%s' "relocate the helper to a stable bare command on PATH and allow that name narrowly — do not prescribe plugin bin/ (see permission-rule-hygiene convention known gap)"
+      ;;
+  esac
+}
+
 scan_rule() {
-  # scan_rule <rule-string> <source-label> — one allow rule or one frontmatter token region
-  local text="$1" src="$2" m
+  # scan_rule <rule-string> <source-label> [<source-file>] — one allow rule or
+  # one frontmatter token region. source-file enables the P4 remedy branch.
+  local text="$1" src="$2" file="${3:-}" m remedy
   while IFS= read -r m; do
     [[ -n "$m" ]] && emit warning P1 "$src" "'$m' is an interpreter/runner-led grant, not the portable bare-name pattern; Claude Code drops the broad forms of this shape (blanket, package-manager runners, and wildcarded/globbed-target interpreters) on entering auto mode. Expose the guarded script as a bare PATH command and allow that, e.g. Bash(babysit_merge.sh:*)."
   done < <(printf '%s\n' "$text" | grep -oE "$P1_ERE" 2>/dev/null | sort -u)
@@ -186,6 +213,14 @@ scan_rule() {
     # genuinely portable forms and are already excluded by `_seg` above.
     emit error P2 "$src" "hardcoded machine path in '$m' — the rule names a concrete user home, so it breaks on other machines and usernames and leaks a username into source control. Portable forms: \${CLAUDE_SKILL_DIR} for a skill's own bundled script (substituted in allowed-tools Bash rules), a bare-name command on PATH, or the ~/ home anchor for Read/Edit rules."
   done < <(printf '%s\n' "$text" | grep -oE "$P2_RULE_ERE" 2>/dev/null | sort -u)
+  while IFS= read -r m; do
+    [[ -z "$m" ]] && continue
+    emit error P2 "$src" "tilde-user path in '$m' — Bash rules match literally and do not expand ~username forms, so the rule names a specific account, leaks a username into version control, and breaks on other machines. Use \${CLAUDE_SKILL_DIR} for a skill's own script, a bare-name command on PATH, or the ~/ home anchor for Read/Edit rules."
+  done < <(printf '%s\n' "$text" | grep -oE "$P2_TILDE_USER_RULE_ERE" 2>/dev/null | sort -u)
+  if printf '%s' "$text" | grep -qE "$P4_INERT_ERE"; then
+    remedy="$(inert_grant_remedy "$file")"
+    emit error P4 "$src" "inert substitution token in allow rule — the grant never matches at runtime ($text). Remedy: $remedy."
+  fi
 }
 
 top_level_tokens() {
@@ -258,7 +293,7 @@ while IFS= read -r file; do
   at="$(extract_allowed_tools "$file")"
   [[ -n "${at//[[:space:]]/}" ]] || continue
   rel="${file#"$ROOT"/}"
-  scan_rule "$at" "$rel allowed-tools"
+  scan_rule "$at" "$rel allowed-tools" "$file"
   scan_bare_tool "$at" "$rel allowed-tools"
   scan_agent "$at" "$rel allowed-tools"
 done < <(
@@ -278,7 +313,7 @@ scan_settings_allow() {
     [[ -n "$rule" ]] || continue
     scan_bare_tool "$rule" "$label"
     scan_agent "$rule" "$label"
-    scan_rule "$rule" "$label"
+    scan_rule "$rule" "$label" ""
     # Trailing tr strips CR: jq emits CRLF on Windows, which would otherwise
     # leave a \r on each rule and pollute the token the scans above match.
   done < <(tr -d '\r' <"$file" | jq -r '.permissions.allow // [] | .[]' 2>/dev/null | tr -d '\r')

--- a/plugins/claude-config/skills/audit-permission-grants/scripts/permission-rule-check.test.sh
+++ b/plugins/claude-config/skills/audit-permission-grants/scripts/permission-rule-check.test.sh
@@ -409,6 +409,39 @@ mkdir -p "$D8E/.claude"
 jq -n --arg l "Read(${LAUNDER_MP})" '{permissions:{allow:[$l]}}' >"$D8E/.claude/settings.json"
 assert_eq "a // prefix does not exempt a user home later in the rule" "1" "$(run "$D8E" --count)"
 
+# --- Case 8f: #2397 A12 — tilde-user Bash paths leak a username ----------------
+D8F="$TEST_TMPDIR/issue-2397-tilde-user"
+mkdir -p "$D8F/.claude"
+jq -n '{permissions:{allow:["Bash(~kyle/scripts/x.sh:*)"]}}' >"$D8F/.claude/settings.json"
+OUT_TILDE=$(run "$D8F")
+assert_contains "flags tilde-user Bash path" "$OUT_TILDE" "~kyle"
+assert_contains "tilde-user finding is P2" "$OUT_TILDE" "[P2]"
+assert_eq "portable ~/ anchor in Read is not flagged" "0" \
+  "$(jq -n '{permissions:{allow:["Read(~/notes.md)"]}}' >"$D8F/.claude/settings.json" && run "$D8F" --count)"
+
+# --- Case 8g: #2397 A7b — inert substitution tokens in allowed-tools ----------
+D8G="$TEST_TMPDIR/issue-2397-inert"
+mkdir -p "$D8G/.claude/skills/demo"
+cat >"$D8G/.claude/skills/demo/SKILL.md" <<'EOF'
+---
+name: demo
+allowed-tools: Bash(${CLAUDE_PLUGIN_ROOT}/scripts/x.sh:*)
+---
+body
+EOF
+OUT_INERT=$(run "$D8G")
+assert_contains "flags inert CLAUDE_PLUGIN_ROOT grant" "$OUT_INERT" "[P4]"
+assert_contains "skill-local remedy recommends CLAUDE_SKILL_DIR" "$OUT_INERT" "CLAUDE_SKILL_DIR"
+
+D8G2="$TEST_TMPDIR/issue-2397-inert-settings"
+mkdir -p "$D8G2/.claude"
+jq -n '{permissions:{allow:["Bash(%USERPROFILE%/scripts/x.sh:*)","Bash($env:USERPROFILE\\scripts\\x.sh:*)"]}}' \
+  >"$D8G2/.claude/settings.json"
+OUT_ENV=$(run "$D8G2")
+assert_contains "flags %USERPROFILE% inert grant" "$OUT_ENV" "%USERPROFILE%"
+assert_contains "flags PowerShell env inert grant" "$OUT_ENV" "\$env:USERPROFILE"
+assert_contains "settings-scope remedy does not prescribe plugin bin" "$OUT_ENV" "bare command on PATH"
+
 # --- Case 9: missing jq exits 2 ---------------------------------------------
 real_bash=$(command -v bash)
 empty_path_dir="$TEST_TMPDIR/empty-path"

--- a/plugins/claude-config/skills/audit-permission-grants/scripts/permission-rule-check.test.sh
+++ b/plugins/claude-config/skills/audit-permission-grants/scripts/permission-rule-check.test.sh
@@ -435,8 +435,16 @@ assert_contains "skill-local remedy recommends CLAUDE_SKILL_DIR" "$OUT_INERT" "C
 
 D8G2="$TEST_TMPDIR/issue-2397-inert-settings"
 mkdir -p "$D8G2/.claude"
-jq -n '{permissions:{allow:["Bash(%USERPROFILE%/scripts/x.sh:*)","Bash($env:USERPROFILE\\scripts\\x.sh:*)"]}}' \
-  >"$D8G2/.claude/settings.json"
+cat >"$D8G2/.claude/settings.json" <<'EOF'
+{
+  "permissions": {
+    "allow": [
+      "Bash(%USERPROFILE%/scripts/x.sh:*)",
+      "Bash($env:USERPROFILE/scripts/x.sh:*)"
+    ]
+  }
+}
+EOF
 OUT_ENV=$(run "$D8G2")
 assert_contains "flags %USERPROFILE% inert grant" "$OUT_ENV" "%USERPROFILE%"
 assert_contains "flags PowerShell env inert grant" "$OUT_ENV" "\$env:USERPROFILE"

--- a/plugins/claude-config/skills/audit-permission-grants/scripts/permission-rule-check.test.sh
+++ b/plugins/claude-config/skills/audit-permission-grants/scripts/permission-rule-check.test.sh
@@ -418,6 +418,11 @@ assert_contains "flags tilde-user Bash path" "$OUT_TILDE" "~kyle"
 assert_contains "tilde-user finding is P2" "$OUT_TILDE" "[P2]"
 assert_eq "portable ~/ anchor in Read is not flagged" "0" \
   "$(jq -n '{permissions:{allow:["Read(~/notes.md)"]}}' >"$D8F/.claude/settings.json" && run "$D8F" --count)"
+D8F_URL="$TEST_TMPDIR/issue-2397-tilde-url"
+mkdir -p "$D8F_URL/.claude"
+jq -n '{permissions:{allow:["Bash(curl https://example.com/~alice/index.html)"]}}' \
+  >"$D8F_URL/.claude/settings.json"
+assert_eq "URL user-directory segment is not flagged as tilde-user path" "0" "$(run "$D8F_URL" --count)"
 
 # --- Case 8g: #2397 A7b — inert substitution tokens in allowed-tools ----------
 D8G="$TEST_TMPDIR/issue-2397-inert"
@@ -449,6 +454,28 @@ OUT_ENV=$(run "$D8G2")
 assert_contains "flags %USERPROFILE% inert grant" "$OUT_ENV" "%USERPROFILE%"
 assert_contains "flags PowerShell env inert grant" "$OUT_ENV" "\$env:USERPROFILE"
 assert_contains "settings-scope remedy does not prescribe plugin bin" "$OUT_ENV" "bare command on PATH"
+
+D8G3="$TEST_TMPDIR/issue-2397-inert-list"
+mkdir -p "$D8G3/.claude/skills/demo"
+cat >"$D8G3/.claude/skills/demo/SKILL.md" <<'EOF'
+---
+name: demo
+allowed-tools:
+  - Bash(git status)
+  - Bash(${CLAUDE_PLUGIN_ROOT}/scripts/x.sh:*)
+  - Bash(%USERPROFILE%/scripts/y.sh:*)
+---
+body
+EOF
+OUT_LIST=$(run "$D8G3")
+assert_contains "flags only the inert grant in a mixed list" "$OUT_LIST" "Bash(\${CLAUDE_PLUGIN_ROOT}/scripts/x.sh:*)"
+assert_not_contains "clean grant in the same list is not embedded in P4 detail" "$OUT_LIST" "Bash(git status)"
+assert_eq "two distinct inert Bash grants emit two P4 findings" "2" "$(run "$D8G3" --count)"
+
+D8G4="$TEST_TMPDIR/issue-2397-inert-read"
+mkdir -p "$D8G4/.claude"
+jq -n '{permissions:{allow:["Read(%USERPROFILE%/notes.txt)"]}}' >"$D8G4/.claude/settings.json"
+assert_eq "non-Bash rules with inert spellings are not P4-flagged" "0" "$(run "$D8G4" --count)"
 
 # --- Case 9: missing jq exits 2 ---------------------------------------------
 real_bash=$(command -v bash)


### PR DESCRIPTION
Fixes #2397.

Adds P2 detection for `Bash(~user/…)` rules that leak a username and are not expanded at runtime, and a new P4 check for inert `${CLAUDE_PLUGIN_ROOT}`, `%USERPROFILE%`, and `$env:USERPROFILE` grants with a branched remedy (skill-local → `${CLAUDE_SKILL_DIR}`; otherwise → bare PATH command).

## Verification
- `permission-rule-check.test.sh`: 94 checks passed

## Related
- #2397 — permission-rule-check A7b/A12