### PR TITLE
fix(repo-hygiene): fail mixed locked+non-locked git clean errors (#602)

### DIFF
--- a/plugins/repo-hygiene/.claude-plugin/plugin.json
+++ b/plugins/repo-hygiene/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "repo-hygiene",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "Repo hygiene action-router: /repo-hygiene:clean sweeps reclaimable caches, build artifacts, and stale git metadata, and can realign the working tree to a fresh-pull state — dry-run-first, with destructive tiers gated behind explicit confirmation and a session-scoped destructive-command guard. Ecosystem targets are detected at runtime; secrets, runtime dependencies, and skill data are preserved by default.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/repo-hygiene/CHANGELOG.md
+++ b/plugins/repo-hygiene/CHANGELOG.md
@@ -16,6 +16,15 @@ All notable changes to the `repo-hygiene` plugin are documented here. Format fol
   `skills/clean/reference/invocation-forms.md`; `allowed-tools-pairing.test.sh` now guards that
   `context/*.md` never adopt the direct `${CLAUDE_SKILL_DIR}/scripts/…` form.
 
+## [0.10.2]
+
+### Fixed
+
+- **`git-tree-reset.sh` mixed locked+non-locked `git clean` errors now fail closed (#602).**
+  A non-zero exit whose stderr mixes tolerated locked-file warnings with unrelated errors
+  exits 7 with `AppliedClean: failed` and preserves the locked-path count. Silent non-zero
+  exits with empty stderr are classified as failures too.
+
 ## [0.10.1]
 
 ### Fixed

--- a/plugins/repo-hygiene/skills/clean/scripts/git-tree-reset.sh
+++ b/plugins/repo-hygiene/skills/clean/scripts/git-tree-reset.sh
@@ -230,13 +230,17 @@ CLEAN_RC=$?
 UNREMOVABLE="$(printf '%s\n' "$CLEAN_STDERR" | grep -c 'failed to remove' || true)"
 CLEAN_NON_LOCKED_FAILURE=0
 if [[ "$CLEAN_RC" -ne 0 ]]; then
-  while IFS= read -r clean_line || [[ -n "$clean_line" ]]; do
-    [[ -z "$clean_line" ]] && continue
-    if [[ "$clean_line" != *'failed to remove'* ]]; then
-      CLEAN_NON_LOCKED_FAILURE=1
-      break
-    fi
-  done <<< "$CLEAN_STDERR"
+  if [[ -z "$CLEAN_STDERR" ]]; then
+    CLEAN_NON_LOCKED_FAILURE=1
+  else
+    while IFS= read -r clean_line || [[ -n "$clean_line" ]]; do
+      [[ -z "$clean_line" ]] && continue
+      if [[ "$clean_line" != *'failed to remove'* ]]; then
+        CLEAN_NON_LOCKED_FAILURE=1
+        break
+      fi
+    done <<< "$CLEAN_STDERR"
+  fi
 fi
 
 # Restore guard runs after clean unconditionally (data-loss guard): recover any
@@ -257,7 +261,7 @@ if [[ "$CLEAN_RC" -ne 0 && "${CLEAN_NON_LOCKED_FAILURE:-0}" -ne 0 ]]; then
   [[ -n "$CLEAN_STDERR" ]] && printf '%s\n' "$CLEAN_STDERR" >&2
   printf 'AppliedClean: failed\n'
   printf 'RestoredTracked: %s\n' "${RESTORED:-0}"
-  printf 'Unremovable: %s\n' "0"
+  printf 'Unremovable: %s\n' "${UNREMOVABLE:-0}"
   # Surface restore-guard activity identically to the success path: a clean that
   # errored mid-run may still have deleted tracked files (reparse-point traversal)
   # before failing, and the machine-readable RestoredTracked line alone can be

--- a/plugins/repo-hygiene/skills/clean/scripts/git-tree-reset.sh
+++ b/plugins/repo-hygiene/skills/clean/scripts/git-tree-reset.sh
@@ -228,6 +228,16 @@ printf 'AppliedReset: git reset --hard %s\n' "$UPSTREAM"
 CLEAN_STDERR="$(git clean -fdx "${PRESERVE_ARGS[@]}" 2>&1 >/dev/null)"
 CLEAN_RC=$?
 UNREMOVABLE="$(printf '%s\n' "$CLEAN_STDERR" | grep -c 'failed to remove' || true)"
+CLEAN_NON_LOCKED_FAILURE=0
+if [[ "$CLEAN_RC" -ne 0 ]]; then
+  while IFS= read -r clean_line || [[ -n "$clean_line" ]]; do
+    [[ -z "$clean_line" ]] && continue
+    if [[ "$clean_line" != *'failed to remove'* ]]; then
+      CLEAN_NON_LOCKED_FAILURE=1
+      break
+    fi
+  done <<< "$CLEAN_STDERR"
+fi
 
 # Restore guard runs after clean unconditionally (data-loss guard): recover any
 # tracked file clean deleted via reparse-point traversal, even on the failure path
@@ -235,15 +245,14 @@ UNREMOVABLE="$(printf '%s\n' "$CLEAN_STDERR" | grep -c 'failed to remove' || tru
 RESTORED="$(clean_restore_tracked_deletions "$REPO_ROOT")"
 
 # Gate the AppliedClean success line on the real outcome. A non-zero exit whose
-# sole cause is locked/in-use files (UNREMOVABLE>0) is NOT a failure: clean ran and
-# removed everything it could, and that is reported honestly as Unremovable — do
-# not regress that into a hard error. Only a non-zero exit with NO 'failed to
-# remove' warnings is a genuine clean failure; emit a distinct failure line and a
-# non-zero exit instead of a success line that misrepresents the outcome.
-# Known limitation: a non-zero exit mixing locked-file warnings AND an unrelated
-# error still falls through to the success path (UNREMOVABLE>0 wins) — the locked-
-# file heuristic predates this gate; a stricter classifier is deferred.
-if [[ "$CLEAN_RC" -ne 0 && "${UNREMOVABLE:-0}" -eq 0 ]]; then
+# sole cause is locked/in-use files (every non-empty stderr line is a 'failed to
+# remove' warning) is NOT a failure: clean ran and removed everything it could,
+# and that is reported honestly as Unremovable — do not regress that into a hard
+# error. A non-zero exit with no stderr, or with any stderr line that is not a
+# tolerated locked-file warning, is a genuine clean failure; emit a distinct
+# failure line and a non-zero exit instead of a success line that misrepresents
+# the outcome.
+if [[ "$CLEAN_RC" -ne 0 && "${CLEAN_NON_LOCKED_FAILURE:-0}" -ne 0 ]]; then
   printf 'FAILED: git clean -fdx exited %s (non-locked-file cause) — untracked removal incomplete; reset --hard already applied.\n' "$CLEAN_RC" >&2
   [[ -n "$CLEAN_STDERR" ]] && printf '%s\n' "$CLEAN_STDERR" >&2
   printf 'AppliedClean: failed\n'

--- a/plugins/repo-hygiene/skills/clean/scripts/git-tree-reset.test.sh
+++ b/plugins/repo-hygiene/skills/clean/scripts/git-tree-reset.test.sh
@@ -278,6 +278,40 @@ assert_contains "clean failure reports a positive RestoredTracked count" "$out" 
 assert_contains "clean failure path emits the RESTORED>0 warning (parity with success path)" "$out" "WARNING: restored 1 tracked file(s) deleted via reparse-point traversal"
 assert_file_exists "restore guard recovered the tracked file on the failure path" "$R5/tracked.txt"
 
+# --- 13. mixed locked-file warning + unrelated clean error exits 7 (#602) ---
+R6="$TEST_TMPDIR/repo-mixed-clean-fail"
+git init "$R6" >/dev/null 2>&1
+git -C "$R6" config user.email "t@example.com"
+git -C "$R6" config user.name "Test"
+echo tracked >"$R6/tracked.txt"
+git -C "$R6" add -A
+git -C "$R6" commit -m "init" >/dev/null
+git -C "$R6" branch -M main
+git -C "$R6" checkout -b feat/mixed-clean-fail >/dev/null 2>&1
+git -C "$R6" branch -u main >/dev/null 2>&1
+echo untracked >"$R6/scratch.txt"
+
+MIXED_SHIM="$TEST_TMPDIR/git-mixed-clean-shim"
+mkdir -p "$MIXED_SHIM"
+cat >"$MIXED_SHIM/git" <<SHIMEOF
+#!/usr/bin/env bash
+if [[ "\$1" == "clean" && "\$*" != *-n* ]]; then
+  echo "warning: failed to remove obj/locked.bin: Device or resource busy" >&2
+  echo "fatal: permission denied removing scratch.txt" >&2
+  exit 1
+fi
+exec "$REAL_GIT" "\$@"
+SHIMEOF
+chmod +x "$MIXED_SHIM/git"
+
+rc=0
+out="$(PATH="$MIXED_SHIM:$PATH" bash -c "cd '$R6' && bash '$RESET' --apply" 2>&1)" || rc=$?
+assert_exit "mixed clean failure exits 7" 7 "$rc"
+assert_contains "mixed clean failure reports failure" "$out" "FAILED: git clean -fdx"
+assert_contains "mixed clean failure emits AppliedClean: failed" "$out" "AppliedClean: failed"
+assert_not_contains "mixed clean failure emits no clean success line" "$out" "AppliedClean: git clean"
+assert_file_exists "mixed clean failure leaves untracked intact" "$R6/scratch.txt"
+
 if [[ $FAILED -ne 0 ]]; then
   echo "FAILED: $FAILED test(s)"
   exit 1

--- a/plugins/repo-hygiene/skills/clean/scripts/git-tree-reset.test.sh
+++ b/plugins/repo-hygiene/skills/clean/scripts/git-tree-reset.test.sh
@@ -310,7 +310,39 @@ assert_exit "mixed clean failure exits 7" 7 "$rc"
 assert_contains "mixed clean failure reports failure" "$out" "FAILED: git clean -fdx"
 assert_contains "mixed clean failure emits AppliedClean: failed" "$out" "AppliedClean: failed"
 assert_not_contains "mixed clean failure emits no clean success line" "$out" "AppliedClean: git clean"
+assert_contains "mixed clean failure preserves locked-path count" "$out" "Unremovable: 1"
 assert_file_exists "mixed clean failure leaves untracked intact" "$R6/scratch.txt"
+
+# --- 14. silent nonzero clean exit with empty stderr exits 7 (#602) ---
+R7="$TEST_TMPDIR/repo-silent-clean-fail"
+git init "$R7" >/dev/null 2>&1
+git -C "$R7" config user.email "t@example.com"
+git -C "$R7" config user.name "Test"
+echo tracked >"$R7/tracked.txt"
+git -C "$R7" add -A
+git -C "$R7" commit -m "init" >/dev/null
+git -C "$R7" branch -M main
+git -C "$R7" checkout -b feat/silent-clean-fail >/dev/null 2>&1
+git -C "$R7" branch -u main >/dev/null 2>&1
+echo untracked >"$R7/scratch.txt"
+
+SILENT_SHIM="$TEST_TMPDIR/git-silent-clean-shim"
+mkdir -p "$SILENT_SHIM"
+cat >"$SILENT_SHIM/git" <<SHIMEOF
+#!/usr/bin/env bash
+if [[ "\$1" == "clean" && "\$*" != *-n* ]]; then
+  exit 1
+fi
+exec "$REAL_GIT" "\$@"
+SHIMEOF
+chmod +x "$SILENT_SHIM/git"
+
+rc=0
+out="$(PATH="$SILENT_SHIM:$PATH" bash -c "cd '$R7' && bash '$RESET' --apply" 2>&1)" || rc=$?
+assert_exit "silent clean failure exits 7" 7 "$rc"
+assert_contains "silent clean failure emits AppliedClean: failed" "$out" "AppliedClean: failed"
+assert_not_contains "silent clean failure emits no clean success line" "$out" "AppliedClean: git clean"
+assert_file_exists "silent clean failure leaves untracked intact" "$R7/scratch.txt"
 
 if [[ $FAILED -ne 0 ]]; then
   echo "FAILED: $FAILED test(s)"


### PR DESCRIPTION
Fixes #602

## Summary

`git-tree-reset.sh` no longer treats any non-zero `git clean` exit with `failed to remove` lines as success. The apply-path gate now requires every non-empty stderr line to be a tolerated locked-file warning; mixed locked + unrelated errors emit `AppliedClean: failed` and exit 7. Silent non-zero exits with empty stderr are classified as failures too.

## Test plan

- [x] `git-tree-reset.test.sh` — mixed locked+unrelated stderr exits 7; silent non-zero clean exits 7

## Related

N/A