### PR TITLE
docs(loop-lane): re-audit the capability-tier table for Opus 5 and Fable 5

### DIFF
--- a/docs/conventions/loop-lane/CHANGELOG.md
+++ b/docs/conventions/loop-lane/CHANGELOG.md
@@ -5,6 +5,27 @@ topology, the escalation contract, the capability-tier vocabulary, or any loop-l
 major bump, and additive guidance is a minor bump. A new model release re-audits the capability-tier
 table (§3); drift found by that audit is recorded here.
 
+## 8.1.0 — 2026-08-12
+
+Additive, minor — §3 gains a **Current alias binding** subsection recording the capability-tier
+re-audit for the Opus 5 / Fable 5 lineup (#1293). This is the §Versioning "new model release
+re-audits the capability-tier table" trigger firing: both models shipped with no re-audit entry
+here. The tier vocabulary, the fixed rules, and every invariant are unchanged; what lands is the
+dated resolution the trigger exists to re-derive, expressed as aliases and never dated model IDs.
+
+- **frontier → `best`, strong → `opus`, fast → `sonnet`; `haiku` admissible nowhere.** Sourced from
+  live fetches of the model-config and models-overview pages on 2026-08-12. The two decisions the
+  obvious binding would have gotten wrong: frontier binds the `best` alias rather than `fable`
+  because `best` self-heals across Fable 5's availability preconditions while meaning exactly
+  "most capable available"; and strong stays on `opus` despite Fable 5 outranking it, because
+  Opus 5's reliable knowledge cutoff (May 2026) is four months fresher than Fable 5's (Jan 2026)
+  and the implementer tier is where harness-knowledge freshness pays. Haiku 4.5 (200k context,
+  Feb 2025 cutoff) fails the reviewer-never-weaker floor in every reachable pairing.
+- **Two Fable 5 known gaps recorded with the binding:** safety-classifier automatic model fallback
+  (most often in cybersecurity domains — the very work frontier unconditionally receives) is
+  undetected by any lane today; and non-interactive Fable 5 requests bill usage credits without a
+  consent prompt, the shape unattended lanes run in.
+
 ## 8.0.1 — 2026-08-05
 
 Corrective, no topology, escalation, tier, or invariant change — §"Out-of-band notification seam"

--- a/docs/conventions/loop-lane/README.md
+++ b/docs/conventions/loop-lane/README.md
@@ -332,6 +332,41 @@ pairings are valid, and a fast orchestrator paired with an advisor at or above t
 recommended shape); a reviewer or verifier is never weaker than the implementer; a security-surface
 work class routes to the frontier tier unconditionally.
 
+### Current alias binding (re-audited 2026-08-12)
+
+The dated resolution of the ordered tiers to live aliases — the artifact the "new model release"
+recheck trigger re-derives. Sourced from live fetches of
+<https://code.claude.com/docs/en/model-config> and
+<https://platform.claude.com/docs/en/about-claude/models/overview> on 2026-08-12 (#1293):
+
+| Tier | Alias | Resolves to today |
+|---|---|---|
+| frontier | `best` | Fable 5 where the organization has access, else the latest Opus |
+| strong | `opus` | Opus 5 |
+| fast | `sonnet` | Sonnet 5 |
+
+- **frontier binds `best`, not `fable`.** `best` is the docs' live handle for exactly the frontier
+  tier's meaning — "Fable 5 where your organization has access to it, otherwise the latest Opus" —
+  so a frontier dispatch self-heals where Fable 5 is unavailable (it requires organization access
+  and Claude Code v2.1.170+, and can bill to usage credits) instead of failing or silently running
+  a stale pin. Two Fable 5 caveats ride along as **known gaps**: its safety classifiers can trigger
+  automatic model fallback "most often in cybersecurity and biology domains", and frontier is the
+  tier every security-surface work class routes to — no lane detects that fallback today; and in
+  non-interactive mode a Fable 5 request that would bill usage credits bills them without a consent
+  prompt, which is the shape every unattended lane runs in.
+- **strong binds `opus`.** The docs' own starting recommendation "for complex agentic coding and
+  enterprise work" — and Opus 5's reliable knowledge cutoff (May 2026) is four months *fresher*
+  than Fable 5's (Jan 2026). For lanes whose subject matter is fast-moving harness behavior, the
+  implementer tier benefits most from the fresher model, so raw capability order (Fable above
+  Opus) deliberately does not decide this binding alone.
+- **fast binds `sonnet`.** "Best combination of speed and intelligence", native 1M context, Jan
+  2026 reliable cutoff — enough headroom to orchestrate and to review mechanical items without
+  breaching the reviewer floor.
+- **`haiku` is admissible nowhere in these lanes today.** Its 200k context sits against 1M
+  everywhere else, and its Feb 2025 reliable cutoff predates the harness surfaces these lanes
+  operate on; since the fast tier also covers reviewers and the implementer is always
+  sonnet-or-above, binding `haiku` anywhere would breach the reviewer-never-weaker floor.
+
 **Independence, where a dispatch stands in for human ratification.** The one dispatch that resolves
 a blocker in place of a human decision — the explicit-`autopilot` merge-authority exception (above)
 — additionally requires the frontier-tier subagent to be a **fresh context sharing no conversation


### PR DESCRIPTION
Fixes #1293

## Summary

Fires the loop-lane convention's own "new model release re-audits the capability-tier table" trigger, which had not fired for either Opus 5 or Fable 5. Section 3 gains a dated **Current alias binding** subsection (frontier → `best`, strong → `opus`, fast → `sonnet`, `haiku` admissible nowhere), and CHANGELOG entry 8.1.0 records the audit and its trigger.

## Fix

The binding is expressed as aliases, never dated model IDs, per the acceptance criteria. Frontier binds `best` rather than `fable` because `best` resolves to "Fable 5 where your organization has access to it, otherwise the latest Opus" — self-healing across Fable 5's availability preconditions while meaning exactly what the frontier tier means. Strong stays on `opus` because Opus 5's reliable knowledge cutoff (May 2026) is four months fresher than Fable 5's (Jan 2026), and the implementer tier is where harness-knowledge freshness pays. Haiku 4.5 fails the reviewer-never-weaker floor in every reachable pairing (200k context, Feb 2025 cutoff). Two Fable 5 known gaps are recorded alongside: safety-classifier automatic fallback on exactly the security-surface work frontier receives, and promptless usage-credit billing in non-interactive mode. Tier vocabulary, fixed rules, and invariants are unchanged — additive guidance, minor bump 8.1.0.

## Verification

- Sourced from live fetches of <https://code.claude.com/docs/en/model-config> and <https://platform.claude.com/docs/en/about-claude/models/overview> on 2026-08-12; they confirm the issue's 2026-07-25 fact table.
- `markdownlint-cli2` clean on both edited files.

## Related

- Refs #1698 (the deferred statusline drift indicator from the same workstream, closed separately with rationale).