### PR TITLE
fix(claude-config): rename scan-root override env var

### DIFF
--- a/plugins/claude-config/.claude-plugin/plugin.json
+++ b/plugins/claude-config/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "claude-config",
-  "version": "0.36.1",
+  "version": "0.36.2",
   "description": "Nine configuration-health skills (plus setup) for a repo's Claude Code configuration: audit (settings.json / .mcp.json / hooks / plugins / permissions drift), audit-automation-gaps (evidence-gated verdicts on automation gaps), audit-permission-grants (allow-rule / allowed-tools grants for auto-mode durability and portability), audit-permission-state (the permission rules actually in effect — every settings scope merged with per-rule provenance, what auto mode drops on entry, config written where nothing reads it, and which managed intents are enforced versus loosenable), draft-auto-mode-rules (interview and draft a paste-ready autoMode classifier block; prints only, never writes), audit-instructions (locally-owned instruction surfaces vs current model capability — proposes removals/rewrites of instructions the model no longer needs, and detects cross-surface instruction conflicts), audit-prompting-postures (the additive lane — posture guidance the prompting guide says a component's purpose needs but the component does not carry), audit-pass (one coordinated, ordered, resumable pass over a named target — three-scope inventory, run-time-derived exclusion set, stable finding identity, suppression memory, resume, one human gate — delegating every check to the plugin that owns it), and unhobble (the empirical bare-baseline experiment: reversibly strip a repo's standing instructions, log real stumbles against the current model, re-add only what evidence earns).",
   "author": {
     "name": "Melodic Software",

--- a/plugins/claude-config/CHANGELOG.md
+++ b/plugins/claude-config/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to the `claude-config` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.36.2]
+
+### Changed
+
+- **`audit-permission-grants` scan-root override is now `$PERMISSION_HYGIENE_SCAN_ROOT`.**
+  `$PERMISSION_HYGIENE_FIXTURE_DIR` remains accepted as a deprecated alias for tests and
+  existing automation.
+
 ## [0.36.1]
 
 ### Fixed

--- a/plugins/claude-config/skills/audit-permission-grants/SKILL.md
+++ b/plugins/claude-config/skills/audit-permission-grants/SKILL.md
@@ -59,7 +59,8 @@ raise it: a missing `jq`, a scan root that resolves to neither a git toplevel no
 `$CLAUDE_PROJECT_DIR`, and an unresolvable user scope when the user-global scan cannot locate
 `${CLAUDE_CONFIG_DIR:-$HOME/.claude}`. On an unresolvable project root, say the scan did not run and
 give the fix — run from inside the repository you mean to scan, or set
-`$PERMISSION_HYGIENE_FIXTURE_DIR` explicitly. Never report "no fragile permission grants found" on
+`$PERMISSION_HYGIENE_SCAN_ROOT` explicitly (`$PERMISSION_HYGIENE_FIXTURE_DIR` remains a
+deprecated alias). Never report "no fragile permission grants found" on
 an exit 2.
 `settings.local.json` is parsed for its `permissions.allow` array only — never echoed wholesale.
 

--- a/plugins/claude-config/skills/audit-permission-grants/scripts/permission-rule-check.sh
+++ b/plugins/claude-config/skills/audit-permission-grants/scripts/permission-rule-check.sh
@@ -31,8 +31,9 @@
 # whether or not it found anything. Environment gaps are the exception and exit 2 —
 # missing jq, and an unresolvable scan root (below).
 #
-# Project-root resolution: $PERMISSION_HYGIENE_FIXTURE_DIR, else the cwd's git
-# toplevel, else $CLAUDE_PROJECT_DIR. Never the plugin's own dir, and NEVER $PWD.
+# Project-root resolution: $PERMISSION_HYGIENE_SCAN_ROOT (or the deprecated
+# $PERMISSION_HYGIENE_FIXTURE_DIR alias), else the cwd's git toplevel, else
+# $CLAUDE_PROJECT_DIR. Never the plugin's own dir, and NEVER $PWD.
 #
 # Why there is no $PWD fallback: outside a git repository $PWD is whatever directory
 # the session happens to stand in, which on a developer machine is typically the user
@@ -70,7 +71,8 @@ settings.json for P3 (unsupported self-granted `permissions`).
 Findings are advisory and never fail the run, so a completed scan exits 0 in both
 modes. Environment gaps exit 2 instead of reporting a clean bill: missing jq, and a
 scan root that resolves to neither a git toplevel nor $CLAUDE_PROJECT_DIR. Set
-$PERMISSION_HYGIENE_FIXTURE_DIR to scan an explicit directory.
+$PERMISSION_HYGIENE_SCAN_ROOT (or the deprecated $PERMISSION_HYGIENE_FIXTURE_DIR
+alias) to scan an explicit directory.
 EOF
 }
 
@@ -99,8 +101,8 @@ fi
 mode="report"
 [[ "${1:-}" == "--count" ]] && mode="count"
 
-if [[ -n "${PERMISSION_HYGIENE_FIXTURE_DIR:-}" ]]; then
-  ROOT="$PERMISSION_HYGIENE_FIXTURE_DIR"
+if [[ -n "${PERMISSION_HYGIENE_SCAN_ROOT:-${PERMISSION_HYGIENE_FIXTURE_DIR:-}}" ]]; then
+  ROOT="${PERMISSION_HYGIENE_SCAN_ROOT:-$PERMISSION_HYGIENE_FIXTURE_DIR}"
 else
   ROOT="$(git rev-parse --show-toplevel 2>/dev/null | tr -d '\r')"
   [[ -n "$ROOT" ]] || ROOT="${CLAUDE_PROJECT_DIR:-}"
@@ -113,13 +115,15 @@ if [[ -z "$ROOT" ]]; then
   cat >&2 <<'EOF'
 ERROR: no scan root resolved — refusing to scan.
 
-Tried, in order: $PERMISSION_HYGIENE_FIXTURE_DIR, the current directory's git
-toplevel, then $CLAUDE_PROJECT_DIR. None resolved, and there is deliberately no
-fallback to the current directory: outside a repository that is usually the user
-profile, and scanning it would walk the whole home tree and still report success.
+Tried, in order: $PERMISSION_HYGIENE_SCAN_ROOT (or
+$PERMISSION_HYGIENE_FIXTURE_DIR), the current directory's git toplevel, then
+$CLAUDE_PROJECT_DIR. None resolved, and there is deliberately no fallback to
+the current directory: outside a repository that is usually the user profile,
+and scanning it would walk the whole home tree and still report success.
 
 Fix by running from inside the repository you mean to scan, or set
-$PERMISSION_HYGIENE_FIXTURE_DIR to the directory to scan explicitly.
+$PERMISSION_HYGIENE_SCAN_ROOT to the directory to scan explicitly
+($PERMISSION_HYGIENE_FIXTURE_DIR remains accepted as a deprecated alias).
 EOF
   exit 2
 fi

--- a/plugins/claude-config/skills/audit-permission-grants/scripts/permission-rule-check.test.sh
+++ b/plugins/claude-config/skills/audit-permission-grants/scripts/permission-rule-check.test.sh
@@ -305,6 +305,13 @@ assert_not_contains "ignores \$HOME once CLAUDE_CONFIG_DIR is set" "$OUT" "Bash(
 assert_eq "relocated config root produces exactly one finding" "1" \
   "$(run_with_config_dir "$D8C" "$RELOCATED" "$FAKE_HOME" --count)"
 
+# --- Case 8f: #2283 A11 — operator-facing scan-root override name ----------------
+D_SCAN="$TEST_TMPDIR/scan-root-alias"
+mkdir -p "$D_SCAN/.claude"
+jq -n '{permissions:{allow:["Bash(npm test)"]}}' >"$D_SCAN/.claude/settings.json"
+assert_eq "PERMISSION_HYGIENE_SCAN_ROOT resolves the scan root" "0" \
+  "$(env -u CLAUDE_CONFIG_DIR HOME="$ISOLATED_HOME" PERMISSION_HYGIENE_SCAN_ROOT="$D_SCAN" bash "$SCRIPT" --count)"
+
 # --- Case 8e: an unresolvable user scope is announced, never silently skipped --
 # With neither CLAUDE_CONFIG_DIR nor HOME set there is no user scope to read. A
 # silent skip would let "No fragile permission grants found." rest on a scope

--- a/plugins/claude-config/skills/audit-permission-grants/scripts/permission-rule-check.test.sh
+++ b/plugins/claude-config/skills/audit-permission-grants/scripts/permission-rule-check.test.sh
@@ -54,9 +54,9 @@ fi
 # and its rules would pollute every case's finding count.
 ISOLATED_HOME="$TEST_TMPDIR/empty-home"
 mkdir -p "$ISOLATED_HOME"
-run() { env -u CLAUDE_CONFIG_DIR HOME="$ISOLATED_HOME" PERMISSION_HYGIENE_FIXTURE_DIR="$1" bash "$SCRIPT" "${2:-}"; }
-run_with_home() { env -u CLAUDE_CONFIG_DIR HOME="$2" PERMISSION_HYGIENE_FIXTURE_DIR="$1" bash "$SCRIPT" "${3:-}"; }
-run_with_config_dir() { env CLAUDE_CONFIG_DIR="$2" HOME="$3" PERMISSION_HYGIENE_FIXTURE_DIR="$1" bash "$SCRIPT" "${4:-}"; }
+run() { env -u CLAUDE_CONFIG_DIR -u PERMISSION_HYGIENE_SCAN_ROOT HOME="$ISOLATED_HOME" PERMISSION_HYGIENE_FIXTURE_DIR="$1" bash "$SCRIPT" "${2:-}"; }
+run_with_home() { env -u CLAUDE_CONFIG_DIR -u PERMISSION_HYGIENE_SCAN_ROOT HOME="$2" PERMISSION_HYGIENE_FIXTURE_DIR="$1" bash "$SCRIPT" "${3:-}"; }
+run_with_config_dir() { env -u PERMISSION_HYGIENE_SCAN_ROOT CLAUDE_CONFIG_DIR="$2" HOME="$3" PERMISSION_HYGIENE_FIXTURE_DIR="$1" bash "$SCRIPT" "${4:-}"; }
 
 # Runtime-assembled machine paths (no contiguous path literal in source).
 SL='/'
@@ -305,25 +305,32 @@ assert_not_contains "ignores \$HOME once CLAUDE_CONFIG_DIR is set" "$OUT" "Bash(
 assert_eq "relocated config root produces exactly one finding" "1" \
   "$(run_with_config_dir "$D8C" "$RELOCATED" "$FAKE_HOME" --count)"
 
+# --- Case 8e: an unresolvable user scope is announced, never silently skipped --
+# With neither CLAUDE_CONFIG_DIR nor HOME set there is no user scope to read. A
+# silent skip would let "No fragile permission grants found." rest on a scope
+# that was never opened.
+err_out=$(env -u CLAUDE_CONFIG_DIR -u HOME -u PERMISSION_HYGIENE_SCAN_ROOT PERMISSION_HYGIENE_FIXTURE_DIR="$D8C" bash "$SCRIPT" 2>&1 >/dev/null)
+assert_contains "unresolvable user scope is announced" "$err_out" "user-global scope not scanned"
+
 # --- Case 8f: #2283 A11 — operator-facing scan-root override name ----------------
 D_SCAN="$TEST_TMPDIR/scan-root-alias"
 mkdir -p "$D_SCAN/.claude"
 jq -n '{permissions:{allow:["Bash(npm test)"]}}' >"$D_SCAN/.claude/settings.json"
 assert_eq "PERMISSION_HYGIENE_SCAN_ROOT resolves the scan root" "0" \
-  "$(env -u CLAUDE_CONFIG_DIR HOME="$ISOLATED_HOME" PERMISSION_HYGIENE_SCAN_ROOT="$D_SCAN" bash "$SCRIPT" --count)"
+  "$(env -u CLAUDE_CONFIG_DIR -u PERMISSION_HYGIENE_FIXTURE_DIR HOME="$ISOLATED_HOME" PERMISSION_HYGIENE_SCAN_ROOT="$D_SCAN" bash "$SCRIPT" --count)"
 
-# --- Case 8e: an unresolvable user scope is announced, never silently skipped --
-# With neither CLAUDE_CONFIG_DIR nor HOME set there is no user scope to read. A
-# silent skip would let "No fragile permission grants found." rest on a scope
-# that was never opened.
-err_out=$(env -u CLAUDE_CONFIG_DIR -u HOME PERMISSION_HYGIENE_FIXTURE_DIR="$D8C" bash "$SCRIPT" 2>&1 >/dev/null)
-assert_contains "unresolvable user scope is announced" "$err_out" "user-global scope not scanned"
+D_FIXTURE="$TEST_TMPDIR/fixture-root-alias"
+mkdir -p "$D_FIXTURE/.claude"
+jq -n '{permissions:{allow:["Bash(python*)"]}}' >"$D_FIXTURE/.claude/settings.json"
+assert_eq "PERMISSION_HYGIENE_SCAN_ROOT wins over deprecated fixture dir" "0" \
+  "$(env -u CLAUDE_CONFIG_DIR HOME="$ISOLATED_HOME" PERMISSION_HYGIENE_SCAN_ROOT="$D_SCAN" PERMISSION_HYGIENE_FIXTURE_DIR="$D_FIXTURE" bash "$SCRIPT" --count)"
 
 # --- Case 9b: unresolvable scan root refuses instead of sweeping -------------
-# The root ladder is $PERMISSION_HYGIENE_FIXTURE_DIR -> git toplevel ->
-# $CLAUDE_PROJECT_DIR, with NO fallback to the cwd. Run from a non-repo directory
-# with every rung unset: the scan must refuse (exit 2, the environment-gap channel)
-# rather than walk whatever the cwd happens to be and report a clean bill.
+# The root ladder is $PERMISSION_HYGIENE_SCAN_ROOT (or the deprecated
+# $PERMISSION_HYGIENE_FIXTURE_DIR) -> git toplevel -> $CLAUDE_PROJECT_DIR, with
+# NO fallback to the cwd. Run from a non-repo directory with every rung unset:
+# the scan must refuse (exit 2, the environment-gap channel) rather than walk
+# whatever the cwd happens to be and report a clean bill.
 #
 # CLAUDE_PROJECT_DIR is unset explicitly as well as the fixture var — an outer
 # session that exports it would otherwise resolve the root and hide the regression.
@@ -331,14 +338,14 @@ nonrepo="$TEST_TMPDIR/not-a-repo"
 mkdir -p "$nonrepo"
 
 rc=0
-root_err=$(cd "$nonrepo" && env -u PERMISSION_HYGIENE_FIXTURE_DIR -u CLAUDE_PROJECT_DIR \
+root_err=$(cd "$nonrepo" && env -u PERMISSION_HYGIENE_SCAN_ROOT -u PERMISSION_HYGIENE_FIXTURE_DIR -u CLAUDE_PROJECT_DIR \
   GIT_CEILING_DIRECTORIES="$TEST_TMPDIR" bash "$SCRIPT" 2>&1) || rc=$?
 assert_exit "unresolvable root exits 2, not 0" 2 "$rc"
 assert_contains "refusal names the failure" "$root_err" "no scan root resolved"
 assert_not_contains "refusal is not a clean bill" "$root_err" "No fragile permission grants found."
 
 rc=0
-count_err=$(cd "$nonrepo" && env -u PERMISSION_HYGIENE_FIXTURE_DIR -u CLAUDE_PROJECT_DIR \
+count_err=$(cd "$nonrepo" && env -u PERMISSION_HYGIENE_SCAN_ROOT -u PERMISSION_HYGIENE_FIXTURE_DIR -u CLAUDE_PROJECT_DIR \
   GIT_CEILING_DIRECTORIES="$TEST_TMPDIR" bash "$SCRIPT" --count 2>&1) || rc=$?
 assert_exit "--count also refuses rather than printing 0" 2 "$rc"
 assert_not_contains "--count prints no count on a refusal" "$count_err" "0


### PR DESCRIPTION
Fixes #2283 (row A11).

Introduces `$PERMISSION_HYGIENE_SCAN_ROOT` as the operator-facing scan-root override. `$PERMISSION_HYGIENE_FIXTURE_DIR` remains accepted as a deprecated alias.

## Verification
- `permission-rule-check.test.sh`: 87 checks passed

## Related
- #2283 — A5/A8/A15/A16 remain open