### PR TITLE
fix(source-control): refuse drive-relative worktree roots

### DIFF
--- a/plugins/source-control/scripts/worktree-create.sh
+++ b/plugins/source-control/scripts/worktree-create.sh
@@ -257,6 +257,14 @@ if [[ "$root" == *\\* && ("$OSTYPE" == msys || "$OSTYPE" == cygwin) ]]; then
   root="${root//"$bslash"/"$fwd"}"
 fi
 
+# Reject drive-relative roots (`C:foo` with no separator after the colon). Git for
+# Windows resolves them against the drive's per-directory CWD, which bypasses the
+# containment ancestor walk (#962).
+if [[ "$root" =~ ^[A-Za-z]:[^/] ]]; then
+  printf '%s: --root %q is drive-relative; pass an absolute path (e.g. C:/worktrees)\n' "$PROG" "$root" >&2
+  exit 2
+fi
+
 # Resolve the source repository top level.
 if ! toplevel=$(git -C "$repo_dir" rev-parse --show-toplevel 2>/dev/null); then
   # Remedy first: this line is surfaced verbatim to a user whose worktree
@@ -467,7 +475,9 @@ worktree_path="${root%/}/${dirname}"
 # top level, so a relative root (e.g. `worktrees`) always lands inside the repo.
 # Anchor it to $toplevel up front so the containment check below sees the real
 # target rather than an unrooted string whose ancestor walk never reaches the repo.
-[[ "$worktree_path" != /* && "$worktree_path" != ?:* ]] && worktree_path="$toplevel/$worktree_path"
+# A drive-letter path counts as absolute only when the colon is followed by a
+# separator (`C:/foo`); `C:foo` is drive-relative and is refused above (#962).
+[[ "$worktree_path" != /* && ! "$worktree_path" =~ ^[A-Za-z]:/ ]] && worktree_path="$toplevel/$worktree_path"
 
 # Collapse `.`/`..` before the containment walk. A root with `..` after a
 # nonexistent component (e.g. `<root>/missing/../<repo>/.claude/worktrees`) would

--- a/plugins/source-control/scripts/worktree-create.test.sh
+++ b/plugins/source-control/scripts/worktree-create.test.sh
@@ -135,6 +135,11 @@ assert_contains "--help documents refuse (exit 3)" "$help_out" "refuse"
 bash "$HELPER" --root "$TEST_TMPDIR/wt" >/dev/null 2>&1
 assert_exit "missing --name exit 2" 2 "$?"
 
+# --- Case: drive-relative --root is refused (exit 2, #962) -------------------
+repo=$(mkrepo)
+bash "$HELPER" --name feat/x --root 'C:foo' --repo-dir "$repo" >/dev/null 2>&1
+assert_exit "drive-relative --root exit 2" 2 "$?"
+
 # --- Case: unset root defaults to <plugin-data-dir>/worktrees (exit 0) ---
 # The invariant is that the worktree lands OUTSIDE every repository, not that the
 # user configured a root by hand. The plugin data dir satisfies it, and reaches the


### PR DESCRIPTION
## Summary
- Reject `--root` values like `C:foo` that git resolves relative to the drive CWD and bypass the containment guard
- Only drive-letter paths with a separator count as absolute for anchoring

Closes #962

## Test plan
- [x] `bash plugins/source-control/scripts/worktree-create.test.sh`

## Related

N/A