### PR TITLE
feat(scripts): add warn-only gate for git-bearing multi-line precompute blocks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1009,6 +1009,10 @@ jobs:
       # event like the schema step above.
       - name: Lint every eval set for quality
         run: bash plugins/skill-quality/scripts/check-evals-quality.sh plugins/*/skills/*/evals/evals.json
+      - name: Test the precompute-compose gate
+        run: bash scripts/check-skill-precompute-compose.test.sh
+      - name: Report precompute git+multi-line violations (warn-only)
+        run: scripts/check-skill-precompute-compose.sh --all
       - name: Test the shared listing-budget reporter
         run: bash plugins/skill-quality/scripts/check-listing-budget.test.sh
       # Report-only (always exit 0 — see the script's own header): pools every

--- a/scripts/check-skill-precompute-compose.sh
+++ b/scripts/check-skill-precompute-compose.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# Gate: a skill whose ## Pre-computed context block contains a git command AND
+# more than one inline `!`command`` injection line is refused in worktree-
+# isolated agents (#1619). Adding a second precompute line silently breaks
+# such skills — CI stays green, normal sessions render fine, only isolated
+# agents fail.
+#
+#   scripts/check-skill-precompute-compose.sh --all
+#   scripts/check-skill-precompute-compose.sh <base-ref>
+#   scripts/check-skill-precompute-compose.sh --paths FILE...
+#
+# Default mode is warn-only (exit 0, prints violations) until the #1619
+# remediation wave graduates the gate to --strict. Pass --strict to fail closed.
+#
+# Exit 0 = clean or warn-only violations; 1 = violations in --strict mode;
+# 2 = usage / environment error.
+set -uo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.." || exit 2
+
+STRICT=0
+POSITIONAL=()
+
+usage() {
+  printf 'usage: check-skill-precompute-compose.sh --all | <base-ref> | --paths FILE...\n' >&2
+  printf '       [--strict]  fail closed on violations (default: warn-only)\n' >&2
+  exit 2
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+  --strict) STRICT=1; shift ;;
+  -h | --help) usage ;;
+  -- | --all | --paths)
+    POSITIONAL+=("$1")
+    shift
+    break
+    ;;
+  *)
+    POSITIONAL+=("$1")
+    shift
+    ;;
+  esac
+done
+POSITIONAL+=("$@")
+
+if [[ ${#POSITIONAL[@]} -eq 0 ]]; then
+  usage
+fi
+
+first="${POSITIONAL[0]}"
+rest=("${POSITIONAL[@]:1}")
+
+# precompute_block <file> — print the ## Pre-computed context section body.
+precompute_block() {
+  awk '
+    /^## Pre-computed context[[:space:]]*$/ { in_block = 1; next }
+    in_block && /^## / { in_block = 0 }
+    in_block { print }
+  ' "$1"
+}
+
+# line_has_git <line> — git appears as a command (word-boundary), not prose.
+line_has_git() {
+  grep -qE '(^|[[:space:]|`])git([[:space:]]|$|[|;&])' <<<"$1"
+}
+
+# scan_skill <skill_md> — print violation message on stdout when found.
+scan_skill() {
+  local skill_md="$1"
+  local block line_count git_count=0
+  block="$(precompute_block "$skill_md")"
+  if [[ -z "${block//[[:space:]]/}" ]]; then
+    return 0
+  fi
+  line_count=0
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    if grep -qE '!`[^`]+`' <<<"$line"; then
+      line_count=$((line_count + 1))
+      if line_has_git "$line"; then
+        git_count=1
+      fi
+    fi
+  done <<<"$block"
+  if ((line_count > 1 && git_count == 1)); then
+    printf 'VIOLATION: %s — %d precompute lines with a git command (#1619 composition rule)\n' \
+      "$skill_md" "$line_count"
+    return 1
+  fi
+  return 0
+}
+
+mapfile -t targets < <(
+  case "$first" in
+  --all)
+    find plugins -path 'plugins/*/skills/*/SKILL.md' -type f 2>/dev/null | sort
+    ;;
+  --paths)
+    printf '%s\n' "${rest[@]}"
+    ;;
+  *)
+    base="$first"
+    if ! git rev-parse --verify --quiet "${base}^{commit}" >/dev/null; then
+      printf 'Error: base ref %s is not a valid commit\n' "$base" >&2
+      exit 2
+    fi
+    git diff --name-only "$base" -- 'plugins/' |
+      sed -nE 's#^(plugins/[^/]+/skills/[^/]+)/SKILL\.md$#\1/SKILL.md#p' |
+      sort -u
+    ;;
+  esac
+)
+
+violations=0
+scanned=0
+
+for skill_md in "${targets[@]}"; do
+  [[ -f "$skill_md" ]] || continue
+  scanned=$((scanned + 1))
+  if ! scan_skill "$skill_md"; then
+    violations=$((violations + 1))
+  fi
+done
+
+if ((scanned == 0)); then
+  echo "No skill SKILL.md files in scope — nothing to gate."
+  exit 0
+fi
+
+printf '\n%d skill(s) scanned, %d violation(s).\n' "$scanned" "$violations"
+
+if ((violations > 0)); then
+  if ((STRICT == 1)); then
+    echo "Strict mode: failing." >&2
+    exit 1
+  fi
+  echo "Warn-only mode: violations reported but step passes (use --strict to fail)." >&2
+fi
+exit 0

--- a/scripts/check-skill-precompute-compose.sh
+++ b/scripts/check-skill-precompute-compose.sh
@@ -75,6 +75,7 @@ scan_skill() {
   fi
   line_count=0
   while IFS= read -r line || [[ -n "$line" ]]; do
+    # shellcheck disable=SC2016  # ERE matches literal backticks around precompute injections
     if grep -qE '!`[^`]+`' <<<"$line"; then
       line_count=$((line_count + 1))
       if line_has_git "$line"; then

--- a/scripts/check-skill-precompute-compose.test.sh
+++ b/scripts/check-skill-precompute-compose.test.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# Unit tests for check-skill-precompute-compose.sh.
+set -uo pipefail
+
+SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$SELF_DIR/check-skill-precompute-compose.sh"
+
+PASS=0
+FAIL=0
+fail() {
+  echo "FAIL: $*" >&2
+  FAIL=$((FAIL + 1))
+}
+ok() {
+  echo "ok: $*"
+  PASS=$((PASS + 1))
+}
+
+new_fixture() {
+  local dir
+  dir="$(mktemp -d)"
+  mkdir -p "$dir/scripts" "$dir/plugins/demo/skills/sample"
+  cp "$SCRIPT" "$dir/scripts/check-skill-precompute-compose.sh"
+  chmod +x "$dir/scripts/check-skill-precompute-compose.sh"
+  printf '%s' "$dir"
+}
+
+skill_md() {
+  local fixture="$1" content="$2"
+  printf '%s\n' "$content" >"$fixture/plugins/demo/skills/sample/SKILL.md"
+}
+
+run_check() (
+  cd "$1" && shift
+  bash scripts/check-skill-precompute-compose.sh "$@"
+)
+
+# --- single git precompute line passes ---------------------------------------
+f="$(new_fixture)"
+skill_md "$f" $'---\ndescription: test\n---\n\n## Pre-computed context\n\nBranch: !`git branch --show-current`\n\n## Body\n'
+if out="$(run_check "$f" --paths "plugins/demo/skills/sample/SKILL.md" 2>&1)"; then
+  if echo "$out" | grep -q '0 violation'; then
+    ok "single git precompute line passes"
+  else
+    fail "single git precompute should pass cleanly: $out"
+  fi
+else
+  fail "single git precompute should exit 0: $out"
+fi
+
+# --- two precompute lines without git passes ---------------------------------
+f="$(new_fixture)"
+skill_md "$f" $'---\ndescription: test\n---\n\n## Pre-computed context\n\nA: !`date`\nB: !`pwd`\n\n## Body\n'
+if out="$(run_check "$f" --paths "plugins/demo/skills/sample/SKILL.md" 2>&1)"; then
+  if echo "$out" | grep -q '0 violation'; then
+    ok "two non-git precompute lines pass"
+  else
+    fail "two non-git lines should pass: $out"
+  fi
+else
+  fail "two non-git lines should exit 0: $out"
+fi
+
+# --- two precompute lines with git warns by default --------------------------
+f="$(new_fixture)"
+skill_md "$f" $'---\ndescription: test\n---\n\n## Pre-computed context\n\nA: !`git branch --show-current`\nB: !`git status --porcelain`\n\n## Body\n'
+if out="$(run_check "$f" --paths "plugins/demo/skills/sample/SKILL.md" 2>&1)"; then
+  if echo "$out" | grep -q 'VIOLATION:' && echo "$out" | grep -q 'Warn-only'; then
+    ok "git + multi-line warns in default mode"
+  else
+    fail "expected violation + warn-only: $out"
+  fi
+else
+  fail "default mode should exit 0 on violation: $out"
+fi
+
+# --- strict mode fails -------------------------------------------------------
+f="$(new_fixture)"
+skill_md "$f" $'---\ndescription: test\n---\n\n## Pre-computed context\n\nA: !`git branch --show-current`\nB: !`git status --porcelain`\n\n## Body\n'
+if out="$(run_check "$f" --strict --paths "plugins/demo/skills/sample/SKILL.md" 2>&1)"; then
+  fail "strict mode should fail on violation"
+else
+  if echo "$out" | grep -q 'Strict mode: failing'; then
+    ok "strict mode fails on violation"
+  else
+    fail "strict mode message missing: $out"
+  fi
+fi
+
+# --- no precompute section passes --------------------------------------------
+f="$(new_fixture)"
+skill_md "$f" $'---\ndescription: test\n---\n\n## Body\n\nNo precompute here.\n'
+if out="$(run_check "$f" --paths "plugins/demo/skills/sample/SKILL.md" 2>&1)"; then
+  ok "missing precompute section passes"
+else
+  fail "missing section should pass: $out"
+fi
+
+printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
Implements the static gate proposed in #1662.

## Summary
- Adds `scripts/check-skill-precompute-compose.sh` to detect skills whose `## Pre-computed context` block has **more than one** inline `!`command`` injection **and** any git command — the composition that #1619 proved breaks worktree-isolated agents.
- Default mode is **warn-only** (exit 0, prints violations); `--strict` fails closed for future graduation after #1619 remediation.
- Wired into the skill-quality CI lane: self-test + whole-repo warn report.

## Decision brief (#1662)
**RECOMMENDED:** warn-first gate in CI, graduate to `--strict` once #1619 remediation clears existing violations. This PR ships warn-only as recommended.

Closes #1662.

## Related

- Refs #1619 (the composition this gate detects; remediation tracked separately).