### PR TITLE
fix(songwriting): state fleet model-tier rule 6 as policy

### DIFF
--- a/plugins/songwriting/.claude-plugin/plugin.json
+++ b/plugins/songwriting/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "songwriting",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "Songwriting craft companion — nine concern-scoped lyric-craft skills (workflow router, rhyme, object-writing, metaphor, meter-prosody, song-form, co-write, diagnose, practice) applying Pat Pattison's methods, with an object-writing agent that performs the sensory exercise itself and per-skill emission boundaries that route generation to the skill that owns it, plus Suno v5.5 prompt engineering (style prompts, tagged lyrics, genre templates, troubleshooting).",
   "author": {
     "name": "Melodic Software",

--- a/plugins/songwriting/CHANGELOG.md
+++ b/plugins/songwriting/CHANGELOG.md
@@ -3,6 +3,32 @@
 All notable changes to the `songwriting` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [1.4.3]
+
+### Changed
+
+- **`object-writing` rule 6 is now stated as policy rather than a pinned model name.** 1.4.2 fixed
+  the tier the rule named; it left the shape that made a wrong tier possible. A rule that pins a
+  model string goes stale at the next model release whether or not the string was right — naming
+  `'opus'` will be wrong exactly as naming `'sonnet'` was. Rule 6 now states the standing rule:
+
+  - Set the model explicitly on every agent call — `model: inherit` is the bug, not a default.
+  - The fleet default is the tier whose writing has cleared the writer's bar, re-checked as models
+    change. Today that is Opus, and the recorded directive is quoted as the evidence for it rather
+    than as the rule itself.
+  - Never run a fleet on a tier priced above that default; a premium tier belongs at a judge or
+    verifier stage at most, where one call reads many writes.
+  - Reach for effort before a cheaper tier. This is cited to the official model guidance
+    (*"Tuning effort is often a better lever than switching models"*), not to the writer. Lever
+    availability differs by surface: a bare agent spawn takes a model and no effort parameter, so a
+    fan-out needing that lever belongs in a workflow.
+  - A tier step-down is a per-stage decision for mechanical legs (rhyme-field enumeration,
+    word-pool merge, syllable counting, dedup), never a fleet default.
+
+  The 1.4.1 release archaeology moved out of the rule and into this file, where the `[1.4.2]` entry
+  below already carries it. Per-token price figures are deliberately not stated in the skill —
+  pinned prices go stale the same way a pinned model name does.
+
 ## [1.4.2]
 
 ### Fixed

--- a/plugins/songwriting/CHANGELOG.md
+++ b/plugins/songwriting/CHANGELOG.md
@@ -13,6 +13,8 @@ All notable changes to the `songwriting` plugin are documented here. Format foll
   `'opus'` will be wrong exactly as naming `'sonnet'` was. Rule 6 now states the standing rule:
 
   - Set the model explicitly on every agent call — `model: inherit` is the bug, not a default.
+    `CLAUDE_CODE_SUBAGENT_MODEL` outranks per-call `model` when set to anything but `inherit`; keep
+    it unset for fleet dispatches.
   - The fleet default is the tier whose writing has cleared the writer's bar, re-checked as models
     change. Today that is Opus, and the recorded directive is quoted as the evidence for it rather
     than as the rule itself.

--- a/plugins/songwriting/skills/object-writing/SKILL.md
+++ b/plugins/songwriting/skills/object-writing/SKILL.md
@@ -73,7 +73,10 @@ Dispatch rules:
 6. **Set the model explicitly on every agent call — never let the fleet inherit the session's.** The
    `object-writer` agent's frontmatter is `model: inherit`, so a dispatch that leaves the model unset
    runs the whole fleet on whatever the session happens to run on — a tier picked for the
-   orchestrator's work, not the writers'. Unset is not a default; it is the bug.
+   orchestrator's work, not the writers'. Unset is not a default; it is the bug. A global
+   `CLAUDE_CODE_SUBAGENT_MODEL` override outranks every per-call `model` argument and agent
+   frontmatter when set to anything but `inherit` — keep it unset for fleet dispatches, and stop to
+   ask if the consumer's settings export a tier above the fleet default before spawning.
 
    **The fleet default is the tier whose writing has cleared the writer's bar** — not a fixed model
    name, which goes stale at the next release. Today that tier is Opus: the directive recorded in the
@@ -86,9 +89,8 @@ Dispatch rules:
    newer.
 
    **Never run a fleet on a tier priced above the fleet default.** Premium tiers cost a multiple per
-   token in both directions, and a fan-out multiplies that by the agent count — on a subscription
-   that burns the usage limit rather than a bill, which is the cost the writer objected to. A tier
-   above the default belongs at a judge or verifier stage at most, where one call reads many writes.
+   token in both directions, and a fan-out multiplies that by the agent count. A tier above the
+   default belongs at a judge or verifier stage at most, where one call reads many writes.
 
    **Reach for effort before reaching for a cheaper tier.** Official guidance: *"Tuning effort is
    often a better lever than switching models."* Effort scales the tokens one agent spends; tier

--- a/plugins/songwriting/skills/object-writing/SKILL.md
+++ b/plugins/songwriting/skills/object-writing/SKILL.md
@@ -70,25 +70,41 @@ Dispatch rules:
    context the writers deliberately lack.
 5. **For rounds:** name what made the strongest write of a round work, then carry that as the
    standard into the next round's dispatch. The bar escalates; rounds are not independent repeats.
-6. **Set the model on each agent call — do not let the fleet inherit the session's.** The
-   `object-writer` agent's frontmatter is `model: inherit`, so a dispatch that leaves the model
-   unset runs the whole fleet on whatever the session runs on. Writer directive (Sofía sessions,
-   2026-08-12), as recorded in the consuming workspace's `research/plugin-gaps.md`: *"creative
-   fan-out fleets run on Opus (`opts.model: 'opus'` per agent call), reserving the expensive model
-   for the judge stage at most."* The cost finding behind it is from the same session: agents that
-   inherited the session model — Fable — spent ~383k subagent tokens at top-tier pricing for a batch
-   the writer rejected wholesale, while the re-run on Opus with voiceprint-first judging produced
-   the only candidates he accepted. Fable is what the directive excludes; Opus is what it names.
+6. **Set the model explicitly on every agent call — never let the fleet inherit the session's.** The
+   `object-writer` agent's frontmatter is `model: inherit`, so a dispatch that leaves the model unset
+   runs the whole fleet on whatever the session happens to run on — a tier picked for the
+   orchestrator's work, not the writers'. Unset is not a default; it is the bug.
 
-   **A cheaper tier is not covered by this directive, and 1.4.1 read it as one.** That release
-   recorded the rule as Sonnet and attributed the string `opts.model: 'sonnet'` to the writer; the
-   workspace log it cites says `'opus'`, and no session record has him authorizing a Sonnet fleet.
-   Sonnet has never been run against his bar. Trading the tier down for cost is a decision he has
-   not made — ask before making it for him.
+   **The fleet default is the tier whose writing has cleared the writer's bar** — not a fixed model
+   name, which goes stale at the next release. Today that tier is Opus: the directive recorded in the
+   consuming workspace's `research/plugin-gaps.md` (2026-08-12) is *"creative fan-out fleets run on
+   Opus (`opts.model: 'opus'` per agent call), reserving the expensive model for the judge stage at
+   most."* Across the only two runs on record the accepted-candidate rate tracked the tier: a fleet
+   that inherited the session's premium tier spent ~383k subagent tokens on a batch he rejected
+   wholesale, while the Opus re-run with voiceprint-first judging produced his only accepted
+   candidates. When a new tier appears, it becomes eligible by clearing that same bar, not by being
+   newer.
 
-   Model tier is not what makes the fleet diverge — rule 2 above names isolation as that mechanism —
-   but across the only two runs on record the accepted-candidate rate did track the tier. Any
-   creative fan-out this plugin adds later inherits the directive.
+   **Never run a fleet on a tier priced above the fleet default.** Premium tiers cost a multiple per
+   token in both directions, and a fan-out multiplies that by the agent count — on a subscription
+   that burns the usage limit rather than a bill, which is the cost the writer objected to. A tier
+   above the default belongs at a judge or verifier stage at most, where one call reads many writes.
+
+   **Reach for effort before reaching for a cheaper tier.** Official guidance: *"Tuning effort is
+   often a better lever than switching models."* Effort scales the tokens one agent spends; tier
+   scales the price of every token AND changes which model wrote the lines. Across a fleet both
+   multiply, but only one of them changes the writing. Lever availability differs by surface: a bare
+   agent spawn takes a model and has no effort parameter, so a fan-out that needs the effort lever
+   belongs in a workflow, whose per-agent call takes both.
+
+   **A tier step-down is a per-stage decision, never a fleet default.** Mechanical legs —
+   rhyme-field enumeration, word-pool merge, syllable counting, dedup — are reading-heavy and
+   low-reasoning, and a cheaper tier is correct there. Object-writing is neither. Dropping the
+   writing fleet's own tier to save cost is the writer's call, not the plugin's: ask, and never
+   record the answer as his without a source that says so.
+
+   Model tier is not what makes the fleet diverge — rule 2 above names isolation as that mechanism.
+   Any creative fan-out this plugin adds later inherits this rule.
 
 **Never transcribe a write into lines.** The whole page is ore. Pat's discipline is to pull one
 image out of it — moving a dive wholesale into a section is the failure this action exists to


### PR DESCRIPTION
Closes #2543

## What

`object-writing` rule 6 is restated as **policy** instead of a pinned model name.

PR #2524 (merged, shipped as 1.4.2) fixed the tier the rule named. It did not change the shape that made a wrong tier possible: the rule pinned a model string plus an attribution, so it goes stale at the next model release whether or not the string is right. Naming `'opus'` will be wrong exactly as naming `'sonnet'` was.

## The rule now states

- **Set the model explicitly on every agent call** — `model: inherit` is the bug, not a default.
- **The fleet default is the tier whose writing has cleared the writer's bar**, re-checked as models change. Today that is Opus; the recorded directive is quoted as the evidence for that tier rather than as the rule itself.
- **Never run a fleet on a tier priced above that default.** A premium tier belongs at a judge or verifier stage at most, where one call reads many writes.
- **Reach for effort before a cheaper tier**, cited to the official model guidance (*"Tuning effort is often a better lever than switching models"*). Lever availability differs by surface: a bare agent spawn takes a model and has no effort parameter, so a fan-out needing that lever belongs in a workflow — which matters, because rule 1 dispatches bare spawns.
- **A tier step-down is a per-stage decision** for mechanical legs (rhyme-field enumeration, word-pool merge, syllable counting, dedup), never a fleet default.

## Attribution ledger

The defect this line of work repairs is a misattributed instruction, so every "the writer" sentence in the rewritten rule maps to one verified source:

- The Opus directive is quoted verbatim from the consuming workspace's `research/plugin-gaps.md` (2026-08-12), and only that sentence is presented as his words.
- **Effort-before-tier is cited to the official model guidance, not to him.** A handoff for this work records "Opus, with effort as the primary cost lever" as his choice, but no primary session log in this workspace confirms the effort half — so the rule cites the documented lever and leaves his name off it. If he did decide that, the right repair is to record it where `plugin-gaps.md` can cite it, not to infer it into the skill.
- Per-token price figures are deliberately **not** baked into the skill. Pinned prices go stale the same way a pinned model name does; the rule states the relation (a premium tier costs a multiple per token, and a fan-out multiplies that by agent count) without the numbers.

## Ratification status

The tier question is settled: `do-not-merge` was cleared and #2524 was merged, ratifying Opus. This PR does not re-open that. What it asks for is agreement on the **form** — that the rule should name the bar a tier must clear rather than the tier itself.

## Changes

- `skills/object-writing/SKILL.md` — rule 6 rewritten as policy; the 1.4.1 release archaeology removed from the rule.
- `CHANGELOG.md` — new `[1.4.3]` entry. The shipped `[1.4.2]` entry is left untouched as historical record and now carries that archaeology alone.
- `.claude-plugin/plugin.json` — 1.4.2 → 1.4.3 (patch: restates an existing instruction, no new behavior).

`skill-quality:check` on `object-writing`: PASS — 0 errors, 1 pre-existing warning (no Gotchas surface), 149/500 lines, markdownlint clean.

## Related

- #2524 — the merged tier correction this follows up. Same rule, different defect: that PR fixed which tier was named, this one fixes naming a tier at all.
- #2525 — the original misquote finding, closed by that merge.
- Consuming workspace `songwriting-enable-plugin`, `research/plugin-gaps.md` — the findings log quoted as the source for the Opus directive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0132Lj8TAJLRVdvBu6wsXHfr
