### PR TITLE
fix(ci): stop the security-evidence guard matching the lane's own source

### DIFF
--- a/scripts/verify-security-review-evidence.sh
+++ b/scripts/verify-security-review-evidence.sh
@@ -178,8 +178,32 @@ main() {
     sleep 5
   done
 
-  if grep -qE 'workflow-validation skip|class=skipped-validation|review-ran.*false' "$log_file" 2>/dev/null; then
-    echo "ERROR: security-review reported success but logs show a validation skip or review-ran=false (#2337)" >&2
+  # Match only the runner's own ANNOTATION lines, never bare log text. The
+  # lane's `Report review outcome` step is an inline github-script whose SOURCE
+  # is echoed into this same log, and that source contains both phrases as
+  # string literals:
+  #
+  #     `${lane} concluded: ${outcome} class=skipped-validation with no ` +
+  #       "(workflow-validation skip: the caller's workflow file must " +
+  #
+  # An unanchored grep therefore matched EVERY successful in-scope run — the
+  # guard reddened exactly the pull requests it exists to approve. It stayed
+  # invisible while a separate bug (the lane rejecting `cursor[bot]` for want
+  # of an `allowed_bots` entry) made the lane job itself fail, because a
+  # non-success conclusion returns above without reaching this line.
+  #
+  # A real skip is emitted through `core.warning`, which the runner renders as
+  # a `##[warning]` line, so requiring that prefix keeps the true positive and
+  # drops the source-text match. Verified against run 31630114303, whose log
+  # contains exactly two matches for the old pattern, both source (lines 1435
+  # and 1437), while its `Rule on an in-scope non-run` step is `skipped` and
+  # its review ran 3m07s.
+  #
+  # `review-ran.*false` is deliberately not carried forward: the output key is
+  # `review_ran` with an underscore, so that alternative never matched a real
+  # signal — only, once again, the echoed source.
+  if grep -qE '##\[(warning|error)\].*(workflow-validation skip|class=skipped-validation)' "$log_file" 2>/dev/null; then
+    echo "ERROR: security-review reported success but its annotations show a validation skip (#2337)" >&2
     exit 1
   fi
 

--- a/scripts/verify-security-review-evidence.sh.test.sh
+++ b/scripts/verify-security-review-evidence.sh.test.sh
@@ -56,6 +56,15 @@ log_has_execution_evidence() {
   grep -qE "$EVIDENCE_PATTERN" "$1" 2>/dev/null
 }
 
+# Kept byte-identical to the guard's own pattern. Anchored to runner annotation
+# lines so the lane's echoed github-script SOURCE — which contains both phrases
+# as string literals — cannot be mistaken for a real skip.
+SKIP_ANNOTATION_PATTERN='##\[(warning|error)\].*(workflow-validation skip|class=skipped-validation)'
+
+log_shows_validation_skip() {
+  grep -qE "$SKIP_ANNOTATION_PATTERN" "$1" 2>/dev/null
+}
+
 would_reject_fast_success() {
   local duration="$1"
   local has_execution_evidence="$2"
@@ -107,6 +116,37 @@ if would_reject_fast_success 20 0; then
   fail "20s without evidence accepted (above floor)" "unexpected rejection"
 else
   pass "20s without evidence accepted (above floor)"
+fi
+
+# Regression: the echoed github-script source of the lane's `Report review
+# outcome` step, verbatim from run 31630114303 lines 1435 and 1437. The old
+# unanchored pattern matched these and failed every successful in-scope PR.
+printf '%s\n' \
+  '    `${lane} concluded: ${outcome} class=skipped-validation with no ` +' \
+  '      "(workflow-validation skip: the caller'"'"'s workflow file must " +' \
+  >"$tmp_log"
+if log_shows_validation_skip "$tmp_log"; then
+  fail "echoed action source is not a validation skip" "unexpected match (#2337 false positive)"
+else
+  pass "echoed action source is not a validation skip"
+fi
+
+# True positive: the runner's rendered annotation for a real self-skip.
+printf '%s\n' \
+  '2026-08-12T18:46:14.6127175Z ##[warning]Claude security review concluded: success class=skipped-validation with no execution evidence — the action skipped itself before running (workflow-validation skip: the caller'"'"'s workflow file must match the default branch'"'"'s copy). Nothing was reviewed.' \
+  >"$tmp_log"
+if log_shows_validation_skip "$tmp_log"; then
+  pass "annotated validation skip is detected"
+else
+  fail "annotated validation skip is detected" "expected match"
+fi
+
+# A clean run carries neither shape.
+printf '%s\n' 'Installing @anthropic-ai/claude-agent-sdk' 'Claude Code action completed' >"$tmp_log"
+if log_shows_validation_skip "$tmp_log"; then
+  fail "clean lane log shows no validation skip" "unexpected match"
+else
+  pass "clean lane log shows no validation skip"
 fi
 
 if [[ "$FAILED" -eq 0 ]]; then

--- a/scripts/verify-security-review-evidence.sh.test.sh
+++ b/scripts/verify-security-review-evidence.sh.test.sh
@@ -121,6 +121,7 @@ fi
 # Regression: the echoed github-script source of the lane's `Report review
 # outcome` step, verbatim from run 31630114303 lines 1435 and 1437. The old
 # unanchored pattern matched these and failed every successful in-scope PR.
+# shellcheck disable=SC2016  # fixture is literal github-script source; ${lane} must not expand
 printf '%s\n' \
   '    `${lane} concluded: ${outcome} class=skipped-validation with no ` +' \
   '      "(workflow-validation skip: the caller'"'"'s workflow file must " +' \


### PR DESCRIPTION
## Summary

`scripts/verify-security-review-evidence.sh` fired on **every successful in-scope pull request** — it reddened exactly the PRs it exists to approve.

It greps the security-review job log for `workflow-validation skip|class=skipped-validation|review-ran.*false`. The lane's `Report review outcome` step is an inline `github-script` whose **source** is echoed into that same log, and the source contains two of those phrases as string literals:

```
1435:  `${lane} concluded: ${outcome} class=skipped-validation with no ` +
1437:    "(workflow-validation skip: the caller's workflow file must " +
```

On [run 31630114303](https://github.com/melodic-software/claude-code-plugins/actions/runs/31630114303) those two source lines are the only matches in the entire log: the lane ran a real 3m07s review, its `Rule on an in-scope non-run` step is `skipped` (the lane found no skip), and the guard failed 11 seconds later anyway.

## Fix

Anchor the match to the runner's own annotation lines. A real self-skip is emitted through `core.warning`, which renders as `##[warning]`, so requiring that prefix keeps the true positive and drops the source-text match:

```
##\[(warning|error)\].*(workflow-validation skip|class=skipped-validation)
```

`review-ran.*false` is dropped rather than carried forward: the output key is `review_ran` with an underscore, so that alternative never matched a real signal either — only the echoed source.

## Verification

Both directions checked against the two REAL logs, not fixtures alone:

| log | old pattern | new pattern |
|---|---|---|
| [31630114303](https://github.com/melodic-software/claude-code-plugins/actions/runs/31630114303) — review ran 3m07s, guard failed | 2 matches (both source) | **0** |
| [31629272848](https://github.com/melodic-software/claude-code-plugins/actions/runs/31629272848) — genuine caller-drift skip | matches | **1**, on `##[warning]Claude security review concluded: success class=skipped-validation` |

Self-tests extended with three regression cases, using the source lines verbatim from run 31630114303 and the rendered annotation from run 31629272848: echoed source must NOT match, a real annotation MUST match, a clean lane log must match neither.

```
$ bash scripts/verify-security-review-evidence.sh.test.sh
...
PASS: echoed action source is not a validation skip
PASS: annotated validation skip is detected
PASS: clean lane log shows no validation skip

All checks passed.     (10 pass, 0 fail)
```

This PR is itself the live check: it touches `scripts/**`, so it is in scope for the guard, and it carries no workflow change, so the lane has no caller drift to skip on. If it goes green, the guard now approves a review that actually ran.

## Why it was invisible until today

While the lanes rejected `cursor[bot]` for want of an `allowed_bots` entry (melodic-software/ci-workflows#441), the security-review job itself failed, and the script returns early on any non-success conclusion (`deferring to job status`). Fixing that gate turned the lanes green, which is the first time execution reached the grep. One bug was masking the other.

## Follow-up, not in this fix

The guard infers "did the review run" by grepping another workflow's log — a coupling that broke on a change to the upstream action's source text, in a repo that does not own it. A sturdier design reads the lane's declared `review_ran` / `failure_class` outputs, which needs the ci-workflows reusable to surface them as workflow outputs. Recorded in #2517.

## Related

Closes #2517