### PR TITLE
fix(claude-config): recognize bare-name remediation platform gap in audit-permission-grants

### DIFF
--- a/plugins/claude-config/.claude-plugin/plugin.json
+++ b/plugins/claude-config/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "claude-config",
-  "version": "0.37.0",
+  "version": "0.37.1",
   "description": "Nine configuration-health skills (plus setup) for a repo's Claude Code configuration: audit (settings.json / .mcp.json / hooks / plugins / permissions drift), audit-automation-gaps (evidence-gated verdicts on automation gaps), audit-permission-grants (allow-rule / allowed-tools grants for auto-mode durability and portability), audit-permission-state (the permission rules actually in effect — every settings scope merged with per-rule provenance, what auto mode drops on entry, config written where nothing reads it, and which managed intents are enforced versus loosenable), draft-auto-mode-rules (interview and draft a paste-ready autoMode classifier block; prints only, never writes), audit-instructions (locally-owned instruction surfaces vs current model capability — proposes removals/rewrites of instructions the model no longer needs, and detects cross-surface instruction conflicts), audit-prompting-postures (the additive lane — posture guidance the prompting guide says a component's purpose needs but the component does not carry), audit-pass (one coordinated, ordered, resumable pass over a named target — three-scope inventory, run-time-derived exclusion set, stable finding identity, suppression memory, resume, one human gate — delegating every check to the plugin that owns it), and unhobble (the empirical bare-baseline experiment: reversibly strip a repo's standing instructions, log real stumbles against the current model, re-add only what evidence earns).",
   "author": {
     "name": "Melodic Software",

--- a/plugins/claude-config/CHANGELOG.md
+++ b/plugins/claude-config/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to the `claude-config` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+
+## [0.37.1]
+
+### Changed
+
+- **`audit-permission-grants` no longer prescribes an unreachable bare-name-on-PATH fix.** P1
+  remediation and Phase 2 reporting now distinguish platforms where plugin `bin/` is reliably on the
+  Bash tool's PATH from the measured Windows/Git Bash gap recorded in the permission-rule-hygiene
+  convention — bundled-path grants and operator-setup notes replace the unconditional bare-name
+  prescription where that end state is not yet reachable.
+
 ## [0.37.0]
 
 ### Changed

--- a/plugins/claude-config/CHANGELOG.md
+++ b/plugins/claude-config/CHANGELOG.md
@@ -3,7 +3,6 @@
 All notable changes to the `claude-config` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
-
 ## [0.37.1]
 
 ### Changed

--- a/plugins/claude-config/skills/audit-permission-grants/SKILL.md
+++ b/plugins/claude-config/skills/audit-permission-grants/SKILL.md
@@ -100,9 +100,12 @@ If a scope filter was given, run the full detector and present only the matching
 
 Present findings as the severity-rated table in
 [reference/criteria.md](reference/criteria.md) "Output format". For each finding, give the concrete
-recommendation from its check: replace the fragile grant with the bare-name-on-PATH pattern from the
-convention, and add an **Operator setup** note where a user-global `~/.claude/settings.json` rule is
-required.
+recommendation from its check. For P1, match the platform reality the convention records: where
+plugin `bin/` is not reliably on the Bash tool's PATH (see the convention's **Known gap** section),
+prescribe the bundled-path grant that works today and an operator-setup note for the bare-name rule —
+do not unconditionally tell the operator to expose a bare command on PATH when that end state is not
+yet reachable on the measured platform. Add an **Operator setup** note wherever a user-global
+`~/.claude/settings.json` rule is required.
 
 ### Severity guide
 

--- a/plugins/claude-config/skills/audit-permission-grants/reference/criteria.md
+++ b/plugins/claude-config/skills/audit-permission-grants/reference/criteria.md
@@ -89,8 +89,14 @@ via an interpreter (`Bash(bash <fixed-path>:*)`) is flagged as the same authorin
 where the doc's dropped-category wording does not clearly reach it; the fix (a bare PATH command) is
 the same. See convention anti-pattern 1.
 
-**Recommend**: expose the helper as a bare command on PATH and allow the bare name narrowly. An
-`Agent` rule has no bare-PATH analog — remove or re-scope it, or run outside auto mode.
+**Recommend**: where the convention's bare-name-on-PATH end state is reachable (see its **Known gap —
+step 1's plugin `bin/` delivery** section), expose the helper as a bare command on PATH and allow the
+bare name narrowly. On platforms where plugin `bin/` is not reliably on the Bash tool's PATH — the
+measured default on Windows/Git Bash today — keep the finding and prescribe the bundled-path
+invocation that works now (`Bash(${CLAUDE_PLUGIN_ROOT}/bin/<helper>:*)` or `${CLAUDE_SKILL_DIR}` for a
+skill's own script), plus an operator-setup note for the bare-name rule the operator can add when
+delivery is stable. An `Agent` rule has no bare-PATH analog — remove or re-scope it, or run outside
+auto mode.
 
 ## P2: Hardcoded absolute machine/user path [error]
 


### PR DESCRIPTION
Recognize bare-name remediation platform gap in audit-permission-grants criteria and reporting.

Fixes #1398

## Summary

Recognize bare-name remediation platform gap in audit-permission-grants criteria and reporting.

## Related

N/A