### PR TITLE
fix(typos-format): make the bundled default-typos.toml parse (0.6.13)

### DIFF
--- a/plugins/typos-format/.claude-plugin/plugin.json
+++ b/plugins/typos-format/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "typos-format",
-  "version": "0.6.12",
+  "version": "0.6.13",
   "description": "Spell-check on edit via typos-cli, unconditionally \u2014 report-only by default, honoring the consuming repo's own typos configuration when one is present.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/typos-format/CHANGELOG.md
+++ b/plugins/typos-format/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to the `typos-format` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.6.13]
+
+### Fixed
+
+- **Bundled `default-typos.toml` parses again (#1257 follow-up):** `extend-ignore-re` was
+  written as a TOML table (`[default.extend-ignore-re]` with the regex as a key), which
+  typos-cli rejects — `invalid type: map, expected valid sequence` — so every hook run
+  failed as a tool break instead of spell-checking. Now the documented array form under
+  `[default]`, restoring both the spell-check and the SHA-corruption guard the file
+  exists to carry.
+
 ## [0.6.12]
 
 ### Fixed

--- a/plugins/typos-format/config/default-typos.toml
+++ b/plugins/typos-format/config/default-typos.toml
@@ -2,7 +2,7 @@
 # config typos discovers from the target path; this file only adds protections
 # the hook must carry fleet-wide (claude-code-plugins#1257).
 
-[default.extend-ignore-re]
+[default]
 # Git commit SHAs (abbreviated and full): typos treats some hex digraphs as English
 # words and silently corrupts SHAs during write mode.
-"\\b[0-9a-f]{7,40}\\b" = ""
+extend-ignore-re = ["\\b[0-9a-f]{7,40}\\b"]


### PR DESCRIPTION
## Summary

The bundled `config/default-typos.toml` wrote `extend-ignore-re` as a TOML table (`[default.extend-ignore-re]` with the regex as a key). typos-cli rejects that shape:

```
TOML parse error at line 5, column 1
  |
5 | [default.extend-ignore-re]
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^
invalid type: map, expected valid sequence
```

Every hook invocation therefore failed as a tool break instead of spell-checking, machine-wide, and the SHA-corruption guard the file exists to carry (#1257) was inert.

## Fix

The documented array form under `[default]`:

```toml
[default]
extend-ignore-re = ["\b[0-9a-f]{7,40}\b"]
```

Verified locally with `typos --config <file> <target>` — parses and runs clean. Version bumped 0.6.12 → 0.6.13, CHANGELOG entry added.

## Related

No linked issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U6CxD2Unscoh7yLVRgk4Yu
