### PR TITLE
docs(scripts): document sanctioned in-place CHANGELOG body corrections

### DIFF
--- a/scripts/check-changelog-parity.sh
+++ b/scripts/check-changelog-parity.sh
@@ -26,6 +26,12 @@
 #                                                         entry it carried at the
 #                                                         fork point
 #
+# Released-entry body edits (--check-preserved watches headings only):
+#   Declared in-place corrections inside an already-released `## [<v>]` section
+#   are sanctioned when the correcting PR names each edit in its body AND in the
+#   new release entry (#2388). Heading preservation stays mechanical via
+#   --check-preserved; body fidelity is review discipline, not an automated gate.
+#
 # Three complementary gaps the same audit surfaced:
 #   * --check is the static repo-wide invariant: a plugins/<name>/.claude-plugin/
 #     plugin.json carrying a `version` must ship a plugins/<name>/CHANGELOG.md.


### PR DESCRIPTION
## Summary
Documents the #2388 decision in `scripts/check-changelog-parity.sh`: declared in-place corrections inside an already-released `## [<v>]` section are **sanctioned** when the correcting PR names each edit in its body **and** in the new release entry.

`--check-preserved` continues to enforce heading survival; body fidelity is review discipline, not an automated gate.

## Decision brief (#2388)
**RECOMMENDED:** Option 2 — declared in-place correction is sanctioned with explicit naming in the correcting PR (the de facto behavior #2312 followed). Option 1 (append-only errata only) is not adopted.

Closes #2388.

## Related

- Refs #2312 (the de facto declared-correction behavior this documents).