### PR TITLE
test(work-items): pin wit_lease_is_live expiry boundary

### DIFF
--- a/plugins/work-items/tools/work-item-tracker/lib/lease.test.sh
+++ b/plugins/work-items/tools/work-item-tracker/lib/lease.test.sh
@@ -31,6 +31,17 @@ if wit_lease_is_live "$FRESH_LIVE" "$NOW"; then pass "fresh 24h lease is live"; 
 SUPERSEDED="$(jq -cn --arg t "$NOW_ISO" '{renewed_at:$t, ttl_hours:24, superseded_at:$t}')"
 if wit_lease_is_live "$SUPERSEDED" "$NOW"; then fail "superseded lease not live" "not live" "live"; else pass "superseded lease not live"; fi
 
+# Expiry boundary vs fixed injected clock (#1675 / medley#1675): exclusive end —
+# live while now < renewed_at+ttl; exact expiry and after are dead.
+FIXED_NOW=1783828800  # 2026-07-12T04:00:00Z
+BOUNDARY_TTL=1
+BOUNDARY_EXPIRY=$((FIXED_NOW + BOUNDARY_TTL * 3600))
+BOUNDARY_RENEWED_ISO="$(date -u -d "@$((BOUNDARY_EXPIRY - BOUNDARY_TTL * 3600))" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -r "$((BOUNDARY_EXPIRY - BOUNDARY_TTL * 3600))" +%Y-%m-%dT%H:%M:%SZ)" # portability-ok: GNU-first, BSD fallback (#1510)
+BOUNDARY_LEASE="$(jq -cn --arg t "$BOUNDARY_RENEWED_ISO" --argjson ttl "$BOUNDARY_TTL" '{renewed_at:$t, ttl_hours:$ttl}')"
+if wit_lease_is_live "$BOUNDARY_LEASE" "$((BOUNDARY_EXPIRY - 1))"; then pass "boundary: expiry-1s is live"; else fail "boundary: expiry-1s is live" "live" "not live"; fi
+if wit_lease_is_live "$BOUNDARY_LEASE" "$BOUNDARY_EXPIRY"; then fail "boundary: exact expiry is dead" "not live" "live"; else pass "boundary: exact expiry is dead"; fi
+if wit_lease_is_live "$BOUNDARY_LEASE" "$((BOUNDARY_EXPIRY + 1))"; then fail "boundary: expiry+1s is dead" "not live" "live"; else pass "boundary: expiry+1s is dead"; fi
+
 # Active-lease selection: newest NON-superseded lease wins, and it is the marker's
 # own selection (a superseded higher-id back-off does not mask the still-active
 # earlier lease — the subtlety both renew-lease and reclaim depend on).


### PR DESCRIPTION
Refs melodic-software/medley#1675

No related issue: tracker item closes after merge

## Summary
Pins exclusive-end lease expiry semantics (`now < renewed_at + ttl`): exact expiry and after are dead; expiry−1s is live. Fixed injected clock.

Code lives in this repo after medley work-items cutover (#1688).

## Related
- melodic-software/medley#1675