### PR TITLE
fix(songwriting): restore the writer's Opus fleet directive (1.4.2)

### DIFF
--- a/plugins/songwriting/.claude-plugin/plugin.json
+++ b/plugins/songwriting/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "songwriting",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Songwriting craft companion — nine concern-scoped lyric-craft skills (workflow router, rhyme, object-writing, metaphor, meter-prosody, song-form, co-write, diagnose, practice) applying Pat Pattison's methods, with an object-writing agent that performs the sensory exercise itself and per-skill emission boundaries that route generation to the skill that owns it, plus Suno v5.5 prompt engineering (style prompts, tagged lyrics, genre templates, troubleshooting).",
   "author": {
     "name": "Melodic Software",

--- a/plugins/songwriting/CHANGELOG.md
+++ b/plugins/songwriting/CHANGELOG.md
@@ -17,11 +17,12 @@ All notable changes to the `songwriting` plugin are documented here. Format foll
   tokens versus the Opus re-run that produced his only accepted candidates — and an explicit note
   that trading the tier down for cost is his call to make, not the plugin's.
 
-  **This is the release's own failure mode, one release later.** 1.4.0 shipped a rubric whose
-  pass 11 is voiceprint match and whose premise is that a named check and a run check are
-  indistinguishable in the output; 1.4.1 then quoted the writer from memory and shipped it as a
-  directive. Both files that carried the claim — the skill rule and the 1.4.1 entry below — cited
-  a workspace log neither had reread.
+  **What is verified here is the disagreement, not its cause.** The shipped rule names
+  `plugin-gaps.md` as its source; that file says `'opus'`; nothing in the consuming workspace
+  authorizes a Sonnet fleet. Why 1.4.1 recorded Sonnet is not established — a later cost decision
+  by the writer, made outside anything this workspace holds, would make the correct fix the
+  reverse: keep Sonnet and repair the attribution. **This change therefore needs the writer's
+  ratification**, and either way the rule should stop citing a log that contradicts it.
 
 ## [1.4.1]
 

--- a/plugins/songwriting/CHANGELOG.md
+++ b/plugins/songwriting/CHANGELOG.md
@@ -3,6 +3,26 @@
 All notable changes to the `songwriting` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [1.4.2]
+
+### Fixed
+
+- **The fleet model-tier directive was attributed to the writer with the wrong tier.**
+  `object-writing`'s rule 6 said *"creative fan-out fleets run on Sonnet — the writer wrote it as
+  `opts.model: 'sonnet'`"*. The source it names, the consuming workspace's
+  `research/plugin-gaps.md`, says `'opus'`: *"creative fan-out fleets run on Opus (`opts.model:
+  'opus'` per agent call), reserving the expensive model for the judge stage at most."* No session
+  record has the writer authorizing a Sonnet fleet, and Sonnet has never been run against his bar.
+  The rule now carries his wording, the evidence behind it — the Fable fleet's ~383k rejected
+  tokens versus the Opus re-run that produced his only accepted candidates — and an explicit note
+  that trading the tier down for cost is his call to make, not the plugin's.
+
+  **This is the release's own failure mode, one release later.** 1.4.0 shipped a rubric whose
+  pass 11 is voiceprint match and whose premise is that a named check and a run check are
+  indistinguishable in the output; 1.4.1 then quoted the writer from memory and shipped it as a
+  directive. Both files that carried the claim — the skill rule and the 1.4.1 entry below — cited
+  a workspace log neither had reread.
+
 ## [1.4.1]
 
 ### Fixed

--- a/plugins/songwriting/skills/object-writing/SKILL.md
+++ b/plugins/songwriting/skills/object-writing/SKILL.md
@@ -73,12 +73,22 @@ Dispatch rules:
 6. **Set the model on each agent call — do not let the fleet inherit the session's.** The
    `object-writer` agent's frontmatter is `model: inherit`, so a dispatch that leaves the model
    unset runs the whole fleet on whatever the session runs on. Writer directive (Sofía sessions,
-   2026-08-12): creative fan-out fleets run on Sonnet — the writer wrote it as
-   `opts.model: 'sonnet'` per agent call — reserving Opus for the judge or verifier stage at most.
-   That directive came from the writer's own observation of the same session: agents that inherited
-   the session model spent ~383k subagent tokens at top-tier pricing for a batch the writer rejected.
-   The fleet loses nothing — rule 2 above names isolation, not model tier, as the mechanism that
-   produces the divergence. Any creative fan-out this plugin adds later inherits the directive.
+   2026-08-12), as recorded in the consuming workspace's `research/plugin-gaps.md`: *"creative
+   fan-out fleets run on Opus (`opts.model: 'opus'` per agent call), reserving the expensive model
+   for the judge stage at most."* The cost finding behind it is from the same session: agents that
+   inherited the session model — Fable — spent ~383k subagent tokens at top-tier pricing for a batch
+   the writer rejected wholesale, while the re-run on Opus with voiceprint-first judging produced
+   the only candidates he accepted. Fable is what the directive excludes; Opus is what it names.
+
+   **A cheaper tier is not covered by this directive, and 1.4.1 read it as one.** That release
+   recorded the rule as Sonnet and attributed the string `opts.model: 'sonnet'` to the writer; the
+   workspace log it cites says `'opus'`, and no session record has him authorizing a Sonnet fleet.
+   Sonnet has never been run against his bar. Trading the tier down for cost is a decision he has
+   not made — ask before making it for him.
+
+   Model tier is not what makes the fleet diverge — rule 2 above names isolation as that mechanism —
+   but across the only two runs on record the accepted-candidate rate did track the tier. Any
+   creative fan-out this plugin adds later inherits the directive.
 
 **Never transcribe a write into lines.** The whole page is ore. Pat's discipline is to pull one
 image out of it — moving a dive wholesale into a section is the failure this action exists to


### PR DESCRIPTION
Closes #2525

## What

`skills/object-writing/SKILL.md` rule 6 attributed `opts.model: 'sonnet'` to the writer and recorded the creative fan-out tier as Sonnet:

> "creative fan-out fleets run on Sonnet — the writer wrote it as `opts.model: 'sonnet'` per agent call"

The source it cites — the consuming workspace's `research/plugin-gaps.md` — says `'opus'`:

> "creative fan-out fleets run on Opus (`opts.model: 'opus'` per agent call), reserving the expensive model for the judge stage at most."

## Why it matters

Nothing in the consuming workspace authorizes a Sonnet fleet, and Sonnet has never been run against the writer's bar. The only two fleet runs on record are:

- **Fable** (inherited session model): ~383k subagent tokens, batch rejected wholesale.
- **Opus** with voiceprint-first judging: the only candidates he accepted.

Fable is what the directive excludes; Opus is what it names. Shipping Sonnet as his instruction points the next fan-out at an untested tier under his authority.

## ⚠ Needs the writer's ratification before merge

**What is verified here is the disagreement, not its cause.** Why 1.4.1 recorded Sonnet is not established. If the writer made a cost decision in a session this workspace does not hold, the correct fix is the reverse — keep Sonnet and repair the attribution instead. Either way the rule should stop citing a log that contradicts it, but which direction it resolves is his call, not this PR's.

Do not auto-merge.

## Changes

- Rule 6 restored to the writer's wording, with the cost evidence attached and an explicit note that trading the tier down for cost is his decision to make, not the plugin's.
- CHANGELOG `[1.4.2]` entry, scoped to the verifiable claim.
- `plugin.json` 1.4.1 → 1.4.2 (patch: corrects a misstated instruction, no new behavior).

Prior CHANGELOG entries are left as the historical record; 1.4.2 corrects forward.

## Related

- #2509 — 1.4.0/1.4.1, the release that introduced the wording in its "Object-writing fleet model tier" Fixed entry, and that ships the eleven-pass line-edit rubric and `voiceprint.md`.
- #2506 — 1.3.0, the Suno documentation release landed alongside it. Not touched here.
- Consuming workspace `songwriting-enable-plugin`, `research/plugin-gaps.md` — the findings log this PR reads as the source of truth, section *"disposition delta: PR A and PR B ALREADY LANDED on main"*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0132Lj8TAJLRVdvBu6wsXHfr
