### PR TITLE
fix(repo-fleet-hygiene): setup verify boundary, maxDepth grammar, cross-volume guidance (#1801)

### DIFF
--- a/plugins/repo-fleet-hygiene/.claude-plugin/plugin.json
+++ b/plugins/repo-fleet-hygiene/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "repo-fleet-hygiene",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "Read-only Git/GitHub fleet audit for merged local branches, orphaned or mismatched worktree registrations, and repository transfers or renames. Findings are confidence-tiered and hand off exact targets to existing per-repository cleanup tools; this plugin never deletes branches or worktrees.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/repo-fleet-hygiene/CHANGELOG.md
+++ b/plugins/repo-fleet-hygiene/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to `repo-fleet-hygiene` are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.12.0]
+
+### Fixed
+
+- **`setup`'s verify step stays within its own boundary (#1801).** `apply` step 5 now enumerates the
+  config-only `check` probes — parse validity, per-entry path resolution, `maxDepth`, and identity
+  normalization — and explicitly forbids invoking the collector. A genuine end-to-end proof remains an
+  opt-in handoff to `/repo-fleet-hygiene:audit`, stated as a real audit.
+- **`setup` can set `maxDepth` through its argument grammar (#1801).** The body now documents
+  `--max-depth <1..12>` alongside the frontmatter `argument-hint`, so the skill that owns the config
+  file can write `[fleet] maxDepth` without hand-editing.
+- **Cross-volume fleet roots no longer read as consumer error (#1801).** When a Windows fleet root sits
+  on a different volume from the config file, the gotcha now states that the absolute path is the only
+  honest form and names remedies when a path-portability guard still rejects it — colocate on one
+  volume, exempt the file or path, or keep a user-global config outside the guard's scan.
+
 ## [0.11.0]
 
 ### Fixed

--- a/plugins/repo-fleet-hygiene/skills/setup/SKILL.md
+++ b/plugins/repo-fleet-hygiene/skills/setup/SKILL.md
@@ -26,6 +26,16 @@ audit runs with that same project directory; a fleet config meant to apply from 
 belongs at the user-global path (`apply --config ~/.claude/repo-fleet-hygiene.conf`). The audit
 report header names which config (if any) was consumed.
 
+## Argument grammar
+
+```text
+check | apply [--config <path>] [--root <dir>]... [--repo <dir>]...
+        [--canonical <github.com/owner/repo=path>]... [--ack-unavailable <github.com/owner/repo>]...
+        [--max-depth <1..12>]
+```
+
+`--max-depth` writes `[fleet] maxDepth`; this skill owns the config file that carries it.
+
 ## `check` (read-only)
 
 The config file and the grammar below are the source of truth. Probe, report a PASS/FAIL/INFO table
@@ -87,13 +97,16 @@ Run `check`, then create or update the config from the supplied arguments.
    consumer mistake. This preference is prose guidance followed by the model, not a property a
    deterministic component enforces; treat it as a default to justify departing from, not a
    guarantee.
-5. Verify after remediation — re-run the `check` probes against the written file (never claim success on
-   the edit alone). Config-only, exactly as `check` defines them: parse validity, then per-entry path
-   resolution.
+5. Verify after remediation — re-run every `check` probe against the written file (never claim success on
+   the edit alone). Config-only, exactly as `check` defines them:
 
-   ```bash
-   git config --file "<config-path>" --list >/dev/null
-   ```
+   - **Parse validity** — `git config --file "<config-path>" --list >/dev/null`
+   - **Entry resolution** — for each `[fleet] root`/`repo` and each `[canonical …] path`, resolve from
+     the config directory and confirm the directory exists and (for roots/repos) `git rev-parse` succeeds
+     read-only
+   - **`maxDepth`** — when present, confirm it is an integer in `1..12`
+   - **Canonical identity** and **acknowledged identities** — confirm each key/value normalizes to
+     `github.com/owner/repository`
 
    Do **not** invoke the collector to verify a write. It is the full fleet walk this skill says it
    never runs — per-repository network queries across every configured root, minutes on a real fleet
@@ -145,8 +158,11 @@ GitHub remote identity on both sides first.
   canonical target written as an absolute path may trip a consumer's write-time path-portability guard;
   the same target written relative to the config file's directory passes and resolves identically, so
   `apply` prefers the relative form — except across Windows volumes, where no relative form exists and
-  the absolute path is the only option. Say so when that happens rather than leaving the consumer to
-  conclude they misconfigured something.
+  the absolute path is the only honest option. When that happens, write the absolute path, say in the
+  report that no relative path exists between volumes, and name the consumer's remedies if the guard
+  still rejects the write: colocate the config with the fleet root on one volume, exempt this file or
+  path from the guard, or keep a user-global config outside the guard's scan — do not fabricate a
+  relative path or leave the consumer to conclude they misconfigured something.
 - **A project-scoped config is consumed only from its own project.** Per the Scoping rule above, a
   config meant to apply from every project belongs at the user-global
   `~/.claude/repo-fleet-hygiene.conf`, not a per-project path — otherwise the audit silently narrows to

--- a/plugins/repo-fleet-hygiene/skills/setup/evals/evals.json
+++ b/plugins/repo-fleet-hygiene/skills/setup/evals/evals.json
@@ -49,6 +49,7 @@
         "Recognizes that a cross-volume relative path does not exist",
         "Writes the absolute path rather than inventing a relative one",
         "States the cross-volume reason in the report",
+        "Names consumer remedies when a path-portability guard still rejects the absolute path",
         "Does not refuse the write or report it as a failure"
       ]
     },


### PR DESCRIPTION
Fixes #1801

## Summary

Fixes setup-skill defects filed in #1801 (items 1–3). Setup skill and evals only — `audit-fleet.sh` untouched.

1. **Verify boundary** — `apply` step 5 now enumerates every config-only `check` probe and explicitly forbids invoking the collector. End-to-end proof remains an opt-in handoff to `/repo-fleet-hygiene:audit`.
2. **`maxDepth` settable** — new body **Argument grammar** section documents `--max-depth <1..12>` alongside the frontmatter `argument-hint`.
3. **Cross-volume exception** — gotcha now names consumer remedies when a path-portability guard still rejects the only honest absolute path.

Plugin bumped to **0.12.0**.

## Test plan

- [x] `bash scripts/check-changelog-parity.sh --check-bump origin/main`
- [x] `bash scripts/check-changed-skills.sh origin/main` — `setup` PASS

## Related

- #1801