### PR TITLE
fix(claude-config): add scan denominator to permission-rule-check

### DIFF
--- a/plugins/claude-config/.claude-plugin/plugin.json
+++ b/plugins/claude-config/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "claude-config",
-  "version": "0.35.4",
+  "version": "0.35.6",
   "description": "Eight configuration-health skills (plus setup) for a repo's Claude Code configuration: audit (settings.json / .mcp.json / hooks / plugins / permissions drift), audit-automation-gaps (evidence-gated verdicts on automation gaps), audit-permission-grants (allow-rule / allowed-tools grants for auto-mode durability and portability), audit-permission-state (which settings scopes exist and what rules each one holds — managed policy, user-global, project, local, and the pre-v2.1.211 start-directory copy), audit-instructions (locally-owned instruction surfaces vs current model capability — proposes removals/rewrites of instructions the model no longer needs, and detects cross-surface instruction conflicts), audit-prompting-postures (the additive lane — posture guidance the prompting guide says a component's purpose needs but the component does not carry), audit-pass (one coordinated, ordered, resumable pass over a named target — three-scope inventory, run-time-derived exclusion set, stable finding identity, suppression memory, resume, one human gate — delegating every check to the plugin that owns it), and unhobble (the empirical bare-baseline experiment: reversibly strip a repo's standing instructions, log real stumbles against the current model, re-add only what evidence earns).",
   "author": {
     "name": "Melodic Software",

--- a/plugins/claude-config/CHANGELOG.md
+++ b/plugins/claude-config/CHANGELOG.md
@@ -3,7 +3,16 @@
 All notable changes to the `claude-config` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
-## [0.35.4]
+## [0.35.6]
+
+### Fixed
+
+- **`audit-permission-grants` clean-bill output now carries a scan denominator.** The detector
+  reports how many frontmatter files with `allowed-tools` and how many `permissions.allow` rules
+  across how many settings files were scanned, so "clean" and "scanned nothing" are no longer the
+  same string.
+
+## [0.35.5]
 
 ### Fixed
 

--- a/plugins/claude-config/skills/audit-permission-grants/SKILL.md
+++ b/plugins/claude-config/skills/audit-permission-grants/SKILL.md
@@ -85,7 +85,8 @@ required.
 | error | Non-portable grant that leaks a username / breaks on other machines (P2) |
 | warning | Interpreter/runner-led grant whose broad forms auto mode drops, or an inert self-grant (P1, P3) |
 
-A clean scan ("No fragile permission grants found.") is a valid outcome — report it as such.
+A clean scan (the detector's "No fragile permission grants found …" line, which now includes
+how many frontmatter files and allow rules were scanned) is a valid outcome — report it as such.
 
 ## Consumer conventions
 

--- a/plugins/claude-config/skills/audit-permission-grants/scripts/permission-rule-check.sh
+++ b/plugins/claude-config/skills/audit-permission-grants/scripts/permission-rule-check.sh
@@ -164,6 +164,9 @@ _p2_path="${_sl}Users${_sl}${_seg}|${_sl}home${_sl}${_seg}|[A-Za-z]:[${_sl}${_bs
 P2_RULE_ERE="[A-Za-z_][A-Za-z0-9_]*\\([^)]*(${_p2_path})[^)]*\\)"
 
 findings=()
+stats_frontmatter=0
+stats_allow_rules=0
+stats_settings_files=0
 
 emit() {
   # emit <severity> <check> <source> <detail>
@@ -257,6 +260,7 @@ while IFS= read -r file; do
   [[ -f "$file" ]] || continue
   at="$(extract_allowed_tools "$file")"
   [[ -n "${at//[[:space:]]/}" ]] || continue
+  stats_frontmatter=$((stats_frontmatter + 1))
   rel="${file#"$ROOT"/}"
   scan_rule "$at" "$rel allowed-tools"
   scan_bare_tool "$at" "$rel allowed-tools"
@@ -271,17 +275,20 @@ done < <(
 
 # --- Settings permissions.allow scan -----------------------------------------
 scan_settings_allow() {
-  local file="$1" label="$2" rule
+  local file="$1" label="$2" rule n=0
   [[ -f "$file" ]] || return 0
   tr -d '\r' <"$file" | jq -e . >/dev/null 2>&1 || return 0
+  stats_settings_files=$((stats_settings_files + 1))
   while IFS= read -r rule; do
     [[ -n "$rule" ]] || continue
+    n=$((n + 1))
     scan_bare_tool "$rule" "$label"
     scan_agent "$rule" "$label"
     scan_rule "$rule" "$label"
     # Trailing tr strips CR: jq emits CRLF on Windows, which would otherwise
     # leave a \r on each rule and pollute the token the scans above match.
   done < <(tr -d '\r' <"$file" | jq -r '.permissions.allow // [] | .[]' 2>/dev/null | tr -d '\r')
+  stats_allow_rules=$((stats_allow_rules + n))
 }
 
 scan_settings_allow "$ROOT/.claude/settings.json" ".claude/settings.json permissions.allow"
@@ -340,8 +347,11 @@ if [[ "$mode" == "count" ]]; then
 fi
 
 if [[ "${#findings[@]}" -eq 0 ]]; then
-  echo "No fragile permission grants found."
+  printf 'No fragile permission grants found after scanning %d frontmatter file(s) with allowed-tools and %d allow rule(s) across %d settings file(s).\n' \
+    "$stats_frontmatter" "$stats_allow_rules" "$stats_settings_files"
 else
+  printf 'NOTE: scanned %d frontmatter file(s) with allowed-tools and %d allow rule(s) across %d settings file(s).\n' \
+    "$stats_frontmatter" "$stats_allow_rules" "$stats_settings_files" >&2
   printf '%s\n' "${findings[@]}"
 fi
 exit 0

--- a/plugins/claude-config/skills/audit-permission-grants/scripts/permission-rule-check.test.sh
+++ b/plugins/claude-config/skills/audit-permission-grants/scripts/permission-rule-check.test.sh
@@ -306,11 +306,23 @@ assert_eq "relocated config root produces exactly one finding" "1" \
   "$(run_with_config_dir "$D8C" "$RELOCATED" "$FAKE_HOME" --count)"
 
 # --- Case 8e: an unresolvable user scope is announced, never silently skipped --
-# With neither CLAUDE_CONFIG_DIR nor HOME set there is no user scope to read. A
-# silent skip would let "No fragile permission grants found." rest on a scope
-# that was never opened.
 err_out=$(env -u CLAUDE_CONFIG_DIR -u HOME PERMISSION_HYGIENE_FIXTURE_DIR="$D8C" bash "$SCRIPT" 2>&1 >/dev/null)
 assert_contains "unresolvable user scope is announced" "$err_out" "user-global scope not scanned"
+
+# --- Case 8f: #2283 A5 — clean bill carries a scan denominator ----------------
+D_EMPTY="$TEST_TMPDIR/empty-scan"
+mkdir -p "$D_EMPTY/.claude"
+OUT_EMPTY=$(run "$D_EMPTY")
+assert_contains "empty scan reports zero frontmatter files" "$OUT_EMPTY" "0 frontmatter file(s)"
+assert_contains "empty scan reports zero allow rules" "$OUT_EMPTY" "0 allow rule(s)"
+assert_contains "clean bill still names no findings" "$OUT_EMPTY" "No fragile permission grants found"
+
+D_DENOM="$TEST_TMPDIR/denom-narrow"
+mkdir -p "$D_DENOM/.claude"
+jq -n '{permissions:{allow:["Bash(npm test)"]}}' >"$D_DENOM/.claude/settings.json"
+OUT_DENOM=$(run "$D_DENOM")
+assert_contains "clean scan with rules names the denominator" "$OUT_DENOM" "1 allow rule(s)"
+assert_contains "clean scan names settings file count" "$OUT_DENOM" "1 settings file(s)"
 
 # --- Case 9b: unresolvable scan root refuses instead of sweeping -------------
 # The root ladder is $PERMISSION_HYGIENE_FIXTURE_DIR -> git toplevel ->


### PR DESCRIPTION
Fixes #2283 (row A5).

The detector's clean-bill line now reports how many frontmatter files with `allowed-tools` and how many `permissions.allow` rules across how many settings files were scanned, so a zero-finding run after scanning nothing is distinguishable from a zero-finding run after a real scan.

## Verification
- `permission-rule-check.test.sh`: 91 checks passed

## Related
- #2283 — audit-permission-grants denominator (A5 only; A8/A11/A15/A16 remain open)