### PR TITLE
fix(scripts): recognize Markdown list/blockquote portability comments

### DIFF
--- a/scripts/check-skill-portability.sh
+++ b/scripts/check-skill-portability.sh
@@ -173,7 +173,13 @@ scan_file() {
     # count as a comment line for pending_annot carry-forward purposes — only a
     # line whose `<!--` opens at the start (after optional whitespace) is a
     # genuine dedicated comment line. See #611.
-    function is_comment(l) { return l ~ /^[[:space:]]*#/ || l ~ /^[[:space:]]*<!--/ }
+    # Block-level HTML comments may follow Markdown list/blockquote prefixes
+    # (`- <!-- ... -->`, `> <!-- ... -->`, etc.) — see #1342; mid-line `<!--`
+    # markers in prose still do not count (#611).
+    function is_comment(l) {
+      return l ~ /^[[:space:]]*#/ \
+        || l ~ /^[[:space:]]*(([-*+] |[0-9]+\.[[:space:]]|>[[:space:]]))*<!--/
+    }
     # Guard markers for the active branch class: branch-detection evidence ONLY
     # — a symbolic-ref / merge-base / origin/HEAD / PR-baseRefName resolution
     # command (or a `-> origin/` symbolic-ref target) co-located on the hit line.

--- a/scripts/check-skill-portability.test.sh
+++ b/scripts/check-skill-portability.test.sh
@@ -204,6 +204,36 @@ else
 fi
 rm -f "$f"
 
+# --- Markdown list/blockquote-prefixed block comments count (#1342) ---------
+f="$(tmpfile '- <!-- portability-ok: list-item annotation -->
+diff against origin/main here')"
+if scan_paths "$f" >/dev/null 2>&1; then
+  ok "list-item portability-ok comment exempts the next line"
+else
+  fail "list-item portability-ok comment should exempt the next line"
+fi
+rm -f "$f"
+
+f="$(tmpfile '> <!-- portability-ok: blockquote annotation -->
+diff against origin/main here')"
+if scan_paths "$f" >/dev/null 2>&1; then
+  ok "blockquote portability-ok comment exempts the next line"
+else
+  fail "blockquote portability-ok comment should exempt the next line"
+fi
+rm -f "$f"
+
+f="$(tmpfile 'Prose with <!-- portability-ok: inline marker --> mid-line
+diff against origin/main here')"
+if out="$(scan_paths "$f" 2>&1)"; then
+  fail "mid-line portability-ok marker must not exempt the next line, got success: $out"
+elif echo "$out" | grep -q ":2:"; then
+  ok "mid-line portability-ok marker does not exempt the next line"
+else
+  fail "expected line 2 flagged after mid-line marker, got: $out"
+fi
+rm -f "$f"
+
 # --- whole-file portability-scope declaration passes -----------------------
 f="$(tmpfile '<!-- portability-scope: forge=github — inherent, declared boundary -->
 This skill diffs origin/main and pushes with origin/master.')"


### PR DESCRIPTION
## Summary

Widen \`is_comment()\` in \`scripts/check-skill-portability.sh\` so a block-level \`<!-- portability-ok: ... -->\` / \`<!-- portability-scope: ... -->\` line may follow Markdown list or blockquote prefixes (\`-\`, \`*\`, \`+\`, ordered-list markers, \`>\`) while still rejecting mid-line inline markers (#611).

## Verification

\`bash scripts/check-skill-portability.test.sh\` — **82 pass, 0 fail** (adds list, blockquote, and mid-line regression cases).

Fixes #1342

## Related

- Refs #611 (the anchor this widens without reopening mid-line inline-comment rejection).