### PR TITLE
docs(discovery): reconcile fork availability wording with discipline preflight

### DIFF
--- a/plugins/discovery/.claude-plugin/plugin.json
+++ b/plugins/discovery/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "discovery",
-  "version": "0.15.2",
+  "version": "0.15.3",
   "description": "Structured discovery before changes: explore the local codebase and run disciplined multi-source external research, both dispatching a purpose-built subagent by default so the reading stays out of the main conversation — with source tiers, falsification, recency gates, and a corpus-coverage ledger — persisting EXPLORE.md / RESEARCH.md index-plus-sidecar handoff artifacts.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/discovery/CHANGELOG.md
+++ b/plugins/discovery/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog — discovery plugin
 
+## [0.15.3]
+
+### Fixed
+
+- **Fork availability wording in setup check.** Reconcile setup skill prose with discipline
+  `sweep-all` preflight: report `CLAUDE_CODE_FORK_SUBAGENT` as a control and defer availability to a
+  live inheritance probe instead of claiming forks are unconditionally on.
+
 ## [0.15.2]
 
 ### Fixed

--- a/plugins/discovery/skills/setup/SKILL.md
+++ b/plugins/discovery/skills/setup/SKILL.md
@@ -78,12 +78,11 @@ Report the effective concern and the guard result as a PASS/FAIL/INFO table. Do 
      which has not seen the work is the outcome-gate verifier, and the parent dispatches that as a
      **sibling** rather than the agent as a child. Note that env vars are read at session start, so a
      value set now takes effect next session.
-   - **Fork availability.** Report it as a control, not a gate: forks have been enabled by default
-     since **2.1.161**, and `CLAUDE_CODE_FORK_SUBAGENT` now only forces them on or off. Report it as
-     a control, never as a prerequisite: older text that made forks conditional on setting that
-     variable is stale, and it also attached the variable to skill-level `context: fork` rather than
-     to the `fork` subagent type, which is a different mechanism. The user-facing command is
-     `/subtask` as of **2.1.212**.
+   - **Fork availability.** Report it as a control, not a gate: `CLAUDE_CODE_FORK_SUBAGENT=1` forces fork
+     mode on and `=0` forces it off; when unset, server-side rollout may still enable or disable the
+     `fork` subagent type — the only authoritative probe is a live inheritance check (see
+     `discipline:sweep-all`'s preflight). Report the env var when set; never claim forks are
+     unconditionally available on every build. The user-facing command is `/subtask` as of **2.1.212**.
 
 ## `apply` (idempotent)
 


### PR DESCRIPTION
No linked issue

Refs #1681

Finding 5: stop claiming forks are unconditionally on-by-default since 2.1.161; document env-var override and staged-rollout ambiguity instead.

## Related

None.