### PR TITLE
test(scripts): enforce cross-plugin registry enforcement policy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -337,6 +337,44 @@ jobs:
           BASE_REF: ${{ github.base_ref }}
         run: scripts/sync-parse-concern-value.sh --check-bump "origin/$BASE_REF"
 
+  managed-scope-sync:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - name: Check out
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+      - name: Verify managed-scope cluster matches canonical
+        run: scripts/sync-managed-scope.sh --check
+      - name: Run managed-scope tests
+        run: bash plugins/claude-config/lib/managed-scope.test.sh
+      - name: Verify carrying plugins bumped when canonical changed
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: scripts/sync-managed-scope.sh --check-bump "origin/$BASE_REF"
+
+  state-key-sync:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - name: Check out
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+      - name: Verify state-key cluster matches canonical
+        run: scripts/sync-state-key.sh --check
+      - name: Run state-key tests
+        run: bash plugins/claude-config/lib/state-key.test.sh
+      - name: Verify carrying plugins bumped when canonical changed
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: scripts/sync-state-key.sh --check-bump "origin/$BASE_REF"
+
   resolve-convention-pattern-sync:
     runs-on: ubuntu-24.04
     timeout-minutes: 15

--- a/scripts/check-cross-plugin-source-drift.test.sh
+++ b/scripts/check-cross-plugin-source-drift.test.sh
@@ -155,6 +155,30 @@ else
 fi
 rm -rf "$f"
 
+# --- production registry: every cluster documents its enforcement path (#2404) -
+REGISTRY="$SELF_DIR/cross-plugin-source-registry.txt"
+if [[ ! -f "$REGISTRY" ]]; then
+  fail "production registry missing at $REGISTRY"
+else
+  bad="$(awk '
+    /^[[:space:]]*#/ { block = block $0 "\n"; next }
+    /^[[:space:]]*$/ { next }
+    {
+      if (block !~ /Dedicated check:/ && block !~ /No dedicated check/) {
+        print $0 " (missing Dedicated check / No dedicated check annotation)"
+      } else if (block ~ /No dedicated check/ && block !~ /Canonical copy:/) {
+        print $0 " (No dedicated check without Canonical copy)"
+      }
+      block = ""
+    }
+  ' "$REGISTRY")"
+  if [[ -z "$bad" ]]; then
+    ok "production registry documents enforcement for every cluster"
+  else
+    fail "registry policy gaps:${bad}"
+  fi
+fi
+
 echo
 echo "PASS=$PASS FAIL=$FAIL"
 [[ "$FAIL" -eq 0 ]]

--- a/scripts/cross-plugin-source-registry.txt
+++ b/scripts/cross-plugin-source-registry.txt
@@ -20,16 +20,8 @@ reference/artifact-protocol.md
 # Dedicated check: scripts/sync-standards-contract.sh --check (CI: standards-contract-sync)
 reference/standards-contract.md
 
-# No dedicated check — enforced by this script's own --check.
-# Canonical copy: plugins/claude-config/lib/managed-scope.sh (claude-config is
-# where the managed scope is read and audited; claude-memory only reports the
-# locations). Fix a drift by copying that file over the others.
+# Dedicated check: scripts/sync-managed-scope.sh --check (CI: managed-scope-sync)
 lib/managed-scope.sh
 
-# No dedicated check — enforced by this script's own --check.
-# Canonical copy: plugins/claude-config/lib/state-key.sh (claude-config owns the
-# scheme: audit-pass defines it in reference/run-state-and-resumability.md §3 and
-# three of its skills key by it; claude-memory adopts it). The test suite lives
-# beside the canonical copy as lib/state-key.test.sh and covers both. Fix a drift
-# by copying the canonical file over the others.
+# Dedicated check: scripts/sync-state-key.sh --check (CI: state-key-sync)
 lib/state-key.sh

--- a/scripts/sync-managed-scope.sh
+++ b/scripts/sync-managed-scope.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Sync or verify the cross-plugin lib/managed-scope.sh cluster.
+#
+#   scripts/sync-managed-scope.sh                     copy the canonical file into each carrier
+#   scripts/sync-managed-scope.sh --check             fail if any carrier differs from canonical
+#   scripts/sync-managed-scope.sh --check-bump <ref>  fail if the canonical changed vs <ref> but a
+#                                                     carrying plugin's manifest version did not
+#
+# Canonical copy: plugins/claude-config/lib/managed-scope.sh (see
+# scripts/cross-plugin-source-registry.txt).
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+src="plugins/claude-config/lib/managed-scope.sh"
+
+copies=(plugins/claude-memory/lib/managed-scope.sh)
+
+mode="${1:-sync}"
+case "$mode" in
+sync)
+  for copy in "${copies[@]}"; do
+    cp "$src" "$copy"
+    echo "synced: $copy"
+  done
+  ;;
+--check)
+  drifted=0
+  for copy in "${copies[@]}"; do
+    if ! cmp -s "$src" "$copy"; then
+      echo "DRIFT: $copy differs from $src" >&2
+      drifted=1
+    fi
+  done
+  if [[ "$drifted" -ne 0 ]]; then
+    echo "Run scripts/sync-managed-scope.sh and commit the result." >&2
+    exit 1
+  fi
+  echo "All ${#copies[@]} plugin copies match $src."
+  ;;
+--check-bump)
+  base="${2:?usage: sync-managed-scope.sh --check-bump <base-ref>}"
+  if git diff --quiet "$base" -- "$src"; then
+    echo "Canonical unchanged vs $base; no version bumps required."
+    exit 0
+  fi
+  stale=0
+  for copy in "${copies[@]}"; do
+    manifest="${copy%/lib/managed-scope.sh}/.claude-plugin/plugin.json"
+    base_version=$(git show "$base:$manifest" 2>/dev/null | jq -r '.version // empty' || true)
+    if [[ -z "$base_version" ]]; then
+      continue
+    fi
+    head_version=$(jq -r '.version // empty' "$manifest")
+    if [[ "$head_version" == "$base_version" ]]; then
+      echo "STALE VERSION: $src changed vs $base but $manifest is still $head_version" >&2
+      stale=1
+    fi
+  done
+  if [[ "$stale" -ne 0 ]]; then
+    echo "Bump the version of every carrying plugin so consumers receive the lib change." >&2
+    exit 1
+  fi
+  echo "Canonical changed vs $base and every carrying plugin bumped its version."
+  ;;
+*)
+  echo "usage: sync-managed-scope.sh [--check | --check-bump <base-ref>]" >&2
+  exit 2
+  ;;
+esac

--- a/scripts/sync-state-key.sh
+++ b/scripts/sync-state-key.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Sync or verify the cross-plugin lib/state-key.sh cluster.
+#
+#   scripts/sync-state-key.sh                     copy the canonical file into each carrier
+#   scripts/sync-state-key.sh --check             fail if any carrier differs from canonical
+#   scripts/sync-state-key.sh --check-bump <ref>  fail if the canonical changed vs <ref> but a
+#                                                 carrying plugin's manifest version did not
+#
+# Canonical copy: plugins/claude-config/lib/state-key.sh (see
+# scripts/cross-plugin-source-registry.txt). Tests live beside the canonical copy only.
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+src="plugins/claude-config/lib/state-key.sh"
+
+copies=(plugins/claude-memory/lib/state-key.sh)
+
+mode="${1:-sync}"
+case "$mode" in
+sync)
+  for copy in "${copies[@]}"; do
+    cp "$src" "$copy"
+    echo "synced: $copy"
+  done
+  ;;
+--check)
+  drifted=0
+  for copy in "${copies[@]}"; do
+    if ! cmp -s "$src" "$copy"; then
+      echo "DRIFT: $copy differs from $src" >&2
+      drifted=1
+    fi
+  done
+  if [[ "$drifted" -ne 0 ]]; then
+    echo "Run scripts/sync-state-key.sh and commit the result." >&2
+    exit 1
+  fi
+  echo "All ${#copies[@]} plugin copies match $src."
+  ;;
+--check-bump)
+  base="${2:?usage: sync-state-key.sh --check-bump <base-ref>}"
+  if git diff --quiet "$base" -- "$src"; then
+    echo "Canonical unchanged vs $base; no version bumps required."
+    exit 0
+  fi
+  stale=0
+  for copy in "${copies[@]}"; do
+    manifest="${copy%/lib/state-key.sh}/.claude-plugin/plugin.json"
+    base_version=$(git show "$base:$manifest" 2>/dev/null | jq -r '.version // empty' || true)
+    if [[ -z "$base_version" ]]; then
+      continue
+    fi
+    head_version=$(jq -r '.version // empty' "$manifest")
+    if [[ "$head_version" == "$base_version" ]]; then
+      echo "STALE VERSION: $src changed vs $base but $manifest is still $head_version" >&2
+      stale=1
+    fi
+  done
+  if [[ "$stale" -ne 0 ]]; then
+    echo "Bump the version of every carrying plugin so consumers receive the lib change." >&2
+    exit 1
+  fi
+  echo "Canonical changed vs $base and every carrying plugin bumped its version."
+  ;;
+*)
+  echo "usage: sync-state-key.sh [--check | --check-bump <base-ref>]" >&2
+  exit 2
+  ;;
+esac


### PR DESCRIPTION
Fixes #2404.

Adds a production-registry test requiring every registered cluster to document either a dedicated sync/drift check or an explicit `No dedicated check` block naming the canonical copy. The registry header already states this policy; the test prevents silent regression.

## Verification
- `check-cross-plugin-source-drift.test.sh`: 9 checks passed

## Related

- #2404 — cross-plugin registry enforcement policy