### PR TITLE
fix(education): move teach workspace probe out of pre-compute block

### DIFF
--- a/plugins/education/.claude-plugin/plugin.json
+++ b/plugins/education/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "education",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Interactive multi-session learning coach: teaches a general subject or a concept grounded in the consuming repo through the Knowledge-Skills-Wisdom progression, with persistent per-topic learning state. Also a single-session domain primer, a one-shot plain-language explainer that drops anything to genuinely plain words, and a post-work comprehension check that quizzes the human on a completed change.",
   "author": {
     "name": "Melodic Software",
@@ -27,7 +27,7 @@
     "quiz_policy": {
       "type": "string",
       "title": "Quiz offer policy",
-      "description": "When quiz-me offers a post-work comprehension quiz. One of: off (never offers), on-request (only when asked), always (after each completed change), above-threshold (when the change is large). Governs offer cadence only — a report is never generated without your confirmation. Unknown values are treated as on-request.",
+      "description": "When quiz-me offers a post-work comprehension quiz. One of: off (never offers), on-request (only when asked), always (after each completed change), above-threshold (when the change is large). Governs offer cadence only \u2014 a report is never generated without your confirmation. Unknown values are treated as on-request.",
       "default": "on-request"
     },
     "report_library_dir": {

--- a/plugins/education/CHANGELOG.md
+++ b/plugins/education/CHANGELOG.md
@@ -3,7 +3,6 @@
 All notable changes to the `education` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
-
 ## [0.6.2]
 
 ### Fixed

--- a/plugins/education/CHANGELOG.md
+++ b/plugins/education/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to the `education` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+
+## [0.6.2]
+
+### Fixed
+
+- **education:teach loads under worktree isolation (#1687).** Workspace listing moved out of the pre-compute block into a body Bash call.
+
 ## [0.6.1]
 
 ### Fixed

--- a/plugins/education/skills/teach/SKILL.md
+++ b/plugins/education/skills/teach/SKILL.md
@@ -54,7 +54,11 @@ Path resolution rules every action MUST follow:
 
 ## Pre-computed Context
 
-Existing workspaces (current project only): !`bash "${CLAUDE_PLUGIN_ROOT}/skills/teach/scripts/list-workspaces.sh" "${CLAUDE_PROJECT_DIR}" "${CLAUDE_PLUGIN_DATA}" 2>/dev/null || echo "none"`
+Gather with one Bash call (worktree-isolated agents refuse `$`-expansion in pre-compute blocks; #1687):
+
+- Existing workspaces — `bash "${CLAUDE_PLUGIN_ROOT}/skills/teach/scripts/list-workspaces.sh" "${CLAUDE_PROJECT_DIR}" "${CLAUDE_PLUGIN_DATA}" 2>/dev/null || echo "none"`
+
+Treat failure as `"none"` and continue.
 
 ## Action Router
 


### PR DESCRIPTION
Fixes #1687 (education/teach scope — session-flow siblings were already fixed in prior PRs).

## Related

N/A