### PR TITLE
fix(disk-hygiene): gate PowerShell move/rename/overwrite spellings

### DIFF
--- a/plugins/disk-hygiene/.claude-plugin/plugin.json
+++ b/plugins/disk-hygiene/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "disk-hygiene",
-  "version": "0.17.2",
+  "version": "0.17.3",
   "description": "Context-aware disk hygiene for arbitrary directory trees: inventories orphaned and temporary artifacts, classifies evidence into review tiers, and offers exact-path cleanup only after a fresh safety preview and explicit per-tier approval. The target is read-only by default; OS-managed paths, links and mount points, VCS-tracked content, changed entries, and live-handle uncertainty fail closed.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/disk-hygiene/CHANGELOG.md
+++ b/plugins/disk-hygiene/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to the `disk-hygiene` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.17.3]
+
+### Fixed
+
+- **PowerShell guard now surfaces move/rename/overwrite spellings (#387).** `Move-Item`, `Rename-Item`,
+  `Set-Content`, `Out-File`, `New-Item -Force`, output redirection, and `Format-Volume`/`Clear-Disk`
+  join the existing deletion-spelling `ask` bar on the PowerShell lane.
+
 ## [0.17.2]
 
 ### Fixed

--- a/plugins/disk-hygiene/skills/clean/scripts/destructive_guard.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/destructive_guard.py
@@ -934,8 +934,15 @@ _POWERSHELL_MUTATION_WORDS = re.compile(
     r"(?i)(?<![\w./\\-])("
     r"remove-item|rm|rmdir|del|erase|rd|ri|clear-content|clear-recyclebin|rimraf|unlink"
     r"|sendtorecyclebin|deletefile|deletedirectory|removedirectory"
+    r"|move-item|rename-item|mv|move|ren|rename"
+    r"|set-content|out-file|add-content"
+    r"|format-volume|clear-disk|initialize-disk"
     r")(?![\w-])"
 )
+_POWERSHELL_NEW_ITEM_FORCE = re.compile(
+    r"(?i)(?<![\w./\\-])new-item(?![\w-]).*-force\b"
+)
+_POWERSHELL_OUTPUT_REDIRECT = re.compile(r"(?<![<>])>(?![=>])")
 _POWERSHELL_DOTNET_DELETE = re.compile(r"(?i)(::\s*delete|\.\s*delete\s*\()")
 # robocopy is an executable normally invocable by full path
 # (C:\Windows\System32\robocopy.exe), so unlike the cmdlet word list its
@@ -983,7 +990,18 @@ def powershell_decision(command: str, enabled: bool) -> tuple[str, str] | None:
     if match:
         return _powershell_mutation_verdict(
             enabled,
-            f'disk-hygiene flagged the deletion spelling "{match.group(0)}".',
+            f'disk-hygiene flagged the mutation spelling "{match.group(0)}".',
+        )
+    new_item_force = _POWERSHELL_NEW_ITEM_FORCE.search(command)
+    if new_item_force:
+        return _powershell_mutation_verdict(
+            enabled,
+            'disk-hygiene flagged New-Item -Force (truncates an existing file).',
+        )
+    if _POWERSHELL_OUTPUT_REDIRECT.search(command):
+        return _powershell_mutation_verdict(
+            enabled,
+            "disk-hygiene flagged shell output redirection (may overwrite a file).",
         )
     if _POWERSHELL_DOTNET_DELETE.search(command):
         return _powershell_mutation_verdict(

--- a/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
@@ -4396,6 +4396,12 @@ class GuardTests(unittest.TestCase):
             "C:\\Windows\\System32\\robocopy.exe C:\\src C:\\dst /MIR",
             "& 'C:/Windows/System32/robocopy.exe' C:/src C:/dst /PURGE",
             "[Microsoft.VisualBasic.FileIO.FileSystem]::DeleteFile('x', 'OnlyErrorDialogs', 'SendToRecycleBin')",
+            "Move-Item C:/tmp/old C:/tmp/new",
+            "Rename-Item C:/tmp/old C:/tmp/new",
+            "Set-Content C:/tmp/file.txt 'overwrite'",
+            "Out-File C:/tmp/file.txt -Force",
+            "New-Item C:/tmp/file.txt -ItemType File -Force",
+            "'data' > C:/tmp/file.txt",
         ):
             result = self.run_guard_powershell(command)
             assert result is not None, command


### PR DESCRIPTION
Fixes #387

Extends the PowerShell lane mutation-spelling set with move, rename, overwrite, and truncation spellings.

## Test plan
- [x] `python3 -m pytest plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py -k powershell_deletion_spellings_force`

## Related

N/A