### PR TITLE
fix(skill-quality): accept when_to_use triggers in check 12

### DIFF
--- a/plugins/skill-quality/.claude-plugin/plugin.json
+++ b/plugins/skill-quality/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "skill-quality",
-  "version": "0.15.4",
+  "version": "0.15.5",
   "description": "Skill-authoring QA tooling: a static contract checker that runs twenty-two deterministic checks over a Claude Code skill (frontmatter, per-skill listing-entry cap, trigger-keyword preservation, line caps, broken internal refs, markdownlint, gotchas surface, evals presence, precompute opportunity, injection shell-declaration, fresh-eyes declaration conformance), a shared skill-listing budget reporter across a set of skills, and a bundled evals.json schema plus a deterministic eval-quality lint (duplicate case identities, missing fixtures, empty or vague grading criteria, set-coverage warnings). Runs against any repo's skills directory via the convention-resolution ladder — no baked layout.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/skill-quality/CHANGELOG.md
+++ b/plugins/skill-quality/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to the `skill-quality` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.15.5]
+
+### Fixed
+
+- **Check 12 accepts a populated `when_to_use` with single-quoted triggers.** Skills no longer need
+  a redundant `Use when:` prefix in `description` when triggers are already declared in
+  `when_to_use`.
+
 ## [0.15.4]
 
 ### Changed

--- a/plugins/skill-quality/scripts/check-skill.sh
+++ b/plugins/skill-quality/scripts/check-skill.sh
@@ -570,7 +570,8 @@ fi
 # hiding the kindle-dedrm failure mode (a phrase reachable only from a dmi-true
 # skill), so the warning stays and the exemptions stay documented instead.
 if [[ -n "$CUR_DESC" ]]; then
-  if ! grep -qi 'use when' <<<"$CUR_DESC$CUR_WTU"; then
+  CUR_TRIG_WTU="$(printf '%s\n' "$CUR_WTU" | skill_frontmatter::extract_triggers)"
+  if ! grep -qi 'use when' <<<"$CUR_DESC$CUR_WTU" && [[ -z "$CUR_TRIG_WTU" ]]; then
     warn "description has no 'Use when:' trigger phrasing — a description is a trigger spec, not a summary"
   elif [[ -z "$(printf '%s\n%s\n' "$CUR_DESC" "$CUR_WTU" | skill_frontmatter::extract_triggers)" ]]; then
     warn "'Use when:' triggers are not single-quoted — drop-regression protection (check 3) tracks only 'quoted' phrases; single-quote each trigger phrase to cover it"

--- a/plugins/skill-quality/scripts/check-skill.test.sh
+++ b/plugins/skill-quality/scripts/check-skill.test.sh
@@ -342,6 +342,29 @@ else
   fail "unquoted triggers should warn without failing (rc=$rc): $out"
 fi
 
+# 9b. Single-quoted triggers in when_to_use alone satisfy check 12 (#1451).
+make_skill wtu-only-skill '---
+name: wtu-only-skill
+description: "Summary without Use-when prose in the description field."
+when_to_use: "'"'alpha trigger'"'", "'"'beta trigger'"'"
+---
+
+## Purpose
+
+Triggers live in when_to_use only.
+
+## Gotchas
+
+None known.
+'
+out="$(run wtu-only-skill 2>&1)"
+rc=$?
+if [[ $rc -eq 0 ]] && ! grep -q "no 'Use when:' trigger phrasing" <<<"$out"; then
+  pass "when_to_use single-quoted triggers satisfy check 12 without description prose"
+else
+  fail "when_to_use triggers should satisfy check 12 (rc=$rc): $out"
+fi
+
 # 10. CHECK_SKILL_BASE_REF catches an ALREADY-COMMITTED trigger drop that the
 #     default working-tree-vs-HEAD comparison misses (HEAD == tree).
 make_skill baseref-skill '---


### PR DESCRIPTION
Fixes #1451.

Check 12 now accepts a populated `when_to_use` field with single-quoted trigger phrases, so skills do not need a redundant `Use when:` prefix in `description`.

## Verification
- `check-skill.test.sh`: all assertions passed

## Related

- #1451 — when_to_use trigger acceptance in skill-quality check 12