### PR TITLE
fix(scripts): make plugin-test skips loud and run the pytest suite in CI

### DIFF
--- a/.github/requirements-ci.txt
+++ b/.github/requirements-ci.txt
@@ -1,5 +1,18 @@
 # Keep this exact Linux x64 wheel pin and hash on a reviewed Dependabot surface.
 # Hosted and local plugin-gate jobs both use Ubuntu 24.04 x64.
+# pytest (and its dependency closure — pure-Python wheels, one hash each) is
+# pinned so the session-flow parse_transcript pytest suite RUNS in CI instead
+# of skipping green (#1313).
+iniconfig==2.3.0 \
+    --hash=sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12
+packaging==26.3 \
+    --hash=sha256:d7193f7c8e4e93f444fde0262bf90af30e16fa0ad0ad44cb553c87339b23cd1c
+pluggy==1.6.0 \
+    --hash=sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746
+pygments==2.20.0 \
+    --hash=sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176
+pytest==9.1.1 \
+    --hash=sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c
 ruff==0.16.2 \
     --hash=sha256:20e66910f2c37cc753f9ef6580c914a621b80c4fa3549d3e3521e29d0f5bfc3f \
     --hash=sha256:335c621622c4650330be50842561c6586ac6971bb8ab5407fe34dcc9efb16bbe \

--- a/scripts/run-plugin-tests.sh
+++ b/scripts/run-plugin-tests.sh
@@ -8,7 +8,20 @@
 # Each test is self-contained and cwd-independent; an individual test SKIPs
 # (exit 0) when an optional tool it needs (shellcheck, shfmt, ...) is absent, so
 # this runner gates on real failures without requiring every tool to be present.
+#
+# Skips are never silent: the summary names every suite that skipped and why,
+# so "exit 0 with skips" reads differently from "all green" (#1313 — a suite
+# whose only coverage skipped used to be indistinguishable from a pass).
+# --strict-skips turns any optional SKIP into a failure, for callers that have
+# provisioned the full toolchain and want a skip to mean the environment
+# regressed rather than that a tool is optional.
 set -uo pipefail
+
+strict_skips=0
+if [[ "${1:-}" == "--strict-skips" ]]; then
+  strict_skips=1
+  shift
+fi
 
 cd "$(dirname "${BASH_SOURCE[0]}")/.." || exit 1
 
@@ -22,6 +35,7 @@ fi
 failed=0
 total_optional_skips=0
 total_discriminating_skips=0
+skipped_suites=()
 
 if command -v git >/dev/null 2>&1; then
   echo "Runner git: $(git --version)"
@@ -42,6 +56,10 @@ for t in "${tests[@]}"; do
   disc_skips="$(grep -c '^DISCRIMINATING SKIP:' "$log" 2>/dev/null || true)"
   total_optional_skips=$((total_optional_skips + opt_skips))
   total_discriminating_skips=$((total_discriminating_skips + disc_skips))
+  if ((opt_skips > 0)); then
+    first_reason="$(grep -m1 '^SKIP:' "$log")"
+    skipped_suites+=("$t — ${opt_skips} SKIP(s), first: ${first_reason#SKIP: }")
+  fi
   if ((disc_skips > 0)); then
     echo "DISCRIMINATING SKIP: $t vacated $disc_skips discriminating case(s)" >&2
   fi
@@ -50,6 +68,12 @@ done
 
 echo ""
 echo "Plugin test aggregate: ${total_optional_skips} optional SKIP(s), ${total_discriminating_skips} DISCRIMINATING SKIP(s)."
+if ((${#skipped_suites[@]} > 0)); then
+  echo "Suites with skipped coverage (exit 0 here is NOT evidence those cases ran):"
+  for s in "${skipped_suites[@]}"; do
+    echo "  SKIPPED: $s"
+  done
+fi
 
 if ((total_discriminating_skips > 0)); then
   {
@@ -59,8 +83,20 @@ if ((total_discriminating_skips > 0)); then
   failed=1
 fi
 
+if ((strict_skips)) && ((total_optional_skips > 0)); then
+  {
+    echo "--strict-skips: ${total_optional_skips} optional SKIP(s) occurred in an"
+    echo "environment declared to have the full toolchain — treating as failure."
+  } >&2
+  failed=1
+fi
+
 if [[ $failed -ne 0 ]]; then
   echo "One or more plugin tests failed." >&2
   exit 1
 fi
-echo "All plugin tests passed or were skipped."
+if ((total_optional_skips > 0)); then
+  echo "All executed plugin tests passed; ${total_optional_skips} case(s) skipped (named above)."
+else
+  echo "All plugin tests passed."
+fi


### PR DESCRIPTION
Fixes #1313

## Summary

`run-plugin-tests.sh` could exit 0 while the only Python suite silently skipped (`SKIP: pytest not installed`), making a green run indistinguishable from verified coverage. Skips are now named per suite in the summary, a `--strict-skips` mode turns them into failures for fully-provisioned callers, and pytest is pinned into CI so the `parse_transcript` suite actually runs there.

## Fix

- The runner records every suite that emitted a `SKIP:` line and prints a `Suites with skipped coverage` section naming each suite, its skip count, and the first reason; the final line now reads `All executed plugin tests passed; N case(s) skipped (named above).` instead of the old undifferentiated `All plugin tests passed or were skipped.`
- `--strict-skips` treats any optional SKIP as a failure, for environments that declare the full toolchain (CI is deliberately not wired to it yet — its toolchain is also missing goimports, typos, PSScriptAnalyzer, and the deliberately-optional shfmt, so blanket strictness is a separate toolchain-completion decision).
- `.github/requirements-ci.txt` pins pytest 9.1.1 and its pure-Python dependency closure (iniconfig, packaging, pluggy, pygments), one sha256 hash each, on the same reviewed Dependabot surface as the existing ruff pin — so the session-flow pytest suite runs in CI instead of skipping green.

## Verification

- Synthetic-tree run of the modified runner: default mode exits 0 and prints `SKIPPED: plugins/demo/skipper.test.sh — 1 SKIP(s), first: pytest not installed for python3`; `--strict-skips` exits 1 with the strict message; an all-green tree prints `All plugin tests passed.` with no skip section.
- `bash plugins/session-flow/skills/retro/scripts/parse-transcript.test.sh` with pytest installed: `37 passed`.
- `shellcheck` and `shfmt -d` clean on the runner.

## Related

- `scripts/check-silent-skips.sh` — same anti-silent-skip posture, scoped to hook entry scripts; extending it to test harnesses stays a separate decision per the triage panel.
- Refs #1296 (the PR whose near-miss motivated this issue).