### PR TITLE
perf(rate-limit-guard): spool the statusline snapshot, drain it on a cadence (0.7.0)

### DIFF
--- a/plugins/rate-limit-guard/.claude-plugin/plugin.json
+++ b/plugins/rate-limit-guard/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "rate-limit-guard",
-  "version": "0.6.3",
+  "version": "0.7.0",
   "description": "Shared rate-limit guard for loop lanes: a statusline wrapper tees the subscription rate-limit windows to a fixed machine-scope file, a StopFailure hook records rate-limit stops reactively, and a reader contract fixes how consuming sessions pause and resume.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/rate-limit-guard/CHANGELOG.md
+++ b/plugins/rate-limit-guard/CHANGELOG.md
@@ -164,11 +164,11 @@ All notable changes to the `rate-limit-guard` plugin are documented here. Format
   by paying a fork more expensive than the execs it steps around, and it lets successive refreshes
   overlap instead of serialise. Measured (Windows, 24 cores, statusline + tee):
 
-  | | sync (default) | async |
-  |---|---|---|
-  | one session, refreshes 1 s apart | 660 ms | **222 ms** |
-  | ten sessions at 1 Hz, median | **2265 ms** | 4476 ms |
-  | ten sessions, peak bash processes | **50** | 71 |
+  |                                   | sync (default) | async      |
+  | --------------------------------- | -------------- | ---------- |
+  | one session, refreshes 1 s apart  | 660 ms         | **222 ms** |
+  | ten sessions at 1 Hz, median      | **2265 ms**    | 4476 ms    |
+  | ten sessions, peak bash processes | **50**         | 71         |
 
   Sessions, not refresh rate, is the variable that decides. Turn it on if you run one or two
   windows; leave it off if you run many. The durable fix removes the cost instead of moving it —
@@ -184,7 +184,7 @@ All notable changes to the `rate-limit-guard` plugin are documented here. Format
 - **Four assertions covering the detached path** (75 total, up from 71): stdout carries only the
   wrapped command's output, the snapshot still lands, it carries the session's windows, and a
   reader consuming stdout to EOF is not made to wait on the child. The suite runs the default
-  synchronous path everywhere else, so assertions that a snapshot was *not* written keep their
+  synchronous path everywhere else, so assertions that a snapshot was _not_ written keep their
   meaning instead of passing vacuously against a race.
 
 ## [0.5.10]
@@ -210,7 +210,7 @@ All notable changes to the `rate-limit-guard` plugin are documented here. Format
   second named function that denies the tool call instead, for the narrow class of guards whose job
   is blocking an irreversible operation (today only two, both in `guardrails`). A sibling function
   rather than a parameter, because a flag's omitted value would default to fail-open and a guard
-  whose flag someone forgot would then fail open *silently* — the exact defect #2146 reports,
+  whose flag someone forgot would then fail open _silently_ — the exact defect #2146 reports,
   reintroduced at the API. The two postures are now argued together in one block above both
   functions, which is what #2146 asked for: previously each call site asserted a posture in a
   comment and nothing where the decision is made explained it. Synced from `lib/hook-utils.sh`.
@@ -241,7 +241,7 @@ All notable changes to the `rate-limit-guard` plugin are documented here. Format
 
   **Precedence is now managed → user settings → environment**, highest first. Managed wins because
   a gate a user or a repository can out-vote is not a policy control. The environment channel also
-  moved *below* user settings, which is a second behaviour change and deliberate: it is retained
+  moved _below_ user settings, which is a second behaviour change and deliberate: it is retained
   only in case `CLAUDE_PLUGIN_OPTION_RATE_LIMIT_GUARD_ENABLED` is ever delivered to a `statusLine`
   process, and for an unconfigured key a repository `.claude/settings.json` `env` block populates it
   freely with no provenance (same convention, fact 4), so it must not out-vote a value a real
@@ -252,7 +252,7 @@ All notable changes to the `rate-limit-guard` plugin are documented here. Format
   exact value this gate exists to detect — using `tostring` plus an explicit `length == 0` emptiness
   test instead.
 
-  **Residuals (accepted, unchanged by this release).** The *user* settings file is still located
+  **Residuals (accepted, unchanged by this release).** The _user_ settings file is still located
   from `${CLAUDE_CONFIG_DIR:-$HOME/.claude}` rather than channel F's install-cache anchor, so a
   repository `env` block that redirects `CLAUDE_CONFIG_DIR` can still hide a user-scope `false`;
   and a value supplied only through a session `--settings` file is invisible to any on-disk read
@@ -267,7 +267,7 @@ All notable changes to the `rate-limit-guard` plugin are documented here. Format
   file, and a file with no `pluginConfigs`), user `false` and user `true`, a `false` under a
   different marketplace suffix (the prefix match), another plugin's identically-named option and a
   prefix-colliding plugin name, malformed JSON and a missing `jq` (both fail open), and managed
-  `false` over user `true` *and* managed `true` over user `false` — the mirror case is what
+  `false` over user `true` _and_ managed `true` over user `false` — the mirror case is what
   distinguishes real precedence from an or-of-falses. Every case also asserts that the wrapped
   statusline's stdout is unchanged, because a gate that blanked the status line would be worse than
   the bug it closes; one unstubbed end-to-end case exercises the script exactly as `settings.json`

--- a/plugins/rate-limit-guard/CHANGELOG.md
+++ b/plugins/rate-limit-guard/CHANGELOG.md
@@ -3,6 +3,78 @@
 All notable changes to the `rate-limit-guard` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.7.0]
+
+### Changed
+
+- **The statusline refresh no longer writes the snapshot; it records to a spool and one
+  elected refresh per 30 seconds flushes the batch.** Measured same-window here
+  (Windows/MSYS, n=9): `render.sh` alone 234.4 ms, `render.sh` behind this wrapper
+  1047.1 ms. The wrapper dominated, and the dominant term inside it was process
+  creation — a cost MSYS has no cheap primitive for, on a path that fires on every
+  assistant message AND every `refreshInterval` tick, once per open session. 0.6.x
+  made that work cheaper (nine spawns to four); this release takes it off the render
+  path instead. The common refresh now runs **zero external processes and zero
+  subshells**, asserted by an `xtrace` of a non-elected render rather than by reading
+  the code.
+
+  What a refresh does now: extract `session_id` by parameter expansion, strip CR/LF
+  (a JSON string cannot contain either, so this is lossless), stamp the epoch with
+  `printf -v '%(%s)T'`, and overwrite `~/.claude/rate-limit-guard/spool/<session>.json`
+  with one line. All builtins.
+
+  **Per-session files, not a shared append spool.** POSIX specifies atomicity for
+  concurrent writes to pipes up to `PIPE_BUF` and explicitly leaves regular-file
+  behaviour unspecified; through Cygwin/MSYS the observed no-interleave bound on
+  appends is around a kilobyte while statusline payloads are multiple kilobytes, and
+  bash's buffered builtin output can split one large record across syscalls anyway.
+  Atomicity therefore comes from **file disjointness** — no two writers ever share a
+  file, each record is one line written with a truncating `>` — instead of from an
+  argument about write sizes. A record torn by a kill mid-write fails `fromjson` in
+  the drain and is dropped, which is covered by a test.
+
+  **The filename is a shard key, never trusted data.** `session_id` arrives in the
+  harness payload; it must match `^[A-Za-z0-9._-]{1,64}$` and not begin with a dot, or
+  it shards to the literal name `misc`. Traversal attempts, embedded quotes,
+  200-character values and JSON nulls are all covered.
+
+  **Election is stamp-based, and the elected refresh drains in-process.** There is no
+  timer to hang this on: Claude Code hooks are strictly event-driven and none fires on
+  a schedule (<https://code.claude.com/docs/en/hooks.md>), an OS scheduler would mean
+  three mechanisms across three platforms, and a resident lock-holder would have to be
+  forked off a render — the exact cost being removed — and would be killed with it,
+  since Claude Code cancels in-flight statusline scripts. So the renders are the clock:
+  whichever finds `spool/.last-drain` older than the cadence takes `spool/.drain.lock`,
+  re-reads the stamp under it (a herd collapses for one failed `mkdir`), and flushes.
+  The drain uses its OWN lock rather than the snapshot lock, so `tee_snapshot` keeps
+  the concurrent-writer lock, the atomic temp-then-rename and the windowless-writer
+  preservation check exactly as they were.
+
+  **The snapshot body is byte-identical apart from `captured_at`**, proven by
+  `diff <(jq -S 'del(.captured_at)' pristine) <(jq -S 'del(.captured_at)' patched)`.
+  The body projection is now one shared jq function called by both the live probe and
+  the drain, so the two cannot drift. `captured_at` is the **observation time of the
+  chosen record**, never the flush time — which is what lets a windowless refresh
+  flush a window-bearing sibling's record without faking freshness.
+
+  **Reader-visible change, inside the existing contract:** the contract file now trails
+  the newest refresh on the machine by up to 30 seconds instead of being rewritten on
+  every refresh. The reader contract budgets ten minutes of staleness and its operable
+  floor values are unchanged; `reference/reader-contract.md` documents the cadence,
+  the `spool/` inventory and the `.tee-disabled` marker.
+
+  **The enablement gate still gates the write**, but it cannot be evaluated on the
+  render path — reading settings costs a `jq`. A drain that reads
+  `rate_limit_guard_enabled: false` writes an epoch-stamped `.tee-disabled` marker and
+  drops the spool; refreshes then stop recording on one builtin test. The marker
+  expires, so a re-enabled plugin recovers on its own without a restart.
+
+  Bash 4.2 is the floor (`%(%s)T` is a 4.2 builtin). Below it — macOS bash 3.2, where
+  `fork` is cheap and this problem does not arise — the previous synchronous path runs
+  untouched, and `RLG_TEE_ASYNC=1` keeps its current behaviour on every version.
+
+  All 75 pre-existing assertions pass unmodified; the suite is now 96.
+
 ## [0.6.3]
 
 ### Changed

--- a/plugins/rate-limit-guard/CHANGELOG.md
+++ b/plugins/rate-limit-guard/CHANGELOG.md
@@ -184,7 +184,7 @@ All notable changes to the `rate-limit-guard` plugin are documented here. Format
 - **Four assertions covering the detached path** (75 total, up from 71): stdout carries only the
   wrapped command's output, the snapshot still lands, it carries the session's windows, and a
   reader consuming stdout to EOF is not made to wait on the child. The suite runs the default
-  synchronous path everywhere else, so assertions that a snapshot was _not_ written keep their
+  synchronous path everywhere else, so assertions that a snapshot was *not* written keep their
   meaning instead of passing vacuously against a race.
 
 ## [0.5.10]
@@ -210,7 +210,7 @@ All notable changes to the `rate-limit-guard` plugin are documented here. Format
   second named function that denies the tool call instead, for the narrow class of guards whose job
   is blocking an irreversible operation (today only two, both in `guardrails`). A sibling function
   rather than a parameter, because a flag's omitted value would default to fail-open and a guard
-  whose flag someone forgot would then fail open _silently_ — the exact defect #2146 reports,
+  whose flag someone forgot would then fail open *silently* — the exact defect #2146 reports,
   reintroduced at the API. The two postures are now argued together in one block above both
   functions, which is what #2146 asked for: previously each call site asserted a posture in a
   comment and nothing where the decision is made explained it. Synced from `lib/hook-utils.sh`.
@@ -241,7 +241,7 @@ All notable changes to the `rate-limit-guard` plugin are documented here. Format
 
   **Precedence is now managed → user settings → environment**, highest first. Managed wins because
   a gate a user or a repository can out-vote is not a policy control. The environment channel also
-  moved _below_ user settings, which is a second behaviour change and deliberate: it is retained
+  moved *below* user settings, which is a second behaviour change and deliberate: it is retained
   only in case `CLAUDE_PLUGIN_OPTION_RATE_LIMIT_GUARD_ENABLED` is ever delivered to a `statusLine`
   process, and for an unconfigured key a repository `.claude/settings.json` `env` block populates it
   freely with no provenance (same convention, fact 4), so it must not out-vote a value a real
@@ -252,7 +252,7 @@ All notable changes to the `rate-limit-guard` plugin are documented here. Format
   exact value this gate exists to detect — using `tostring` plus an explicit `length == 0` emptiness
   test instead.
 
-  **Residuals (accepted, unchanged by this release).** The _user_ settings file is still located
+  **Residuals (accepted, unchanged by this release).** The *user* settings file is still located
   from `${CLAUDE_CONFIG_DIR:-$HOME/.claude}` rather than channel F's install-cache anchor, so a
   repository `env` block that redirects `CLAUDE_CONFIG_DIR` can still hide a user-scope `false`;
   and a value supplied only through a session `--settings` file is invisible to any on-disk read
@@ -267,7 +267,7 @@ All notable changes to the `rate-limit-guard` plugin are documented here. Format
   file, and a file with no `pluginConfigs`), user `false` and user `true`, a `false` under a
   different marketplace suffix (the prefix match), another plugin's identically-named option and a
   prefix-colliding plugin name, malformed JSON and a missing `jq` (both fail open), and managed
-  `false` over user `true` _and_ managed `true` over user `false` — the mirror case is what
+  `false` over user `true` *and* managed `true` over user `false` — the mirror case is what
   distinguishes real precedence from an or-of-falses. Every case also asserts that the wrapped
   statusline's stdout is unchanged, because a gate that blanked the status line would be worse than
   the bug it closes; one unstubbed end-to-end case exercises the script exactly as `settings.json`

--- a/plugins/rate-limit-guard/reference/reader-contract.md
+++ b/plugins/rate-limit-guard/reference/reader-contract.md
@@ -26,13 +26,14 @@ loop-lane convention (`docs/conventions/loop-lane/README.md` §6 in the marketpl
 ## Tee file shape
 
 One JSON object, rewritten atomically on a **drain cadence** rather than on every refresh (temp file
-+ rename — a reader never sees torn JSON; the file is **last-writer-wins** across all sessions on the
-machine). Each refresh records its observation to a private per-session spool file with no external
-process at all, and one elected refresh per cadence flushes the batch into this file, so the snapshot
-trails the newest refresh on the machine by **at most 30 seconds**. That is well inside the
-10-minute staleness budget below, and the operable floor values are unchanged. `captured_at` is the
-**observation time of the record the drain chose** — when those windows were seen — not the time the
-file was written:
+
+- rename — a reader never sees torn JSON; the file is **last-writer-wins** across all sessions on the
+  machine). Each refresh records its observation to a private per-session spool file with no external
+  process at all, and one elected refresh per cadence flushes the batch into this file, so the snapshot
+  trails the newest refresh on the machine by **at most 30 seconds**. That is well inside the
+  10-minute staleness budget below, and the operable floor values are unchanged. `captured_at` is the
+  **observation time of the record the drain chose** — when those windows were seen — not the time the
+  file was written:
 
 ```json
 {
@@ -73,12 +74,12 @@ file was written:
 Windows may be unobservable (API-key and enterprise auth carry limits but expose no
 `rate_limits`). A consumer classifies its guard mode before every pause decision:
 
-| Observation | Scope | Mode |
-|---|---|---|
-| Fresh snapshot with plausible `rate_limits` | whole guard | **proactive** — apply the operable floor |
-| Tee file absent, stale, or missing `rate_limits` | whole guard | **unknown → reactive-only** |
-| Absurd `used_percentage` or `resets_at` | that window | that window **unknown**; the floor still applies to every window still plausible |
-| No window plausible | whole guard | **unknown → reactive-only** |
+| Observation                                      | Scope       | Mode                                                                             |
+| ------------------------------------------------ | ----------- | -------------------------------------------------------------------------------- |
+| Fresh snapshot with plausible `rate_limits`      | whole guard | **proactive** — apply the operable floor                                         |
+| Tee file absent, stale, or missing `rate_limits` | whole guard | **unknown → reactive-only**                                                      |
+| Absurd `used_percentage` or `resets_at`          | that window | that window **unknown**; the floor still applies to every window still plausible |
+| No window plausible                              | whole guard | **unknown → reactive-only**                                                      |
 
 The scope column is load-bearing: only the whole-guard rows drop the guard to reactive-only. Absurd
 values fail open, never closed: a `used_percentage` outside 0–100 or non-numeric, or a `resets_at`
@@ -100,7 +101,12 @@ proactive.
 appended by the hook:
 
 ```json
-{"detected_at":"2026-07-23T17:41:02Z","hook_event_name":"StopFailure","matcher":"rate_limit","session_id":"abc123"}
+{
+  "detected_at": "2026-07-23T17:41:02Z",
+  "hook_event_name": "StopFailure",
+  "matcher": "rate_limit",
+  "session_id": "abc123"
+}
 ```
 
 The hook is side-effect-only (the harness ignores StopFailure output and exit codes) and the

--- a/plugins/rate-limit-guard/reference/reader-contract.md
+++ b/plugins/rate-limit-guard/reference/reader-contract.md
@@ -25,8 +25,14 @@ loop-lane convention (`docs/conventions/loop-lane/README.md` §6 in the marketpl
 
 ## Tee file shape
 
-One JSON object, rewritten atomically on every statusline refresh (temp file + rename — a reader
-never sees torn JSON; the file is **last-writer-wins** across all sessions on the machine):
+One JSON object, rewritten atomically on a **drain cadence** rather than on every refresh (temp file
++ rename — a reader never sees torn JSON; the file is **last-writer-wins** across all sessions on the
+machine). Each refresh records its observation to a private per-session spool file with no external
+process at all, and one elected refresh per cadence flushes the batch into this file, so the snapshot
+trails the newest refresh on the machine by **at most 30 seconds**. That is well inside the
+10-minute staleness budget below, and the operable floor values are unchanged. `captured_at` is the
+**observation time of the record the drain chose** — when those windows were seen — not the time the
+file was written:
 
 ```json
 {
@@ -42,7 +48,9 @@ never sees torn JSON; the file is **last-writer-wins** across all sessions on th
 (The example is internally consistent: `1784841300` is 2026-07-23T21:15:00Z — within five hours of
 `captured_at` — and `1785142800` is 2026-07-27T09:00:00Z, within the seven-day window.)
 
-- `captured_at` — ISO-8601 UTC write time; always present. Drives the staleness rule.
+- `captured_at` — ISO-8601 UTC **observation** time of the chosen record; always present. Drives the
+  staleness rule. It can trail the file's mtime by up to the drain cadence (30 s), which is why the
+  rule is written against this field and never against the file's modification time.
 - `rate_limits` — copied verbatim from the statusline stdin schema
   (<https://code.claude.com/docs/en/statusline>, verified 2026-08-10): `used_percentage` is 0–100,
   `resets_at` is Unix epoch seconds. The key is present **only** when the session observes
@@ -111,6 +119,19 @@ sweeping the directory expects them:
 
 - `stop-events.jsonl.lock` — the advisory-lock sibling the hook's serialized append and rotation use
   (present wherever `flock` exists).
+- `spool/` — the tee's per-session write-ahead spool, owner-only by inheritance from the contract
+  directory. `spool/<session>.json` holds ONE line: the newest observation that session recorded,
+  overwritten in place each refresh (never appended, so no two writers ever share a file). The name
+  is a shard key derived from `session_id` and reduced to `misc` unless it matches
+  `^[A-Za-z0-9._-]{1,64}$` without a leading dot — it is **never** trusted as a path. `spool/.last-drain`
+  holds the epoch seconds of the last flush and is what elects the next draining refresh; a stale
+  `spool/.drain.lock` directory can appear if a drain is killed and is stolen after two minutes.
+  Records older than 15 minutes are swept by the next drain. Readers consume none of this: the
+  contract file above is still the only proactive surface.
+- `.tee-disabled` — written by a drain that read `rate_limit_guard_enabled: false`, holding the epoch
+  seconds at which it was written. While it is present and younger than the recheck interval the
+  refreshes stop recording entirely; when it ages out the next drain re-reads the real setting and
+  removes the marker, so re-enabling the plugin recovers without a restart.
 - `.rate-limits.json.tmp.<pid>.<random>` — the tee's atomic-write staging file. Normally it exists
   for well under a second between write and rename. It can outlive its writer: Claude Code
   [cancels an in-flight statusline script](https://code.claude.com/docs/en/statusline) when a new

--- a/plugins/rate-limit-guard/scripts/statusline-tee.sh
+++ b/plugins/rate-limit-guard/scripts/statusline-tee.sh
@@ -97,14 +97,17 @@
 # children oversubscribe the box, so the same total work takes twice as long and
 # the process count nearly doubles. Sessions, not refresh rate, is the variable
 # that decides: turn this on if you run one or two, leave it off if you run many.
-# A future design that removes the cost rather than moving it -- the render
-# appending the payload to a spool file with zero forks, drained by one periodic
-# writer -- is the durable answer, and is not this flag.
+# The design that removes the cost rather than moving it -- the render writing
+# its payload to a per-session spool file with zero forks, drained by one
+# elected render per cadence -- is THE SPOOL below, and is the default from bash
+# 4.2 up. This flag is the older answer, kept for the machines where it measured
+# well; setting it opts back out of the spool entirely.
 #
-# Because the default is synchronous, "the snapshot has been written" remains
-# observable the moment the wrapper returns, which is what the test suite relies
-# on: assertions that a snapshot was NOT written would pass vacuously against a
-# race. The suite covers the detached path in dedicated cases that wait for it.
+# Neither default is asynchronous, so "the snapshot has been written" is
+# observable the moment the wrapper returns on any refresh that drains, which is
+# what the test suite relies on: assertions that a snapshot was NOT written would
+# pass vacuously against a race. The suite pins RLG_TEE_DRAIN_INTERVAL=0 so every
+# refresh drains, and covers election and the detached path in dedicated cases.
 #
 # jq is required for the tee and for the standalone line; when absent the
 # wrapper stays transparent and appends a visible one-line notice instead of
@@ -155,11 +158,21 @@ release_tee_lock() {
   return 0
 }
 
+# Election lock held by an in-process drain (see _rlg_drain below). A SECOND
+# lock, deliberately not the snapshot lock: see the DRAIN LOCK note there.
+TEE_DRAIN_LOCK=""
+
+release_drain_lock() {
+  [[ -n "$TEE_DRAIN_LOCK" ]] && rmdir "$TEE_DRAIN_LOCK" 2>/dev/null
+  TEE_DRAIN_LOCK=""
+  return 0
+}
+
 # The signal traps exit rather than reclaiming directly, so the EXIT trap stays
 # the single reclaim path. Exiting is also the right response to a cancelling
 # signal: this refresh's snapshot is already superseded by the update that
 # cancelled it.
-trap 'reclaim_tee_tmp; release_tee_lock' EXIT
+trap 'reclaim_tee_tmp; release_tee_lock; release_drain_lock' EXIT
 trap 'exit 143' TERM
 trap 'exit 130' INT
 trap 'exit 129' HUP
@@ -431,6 +444,22 @@ _RLG_VERDICT_JQ='[ ($doc.pluginConfigs // {}) | to_entries[]
       | select(. != null) | tostring ]
     | if length == 0 then "" else last end'
 
+# The snapshot BODY projection, as a jq function so the live probe and the
+# drainer below emit byte-identical bodies from the same text. It is applied to
+# a statusline payload object and takes the ISO-8601 timestamp to stamp it with:
+# the probe passes its own render time, the drainer passes the OBSERVATION time
+# of the record it chose (never "now"), which is what keeps captured_at honest
+# about when the windows were seen rather than when they were flushed.
+#
+# Selection is on the TOP-LEVEL key name only and a selected key carries its
+# whole value across — the rule reference/reader-contract.md states.
+# shellcheck disable=SC2016  # jq filter text; $ts is a jq parameter, not a shell variable
+_RLG_BODY_JQ='def rlg_body($ts): {captured_at: $ts}
+      + (to_entries
+         | map(select(.key == "rate_limits" or .key == "session_id"
+                      or .key == "session_name" or (.key | test("account"; "i"))))
+         | from_entries);'
+
 _rlg_settings_option() {
   local file="$1" out
   [[ -r "$file" ]] || return 1
@@ -547,12 +576,9 @@ _rlg_probe() {
   # `jq -c` escapes any newline inside a string and the other two are bare
   # tokens, so every line is single-line by construction and the split is exact.
   out="$(RLG_SETTINGS_DOC="$settings_json" jq -rc --arg ts "$ts" "
+    $_RLG_BODY_JQ
     $_RLG_DOC_JQ"'
-    | ({captured_at: $ts}
-       + (to_entries
-          | map(select(.key == "rate_limits" or .key == "session_id"
-                       or .key == "session_name" or (.key | test("account"; "i"))))
-          | from_entries)) as $p
+    | (rlg_body($ts)) as $p
     | $p,
       ($p | has("rate_limits")),
       (try ('"$_RLG_VERDICT_JQ"') catch "")
@@ -586,9 +612,270 @@ _rlg_tee_run() {
   return 0
 }
 
+# =============================== THE SPOOL ==================================
+#
+# The render path above costs a jq, a lock, a write and a rename on EVERY
+# refresh — once per assistant message and once per refreshInterval tick, per
+# open session. Measured same-window here (Windows/MSYS, n=9): render.sh alone
+# 234.4 ms, render.sh + this wrapper 1047.1 ms. The wrapper dominates, and the
+# dominant term in the wrapper is process creation, which MSYS has no cheap
+# primitive for. So the render stops doing the work: it APPENDS NOTHING and
+# FORKS NOTHING, it overwrites one small per-session file with builtins, and
+# one elected render per cadence flushes the batch into the same contract
+# snapshot the same tee_snapshot writes today.
+#
+# WHY PER-SESSION FILES, NOT ONE SHARED APPEND SPOOL. A shared O_APPEND spool
+# would be the obvious shape and it is not safe here. POSIX guarantees
+# atomicity for concurrent writes to PIPES up to PIPE_BUF; for REGULAR FILES it
+# explicitly leaves concurrent-write behaviour unspecified. Through
+# Cygwin/MSYS the observed no-interleave bound on appends is around a kilobyte
+# while statusline payloads are multiple kilobytes, and bash's buffered builtin
+# output can split one large record across syscalls regardless. Atomicity is
+# therefore obtained from FILE DISJOINTNESS instead of from any write-size
+# argument: no two writers ever share a file, each record is one line written
+# with a TRUNCATING '>', and a reader either sees the previous complete record
+# or the new one. A record that is torn anyway (killed mid-write) fails
+# `fromjson` in the drain and is dropped.
+#
+# THE FILENAME IS A SHARD KEY, NEVER TRUSTED DATA. session_id is extracted from
+# the payload with parameter expansion and must match ^[A-Za-z0-9._-]{1,64}$
+# and not begin with a dot; anything else — a traversal attempt, an embedded
+# quote, a 200-character value, a JSON null — shards to the literal name
+# `misc`. Sessions that collide on `misc` overwrite each other's record, which
+# costs one refresh of freshness and nothing else.
+#
+# DRAIN LOCK. The election takes its OWN lock (spool/.drain.lock), not the
+# snapshot lock. Two reasons, both load-bearing: tee_snapshot acquires and
+# releases the snapshot lock through one global, so a drain holding it would
+# have tee_snapshot burn its full retry budget and then rmdir the lock out from
+# under its own caller; and the snapshot lock's existing semantics — a
+# window-bearing writer proceeds through a lock it could not take — must keep
+# working, which a drain gated on that same lock would break.
+#
+# TRIGGER. There is no timer to hang this on: Claude Code hooks are strictly
+# event-driven (https://code.claude.com/docs/en/hooks.md) and none fires on a
+# schedule, an OS scheduler would mean three mechanisms across three platforms,
+# and a resident lock-holder would have to be forked off a render — the one
+# thing this design exists to stop — and would be killed with it, since Claude
+# Code cancels in-flight statusline scripts. The renders themselves are the
+# clock: whichever one finds the stamp older than the cadence does the work,
+# in-process, for everyone.
+#
+# BASH FLOOR. %(%s)T is a bash 4.2 builtin. Below that (macOS ships 3.2) the
+# synchronous path above runs untouched — and that is the platform where fork
+# is cheap and this problem does not exist. RLG_TEE_ASYNC=1 also keeps its
+# current behaviour.
+
+# Extract session_id from the raw payload with parameter expansion only, and
+# reduce it to a safe shard name. Sets _RLG_SHARD.
+_RLG_SHARD=""
+_rlg_shard_name() {
+  local rest="${INPUT#*\"session_id\"}" sid=""
+  if [[ "$rest" != "$INPUT" ]]; then
+    rest="${rest#*\"}"
+    sid="${rest%%\"*}"
+  fi
+  # Charset AND a leading-dot rejection: a name beginning with a dot would be
+  # skipped by the drain's spool glob, letting a session's own record sit
+  # unread forever.
+  if [[ "$sid" =~ ^[A-Za-z0-9._-]{1,64}$ && "$sid" != .* ]]; then
+    _RLG_SHARD="$sid"
+  else
+    _RLG_SHARD="misc"
+  fi
+  return 0
+}
+
+# Take the election lock, or return 1. No retry loop and no sleep: a render
+# that loses the election has nothing to wait for — the winner is doing the
+# work — so the collapse costs exactly one failed mkdir. The stale-lock steal
+# is attempted only when the stamp itself is far past due, which is the only
+# state a lock abandoned by a killed holder can produce.
+acquire_drain_lock() {
+  local spool="$1" steal="$2" lock="$1/.drain.lock"
+  if mkdir "$lock" 2>/dev/null; then
+    TEE_DRAIN_LOCK="$lock"
+    return 0
+  fi
+  ((steal)) || return 1
+  find "$spool" -maxdepth 1 -type d -name '.drain.lock' \
+    -mmin +2 -exec rmdir {} + 2>/dev/null || true
+  if mkdir "$lock" 2>/dev/null; then
+    TEE_DRAIN_LOCK="$lock"
+    return 0
+  fi
+  return 1
+}
+
+# Flush the spool into one contract snapshot. Runs IN-PROCESS in the elected
+# render: detaching would pay back the fork this whole design removes.
+_rlg_drain() {
+  local dir="$1" spool="$2" now="$3" self="$4" interval="$5" steal="$6"
+  local marker="$dir/.tee-disabled" stamp="$spool/.last-drain"
+  command -v jq >/dev/null 2>&1 || return 0
+  acquire_drain_lock "$spool" "$steal" || return 0
+
+  # Re-read the stamp UNDER the lock. Without this, every render that queued
+  # behind the winner would drain again the moment the winner released.
+  local last2=0
+  if [[ -f "$stamp" ]]; then
+    IFS= read -r last2 <"$stamp" || last2=0
+  fi
+  [[ "$last2" =~ ^[0-9]+$ ]] || last2=0
+  if ((now - last2 < interval)); then
+    release_drain_lock
+    return 0
+  fi
+
+  # Records from sessions that are gone. The floor is 15 minutes — far past the
+  # reader contract's 10-minute staleness budget, so nothing still usable is
+  # ever swept, and far past any live session's refresh interval.
+  find "$spool" -maxdepth 1 -type f -name '*.json' \
+    -mmin +15 -exec rm -f {} + 2>/dev/null || true
+
+  local batch="" f line
+  for f in "$spool"/*.json; do
+    [[ -f "$f" ]] || continue
+    IFS= read -r line <"$f" || true
+    [[ -n "$line" ]] || continue
+    batch+="$line"$'\n'
+  done
+
+  local settings_file settings_json out
+  settings_file="${CLAUDE_CONFIG_DIR:-${HOME:-}/.claude}/settings.json"
+  settings_json='null'
+  if [[ -r "$settings_file" ]]; then
+    settings_json="$(<"$settings_file")"
+    [[ -n "$settings_json" ]] || settings_json='null'
+  fi
+
+  # ONE jq pass, same three lines in the same order _rlg_probe emits, so
+  # everything downstream is shared code. Lines are read raw and parsed under
+  # `try` so a torn record is dropped instead of failing the batch. The chosen
+  # record is the newest WINDOW-BEARING one, falling back to the newest overall
+  # when the machine has no window-bearing session at all; ties on the
+  # one-second stamp are broken in favour of THIS render's own shard, whose
+  # observation is the freshest by construction.
+  if [[ -n "$batch" ]]; then
+    out="$(RLG_SETTINGS_DOC="$settings_json" jq -Rrcn --arg self "$self" "
+      $_RLG_BODY_JQ
+      $_RLG_DOC_JQ"'
+      | [ inputs
+          | (try fromjson catch empty)
+          | select(type == "object" and (.e | type) == "number"
+                   and (.p | type) == "object") ] as $recs
+      | ([ $recs[] | select(.p | has("rate_limits")) ]) as $win
+      | (if ($win | length) > 0 then $win else $recs end) as $pool
+      | if ($pool | length) == 0 then empty
+        else
+          ($pool | map(.e) | max) as $maxe
+          | ([ $pool[] | select(.e == $maxe) ]) as $tied
+          | (([ $tied[] | select(.p.session_id == $self) ] | last)
+             // ($tied | last)) as $chosen
+          | ($chosen.p | rlg_body($chosen.e | floor | todate)) as $body
+          | $body,
+            ($body | has("rate_limits")),
+            (try ('"$_RLG_VERDICT_JQ"') catch "")
+        end
+    ' <<<"$batch" 2>/dev/null)" || out=""
+    local -a lines=()
+    while IFS= read -r line || [[ -n "$line" ]]; do
+      lines[${#lines[@]}]="$line"
+    done <<<"$out"
+    _RLG_PAYLOAD="${lines[0]:-}"
+    [[ "${lines[1]:-}" == true ]] && _RLG_HAS_WINDOWS=true
+    if [[ -n "$_RLG_PAYLOAD" ]]; then
+      _RLG_USER_VERDICT="${lines[2]:-}"
+      _RLG_USER_PROBED=1
+    fi
+  fi
+
+  # Bootstrap, or every line torn: fall back to this render's own payload so the
+  # first-ever refresh on a machine still snapshots immediately.
+  [[ -n "$_RLG_PAYLOAD" ]] || _rlg_probe
+
+  if _rlg_tee_enabled; then
+    [[ -e "$marker" ]] && rm -f "$marker" 2>/dev/null
+    tee_snapshot
+  else
+    # Stamp the marker so the render path can stop spooling with one builtin
+    # test, and drop what is already spooled — a disabled plugin holds no data.
+    printf '%s\n' "$now" >"$marker" 2>/dev/null || true
+    local any=""
+    for f in "$spool"/*.json; do
+      [[ -f "$f" ]] || continue
+      any=1
+      break
+    done
+    [[ -n "$any" ]] && rm -f "$spool"/*.json 2>/dev/null
+  fi
+
+  printf '%s\n' "$now" >"$stamp" 2>/dev/null || true
+  release_drain_lock
+  return 0
+}
+
+# The zero-fork render path. Every construct below is a bash builtin: no `$( )`
+# anywhere, because command substitution forks a subshell and the subshell fork
+# is the cost being removed.
+_rlg_spool_dispatch() {
+  [[ -n "${HOME:-}" ]] || return 0
+  [[ -n "$INPUT" ]] || return 0
+  local dir="$HOME/.claude/rate-limit-guard" spool="$HOME/.claude/rate-limit-guard/spool"
+
+  # Cold start only, exactly as tee_snapshot guards its own directory. The
+  # owner-only mode is asserted on the PARENT at creation; spool/ inherits its
+  # protection from that, since traversal is what gates access to a child.
+  if [[ ! -d "$spool" ]]; then
+    if [[ ! -d "$dir" ]]; then
+      mkdir -p "$dir" 2>/dev/null || return 0
+      chmod 700 "$dir" 2>/dev/null || true
+    fi
+    mkdir "$spool" 2>/dev/null || return 0
+  fi
+
+  local now
+  printf -v now '%(%s)T' -1 2>/dev/null || return 0
+
+  # Disabled: a drain wrote this marker after reading the real gate. Rechecking
+  # costs a jq, so it happens on a cadence rather than per refresh; until then
+  # this render does nothing at all.
+  local marker="$dir/.tee-disabled" m=0
+  if [[ -f "$marker" ]]; then
+    IFS= read -r m <"$marker" || m=0
+    [[ "$m" =~ ^[0-9]+$ ]] || m=0
+    ((now - m < ${RLG_TEE_DISABLED_RECHECK:-300})) && return 0
+  fi
+
+  # JSON strings cannot contain a raw CR or LF, so stripping them cannot change
+  # what a parser reads — and it guarantees the record is exactly one line.
+  local payload="${INPUT//$'\r'/}"
+  payload="${payload//$'\n'/}"
+
+  _rlg_shard_name
+  printf '{"e":%s,"p":%s}\n' "$now" "$payload" >"$spool/$_RLG_SHARD.json" 2>/dev/null || return 0
+
+  local interval="${RLG_TEE_DRAIN_INTERVAL:-30}" stamp="$spool/.last-drain" last=0
+  [[ "$interval" =~ ^[0-9]+$ ]] || interval=30
+  if [[ -f "$stamp" ]]; then
+    IFS= read -r last <"$stamp" || last=0
+  fi
+  [[ "$last" =~ ^[0-9]+$ ]] || last=0
+  ((now - last >= interval)) || return 0
+
+  local steal=0
+  ((now - last >= interval + 120)) && steal=1
+  _rlg_drain "$dir" "$spool" "$now" "$_RLG_SHARD" "$interval" "$steal"
+  return 0
+}
+
 rlg_tee_dispatch() {
   if [[ "${RLG_TEE_ASYNC:-0}" != "1" ]]; then
-    _rlg_tee_run
+    if ((BASH_VERSINFO[0] > 4 || (BASH_VERSINFO[0] == 4 && BASH_VERSINFO[1] >= 2))); then
+      _rlg_spool_dispatch
+    else
+      _rlg_tee_run
+    fi
     return 0
   fi
   # See ASYNCHRONY at the top of this file for why all three redirections are

--- a/plugins/rate-limit-guard/scripts/statusline-tee.test.sh
+++ b/plugins/rate-limit-guard/scripts/statusline-tee.test.sh
@@ -22,6 +22,18 @@ set -uo pipefail
 # to _rlg_tee_enabled, so a developer's own exported value would otherwise decide
 # what this suite proves. Every case supplies its settings through a scoped HOME.
 unset CLAUDE_CONFIG_DIR CLAUDE_PLUGIN_OPTION_RATE_LIMIT_GUARD_ENABLED
+unset RLG_TEE_ASYNC RLG_TEE_DISABLED_RECHECK
+
+# The render path no longer writes the snapshot itself: it spools a per-session
+# record with zero forks and ONE elected render per cadence drains the batch
+# into the contract file (see THE SPOOL in statusline-tee.sh). Pinning the
+# cadence to zero makes every refresh the elected one, which is exactly the
+# synchronous visibility every case below already assumes — "the snapshot has
+# been written" observable the moment the wrapper returns, so an assertion that
+# a snapshot was NOT written cannot pass vacuously against a race. EXPORTED, not
+# assigned: the suite runs the tee as a child process. Election itself is proven
+# in dedicated cases at the end, which set their own cadence per invocation.
+export RLG_TEE_DRAIN_INTERVAL=0
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 TEE="$SCRIPT_DIR/statusline-tee.sh"
@@ -590,6 +602,201 @@ EOF_DEADLINE=$((SECONDS + 10))
 while [[ ! -f "$HOME_EOF/$TEE_REL" && $SECONDS -lt $EOF_DEADLINE ]]; do
   sleep 0.05
 done
+
+# --- THE SPOOL: election, drain selection, sharding, and the zero-fork claim --
+# Everything above pins RLG_TEE_DRAIN_INTERVAL=0 so each refresh drains
+# synchronously. These cases set the cadence per invocation instead, because
+# what they prove IS the cadence: a render that loses the election must spool
+# and stop, and the render that wins must apply the whole batch.
+
+SPOOL_REL=".claude/rate-limit-guard/spool"
+
+# --- Case 22: a fresh stamp → the second render spools but does NOT drain ----
+HOME_EL="$WORK/home-elect"
+mkdir -p "$HOME_EL"
+# Bootstrap: no stamp yet, so this render is elected and snapshots immediately.
+printf '%s' "$(build_input)" | HOME="$HOME_EL" RLG_TEE_DRAIN_INTERVAL=30 bash "$TEE" cat >/dev/null
+EL_FILE="$HOME_EL/$TEE_REL"
+if [[ -f "$EL_FILE" ]] && [[ "$(jq -r '.session_id' <"$EL_FILE")" == "sess-42" ]]; then
+  ok "election: the first-ever render drains immediately (bootstrap)"
+else
+  fail "election: bootstrap render did not snapshot: $(cat "$EL_FILE" 2>/dev/null)"
+fi
+printf '{"session_id":"sess-fresh","rate_limits":{"five_hour":{"used_percentage":99,"resets_at":1738425600}}}' |
+  HOME="$HOME_EL" RLG_TEE_DRAIN_INTERVAL=30 bash "$TEE" cat >/dev/null
+if [[ -f "$HOME_EL/$SPOOL_REL/sess-fresh.json" ]]; then
+  ok "election: the non-elected render still spools its record"
+else
+  fail "election: non-elected render wrote no spool record"
+fi
+if [[ "$(jq -r '.session_id' <"$EL_FILE")" == "sess-42" ]]; then
+  ok "election: a fresh stamp suppresses the drain (snapshot untouched)"
+else
+  fail "election: fresh stamp did not suppress the drain: $(jq -r '.session_id' <"$EL_FILE")"
+fi
+
+# --- Case 23: a stale stamp → drain applies the newest window-bearing record --
+# Two sessions have spooled; the draining render is a THIRD, windowless one, so
+# what lands can only have come from the batch and not from this render.
+write_settings "$HOME_EL/$SPOOL_REL/.last-drain" "0"
+printf '{"session_id":"sess-drainer"}' |
+  HOME="$HOME_EL" RLG_TEE_DRAIN_INTERVAL=30 bash "$TEE" cat >/dev/null
+if [[ "$(jq -r '.session_id' <"$EL_FILE")" == "sess-fresh" ]]; then
+  ok "election: a stale stamp drains, and the newest window-bearing record wins"
+else
+  fail "election: stale-stamp drain chose $(jq -r '.session_id' <"$EL_FILE"), want sess-fresh"
+fi
+if [[ "$(jq -r '.rate_limits.five_hour.used_percentage' <"$EL_FILE")" == "99" ]]; then
+  ok "election: the drained snapshot carries the chosen record's windows"
+else
+  fail "election: drained windows wrong: $(jq -c '.rate_limits' <"$EL_FILE")"
+fi
+# captured_at is the OBSERVATION time of the chosen record, not the drain time.
+WANT_CAP="$(jq -r '.e | todate' <"$HOME_EL/$SPOOL_REL/sess-fresh.json")"
+if [[ "$(jq -r '.captured_at' <"$EL_FILE")" == "$WANT_CAP" ]]; then
+  ok "election: captured_at is the chosen record's observation time"
+else
+  fail "election: captured_at = $(jq -r '.captured_at' <"$EL_FILE"), want $WANT_CAP"
+fi
+if [[ "$(cat "$HOME_EL/$SPOOL_REL/.last-drain")" != "0" ]]; then
+  ok "election: the drain refreshes the stamp"
+else
+  fail "election: stamp not refreshed — every later render would re-drain"
+fi
+
+# --- Case 24: a torn spool line is dropped, a valid sibling still drains ------
+# Atomicity here comes from file disjointness, not from a write-size argument,
+# so a record torn by a kill mid-write is a case the drain must survive rather
+# than one it can rule out. The torn record carries a far-future epoch: if it
+# parsed at all it would win, so this cannot pass by accident.
+HOME_TORN="$WORK/home-torn"
+mkdir -p "$HOME_TORN/$SPOOL_REL"
+write_settings "$HOME_TORN/$SPOOL_REL/sess-torn.json" \
+  '{"e":9999999999,"p":{"session_id":"sess-torn","rate_limits":{"five_hour":{"used_perc'
+run "$HOME_TORN" "$(build_input)" cat >/dev/null
+if [[ "$(jq -r '.session_id' <"$HOME_TORN/$TEE_REL")" == "sess-42" ]]; then
+  ok "drain: a torn spool line is dropped and the valid sibling still lands"
+else
+  fail "drain: torn line polluted the snapshot: $(cat "$HOME_TORN/$TEE_REL" 2>/dev/null)"
+fi
+if jq -e '.rate_limits.five_hour.used_percentage == 23.5' <"$HOME_TORN/$TEE_REL" >/dev/null 2>&1; then
+  ok "drain: the surviving record's windows are intact"
+else
+  fail "drain: surviving windows wrong: $(jq -c '.rate_limits' <"$HOME_TORN/$TEE_REL")"
+fi
+
+# --- Case 25: a hostile session_id shards to `misc` and never escapes spool/ --
+# The spool filename is a SHARD KEY, never trusted data: session_id reaches the
+# writer from the harness payload, and a name that escaped the directory would
+# turn a statusline refresh into an arbitrary-path write.
+HOME_HOSTILE="$WORK/home-hostile"
+mkdir -p "$HOME_HOSTILE"
+printf -v LONG_ID '%0200d' 0
+HOSTILE_N=0
+for bad in '../../pwned' 'a\"b' "$LONG_ID" '.hidden' 'has space'; do
+  printf '{"session_id":"%s","rate_limits":{"five_hour":{"used_percentage":7,"resets_at":1738425600}}}' "$bad" |
+    HOME="$HOME_HOSTILE" bash "$TEE" cat >/dev/null
+  HOSTILE_N=$((HOSTILE_N + 1))
+done
+HOSTILE_JSON="$(find "$HOME_HOSTILE/$SPOOL_REL" -maxdepth 1 -type f -name '*.json' | wc -l | tr -d ' \r')"
+if [[ "$HOSTILE_JSON" == "1" && -f "$HOME_HOSTILE/$SPOOL_REL/misc.json" ]]; then
+  ok "shard: $HOSTILE_N hostile session_ids all collapse to the single misc shard"
+else
+  fail "shard: $HOSTILE_JSON spool files: $(find "$HOME_HOSTILE/$SPOOL_REL" -maxdepth 1 -type f | tr '\n' ' ')"
+fi
+ESCAPED="$(find "$HOME_HOSTILE" -mindepth 1 -maxdepth 4 \
+  -not -path "$HOME_HOSTILE/.claude*" 2>/dev/null | wc -l | tr -d ' \r')"
+if [[ "$ESCAPED" == "0" ]]; then
+  ok "shard: nothing was written outside the contract directory"
+else
+  fail "shard: $ESCAPED path(s) escaped: $(find "$HOME_HOSTILE" -mindepth 1 -maxdepth 4 -not -path "$HOME_HOSTILE/.claude*" | tr '\n' ' ')"
+fi
+if [[ ! -e "$HOME_HOSTILE/.claude/rate-limit-guard/pwned" && ! -e "$HOME_HOSTILE/pwned.json" ]]; then
+  ok "shard: the traversal attempt created no file above spool/"
+else
+  fail "shard: a traversal attempt escaped spool/"
+fi
+
+# --- Case 26: a disabled verdict marks, stops spooling, and rechecks back -----
+# The render path cannot evaluate the gate — that costs a jq, which is the whole
+# expense being removed — so the drain stamps a marker the render can read with
+# one builtin test, and the marker expires so a re-enabled plugin recovers on
+# its own rather than needing a restart.
+HOME_DIS="$WORK/home-disabled"
+mkdir -p "$HOME_DIS"
+DIS_MARKER="$HOME_DIS/.claude/rate-limit-guard/.tee-disabled"
+write_settings "$HOME_DIS/.claude/settings.json" "$USER_FALSE"
+DIS_OUT="$(run "$HOME_DIS" "$GATE_INPUT" jq -r '.model.display_name')"
+if [[ "$DIS_OUT" == "Opus" ]]; then ok "disabled: statusline passthrough unchanged"; else fail "disabled: passthrough broken ($DIS_OUT)"; fi
+if [[ -f "$DIS_MARKER" && ! -e "$HOME_DIS/$TEE_REL" ]]; then
+  ok "disabled: the drain writes the marker and no snapshot"
+else
+  fail "disabled: marker=$([[ -f $DIS_MARKER ]] && echo yes || echo no) snapshot=$([[ -e $HOME_DIS/$TEE_REL ]] && echo yes || echo no)"
+fi
+DIS_SPOOLED="$(find "$HOME_DIS/$SPOOL_REL" -maxdepth 1 -type f -name '*.json' 2>/dev/null | wc -l | tr -d ' \r')"
+if [[ "$DIS_SPOOLED" == "0" ]]; then
+  ok "disabled: the drain drops what was already spooled"
+else
+  fail "disabled: $DIS_SPOOLED spool record(s) retained while disabled"
+fi
+printf '%s' "$GATE_INPUT" | HOME="$HOME_DIS" bash "$TEE" cat >/dev/null
+DIS_SPOOLED2="$(find "$HOME_DIS/$SPOOL_REL" -maxdepth 1 -type f -name '*.json' 2>/dev/null | wc -l | tr -d ' \r')"
+if [[ "$DIS_SPOOLED2" == "0" ]]; then
+  ok "disabled: a fresh marker stops the render spooling at all"
+else
+  fail "disabled: render spooled through a fresh marker"
+fi
+write_settings "$HOME_DIS/.claude/settings.json" "$USER_TRUE"
+printf '%s' "$GATE_INPUT" | HOME="$HOME_DIS" RLG_TEE_DISABLED_RECHECK=0 bash "$TEE" cat >/dev/null
+if [[ ! -e "$DIS_MARKER" && -f "$HOME_DIS/$TEE_REL" ]]; then
+  ok "disabled: the recheck clears the marker and the tee resumes"
+else
+  fail "disabled: recheck did not restore (marker=$([[ -e $DIS_MARKER ]] && echo present || echo gone))"
+fi
+
+# --- Case 27: the zero-fork render path, proven by trace ----------------------
+# Reading the code cannot prove this: a command substitution anywhere on the
+# render path forks a subshell, and the subshell fork is precisely the MSYS cost
+# the spool exists to remove. So the claim is asserted against an xtrace of a
+# NON-ELECTED render — stamp and spool primed so even the cold-start mkdir is
+# out of the picture — up to the passthrough, which is the one fork the wrapper
+# has always paid.
+TRACE_HOME="$WORK/home-trace"
+TRACE_SPOOL="$TRACE_HOME/$SPOOL_REL"
+mkdir -p "$TRACE_SPOOL"
+TRACE_NOW="$(date +%s)"
+TRACE_INPUT='{"session_id":"sess-trace","rate_limits":{"five_hour":{"used_percentage":5,"resets_at":1738425600}}}'
+write_settings "$TRACE_SPOOL/.last-drain" "$TRACE_NOW"
+write_settings "$TRACE_SPOOL/sess-trace.json" "{\"e\":$TRACE_NOW,\"p\":$TRACE_INPUT}"
+TRACE_LOG="$WORK/xtrace.log"
+printf '%s' "$TRACE_INPUT" | HOME="$TRACE_HOME" RLG_TEE_DRAIN_INTERVAL=30 \
+  BASH_XTRACEFD=9 bash -x "$TEE" cat >/dev/null 9>"$TRACE_LOG"
+# Up to `set +o pipefail`, which main executes immediately before the
+# passthrough pipeline. (The script's own `set -uo pipefail` does not match.)
+TRACE_PRE="$(sed -n '1,/set +o pipefail/p' "$TRACE_LOG")"
+if [[ -n "$TRACE_PRE" ]] && printf '%s\n' "$TRACE_PRE" | grep -q '_rlg_spool_dispatch'; then
+  ok "trace: the render path was traced (spool dispatch present)"
+else
+  fail "trace: no usable xtrace captured: $(head -c 200 "$TRACE_LOG" 2>/dev/null)"
+fi
+FORKED="$(printf '%s\n' "$TRACE_PRE" |
+  grep -nE '(^|[^[:alnum:]_])(jq|mkdir|mv|rmdir|find|date|uname|sleep|chmod|rm)([^[:alnum:]_]|$)' || true)"
+if [[ -z "$FORKED" ]]; then
+  ok "trace: no external command runs before the passthrough (zero forks)"
+else
+  fail "trace: external command(s) on the render path: $FORKED"
+fi
+SUBSHELLS="$(printf '%s\n' "$TRACE_PRE" | grep -c '^++' | tr -d ' \r')"
+if [[ "$SUBSHELLS" == "0" ]]; then
+  ok "trace: no command-substitution subshell frames on the non-elected path"
+else
+  fail "trace: $SUBSHELLS subshell frame(s) before the passthrough"
+fi
+if [[ ! -e "$TRACE_HOME/$TEE_REL" ]]; then
+  ok "trace: the non-elected render wrote no snapshot, as elected"
+else
+  fail "trace: the non-elected render drained anyway"
+fi
 
 echo
 echo "PASS=$PASS FAIL=$FAIL"


### PR DESCRIPTION
## What

The statusline tee fires on **every assistant message and every `refreshInterval` tick, once per open session**. Measured same-window here (Windows/MSYS, n=9): `render.sh` alone **234.4 ms**, `render.sh` behind this wrapper **1047.1 ms**. The wrapper dominates, and the dominant term inside it is *process creation* — a cost MSYS has no cheap primitive for.

0.6.x made that work cheaper (nine spawns to four). This release takes it **off the render path** instead.

A refresh now records one line to a per-session spool file using **only bash builtins** — zero external processes, zero subshells — and **one elected refresh per 30 s** drains the batch through the same `tee_snapshot`, unchanged.

## Design

**Per-session files with a truncating `>`, not a shared append spool.** POSIX guarantees write atomicity for *pipes* up to `PIPE_BUF` and explicitly leaves *regular-file* concurrent-write behaviour unspecified. Through Cygwin/MSYS the observed no-interleave bound on appends is around a kilobyte, while statusline payloads are multiple kilobytes — and bash's buffered builtin output can split one large record across syscalls regardless. Atomicity therefore comes from **file disjointness**: no two writers ever share a file. A record torn by a kill mid-write fails `fromjson` in the drain and is dropped (covered by a test).

**The filename is a shard key, never trusted data.** `session_id` arrives in the harness payload. It must match `^[A-Za-z0-9._-]{1,64}$` and not begin with a dot, or it shards to the literal name `misc`. Traversal attempts, embedded quotes, 200-character values, `has space`, and JSON nulls are all covered by a test asserting nothing is written outside `spool/`.

**Election is stamp-based and the elected refresh drains in-process.** There is no timer to hang this on: Claude Code hooks are strictly event-driven and none fires on a schedule ([hooks docs](https://code.claude.com/docs/en/hooks.md)), an OS scheduler would mean three mechanisms across three platforms, and a resident lock-holder would have to be forked off a render — the exact cost being removed — and would be killed with it, since Claude Code cancels in-flight statusline scripts. So the renders are the clock. A herd collapses for one failed `mkdir`.

**Bash 4.2 floor** (`%(%s)T` is a 4.2 builtin). Below it — macOS bash 3.2, where `fork` is cheap and this problem does not arise — the previous synchronous path runs untouched. `RLG_TEE_ASYNC=1` keeps its current behaviour on every version.

## Design deviation from the brief

The election takes its **own** lock (`spool/.drain.lock`) rather than the existing snapshot lock. Two reasons, both load-bearing:

1. `tee_snapshot` acquires and releases the snapshot lock through one global (`TEE_LOCK`). A drain holding that lock would make `tee_snapshot` burn its full retry budget (3× `find` + 3× `sleep`) and then `rmdir` the lock out from under its own caller.
2. The snapshot lock's existing semantics — a **window-bearing writer proceeds through a lock it could not take** — must keep working. Gating the drain on that same lock breaks it, and the pre-existing assertion "held lock → window-bearing writer still writes" proves it.

`tee_snapshot` itself is untouched: same atomic temp-then-rename, same `mkdir`/`rmdir` concurrent-writer lock, same windowless-writer preservation check.

## Verification

- **`PASS=96 FAIL=0`** — all **75** pre-existing assertions pass unmodified, plus 21 new. `RLG_TEE_DRAIN_INTERVAL=0` is exported once near the top of the suite so existing cases keep their synchronous-visibility semantics; election is covered in dedicated cases that set the cadence per invocation.
- **Snapshot body byte-identical apart from `captured_at`**, proven rather than asserted:
  ```
  diff <(jq -S 'del(.captured_at)' pristine.json) <(jq -S 'del(.captured_at)' patched.json)   # empty
  ```
  The body projection is now one shared jq function (`rlg_body`) called by both the live probe and the drain, so the two cannot drift.
- **Zero-fork claim proven by trace, not by reading the code.** A test primes a scratch `HOME` with a fresh stamp, runs the tee under `bash -x` with `BASH_XTRACEFD`, and asserts that no `jq|mkdir|mv|rmdir|find|date|uname|sleep|chmod|rm` invocation and no command-substitution subshell frame appears before the passthrough.

## Reader-visible change (inside the existing contract)

The contract file now trails the newest refresh on the machine by **up to 30 s** instead of being rewritten on every refresh, and `captured_at` is the **observation time of the chosen record** rather than the flush time — which is what lets a windowless refresh flush a window-bearing sibling's record without faking freshness. The reader contract budgets **ten minutes** of staleness and its operable floor values are unchanged. `reference/reader-contract.md` documents the cadence, the `spool/` inventory, and the `.tee-disabled` marker.

## Enablement gate

The gate still gates the write, but it cannot be evaluated on the render path — reading settings costs a `jq`. A drain that reads `rate_limit_guard_enabled: false` writes an epoch-stamped `.tee-disabled` marker and drops the spool; refreshes then stop recording on one builtin test. The marker expires, so re-enabling the plugin recovers without a restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lah151d2hvN4fBgMYdyjSH

## Related

No linked issue — performance work with no tracked issue.