### PR TITLE
chore(claude-lanes): re-pin both callers to ci-workflows v0.14.0

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -32,7 +32,7 @@ jobs:
     concurrency:
       group: claude-review-${{ github.repository }}
       queue: max
-    uses: melodic-software/ci-workflows/.github/workflows/claude-review.yml@734158c4cb6e67b0b99fd703045ac0f7f9f042d5 # v0.12.0
+    uses: melodic-software/ci-workflows/.github/workflows/claude-review.yml@62bef7bab01e8532fedfa739879034a210e9e67d # v0.14.0
     with:
       runner: ubuntu-24.04
     # Pass only the one named secret (least privilege) rather than `secrets:

--- a/.github/workflows/claude-security-review.yml
+++ b/.github/workflows/claude-security-review.yml
@@ -31,7 +31,7 @@ jobs:
       contents: read         # checkout + read the diff
       pull-requests: write   # post the security review
       id-token: write        # OIDC — mints the Claude GitHub App token
-    uses: melodic-software/ci-workflows/.github/workflows/claude-security-review.yml@734158c4cb6e67b0b99fd703045ac0f7f9f042d5 # v0.12.0
+    uses: melodic-software/ci-workflows/.github/workflows/claude-security-review.yml@62bef7bab01e8532fedfa739879034a210e9e67d # v0.14.0
     with:
       runner: ubuntu-24.04
       paths-file: .github/claude-security-paths


### PR DESCRIPTION
## Summary

Re-pins this repository's `claude-review` and `claude-security-review` callers from ci-workflows v0.12.0 to **v0.14.0** (`62bef7bab01e8532fedfa739879034a210e9e67d`).

Needed by hand because this repo holds **both** callers as `locally-owned` in the standards sync manifest, so the fleet cascade cannot re-pin them — it delivered only `.github/standards/runner-policy/policy.json` (#2495). dotfiles, github-iac, medley, and provisioning each got their `claude-review.yml` pin bumped automatically; this repo did not, and it is the one where the failure is visible.

v0.14.0 carries the `allowed_bots` fix (melodic-software/ci-workflows#442, delivered through melodic-software/standards#374) that admits `cursor[bot]` to both lanes.

## What this fixes

`anthropics/claude-code-action` rejects any non-`User` actor absent from `allowed_bots`. Both lanes named only `dependabot[bot]`, so every event whose `github.actor` is `cursor[bot]` hit:

```
Workflow initiated by non-human actor: cursor (type: Bot).
Add bot to allowed_bots list or use '*' to allow all bots.
```

The security caller in this repo already predicted the consequence in its own comment:

> for an actor the reusable's `allowed_bots` does not permit, the action throws and this lane's fail-closed mapping turns that into a RED required check no push can fix — a merge block, not an extra review

Measured, not assumed: **15 of the last 100 `pull_request` runs** of `claude-security-review` failed, every one with a `cursor[bot]` actor, each on `Verify security-review execution evidence` reporting `succeeded in 25s (<45s) with no execution evidence` (#2337). The `claude-review` lane failed silently over the same window — its action step is `continue-on-error`, so the job read green while no review ran.

## What is deliberately NOT changed

`skip-actors` stays as it is. `cursor[bot]` should be **reviewed**, not skipped, and the two levers are different: `allowed_bots` (upstream, in the reusable) decides whether the action runs at all; `skip-actors` (here) decides whether this repo wants a review for that actor. Only the former was wrong. Per the standing comment on that line, removing a name there is never a one-line change.

## Verification

- Ordering verified rather than assumed: with these pins applied against the **pre-sync** `policy.json`, `CI_REPOSITORY_VISIBILITY=public node .github/standards/runner-policy/runner-policy.mjs --root .` fails both jobs with `runner-target-contract: the reusable workflow path@SHA has no reviewed runner-input contract`. After #2495 merged and this branch was rebased onto it, the same command reports `Runner policy passed.` That is why this PR is sequenced after #2495 rather than opened alongside it.
- The v0.14.0 contracts it validates against were reviewed in melodic-software/standards#374: both lane contracts copy forward unchanged (the new lane inputs `plugins`, `plugin-marketplaces`, `plugin-command`, `pr-number` are optional and unpassed), and no secret, caller permission, or routing surface changes.

**Not verified here, and cannot be from this PR:** that a `cursor[bot]`-triggered event now actually gets reviewed. That needs this merged and one bot-triggered run afterwards. I will record that proof on melodic-software/ci-workflows#441.

## Related

No linked issue — fleet re-pin delivering melodic-software/ci-workflows#442; this repo has no tracking issue of its own for it.