### PR TITLE
fix(source-control): refuse autonomous resolve on own PRs

### DIFF
--- a/plugins/source-control/skills/babysit-prs/scripts/babysit_gh.py
+++ b/plugins/source-control/skills/babysit-prs/scripts/babysit_gh.py
@@ -355,6 +355,15 @@ def discover_prs(
     return sorted(found.values()), list(dict.fromkeys(errors))
 
 
+def fetch_pull_request_author(repo: str, number: int) -> str:
+    """The PR author's login from `gh pr view --json author`."""
+    repo = repo.casefold()
+    author = gh_json(["pr", "view", str(number), "--repo", repo, "--json", "author"])
+    if not is_json_object(author):
+        raise RuntimeError(f"Unexpected gh pr view author for {repo}#{number}")
+    return str(author.get("login") or "")
+
+
 def view_pr(repo: str, number: int) -> dict[str, Any]:
     repo = repo.casefold()
     data = gh_json(["pr", "view", str(number), "--repo", repo, "--json", VIEW_FIELDS])

--- a/plugins/source-control/skills/babysit-prs/scripts/babysit_resolve_thread.py
+++ b/plugins/source-control/skills/babysit-prs/scripts/babysit_resolve_thread.py
@@ -63,6 +63,12 @@ Deterministic guards encoded here:
   thread whose comment page is truncated cannot prove the absence of a marker
   and is refused the same way. Interactive modes are unaffected -- severity
   judgment there stays with the evaluating agent.
+- `--autonomous` and `--independent-resolver` refuse when the PR author is a
+  configured self login (`--self-logins`, including `@me`). Resolving threads on
+  the caller's own PR is the same actor signing its own permission slip the
+  unattended guards exist to prevent; there is no autonomous override (mirroring
+  the merge gate's human-only `--allow-unprotected` pattern). Interactive modes
+  are unaffected.
 - `--independent-resolver` is a THIRD mode, parallel to `--autonomous` and not a
   relaxation of it. `--autonomous`'s `isOutdated` requirement is right about the
   merging worker, but `isOutdated` means "the referenced code moved" -- on a prose
@@ -182,6 +188,7 @@ from babysit_classify import (
 from babysit_gh import (
     GITHUB_OWNER_RE,
     GITHUB_REPOSITORY_RE,
+    fetch_pull_request_author,
     fetch_review_threads,
     gh_capture,
     parse_repo_number,
@@ -1139,6 +1146,33 @@ def main() -> int:
             for token in (args.self_logins or "").split(",")
             if token.strip().casefold() != "@me"
         )
+
+    if args.autonomous or args.independent_resolver:
+        try:
+            pr_author = fetch_pull_request_author(repo, number)
+        except (RuntimeError, ValueError, json.JSONDecodeError) as exc:
+            print(json.dumps({"pr": args.pr, "error": f"{type(exc).__name__}: {exc}"}))
+            return 2
+        if is_self_login(pr_author, self_logins):
+            print(
+                json.dumps(
+                    {
+                        "pr": args.pr,
+                        "prAuthor": pr_author,
+                        "skippedOwnPr": True,
+                        "eligibleCount": 0,
+                        "humanThreadsActed": 0,
+                        "threads": [],
+                        "error": (
+                            "refused: PR author is a configured self login; "
+                            "--autonomous and --independent-resolver do not "
+                            "resolve threads on own PRs"
+                        ),
+                    },
+                    indent=2,
+                )
+            )
+            return 2 if args.resolve else 0
 
     try:
         threads = fetch_threads(

--- a/plugins/source-control/skills/babysit-prs/scripts/tests/test_babysit_resolve_thread.py
+++ b/plugins/source-control/skills/babysit-prs/scripts/tests/test_babysit_resolve_thread.py
@@ -40,6 +40,7 @@ self. Self authorship is admissible as a REPLY only. See
 
 from __future__ import annotations
 
+import contextlib
 import io
 import json
 import pathlib
@@ -85,11 +86,18 @@ def _thread(
 
 def _run(threads: list[dict[str, object]], argv: list[str]) -> dict[str, object]:
     buffer = io.StringIO()
-    with (
-        mock.patch.object(rt, "fetch_threads", return_value=threads),
-        mock.patch.object(sys, "argv", ["babysit_resolve_thread.py", *argv]),
-        redirect_stdout(buffer),
-    ):
+    with contextlib.ExitStack() as stack:
+        stack.enter_context(mock.patch.object(rt, "fetch_threads", return_value=threads))
+        if "--autonomous" in argv or "--independent-resolver" in argv:
+            stack.enter_context(
+                mock.patch.object(
+                    rt, "fetch_pull_request_author", return_value="someone-else"
+                )
+            )
+        stack.enter_context(
+            mock.patch.object(sys, "argv", ["babysit_resolve_thread.py", *argv])
+        )
+        stack.enter_context(redirect_stdout(buffer))
         rt.main()
     return json.loads(buffer.getvalue())
 
@@ -292,15 +300,24 @@ class SelfLoginsNeutralizeOwnReply(unittest.TestCase):
         # exercising the CLI's `--self-logins` parsing together with the
         # classifier fix, not a pre-projected fixture that bypasses both.
         buffer = io.StringIO()
-        with (
-            mock.patch.object(
-                rt,
-                "fetch_review_threads",
-                side_effect=lambda repo, number, **kw: [kw["projection"](record)],
-            ),
-            mock.patch.object(sys, "argv", ["babysit_resolve_thread.py", *argv]),
-            redirect_stdout(buffer),
-        ):
+        with contextlib.ExitStack() as stack:
+            stack.enter_context(
+                mock.patch.object(
+                    rt,
+                    "fetch_review_threads",
+                    side_effect=lambda repo, number, **kw: [kw["projection"](record)],
+                )
+            )
+            if "--autonomous" in argv or "--independent-resolver" in argv:
+                stack.enter_context(
+                    mock.patch.object(
+                        rt, "fetch_pull_request_author", return_value="someone-else"
+                    )
+                )
+            stack.enter_context(
+                mock.patch.object(sys, "argv", ["babysit_resolve_thread.py", *argv])
+            )
+            stack.enter_context(redirect_stdout(buffer))
             rt.main()
         return json.loads(buffer.getvalue())
 
@@ -491,6 +508,9 @@ class BotOnlyRequiresABotOpener(unittest.TestCase):
                 side_effect=lambda repo, number, **kw: [kw["projection"](record)],
             ),
             mock.patch.object(
+                rt, "fetch_pull_request_author", return_value="someone-else"
+            ),
+            mock.patch.object(
                 sys,
                 "argv",
                 [
@@ -541,6 +561,85 @@ class HumanThreadsActedExtraBotLogins(unittest.TestCase):
 
 
 class AutonomousSeverityGuard(unittest.TestCase):
+    def test_own_pr_is_refused_in_autonomous_mode(self) -> None:
+        with (
+            mock.patch.object(rt, "fetch_threads") as fetch_threads,
+            mock.patch.object(
+                rt, "fetch_pull_request_author", return_value="worker-bot"
+            ),
+            mock.patch.object(
+                sys,
+                "argv",
+                [
+                    "babysit_resolve_thread.py",
+                    "owner/repo#1",
+                    "--allowed-owners",
+                    "owner",
+                    "--self-logins",
+                    "worker-bot",
+                    "--autonomous",
+                ],
+            ),
+            redirect_stdout(io.StringIO()) as buffer,
+        ):
+            code = rt.main()
+        fetch_threads.assert_not_called()
+        result = json.loads(buffer.getvalue())
+        self.assertTrue(result["skippedOwnPr"])
+        self.assertEqual(result["prAuthor"], "worker-bot")
+        self.assertEqual(code, 0)
+
+    def test_own_pr_resolve_exits_2(self) -> None:
+        with (
+            mock.patch.object(rt, "fetch_threads") as fetch_threads,
+            mock.patch.object(
+                rt, "fetch_pull_request_author", return_value="worker-bot"
+            ),
+            mock.patch.object(
+                sys,
+                "argv",
+                [
+                    "babysit_resolve_thread.py",
+                    "owner/repo#1",
+                    "--allowed-owners",
+                    "owner",
+                    "--self-logins",
+                    "worker-bot",
+                    "--autonomous",
+                    "--resolve",
+                    "--thread-id",
+                    "T1",
+                    "--expected-comment-count",
+                    "2",
+                    "--expected-last-updated",
+                    "2026-01-01T00:00:00Z",
+                ],
+            ),
+            redirect_stdout(io.StringIO()) as buffer,
+        ):
+            code = rt.main()
+        fetch_threads.assert_not_called()
+        result = json.loads(buffer.getvalue())
+        self.assertTrue(result["skippedOwnPr"])
+        self.assertEqual(code, 2)
+
+    def test_non_self_pr_author_proceeds_in_autonomous_mode(self) -> None:
+        with mock.patch.object(
+            rt, "fetch_pull_request_author", return_value="someone-else"
+        ):
+            result = _run(
+                [_thread("T_ok", "codex[bot]", "Bot", bot_only=True, is_outdated=True)],
+                [
+                    "owner/repo#1",
+                    "--allowed-owners",
+                    "owner",
+                    "--self-logins",
+                    "worker-bot",
+                    "--autonomous",
+                ],
+            )
+        self.assertEqual(result["threads"][0]["action"], "would-resolve")
+
     def test_severity_marked_thread_is_skipped_in_autonomous_mode(self) -> None:
         result = _run(
             [
@@ -725,6 +824,9 @@ def _run_independent(
     buffer = io.StringIO()
     with (
         mock.patch.object(rt, "fetch_threads", return_value=threads),
+        mock.patch.object(
+            rt, "fetch_pull_request_author", return_value="someone-else"
+        ),
         mock.patch.object(rt, "gh_capture", side_effect=list(gh_results or [])),
         mock.patch.object(rt, "resolve_thread", return_value=(resolve_ok, "")),
         mock.patch.object(sys, "argv", ["babysit_resolve_thread.py", *argv]),


### PR DESCRIPTION
## Summary
- Add `fetch_pull_request_author` and fail closed when `--autonomous` or `--independent-resolver` targets a PR whose author is in `--self-logins`
- Interactive modes are unchanged

Closes #1287

## Test plan
- [x] `python3 -m pytest plugins/source-control/skills/babysit-prs/scripts/tests/test_babysit_resolve_thread.py` (109 passed)

## Related

N/A