### PR TITLE
chore(plugin-quality): adopt upstream-drift stamp on hook exit-code semantics

### DIFF
--- a/plugins/plugin-quality/.claude-plugin/plugin.json
+++ b/plugins/plugin-quality/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "plugin-quality",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Post-use behavioral audit of Claude Code plugin components: a six-step audit workflow (evidence capture, grounded mapping in a fresh subagent, blindspot pass, interactive contract lock, presence-gated review seams, work-item emit with draft+confirm) over any skill, agent, hook, command, or config you have actually used — zone-informed by context-guard snapshots when present, conservative when not.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/plugin-quality/CHANGELOG.md
+++ b/plugins/plugin-quality/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to the `plugin-quality` plugin.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.2]
+
+### Changed
+
+- **Adopt upstream-drift stamp on hook audit exit-code semantics (#2297 carrier 1).** The
+  component-type checklist now carries basis, as-of date, and a recheck trigger for the
+  PreToolUse/PostToolUse exit-code contract instead of an unstamped harness assertion.
+
 ## [0.6.1]
 
 ### Changed

--- a/plugins/plugin-quality/skills/audit/references/component-types/hook.md
+++ b/plugins/plugin-quality/skills/audit/references/component-types/hook.md
@@ -15,6 +15,9 @@ PreToolUse / PostToolUse / lifecycle hook scripts. Growable — add cases as you
 - **Exit-code semantics** — PreToolUse: 0 allow, 2 block; PostToolUse: 2 shows stderr to Claude.
   Does the script use them correctly, and fail closed where blocking matters? Verify the semantics
   against the current hooks reference, not memory.
+  Verified 2026-08-12 against [Hooks reference — Exit codes](https://code.claude.com/docs/en/hooks#exit-codes).
+  Recheck when the hooks reference changelog or the `hooks` doc page changes in a Claude Code release
+  this repo's `OFFICIAL-DOCS.md` index records.
 - **Fail-open vs fail-closed** on missing deps (jq), empty/timed-out stdin, parse errors.
 - **Enablement/scope probe** — if it self-disables based on plugin enablement or settings, does it
   read the *merged effective* scopes (user-global + project + local), not just one?


### PR DESCRIPTION
Fixes #2297.

Part of #2297 — adopts carrier 1 from the upstream-drift adoption backlog.

## Summary

Stamps the hook component-type checklist exit-code semantics row with basis URL, as-of date, and a recheck trigger per docs/conventions/upstream-drift/.

## Test plan

- [x] Doc-only change; stamp format matches convention

## Related

- #2297 — upstream-drift adoption backlog