### PR TITLE
feat(eol-normalizer): disclose line-ending rewrites on the user channel

### DIFF
--- a/plugins/eol-normalizer/.claude-plugin/plugin.json
+++ b/plugins/eol-normalizer/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "eol-normalizer",
-  "version": "0.6.10",
+  "version": "0.6.11",
   "description": "Normalize a written file's working-tree line endings to its .gitattributes eol value on edit \u2014 symmetric CRLF/LF driven by git check-attr, advisory and never blocking.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/eol-normalizer/CHANGELOG.md
+++ b/plugins/eol-normalizer/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to the `eol-normalizer` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.9.8]
+
+### Added
+
+- **Line-ending rewrites are disclosed on the user channel** when the hook normalizes
+  CRLF/LF mismatches, so agents see the mutation instead of silently rewriting (#1256).
+
 ## [0.6.10]
 
 ### Changed

--- a/plugins/eol-normalizer/CHANGELOG.md
+++ b/plugins/eol-normalizer/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to the `eol-normalizer` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
-## [0.9.8]
+## [0.6.11]
 
 ### Added
 

--- a/plugins/eol-normalizer/hooks/eol-normalizer.sh
+++ b/plugins/eol-normalizer/hooks/eol-normalizer.sh
@@ -102,14 +102,37 @@ build_data_json() {
 
 # The lib mutates the file in place (side effect persists past the subshell) and
 # echoes the action taken: lf | crlf | skip.
+_eol_tmp="$(mktemp "${TMPDIR:-/tmp}/eol-normalizer.XXXXXX")"
+cp -p "$FILE" "$_eol_tmp"
 ACTION=$(normalize_eol_file "$REPO_ROOT" "$FILE")
+if cmp -s "$FILE" "$_eol_tmp"; then
+  EFFECTIVE_ACTION="skip"
+else
+  EFFECTIVE_ACTION="$ACTION"
+fi
+rm -f "$_eol_tmp"
 
 # status "ok" when the file was actually normalized (lf/crlf); "skipped" when the
-# attr was unspecified, the path is -text, or content sniffed binary.
-case "$ACTION" in
+# attr was unspecified, the path is -text, content sniffed binary, or idempotent.
+case "$EFFECTIVE_ACTION" in
 lf | crlf) status="ok" ;;
 *) status="skipped" ;;
 esac
 
 emit_tel "$status" "$ACTION"
+
+# Content-mutation disclosure (#1596): line-ending normalization is a structural
+# rewrite the user did not request. Name what changed on the user channel; stay
+# silent on skip/no-op paths.
+case "$EFFECTIVE_ACTION" in
+lf)
+  hook::emit_system_message "eol-normalizer: normalized line endings to LF in $(basename "$FILE")."
+  ;;
+crlf)
+  hook::emit_system_message "eol-normalizer: normalized line endings to CRLF in $(basename "$FILE")."
+  ;;
+*)
+  ;;
+esac
+
 exit 0

--- a/plugins/eol-normalizer/hooks/eol-normalizer.test.sh
+++ b/plugins/eol-normalizer/hooks/eol-normalizer.test.sh
@@ -226,7 +226,9 @@ fi
 rm -f "$TEL"
 
 # --- Normalized .sh -> systemMessage names the target ending (#1596) ----------
-OUT_LF=$(run_hook_env "$REPO/tel2.sh" CLAUDE_PLUGIN_OPTION_EOL_NORMALIZER_ENABLED=true)
+# Fresh file: tel2.sh was already normalized in the telemetry stub-sink case above.
+printf 'echo r\r\n' >"$REPO/tel2b.sh"
+OUT_LF=$(run_hook_env "$REPO/tel2b.sh" CLAUDE_PLUGIN_OPTION_EOL_NORMALIZER_ENABLED=true)
 if [[ "$OUT_LF" == *'"systemMessage"'* && "$OUT_LF" == *'normalized line endings to LF'* ]]; then
   ok "mutation disclosure: LF normalization names target ending"
 else

--- a/plugins/eol-normalizer/hooks/eol-normalizer.test.sh
+++ b/plugins/eol-normalizer/hooks/eol-normalizer.test.sh
@@ -109,7 +109,7 @@ if [[ "$(cr_count "$REPO/seed.sh")" == "2" ]]; then ok "pre: seed.sh seeded with
 OUT=$(run_hook "$REPO/seed.sh")
 RC=$?
 if [[ $RC -eq 0 ]]; then ok "LF arm .sh -> exit 0"; else fail "LF arm .sh exit $RC"; fi
-if [[ -z "$OUT" ]]; then ok "LF arm .sh -> empty stdout (advisory)"; else fail "LF arm stdout not empty: $OUT"; fi
+if [[ "$OUT" == *'"systemMessage"'* && "$OUT" == *'normalized line endings to LF'* ]]; then ok "LF arm .sh -> mutation disclosure on stdout"; else fail "LF arm stdout missing disclosure: $OUT"; fi
 if [[ "$(cr_count "$REPO/seed.sh")" == "0" ]]; then ok "LF arm CRLF .sh -> 0 CR (every OS)"; else fail "LF arm .sh CR=$(cr_count "$REPO/seed.sh")"; fi
 
 # --- Case 2: unspecified (.png) -> no-op, every OS ---------------------------
@@ -192,8 +192,8 @@ if [[ -x "$REPO/exec.sh" ]]; then ok "fallback: executable mode preserved"; else
 printf 'echo p\r\n' >"$REPO/tel1.sh"
 OUT_NS=$(run_hook_env "$REPO/tel1.sh" -u HOOK_TELEMETRY_SINK CLAUDE_PLUGIN_OPTION_EOL_NORMALIZER_ENABLED=true)
 RC_NS=$?
-if [[ $RC_NS -eq 0 && -z "$OUT_NS" ]]; then
-  ok "telemetry/sink-unset: exit 0, empty stdout (parity)"
+if [[ $RC_NS -eq 0 && "$OUT_NS" == *'"systemMessage"'* ]]; then
+  ok "telemetry/sink-unset: exit 0 with mutation disclosure (no telemetry envelope)"
 else
   fail "telemetry/sink-unset: rc=$RC_NS out=$OUT_NS"
 fi
@@ -224,6 +224,14 @@ else
   fail "telemetry/stub-sink: no envelope written"
 fi
 rm -f "$TEL"
+
+# --- Normalized .sh -> systemMessage names the target ending (#1596) ----------
+OUT_LF=$(run_hook_env "$REPO/tel2.sh" CLAUDE_PLUGIN_OPTION_EOL_NORMALIZER_ENABLED=true)
+if [[ "$OUT_LF" == *'"systemMessage"'* && "$OUT_LF" == *'normalized line endings to LF'* ]]; then
+  ok "mutation disclosure: LF normalization names target ending"
+else
+  fail "mutation disclosure: LF out=$OUT_LF"
+fi
 
 # --- Stub sink + unspecified .png -> status skipped, action skip ------------
 printf 'x\r\n' >"$REPO/tel3.png"


### PR DESCRIPTION
No linked issue

## Summary
- Emit a `systemMessage` when the hook normalizes line endings to LF or CRLF
- Skip and no-op paths stay silent

Partially addresses #1596 (eol-normalizer only; sibling autofix hooks remain tracked there).

## Test plan
- [x] `bash plugins/eol-normalizer/hooks/eol-normalizer.test.sh` (36 passed)

## Related

Refs #1596