### PR TITLE
chore(playwright): sync to upstream v0.1.18

### DIFF
--- a/plugins/playwright/.claude-plugin/plugin.json
+++ b/plugins/playwright/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "playwright",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Live E2E browser automation via Microsoft's @playwright/cli — named sessions, accessibility-ref snapshots, click/fill by ref, screenshots, console and network capture, mocking, tracing, video, and auth state, with artifacts written to disk so only paths enter context, plus a vendored upstream baseline and maintainer drift-check update flow.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/playwright/CHANGELOG.md
+++ b/plugins/playwright/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to the `playwright` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.6.1]
+
+### Changed
+
+- Synced vendored `@playwright/cli` baseline metadata to upstream v0.1.18 via
+  `skills/playwright/scripts/update.sh --apply`. Upstream skill content is
+  byte-identical to v0.1.17; no distilled `reference/*.md` integration required.
+
 ## [0.6.0]
 
 ### Fixed

--- a/plugins/playwright/skills/playwright/SKILL.md
+++ b/plugins/playwright/skills/playwright/SKILL.md
@@ -8,9 +8,9 @@ allowed-tools: Bash(playwright-cli:*)
 metadata:
   source: https://github.com/microsoft/playwright-cli
   upstream-package: "@playwright/cli"
-  upstream-version: 0.1.17
-  upstream-sha: abfd43bec9e9fca2628ba98f7061a81cde7ec6bb
-  synced: 2026-07-21
+  upstream-version: 0.1.18
+  upstream-sha: 28616039f0fa7f1c18d8d3b56204ebea38776d82
+  synced: 2026-08-12
   workflow-stage: test
   summary: Live E2E browser automation with disk-written artifacts
 ---


### PR DESCRIPTION
No related issue: cross-repo maintenance for medley recurring schedule

## Summary
- Syncs vendored `@playwright/cli` baseline metadata from 0.1.17 to 0.1.18 via `update.sh --apply`.
- Upstream skill content is byte-identical to 0.1.17; no distilled `reference/*.md` integration required.
- Bumps plugin version 0.6.0 → 0.6.1.

## Test plan
- [x] `bash skills/playwright/scripts/update.sh --check` — no drift after sync
- [x] `bash skills/playwright/scripts/update.test.sh` — 22/22 pass

## Related
- melodic-software/medley#1718 recurring maintenance
- Medley CI `@playwright/test` + MCR image pin landed separately in medley#1773