### PR TITLE
fix(ci): fail --check-bump on published-version reuse without manifest bump

### DIFF
--- a/scripts/check-changelog-parity.sh
+++ b/scripts/check-changelog-parity.sh
@@ -405,6 +405,8 @@ fi
 # plugin-root scoping) a cosmetic touch elsewhere under the plugin dir cannot pull
 # a main-only advance back into scope.
 declare -A bumped_candidate
+declare -A plugin_changed
+declare -A shipped_changed
 # The changelogs this change set touched, in `git diff` order, for
 # --check-preserved. Same two roots --check-order sweeps.
 touched_changelogs=()
@@ -444,12 +446,24 @@ while IFS= read -r path; do
     rest="${path#plugins/}"
     bumped_candidate["${rest%%/*}"]=1
     ;;
-  plugins/*/CHANGELOG.md | docs/conventions/*/CHANGELOG.md)
+  plugins/*/CHANGELOG.md)
+    rest="${path#plugins/}"
+    plugin_changed["${rest%%/*}"]=1
+    if [[ -z "${seen_changelog[$path]:-}" ]]; then
+      seen_changelog["$path"]=1
+      touched_changelogs+=("$path")
+    fi
+    ;;
+  plugins/*/*)
+    rest="${path#plugins/}"
+    plugin_changed["${rest%%/*}"]=1
+    shipped_changed["${rest%%/*}"]=1
+    ;;
+  docs/conventions/*/CHANGELOG.md)
     # A `case` glob's `*` spans `/`, so the depth is re-checked explicitly: only
     # a changelog exactly one directory below a root is in scope, never one
     # nested deeper inside a plugin.
-    rest="${path#plugins/}"
-    rest="${rest#docs/conventions/}"
+    rest="${path#docs/conventions/}"
     if [[ "$rest" == "${rest%%/*}/CHANGELOG.md" && -z "${seen_changelog[$path]:-}" ]]; then
       seen_changelog["$path"]=1
       touched_changelogs+=("$path")
@@ -560,6 +574,7 @@ undocumented=0
 malformed=0
 preexisting=0
 nonmonotonic=0
+published_reuse=0
 absorbed=0
 declare -A absorbed_reported
 
@@ -584,15 +599,27 @@ for manifest in "${manifests[@]}"; do
   name="${plugin_dir##*/}"
   changelog="$plugin_dir/CHANGELOG.md"
 
+  base_version="$(git show "$base:$manifest" 2>/dev/null | jq -r '.version // empty' 2>/dev/null || true)"
+  [[ -n "$base_version" ]] || continue
+  head_version="$(version_of "$manifest")"
+
+  # A branch that changes shipped plugin files but leaves the manifest version
+  # byte-identical to the base tip reuses a published version number (#1559).
+  # Changelog-only edits and manifest bumps are out of scope here — the former
+  # is --check-preserved / review discipline; the latter is collision/preexisting.
+  if [[ -n "${shipped_changed[$name]:-}" && -z "${bumped_candidate[$name]:-}" && "$head_version" == "$base_version" ]]; then
+    echo "PUBLISHED VERSION REUSE: $name still carries $head_version while this change set modifies files under plugins/$name/ — bump the manifest and add a new '## [$head_version]' release entry instead of editing in place." >&2
+    published_reuse=$((published_reuse + 1))
+    continue
+  fi
+
   # Only plugins whose manifest this change set touched are in scope (see the
   # bumped_candidate note above); a plugin main advanced but this branch never
   # touched is not the PR's to document.
   [[ -n "${bumped_candidate[$name]:-}" ]] || continue
 
-  base_version="$(git show "$base:$manifest" 2>/dev/null | jq -r '.version // empty' 2>/dev/null || true)"
   # Absent at base => new plugin in this change set; the static --check owns
   # whether its initial CHANGELOG.md exists, not the bump gate.
-  [[ -n "$base_version" ]] || continue
   head_version="$(version_of "$manifest")"
 
   # "Did this branch bump?" is head vs the FORK POINT, never vs the base tip:
@@ -681,12 +708,13 @@ for manifest in "${manifests[@]}"; do
   fi
 done
 
-if ((undocumented > 0 || malformed > 0 || preexisting > 0 || nonmonotonic > 0 || absorbed > 0)); then
+if ((undocumented > 0 || malformed > 0 || preexisting > 0 || nonmonotonic > 0 || absorbed > 0 || published_reuse > 0)); then
   ((undocumented > 0)) && echo "Add a '## [<version>]' entry for every plugin whose version changed." >&2
   ((malformed > 0)) && echo "Convert unbracketed changelog headings to the '## [<version>]' Keep-a-Changelog form." >&2
   ((preexisting > 0)) && echo "Add the bumped version's '## [<version>]' entry in this change set; it must be absent from the base changelog, not merely present at head." >&2
   ((nonmonotonic > 0)) && echo "Renumber every bumped version strictly above the base ref's CURRENT version, not the version the branch was cut from." >&2
   ((absorbed > 0)) && echo "Restore every '## [<version>]' heading that existed at the fork point; release notes must not be relabelled or absorbed into a newer section." >&2
+  ((published_reuse > 0)) && echo "Bump the manifest version and add a new '## [<version>]' release entry whenever this change set modifies shipped plugin files — reusing a published version number is not allowed." >&2
   exit 1
 fi
 echo "Every plugin whose version changed vs $base has a '## [<version>]' CHANGELOG.md entry."

--- a/scripts/check-changelog-parity.sh
+++ b/scripts/check-changelog-parity.sh
@@ -405,7 +405,6 @@ fi
 # plugin-root scoping) a cosmetic touch elsewhere under the plugin dir cannot pull
 # a main-only advance back into scope.
 declare -A bumped_candidate
-declare -A plugin_changed
 declare -A shipped_changed
 # The changelogs this change set touched, in `git diff` order, for
 # --check-preserved. Same two roots --check-order sweeps.
@@ -448,15 +447,15 @@ while IFS= read -r path; do
     ;;
   plugins/*/CHANGELOG.md)
     rest="${path#plugins/}"
-    plugin_changed["${rest%%/*}"]=1
-    if [[ -z "${seen_changelog[$path]:-}" ]]; then
+    # A `case` glob's `*` spans `/`, so re-check depth: only the plugin-root
+    # changelog is in scope, never one nested deeper (e.g. plugins/alpha/docs/…).
+    if [[ "$rest" == "${rest%%/*}/CHANGELOG.md" && -z "${seen_changelog[$path]:-}" ]]; then
       seen_changelog["$path"]=1
       touched_changelogs+=("$path")
     fi
     ;;
   plugins/*/*)
     rest="${path#plugins/}"
-    plugin_changed["${rest%%/*}"]=1
     shipped_changed["${rest%%/*}"]=1
     ;;
   docs/conventions/*/CHANGELOG.md)
@@ -600,17 +599,25 @@ for manifest in "${manifests[@]}"; do
   changelog="$plugin_dir/CHANGELOG.md"
 
   base_version="$(git show "$base:$manifest" 2>/dev/null | jq -r '.version // empty' 2>/dev/null || true)"
+  # Absent at base => new plugin in this change set; the static --check owns
+  # whether its initial CHANGELOG.md exists, not the bump gate.
   [[ -n "$base_version" ]] || continue
   head_version="$(version_of "$manifest")"
+  fork_version="$(git show "$merge_base:$manifest" 2>/dev/null | jq -r '.version // empty' 2>/dev/null || true)"
 
   # A branch that changes shipped plugin files but leaves the manifest version
-  # byte-identical to the base tip reuses a published version number (#1559).
-  # Changelog-only edits and manifest bumps are out of scope here — the former
-  # is --check-preserved / review discipline; the latter is collision/preexisting.
-  if [[ -n "${shipped_changed[$name]:-}" && -z "${bumped_candidate[$name]:-}" && "$head_version" == "$base_version" ]]; then
-    echo "PUBLISHED VERSION REUSE: $name still carries $head_version while this change set modifies files under plugins/$name/ — bump the manifest and add a new '## [$head_version]' release entry instead of editing in place." >&2
-    published_reuse=$((published_reuse + 1))
-    continue
+  # unchanged vs the fork point reuses a published version number (#1559). Two
+  # cases: (1) manifest untouched and head still matches the base tip — reuse;
+  # (2) manifest touched cosmetically (path in diff, .version unchanged) while
+  # shipped files also changed — the old bumped_candidate guard let this evade
+  # detection. A stale branch whose base advanced without integrating stays out
+  # of scope when the manifest was never touched (manifest-scoping).
+  if [[ -n "${shipped_changed[$name]:-}" && "$head_version" == "$fork_version" ]]; then
+    if [[ -n "${bumped_candidate[$name]:-}" || "$head_version" == "$base_version" ]]; then
+      echo "PUBLISHED VERSION REUSE: $name still carries $head_version while this change set modifies files under plugins/$name/ — bump the manifest and add a new '## [$head_version]' release entry instead of editing in place." >&2
+      published_reuse=$((published_reuse + 1))
+      continue
+    fi
   fi
 
   # Only plugins whose manifest this change set touched are in scope (see the
@@ -618,17 +625,12 @@ for manifest in "${manifests[@]}"; do
   # touched is not the PR's to document.
   [[ -n "${bumped_candidate[$name]:-}" ]] || continue
 
-  # Absent at base => new plugin in this change set; the static --check owns
-  # whether its initial CHANGELOG.md exists, not the bump gate.
-  head_version="$(version_of "$manifest")"
-
   # "Did this branch bump?" is head vs the FORK POINT, never vs the base tip:
   # once the base ref advances past the fork, the tip comparison misreads both
   # directions — head==tip despite a real bump (two branches claimed the same
   # number: a collision that must FAIL, not read as not-bumped), and head!=tip
   # despite no bump at all (a cosmetic manifest edit on a stale branch, which
   # must stay out of scope rather than red-line as a regression).
-  fork_version="$(git show "$merge_base:$manifest" 2>/dev/null | jq -r '.version // empty' 2>/dev/null || true)"
   [[ "$head_version" != "$fork_version" ]] || continue
 
   # Monotonicity: the bumped version must land strictly ABOVE what the base ref

--- a/scripts/check-changelog-parity.test.sh
+++ b/scripts/check-changelog-parity.test.sh
@@ -471,15 +471,28 @@ rc=$?
 if [[ $rc -ne 0 && "$out" == *"UNDOCUMENTED BUMP"*"alpha"* ]]; then ok "bump without changelog fails --check-bump (synthetic undocumented bump caught)"; else fail "undocumented bump not caught: rc=$rc out='$out'"; fi
 rm -rf "$repo"
 
-# version unchanged -> passes (no bump, nothing to document)
+# version unchanged but plugin files changed -> fails (published version reuse, #1559)
 repo="$(mk_repo)"
 git_init "$repo"
 mk_plugin "$repo" alpha 1.0.0 yes
 git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm base
 base="$(git -C "$repo" rev-parse HEAD)"
-printf 'unrelated\n' >"$repo/plugins/alpha/README.md"
+printf 'shipped\n' >"$repo/plugins/alpha/shipped.txt"
 git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm noop
-if (cd "$repo" && bash scripts/check-changelog-parity.sh --check-bump "$base" >/dev/null 2>&1); then ok "unchanged version passes --check-bump"; else fail "unchanged version wrongly failed"; fi
+out="$(cd "$repo" && bash scripts/check-changelog-parity.sh --check-bump "$base" 2>&1)"
+rc=$?
+if [[ $rc -ne 0 && "$out" == *"PUBLISHED VERSION REUSE"*"alpha"* ]]; then ok "unchanged version with plugin file edits fails --check-bump"; else fail "published version reuse not caught: rc=$rc out='$out'"; fi
+rm -rf "$repo"
+
+# version unchanged and no plugin file edits -> passes
+repo="$(mk_repo)"
+git_init "$repo"
+mk_plugin "$repo" alpha 1.0.0 yes
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm base
+base="$(git -C "$repo" rev-parse HEAD)"
+printf 'unrelated\n' >"$repo/README.md"
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm noop
+if (cd "$repo" && bash scripts/check-changelog-parity.sh --check-bump "$base" >/dev/null 2>&1); then ok "unchanged version with no plugin edits passes --check-bump"; else fail "repo-only edit wrongly failed --check-bump"; fi
 rm -rf "$repo"
 
 # new plugin absent at base -> --check-bump skips it (static --check owns it)

--- a/scripts/check-changelog-parity.test.sh
+++ b/scripts/check-changelog-parity.test.sh
@@ -484,6 +484,20 @@ rc=$?
 if [[ $rc -ne 0 && "$out" == *"PUBLISHED VERSION REUSE"*"alpha"* ]]; then ok "unchanged version with plugin file edits fails --check-bump"; else fail "published version reuse not caught: rc=$rc out='$out'"; fi
 rm -rf "$repo"
 
+# cosmetic manifest touch (no version change) + shipped file edit -> fails (#1559 gap)
+repo="$(mk_repo)"
+git_init "$repo"
+mk_plugin "$repo" alpha 1.0.0 yes
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm base
+base="$(git -C "$repo" rev-parse HEAD)"
+printf '{ "name": "alpha", "version": "1.0.0", "description": "touched" }\n' >"$repo/plugins/alpha/.claude-plugin/plugin.json"
+printf 'shipped\n' >"$repo/plugins/alpha/shipped.txt"
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm noop
+out="$(cd "$repo" && bash scripts/check-changelog-parity.sh --check-bump "$base" 2>&1)"
+rc=$?
+if [[ $rc -ne 0 && "$out" == *"PUBLISHED VERSION REUSE"*"alpha"* ]]; then ok "cosmetic manifest touch with shipped file edits fails --check-bump"; else fail "cosmetic manifest reuse not caught: rc=$rc out='$out'"; fi
+rm -rf "$repo"
+
 # version unchanged and no plugin file edits -> passes
 repo="$(mk_repo)"
 git_init "$repo"


### PR DESCRIPTION
Closes #1559

## Summary

Fail `--check-bump` when a change set modifies shipped plugin files under a plugin directory without bumping the manifest version, including when a cosmetic `plugin.json` edit would previously have evaded detection.

## Fix

- Track `shipped_changed` separately from manifest-path touches
- Detect published-version reuse when head matches fork/base without a real bump
- Limit plugin changelog scoping to plugin-root `CHANGELOG.md` paths

## Verification

- `bash scripts/check-changelog-parity.test.sh` — 84 pass, 0 fail

## Related

N/A