### PR TITLE
feat(work-items): enforce standing-item schedule preconditions

### DIFF
--- a/.github/recurring-schedule.json
+++ b/.github/recurring-schedule.json
@@ -7,6 +7,11 @@
       "area": [],
       "category": "general",
       "triggers": ["frontier-model-release"],
+      "precondition": {
+        "id": "frontier-release-since-last-checked",
+        "prompt": "A frontier Claude model release must have occurred since last_checked. If none has, unclaim and leave the standing item open — never recheck-close on cadence alone.",
+        "requires_operator_confirmation": true
+      },
       "last_checked": "2026-08-08",
       "next_due": "2026-11-06",
       "notes": "On each frontier model release (primary trigger), run /claude-config:audit-instructions and /claude-config:unhobble over this repository's session surfaces to re-test which standing instructions the new model still needs. No automation observes the release event: the trigger's consumer is the standing OPEN [Maintenance] issue (#2019) — kept open continuously so /work-items:work can select it the moment an operator or agent notices a release, ahead of next_due. The quarterly cadence is a backstop only, guaranteeing the pass happens even when a release goes unnoticed (docs/PLUGIN-PHILOSOPHY.md, Instruction economy). Tier-4 caveat (known limitation, unenforced): last-resort selection can pick the open issue when no release has occurred, and neither the work skill's tier-4 step nor recheck's close step consults any precondition — the issue body instructs the claimant (no frontier release since last_checked: unclaim, leave open, never recheck-close), but honoring that depends on the claimant reading the body and deviating from the unconditional close step. If a premature close drains the item before a real release, re-open or re-create it from this row. Session surfaces only, never the shipped plugin components.",

--- a/.github/requirements-ci.txt
+++ b/.github/requirements-ci.txt
@@ -1,5 +1,18 @@
 # Keep this exact Linux x64 wheel pin and hash on a reviewed Dependabot surface.
 # Hosted and local plugin-gate jobs both use Ubuntu 24.04 x64.
+# pytest (and its dependency closure — pure-Python wheels, one hash each) is
+# pinned so the session-flow parse_transcript pytest suite RUNS in CI instead
+# of skipping green (#1313).
+iniconfig==2.3.0 \
+    --hash=sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12
+packaging==26.3 \
+    --hash=sha256:d7193f7c8e4e93f444fde0262bf90af30e16fa0ad0ad44cb553c87339b23cd1c
+pluggy==1.6.0 \
+    --hash=sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746
+pygments==2.20.0 \
+    --hash=sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176
+pytest==9.1.1 \
+    --hash=sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c
 ruff==0.16.2 \
     --hash=sha256:20e66910f2c37cc753f9ef6580c914a621b80c4fa3549d3e3521e29d0f5bfc3f \
     --hash=sha256:335c621622c4650330be50842561c6586ac6971bb8ab5407fe34dcc9efb16bbe \

--- a/plugins/work-items/.claude-plugin/plugin.json
+++ b/plugins/work-items/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "work-items",
-  "version": "0.35.5",
+  "version": "0.35.6",
   "description": "Manages development work items through a provider-neutral tracker seam that ships with the plugin (bundled dispatcher plus github and local-markdown adapters; seam plugin-dir canonical, adapters consumer-local-first): dashboard, taxonomy-labeled creation, a race-safe assignee-plus-lease claim protocol, recurring-schedule checks, TODO scanning, stale-lease auditing, plan decomposition into vertical-slice items, raw-intake triage (issues and unsolicited PRs through raw, verified, briefed, autonomous-eligible states), plus the two work-items loop lanes of the loop-lane convention: a self-paced autonomous work-loop drain (work-class admission gate, adaptive item cap, PR-only) and an attended attend-queue escalation lane. The re-runnable setup skill binds the provider (.work-item-tracker.json), seeds the recurring-schedule seam (.github/recurring-schedule.json), and remaps canonical role labels.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/work-items/CHANGELOG.md
+++ b/plugins/work-items/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to the `work-items` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.35.6]
+
+### Added
+
+- **Standing-item `precondition` field on recurring schedule rows (#2052).** Tier-4 `/work-items:work`
+  selection and `/work-items:track recheck` consult `precondition` via
+  `scripts/evaluate-schedule-precondition.sh` before claiming or closing. Migrated #2019's
+  frontier-release guard onto the new surface.
+
 ## [0.35.5]
 
 ### Fixed

--- a/plugins/work-items/reference/standing-item-preconditions.md
+++ b/plugins/work-items/reference/standing-item-preconditions.md
@@ -1,0 +1,42 @@
+# Standing-item preconditions
+
+Machine-readable guards on `.github/recurring-schedule.json` rows. The schedule
+`notes` field remains defense-in-depth; these fields are what `/work-items:work`
+tier-4 selection and `/work-items:track recheck` consult before claiming or
+closing (#2052).
+
+## Field shape
+
+Optional `precondition` object on a schedule row:
+
+| Key | Type | Meaning |
+|-----|------|---------|
+| `id` | string | Stable identifier for the check (`frontier-release-since-last-checked`, …) |
+| `prompt` | string | Inline guidance to surface when the precondition is not yet satisfied |
+| `requires_operator_confirmation` | boolean | When true, only an explicit operator confirmation satisfies the check — autonomous lanes must skip the row |
+
+Rows without `precondition` behave as today.
+
+## Supported `id` values
+
+### `frontier-release-since-last-checked`
+
+The standing item fires on frontier model releases, not on quarterly cadence alone.
+Before claiming (tier 4) or recheck-closing:
+
+1. Read the row's `last_checked` date.
+2. Ask whether a **frontier Claude model release** occurred **after** that date.
+3. If **no** (or unknown): **do not claim, do not recheck-close** — leave the open
+   `[Maintenance]` issue open and report the `prompt` text inline.
+4. If **yes**: proceed, and record in the claim/recheck comment that the operator
+   confirmed a post-`last_checked` frontier release.
+
+There is no automated release oracle in-repo; `requires_operator_confirmation: true`
+makes the confirmation explicit rather than inferred from cadence.
+
+## Seam helper
+
+`plugins/work-items/scripts/evaluate-schedule-precondition.sh` prints `met`,
+`unmet`, or `needs-confirmation` for a schedule row id. Pass
+`--operator-confirmed` when the operator has affirmed a confirmation-style
+precondition.

--- a/plugins/work-items/scripts/evaluate-schedule-precondition.sh
+++ b/plugins/work-items/scripts/evaluate-schedule-precondition.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# evaluate-schedule-precondition.sh — evaluate a recurring schedule row precondition.
+#
+# Usage:
+#   evaluate-schedule-precondition.sh <schedule.json> <item-id> [--operator-confirmed]
+#
+# Prints: met | unmet | needs-confirmation | no-precondition
+# Exit: 0 met/no-precondition; 1 unmet; 2 needs-confirmation
+
+set -euo pipefail
+
+SCHEDULE="${1:-}"
+ITEM_ID="${2:-}"
+OPERATOR_CONFIRMED=0
+shift 2 || true
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --operator-confirmed) OPERATOR_CONFIRMED=1; shift ;;
+    *) echo "ERROR: unknown flag: $1" >&2; exit 1 ;;
+  esac
+done
+
+[[ -n "$SCHEDULE" && -n "$ITEM_ID" ]] || {
+  echo "Usage: evaluate-schedule-precondition.sh <schedule.json> <item-id> [--operator-confirmed]" >&2
+  exit 1
+}
+command -v jq >/dev/null 2>&1 || { echo "ERROR: jq required" >&2; exit 1; }
+[[ -f "$SCHEDULE" ]] || { echo "ERROR: schedule not found: $SCHEDULE" >&2; exit 1; }
+
+row="$(jq -c --arg id "$ITEM_ID" '.items[] | select(.id == $id)' "$SCHEDULE")"
+[[ -n "$row" ]] || { echo "ERROR: no schedule row with id=$ITEM_ID" >&2; exit 1; }
+
+has_precond="$(printf '%s' "$row" | jq -r 'has("precondition")')"
+if [[ "$has_precond" != "true" ]]; then
+  echo "no-precondition"
+  exit 0
+fi
+
+precond_id="$(printf '%s' "$row" | jq -r '.precondition.id // empty')"
+requires_confirm="$(printf '%s' "$row" | jq -r '.precondition.requires_operator_confirmation // false')"
+
+case "$precond_id" in
+  frontier-release-since-last-checked)
+    if [[ "$requires_confirm" == "true" && "$OPERATOR_CONFIRMED" -eq 0 ]]; then
+      printf '%s\n' "$(printf '%s' "$row" | jq -r '.precondition.prompt // "precondition unmet"')"
+      echo "needs-confirmation"
+      exit 2
+    fi
+    echo "met"
+    exit 0
+    ;;
+  *)
+    printf 'ERROR: unknown precondition id: %s\n' "$precond_id" >&2
+    echo "unmet"
+    exit 1
+    ;;
+esac

--- a/plugins/work-items/scripts/evaluate-schedule-precondition.test.sh
+++ b/plugins/work-items/scripts/evaluate-schedule-precondition.test.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EVAL="$SCRIPT_DIR/evaluate-schedule-precondition.sh"
+TMP="$(mktemp)"
+trap 'rm -f "$TMP"' EXIT
+
+cat >"$TMP" <<'JSON'
+{
+  "items": [
+    {
+      "id": "demo",
+      "title": "Demo",
+      "precondition": {
+        "id": "frontier-release-since-last-checked",
+        "prompt": "confirm release",
+        "requires_operator_confirmation": true
+      }
+    },
+    {
+      "id": "plain",
+      "title": "Plain"
+    }
+  ]
+}
+JSON
+
+FAILED=0
+pass() { printf 'PASS: %s\n' "$1"; }
+fail() { FAILED=$((FAILED + 1)); printf 'FAIL: %s\n' "$1" >&2; }
+
+chmod +x "$EVAL"
+out="$("$EVAL" "$TMP" plain)"
+[[ "$out" == "no-precondition" ]] && pass "plain row has no precondition" || fail "plain row"
+
+rc=0
+"$EVAL" "$TMP" demo >/dev/null 2>&1 || rc=$?
+[[ "$rc" -eq 2 ]] && pass "confirmation precondition needs operator" || fail "confirmation precondition exit=$rc"
+
+rc=0
+out="$("$EVAL" "$TMP" demo --operator-confirmed)" || rc=$?
+[[ "$rc" -eq 0 && "$out" == "met" ]] && pass "operator confirmation satisfies precondition" || fail "confirmed path"
+
+[[ "$FAILED" -eq 0 ]] && exit 0
+exit 1

--- a/plugins/work-items/scripts/evaluate-schedule-precondition.test.sh
+++ b/plugins/work-items/scripts/evaluate-schedule-precondition.test.sh
@@ -32,15 +32,36 @@ fail() { FAILED=$((FAILED + 1)); printf 'FAIL: %s\n' "$1" >&2; }
 
 chmod +x "$EVAL"
 out="$("$EVAL" "$TMP" plain)"
-[[ "$out" == "no-precondition" ]] && pass "plain row has no precondition" || fail "plain row"
+if [[ "$out" == "no-precondition" ]]; then
+  pass "plain row has no precondition"
+else
+  fail "plain row"
+fi
 
 rc=0
-"$EVAL" "$TMP" demo >/dev/null 2>&1 || rc=$?
-[[ "$rc" -eq 2 ]] && pass "confirmation precondition needs operator" || fail "confirmation precondition exit=$rc"
+if ! "$EVAL" "$TMP" demo >/dev/null 2>&1; then
+  rc=$?
+fi
+if [[ "$rc" -eq 2 ]]; then
+  pass "confirmation precondition needs operator"
+else
+  fail "confirmation precondition exit=$rc"
+fi
 
 rc=0
-out="$("$EVAL" "$TMP" demo --operator-confirmed)" || rc=$?
-[[ "$rc" -eq 0 && "$out" == "met" ]] && pass "operator confirmation satisfies precondition" || fail "confirmed path"
+out=""
+if out="$("$EVAL" "$TMP" demo --operator-confirmed)"; then
+  :
+else
+  rc=$?
+fi
+if [[ "$rc" -eq 0 && "$out" == "met" ]]; then
+  pass "operator confirmation satisfies precondition"
+else
+  fail "confirmed path"
+fi
 
-[[ "$FAILED" -eq 0 ]] && exit 0
+if [[ "$FAILED" -eq 0 ]]; then
+  exit 0
+fi
 exit 1

--- a/plugins/work-items/scripts/evaluate-schedule-precondition.test.sh
+++ b/plugins/work-items/scripts/evaluate-schedule-precondition.test.sh
@@ -39,9 +39,8 @@ else
 fi
 
 rc=0
-if ! "$EVAL" "$TMP" demo >/dev/null 2>&1; then
-  rc=$?
-fi
+"$EVAL" "$TMP" demo >/dev/null 2>&1
+rc=$?
 if [[ "$rc" -eq 2 ]]; then
   pass "confirmation precondition needs operator"
 else
@@ -49,12 +48,8 @@ else
 fi
 
 rc=0
-out=""
-if out="$("$EVAL" "$TMP" demo --operator-confirmed)"; then
-  :
-else
-  rc=$?
-fi
+out="$("$EVAL" "$TMP" demo --operator-confirmed)"
+rc=$?
 if [[ "$rc" -eq 0 && "$out" == "met" ]]; then
   pass "operator confirmation satisfies precondition"
 else

--- a/plugins/work-items/skills/track/actions/recheck.md
+++ b/plugins/work-items/skills/track/actions/recheck.md
@@ -29,7 +29,7 @@ fi
 
 If multiple matches, present them and ask the user to clarify.
 
-1. **Evaluate any `precondition` on the matched row** before mutating dates or closing the issue ([`reference/standing-item-preconditions.md`](${CLAUDE_PLUGIN_ROOT}/reference/standing-item-preconditions.md)):
+1. **Evaluate any `precondition` on the matched row** before mutating dates or closing the issue ([`${CLAUDE_PLUGIN_ROOT}/reference/standing-item-preconditions.md`](${CLAUDE_PLUGIN_ROOT}/reference/standing-item-preconditions.md)):
 
 ```bash
 EVAL="${CLAUDE_PLUGIN_ROOT}/scripts/evaluate-schedule-precondition.sh"

--- a/plugins/work-items/skills/track/actions/recheck.md
+++ b/plugins/work-items/skills/track/actions/recheck.md
@@ -29,6 +29,16 @@ fi
 
 If multiple matches, present them and ask the user to clarify.
 
+1. **Evaluate any `precondition` on the matched row** before mutating dates or closing the issue ([`reference/standing-item-preconditions.md`](${CLAUDE_PLUGIN_ROOT}/reference/standing-item-preconditions.md)):
+
+```bash
+EVAL="${CLAUDE_PLUGIN_ROOT}/scripts/evaluate-schedule-precondition.sh"
+[[ -f "$EVAL" ]] || EVAL="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel)}/plugins/work-items/scripts/evaluate-schedule-precondition.sh"
+"$EVAL" "$SCHEDULE" "<matched-id>"   # add --operator-confirmed when the operator affirmed
+```
+
+Refuse to advance `last_checked`/`next_due` or close the associated issue when the helper exits `2` (`needs-confirmation`) or `1` (`unmet`). Surface the printed prompt inline instead.
+
 1. **Update dates.** Always set `last_checked` to today. Only advance `next_due` if it's in the past or today — if it's already in the future, the recurring-issues automation has already advanced it and re-advancing would skip a cycle.
 
 | Cadence | Days |

--- a/plugins/work-items/skills/work/SKILL.md
+++ b/plugins/work-items/skills/work/SKILL.md
@@ -166,7 +166,7 @@ For tier 1 and tier 4 (recurring candidates), cross-reference against open items
 
 **Last-resort recurring tiers (`last-resort: true` AND `where: 'next_due > today'`):** by design the consuming repo's recurring-issues automation typically creates items only when `next_due <= today`, so there is usually no open item to hold. Since picking early shifts the cadence, **skip last-resort candidates that have no open item and advance to the next candidate**. Only hold/claim a last-resort item when an open one already exists. If every last-resort candidate is skipped for lack of an item, report "no actionable work" rather than forcing one into existence.
 
-**Standing-item preconditions (tiers 1 and 4).** After a recurring candidate is identified and before cross-reference/claim, evaluate any `precondition` on its schedule row ([`reference/standing-item-preconditions.md`](${CLAUDE_PLUGIN_ROOT}/reference/standing-item-preconditions.md)):
+**Standing-item preconditions (tiers 1 and 4).** After a recurring candidate is identified and before cross-reference/claim, evaluate any `precondition` on its schedule row ([`${CLAUDE_PLUGIN_ROOT}/reference/standing-item-preconditions.md`](${CLAUDE_PLUGIN_ROOT}/reference/standing-item-preconditions.md)):
 
 ```bash
 SCHEDULE="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel)}/.github/recurring-schedule.json"

--- a/plugins/work-items/skills/work/SKILL.md
+++ b/plugins/work-items/skills/work/SKILL.md
@@ -166,6 +166,21 @@ For tier 1 and tier 4 (recurring candidates), cross-reference against open items
 
 **Last-resort recurring tiers (`last-resort: true` AND `where: 'next_due > today'`):** by design the consuming repo's recurring-issues automation typically creates items only when `next_due <= today`, so there is usually no open item to hold. Since picking early shifts the cadence, **skip last-resort candidates that have no open item and advance to the next candidate**. Only hold/claim a last-resort item when an open one already exists. If every last-resort candidate is skipped for lack of an item, report "no actionable work" rather than forcing one into existence.
 
+**Standing-item preconditions (tiers 1 and 4).** After a recurring candidate is identified and before cross-reference/claim, evaluate any `precondition` on its schedule row ([`reference/standing-item-preconditions.md`](${CLAUDE_PLUGIN_ROOT}/reference/standing-item-preconditions.md)):
+
+```bash
+SCHEDULE="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel)}/.github/recurring-schedule.json"
+EVAL="${CLAUDE_PLUGIN_ROOT}/scripts/evaluate-schedule-precondition.sh"
+[[ -f "$EVAL" ]] || EVAL="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel)}/plugins/work-items/scripts/evaluate-schedule-precondition.sh"
+"$EVAL" "$SCHEDULE" "<schedule-item-id>"   # add --operator-confirmed when the operator affirmed
+```
+
+- Exit `0` with `met` or `no-precondition` → proceed.
+- Exit `2` with `needs-confirmation` → surface the printed `prompt` inline, **skip this candidate**, and do not claim. Autonomous invocations must skip without claiming unless the invocation explicitly records operator confirmation for that schedule id (then pass `--operator-confirmed`).
+- Exit `1` with `unmet` → skip the candidate and report why.
+
+This is what makes #2019's tier-4 caveat enforceable instead of convention-only prose in the issue body.
+
 ### Step 3: Present and confirm
 
 Because the frontier is already unassigned + unblocked, present the top candidate directly — no pre-hold is needed (the seam `claim` in Step 4 is the atomic acquisition point):


### PR DESCRIPTION
Fixes #2052

- Adds optional \`precondition\` object on \`.github/recurring-schedule.json\` rows
- \`scripts/evaluate-schedule-precondition.sh\` (+ tests)
- \`/work-items:work\` tiers 1/4 and \`/work-items:track recheck\` honor preconditions before claim/close
- Migrates #2019's \`frontier-release-since-last-checked\` guard onto the new surface

Docs: \`plugins/work-items/reference/standing-item-preconditions.md\`

## Related

- Refs #2019 (frontier-release-since-last-checked guard migrated onto the new precondition surface).