### PR TITLE
fix(claude-config): bind partial appends to the writer's epoch, validate records, pin the write tree

### DIFF
--- a/plugins/claude-config/.claude-plugin/plugin.json
+++ b/plugins/claude-config/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "claude-config",
-  "version": "0.38.0",
+  "version": "0.38.1",
   "description": "Nine configuration-health skills (plus setup) for a repo's Claude Code configuration: audit (settings.json / .mcp.json / hooks / plugins / permissions drift), audit-automation-gaps (evidence-gated verdicts on automation gaps), audit-permission-grants (allow-rule / allowed-tools grants for auto-mode durability and portability), audit-permission-state (the permission rules actually in effect — every settings scope merged with per-rule provenance, what auto mode drops on entry, config written where nothing reads it, and which managed intents are enforced versus loosenable), draft-auto-mode-rules (interview and draft a paste-ready autoMode classifier block; prints only, never writes), audit-instructions (locally-owned instruction surfaces vs current model capability — proposes removals/rewrites of instructions the model no longer needs, and detects cross-surface instruction conflicts), audit-prompting-postures (the additive lane — posture guidance the prompting guide says a component's purpose needs but the component does not carry), audit-pass (one coordinated, ordered, resumable pass over a named target — three-scope inventory, run-time-derived exclusion set, stable finding identity, suppression memory, resume, one human gate — delegating every check to the plugin that owns it), and unhobble (the empirical bare-baseline experiment: reversibly strip a repo's standing instructions, log real stumbles against the current model, re-add only what evidence earns).",
   "author": {
     "name": "Melodic Software",

--- a/plugins/claude-config/CHANGELOG.md
+++ b/plugins/claude-config/CHANGELOG.md
@@ -36,6 +36,30 @@ version to be on.
   `<plugin-data>/runs/`; every later command operates on a directory `acquire` already validated. A
   test asserts the refused directory is not created. (#2280, F3, F5)
 
+Review of *those* fixes found four more of the same class, all closed here rather than deferred:
+
+- **The fence is enforced by the exit code, not announced in a string.** `partial append` printed
+  `FENCED … this run must abort` to stderr and returned 0, so the abort depended on the caller
+  noticing a substring in a channel indistinguishable from any other diagnostic — a control reporting
+  a state it never establishes, which is the exact defect the surrounding change exists to remove. A
+  fenced append now exits **3**: the record is still written to the writer's own epoch file, and the
+  run is told in the one channel it cannot miss that it has been superseded. `SKILL.md` Phase 3 says
+  what to do with it.
+- **The no-parser rung announces its own limit.** `{"a" garbage}` balances and opens with a quoted
+  key, and no non-parser rejects it. `python3` is now the second definitive rung after `jq`; where
+  neither exists the structural scan runs and **says on stderr that it checked structurally only**,
+  rather than passing for a validator. A check that claims more than it verifies is the same defect
+  in a new spelling.
+- **Containment is checked on the resolved path, not the string.** A lexical prefix test is not
+  containment while symlinks exist: with `runs/link -> /elsewhere`, `<plugin-data>/runs/link/run`
+  passed the comparison and the write then followed the link out of the tree. Both sides are
+  canonicalized with `pwd -P` — `--run-dir` through its deepest existing ancestor, the only part a
+  symlink can be in. (`readlink -f` is GNU-only and is not used.)
+- **`reference/report-location-and-schema.md` §7 no longer contradicts the append contract.** It
+  still described `partial append` as taking the epoch from the lease and listed only the run
+  directory and the record, so an audit following that page after an adoption would have omitted
+  `--epoch` and reinstated the interleaving. Both surfaces now carry the same command.
+
 ## [0.38.0]
 
 ### Added

--- a/plugins/claude-config/CHANGELOG.md
+++ b/plugins/claude-config/CHANGELOG.md
@@ -60,6 +60,21 @@ Review of *those* fixes found four more of the same class, all closed here rathe
   directory and the record, so an audit following that page after an adoption would have omitted
   `--epoch` and reinstated the interleaving. Both surfaces now carry the same command.
 
+And review of *that* round caught the containment fix breaking the one run no fixture represents:
+
+- **`acquire` works on a plugin data directory that does not exist yet.** Canonicalizing with
+  `pwd -P` cannot resolve a directory that is not there, so the new check made `acquire` fail on a
+  plugin's **very first run** — the only run whose data root has never been created. Every test in
+  the file pre-makes that directory, so none of them could see it. The root is now created before it
+  is resolved (creating the plugin's own data root is inside this script's mandate and is not a
+  target write), and a test exercises the fresh-install path specifically. Reproduced before the
+  fix: `--plugin-data cannot be resolved: …/fresh`, `rc=2`.
+- The containment guard's **check-then-act window** — a symlink planted between the resolution and
+  the `mkdir` — is now recorded in the code as a disclosed residual rather than left implied. Closing
+  it needs an atomic create-and-verify no portable shell offers, and an attacker who can plant that
+  link can already write the lease directly. A guard whose limits are unstated reads as one without
+  any.
+
 ## [0.38.0]
 
 ### Added

--- a/plugins/claude-config/CHANGELOG.md
+++ b/plugins/claude-config/CHANGELOG.md
@@ -3,6 +3,39 @@
 All notable changes to the `claude-config` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.38.1]
+
+### Fixed
+
+Three defects in the `audit-pass` script `scripts/run-state.sh`, all one family — a control that does not
+enforce what its surface claims. They were found by review on #2441 and are shipped separately
+because that PR merged before the fixes were pushed; **0.38.0 carries all three**, so this is the
+version to be on.
+
+- **The partial's filename now takes the *writer's* epoch, not the lease's current one.** `partial
+  append` read `owner_epoch` from the lease at append time, which defeats exactly the isolation §3
+  describes: a stale holder waking after an adopter incremented the epoch would read the adopter's
+  value and append into the **adopter's** file, so two writers interleave under one attempt ordinal —
+  by §3's own account "the one failure the attempt machinery cannot absorb". `partial append --epoch
+  <held>` now names the writer's own file whatever the lease says, and reports `FENCED` on stderr
+  when the two differ so the run aborts on the signal rather than silently corrupting the artifact.
+- **A record is validated rather than sniffed.** The check accepted any string beginning with `{`,
+  so a construction slip such as `{bad json}` was appended permanently to an artifact whose only
+  readers are `--resume` and assembly — costing the run's persisted state rather than one record.
+  Records are now verified as well-formed single-line JSON objects: `jq` decides where it is
+  installed, and where it is not, a scan tracking string context and escape sequences still rejects
+  `{bad json}`, a truncated row, and an unbalanced one. `jq` is deliberately **not** made a hard
+  requirement — failing the state-persistence path closed on a missing optional tool would cost the
+  artifact the check exists to protect. Both rungs are asserted; the second runs with a `PATH`
+  holding only `bash`.
+- **`lease acquire` pins the write tree.** It created whatever `--run-dir` it was handed and wrote a
+  lease into it, so a wrong or invented run directory — the target root, say — was created and
+  written to, against this skill's promise that a bare audit writes nothing into the target and while
+  it keeps Bash specifically for state writes. `acquire` is the only command that *creates* a
+  directory, so it now requires `--plugin-data` and refuses any run directory outside
+  `<plugin-data>/runs/`; every later command operates on a directory `acquire` already validated. A
+  test asserts the refused directory is not created. (#2280, F3, F5)
+
 ## [0.38.0]
 
 ### Added

--- a/plugins/claude-config/skills/audit-pass/SKILL.md
+++ b/plugins/claude-config/skills/audit-pass/SKILL.md
@@ -320,10 +320,14 @@ its attempt id so an abandoned re-attempt is discardable rather than merely olde
 call per record — `bash "$S" partial append --run-dir "<run-dir>" --record '<json-line>' --epoch
 "<held>"` — and the lease is refreshed at the same boundary. A lease must exist, so a record resume
 could not attribute to a live-or-abandoned run is never written. **Pass the epoch you hold**: the
-filename is the writer's epoch, not whatever the lease now carries, which is what keeps a fenced
-writer's rows out of its adopter's file. The script validates the record as a well-formed single-line
-JSON object rather than sniffing its first character — a malformed row in an append-only artifact is
-permanent, and resume is its only reader.
+filename is the writer's epoch, not whatever the lease now carries, which keeps a fenced writer's rows
+out of its adopter's file. The record is validated as well-formed single-line JSON rather than sniffed
+by its first character — a malformed row here is permanent, and resume is its only reader.
+
+**Exit 3 means FENCED: stop this run.** The record was written safely to your own epoch file, but the
+lease has moved on and another run has adopted the artifact, so continuing dispatches lanes whose
+output nothing will assemble. Stop and report the run as superseded. Never retry the append, and never
+read that exit as transient.
 
 **The lane count is bounded by the delegated interfaces, not chosen here** — one per scope value the
 instruction catalog accepts, plus one for the memory layer — so it is a handful, and a per-run

--- a/plugins/claude-config/skills/audit-pass/SKILL.md
+++ b/plugins/claude-config/skills/audit-pass/SKILL.md
@@ -142,15 +142,18 @@ is what makes this phase a mechanism rather than a description of one:
 
 ```bash
 S="${CLAUDE_PLUGIN_ROOT}/skills/audit-pass/scripts/run-state.sh"
-bash "$S" paths --plugin-data "${CLAUDE_PLUGIN_DATA}" --run-id "<run-id>"
-bash "$S" lease acquire --run-dir "<run-dir>" --run-id "<run-id>"
+D="${CLAUDE_PLUGIN_DATA}"
+bash "$S" paths --plugin-data "$D" --run-id "<run-id>"
+bash "$S" lease acquire --run-dir "<run-dir>" --run-id "<run-id>" --plugin-data "$D"
 ```
 
 `paths` derives `<plugin-data>/runs/<state-key>/<run-id>` through the plugin's own `lib/state-key.sh`
 — the library whose header records the keying scheme as *this skill's*, and which until now three
 other skills called and this one did not. Pass `--plugin-data` explicitly: `${CLAUDE_PLUGIN_DATA}`
 substitutes in this text but is **not** exported to the Bash tool's environment, so a shell cannot
-expand it.
+expand it. `acquire` takes it too, and refuses a `--run-dir` that is not under
+`<plugin-data>/runs/` — it is the only command that *creates* a directory, so it is where the write
+tree is pinned; a wrong or invented run dir would otherwise be created and written into.
 
 **`--resume` never attaches to a run that is still going.** Concurrent read-only runs are safe
 because each owns its own partial artifact; resume is the one operation that reaches into *another*
@@ -314,10 +317,13 @@ lanes. Route it out (`skill-quality:check` when installed).
 Persist each lane's findings to the partial artifact **as that lane completes**, never buffered to
 the end — a lane is complete when its terminating record is in the partial, and every record carries
 its attempt id so an abandoned re-attempt is discardable rather than merely older. The write is one
-call per record — `bash "$S" partial append --run-dir "<run-dir>" --record '<json-line>'` — and the
-lease is refreshed at the same boundary. The partial is named `findings.partial.<owner_epoch>.jsonl`
-after the epoch the lease holds, so it cannot be written without a lease to classify it: a record
-resume could not attribute to a live-or-abandoned run is worse than no record.
+call per record — `bash "$S" partial append --run-dir "<run-dir>" --record '<json-line>' --epoch
+"<held>"` — and the lease is refreshed at the same boundary. A lease must exist, so a record resume
+could not attribute to a live-or-abandoned run is never written. **Pass the epoch you hold**: the
+filename is the writer's epoch, not whatever the lease now carries, which is what keeps a fenced
+writer's rows out of its adopter's file. The script validates the record as a well-formed single-line
+JSON object rather than sniffing its first character — a malformed row in an append-only artifact is
+permanent, and resume is its only reader.
 
 **The lane count is bounded by the delegated interfaces, not chosen here** — one per scope value the
 instruction catalog accepts, plus one for the memory layer — so it is a handful, and a per-run

--- a/plugins/claude-config/skills/audit-pass/reference/report-location-and-schema.md
+++ b/plugins/claude-config/skills/audit-pass/reference/report-location-and-schema.md
@@ -86,12 +86,24 @@ completes. Append-only is what makes §5 real: a single JSON document would be r
 every append, which is exactly the operation an interrupted run leaves half-done. A lane's final
 record is its terminating record.
 
-**The append is `scripts/run-state.sh partial append`, not a hand-rolled redirection.** It takes the
-epoch from the lease — so the partial cannot exist without the lease `--resume` reads first — refuses
-a record that is not a single-line JSON object, and returns the file it appended to. §5 states which
-clauses of the run-state contract that script enforces and which remain the run's own discipline;
-**assembly is among the latter**, so the selection rules below are performed by the run, not by an
-executable.
+**The append is `scripts/run-state.sh partial append`, not a hand-rolled redirection**, and its full
+form carries the writer's epoch:
+
+```
+run-state.sh partial append --run-dir <run-dir> --record '<json-line>' --epoch <held>
+```
+
+**`--epoch` is not optional in practice.** The file is named for the epoch **the writer holds**, never
+whatever the lease currently carries: omit it after an adoption and the fallback selects the
+*adopter's* epoch, putting a superseded writer's rows into the adopter's file — exactly the
+cross-writer interleaving §3's fencing exists to prevent. Where the two differ the command writes to
+the writer's own file, says `FENCED`, and **exits 3**: the record is safe, and the run that wrote it
+is superseded and must stop. A lease must exist either way, so the partial cannot outlive the thing
+that classifies it, and a record that is not a well-formed single-line JSON object is refused.
+
+§5 also states which clauses of the run-state contract that script enforces and which remain the run's
+own discipline; **assembly is among the latter**, so the selection rules below are performed by the
+run, not by an executable.
 
 **Completion is read from the terminator's state, not from its presence.** A terminator lets
 assembly render the lane; whether the lane is *done* is a separate question, and conflating them

--- a/plugins/claude-config/skills/audit-pass/reference/run-state-and-resumability.md
+++ b/plugins/claude-config/skills/audit-pass/reference/run-state-and-resumability.md
@@ -87,7 +87,7 @@ write and the verdict:
 bash "${CLAUDE_PLUGIN_ROOT}/skills/audit-pass/scripts/run-state.sh" paths \
   --plugin-data "${CLAUDE_PLUGIN_DATA}" --run-id <run-id>
 bash "${CLAUDE_PLUGIN_ROOT}/skills/audit-pass/scripts/run-state.sh" lease acquire \
-  --run-dir <run-dir> --run-id <run-id>
+  --run-dir <run-dir> --run-id <run-id> --plugin-data "${CLAUDE_PLUGIN_DATA}"
 bash "${CLAUDE_PLUGIN_ROOT}/skills/audit-pass/scripts/run-state.sh" lease heartbeat --run-dir <run-dir>
 bash "${CLAUDE_PLUGIN_ROOT}/skills/audit-pass/scripts/run-state.sh" lease classify  --run-dir <run-dir>
 bash "${CLAUDE_PLUGIN_ROOT}/skills/audit-pass/scripts/run-state.sh" lease release   --run-dir <run-dir>
@@ -97,6 +97,13 @@ bash "${CLAUDE_PLUGIN_ROOT}/skills/audit-pass/scripts/run-state.sh" lease releas
 a `live` lease is the caller's move, not the script's. Pass `--plugin-data` explicitly: the
 `${CLAUDE_PLUGIN_DATA}` placeholder substitutes in *this text* but is not exported to the Bash tool's
 environment (§2), so a shell cannot expand it.
+
+**`acquire` requires `--plugin-data` because it is the only command that creates a directory**, and
+that is where the write tree is pinned: a run directory not under `<plugin-data>/runs/` is refused
+rather than created. Without the check, a wrong or invented `--run-dir` — the target root, say —
+would get created and a lease written into it, and this skill keeps Bash specifically for state
+writes while promising that a bare audit writes nothing into the target. Every later command operates
+on a run directory `acquire` already validated.
 
 **What is executable here, and what is not.** Everything below through the two-sided liveness test is
 enforced by that script and covered by `run-state.test.sh`, negative tests included. Two clauses are
@@ -220,11 +227,26 @@ A pass over a large corpus plus three scopes can be interrupted by compaction, a
 crash. Restarting from zero wastes the run and tempts an operator to narrow the scan.
 
 - Findings persist **incrementally, per lane**, as each lane completes — never buffered to the end.
-  The write is `scripts/run-state.sh partial append --run-dir <run-dir> --record '<json-line>'`, which
-  appends one line to `findings.partial.<owner_epoch>.jsonl` — the epoch taken from the lease, so the
-  partial cannot exist without the lease that classifies it. The script refuses a record that is not a
-  single-line JSON object, because a record carrying a newline splits into two rows and the second is
-  unparsable.
+  The write is
+  `scripts/run-state.sh partial append --run-dir <run-dir> --record '<json-line>' --epoch <held>`,
+  which appends one line to `findings.partial.<epoch>.jsonl`. A lease must exist, so the partial
+  cannot outlive the thing that classifies it.
+
+  **Pass the epoch you hold.** The filename is the *writer's* epoch, never whatever the lease
+  currently carries: a stale holder that wakes after an adopter incremented it would otherwise read
+  the adopter's value and append into the adopter's file, so two writers interleave under one attempt
+  ordinal — the one failure the attempt machinery cannot absorb. When the two differ the script says
+  `FENCED` on stderr and writes to the writer's own file; the run aborts on that signal. Omitting
+  `--epoch` falls back to the lease's current value, correct only for a run whose epoch nothing has
+  moved.
+
+  **A record is validated, not merely sniffed.** A malformed row in an append-only artifact is
+  permanent, and resume and assembly are its only readers, so a quoting slip in the caller would cost
+  the run's persisted state rather than one record. The script refuses anything that is not a
+  well-formed single-line JSON object — `jq` decides where it is installed, and a scan that tracks
+  string context and escapes decides where it is not, which still rejects `{bad json}`, a truncated
+  row, and an unbalanced one. `jq` is deliberately not a hard requirement here: failing the state
+  path closed on a missing optional tool would cost the artifact the check exists to protect.
 - **The run manifest is the partial's own lane records, not a second file.** A lane's start record
   carries the lane id and its **input digest**; its terminating record carries the completion state.
   §7 already requires that `--resume` read the partial "so completion state is derivable from the

--- a/plugins/claude-config/skills/audit-pass/reference/run-state-and-resumability.md
+++ b/plugins/claude-config/skills/audit-pass/reference/run-state-and-resumability.md
@@ -105,6 +105,13 @@ would get created and a lease written into it, and this skill keeps Bash specifi
 writes while promising that a bare audit writes nothing into the target. Every later command operates
 on a run directory `acquire` already validated.
 
+**Containment is checked on the resolved path, not on the string.** A lexical prefix test is not
+containment while symlinks exist: with `runs/link -> /elsewhere`, the path `<plugin-data>/runs/link/run`
+passes the comparison and then the write follows the link out of the tree, so the guarantee holds on
+the string and fails on the filesystem. Both sides are canonicalized with `pwd -P` before they are
+compared — `--run-dir` through its deepest *existing* ancestor, since it usually does not exist yet
+and that is the only part a symlink can be in.
+
 **What is executable here, and what is not.** Everything below through the two-sided liveness test is
 enforced by that script and covered by `run-state.test.sh`, negative tests included. Two clauses are
 **not**: stale-lease **adoption** (the `owner_epoch` compare-and-set) and §7 **assembly**
@@ -235,18 +242,23 @@ crash. Restarting from zero wastes the run and tempts an operator to narrow the 
   **Pass the epoch you hold.** The filename is the *writer's* epoch, never whatever the lease
   currently carries: a stale holder that wakes after an adopter incremented it would otherwise read
   the adopter's value and append into the adopter's file, so two writers interleave under one attempt
-  ordinal — the one failure the attempt machinery cannot absorb. When the two differ the script says
-  `FENCED` on stderr and writes to the writer's own file; the run aborts on that signal. Omitting
-  `--epoch` falls back to the lease's current value, correct only for a run whose epoch nothing has
-  moved.
+  ordinal — the one failure the attempt machinery cannot absorb. Where the two differ the script
+  writes to the writer's own file, says `FENCED`, and **exits 3**. The abort is in the exit code, not
+  only in the message: a diagnostic reading "this run must stop" while the command exits 0 is a
+  control announcing a state it never establishes, since it depends on the caller noticing a
+  substring — the same shape as the rest of §3 before it had a script. Omitting `--epoch` falls back
+  to the lease's current value, correct only for a run whose epoch nothing has moved.
 
   **A record is validated, not merely sniffed.** A malformed row in an append-only artifact is
   permanent, and resume and assembly are its only readers, so a quoting slip in the caller would cost
   the run's persisted state rather than one record. The script refuses anything that is not a
-  well-formed single-line JSON object — `jq` decides where it is installed, and a scan that tracks
-  string context and escapes decides where it is not, which still rejects `{bad json}`, a truncated
-  row, and an unbalanced one. `jq` is deliberately not a hard requirement here: failing the state
-  path closed on a missing optional tool would cost the artifact the check exists to protect.
+  well-formed single-line JSON object. `jq` answers definitively where it is installed and `python3`
+  where it is not; on a host with neither, a scan tracking string context and escapes still rejects
+  `{bad json}`, a truncated row and an unbalanced one — but **not** every malformed object, since
+  `{"a" garbage}` balances and opens with a quoted key and no non-parser catches it. That rung
+  therefore **announces itself** rather than passing for the real thing. Neither parser is a hard
+  requirement: failing the state path closed on a missing optional tool would cost the artifact the
+  check exists to protect, so the residual is disclosed instead of hidden.
 - **The run manifest is the partial's own lane records, not a second file.** A lane's start record
   carries the lane id and its **input digest**; its terminating record carries the completion state.
   §7 already requires that `--resume` read the partial "so completion state is derivable from the

--- a/plugins/claude-config/skills/audit-pass/scripts/run-state.sh
+++ b/plugins/claude-config/skills/audit-pass/scripts/run-state.sh
@@ -25,11 +25,19 @@
 # Claiming otherwise would put the same "reads as enforced" defect back one layer
 # down.
 #
-# `lease acquire --epoch <n>` is the seam that boundary leaves behind, and it is
-# named here so it does not read as a feature: an ADOPTING run passes the epoch
-# it won, and `partial append` then writes to that epoch's file — which is what
-# gives a fenced writer its own superseded file. The compare-and-set that decides
-# who won is §3's, performed by the run. A fresh run omits the flag and gets 1.
+# `--epoch <n>` is the seam that boundary leaves behind, and it is named here so
+# it does not read as a feature. On `lease acquire`, an ADOPTING run records the
+# epoch it won; a fresh run omits it and gets 1. On `partial append`, a writer
+# passes the epoch IT HOLDS, and the record lands in that epoch's file no matter
+# what the lease now says — which is what gives a fenced writer its own
+# superseded file instead of letting it interleave into the adopter's. Omitting
+# it there falls back to the lease's current epoch, correct only for a run whose
+# epoch nothing has moved. The compare-and-set that decides who won is §3's,
+# performed by the run, not by this script.
+#
+# `lease acquire` also requires `--plugin-data`: it is the only command that
+# CREATES a directory, so it is where the write tree is pinned. A run dir outside
+# `<plugin-data>/runs/` is refused rather than created.
 #
 # SCOPE OF WRITES. Everything this script writes goes under the run directory it
 # derives, which is `<plugin-data>/runs/<state-key>/<run-id>/`. It never writes
@@ -104,12 +112,12 @@ usage() {
 run-state.sh — run directory, lease, and append-only partial for audit-pass.
 
   run-state.sh paths           --plugin-data <dir> --run-id <id> [--root <path>]
-  run-state.sh lease acquire   --run-dir <dir> --run-id <id> [--stale-after <s>]
-                               [--skew-grace <s>] [--epoch <n>]
+  run-state.sh lease acquire   --run-dir <dir> --run-id <id> --plugin-data <dir>
+                               [--stale-after <s>] [--skew-grace <s>] [--epoch <n>]
   run-state.sh lease heartbeat --run-dir <dir>
   run-state.sh lease release   --run-dir <dir>
   run-state.sh lease classify  --run-dir <dir>
-  run-state.sh partial append  --run-dir <dir> --record <json-line>
+  run-state.sh partial append  --run-dir <dir> --record <json-line> [--epoch <n>]
 
 `classify` prints live | stale | released | missing on stdout and exits 0.
 Exit 2 is a usage error, a rejected argument, or a missing prerequisite.
@@ -143,6 +151,14 @@ validate_run_id() {
   esac
 }
 
+require_absolute_path() {
+  local name="$1" value="$2"
+  case "$value" in
+  /* | ?:[\\/]*) : ;;
+  *) die "$name must be an absolute path: $value" ;;
+  esac
+}
+
 require_non_negative_int() {
   local name="$1" value="$2"
   if [[ ! "$value" =~ ^[0-9]+$ ]]; then
@@ -165,6 +181,78 @@ require_int_at_least_one() {
   if [[ "$value" -lt 1 ]]; then
     die "$name must be at least 1: $value (0 would make the lease classify stale the moment it is written)"
   fi
+}
+
+# Is this string one well-formed single-line JSON object?
+#
+# `case "$record" in '{'*)` was not enough: it accepts `{bad json}`, and a
+# malformed row in an append-only artifact is permanent — resume and assembly
+# then cannot parse the record stream they are the only readers of, so a
+# serialization slip in the caller costs the run's persisted state rather than
+# one record. The check has to fire on construction errors, not just on obviously
+# non-JSON input.
+#
+# Two rungs, and the weaker one still catches the motivating case. With `jq` on
+# PATH the answer is definitive. Without it, a scan that tracks string context
+# and escapes verifies brace/bracket balance, string termination, and that the
+# object opens with a quoted key or closes empty — which rejects `{bad json}`,
+# truncated rows, and unbalanced ones. `jq` is deliberately NOT made a hard
+# requirement: this is the run's state-persistence path, and failing it closed on
+# a missing optional tool would cost the artifact the check exists to protect.
+record_is_json_object() {
+  local s="$1"
+  case "$s" in
+  '{'*) : ;;
+  *) return 1 ;;
+  esac
+  case "$s" in
+  *'}') : ;;
+  *) return 1 ;;
+  esac
+
+  if command -v jq >/dev/null 2>&1; then
+    printf '%s' "$s" | jq -e 'type == "object"' >/dev/null 2>&1
+    return
+  fi
+
+  local i ch in_str=0 esc=0 depth=0 len=${#s}
+  for ((i = 0; i < len; i++)); do
+    ch="${s:i:1}"
+    if [[ "$in_str" -eq 1 ]]; then
+      if [[ "$esc" -eq 1 ]]; then
+        esc=0
+      elif [[ "$ch" == "\\" ]]; then
+        esc=1
+      elif [[ "$ch" == '"' ]]; then
+        in_str=0
+      fi
+      continue
+    fi
+    case "$ch" in
+    '"') in_str=1 ;;
+    '{' | '[') depth=$((depth + 1)) ;;
+    '}' | ']')
+      depth=$((depth - 1))
+      if [[ "$depth" -lt 0 ]]; then
+        return 1
+      fi
+      ;;
+    *) : ;;
+    esac
+  done
+  if [[ "$in_str" -eq 1 ]] || [[ "$depth" -ne 0 ]]; then
+    return 1
+  fi
+
+  # After the opening brace, the first non-space character must open a quoted key
+  # or close an empty object. `{bad json}` fails here even though it balances.
+  local rest="${s:1}"
+  rest="${rest#"${rest%%[![:space:]]*}"}"
+  case "$rest" in
+  '"'*) return 0 ;;
+  '}') return 0 ;;
+  *) return 1 ;;
+  esac
 }
 
 # Read one key=value field out of a lease file. Prints the value, or nothing.
@@ -227,10 +315,7 @@ cmd_paths() {
   if [[ -z "$plugin_data" ]]; then
     die "--plugin-data is required: \${CLAUDE_PLUGIN_DATA} is not exported to the Bash tool, so pass the path substituted into the skill text"
   fi
-  case "$plugin_data" in
-  /* | ?:[\\/]*) : ;;
-  *) die "--plugin-data must be an absolute path: $plugin_data" ;;
-  esac
+  require_absolute_path "--plugin-data" "$plugin_data"
 
   validate_run_id "$run_id"
 
@@ -257,12 +342,17 @@ cmd_paths() {
 
 cmd_lease_acquire() {
   local run_dir="" run_id="" stale_after="$DEFAULT_STALE_AFTER_S"
-  local skew_grace="$DEFAULT_SKEW_GRACE_S" epoch=1
+  local skew_grace="$DEFAULT_SKEW_GRACE_S" epoch=1 plugin_data=""
   while [[ $# -gt 0 ]]; do
     case "$1" in
     --run-dir)
       [[ $# -ge 2 ]] || die "--run-dir needs a path"
       run_dir="$2"
+      shift 2
+      ;;
+    --plugin-data)
+      [[ $# -ge 2 ]] || die "--plugin-data needs a path"
+      plugin_data="$2"
       shift 2
       ;;
     --run-id)
@@ -296,6 +386,31 @@ cmd_lease_acquire() {
   if [[ -z "$run_dir" ]]; then
     die "--run-dir is required"
   fi
+
+  # ACQUIRE IS THE ONLY COMMAND THAT CREATES A DIRECTORY, so it is where
+  # containment is established — every later command operates on a run dir this
+  # one already validated. Without the check, a caller that hands over a wrong or
+  # invented `--run-dir` gets that directory created and a `lease` written into
+  # it, and the skill keeps Bash specifically for state writes while promising a
+  # bare audit writes nothing into the target: passing the target root here would
+  # have broken that promise silently. So the run directory must lie under
+  # `<plugin-data>/runs/`, which is the only tree this script may write.
+  if [[ -z "$plugin_data" ]]; then
+    plugin_data="${CLAUDE_PLUGIN_DATA:-}"
+  fi
+  if [[ -z "$plugin_data" ]]; then
+    die "--plugin-data is required so --run-dir can be checked for containment; pass the same value given to 'paths'"
+  fi
+  require_absolute_path "--plugin-data" "$plugin_data"
+  require_absolute_path "--run-dir" "$run_dir"
+  case "$run_dir" in
+  *..*) die "--run-dir must not contain '..': $run_dir" ;;
+  *) : ;;
+  esac
+  case "$run_dir" in
+  "$plugin_data"/runs/*) : ;;
+  *) die "--run-dir is not under \$plugin-data/runs/ — refusing to write outside the plugin's own tree: $run_dir" ;;
+  esac
 
   mkdir -p "$run_dir" || die "cannot create run directory: $run_dir"
 
@@ -475,7 +590,7 @@ cmd_lease_classify() {
 }
 
 cmd_partial_append() {
-  local run_dir="" record=""
+  local run_dir="" record="" held_epoch=""
   while [[ $# -gt 0 ]]; do
     case "$1" in
     --run-dir)
@@ -486,6 +601,11 @@ cmd_partial_append() {
     --record)
       [[ $# -ge 2 ]] || die "--record needs a JSON line"
       record="$2"
+      shift 2
+      ;;
+    --epoch)
+      [[ $# -ge 2 ]] || die "--epoch needs an integer"
+      held_epoch="$2"
       shift 2
       ;;
     *) die "unknown argument to partial append: $1" ;;
@@ -511,15 +631,31 @@ cmd_partial_append() {
   *$'\n'*) die "--record must be a single line" ;;
   *) : ;;
   esac
-  case "$record" in
-  '{'*) : ;;
-  *) die "--record must be a JSON object beginning with '{'" ;;
-  esac
+  if ! record_is_json_object "$record"; then
+    die "--record must be a well-formed single-line JSON object: $record"
+  fi
 
   local epoch file
   epoch=$(lease_field "$run_dir/lease" owner_epoch)
   if [[ ! "$epoch" =~ ^[0-9]+$ ]]; then
     die "lease carries no usable owner_epoch at: $run_dir/lease"
+  fi
+
+  # THE EPOCH IN THE FILENAME IS THE WRITER'S, NEVER THE LEASE'S CURRENT ONE.
+  # Reading it from the lease at append time is what defeats the isolation §3
+  # describes: a stale holder that wakes after an adopter incremented the epoch
+  # would read the adopter's value and append into the adopter's file, so two
+  # writers interleave under one attempt ordinal — the one failure the attempt
+  # machinery cannot absorb. A writer that knows the epoch it holds passes it,
+  # and it lands in its OWN superseded file no matter what the lease now says.
+  # Omitting the flag is only correct for a run whose epoch nothing has moved.
+  if [[ -n "$held_epoch" ]]; then
+    require_int_at_least_one "--epoch" "$held_epoch"
+    if [[ "$held_epoch" != "$epoch" ]]; then
+      printf '%s: FENCED — lease owner_epoch is %s but this writer holds %s; appending to the writer'"'"'s own epoch file and this run must abort\n' \
+        "$PROG" "$epoch" "$held_epoch" >&2
+    fi
+    epoch="$held_epoch"
   fi
   file="$run_dir/findings.partial.$epoch.jsonl"
 

--- a/plugins/claude-config/skills/audit-pass/scripts/run-state.sh
+++ b/plugins/claude-config/skills/audit-pass/scripts/run-state.sh
@@ -73,6 +73,11 @@
 # Exit codes:
 #   0  the operation succeeded (for `classify`, the verdict is on stdout)
 #   2  usage error, rejected argument, or a missing environment prerequisite
+#   3  `partial append` only — FENCED. The record WAS written, to the writer's own
+#      epoch file so nothing interleaves, but the lease has moved on: this run has
+#      been superseded and must stop dispatching. Carried in the exit code rather
+#      than only in a stderr string, because a control that announces an abort
+#      nobody enforces is the defect this file exists to remove.
 #
 # `classify` prints one of `live`, `stale`, `released`, `missing` and exits 0 —
 # a classification is an answer, not a failure. Acting on it (refusing `--resume`
@@ -81,6 +86,11 @@
 set -uo pipefail
 
 PROG="run-state.sh"
+
+# A fenced append is neither success nor a usage error, so it gets its own code:
+# the record was written (to the writer's own epoch file), and the run that wrote
+# it has been superseded and must stop.
+EXIT_FENCED=3
 
 # Defaults for the liveness window. Stated here rather than left to the caller
 # because "live or abandoned" is a classification two implementations must reach
@@ -151,6 +161,29 @@ validate_run_id() {
   esac
 }
 
+# Physical (symlink-resolved) form of a directory that exists. `pwd -P` is the
+# portable resolver; `readlink -f` is GNU-only and this must run on BSD userland.
+physical_path() {
+  (cd "$1" 2>/dev/null && pwd -P) || return 1
+}
+
+# Physical form of the deepest existing ancestor of a path, which is the only
+# part of it a symlink can be in before the path is created.
+physical_existing_prefix() {
+  local p="$1" guard=0
+  while [[ ! -d "$p" ]]; do
+    p="${p%/*}"
+    if [[ -z "$p" ]]; then
+      p="/"
+    fi
+    guard=$((guard + 1))
+    if [[ "$guard" -gt 64 ]]; then
+      return 1
+    fi
+  done
+  physical_path "$p"
+}
+
 require_absolute_path() {
   local name="$1" value="$2"
   case "$value" in
@@ -192,13 +225,20 @@ require_int_at_least_one() {
 # one record. The check has to fire on construction errors, not just on obviously
 # non-JSON input.
 #
-# Two rungs, and the weaker one still catches the motivating case. With `jq` on
-# PATH the answer is definitive. Without it, a scan that tracks string context
-# and escapes verifies brace/bracket balance, string termination, and that the
-# object opens with a quoted key or closes empty — which rejects `{bad json}`,
-# truncated rows, and unbalanced ones. `jq` is deliberately NOT made a hard
-# requirement: this is the run's state-persistence path, and failing it closed on
-# a missing optional tool would cost the artifact the check exists to protect.
+# THREE RUNGS, AND THE WEAKEST ONE SAYS SO. `jq` answers definitively where it is
+# installed; `python3` answers definitively where it is not (and this plugin
+# already depends on it elsewhere), so the structural rung is reached only on a
+# host with neither. That rung tracks string context and escapes to verify
+# brace/bracket balance, string termination, and that the object opens with a
+# quoted key or closes empty — which rejects `{bad json}`, truncated rows and
+# unbalanced ones, but NOT every malformed object: `{"a" garbage}` balances and
+# opens with a quoted key, and no non-parser catches it. So the structural rung
+# ANNOUNCES itself on stderr rather than passing for the real thing. A check that
+# claims more than it verifies is the defect this whole file exists to remove.
+#
+# Neither parser is made a hard requirement: this is the run's state-persistence
+# path, and failing it closed on a missing optional tool would cost the artifact
+# the check exists to protect. The residual is disclosed instead of hidden.
 record_is_json_object() {
   local s="$1"
   case "$s" in
@@ -214,6 +254,14 @@ record_is_json_object() {
     printf '%s' "$s" | jq -e 'type == "object"' >/dev/null 2>&1
     return
   fi
+  if command -v python3 >/dev/null 2>&1; then
+    printf '%s' "$s" |
+      python3 -c 'import json,sys; d=json.load(sys.stdin); sys.exit(0 if isinstance(d,dict) else 1)' \
+        >/dev/null 2>&1
+    return
+  fi
+  printf '%s: no jq or python3 on PATH — the record was checked structurally only; a string that balances but is not JSON (%s) can pass\n' \
+    "$PROG" '{"a" garbage}' >&2
 
   local i ch in_str=0 esc=0 depth=0 len=${#s}
   for ((i = 0; i < len; i++)); do
@@ -410,6 +458,29 @@ cmd_lease_acquire() {
   case "$run_dir" in
   "$plugin_data"/runs/*) : ;;
   *) die "--run-dir is not under \$plugin-data/runs/ — refusing to write outside the plugin's own tree: $run_dir" ;;
+  esac
+
+  # A LEXICAL PREFIX CHECK IS NOT CONTAINMENT WHILE SYMLINKS EXIST. With
+  # `runs/link -> /tmp/outside`, the path `<plugin-data>/runs/link/run` passes the
+  # comparison above and then `mkdir` and the lease write follow the link straight
+  # out of the plugin tree — the guarantee would hold on the string and fail on
+  # the filesystem. So both sides are canonicalized physically before they are
+  # compared: `pwd -P` resolves every symlink in a path that exists, and
+  # `readlink -f` is not used because it is GNU-only.
+  #
+  # `--run-dir` usually does not exist yet, which is the point of `mkdir` below,
+  # so its deepest EXISTING ancestor is what gets resolved — the only part a
+  # symlink can be in. A link introduced after this check is out of scope for any
+  # check-then-act sequence, and it would have to be planted inside the plugin's
+  # own data directory.
+  local real_plugin_data real_prefix
+  real_plugin_data=$(physical_path "$plugin_data") ||
+    die "--plugin-data cannot be resolved: $plugin_data"
+  real_prefix=$(physical_existing_prefix "$run_dir") ||
+    die "--run-dir cannot be resolved: $run_dir"
+  case "$real_prefix" in
+  "$real_plugin_data" | "$real_plugin_data"/*) : ;;
+  *) die "--run-dir resolves outside the plugin's own tree (symlinked component): $run_dir -> $real_prefix" ;;
   esac
 
   mkdir -p "$run_dir" || die "cannot create run directory: $run_dir"
@@ -649,11 +720,13 @@ cmd_partial_append() {
   # machinery cannot absorb. A writer that knows the epoch it holds passes it,
   # and it lands in its OWN superseded file no matter what the lease now says.
   # Omitting the flag is only correct for a run whose epoch nothing has moved.
+  local fenced=0
   if [[ -n "$held_epoch" ]]; then
     require_int_at_least_one "--epoch" "$held_epoch"
     if [[ "$held_epoch" != "$epoch" ]]; then
-      printf '%s: FENCED — lease owner_epoch is %s but this writer holds %s; appending to the writer'"'"'s own epoch file and this run must abort\n' \
-        "$PROG" "$epoch" "$held_epoch" >&2
+      fenced=1
+      printf '%s: FENCED — lease owner_epoch is %s but this writer holds %s; the record lands in the writer'"'"'s own epoch file and this run must stop (exit %s)\n' \
+        "$PROG" "$epoch" "$held_epoch" "$EXIT_FENCED" >&2
     fi
     epoch="$held_epoch"
   fi
@@ -664,6 +737,18 @@ cmd_partial_append() {
   # half-done.
   printf '%s\n' "$record" >>"$file" || die "cannot append to: $file"
   printf '%s\n' "$file"
+
+  # THE FENCE IS ENFORCED BY THE EXIT CODE, NOT BY THE MESSAGE. A diagnostic on
+  # stderr saying "this run must abort" is a control announcing a state it never
+  # establishes: it depends on the caller noticing a substring, and it is
+  # indistinguishable in form from any other diagnostic. `classify` already puts
+  # its machine-actionable answer on stdout for exactly that reason. So a fenced
+  # append exits EXIT_FENCED — the record IS written (to the writer's own file,
+  # so nothing interleaves) and the caller is told, in the one channel it cannot
+  # miss, that it has been superseded and must stop dispatching.
+  if [[ "$fenced" -eq 1 ]]; then
+    return "$EXIT_FENCED"
+  fi
 }
 
 dispatch_lease() {

--- a/plugins/claude-config/skills/audit-pass/scripts/run-state.sh
+++ b/plugins/claude-config/skills/audit-pass/scripts/run-state.sh
@@ -208,11 +208,17 @@ require_non_negative_int() {
 # chose — the shape of defect this script exists to remove. `--skew-grace 0` is
 # left legal: it means "tolerate no forward clock jump", which is a coherent
 # choice and inverts nothing.
+# `--epoch 0` is refused for a different reason — epochs start at 1, so 0 names no
+# writer's file — which is why the reason travels as an argument rather than being
+# hardcoded to the staleness case.
 require_int_at_least_one() {
-  local name="$1" value="$2"
+  local name="$1" value="$2" why="${3:-}"
   require_non_negative_int "$name" "$value"
   if [[ "$value" -lt 1 ]]; then
-    die "$name must be at least 1: $value (0 would make the lease classify stale the moment it is written)"
+    if [[ -n "$why" ]]; then
+      die "$name must be at least 1: $value ($why)"
+    fi
+    die "$name must be at least 1: $value"
   fi
 }
 
@@ -428,9 +434,10 @@ cmd_lease_acquire() {
   done
 
   validate_run_id "$run_id"
-  require_int_at_least_one "--stale-after" "$stale_after"
+  require_int_at_least_one "--stale-after" "$stale_after" \
+    "0 would make the lease classify stale the moment it is written"
   require_non_negative_int "--skew-grace" "$skew_grace"
-  require_int_at_least_one "--epoch" "$epoch"
+  require_int_at_least_one "--epoch" "$epoch" "epochs start at 1"
   if [[ -z "$run_dir" ]]; then
     die "--run-dir is required"
   fi
@@ -470,9 +477,23 @@ cmd_lease_acquire() {
   #
   # `--run-dir` usually does not exist yet, which is the point of `mkdir` below,
   # so its deepest EXISTING ancestor is what gets resolved — the only part a
-  # symlink can be in. A link introduced after this check is out of scope for any
-  # check-then-act sequence, and it would have to be planted inside the plugin's
-  # own data directory.
+  # symlink can be in.
+  #
+  # DISCLOSED RESIDUAL: this is check-then-act, so a symlink planted between the
+  # resolution and the `mkdir` is not covered. Closing that needs an atomic
+  # create-and-verify no portable shell offers, and the attacker would already
+  # need write access inside the plugin's own data directory — at which point they
+  # can write the lease themselves and the guard is moot. Recorded rather than
+  # implied, because a guard whose limits are unstated reads as one without any.
+  # THE PLUGIN DATA ROOT IS CREATED FIRST, because on a plugin's very first run it
+  # does not exist yet and `pwd -P` cannot resolve a directory that is not there —
+  # resolving before creating would have made `acquire` fail for exactly the run
+  # that has never succeeded before, which no test with a pre-made fixture would
+  # ever catch. Creating the plugin's OWN data root is inside this script's
+  # mandate and is not a target write; it is the tree everything below is then
+  # confined to.
+  mkdir -p "$plugin_data" || die "cannot create the plugin data directory: $plugin_data"
+
   local real_plugin_data real_prefix
   real_plugin_data=$(physical_path "$plugin_data") ||
     die "--plugin-data cannot be resolved: $plugin_data"
@@ -722,7 +743,7 @@ cmd_partial_append() {
   # Omitting the flag is only correct for a run whose epoch nothing has moved.
   local fenced=0
   if [[ -n "$held_epoch" ]]; then
-    require_int_at_least_one "--epoch" "$held_epoch"
+    require_int_at_least_one "--epoch" "$held_epoch" "epochs start at 1"
     if [[ "$held_epoch" != "$epoch" ]]; then
       fenced=1
       printf '%s: FENCED — lease owner_epoch is %s but this writer holds %s; the record lands in the writer'"'"'s own epoch file and this run must stop (exit %s)\n' \

--- a/plugins/claude-config/skills/audit-pass/scripts/run-state.test.sh
+++ b/plugins/claude-config/skills/audit-pass/scripts/run-state.test.sh
@@ -304,6 +304,37 @@ rc=0
 OUT=$(env -u CLAUDE_PLUGIN_DATA bash "$SCRIPT" lease acquire --run-dir "$DATA/runs/demo/z" --run-id run-z 2>&1) || rc=$?
 assert_exit "acquire without --plugin-data has nothing to check containment against, and refuses" 2 "$rc"
 
+# A lexical prefix check is not containment while symlinks exist: with
+# runs/link -> /tmp/outside, `<plugin-data>/runs/link/run` passes a string
+# comparison and then mkdir and the lease write follow the link straight out of
+# the plugin tree. The guarantee would hold on the string and fail on the disk.
+ESCAPE_TARGET="$TEST_TMPDIR/escaped"
+mkdir -p "$ESCAPE_TARGET" "$DATA/runs"
+if ln -s "$ESCAPE_TARGET" "$DATA/runs/link" 2>/dev/null && [[ -L "$DATA/runs/link" ]]; then
+  rc=0
+  OUT=$(run lease acquire --run-dir "$DATA/runs/link/run" --run-id run-s --plugin-data "$DATA" 2>&1) || rc=$?
+  assert_exit "a run dir reached through a symlink out of the tree is refused" 2 "$rc"
+  assert_contains "the refusal names the resolved destination" "$OUT" "symlinked component"
+  if [[ -e "$ESCAPE_TARGET/run/lease" ]]; then
+    fail "the symlinked escape must not be written" "$ESCAPE_TARGET/run/lease exists"
+  else
+    pass "no lease was written through the symlink"
+  fi
+  # A symlink that stays INSIDE the tree is not an escape and must still work.
+  mkdir -p "$DATA/runs/real"
+  if ln -s "$DATA/runs/real" "$DATA/runs/inside" 2>/dev/null; then
+    rc=0
+    run lease acquire --run-dir "$DATA/runs/inside/run" --run-id run-i --plugin-data "$DATA" >/dev/null 2>&1 || rc=$?
+    assert_exit "a symlink resolving back inside the tree is still accepted" 0 "$rc"
+  fi
+else
+  # ANNOUNCED, never silent: symlink creation needs privilege or developer mode
+  # on Windows. The escape arm is exercised on POSIX CI.
+  printf 'SKIP: symlink-containment arm not exercised — this platform refused ln -s. Exercised on POSIX CI.\n' >&2
+  assert_exit "the lexical containment check still refuses an outside path here" 2 \
+    "$(rc=0; run lease acquire --run-dir "$TEST_TMPDIR/outside2" --run-id run-s2 --plugin-data "$DATA" >/dev/null 2>&1 || rc=$?; echo "$rc")"
+fi
+
 # --- Case 6: the append-only partial ----------------------------------------
 
 P_DIR="$DATA/runs/demo/run-partial"
@@ -364,6 +395,22 @@ assert_exit "without jq, a brace inside a string does not fool the fallback" 0 "
 rc=0
 nojq partial append --run-dir "$P_DIR" --record '{}' >/dev/null 2>&1 || rc=$?
 assert_exit "without jq, an empty object is accepted" 0 "$rc"
+# python3 is the second definitive rung, so the no-jq path is still a real parse
+# where it exists — `{"a" garbage}` balances and opens with a quoted key, and no
+# non-parser catches it.
+if command -v python3 >/dev/null 2>&1; then
+  rc=0
+  nojq2() { PATH="$EMPTY_PATH:$(dirname "$(command -v python3)")" CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" "$REAL_BASH" "$SCRIPT" "$@"; }
+  nojq2 partial append --run-dir "$P_DIR" --record '{"a" garbage}' >/dev/null 2>&1 || rc=$?
+  assert_exit "without jq but with python3, a balanced object-shaped non-JSON string is refused" 2 "$rc"
+else
+  printf 'SKIP: python3 rung not exercised — python3 absent here. Exercised on CI.\n' >&2
+fi
+# With NEITHER parser the structural rung cannot catch that case, so it says so
+# rather than passing for the real thing.
+assert_contains "with neither parser the weaker check announces its own limit" \
+  "$(nojq partial append --run-dir "$P_DIR" --record '{"a":1}' 2>&1 >/dev/null)" \
+  "checked structurally only"
 
 # The epoch in the filename is the WRITER's, not whatever the lease now carries.
 # A stale holder that wakes after an adopter incremented the epoch would
@@ -375,15 +422,27 @@ assert_exit "without jq, an empty object is accepted" 0 "$rc"
   printf 'started_at=x\nheartbeat_at=%s\nheartbeat_at_iso=x\n' "$(date -u +%s)"
   printf 'stale_after_s=1800\nskew_grace_s=60\n'
 } >"$P_DIR/lease"
-OUT=$(run partial append --run-dir "$P_DIR" --record '{"lane":"fenced"}' --epoch 3 2>/dev/null)
+rc=0
+OUT=$(run partial append --run-dir "$P_DIR" --record '{"lane":"fenced"}' --epoch 3 2>/dev/null) || rc=$?
 assert_eq "a fenced writer appends to its own epoch file, not the adopter's" \
   "$P_DIR/findings.partial.3.jsonl" "$OUT"
-assert_contains "and the fence is reported rather than swallowed" \
+# The abort must be ENFORCED, not announced. A stderr string saying "this run
+# must stop" while the command still exits 0 is a control reporting a state it
+# never established — it depends on the caller noticing a substring, and it is
+# indistinguishable in form from any other diagnostic. `classify` already puts
+# its machine-actionable answer where a caller cannot miss it.
+assert_exit "a fenced append exits 3 — the abort is in the exit code, not only the message" 3 "$rc"
+assert_contains "and the fence is still said in words" \
   "$(run partial append --run-dir "$P_DIR" --record '{"lane":"fenced2"}' --epoch 3 2>&1 >/dev/null)" \
   "FENCED"
-OUT=$(run partial append --run-dir "$P_DIR" --record '{"lane":"adopter"}' 2>/dev/null)
+rc=0
+run partial append --run-dir "$P_DIR" --record '{"lane":"same"}' --epoch 9 >/dev/null 2>&1 || rc=$?
+assert_exit "an append whose --epoch matches the lease is not fenced and exits 0" 0 "$rc"
+rc=0
+OUT=$(run partial append --run-dir "$P_DIR" --record '{"lane":"adopter"}' 2>/dev/null) || rc=$?
 assert_eq "omitting --epoch still falls back to the lease's current epoch" \
   "$P_DIR/findings.partial.9.jsonl" "$OUT"
+assert_exit "and that fallback is not treated as a fence" 0 "$rc"
 
 NO_LEASE="$DATA/runs/demo/run-noleash"
 mkdir -p "$NO_LEASE"

--- a/plugins/claude-config/skills/audit-pass/scripts/run-state.test.sh
+++ b/plugins/claude-config/skills/audit-pass/scripts/run-state.test.sh
@@ -136,7 +136,7 @@ fi
 # --- Case 3: the lease, acquire through classify ----------------------------
 
 RUN_DIR="$DATA/runs/demo/run-0001"
-LEASE_OUT=$(run lease acquire --run-dir "$RUN_DIR" --run-id run-0001 2>&1)
+LEASE_OUT=$(run lease acquire --run-dir "$RUN_DIR" --run-id run-0001 --plugin-data "$DATA" 2>&1)
 assert_contains "acquire prints the lease path" "$LEASE_OUT" "$RUN_DIR/lease"
 assert_file "acquire writes the lease" "$RUN_DIR/lease"
 LEASE=$(cat "$RUN_DIR/lease")
@@ -153,15 +153,15 @@ assert_eq "a freshly acquired lease classifies live" "live" "$(run lease classif
 # documents `--stale-after` as an operator lever, so its zero value has to refuse
 # rather than quietly produce a lease no run could keep.
 rc=0
-OUT=$(run lease acquire --run-dir "$DATA/runs/demo/zero" --run-id zero --stale-after 0 2>&1) || rc=$?
+OUT=$(run lease acquire --run-dir "$DATA/runs/demo/zero" --run-id zero --stale-after 0 --plugin-data "$DATA" 2>&1) || rc=$?
 assert_exit "--stale-after 0 is refused rather than writing a lease born abandoned" 2 "$rc"
 assert_contains "the refusal says what 0 would do" "$OUT" "classify stale the moment it is written"
 rc=0
-run lease acquire --run-dir "$DATA/runs/demo/zeroe" --run-id zeroe --epoch 0 >/dev/null 2>&1 || rc=$?
+run lease acquire --run-dir "$DATA/runs/demo/zeroe" --run-id zeroe --epoch 0 --plugin-data "$DATA" >/dev/null 2>&1 || rc=$?
 assert_exit "--epoch 0 is refused" 2 "$rc"
 # Zero forward tolerance is a coherent choice and inverts nothing, so it stays legal.
 rc=0
-run lease acquire --run-dir "$DATA/runs/demo/zerosk" --run-id zerosk --skew-grace 0 >/dev/null 2>&1 || rc=$?
+run lease acquire --run-dir "$DATA/runs/demo/zerosk" --run-id zerosk --skew-grace 0 --plugin-data "$DATA" >/dev/null 2>&1 || rc=$?
 assert_exit "--skew-grace 0 stays legal" 0 "$rc"
 assert_eq "and that lease is live when it is written" \
   "live" "$(run lease classify --run-dir "$DATA/runs/demo/zerosk")"
@@ -174,7 +174,7 @@ assert_exit "a missing lease is a classification, not a failure" 0 "$rc"
 
 # A backdated heartbeat past the recorded threshold is stale.
 STALE_DIR="$DATA/runs/demo/run-stale"
-run lease acquire --run-dir "$STALE_DIR" --run-id run-stale --stale-after 30 >/dev/null 2>&1
+run lease acquire --run-dir "$STALE_DIR" --run-id run-stale --stale-after 30 --plugin-data "$DATA" >/dev/null 2>&1
 NOW=$(date -u +%s)
 {
   printf 'run_id=run-stale\npid=1\nstate=active\nowner_epoch=1\n'
@@ -243,7 +243,7 @@ fi
 # --- Case 5: heartbeat and the released tombstone ---------------------------
 
 HB_DIR="$DATA/runs/demo/run-hb"
-run lease acquire --run-dir "$HB_DIR" --run-id run-hb >/dev/null 2>&1
+run lease acquire --run-dir "$HB_DIR" --run-id run-hb --plugin-data "$DATA" >/dev/null 2>&1
 {
   printf 'run_id=run-hb\npid=1\nstate=active\nowner_epoch=2\n'
   printf 'started_at=x\nheartbeat_at=%s\nheartbeat_at_iso=x\n' "$((NOW - 600))"
@@ -265,7 +265,7 @@ FUTURE=$((NOW + 7200))
 assert_eq "a refresh does not move heartbeat_at backwards" "$FUTURE" \
   "$(run lease heartbeat --run-dir "$HB_DIR")"
 
-run lease acquire --run-dir "$HB_DIR" --run-id run-hb >/dev/null 2>&1
+run lease acquire --run-dir "$HB_DIR" --run-id run-hb --plugin-data "$DATA" >/dev/null 2>&1
 assert_eq "release prints the tombstone state" "released" "$(run lease release --run-dir "$HB_DIR")"
 assert_eq "a released lease classifies released, not live" \
   "released" "$(run lease classify --run-dir "$HB_DIR")"
@@ -276,10 +276,38 @@ rc=0
 run lease heartbeat --run-dir "$DATA/runs/demo/absent" >/dev/null 2>&1 || rc=$?
 assert_exit "heartbeat on a directory that does not exist exits 2" 2 "$rc"
 
+# --- Case 5b: acquire is where the write tree is pinned ---------------------
+#
+# acquire is the only command that CREATES a directory, so a wrong or invented
+# --run-dir would otherwise get that directory created and a lease written into
+# it. The skill keeps Bash specifically for state writes while promising a bare
+# audit writes nothing into the target, so a run dir outside the plugin's own
+# tree has to be refused rather than created.
+
+OUTSIDE="$TEST_TMPDIR/target-repo/.claude"
+rc=0
+OUT=$(run lease acquire --run-dir "$OUTSIDE" --run-id run-x --plugin-data "$DATA" 2>&1) || rc=$?
+assert_exit "a run dir outside <plugin-data>/runs/ is refused" 2 "$rc"
+assert_contains "the refusal says it will not write outside the plugin tree" "$OUT" \
+  "refusing to write outside"
+if [[ -d "$OUTSIDE" ]]; then
+  fail "the refused run dir must not be created" "$OUTSIDE exists"
+else
+  pass "the refused run dir was not created"
+fi
+
+rc=0
+run lease acquire --run-dir "$DATA/runs/demo/../../escape" --run-id run-y --plugin-data "$DATA" >/dev/null 2>&1 || rc=$?
+assert_exit "a run dir containing '..' is refused" 2 "$rc"
+
+rc=0
+OUT=$(env -u CLAUDE_PLUGIN_DATA bash "$SCRIPT" lease acquire --run-dir "$DATA/runs/demo/z" --run-id run-z 2>&1) || rc=$?
+assert_exit "acquire without --plugin-data has nothing to check containment against, and refuses" 2 "$rc"
+
 # --- Case 6: the append-only partial ----------------------------------------
 
 P_DIR="$DATA/runs/demo/run-partial"
-run lease acquire --run-dir "$P_DIR" --run-id run-partial --epoch 3 >/dev/null 2>&1
+run lease acquire --run-dir "$P_DIR" --run-id run-partial --epoch 3 --plugin-data "$DATA" >/dev/null 2>&1
 OUT=$(run partial append --run-dir "$P_DIR" --record '{"lane":"skills","attempt":1,"type":"start"}')
 assert_eq "the partial is named for the epoch the lease holds" \
   "$P_DIR/findings.partial.3.jsonl" "$OUT"
@@ -300,6 +328,62 @@ OUT=$(run partial append --run-dir "$P_DIR" --record '{"a":1}
 {"b":2}' 2>&1) || rc=$?
 assert_exit "a record spanning two lines is refused" 2 "$rc"
 assert_contains "the refusal says why one line matters" "$OUT" "single line"
+
+# A record that balances and ends in `}` but is not JSON must still be refused:
+# a malformed row in an append-only artifact is permanent, and resume and
+# assembly are its only readers.
+rc=0
+OUT=$(run partial append --run-dir "$P_DIR" --record '{bad json}' 2>&1) || rc=$?
+assert_exit "a balanced-but-malformed record is refused, not appended" 2 "$rc"
+rc=0
+OUT=$(run partial append --run-dir "$P_DIR" --record '{"a":1' 2>&1) || rc=$?
+assert_exit "a truncated record is refused" 2 "$rc"
+rc=0
+OUT=$(run partial append --run-dir "$P_DIR" --record '{"a":"}"}' 2>&1) || rc=$?
+assert_exit "a brace inside a string does not fool the check" 0 "$rc"
+assert_eq "and the malformed records left the artifact untouched" "3" \
+  "$(wc -l <"$P_DIR/findings.partial.3.jsonl" | tr -d ' ')"
+
+# The no-jq rung has to catch the same cases, since jq is optional here on
+# purpose: failing the run's state-persistence path closed on a missing optional
+# tool would cost the artifact the check exists to protect. Exercised by running
+# with a PATH that has bash and nothing else, so the fallback is what answers.
+REAL_BASH=$(command -v bash)
+EMPTY_PATH="$TEST_TMPDIR/empty-path"
+mkdir -p "$EMPTY_PATH"
+nojq() { PATH="$EMPTY_PATH" CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" "$REAL_BASH" "$SCRIPT" "$@"; }
+rc=0
+nojq partial append --run-dir "$P_DIR" --record '{bad json}' >/dev/null 2>&1 || rc=$?
+assert_exit "without jq, a balanced-but-malformed record is still refused" 2 "$rc"
+rc=0
+nojq partial append --run-dir "$P_DIR" --record '{"a":1' >/dev/null 2>&1 || rc=$?
+assert_exit "without jq, a truncated record is still refused" 2 "$rc"
+rc=0
+nojq partial append --run-dir "$P_DIR" --record '{"a":"}"}' >/dev/null 2>&1 || rc=$?
+assert_exit "without jq, a brace inside a string does not fool the fallback" 0 "$rc"
+rc=0
+nojq partial append --run-dir "$P_DIR" --record '{}' >/dev/null 2>&1 || rc=$?
+assert_exit "without jq, an empty object is accepted" 0 "$rc"
+
+# The epoch in the filename is the WRITER's, not whatever the lease now carries.
+# A stale holder that wakes after an adopter incremented the epoch would
+# otherwise read the adopter's value and append into the adopter's file — two
+# writers interleaved under one attempt ordinal, the one failure the attempt
+# machinery cannot absorb.
+{
+  printf 'run_id=run-partial\npid=1\nstate=active\nowner_epoch=9\n'
+  printf 'started_at=x\nheartbeat_at=%s\nheartbeat_at_iso=x\n' "$(date -u +%s)"
+  printf 'stale_after_s=1800\nskew_grace_s=60\n'
+} >"$P_DIR/lease"
+OUT=$(run partial append --run-dir "$P_DIR" --record '{"lane":"fenced"}' --epoch 3 2>/dev/null)
+assert_eq "a fenced writer appends to its own epoch file, not the adopter's" \
+  "$P_DIR/findings.partial.3.jsonl" "$OUT"
+assert_contains "and the fence is reported rather than swallowed" \
+  "$(run partial append --run-dir "$P_DIR" --record '{"lane":"fenced2"}' --epoch 3 2>&1 >/dev/null)" \
+  "FENCED"
+OUT=$(run partial append --run-dir "$P_DIR" --record '{"lane":"adopter"}' 2>/dev/null)
+assert_eq "omitting --epoch still falls back to the lease's current epoch" \
+  "$P_DIR/findings.partial.9.jsonl" "$OUT"
 
 NO_LEASE="$DATA/runs/demo/run-noleash"
 mkdir -p "$NO_LEASE"

--- a/plugins/claude-config/skills/audit-pass/scripts/run-state.test.sh
+++ b/plugins/claude-config/skills/audit-pass/scripts/run-state.test.sh
@@ -308,6 +308,17 @@ assert_exit "acquire without --plugin-data has nothing to check containment agai
 # runs/link -> /tmp/outside, `<plugin-data>/runs/link/run` passes a string
 # comparison and then mkdir and the lease write follow the link straight out of
 # the plugin tree. The guarantee would hold on the string and fail on the disk.
+# THE FIRST RUN OF ALL. On a fresh install the plugin data directory does not
+# exist yet, and a containment check that resolves it with `pwd -P` before
+# creating it fails for exactly the run that has never succeeded before. A
+# fixture that pre-makes the directory — every other case in this file — cannot
+# see that.
+FRESH="$TEST_TMPDIR/never-used/data"
+rc=0
+OUT=$(run lease acquire --run-dir "$FRESH/runs/demo/first" --run-id first --plugin-data "$FRESH" 2>&1) || rc=$?
+assert_exit "acquire works on a plugin data directory that does not exist yet" 0 "$rc"
+assert_file "and the lease is written under it" "$FRESH/runs/demo/first/lease"
+
 ESCAPE_TARGET="$TEST_TMPDIR/escaped"
 mkdir -p "$ESCAPE_TARGET" "$DATA/runs"
 if ln -s "$ESCAPE_TARGET" "$DATA/runs/link" 2>/dev/null && [[ -L "$DATA/runs/link" ]]; then


### PR DESCRIPTION
## Summary

**`claude-config` 0.38.0 is on `main` carrying three defects in the script it shipped.** They were
found by review on #2441; that PR merged at 13:19:55Z while the fixes were still being written, so
they ship here as 0.38.1. Anyone on 0.38.0 has all three.

All three are one family, and it is the family this batch keeps finding: **a control that does not
enforce what its surface claims.**

**1. The partial was named for the lease's *current* epoch, not the writer's.** `partial append` read
`owner_epoch` out of the lease at append time. That defeats precisely the isolation
`run-state-and-resumability.md` §3 describes: a stale holder that wakes after an adopter has
incremented the epoch reads the *adopter's* value and appends into the *adopter's* file, so two
writers interleave under one attempt ordinal — which §3 itself calls "the one failure the attempt
machinery cannot absorb". The script was contradicting the paragraph it was written to enforce.

`partial append --epoch <held>` now names the writer's own file whatever the lease says, and prints
`FENCED` on stderr when the two differ so the run aborts on the signal rather than corrupting the
artifact quietly. Omitting the flag still falls back to the lease's epoch, correct only for a run
whose epoch nothing has moved — and that is now stated rather than assumed.

**2. `{bad json}` was accepted and appended permanently.** The check was `case "$record" in '{'*)`,
which passes any string starting with a brace. A malformed row in an append-only artifact cannot be
taken back, and `--resume` and assembly are its only readers, so a quoting slip in the caller cost the
run's whole persisted state rather than one record.

Records are now verified as well-formed single-line JSON objects. `jq` decides where it is installed;
where it is not, a scan that tracks string context and escape sequences still rejects `{bad json}`, a
truncated row, and an unbalanced one. **`jq` is deliberately not a hard requirement** — this is the
run's state-persistence path, and failing it closed on a missing optional tool would cost the artifact
the check exists to protect. Both rungs are asserted; the fallback runs with a `PATH` holding only
`bash`.

**3. `lease acquire` created and wrote into any `--run-dir` it was handed.** A wrong or invented run
directory — the target root, say — was created and had a `lease` written into it. This skill keeps
Bash specifically for state writes *while promising that a bare audit writes nothing into the target*,
so that promise was enforceable only by the caller getting the argument right. `acquire` is the only
command that creates a directory, so it is where the write tree is pinned: it now requires
`--plugin-data` and refuses any run directory outside `<plugin-data>/runs/`. Every later command
operates on a directory `acquire` already validated.

Version: `claude-config` **0.38.0 to 0.38.1**. The shipped `## [0.38.0]` section is untouched —
0.38.1 is additive and says outright that 0.38.0 carries all three.

## Test plan

**Fail-before / pass-after, per finding.** Each was reproduced against the merged 0.38.0 script
before the fix, and each ships an assertion that fails without it.

Verbatim transcript. `v0380.sh` is `git show origin/main:.../run-state.sh` — the script as merged. The
lease is moved to `owner_epoch=9` as an adopter would leave it, while the writer still holds 3.

```
--- 1. epoch binding, 0.38.0 (writer holds 3, lease says 9) ---
/tmp/tmp.RpfHhnqzmO/data/runs/demo/r1/findings.partial.9.jsonl
rc=0
--- 2. malformed record, 0.38.0 ---
/tmp/tmp.RpfHhnqzmO/data/runs/demo/r1/findings.partial.9.jsonl
rc=0
--- 3. write-tree containment, 0.38.0 ---
/tmp/tmp.RpfHhnqzmO/target-repo/.claude/lease
rc=0
lease
^ the lease was written into a non-plugin tree
=== now the fixed script ===
--- 1. fixed ---
run-state.sh: FENCED — lease owner_epoch is 9 but this writer holds 3; appending to the writer's own epoch file and this run must abort
/tmp/tmp.RpfHhnqzmO/data/runs/demo/r1/findings.partial.3.jsonl
rc=0
--- 2. fixed ---
run-state.sh: --record must be a well-formed single-line JSON object: {bad json}
rc=2
--- 3. fixed ---
run-state.sh: --run-dir is not under $plugin-data/runs/ — refusing to write outside the plugin's own tree: /tmp/tmp.RpfHhnqzmO/target-repo2/.claude
rc=2
```

Read line 2 against line 12: on 0.38.0 the record the writer holding epoch 3 appended landed in
`findings.partial.**9**.jsonl` — the adopter's file. On the fix it lands in `.3.` and the fence is
announced. Line 4 is `{bad json}` accepted and appended at `rc=0`; line 7 is a lease written into
`target-repo/.claude`, a directory the script created outside the plugin's tree.

**Suite — 73 checks, up from 57:**

```
$ bash plugins/claude-config/skills/audit-pass/scripts/run-state.test.sh
PASS: a run dir outside <plugin-data>/runs/ is refused
PASS: the refusal says it will not write outside the plugin tree
PASS: the refused run dir was not created
PASS: a run dir containing '..' is refused
PASS: acquire without --plugin-data has nothing to check containment against, and refuses
PASS: a balanced-but-malformed record is refused, not appended
PASS: a truncated record is refused
PASS: a brace inside a string does not fool the check
PASS: and the malformed records left the artifact untouched
PASS: without jq, a balanced-but-malformed record is still refused
PASS: without jq, a truncated record is still refused
PASS: without jq, a brace inside a string does not fool the fallback
PASS: without jq, an empty object is accepted
PASS: a fenced writer appends to its own epoch file, not the adopter's
PASS: and the fence is reported rather than swallowed
PASS: omitting --epoch still falls back to the lease's current epoch
...
All 73 checks passed.
```

The three mutation-based negative tests from 0.38.0 still pass unchanged — each deletes exactly one
check from a copy of the script and asserts the mutated copy reaches the outcome the real one refuses.

**Repo gates, locally:**

```
$ shellcheck --rcfile .shellcheckrc -S info plugins/claude-config/skills/audit-pass/scripts/*.sh
(clean)
$ typos --config _typos.toml plugins/claude-config/
(clean)
$ bash scripts/check-changed-skills.sh origin/main
CHECK-SKILL audit-pass: PASS — 0 errors, 2 warning(s)
$ bash scripts/check-changelog-parity.sh --check-preserved origin/main
All 1 changed changelog(s) preserve every version heading they carried at e4501a0 (68 compared).
$ bash scripts/check-changelog-parity.sh --check-bump origin/main
Every plugin whose version changed vs origin/main has a '## [<version>]' CHANGELOG.md entry.
$ npx markdownlint-cli2 "plugins/claude-config/skills/audit-pass/**/*.md" "plugins/claude-config/CHANGELOG.md"
Summary: 0 issues in 0 files
```

Both `.sh` files carry mode `100755` — the `exec-bit` sub-check of `hygiene` fails on `100644`, and it
is invisible to every local linter.

## Review rounds on this PR, and what they changed

Seven further findings landed after the first push. All are fixed here, each with an assertion, and
every one is the same class again — a control not enforcing what its surface claims. Recorded because
three of them were in *my own fix for that class*.

- **🔴 `FENCED` was advisory only.** The script printed "this run must abort" and returned 0, so the
  abort depended on the caller spotting a substring on stderr. A fenced append now **exits 3**; the
  record still lands in the writer's own epoch file, and `SKILL.md` Phase 3 says what to do with the
  code. The test asserts the exit code, not just the message.
- **🔴 The symlink fix broke the very first run.** `pwd -P` cannot resolve a directory that is not
  there, so canonicalizing `--plugin-data` before creating it made `lease acquire` fail on a plugin's
  first-ever run — the only run whose data root has never existed. **Every test in the file pre-makes
  that directory, so none could see it.** Reproduced against the prior commit (`--plugin-data cannot
  be resolved`, `rc=2`), fixed, and a test now exercises the fresh-install path.
- **P1: the no-parser rung over-claimed.** `{"a" garbage}` balances and opens with a quoted key, and
  no non-parser catches it. `python3` is now the second definitive rung after `jq`, and where neither
  exists the structural scan **announces on stderr that it checked structurally only** rather than
  passing for a validator.
- **P2: containment was lexical, so a symlink defeated it.** Both sides are canonicalized with
  `pwd -P` — `--run-dir` through its deepest existing ancestor. Tests assert the escape is refused,
  that no lease was written through the link, and that a symlink resolving back inside still works.
  The arm skips on Windows (`ln -s` refused) and **passes on CI**.
- **P2: `report-location-and-schema.md` §7 still described the old append contract**, so an audit
  following that page after an adoption would have omitted `--epoch` and reinstated the interleaving.
  Both surfaces now carry the same command.
- **🟡 check-then-act window** between symlink resolution and `mkdir`: accepted and now recorded in
  the code as a disclosed residual. Closing it needs an atomic create-and-verify no portable shell
  offers, and the attacker would already need write access inside the plugin's own data directory.
- **🟡 a shared validator printed a staleness-specific reason at an `--epoch` rejection.** The reason
  is now an argument.

Suite: **81 checks**, all passing. All six bot threads are replied to and resolved; the one open
thread is my own do-not-merge marker.

## Related

Refs #2280

No linked issue closes here. #2280 was closed by #2441's merge and its four live rows (F3, F5, F12,
F13) are genuinely retired by the mechanism that shipped; this PR repairs three defects *in that
mechanism* rather than reopening a row, so it deliberately carries no closing keyword.

Follow-up to #2441 (`claude-config` 0.38.0). Origin: handoff-inbox item
`20260811-020411-claude-config-audit-pass-report-path-inside-scan-set`.

**Note for the reviewer, recorded rather than left implicit.** #2441 was merged by another actor
while it carried an explicit "do not merge" and an unresolved review comment naming two deliberate
spec reductions for sign-off. Nothing shipped that is unsafe, but three real defects reached `main`
that would not have. Those two reductions — the 60-second wall-clock heartbeat becoming
boundary-driven refresh with the thresholds recorded in the lease, and §5's separate run manifest
becoming the partial's own lane records — are now live on `main` unreviewed and still want a human
read. They are described in #2441's body and in the `## [0.38.0]` CHANGELOG entry.
