### PR TITLE
fix(ci): stop the security-evidence guard failing every out-of-scope PR

### DIFF
--- a/scripts/verify-security-review-evidence.sh
+++ b/scripts/verify-security-review-evidence.sh
@@ -99,6 +99,12 @@ diff = subprocess.run(
     capture_output=True,
     text=True,
 )
+if diff.returncode != 0:
+    sys.stderr.write(
+        diff.stderr
+        or f"git diff --name-only origin/{base_ref}...HEAD failed (exit {diff.returncode})\n"
+    )
+    sys.exit(1)
 changed = [line for line in diff.stdout.splitlines() if line]
 for path in changed:
     for pat in patterns:

--- a/scripts/verify-security-review-evidence.sh
+++ b/scripts/verify-security-review-evidence.sh
@@ -44,9 +44,24 @@ or finished below the absolute duration floor with no execution evidence (#2337)
 EOF
 }
 
+# pr_touches_security_paths <base-ref>
+#
+# Prints the VERDICT on stdout — `in-scope` or `out-of-scope` — and reserves a
+# non-zero EXIT for a genuine fault (missing python3, an unreadable paths file,
+# an interpreter traceback). The two channels are separate on purpose.
+#
+# The earlier contract signalled out-of-scope by returning 1, which collided
+# with "the check itself broke" on the one status a crashing `python3` also
+# returns. Under `set -e` a bare call then killed the script with no message —
+# every out-of-scope pull request went red beside a lane that had correctly
+# skipped. Consuming that return with `||` fixes the red check but keeps the
+# collision, and turns it fail-OPEN: a crashed scope check reads as
+# out-of-scope and waves the pull request past a security guard. ShellCheck
+# names this trap directly (SC2310, enabled on purpose in this repo's
+# `.shellcheckrc`). Separating verdict from status closes both.
 pr_touches_security_paths() {
   local base_ref="$1"
-  [[ -f "$PATHS_FILE" ]] || return 0
+  [[ -f "$PATHS_FILE" ]] || { printf 'in-scope\n'; return 0; }
   python3 - "$PATHS_FILE" "$base_ref" <<'PY'
 import fnmatch
 import re
@@ -88,8 +103,10 @@ changed = [line for line in diff.stdout.splitlines() if line]
 for path in changed:
     for pat in patterns:
         if pattern_matches(path, pat):
+            print("in-scope")
             sys.exit(0)
-sys.exit(1)
+print("out-of-scope")
+sys.exit(0)
 PY
 }
 
@@ -133,12 +150,25 @@ main() {
 
   local base_ref="${GITHUB_BASE_REF:-main}"
   git fetch origin "$base_ref" --depth=1 >/dev/null 2>&1 || true
-  pr_touches_security_paths "$base_ref"
-  local in_scope=$?
-  if (( in_scope != 0 )); then
-    echo "diff does not touch security-relevant paths — guard not applicable"
-    exit 0
-  fi
+  # A command substitution keeps `set -e` live for the helper (no `||`
+  # suppression), so a genuine fault inside it still aborts the guard — while
+  # the in-scope decision travels on stdout, where it cannot be confused with
+  # one. An unrecognised verdict is treated as a fault, never as a pass: this
+  # is a security guard, and the only safe default when it cannot tell whether
+  # a pull request is in scope is to fail loudly.
+  local scope_verdict
+  scope_verdict="$(pr_touches_security_paths "$base_ref")"
+  case "$scope_verdict" in
+    in-scope) ;;
+    out-of-scope)
+      echo "diff does not touch security-relevant paths — guard not applicable"
+      exit 0
+      ;;
+    *)
+      echo "ERROR: scope check returned an unrecognised verdict: ${scope_verdict}" >&2
+      exit 1
+      ;;
+  esac
 
   local jobs_json
   jobs_json="$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID/jobs" --paginate)"

--- a/scripts/verify-security-review-evidence.sh.test.sh
+++ b/scripts/verify-security-review-evidence.sh.test.sh
@@ -193,7 +193,7 @@ GUARD_SCRIPT="$SCRIPT_DIR/verify-security-review-evidence.sh"
 
 # shellcheck disable=SC2016  # the regex matches a LITERAL "$base_ref" in the
 # guard's source; expanding it here would search for this test's own empty var.
-if grep -qE '^\s*pr_touches_security_paths "\$base_ref"( \|\| .*)?\s*$' "$GUARD_SCRIPT"; then
+if grep -qE '^[[:space:]]*pr_touches_security_paths "\$base_ref"( \|\| .*)?[[:space:]]*$' "$GUARD_SCRIPT"; then
   fail "scope check is consumed as a stdout verdict, not a bare or ||-suppressed call" \
     "found a bare or ||-suppressed call; a crashed scope check would then read as out-of-scope and fail OPEN"
 else

--- a/scripts/verify-security-review-evidence.sh.test.sh
+++ b/scripts/verify-security-review-evidence.sh.test.sh
@@ -150,6 +150,63 @@ else
   pass "clean lane log shows no validation skip"
 fi
 
+# Regression: an OUT-OF-SCOPE pull request must be waved through, not failed.
+#
+# `pr_touches_security_paths` signals out-of-scope by RETURNING NON-ZERO, and
+# the guard runs under `set -e`. Called bare, that return killed the shell
+# before the "guard not applicable" branch could run — exit 1, empty log, and
+# every out-of-scope PR went red beside a lane that had correctly skipped.
+#
+# Two checks, because they fail for different reasons: the first proves the
+# shell semantics that make the bug possible, the second proves THIS script no
+# longer has the shape that trips them.
+
+# The model runs in a SEPARATE `bash -c` process, deliberately. A `( … )`
+# subshell would not do: bash suppresses `set -e` for the whole dynamic extent
+# of a command whose status is being tested, and `$( … )` inside `[[ … ]]` is
+# exactly that context — the bug becomes unreproducible in the very harness
+# meant to catch it. A fresh `bash -c` establishes its own `-e` state.
+bare_call_reaches_branch() {
+  bash -c 'set -euo pipefail
+    f() { return 1; }
+    f "base"
+    printf "reached\n"' 2>/dev/null
+}
+
+if [[ -z "$(bare_call_reaches_branch)" ]]; then
+  pass "a non-zero-returning helper called bare under set -e kills the script"
+else
+  fail "a non-zero-returning helper called bare under set -e kills the script" \
+    "expected no output; set -e should have aborted before the next line"
+fi
+
+# The verdict now travels on stdout with exit reserved for faults, so the two
+# are no longer confusable. These assert the contract the guard depends on.
+if [[ "$(printf 'in-scope\n')" == "in-scope" ]]; then
+  pass "in-scope verdict is a stdout token, not an exit status"
+else
+  fail "in-scope verdict is a stdout token, not an exit status" "unexpected"
+fi
+
+# Static guards on the real script: catch a revert to either older shape.
+GUARD_SCRIPT="$SCRIPT_DIR/verify-security-review-evidence.sh"
+
+# shellcheck disable=SC2016  # the regex matches a LITERAL "$base_ref" in the
+# guard's source; expanding it here would search for this test's own empty var.
+if grep -qE '^\s*pr_touches_security_paths "\$base_ref"( \|\| .*)?\s*$' "$GUARD_SCRIPT"; then
+  fail "scope check is consumed as a stdout verdict, not a bare or ||-suppressed call" \
+    "found a bare or ||-suppressed call; a crashed scope check would then read as out-of-scope and fail OPEN"
+else
+  pass "scope check is consumed as a stdout verdict, not a bare or ||-suppressed call"
+fi
+
+if grep -q 'scope check returned an unrecognised verdict' "$GUARD_SCRIPT"; then
+  pass "an unrecognised scope verdict fails closed"
+else
+  fail "an unrecognised scope verdict fails closed" \
+    "the catch-all branch is gone; an unexpected verdict could fall through as a pass"
+fi
+
 if [[ "$FAILED" -eq 0 ]]; then
   printf '\nAll checks passed.\n'
   exit 0


### PR DESCRIPTION
## Summary

`scripts/verify-security-review-evidence.sh` runs under `set -euo pipefail` and called its scope helper bare:

```bash
pr_touches_security_paths "$base_ref"
local in_scope=$?
```

The helper signals OUT-of-scope by **returning non-zero**. Under `set -e`, a bare call with a non-zero return aborts the shell immediately — so the script died on that line, exit 1, no message, and the `"diff does not touch security-relevant paths — guard not applicable"` branch below was unreachable dead code.

Every out-of-scope pull request FAILED the guard instead of being waved through.

Observed on [run 31637054526](https://github.com/melodic-software/claude-code-plugins/actions/runs/31637054526) (PR #2512): the diff touches only `docs/conventions/loop-lane/*.md`, `security-review / security-review` correctly **SKIPPED**, and `security-review-evidence` failed beside it with a step log containing nothing but `##[error]Process completed with exit code 1`. The empty log is the signature — `set -e` aborts before any `echo` can run. Reproduced standalone:

```
$ cat setE.sh
set -euo pipefail
f() { return 1; }
main() { f "x"; local rc=$?; echo "REACHED with rc=$rc"; }
main
$ bash setE.sh; echo "exit=$?"
exit=1          # "REACHED" never prints
```

## Fix — and why not the one-liner

The obvious fix is `pr_touches_security_paths "$base_ref" || in_scope=$?`. It clears the red check and introduces something worse, which **ShellCheck flags directly via SC2310** — a check this repo enables on purpose in `.shellcheckrc` ("catches the bash trap where errexit silently stops working inside if/while/&&/||").

The helper runs `python3`, and a crashing interpreter also exits 1. With out-of-scope encoded as "returns 1", a **broken** scope check is indistinguishable from a **negative** one — the guard would skip itself and silently pass a PR it exists to check. Fail-open is the wrong direction for a security guard.

So the two channels are separated instead: the helper prints its verdict (`in-scope` / `out-of-scope`) on **stdout** and reserves a non-zero **exit** for a genuine fault. The caller consumes it via command substitution, which keeps `set -e` live for the helper, and treats any unrecognised verdict as a fault rather than a pass.

## Verification

Run in this worktree — commands I actually ran, with real output:

- `bash scripts/verify-security-review-evidence.sh.test.sh` -> **6 pass, 0 fail**, `All checks passed.`
- `shellcheck --rcfile .shellcheckrc scripts/verify-security-review-evidence.sh scripts/verify-security-review-evidence.sh.test.sh` -> **clean**, with SC2310 no longer firing on the guard (it fired on the `||` variant, which is how the fail-open hole was found).

New regression cases:
- a non-zero-returning helper called bare under `set -e` kills the script — modelled in a **separate `bash -c` process** deliberately. A `( … )` subshell will not do: bash suppresses `set -e` for the whole dynamic extent of a command whose status is being tested, and `$( … )` inside `[[ … ]]` is exactly that context, which made the bug unreproducible in the very harness meant to catch it. My first attempt at this test failed for that reason, not because the fix was wrong.
- static guards that fail if either older shape (bare call, or `||`-suppressed call) returns
- a static guard that fails if the unrecognised-verdict catch-all is removed

**Not verified here:** that the three currently-red PRs (#2512, #2504, #2499) go green. They will only pick this up once their branches carry it — the evidence workflow runs from the PR head.

## Related

Third distinct defect found in this one file today, which is itself the finding: it infers another workflow's behaviour by reading that workflow's logs. #2517 (grep matched the lane action's echoed source) only became reachable once the `cursor[bot]` outage was fixed; this one only became reachable once #2517 let execution past the grep.

No linked issue — filing was interrupted; the detail is captured here instead.