### PR TITLE
fix(claude-config): audit-prompting-postures contract coherence

### DIFF
--- a/plugins/claude-config/.claude-plugin/plugin.json
+++ b/plugins/claude-config/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "claude-config",
-  "version": "0.35.4",
+  "version": "0.35.5",
   "description": "Eight configuration-health skills (plus setup) for a repo's Claude Code configuration: audit (settings.json / .mcp.json / hooks / plugins / permissions drift), audit-automation-gaps (evidence-gated verdicts on automation gaps), audit-permission-grants (allow-rule / allowed-tools grants for auto-mode durability and portability), audit-permission-state (which settings scopes exist and what rules each one holds — managed policy, user-global, project, local, and the pre-v2.1.211 start-directory copy), audit-instructions (locally-owned instruction surfaces vs current model capability — proposes removals/rewrites of instructions the model no longer needs, and detects cross-surface instruction conflicts), audit-prompting-postures (the additive lane — posture guidance the prompting guide says a component's purpose needs but the component does not carry), audit-pass (one coordinated, ordered, resumable pass over a named target — three-scope inventory, run-time-derived exclusion set, stable finding identity, suppression memory, resume, one human gate — delegating every check to the plugin that owns it), and unhobble (the empirical bare-baseline experiment: reversibly strip a repo's standing instructions, log real stumbles against the current model, re-add only what evidence earns).",
   "author": {
     "name": "Melodic Software",

--- a/plugins/claude-config/CHANGELOG.md
+++ b/plugins/claude-config/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to the `claude-config` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.35.5]
+
+### Fixed
+
+- **`audit-prompting-postures` contract coherence pass.** Verdict vocabulary now includes
+  `wording-unverified` and `info`; Phase A defers model-specific fetches until an applicable row
+  needs them and aborts when the best-practices page is unreachable; Phase B inventories hook
+  scripts and settings deny/ask for P7 presence; `output-styles` is documented as out of scope;
+  P8 carries an explicit model condition; `disallowed-tools: Edit, NotebookEdit` enforces the
+  read-only contract mechanically. `audit-instructions` now routes the additive posture lane here.
+
 ## [0.35.4]
 
 ### Fixed

--- a/plugins/claude-config/skills/audit-instructions/SKILL.md
+++ b/plugins/claude-config/skills/audit-instructions/SKILL.md
@@ -40,6 +40,8 @@ concerns its siblings already cover — route rather than re-answer:
 - Token brevity for its own sake is `docs-hygiene:compress`.
 - Config-file mechanics (settings.json, .mcp.json, hooks wiring) is `claude-config:audit`; grant
   portability is `claude-config:audit-permission-grants`.
+- Missing posture guidance the prompting guide says a component's purpose needs (the additive lane)
+  is `claude-config:audit-prompting-postures`.
 - The empirical bare-baseline experiment — strip the surfaces, observe the bare model, re-add on
   repeated stumble evidence — is `unhobble` (same plugin): this skill judges instruction *text*
   against doctrine; unhobble measures the *model*.

--- a/plugins/claude-config/skills/audit-prompting-postures/SKILL.md
+++ b/plugins/claude-config/skills/audit-prompting-postures/SKILL.md
@@ -1,8 +1,9 @@
 ---
 description: "Audit locally-owned instruction components — skill bodies, agent definitions, hook instruction text, CLAUDE.md, rules — for MISSING posture guidance the official prompting guide says their purpose needs: delegation criteria/caps in orchestration components, minimal-scope and anti-test-gaming guardrails in code-changing components, investigate-before-answering grounding, progress-claim grounding on long runs, autonomy vs checkpoint posture, destructive-action confirmation, context-budget reassurance, multi-window state guidance, parallel-tool-call steering. The additive complement to audit-instructions (which finds text that is present and wrong; this finds text that is absent and needed). Report-only: emits proposed additions sourced from a live fetch of the guide, gated to the human, never auto-applied. Use when: 'posture audit', 'audit prompting postures', 'is my skill missing guardrails', 'missing delegation criteria', 'should this component confirm destructive actions', 'align my components with the prompting guide', after authoring a new skill or agent, or as the additive lane of a prompting-guide alignment pass. Not for removing or rewriting existing instructions (audit-instructions), structural skill lint (skill-quality:check), or brevity (docs-hygiene:compress)."
-argument-hint: "[scope] — scope: skills|agents|hooks|claude-md|rules|all (default: all)"
+argument-hint: "[scope] — scope: skills|agents|hooks|claude-md|rules|all (default: all; output-styles are out of scope — use audit-instructions)"
 user-invocable: true
 disable-model-invocation: false
+disallowed-tools: Edit, NotebookEdit
 metadata:
   workflow-stage: anytime
   summary: Find posture guidance the prompting guide says a component needs but does not carry
@@ -37,20 +38,26 @@ one — the default verdict per posture is NOT-APPLICABLE, not MISSING.
 
 The posture catalog in [reference/postures.md](reference/postures.md) carries, per posture, an
 applicability predicate and a POINTER to the guide section that states the recommended wording.
-It deliberately carries no copied sample text. Before judging anything, WebFetch the pages the
-catalog names (the best-practices page always; a model-specific subpage only when a posture row
-names it) and hold the current wording. If a fetch fails, mark that posture's findings
-`wording-unverified` and cite the pointer rather than inventing text.
+It deliberately carries no copied sample text. Fetch the best-practices page before Phase C.
+Fetch a model-specific subpage only when Phase C finds an applicable posture row that names it —
+do not prefetch every subpage named anywhere in the catalog up front. Hold the current wording
+from each page you fetch. If the best-practices page is unreachable, **abort the run** with an
+error naming the URL — do not emit posture findings from memory. If a named subpage fetch fails,
+mark that posture's findings `wording-unverified` and cite the pointer rather than inventing text.
 
 ## Phase B — Inventory and classify
 
 Parse `$ARGUMENTS` for an optional scope filter (`skills`, `agents`, `hooks`, `claude-md`,
 `rules`, or `all`, the default). The filter narrows which surfaces may produce findings, never
-which pages Phase A fetches.
+which pages Phase A fetches. **`output-styles` is intentionally out of scope** — that surface
+belongs to `audit-instructions`; this skill does not inherit it.
 
 Enumerate locally-owned instruction components in scope (same surface set and liveness rules as
 `audit-instructions` Phase A — resolve `${CLAUDE_CONFIG_DIR:-~/.claude}`, project `.claude/`,
-CLAUDE.md files, hook instruction text of both kinds). For each component, classify its purpose
+CLAUDE.md files, hook instruction text of both kinds). For **P7 (destructive-action confirmation)**,
+also inspect hook scripts registered in `hooks.json` and `permissions.deny` / `permissions.ask`
+entries in settings files — a deny-by-default hook or script gate counts as presence even when
+no prose says so. For each component, classify its purpose
 from its own description and body — the classification vocabulary and its tie to each posture's
 predicate live in the catalog. A component can match several purposes or none; none is the common
 case, and unclassified components are reported in the coverage line, not force-fitted.
@@ -132,7 +139,10 @@ Then summarize in chat:
 |---|---------|-----------|---------|-------------------|
 
 Verdicts: `MISSING` (finding, with proposed addition as a fenced diff), `PRESENT` (where it is),
-`NOT-APPLICABLE` (with the failed predicate). End with a coverage line — components inventoried,
+`NOT-APPLICABLE` (with the failed predicate), `wording-unverified` (guide fetch failed for this
+posture — cite the pointer, do not invent text), and `info` (verifier-demoted or informational,
+not a finding). The Proposed addition column may carry a URL when the verdict is
+`wording-unverified`. End with a coverage line — components inventoried,
 classified, unclassified — and a Sources line citing the pages fetched this run with dates. When
 Phase D ran, end with a verifier attestation line — surface batches verified, verified inline, or
 skipped.

--- a/plugins/claude-config/skills/audit-prompting-postures/reference/postures.md
+++ b/plugins/claude-config/skills/audit-prompting-postures/reference/postures.md
@@ -81,6 +81,10 @@ Classify each component by what its body has the model DO (multiple or none):
 ### P8 — Context-budget reassurance
 
 - **Predicate:** context-surfacing.
+- **Model condition:** applies only on models the guide names as context-aware (currently Claude
+  Sonnet 5, Claude Sonnet 4.6, Claude Sonnet 4.5, and Claude Haiku 4.5 per the guide's context-
+  awareness section on platform.claude.com). Proposals for other models must be NOT-APPLICABLE or
+  carry the same condition explicitly.
 - **Present when:** the surfaced figure is accompanied by do-not-wrap-up-early framing (or the
   component deliberately avoids surfacing raw countdowns at all — the stronger form).
 - **Pointer:** main page, "Context awareness and multiwindow workflows"; Fable 5 subpage, "Rare


### PR DESCRIPTION
Refs #2281 — takes CC-F3, CC-F4, CC-F5, CC-F6, CC-F7, CC-F8, CC-F10. CC-F11 (informational) remains open.

## Summary
- Verdict schema adds `wording-unverified` and `info`
- Phase A defers model-specific fetches until Phase C needs them; aborts when best-practices page unreachable
- Phase B inventories hook scripts and settings deny/ask for P7 presence evidence
- Documents `output-styles` as out of scope (CC-F6)
- P8 row carries explicit model condition (CC-F7)
- `disallowed-tools: Edit, NotebookEdit` enforces read-only contract (CC-F4)
- `audit-instructions` routes additive posture lane here (CC-F8)

## Related
- #2281 — CC-F11 informational row not taken