### PR TITLE
fix(scripts): require a nonempty portability-ok reason

### DIFF
--- a/scripts/check-skill-portability.sh
+++ b/scripts/check-skill-portability.sh
@@ -167,7 +167,7 @@ scan_file() {
   *) awk_file="./$awk_file" ;;
   esac
   awk '
-    function is_annotated(l) { return l ~ /portability-ok:/ }
+    function is_annotated(l) { return l ~ /portability-ok:[[:space:]]*[^[:space:]#<\-]/ }
     # Block-level only: a content line that merely happens to carry an inline
     # HTML comment marker (e.g. prose with `<!-- note -->` mid-line) must NOT
     # count as a comment line for pending_annot carry-forward purposes — only a

--- a/scripts/check-skill-portability.test.sh
+++ b/scripts/check-skill-portability.test.sh
@@ -160,6 +160,17 @@ else
 fi
 rm -f "$f"
 
+# --- empty portability-ok does not exempt (#624 finding 2) ------------------
+f="$(tmpfile 'reset --hard origin/main <!-- portability-ok: -->')"
+if out="$(scan_paths "$f" 2>&1)"; then
+  fail "empty portability-ok should not exempt the hit, got success: $out"
+elif echo "$out" | grep -q "COUPLING:"; then
+  ok "empty portability-ok does not exempt"
+else
+  fail "expected COUPLING for empty portability-ok, got: $out"
+fi
+rm -f "$f"
+
 # --- portability-ok in the comment block above passes ----------------------
 f="$(tmpfile '<!-- portability-ok: this reference is intentionally pinned -->
 The base branch is origin/main here.')"


### PR DESCRIPTION
## Summary

Tighten \`is_annotated()\` in \`scripts/check-skill-portability.sh\` so \`portability-ok:\` must be followed by a non-whitespace reason character before the HTML comment closes. Empty \`<!-- portability-ok: -->\` no longer suppresses hits.

## Verification

\`bash scripts/check-skill-portability.test.sh\` — **80 pass, 0 fail**.

No linked issue

## Related

- Refs #624 (finding 2 — nonempty portability-ok reason; finding 1 standalone \`portability-scope:\` grammar remains open).