### PR TITLE
fix(scripts): recognize container-nested block comments in the skill-portability gate

### DIFF
--- a/scripts/check-skill-portability.sh
+++ b/scripts/check-skill-portability.sh
@@ -151,7 +151,13 @@ scan_file() {
   # #1513), not a bare substring match anywhere in the file: an unanchored
   # search would also match this very sentence (a doc-block comment merely
   # explaining the mechanism) or a mention inside prose/a string literal.
-  if grep -qE '^[[:space:]]*(#|<!--)[[:space:]]*portability-scope:' -- "$file"; then
+  # The `<!--` alternative also admits a block comment nested inside Markdown
+  # list/blockquote containers (`- <!--`, `> <!--`, `1. <!--`, nested
+  # combinations) — the opener is still the first content of its container, so
+  # it is a genuine dedicated comment line, not the #611 mid-sentence case.
+  # Each container marker must be followed by whitespace, so prose that merely
+  # contains a dash or digit before an inline `<!--` stays rejected. See #1342.
+  if grep -qE '^[[:space:]]*(#|((>|[-*+]|[0-9]+[.)])[[:space:]]+)*<!--)[[:space:]]*portability-scope:' -- "$file"; then
     return 0
   fi
   # awk operand disambiguation: a bare relative operand shaped like
@@ -173,7 +179,17 @@ scan_file() {
     # count as a comment line for pending_annot carry-forward purposes — only a
     # line whose `<!--` opens at the start (after optional whitespace) is a
     # genuine dedicated comment line. See #611.
-    function is_comment(l) { return l ~ /^[[:space:]]*#/ || l ~ /^[[:space:]]*<!--/ }
+    #
+    # A block comment nested inside Markdown list/blockquote containers
+    # (`- <!--`, `> <!--`, `1. <!--`, nested combinations like `> - <!--`)
+    # still qualifies: the opener is the first content of its container, so the
+    # line is dedicated to the comment. Each container marker must be followed
+    # by whitespace, which keeps the #611 mid-sentence shape (any real prose
+    # before the `<!--`) rejected. See #1342.
+    function is_comment(l) {
+      return l ~ /^[[:space:]]*#/ ||
+        l ~ /^[[:space:]]*((>|[-*+]|[0-9]+[.)])[[:space:]]+)*<!--/
+    }
     # Guard markers for the active branch class: branch-detection evidence ONLY
     # — a symbolic-ref / merge-base / origin/HEAD / PR-baseRefName resolution
     # command (or a `-> origin/` symbolic-ref target) co-located on the hit line.

--- a/scripts/check-skill-portability.test.sh
+++ b/scripts/check-skill-portability.test.sh
@@ -204,6 +204,46 @@ else
 fi
 rm -f "$f"
 
+# --- container-nested block comments still count as comment lines (#1342) --
+# A `<!--` opener that is the first content of a Markdown list item or
+# blockquote is a dedicated comment line, so a portability-ok annotation
+# written in that style must set/carry pending_annot to the line it precedes.
+for prefix in '- ' '> ' '* ' '+ ' '1. ' '2) ' '> - '; do
+  f="$(tmpfile "${prefix}<!-- portability-ok: container-nested annotation -->
+The base branch is origin/main here.")"
+  if scan_paths "$f" >/dev/null 2>&1; then
+    ok "container-nested annotation comment (\`${prefix}<!--\`) carries to the next line"
+  else
+    fail "container-nested annotation comment (\`${prefix}<!--\`) should exempt the next line"
+  fi
+  rm -f "$f"
+done
+
+# --- a list-item CONTENT line with an inline comment is still not a comment --
+# line (#1342 must not reopen #611): the marker is followed by prose, not by
+# the `<!--` opener, so pending_annot must reset and line 3 must flag.
+f="$(tmpfile '<!-- portability-ok: covers only line 2 -->
+- diff against origin/main here <!-- inline note, not an annotation -->
+- diff against origin/main again, unannotated')"
+if out="$(scan_paths "$f" 2>&1)"; then
+  fail "list-item content line with inline comment must not carry annotation to line 3, got success: $out"
+elif echo "$out" | grep -q ":3:" && ! echo "$out" | grep -q ":2:"; then
+  ok "list-item content line with inline HTML comment does not extend pending_annot"
+else
+  fail "expected line 3 flagged and line 2 excused (annotated above), got: $out"
+fi
+rm -f "$f"
+
+# --- blockquote-nested whole-file portability-scope declaration passes ------
+f="$(tmpfile '> <!-- portability-scope: forge=github — inherent, declared boundary -->
+This skill diffs origin/main and pushes with origin/master.')"
+if scan_paths "$f" >/dev/null 2>&1; then
+  ok "blockquote-nested portability-scope declaration exempts the file"
+else
+  fail "blockquote-nested portability-scope declaration should exempt the file"
+fi
+rm -f "$f"
+
 # --- whole-file portability-scope declaration passes -----------------------
 f="$(tmpfile '<!-- portability-scope: forge=github — inherent, declared boundary -->
 This skill diffs origin/main and pushes with origin/master.')"


### PR DESCRIPTION
Fixes #1342

## Summary

A `portability-ok`/`portability-scope` annotation written as the first content of a Markdown list item or blockquote (`- <!-- ... -->`, `> <!-- ... -->`) was classified as a non-comment line by the #611 anchor, so it cleared `pending_annot` instead of setting it and the gate would wrongly flag the line it was meant to exempt. Forward-looking hardening — no annotation in the corpus uses this shape today.

## Fix

`scripts/check-skill-portability.sh` widens the HTML-comment anchor from `^[[:space:]]*<!--` to admit an optional chain of Markdown container markers before the opener: `((>|[-*+]|[0-9]+[.)])[[:space:]]+)*`. Each marker must be followed by whitespace and the chain must start at line start, so the #611 mid-sentence inline-comment shape stays rejected. Applied to both consumers of the anchor: `is_comment()` (annotation carry-forward) and the whole-file `portability-scope:` declaration grep.

## Verification

`bash scripts/check-skill-portability.test.sh` — 88 passing, 0 failing, including 9 new cases: seven container prefixes (`- `, `> `, `* `, `+ `, `1. `, `2) `, nested `> - `) carrying an annotation to the next line, a list-item content line with an inline comment still resetting `pending_annot` (line 3 flagged, line 2 excused), and a blockquote-nested `portability-scope` declaration exempting the file. `shellcheck` clean on both files.

## Related

- Refs #611 (the anchor this widens without reopening), #624 (sibling escape-hatch grammar thread), PR #1338 (where the bot finding was raised).