### PR TITLE
fix(autonomy): reject dot-traversal segments in concrete credential paths

### DIFF
--- a/plugins/autonomy/.claude-plugin/plugin.json
+++ b/plugins/autonomy/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "autonomy",
-  "version": "0.16.5",
+  "version": "0.16.6",
   "description": "Governed autonomous agent operation: role-topology, binding-seam, wiring-vs-advisor, telemetry, return-accounting, trigger-dispatch, per-work-class guardrail-matrix, standing-routine-catalog, and design-only runner-charter contracts for climbing the AI-adoption ladder, plus a guided-setup skill that discovers an adopting org's state, writes its schema-versioned binding, wires standards-pinned OTLP emission with a zero-cost file-artifact default, wires human-attested return capture at the task boundary, wires signal adapters with one governed dispatch entrypoint, binds the five-class guardrail matrix to an org's isolation substrates with an in-boundary live-validation probe before recording each fail-closed binding, and stands up standing-routine-catalog classes as scheduled temporal signal adapters behind the one governed queue with free scheduling defaults wired as reviewable changes and each routine's work-class mapping homed on the security surface.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/autonomy/CHANGELOG.md
+++ b/plugins/autonomy/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to the `autonomy` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.16.6]
+
+### Fixed
+
+- **Concrete credential paths with dot-traversal segments now fail the expansion-coherence
+  check explicitly (#949).** A path like `/configured-root/subdir/../.ssh/id_rsa` that
+  repeats verbatim in `host_expanded` no longer passes coherence only to be denied later
+  by containment normalization; operators see the canonical-path remediation instead.
+
 ## [0.16.5]
 
 ### Changed

--- a/plugins/autonomy/skills/setup/evals/fixtures/security-binding/probe-evidence-concrete-dot-traversal.json
+++ b/plugins/autonomy/skills/setup/evals/fixtures/security-binding/probe-evidence-concrete-dot-traversal.json
@@ -1,0 +1,97 @@
+{
+  "schema_version": "1.0",
+  "executor_class": "self-operated",
+  "dispatch_posture": "autonomous-enabled",
+  "isolation_bindings": {
+    "ci-pool-a": {
+      "L2": {
+        "substrate": "egress-denied-container-pool",
+        "substrate_class": "container",
+        "component_reachable_hosts": [
+          "example.com"
+        ],
+        "probe_evidence": "probe-transcripts/ci-pool-a-l2-concrete-dot-traversal.json",
+        "runtime_markers": {
+          "runner-pool": "ci-pool-a",
+          "region": "us-east"
+        }
+      }
+    }
+  },
+  "merge_policy": {
+    "C1": "human",
+    "C2": "human",
+    "C3": "human",
+    "C4": "human",
+    "C5": "human"
+  },
+  "verification_blocking": {
+    "deterministic": {
+      "C1": "not-required",
+      "C2": "blocking",
+      "C3": "blocking",
+      "C4": "blocking",
+      "C5": "blocking"
+    },
+    "ai-review": {
+      "C1": "not-required",
+      "C2": "not-required",
+      "C3": "advisory",
+      "C4": "blocking",
+      "C5": "blocking"
+    }
+  },
+  "escalation_routes": {
+    "gate-failure": "queue:escalations/gate-failure",
+    "verification-divergence": "queue:escalations/verification-divergence",
+    "admission-rejection": "queue:escalations/admission-rejection",
+    "demotion": "queue:escalations/demotion",
+    "structural-plan-approval": "queue:escalations/structural-plan-approval",
+    "untrusted-provenance": "queue:escalations/untrusted-provenance"
+  },
+  "admission": {
+    "classification": {
+      "tracker-vcs-event": {
+        "autonomy:audit": "C1",
+        "autonomy:mechanical": "C2",
+        "autonomy:scoped": "C3",
+        "autonomy:structural": "C4",
+        "autonomy:untrusted": "C5"
+      }
+    },
+    "rules": [
+      {
+        "signal_class": "*",
+        "provenance": "*",
+        "work_class": "C1",
+        "disposition": "autonomous-eligible"
+      },
+      {
+        "signal_class": "*",
+        "provenance": "*",
+        "work_class": "C2",
+        "disposition": "autonomous-eligible"
+      },
+      {
+        "signal_class": "*",
+        "provenance": "*",
+        "work_class": "C3",
+        "disposition": "human-gated"
+      },
+      {
+        "signal_class": "*",
+        "provenance": "*",
+        "work_class": "C4",
+        "disposition": "human-gated"
+      },
+      {
+        "signal_class": "*",
+        "provenance": "*",
+        "work_class": "C5",
+        "disposition": "human-gated"
+      }
+    ],
+    "autonomous_concurrency": 1,
+    "items_per_run": 3
+  }
+}

--- a/plugins/autonomy/skills/setup/evals/fixtures/security-binding/probe-transcripts/ci-pool-a-l2-concrete-dot-traversal.json
+++ b/plugins/autonomy/skills/setup/evals/fixtures/security-binding/probe-transcripts/ci-pool-a-l2-concrete-dot-traversal.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": "1",
+  "surface": "ci-pool-a",
+  "level": "L2",
+  "substrate": "egress-denied-container-pool",
+  "substrate_class": "container",
+  "probed_at": "2026-07-06T10:00:00Z",
+  "assertions": {
+    "egress_denied": { "host": "example.com", "exit_code": "7", "outer_exit_code": "0", "outcome": "denied" },
+    "credentials_absent": {
+      "path": "/configured-root/subdir/../.ssh/id_rsa",
+      "host_expanded": "/configured-root/subdir/../.ssh/id_rsa",
+      "exit_code": "1",
+      "outer_exit_code": "0",
+      "transport_outcome": "read-denied",
+      "outcome": "absent-or-denied"
+    }
+  },
+  "outer_context_networked": true
+}

--- a/plugins/autonomy/skills/setup/scripts/check-security-binding.fixtures.test.manifest.json
+++ b/plugins/autonomy/skills/setup/scripts/check-security-binding.fixtures.test.manifest.json
@@ -306,7 +306,14 @@
       "exit": 1,
       "credential_roots": "/root",
       "findings_substrings": [
-        "\"/root/../var/empty/.ssh/id_rsa\" does not resolve under any configured --credential-roots"
+        "a concrete credential path must not contain dot-traversal segments"
+      ]
+    },
+    "probe-evidence-concrete-dot-traversal.json": {
+      "exit": 1,
+      "credential_roots": "/configured-root",
+      "findings_substrings": [
+        "a concrete credential path must not contain dot-traversal segments"
       ]
     },
     "probe-evidence-dummy-prefix.json": {
@@ -993,6 +1000,7 @@
     "ci-pool-a-l2-bogus-metadata.json",
     "ci-pool-a-l2-cred-outer-missing.json",
     "ci-pool-a-l2-cred-outer-nonzero.json",
+    "ci-pool-a-l2-concrete-dot-traversal.json",
     "ci-pool-a-l2-credpath-code-count.json",
     "ci-pool-a-l2-credpath-partial-zero.json",
     "ci-pool-a-l2-discard-only.json",

--- a/plugins/autonomy/skills/setup/scripts/check-security-binding.mjs
+++ b/plugins/autonomy/skills/setup/scripts/check-security-binding.mjs
@@ -324,6 +324,10 @@ function credentialExpansionProblem(entry, expanded) {
   const homeAnchored =
     !normalizedEntry.includes("://") && segments.length > 1 && isHomeEnvToken(segments[0]);
   if (!homeAnchored) {
+    const concreteSegments = normalizedEntry.split("/").filter((segment) => segment.length > 0);
+    if (concreteSegments.some((segment) => segment === "." || segment === "..")) {
+      return "a concrete credential path must not contain dot-traversal segments — use the canonical path";
+    }
     return normalizedExpanded === normalizedEntry
       ? null
       : "a concrete entry needs no host-side expansion, so host_expanded must repeat the entry verbatim";


### PR DESCRIPTION
Fixes #949

## Summary

Concrete credential paths containing `.` or `..` segments now fail the expansion-coherence check with an explicit canonical-path remediation, instead of passing verbatim equality and surfacing only a later containment denial.

## Test plan

- [x] `node --test plugins/autonomy/skills/setup/scripts/check-security-binding.fixtures.test.mjs`

## Related

None.