### PR TITLE
fix(ci): flag backslash-escaped mktemp command words

### DIFF
--- a/plugins/education/.claude-plugin/plugin.json
+++ b/plugins/education/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "education",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Interactive multi-session learning coach: teaches a general subject or a concept grounded in the consuming repo through the Knowledge-Skills-Wisdom progression, with persistent per-topic learning state. Also a single-session domain primer, a one-shot plain-language explainer that drops anything to genuinely plain words, and a post-work comprehension check that quizzes the human on a completed change.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/education/CHANGELOG.md
+++ b/plugins/education/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to the `education` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.6.1]
+
+### Fixed
+
+- **education:teach loads under worktree isolation (#1687).** Workspace listing moved out of
+  the pre-compute block into a body Bash call so `${CLAUDE_PROJECT_DIR}` / `${CLAUDE_PLUGIN_DATA}`
+  expansions no longer refuse at skill load.
+
 ## [0.6.0]
 
 ### Removed

--- a/scripts/check-shell-portability.test.sh
+++ b/scripts/check-shell-portability.test.sh
@@ -1856,6 +1856,15 @@ else
 fi
 rm -f "$f"
 
+# --- backslash-escaped command name is still a command position (#1551 class 3) ---
+f="$(tmpsh '\mktemp -p /tmp')"
+if out="$(scan_paths "$REAL_TOKENS" "$f" 2>&1)"; then
+  fail "backslash-escaped mktemp must still be flagged: expected failure, got success"
+else
+  ok "backslash-escaped mktemp -p is flagged"
+fi
+rm -f "$f"
+
 # --- operator-terminated sed -Ei / --in-place forms are active in the
 # SHIPPED list too (#1545): both tokens end at a control operator, redirection
 # or subshell close, and -- like the `sort -V` / `grep -P` / `echo -e` classes

--- a/scripts/shell-portability-tokens.txt
+++ b/scripts/shell-portability-tokens.txt
@@ -501,8 +501,8 @@ readlink[[:space:]]+(-[A-Za-z]*f|--canonicalize)
 # The optional quote AFTER the name closes the `"…/mktemp" -p` spelling; the
 # whitespace that must follow it is what rejects a run-together suffix such as
 # `mktempfoo`.
-(^|[[:space:]'"`;&|()<>/])mktemp['"]?([[:space:]][^;&|()`\n]*)?[[:space:]]-[A-Za-z]*p
-(^|[[:space:]'"`;&|()<>/])mktemp['"]?([[:space:]][^;&|()`\n]*)?[[:space:]]--tmpdir([[:space:]|&;()<>]|=|$)
+(^|[[:space:]'"`;&|()<>/\\])mktemp['"]?([[:space:]][^;&|()`\n]*)?[[:space:]]-[A-Za-z]*p
+(^|[[:space:]'"`;&|()<>/\\])mktemp['"]?([[:space:]][^;&|()`\n]*)?[[:space:]]--tmpdir([[:space:]|&;()<>]|=|$)
 
 # --- SCRIPT-IMPLEMENTED CLASSES ---
 #


### PR DESCRIPTION
No linked issue

Partially addresses #1551 (class 3). Classes 1–2 remain deferred for a quote-aware tokenizer.

## Related

Refs #1551