### PR TITLE
feat(education): add check-only setup skill for userConfig

### DIFF
--- a/plugins/education/.claude-plugin/plugin.json
+++ b/plugins/education/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "education",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Interactive multi-session learning coach: teaches a general subject or a concept grounded in the consuming repo through the Knowledge-Skills-Wisdom progression, with persistent per-topic learning state. Also a single-session domain primer, a one-shot plain-language explainer that drops anything to genuinely plain words, and a post-work comprehension check that quizzes the human on a completed change.",
   "author": {
     "name": "Melodic Software",
@@ -27,7 +27,7 @@
     "quiz_policy": {
       "type": "string",
       "title": "Quiz offer policy",
-      "description": "When quiz-me offers a post-work comprehension quiz. One of: off (never offers), on-request (only when asked), always (after each completed change), above-threshold (when the change is large). Governs offer cadence only \u2014 a report is never generated without your confirmation. Unknown values are treated as on-request.",
+      "description": "When quiz-me offers a post-work comprehension quiz. One of: off (never offers), on-request (only when asked), always (after each completed change), above-threshold (when the change is large). Governs offer cadence only — a report is never generated without your confirmation. Unknown values are treated as on-request.",
       "default": "on-request"
     },
     "report_library_dir": {

--- a/plugins/education/CHANGELOG.md
+++ b/plugins/education/CHANGELOG.md
@@ -5,9 +5,16 @@ All notable changes to the `education` plugin are documented here. Format follow
 
 ## [0.6.2]
 
+<<<<<<< HEAD
 ### Fixed
 
 - **education:teach loads under worktree isolation (#1687).** Workspace listing moved out of the pre-compute block into a body Bash call.
+=======
+### Added
+
+- **`/education:setup` check-only setup skill** for `quiz_policy` and `report_library_dir`
+  userConfig verification (#988).
+>>>>>>> dc513c6a (feat(education): add check-only setup skill for userConfig)
 
 ## [0.6.1]
 

--- a/plugins/education/CHANGELOG.md
+++ b/plugins/education/CHANGELOG.md
@@ -3,18 +3,18 @@
 All notable changes to the `education` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
-## [0.6.2]
+## [0.6.3]
 
-<<<<<<< HEAD
-### Fixed
-
-- **education:teach loads under worktree isolation (#1687).** Workspace listing moved out of the pre-compute block into a body Bash call.
-=======
 ### Added
 
 - **`/education:setup` check-only setup skill** for `quiz_policy` and `report_library_dir`
   userConfig verification (#988).
->>>>>>> dc513c6a (feat(education): add check-only setup skill for userConfig)
+
+## [0.6.2]
+
+### Fixed
+
+- **education:teach loads under worktree isolation (#1687).** Workspace listing moved out of the pre-compute block into a body Bash call.
 
 ## [0.6.1]
 

--- a/plugins/education/README.md
+++ b/plugins/education/README.md
@@ -92,6 +92,9 @@ Configure them through the `/plugin` dialog, or headless at install time with
 non-home `report_library_dir` may be rejected by the hardcoded-path guardrails until
 the #798 path-indirection work lands.
 
+Run `/education:setup` to validate the effective `quiz_policy` and report-library root
+without reading settings files.
+
 <!-- BEGIN GENERATED: plugin options — edit plugin.json, then run scripts/sync-plugin-options-docs.py -->
 
 ### Options reference

--- a/plugins/education/skills/setup/SKILL.md
+++ b/plugins/education/skills/setup/SKILL.md
@@ -1,0 +1,60 @@
+---
+description: "Validate the education plugin's quiz and report-library configuration and explain how to change it through Claude Code's plugin configuration prompt. Use when: 'set up education', 'configure education', 'education setup', quiz offers feel wrong, or report recall cannot find prior quizzes. Actions: check (read-only verification, default and only action — this plugin's entire configuration is native userConfig, so there is nothing an apply could write)."
+argument-hint: "check"
+user-invocable: true
+disable-model-invocation: true
+---
+
+## Purpose
+
+Confirm how `/education:quiz-me` offers comprehension checks and where generated quiz reports
+are stored, without editing Claude Code settings. `quiz_policy` and `report_library_dir` are
+native `userConfig` values. Claude Code prompts for them when the plugin is enabled and owns
+persistence.
+
+Check-only per the uniform setup contract's userConfig-only carve-out: this plugin's entire
+configuration surface is native `userConfig`, so `check` (the default and only action) verifies
+and reports, and reconfiguration routes through Claude Code's native flow — an `apply` here
+would have nothing to write except the `pluginConfigs` setup must never touch. Non-interactive:
+report and recommend; never block on a question.
+
+Official contract: <https://code.claude.com/docs/en/plugins-reference#user-configuration>.
+
+## `check` (read-only, the only action)
+
+1. Read the rendered `${user_config.quiz_policy}` and `${user_config.report_library_dir}`
+   values from this skill. Do not inspect or edit `settings.json`, `settings.local.json`,
+   managed settings, or `pluginConfigs` directly.
+2. Explain the effective `quiz_policy`:
+   - `off` — quiz-me never offers a post-work quiz;
+   - `on-request` (default) — offers only when asked;
+   - `always` — offers after each completed change;
+   - `above-threshold` — offers when the change is large;
+   - any other value is treated as `on-request` at runtime.
+3. Explain the effective report library root:
+   - empty or unexpanded `report_library_dir` — reports live under the plugin's own persistent
+     data directory;
+   - configured directory — reports and recall search that checkout instead.
+4. State the tradeoff instead of asking: machine-private plugin data (default) versus a dedicated
+   corpus checkout for long-lived recall across machines. For a repository-backed library,
+   inspect the consumer's artifact conventions and recommend one portable location. Never
+   recommend a machine-absolute team path.
+5. If a recommended value differs from the effective one, direct the user to Claude Code's plugin
+   configuration prompt for `education` (interactive `/plugin configure education` any time;
+   headless, `--config` applies only on a fresh install — uninstall then reinstall to
+   reconfigure). Claude Code owns persistence. Do not hand-edit any `pluginConfigs` key.
+6. Tell the user to rerun `check` after reconfiguration — in a fresh session, since the rendered
+   values are injected at load — then verify and report the effective settings.
+
+## Output
+
+Report the current effective `quiz_policy`, the effective report-library root, any recommended
+changes, and whether the user must reconfigure through Claude Code. Do not claim a configuration
+change until a rerun observes the new rendered values.
+
+## Boundaries
+
+- Do not start a teach, explain, or quiz session; use `/education:teach`, `/education:explain`,
+  or `/education:quiz-me`.
+- Do not write Claude Code settings.
+- Do not invent an organization, repository, marketplace, or environment-variable prefix.

--- a/plugins/education/skills/setup/SKILL.md
+++ b/plugins/education/skills/setup/SKILL.md
@@ -34,7 +34,10 @@ Official contract: <https://code.claude.com/docs/en/plugins-reference#user-confi
 3. Explain the effective report library root:
    - empty or unexpanded `report_library_dir` — reports live under the plugin's own persistent
      data directory;
-   - configured directory — reports and recall search that checkout instead.
+   - configured directory outside the consuming project — reports and recall search that checkout;
+   - configured directory that is `${CLAUDE_PROJECT_DIR}` or nested under it — quiz-me's
+     repo-tree guard refuses it and falls back to `${CLAUDE_PLUGIN_DATA}` (same effective root
+     as unset).
 4. State the tradeoff instead of asking: machine-private plugin data (default) versus a dedicated
    corpus checkout for long-lived recall across machines. For a repository-backed library,
    inspect the consumer's artifact conventions and recommend one portable location. Never

--- a/plugins/education/skills/setup/evals/evals.json
+++ b/plugins/education/skills/setup/evals/evals.json
@@ -1,0 +1,29 @@
+{
+  "skill_name": "setup",
+  "evals": [
+    {
+      "id": 1,
+      "name": "validates-rendered-quiz-policy-without-settings-edits",
+      "prompt": "/education:setup",
+      "expected_output": "Reports the rendered quiz_policy and report_library_dir (or their defaults), explains quiz offer cadence, and never reads or edits settings files or pluginConfigs.",
+      "files": [],
+      "expectations": [
+        "Reads only the rendered user_config values supplied to the skill",
+        "Explains the on-request default and the private plugin-data report fallback",
+        "Does not inspect or edit settings files or pluginConfigs"
+      ]
+    },
+    {
+      "id": 2,
+      "name": "routes-changes-through-claude-configuration",
+      "prompt": "/education:setup\n\nStore quiz reports in a shared corpus checkout.",
+      "expected_output": "Recommends a portable corpus location, directs the user to Claude Code's plugin configuration prompt for report_library_dir, and requires a rerun before claiming the value changed.",
+      "files": [],
+      "expectations": [
+        "Uses repository evidence before recommending a library location",
+        "Rejects machine-absolute team paths",
+        "Routes persistence through Claude Code and verifies on rerun"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Fixes #988 (education half)

Adds `/education:setup` — a check-only setup skill for `quiz_policy` and `report_library_dir`.

**repo-hygiene:** left exempt. Its single boolean kill-switch is below the setup-requirement bar per the philosophy's trivial-scalar carve-out; no setup skill added there.

## Test plan
- [x] Skill follows the userConfig-only setup contract (bug-report/dometrain pattern)

## Related
- Closes #988