### PR TITLE
fix(security-evidence): decide from the lane's declared verdict, not its log

### DIFF
--- a/.github/workflows/claude-security-review.yml
+++ b/.github/workflows/claude-security-review.yml
@@ -71,9 +71,17 @@ jobs:
 
   # Repo-owned fail-closed supplement for #2337: the reusable workflow is
   # advisory on some infra-failure classes and can report success without a
-  # review when validation skips or the job finishes implausibly fast on an
-  # in-scope diff. This job is intentionally separate so the guard stays
-  # readable in-repo and does not require a ci-workflows pin bump.
+  # review when the action skips itself on an in-scope diff. This job is
+  # intentionally separate so the guard stays readable in-repo.
+  #
+  # It reads the lane's DECLARED outputs, passed below out of `needs`. It used
+  # to scrape the lane's job log instead, and a log is not a contract: the
+  # lane's `Report review outcome` step is an inline github-script whose source
+  # is echoed into that log, so the grep matched the source that mentions the
+  # skip phrases and reddened every successful in-scope pull request (#2517).
+  # Those outputs exist as of ci-workflows#461, which is why this job is now
+  # coupled to the pin above — the guard fails CLOSED when they are absent at
+  # an unmoved head, so a re-pin BACKWARDS past that release turns this red.
   security-review-evidence:
     needs: security-review
     if: >-
@@ -84,20 +92,32 @@ jobs:
     timeout-minutes: 5
     permissions:
       contents: read
-      actions: read
+      # The guard reads the pull request's live head on one path only —
+      # telling a retired superseded run apart from an absent verdict. It no
+      # longer reads run jobs or logs, so `actions: read` is gone with them.
+      pull-requests: read
     steps:
       - name: Check out
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-          fetch-depth: 0
+      # Self-test first, so a broken guard cannot mask the regression it exists
+      # to catch — the shape #2517 was: the guard agreed with itself while
+      # failing every pull request.
+      - name: Run security-review evidence guard tests
+        run: bash scripts/verify-security-review-evidence.sh.test.sh
       - name: Verify security-review execution evidence
         env:
           GH_TOKEN: ${{ github.token }}
-          GITHUB_RUN_ID: ${{ github.run_id }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           GITHUB_EVENT_NAME: ${{ github.event_name }}
-          GITHUB_BASE_REF: ${{ github.base_ref }}
           GITHUB_ACTOR: ${{ github.actor }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          LANE_RESULT: ${{ needs.security-review.result }}
+          LANE_RELEVANT: ${{ needs.security-review.outputs.relevant }}
+          LANE_REVIEW_RAN: ${{ needs.security-review.outputs.review-ran }}
+          LANE_REVIEW_FAILED: ${{ needs.security-review.outputs.review-failed }}
+          LANE_FAILURE_CLASS: ${{ needs.security-review.outputs.failure-class }}
           SKIP_ACTORS: dependabot[bot],claude[bot],melodic-ai[bot],melodic-standards-sync[bot]
         run: bash scripts/verify-security-review-evidence.sh

--- a/.github/workflows/claude-security-review.yml
+++ b/.github/workflows/claude-security-review.yml
@@ -79,9 +79,12 @@ jobs:
   # lane's `Report review outcome` step is an inline github-script whose source
   # is echoed into that log, so the grep matched the source that mentions the
   # skip phrases and reddened every successful in-scope pull request (#2517).
-  # Those outputs exist as of ci-workflows#461, which is why this job is now
-  # coupled to the pin above — the guard fails CLOSED when they are absent at
-  # an unmoved head, so a re-pin BACKWARDS past that release turns this red.
+  # Those outputs exist as of ci-workflows v0.14.2, which is why this job is
+  # now coupled to the pin above — the guard fails CLOSED when they are absent
+  # at an unmoved head, so a re-pin BACKWARDS past that release turns this red.
+  # The release, never a pull request number: a reader checking whether their
+  # pin carries the outputs needs a version they can compare against, and the
+  # guard's own message says the same thing the same way.
   security-review-evidence:
     needs: security-review
     if: >-

--- a/.github/workflows/claude-security-review.yml
+++ b/.github/workflows/claude-security-review.yml
@@ -31,7 +31,7 @@ jobs:
       contents: read         # checkout + read the diff
       pull-requests: write   # post the security review
       id-token: write        # OIDC — mints the Claude GitHub App token
-    uses: melodic-software/ci-workflows/.github/workflows/claude-security-review.yml@62bef7bab01e8532fedfa739879034a210e9e67d # v0.14.0
+    uses: melodic-software/ci-workflows/.github/workflows/claude-security-review.yml@7107b34832a7b6db5d08d3b132621c599fbe5e50 # v0.14.2
     with:
       runner: ubuntu-24.04
       paths-file: .github/claude-security-paths

--- a/scripts/verify-security-review-evidence.sh
+++ b/scripts/verify-security-review-evidence.sh
@@ -102,7 +102,7 @@ classify_absent_verdict() {
     printf 'retired\n'
     return 0
   fi
-  echo "ERROR: in-scope security-review concluded success but declared NO verdict at the current head — the caller's ci-workflows pin predates the declared-output contract (melodic-software/ci-workflows#460), or the lane stopped forwarding it. Re-pin the caller; do not wave this through (#2337)" >&2
+  echo "ERROR: in-scope security-review concluded success but declared NO verdict at the current head — the caller's ci-workflows pin predates the declared-output contract (melodic-software/ci-workflows#460), the lane stopped forwarding it, or the lane's relevance gate hard-errored on a rejected \`!\` / \`?\` / \`+\` pattern in .github/claude-security-paths and took its outputs down with it. Check the lane's own annotations for which; do not wave this through (#2337)" >&2
   printf 'blind\n'
   return 0
 }

--- a/scripts/verify-security-review-evidence.sh
+++ b/scripts/verify-security-review-evidence.sh
@@ -5,130 +5,114 @@
 #
 # The ci-workflows reusable deliberately reports GREEN on some infra-failure
 # classes; this script is a repo-owned supplement that catches the subset the
-# issue filed: an in-scope PR whose security-review job succeeded suspiciously
-# fast, or whose logs show a validation skip while the check still went green.
+# issue filed: an in-scope PR whose security-review job concluded success while
+# nothing was actually reviewed.
 #
-# Intended to run as a sibling job after security-review in
-# .github/workflows/claude-security-review.yml.
+# READS THE LANE'S DECLARED VERDICT, NEVER ITS LOG. The reusable classifies
+# every attempt and surfaces the result as workflow_call outputs
+# (melodic-software/ci-workflows#460); this guard consumes those. The earlier
+# shape scraped the job log, and a log is not a contract: the lane's
+# `Report review outcome` step is an inline github-script whose SOURCE is
+# echoed into that same log and contains the skip phrases as string literals,
+# so the grep matched every successful in-scope pull request and reddened
+# exactly the ones the guard exists to approve (#2517). Anchoring the grep to
+# `##[warning]`/`##[error]` lines fixed the false positive but left the guard
+# coupled to log text no test upstream pins. Do not reintroduce a log read.
+#
+# Scope is the lane's own `relevant` output, not a second implementation of the
+# same matcher. This script used to re-derive it in Python with `fnmatch`
+# semantics while the lane matched with `git check-ignore` gitignore semantics —
+# two matchers that disagree on the patterns that distinguish them, and the
+# source of the `set -e` scope-verdict defect that turned every out-of-scope PR
+# red. One matcher, upstream, is the fix.
+#
+# Runs as a sibling job after security-review in
+# .github/workflows/claude-security-review.yml, which supplies the LANE_* values
+# from `needs.security-review`.
 #
 # Environment:
-#   GITHUB_RUN_ID          current workflow run (required)
-#   GITHUB_REPOSITORY      owner/repo (required)
-#   GITHUB_EVENT_NAME      pull_request expected
-#   GITHUB_BASE_REF        base branch name
-#   GITHUB_HEAD_REF        head branch name (optional)
-#   GITHUB_ACTOR           PR author login
-#   MIN_REVIEW_SECONDS     absolute floor: shorter than this with no positive
-#                          execution evidence is a false pass (default 8).
-#                          Real Claude reviews commonly finish under 45s on
-#                          small diffs; duration alone above this floor is not
-#                          decisive once logs show the review action ran.
-#   SKIP_ACTORS            comma-separated actors exempt from review
+#   GITHUB_EVENT_NAME    pull_request expected; anything else is not applicable
+#   GITHUB_ACTOR         PR author login
+#   SKIP_ACTORS          comma-separated actors exempt from review
+#   LANE_RESULT          needs.security-review.result
+#   LANE_RELEVANT        the lane's `relevant` output
+#   LANE_REVIEW_RAN      the lane's `review-ran` output
+#   LANE_REVIEW_FAILED   the lane's `review-failed` output
+#   LANE_FAILURE_CLASS   the lane's `failure-class` output (message text only)
+#   GITHUB_REPOSITORY    owner/repo — only read on the no-verdict path
+#   PR_NUMBER            pull request number — only read on the no-verdict path
+#   EVENT_HEAD_SHA       the head SHA this run was triggered at
+#   GH_TOKEN             token for the one API read on the no-verdict path
 #
 # Exit: 0 evidence OK or not applicable; 1 in-scope false pass detected.
 
 set -euo pipefail
 
-MIN_REVIEW_SECONDS="${MIN_REVIEW_SECONDS:-8}"
 SKIP_ACTORS="${SKIP_ACTORS:-dependabot[bot],claude[bot],melodic-ai[bot],melodic-standards-sync[bot]}"
-PATHS_FILE="${PATHS_FILE:-.github/claude-security-paths}"
 
 usage() {
   cat <<'EOF'
 verify-security-review-evidence.sh — guard against in-scope security-review false passes.
 
-Reads the current workflow run's security-review job. Exits 0 when the PR is
-out of scope, exempt, skipped, or shows plausible execution evidence. Exits 1
-when an in-scope PR's security-review job succeeded with a validation skip,
-or finished below the absolute duration floor with no execution evidence (#2337).
+Reads the security-review lane's DECLARED outputs from the environment. Exits 0
+when the PR is out of scope, exempt, skipped, or the lane declares that a review
+ran. Exits 1 when an in-scope lane concluded success while declaring that no
+review happened, and when the lane declares no verdict at all at a head that has
+not moved (#2337).
 EOF
 }
 
-# pr_touches_security_paths <base-ref>
-#
-# Prints the VERDICT on stdout — `in-scope` or `out-of-scope` — and reserves a
-# non-zero EXIT for a genuine fault (missing python3, an unreadable paths file,
-# an interpreter traceback). The two channels are separate on purpose.
-#
-# The earlier contract signalled out-of-scope by returning 1, which collided
-# with "the check itself broke" on the one status a crashing `python3` also
-# returns. Under `set -e` a bare call then killed the script with no message —
-# every out-of-scope pull request went red beside a lane that had correctly
-# skipped. Consuming that return with `||` fixes the red check but keeps the
-# collision, and turns it fail-OPEN: a crashed scope check reads as
-# out-of-scope and waves the pull request past a security guard. ShellCheck
-# names this trap directly (SC2310, enabled on purpose in this repo's
-# `.shellcheckrc`). Separating verdict from status closes both.
-pr_touches_security_paths() {
-  local base_ref="$1"
-  [[ -f "$PATHS_FILE" ]] || { printf 'in-scope\n'; return 0; }
-  python3 - "$PATHS_FILE" "$base_ref" <<'PY'
-import fnmatch
-import re
-import subprocess
-import sys
-
-paths_file, base_ref = sys.argv[1], sys.argv[2]
-patterns = []
-with open(paths_file, encoding="utf-8") as fh:
-    for line in fh:
-        line = line.strip()
-        if not line or line.startswith("#"):
-            continue
-        patterns.append(line)
-
-def pattern_matches(path: str, pat: str) -> bool:
-    if fnmatch.fnmatch(path, pat):
-        return True
-    if pat.endswith("/**"):
-        prefix = pat[:-3].replace("*", "[^/]*")
-        if re.match("^" + prefix + ".*", path):
-            return True
-    if pat.startswith("**/"):
-        suffix = pat[3:]
-        if fnmatch.fnmatch(path, "*" + suffix) or path.endswith(suffix.lstrip("*")):
-            return True
-    if pat == "**/*.sh" and path.endswith(".sh"):
-        return True
-    norm = pat.replace("**/", "*/").replace("/**", "/*")
-    return fnmatch.fnmatch(path, norm)
-
-diff = subprocess.run(
-    ["git", "diff", "--name-only", f"origin/{base_ref}...HEAD"],
-    check=False,
-    capture_output=True,
-    text=True,
-)
-if diff.returncode != 0:
-    sys.stderr.write(
-        diff.stderr
-        or f"git diff --name-only origin/{base_ref}...HEAD failed (exit {diff.returncode})\n"
-    )
-    sys.exit(1)
-changed = [line for line in diff.stdout.splitlines() if line]
-for path in changed:
-    for pat in patterns:
-        if pattern_matches(path, pat):
-            print("in-scope")
-            sys.exit(0)
-print("out-of-scope")
-sys.exit(0)
-PY
+# live_head_sha — the pull request's current head, for the ONE case that needs
+# it: telling a retired superseded run apart from a genuinely absent verdict.
+# Defined as a function so the self-tests can substitute it without an API call.
+live_head_sha() {
+  gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq '.head.sha'
 }
 
-job_duration_seconds() {
-  local started completed
-  started="$1"
-  completed="$2"
-  local s c
-  s=$(date -u -d "$started" +%s) # portability-ok: GNU date -d for GitHub Actions ISO timestamps; CI runs on ubuntu only
-  c=$(date -u -d "$completed" +%s) # portability-ok: GNU date -d for GitHub Actions ISO timestamps; CI runs on ubuntu only
-  echo $((c - s))
+# classify_absent_verdict
+#
+# The lane declares nothing when its steps never reached the outcome composite.
+# Exactly one legitimate cause exists: the lane's freshness guard retired the
+# run because the head moved on, and the newer head's run reports in its place.
+# Every other cause — a caller pinned to a release older than the
+# declared-output contract, or a lane shape that stopped forwarding — is a
+# guard that has gone blind, and a blind security guard must not report safety.
+#
+# Prints the VERDICT on stdout — `retired` or `blind` — and reserves a non-zero
+# EXIT for a genuine fault, the same split the scope check used to need. The
+# explanation goes to stderr so it cannot be mistaken for the verdict. Calling
+# this from an `if` instead would disable `set -e` for its whole dynamic extent
+# (ShellCheck SC2310, enabled on purpose in this repository's `.shellcheckrc`),
+# which is how a fault inside a helper stops being a fault.
+classify_absent_verdict() {
+  if [[ -z "${GITHUB_REPOSITORY:-}" || -z "${PR_NUMBER:-}" || -z "${EVENT_HEAD_SHA:-}" ]]; then
+    echo "ERROR: security-review declared no verdict and this guard cannot tell whether the head moved (GITHUB_REPOSITORY, PR_NUMBER, and EVENT_HEAD_SHA are all required to decide) — refusing to report evidence it did not check (#2337)" >&2
+    printf 'blind\n'
+    return 0
+  fi
+  local head
+  head="$(live_head_sha)"
+  if [[ -z "$head" ]]; then
+    echo "ERROR: security-review declared no verdict and the live head could not be read, so a retired superseded run cannot be ruled out — refusing to report evidence it did not check (#2337)" >&2
+    printf 'blind\n'
+    return 0
+  fi
+  if [[ "$head" != "$EVENT_HEAD_SHA" ]]; then
+    echo "security-review declared no verdict and the head has moved (${EVENT_HEAD_SHA} -> ${head}) — this run was retired as superseded and the newer head's run reports instead; guard not applicable" >&2
+    printf 'retired\n'
+    return 0
+  fi
+  echo "ERROR: in-scope security-review concluded success but declared NO verdict at the current head — the caller's ci-workflows pin predates the declared-output contract (melodic-software/ci-workflows#460), or the lane stopped forwarding it. Re-pin the caller; do not wave this through (#2337)" >&2
+  printf 'blind\n'
+  return 0
 }
 
 main() {
   case "${1:-}" in
-    -h | --help) usage; exit 0 ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
     *) ;;
   esac
 
@@ -136,128 +120,83 @@ main() {
     echo "not a pull_request event — guard not applicable"
     exit 0
   }
-  [[ -n "${GITHUB_RUN_ID:-}" && -n "${GITHUB_REPOSITORY:-}" ]] || {
-    echo "ERROR: GITHUB_RUN_ID and GITHUB_REPOSITORY are required" >&2
-    exit 1
-  }
-  command -v gh >/dev/null 2>&1 || {
-    echo "ERROR: gh required" >&2
-    exit 1
-  }
-  command -v jq >/dev/null 2>&1 || {
-    echo "ERROR: jq required" >&2
-    exit 1
-  }
 
   if [[ ",${SKIP_ACTORS}," == *",${GITHUB_ACTOR:-},"* ]]; then
     echo "actor ${GITHUB_ACTOR} is skip-listed — guard not applicable"
     exit 0
   fi
 
-  local base_ref="${GITHUB_BASE_REF:-main}"
-  git fetch origin "$base_ref" --depth=1 >/dev/null 2>&1 || true
-  # A command substitution keeps `set -e` live for the helper (no `||`
-  # suppression), so a genuine fault inside it still aborts the guard — while
-  # the in-scope decision travels on stdout, where it cannot be confused with
-  # one. An unrecognised verdict is treated as a fault, never as a pass: this
-  # is a security guard, and the only safe default when it cannot tell whether
-  # a pull request is in scope is to fail loudly.
-  local scope_verdict
-  scope_verdict="$(pr_touches_security_paths "$base_ref")"
-  case "$scope_verdict" in
-    in-scope) ;;
-    out-of-scope)
-      echo "diff does not touch security-relevant paths — guard not applicable"
+  # A skipped lane job is one of the four no-verdict paths the lane documents —
+  # out of scope, a fork PR, a skip-listed actor, or either kill-switch. None is
+  # something this PR can act on, and the lane's own contract makes each a
+  # name-stable skip a required-check ruleset reads as success.
+  case "${LANE_RESULT:-}" in
+    skipped)
+      echo "security-review job skipped — guard not applicable"
       exit 0
       ;;
-    *)
-      echo "ERROR: scope check returned an unrecognised verdict: ${scope_verdict}" >&2
+    cancelled)
+      echo "security-review job cancelled — guard not applicable"
+      exit 0
+      ;;
+    "")
+      # `needs.<job>.result` is populated on every outcome, so an empty value
+      # means this guard is not wired to the lane at all. It cannot determine
+      # anything, and a guard that passes on uncertainty reports safety it did
+      # not check.
+      echo "ERROR: LANE_RESULT is empty — this guard is not wired to the security-review job, so it can determine nothing about it (#2337)" >&2
       exit 1
+      ;;
+    success) ;;
+    *)
+      echo "security-review job result=${LANE_RESULT} — deferring to job status"
+      exit 0
       ;;
   esac
 
-  local jobs_json
-  jobs_json="$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID/jobs" --paginate)"
-  local job
-  job="$(printf '%s' "$jobs_json" | jq -c '.jobs[] | select(.name == "security-review / security-review" or .name == "security-review")' | head -n1)"
-  if [[ -z "$job" ]]; then
-    echo "ERROR: security-review job not found in run $GITHUB_RUN_ID" >&2
-    exit 1
-  fi
-
-  local conclusion started completed
-  conclusion="$(printf '%s' "$job" | jq -r '.conclusion // .status')"
-  started="$(printf '%s' "$job" | jq -r '.started_at // empty')"
-  completed="$(printf '%s' "$job" | jq -r '.completed_at // empty')"
-
-  if [[ "$conclusion" == "skipped" ]]; then
-    echo "security-review job skipped — guard not applicable"
-    exit 0
-  fi
-  if [[ "$conclusion" != "success" ]]; then
-    echo "security-review job conclusion=$conclusion — deferring to job status"
+  if [[ "${LANE_RELEVANT:-}" == "false" ]]; then
+    echo "diff does not touch security-relevant paths — guard not applicable"
     exit 0
   fi
 
-  local duration=0
-  if [[ -n "$started" && -n "$completed" ]]; then
-    duration="$(job_duration_seconds "$started" "$completed")"
-  fi
-
-  local log_file
-  log_file="$(mktemp)"
-  trap 'rm -f "$log_file"' RETURN
-  for _ in 1 2 3 4 5; do
-    if gh run view "$GITHUB_RUN_ID" --repo "$GITHUB_REPOSITORY" --job "$(printf '%s' "$job" | jq -r '.id')" --log >"$log_file" 2>/dev/null && [[ -s "$log_file" ]]; then
-      break
-    fi
-    sleep 5
-  done
-
-  # Match only the runner's own ANNOTATION lines, never bare log text. The
-  # lane's `Report review outcome` step is an inline github-script whose SOURCE
-  # is echoed into this same log, and that source contains both phrases as
-  # string literals:
-  #
-  #     `${lane} concluded: ${outcome} class=skipped-validation with no ` +
-  #       "(workflow-validation skip: the caller's workflow file must " +
-  #
-  # An unanchored grep therefore matched EVERY successful in-scope run — the
-  # guard reddened exactly the pull requests it exists to approve. It stayed
-  # invisible while a separate bug (the lane rejecting `cursor[bot]` for want
-  # of an `allowed_bots` entry) made the lane job itself fail, because a
-  # non-success conclusion returns above without reaching this line.
-  #
-  # A real skip is emitted through `core.warning`, which the runner renders as
-  # a `##[warning]` line, so requiring that prefix keeps the true positive and
-  # drops the source-text match. Verified against run 31630114303, whose log
-  # contains exactly two matches for the old pattern, both source (lines 1435
-  # and 1437), while its `Rule on an in-scope non-run` step is `skipped` and
-  # its review ran 3m07s.
-  #
-  # `review-ran.*false` is deliberately not carried forward: the output key is
-  # `review_ran` with an underscore, so that alternative never matched a real
-  # signal — only, once again, the echoed source.
-  if grep -qE '##\[(warning|error)\].*(workflow-validation skip|class=skipped-validation)' "$log_file" 2>/dev/null; then
-    echo "ERROR: security-review reported success but its annotations show a validation skip (#2337)" >&2
-    exit 1
-  fi
-
-  # Positive execution evidence: the Claude review action progressed past
-  # install into the agent SDK (or posted a review). Marker strings sampled
-  # from real claude-security-review job logs (melodic-software/ci-workflows
-  # reusable); re-verify when re-pinning that workflow.
-  local has_execution_evidence=0
-  if grep -qE '@anthropic-ai/claude-agent-sdk|mcp__github_inline_comment__create_inline_comment|Posted review|create_inline_comment|Claude Code action completed' "$log_file" 2>/dev/null; then
-    has_execution_evidence=1
-  fi
-
-  if (( duration > 0 && duration < MIN_REVIEW_SECONDS && has_execution_evidence == 0 )); then
-    echo "ERROR: in-scope security-review succeeded in ${duration}s (<${MIN_REVIEW_SECONDS}s) with no execution evidence — likely no review ran (#2337)" >&2
-    exit 1
-  fi
-
-  echo "security-review evidence OK (duration=${duration}s, execution_evidence=${has_execution_evidence}, in-scope)"
+  case "${LANE_REVIEW_RAN:-}" in
+    true)
+      echo "security-review evidence OK (the lane declares a review ran, in-scope)"
+      exit 0
+      ;;
+    false)
+      if [[ "${LANE_REVIEW_FAILED:-}" == "true" ]]; then
+        # The lane rules this GREEN on purpose: the cause is outside this PR's
+        # and the org's control, and a required context that reddens on a
+        # provider outage locks every merge for the length of it. This guard
+        # exists to catch a FALSE pass, not to overturn that ruling — so it
+        # says loudly that nothing was reviewed and defers.
+        echo "::warning::security-review was in scope and did not complete (class=${LANE_FAILURE_CLASS:-unknown}). Nothing was reviewed at this head, and the lane reports green by contract. A human should review the security-sensitive changes here before merging."
+        exit 0
+      fi
+      echo "ERROR: in-scope security-review concluded success but declares that no review ran and no failure occurred — the action skipped itself (workflow-validation skip: the caller's workflow file must match the default branch's copy). Merging the caller-workflow change clears it; a re-run cannot (#2337)" >&2
+      exit 1
+      ;;
+    *)
+      # A command substitution, so `set -e` stays live for the helper and a
+      # genuine fault inside it still aborts the guard, while the verdict
+      # travels on stdout where it cannot be confused with one. An
+      # unrecognised verdict is a fault, never a pass.
+      local absent_verdict
+      absent_verdict="$(classify_absent_verdict)"
+      case "$absent_verdict" in
+        retired) exit 0 ;;
+        blind) exit 1 ;;
+        *)
+          echo "ERROR: the absent-verdict classifier returned an unrecognised verdict: ${absent_verdict}" >&2
+          exit 1
+          ;;
+      esac
+      ;;
+  esac
 }
 
-main "$@"
+# Sourced by the self-tests, which substitute live_head_sha; executed in CI.
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  main "$@"
+fi

--- a/scripts/verify-security-review-evidence.sh
+++ b/scripts/verify-security-review-evidence.sh
@@ -10,7 +10,7 @@
 #
 # READS THE LANE'S DECLARED VERDICT, NEVER ITS LOG. The reusable classifies
 # every attempt and surfaces the result as workflow_call outputs
-# (melodic-software/ci-workflows#460); this guard consumes those. The earlier
+# from ci-workflows v0.14.2 onward; this guard consumes those. The earlier
 # shape scraped the job log, and a log is not a contract: the lane's
 # `Report review outcome` step is an inline github-script whose SOURCE is
 # echoed into that same log and contains the skip phrases as string literals,
@@ -102,7 +102,7 @@ classify_absent_verdict() {
     printf 'retired\n'
     return 0
   fi
-  echo "ERROR: in-scope security-review concluded success but declared NO verdict at the current head — the caller's ci-workflows pin predates the declared-output contract (melodic-software/ci-workflows#460), the lane stopped forwarding it, or the lane's relevance gate hard-errored on a rejected \`!\` / \`?\` / \`+\` pattern in .github/claude-security-paths and took its outputs down with it. Check the lane's own annotations for which; do not wave this through (#2337)" >&2
+  echo "ERROR: in-scope security-review concluded success but declared NO verdict at the current head — the caller's ci-workflows pin predates the declared-output contract (ci-workflows v0.14.2), the lane stopped forwarding it, or the lane's relevance gate hard-errored on a rejected \`!\` / \`?\` / \`+\` pattern in .github/claude-security-paths and took its outputs down with it. Check the lane's own annotations for which; do not wave this through (#2337)" >&2
   printf 'blind\n'
   return 0
 }

--- a/scripts/verify-security-review-evidence.sh.test.sh
+++ b/scripts/verify-security-review-evidence.sh.test.sh
@@ -1,210 +1,211 @@
 #!/usr/bin/env bash
-# Self-tests for verify-security-review-evidence.sh helpers.
+# Self-tests for verify-security-review-evidence.sh.
+#
+# These EXECUTE the guard rather than re-implement its shapes. That became
+# possible when the guard stopped scraping the lane's job log and started
+# reading the lane's declared outputs: every input is now an environment
+# variable, and the one API read left behind lives in a function the tests
+# substitute. The previous harness could only copy the guard's regexes into
+# itself and assert on the copies, which is why it agreed with a guard that was
+# reddening every pull request it exists to approve (#2517).
 set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PATHS_FILE="$SCRIPT_DIR/../.github/claude-security-paths"
-EVIDENCE_PATTERN='@anthropic-ai/claude-agent-sdk|mcp__github_inline_comment__create_inline_comment|Posted review|create_inline_comment|Claude Code action completed'
-MIN_REVIEW_SECONDS=8
+GUARD_SCRIPT="$SCRIPT_DIR/verify-security-review-evidence.sh"
 
 FAILED=0
 pass() { printf 'PASS: %s\n' "$1"; }
-fail() { FAILED=$((FAILED + 1)); printf 'FAIL: %s\n  %s\n' "$1" "$2" >&2; }
-
-matches_paths() {
-  local paths_file="$1"
-  shift
-  python3 - "$paths_file" "$@" <<'PY'
-import fnmatch
-import re
-import sys
-
-paths_file = sys.argv[1]
-patterns = []
-with open(paths_file, encoding="utf-8") as fh:
-    for line in fh:
-        line = line.strip()
-        if not line or line.startswith("#"):
-            continue
-        patterns.append(line)
-
-def pattern_matches(path: str, pat: str) -> bool:
-    if fnmatch.fnmatch(path, pat):
-        return True
-    if pat.endswith("/**"):
-        prefix = pat[:-3].replace("*", "[^/]*")
-        if re.match("^" + prefix + ".*", path):
-            return True
-    if pat.startswith("**/"):
-        suffix = pat[3:]
-        if fnmatch.fnmatch(path, "*" + suffix) or path.endswith(suffix.lstrip("*")):
-            return True
-    if pat == "**/*.sh" and path.endswith(".sh"):
-        return True
-    norm = pat.replace("**/", "*/").replace("/**", "/*")
-    return fnmatch.fnmatch(path, norm)
-
-for path in sys.argv[2:]:
-    for pat in patterns:
-        if pattern_matches(path, pat):
-            sys.exit(0)
-sys.exit(1)
-PY
+fail() {
+  FAILED=$((FAILED + 1))
+  printf 'FAIL: %s\n  %s\n' "$1" "$2" >&2
 }
 
-log_has_execution_evidence() {
-  grep -qE "$EVIDENCE_PATTERN" "$1" 2>/dev/null
-}
-
-# Kept byte-identical to the guard's own pattern. Anchored to runner annotation
-# lines so the lane's echoed github-script SOURCE — which contains both phrases
-# as string literals — cannot be mistaken for a real skip.
-SKIP_ANNOTATION_PATTERN='##\[(warning|error)\].*(workflow-validation skip|class=skipped-validation)'
-
-log_shows_validation_skip() {
-  grep -qE "$SKIP_ANNOTATION_PATTERN" "$1" 2>/dev/null
-}
-
-would_reject_fast_success() {
-  local duration="$1"
-  local has_execution_evidence="$2"
-  (( duration > 0 && duration < MIN_REVIEW_SECONDS && has_execution_evidence == 0 ))
-}
-
-if matches_paths "$PATHS_FILE" "plugins/guardrails/hooks/block-hook-bypass.sh"; then
-  pass "guardrails hook path is security-relevant"
-else
-  fail "guardrails hook path is security-relevant" "expected match"
-fi
-
-if matches_paths "$PATHS_FILE" "docs/README.md"; then
-  fail "docs-only path is not security-relevant" "unexpected match"
-else
-  pass "docs-only path is not security-relevant"
-fi
-
-tmp_log="$(mktemp)"
-trap 'rm -f "$tmp_log"' EXIT
-
-printf '%s\n' 'Installing @anthropic-ai/claude-agent-sdk' >"$tmp_log"
-if log_has_execution_evidence "$tmp_log"; then
-  pass "fixture log with SDK marker counts as execution evidence"
-else
-  fail "fixture log with SDK marker counts as execution evidence" "expected match"
-fi
-
-printf '%s\n' 'checkout complete' 'job finished' >"$tmp_log"
-if log_has_execution_evidence "$tmp_log"; then
-  fail "fixture log without markers lacks execution evidence" "unexpected match"
-else
-  pass "fixture log without markers lacks execution evidence"
-fi
-
-if would_reject_fast_success 5 0; then
-  pass "5s without evidence rejected"
-else
-  fail "5s without evidence rejected" "expected rejection"
-fi
-
-if would_reject_fast_success 5 1; then
-  fail "5s with evidence accepted" "unexpected rejection"
-else
-  pass "5s with evidence accepted"
-fi
-
-if would_reject_fast_success 20 0; then
-  fail "20s without evidence accepted (above floor)" "unexpected rejection"
-else
-  pass "20s without evidence accepted (above floor)"
-fi
-
-# Regression: the echoed github-script source of the lane's `Report review
-# outcome` step, verbatim from run 31630114303 lines 1435 and 1437. The old
-# unanchored pattern matched these and failed every successful in-scope PR.
-# shellcheck disable=SC2016  # fixture is literal github-script source; ${lane} must not expand
-printf '%s\n' \
-  '    `${lane} concluded: ${outcome} class=skipped-validation with no ` +' \
-  '      "(workflow-validation skip: the caller'"'"'s workflow file must " +' \
-  >"$tmp_log"
-if log_shows_validation_skip "$tmp_log"; then
-  fail "echoed action source is not a validation skip" "unexpected match (#2337 false positive)"
-else
-  pass "echoed action source is not a validation skip"
-fi
-
-# True positive: the runner's rendered annotation for a real self-skip.
-printf '%s\n' \
-  '2026-08-12T18:46:14.6127175Z ##[warning]Claude security review concluded: success class=skipped-validation with no execution evidence — the action skipped itself before running (workflow-validation skip: the caller'"'"'s workflow file must match the default branch'"'"'s copy). Nothing was reviewed.' \
-  >"$tmp_log"
-if log_shows_validation_skip "$tmp_log"; then
-  pass "annotated validation skip is detected"
-else
-  fail "annotated validation skip is detected" "expected match"
-fi
-
-# A clean run carries neither shape.
-printf '%s\n' 'Installing @anthropic-ai/claude-agent-sdk' 'Claude Code action completed' >"$tmp_log"
-if log_shows_validation_skip "$tmp_log"; then
-  fail "clean lane log shows no validation skip" "unexpected match"
-else
-  pass "clean lane log shows no validation skip"
-fi
-
-# Regression: an OUT-OF-SCOPE pull request must be waved through, not failed.
+# run_guard <expected-exit> <name> [VAR=value ...]
 #
-# `pr_touches_security_paths` signals out-of-scope by RETURNING NON-ZERO, and
-# the guard runs under `set -e`. Called bare, that return killed the shell
-# before the "guard not applicable" branch could run — exit 1, empty log, and
-# every out-of-scope PR went red beside a lane that had correctly skipped.
+# Runs the guard in a separate bash process with only the named environment,
+# so one case cannot leak state into the next and so `set -e` is genuinely in
+# force — a subshell would inherit this harness's suppressed state and hide the
+# very failures these cases exist to catch.
 #
-# Two checks, because they fail for different reasons: the first proves the
-# shell semantics that make the bug possible, the second proves THIS script no
-# longer has the shape that trips them.
-
-# The model runs in a SEPARATE `bash -c` process, deliberately. A `( … )`
-# subshell would not do: bash suppresses `set -e` for the whole dynamic extent
-# of a command whose status is being tested, and `$( … )` inside `[[ … ]]` is
-# exactly that context — the bug becomes unreproducible in the very harness
-# meant to catch it. A fresh `bash -c` establishes its own `-e` state.
-bare_call_reaches_branch() {
-  bash -c 'set -euo pipefail
-    f() { return 1; }
-    f "base"
-    printf "reached\n"' 2>/dev/null
+# `$0` is deliberately NOT the guard's path: the guard runs `main` on its own
+# when `BASH_SOURCE[0]` equals `$0`, so sourcing it as `$0` would execute it
+# before the stub could replace anything.
+run_guard() {
+  local expected="$1" name="$2"
+  shift 2
+  local output status
+  # shellcheck disable=SC2016  # the bash -c body is literal source for the
+  # child shell; expanding $1 here would substitute this harness's own args.
+  output="$(env -i \
+    PATH="$PATH" \
+    HOME="${HOME:-/tmp}" \
+    LIVE_HEAD_SHA_STUB="${LIVE_HEAD_SHA_STUB:-}" \
+    "$@" \
+    bash -c '
+      source "$1"
+      live_head_sha() { printf "%s\n" "${LIVE_HEAD_SHA_STUB:-}"; }
+      main
+    ' harness "$GUARD_SCRIPT" 2>&1)"
+  status=$?
+  if [[ "$status" -eq "$expected" ]]; then
+    pass "$name"
+    LAST_OUTPUT="$output"
+    return 0
+  fi
+  fail "$name" "expected exit $expected, got $status; output: $output"
+  LAST_OUTPUT="$output"
+  return 1
 }
 
-if [[ -z "$(bare_call_reaches_branch)" ]]; then
-  pass "a non-zero-returning helper called bare under set -e kills the script"
+assert_output_contains() {
+  local name="$1" needle="$2"
+  if [[ "$LAST_OUTPUT" == *"$needle"* ]]; then
+    pass "$name"
+  else
+    fail "$name" "expected output to contain '$needle'; got: $LAST_OUTPUT"
+  fi
+}
+
+IN_SCOPE_RAN=(
+  GITHUB_EVENT_NAME=pull_request
+  GITHUB_ACTOR=kyle-sexton
+  LANE_RESULT=success
+  LANE_RELEVANT=true
+  LANE_REVIEW_RAN=true
+  LANE_REVIEW_FAILED=false
+)
+
+# --- the shape the guard exists to approve -----------------------------------
+
+run_guard 0 "an in-scope run that declares a review ran passes" "${IN_SCOPE_RAN[@]}"
+assert_output_contains "the pass says what it read" "the lane declares a review ran"
+
+# --- the shape the guard exists to catch -------------------------------------
+
+run_guard 1 "an in-scope validation skip fails closed" \
+  GITHUB_EVENT_NAME=pull_request \
+  GITHUB_ACTOR=kyle-sexton \
+  LANE_RESULT=success \
+  LANE_RELEVANT=true \
+  LANE_REVIEW_RAN=false \
+  LANE_REVIEW_FAILED=false
+assert_output_contains "the failure names the skip and its remedy" "workflow-validation skip"
+
+# --- the shapes that are not this guard's ruling to make ---------------------
+
+run_guard 0 "an external failure defers to the lane's deliberate green" \
+  GITHUB_EVENT_NAME=pull_request \
+  GITHUB_ACTOR=kyle-sexton \
+  LANE_RESULT=success \
+  LANE_RELEVANT=true \
+  LANE_REVIEW_RAN=false \
+  LANE_REVIEW_FAILED=true \
+  LANE_FAILURE_CLASS=rate-limit
+assert_output_contains "deferring still says nothing was reviewed" "Nothing was reviewed at this head"
+
+run_guard 0 "an out-of-scope pull request is waved through, not failed" \
+  GITHUB_EVENT_NAME=pull_request \
+  GITHUB_ACTOR=kyle-sexton \
+  LANE_RESULT=success \
+  LANE_RELEVANT=false \
+  LANE_REVIEW_RAN="" \
+  LANE_REVIEW_FAILED=""
+
+run_guard 0 "a skipped lane job is not applicable" \
+  GITHUB_EVENT_NAME=pull_request \
+  GITHUB_ACTOR=kyle-sexton \
+  LANE_RESULT=skipped
+
+run_guard 0 "a failed lane job defers to the job's own red" \
+  GITHUB_EVENT_NAME=pull_request \
+  GITHUB_ACTOR=kyle-sexton \
+  LANE_RESULT=failure
+
+run_guard 0 "a skip-listed actor is not applicable" \
+  GITHUB_EVENT_NAME=pull_request \
+  GITHUB_ACTOR="dependabot[bot]" \
+  LANE_RESULT=success \
+  LANE_RELEVANT=true \
+  LANE_REVIEW_RAN=false \
+  LANE_REVIEW_FAILED=false
+
+run_guard 0 "a non-pull_request event is not applicable" \
+  GITHUB_EVENT_NAME=push \
+  LANE_RESULT=success
+
+# --- absent verdict: fail closed unless the head demonstrably moved ----------
+
+LIVE_HEAD_SHA_STUB=1111111111111111111111111111111111111111 \
+  run_guard 0 "a retired superseded run is recognised by a moved head" \
+  GITHUB_EVENT_NAME=pull_request \
+  GITHUB_ACTOR=kyle-sexton \
+  LANE_RESULT=success \
+  LANE_RELEVANT=true \
+  LANE_REVIEW_RAN="" \
+  GITHUB_REPOSITORY=melodic-software/claude-code-plugins \
+  PR_NUMBER=1 \
+  EVENT_HEAD_SHA=0000000000000000000000000000000000000000
+assert_output_contains "the supersede pass names the move" "the head has moved"
+
+LIVE_HEAD_SHA_STUB=0000000000000000000000000000000000000000 \
+  run_guard 1 "an absent verdict at an unmoved head fails closed" \
+  GITHUB_EVENT_NAME=pull_request \
+  GITHUB_ACTOR=kyle-sexton \
+  LANE_RESULT=success \
+  LANE_RELEVANT=true \
+  LANE_REVIEW_RAN="" \
+  GITHUB_REPOSITORY=melodic-software/claude-code-plugins \
+  PR_NUMBER=1 \
+  EVENT_HEAD_SHA=0000000000000000000000000000000000000000
+assert_output_contains "the failure names the stale pin as the likely cause" "predates the declared-output contract"
+
+LIVE_HEAD_SHA_STUB="" \
+  run_guard 1 "an unreadable live head fails closed rather than assuming a supersede" \
+  GITHUB_EVENT_NAME=pull_request \
+  GITHUB_ACTOR=kyle-sexton \
+  LANE_RESULT=success \
+  LANE_RELEVANT=true \
+  LANE_REVIEW_RAN="" \
+  GITHUB_REPOSITORY=melodic-software/claude-code-plugins \
+  PR_NUMBER=1 \
+  EVENT_HEAD_SHA=0000000000000000000000000000000000000000
+
+run_guard 1 "an absent verdict with nothing to check the head against fails closed" \
+  GITHUB_EVENT_NAME=pull_request \
+  GITHUB_ACTOR=kyle-sexton \
+  LANE_RESULT=success \
+  LANE_RELEVANT=true \
+  LANE_REVIEW_RAN=""
+
+run_guard 1 "a guard not wired to the lane at all fails closed" \
+  GITHUB_EVENT_NAME=pull_request \
+  GITHUB_ACTOR=kyle-sexton \
+  LANE_RESULT=""
+
+# --- static guards on the source ---------------------------------------------
+
+# The defect this rewrite removes. A log read is not a contract: the lane's
+# `Report review outcome` step is an inline github-script whose source is echoed
+# into the same log, so any grep for the phrases that name a skip also matches
+# the source that mentions them (#2517).
+if grep -qE 'gh run view|--log' "$GUARD_SCRIPT"; then
+  fail "the guard reads declared outputs, never the lane's log" \
+    "found a log read; the lane's echoed github-script source contains the skip phrases as string literals (#2517)"
 else
-  fail "a non-zero-returning helper called bare under set -e kills the script" \
-    "expected no output; set -e should have aborted before the next line"
+  pass "the guard reads declared outputs, never the lane's log"
 fi
 
-# The verdict now travels on stdout with exit reserved for faults, so the two
-# are no longer confusable. These assert the contract the guard depends on.
-if [[ "$(printf 'in-scope\n')" == "in-scope" ]]; then
-  pass "in-scope verdict is a stdout token, not an exit status"
+# One matcher, upstream. A second local implementation of the paths matcher is
+# what produced the `set -e` scope-verdict defect and disagreed with the lane's
+# `git check-ignore` semantics besides.
+# Comment lines are excluded on purpose — the guard's header explains the
+# defect by naming it, and a check that cannot tell an explanation from an
+# implementation would forbid recording why this shape is gone.
+if grep -vE '^[[:space:]]*#' "$GUARD_SCRIPT" | grep -qE 'python3|fnmatch|pr_touches_security_paths'; then
+  fail "scope comes from the lane's relevant output, not a second matcher" \
+    "found a local scope implementation; the lane already decided this with git check-ignore"
 else
-  fail "in-scope verdict is a stdout token, not an exit status" "unexpected"
-fi
-
-# Static guards on the real script: catch a revert to either older shape.
-GUARD_SCRIPT="$SCRIPT_DIR/verify-security-review-evidence.sh"
-
-# shellcheck disable=SC2016  # the regex matches a LITERAL "$base_ref" in the
-# guard's source; expanding it here would search for this test's own empty var.
-if grep -qE '^[[:space:]]*pr_touches_security_paths "\$base_ref"( \|\| .*)?[[:space:]]*$' "$GUARD_SCRIPT"; then
-  fail "scope check is consumed as a stdout verdict, not a bare or ||-suppressed call" \
-    "found a bare or ||-suppressed call; a crashed scope check would then read as out-of-scope and fail OPEN"
-else
-  pass "scope check is consumed as a stdout verdict, not a bare or ||-suppressed call"
-fi
-
-if grep -q 'scope check returned an unrecognised verdict' "$GUARD_SCRIPT"; then
-  pass "an unrecognised scope verdict fails closed"
-else
-  fail "an unrecognised scope verdict fails closed" \
-    "the catch-all branch is gone; an unexpected verdict could fall through as a pass"
+  pass "scope comes from the lane's relevant output, not a second matcher"
 fi
 
 if [[ "$FAILED" -eq 0 ]]; then


### PR DESCRIPTION
Closes #2541

## Summary

The security-evidence guard inferred a verdict the lane had already computed, through two channels that were wrong in the same way.

It downloaded the lane's job log and grepped it. The lane's `Report review outcome` step is an inline `github-script` whose SOURCE is echoed into that same log and contains the skip phrases as string literals, so the grep matched every successful in-scope pull request and reddened exactly the ones the guard exists to approve (#2517). Anchoring to `##[warning]`/`##[error]` lines removed the false positive but left the guard coupled to log text nothing upstream pins.

It also re-derived the PR's security scope in its own Python `fnmatch` implementation while the lane matches with `git check-ignore` — two matchers that disagree on exactly the patterns that distinguish them, and where the `set -e` scope-verdict defect lived.

## Fix

Both channels are replaced by the lane's declared outputs (melodic-software/ci-workflows#461), passed in from `needs.security-review`:

| lane says | guard does |
| --- | --- |
| job `skipped` / `cancelled` | not applicable |
| job not `success` | defer to the job's own red |
| `relevant: false` | out of scope, not applicable |
| `review-ran: true` | evidence OK |
| `review-ran: false`, `review-failed: true` | defer — the lane rules this GREEN on purpose so a provider outage cannot lock every merge; the guard says loudly that nothing was reviewed and does not overturn it |
| `review-ran: false`, `review-failed: false` | FAIL — the action skipped itself; merging the caller change clears it, a re-run cannot |
| no verdict at all | FAIL, unless the live head has moved — a run retired as superseded is the one legitimate cause, and it is identified by comparing the live head against the event head rather than assumed |
| `LANE_RESULT` empty | FAIL — the guard is not wired to the lane, so it can determine nothing |

The guard is now coupled to the pin: it fails closed when the outputs are absent at an unmoved head, so re-pinning BACKWARDS past the release carrying them turns it red rather than quietly blind. The caller's pin is bumped in this PR for exactly that reason.

`actions: read` is gone with the log read; `pull-requests: read` covers the one remaining API call.

## Verification

- `scripts/verify-security-review-evidence.sh.test.sh` rewritten to EXECUTE the guard against environment fixtures in an `env -i` child shell, instead of re-implementing its regexes inside the harness and asserting on the copies — the shape that let the tests agree with a guard that was failing every pull request. 20 cases, all pass locally, covering every row of the table above plus two static checks (no log read, no second paths matcher).
- `shellcheck --rcfile .shellcheckrc` clean on both scripts, including the deliberately-enabled SC2310: the absent-verdict classifier reports on stdout with exit reserved for faults, the same verdict/status split the scope check needed.
- The tests now run in CI, in the guard's own job, ahead of the guard. They ran nowhere before.

## Related

- #2517 — the log-grep false positive this removes the possibility of
- #2337 — the false-pass class the guard exists to catch
- melodic-software/ci-workflows#461 — the declared outputs this consumes
