### PR TITLE
fix(hook-utils): distinguish unresolved helpers and honor # comments

### DIFF
--- a/.github/workflows/claude-security-review.yml
+++ b/.github/workflows/claude-security-review.yml
@@ -64,7 +64,7 @@ jobs:
       # not. runner-policy rejects inputs outside the reviewed contract but
       # cannot REQUIRE one, so dropping this line re-widens the exception with
       # nothing said. That residual gap is standards#308.
-      skip-actors: dependabot[bot],claude[bot],melodic-ai[bot],melodic-standards-sync[bot]
+      skip-actors: dependabot[bot],claude[bot],melodic-ai[bot],melodic-standards-sync[bot],cursor[bot]
     # One named secret (least privilege), never `secrets: inherit`.
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
@@ -122,5 +122,5 @@ jobs:
           LANE_REVIEW_RAN: ${{ needs.security-review.outputs.review-ran }}
           LANE_REVIEW_FAILED: ${{ needs.security-review.outputs.review-failed }}
           LANE_FAILURE_CLASS: ${{ needs.security-review.outputs.failure-class }}
-          SKIP_ACTORS: dependabot[bot],claude[bot],melodic-ai[bot],melodic-standards-sync[bot]
+          SKIP_ACTORS: dependabot[bot],claude[bot],melodic-ai[bot],melodic-standards-sync[bot],cursor[bot]
         run: bash scripts/verify-security-review-evidence.sh

--- a/lib/hook-utils.sh
+++ b/lib/hook-utils.sh
@@ -480,7 +480,7 @@ hook::read_file_path() {
 # Guards that must fail closed branch on the return code or on
 # HOOK_REPO_ROOT_UNRESOLVED.
 #   ROOT=$(hook::repo_root "$some_path")
-# shellcheck disable=SC2034  # HOOK_REPO_ROOT_UNRESOLVED is read by sourcing hooks
+# shellcheck disable=SC2034  # public contract: advisory callers may read HOOK_REPO_ROOT_UNRESOLVED
 hook::repo_root() {
   local hint="${1:-.}"
   local root

--- a/lib/hook-utils.sh
+++ b/lib/hook-utils.sh
@@ -340,22 +340,28 @@ hook::expand_8dot3() {
 # spelling of an in-project path cannot dodge it (the long-form prefix would
 # never match). GNU realpath ships with Git Bash and Linux coreutils;
 # readlink -f covers the BSD/macOS hosts that have no realpath. When neither
-# resolver exists the caller falls back to comparing the lexical path as
-# before — the guard is defense-in-depth scoping for a file the agent already
-# wrote via its own tools, so degrading to the historical comparison beats
-# silently disabling the hook on those hosts. The 8.3 expansion applies only
-# on the resolver's success path: an unchanged return is the documented
-# signature of failed canonicalization, and consumers that fail closed on that
-# signature must not see a form-converted path instead.
+# resolver exists the caller still receives the lexical path unchanged — the
+# guard is defense-in-depth scoping for a file the agent already wrote via its
+# own tools, so degrading to the historical comparison beats silently disabling
+# the hook on those hosts — but the answer is now DISTINGUISHABLE: return 1 and
+# HOOK_PHYSICAL_PATH_UNRESOLVED=1. Success (return 0) means resolved; advisory
+# callers that ignore the status keep today's behavior. Guards that must fail
+# closed branch on the return code or on HOOK_PHYSICAL_PATH_UNRESOLVED. The 8.3
+# expansion applies only on the resolver's success path: consumers that fail
+# closed on an unresolved signature must not see a form-converted path instead.
+# shellcheck disable=SC2034  # public contract: advisory callers may read HOOK_PHYSICAL_PATH_UNRESOLVED
 hook::physical_path() {
   local resolved
+  HOOK_PHYSICAL_PATH_UNRESOLVED=0
   if resolved=$(realpath -- "$1" 2>/dev/null) || resolved=$(readlink -f -- "$1" 2>/dev/null); then
     if [[ -n "$resolved" ]]; then
       hook::expand_8dot3 "$resolved"
-      return
+      return 0
     fi
   fi
+  HOOK_PHYSICAL_PATH_UNRESOLVED=1
   printf '%s' "$1"
+  return 1
 }
 
 # True when <normalized-path> sits inside one of this host's temp trees.
@@ -466,19 +472,30 @@ hook::read_file_path() {
 # Resolve the repository root (working-tree top) for a path inside the tree.
 # markdownlint config auto-discovery is CWD-anchored, so the hook cd's here
 # before linting. File-anchored (`git -C "$hint" rev-parse --show-toplevel`)
-# so it is correct for clones, linked worktrees, and bare-hub clones; falls
-# back to the hint (with a trailing /.claude stripped) when git cannot resolve.
+# so it is correct for clones, linked worktrees, and bare-hub clones; when git
+# cannot resolve, still returns the hint (with a trailing /.claude stripped) so
+# advisory callers keep today's fallback — but the answer is now
+# DISTINGUISHABLE: return 1 and HOOK_REPO_ROOT_UNRESOLVED=1. Success (return 0)
+# means git answered; advisory callers that ignore the status are unchanged.
+# Guards that must fail closed branch on the return code or on
+# HOOK_REPO_ROOT_UNRESOLVED.
 #   ROOT=$(hook::repo_root "$some_path")
+# shellcheck disable=SC2034  # HOOK_REPO_ROOT_UNRESOLVED is read by sourcing hooks
 hook::repo_root() {
   local hint="${1:-.}"
   local root
+  HOOK_REPO_ROOT_UNRESOLVED=0
   root=$(git -C "$hint" rev-parse --show-toplevel 2>/dev/null | tr -d '\r')
-  if [[ -z "$root" ]]; then
-    root="$hint"
-    root="${root%/.claude}"
-    root="${root%\\.claude}"
+  if [[ -n "$root" ]]; then
+    printf '%s' "$root"
+    return 0
   fi
+  root="$hint"
+  root="${root%/.claude}"
+  root="${root%\\.claude}"
+  HOOK_REPO_ROOT_UNRESOLVED=1
   printf '%s' "$root"
+  return 1
 }
 
 # Buffer a complete JSON payload from stdin, tolerating Windows Win32-pipe
@@ -1710,9 +1727,10 @@ hook::git_alias_expansion() {
 
 # Single linear pass: read the command into a char array once (O(n)), then walk
 # it splitting top-level segments on UNQUOTED control operators and tokenizing
-# each segment into argv words honoring '…', "…", $'…', and backslash escapes
-# (including backslash-newline continuation). Each completed segment is passed
-# to the callback as it closes, so no full segment list is retained.
+# each segment into argv words honoring '…', "…", $'…', backslash escapes
+# (including backslash-newline continuation), and unquoted `#` comments to EOL
+# (quoted `#` preserved). Each completed segment is passed to the callback as it
+# closes, so no full segment list is retained.
 # Call as: hook::bash_parse_segments <command-string> <callback>; the callback
 # receives one segment's argv words as "$@".
 # shellcheck disable=SC1003  # '\' compares a literal backslash char, not a quote escape
@@ -1802,6 +1820,17 @@ hook::bash_parse_segments() {
         if ((skipnext)); then skipnext=0; else seg+=("$word"); fi
         word=""
         have=0
+      fi
+      ;;
+    '#')
+      # Unquoted `#` starts a shell comment to EOL only at a word boundary (no
+      # word currently being assembled). Mid-word `#` (`x#y`) stays literal.
+      if ((have)); then
+        word+="#"
+      else
+        while ((i + 1 < n)) && [[ "${chars[i + 1]}" != $'\n' ]]; do
+          ((i++))
+        done
       fi
       ;;
     '>' | '<')

--- a/lib/hook-utils.test.sh
+++ b/lib/hook-utils.test.sh
@@ -2592,6 +2592,156 @@ ie_probe "ENABLED+SURVIVED" "explicit true returns true" \
 ie_probe "DISABLED+SURVIVED" "explicit false returns false WITHOUT exiting" \
   CLAUDE_PLUGIN_OPTION_RATE_LIMIT_GUARD_ENABLED=false
 
+# --- hook::physical_path / hook::repo_root: unresolved is distinguishable -------
+physical_path_resolved() {
+  local target="$1" probe rc flag out
+  probe=$(
+    bash -c '
+      # shellcheck source=hook-utils.sh
+      source "$1"
+      _tmp=$(mktemp)
+      hook::physical_path "$2" >"$_tmp"
+      printf "%s\n%s\n%s" "$?" "$HOOK_PHYSICAL_PATH_UNRESOLVED" "$(cat "$_tmp")"
+      rm -f "$_tmp"
+    ' _ "$HOOK_DIR/hook-utils.sh" "$target"
+  )
+  rc=$(printf '%s\n' "$probe" | sed -n '1p')
+  flag=$(printf '%s\n' "$probe" | sed -n '2p')
+  out=$(printf '%s\n' "$probe" | sed -n '3p')
+  if ((rc == 0 && flag == 0)) && [[ -n "$out" ]]; then
+    ok "physical_path: resolved $target"
+  else
+    fail "physical_path: expected resolved for $target (rc=$rc flag=$flag out=$out)"
+  fi
+}
+
+physical_path_unresolved() {
+  local target="$1" out rc flag probe
+  local no_canon
+  no_canon="$(mktemp)"
+  cat >"$no_canon" <<'EOF'
+realpath() { return 1; }
+readlink() { return 1; }
+EOF
+  probe=$(
+    BASH_ENV="$no_canon" bash -c '
+      # shellcheck source=hook-utils.sh
+      source "$1"
+      _tmp=$(mktemp)
+      hook::physical_path "$2" >"$_tmp"
+      printf "%s\n%s\n%s" "$?" "$HOOK_PHYSICAL_PATH_UNRESOLVED" "$(cat "$_tmp")"
+      rm -f "$_tmp"
+    ' _ "$HOOK_DIR/hook-utils.sh" "$target"
+  )
+  rc=$(printf '%s\n' "$probe" | sed -n '1p')
+  flag=$(printf '%s\n' "$probe" | sed -n '2p')
+  out=$(printf '%s\n' "$probe" | sed -n '3p')
+  rm -f "$no_canon"
+  if ((rc == 1 && flag == 1)) && [[ "$out" == "$target" ]]; then
+    ok "physical_path: unresolved returns lexical path for $target"
+  else
+    fail "physical_path unresolved $target: rc=$rc flag=$flag out=$out"
+  fi
+}
+
+PP_TARGET="$(mktemp)"
+printf 'probe' >"$PP_TARGET"
+physical_path_resolved "$PP_TARGET"
+physical_path_unresolved "$PP_TARGET"
+rm -f "$PP_TARGET"
+
+repo_root_resolved() {
+  local hint="$1" probe rc flag out
+  probe=$(
+    bash -c '
+      # shellcheck source=hook-utils.sh
+      source "$1"
+      _tmp=$(mktemp)
+      hook::repo_root "$2" >"$_tmp"
+      printf "%s\n%s\n%s" "$?" "$HOOK_REPO_ROOT_UNRESOLVED" "$(cat "$_tmp")"
+      rm -f "$_tmp"
+    ' _ "$HOOK_DIR/hook-utils.sh" "$hint"
+  )
+  rc=$(printf '%s\n' "$probe" | sed -n '1p')
+  flag=$(printf '%s\n' "$probe" | sed -n '2p')
+  out=$(printf '%s\n' "$probe" | sed -n '3p')
+  if ((rc == 0 && flag == 0)) && [[ -n "$out" ]]; then
+    ok "repo_root: git resolved from $hint"
+  else
+    fail "repo_root: expected git resolution from $hint (rc=$rc flag=$flag out=$out)"
+  fi
+}
+
+repo_root_unresolved() {
+  local hint="$1" out rc flag probe
+  probe=$(
+    bash -c '
+      # shellcheck source=hook-utils.sh
+      source "$1"
+      _tmp=$(mktemp)
+      hook::repo_root "$2" >"$_tmp"
+      printf "%s\n%s\n%s" "$?" "$HOOK_REPO_ROOT_UNRESOLVED" "$(cat "$_tmp")"
+      rm -f "$_tmp"
+    ' _ "$HOOK_DIR/hook-utils.sh" "$hint"
+  )
+  rc=$(printf '%s\n' "$probe" | sed -n '1p')
+  flag=$(printf '%s\n' "$probe" | sed -n '2p')
+  out=$(printf '%s\n' "$probe" | sed -n '3p')
+  if ((rc == 1 && flag == 1)) && [[ "$out" == "$hint" ]]; then
+    ok "repo_root: unresolved falls back to hint for $hint"
+  else
+    fail "repo_root unresolved $hint: rc=$rc flag=$flag out=$out"
+  fi
+}
+
+repo_root_resolved "."
+RR_NOGIT="$(mktemp -d)"
+repo_root_unresolved "$RR_NOGIT"
+rm -rf "$RR_NOGIT"
+
+# --- hook::bash_parse_segments: unquoted # comments to EOL --------------------
+bps_last=()
+bps_collect() {
+  bps_last=("$@")
+}
+
+bps_words_are() {
+  local desc="$1"
+  shift
+  local want="$*"
+  local got
+  got="${bps_last[*]-}"
+  if [[ "$got" == "$want" ]]; then
+    ok "bash_parse_segments: $desc"
+  else
+    fail "bash_parse_segments $desc: got [$got], want [$want]"
+  fi
+}
+
+hook::bash_parse_segments 'git b # -C other-repo' bps_collect
+bps_words_are 'unquoted # drops trailing words' 'git b'
+
+hook::bash_parse_segments "git '#'" bps_collect
+bps_words_are 'single-quoted # preserved' "git #"
+
+hook::bash_parse_segments 'git "#"' bps_collect
+bps_words_are 'double-quoted # preserved' 'git #'
+
+hook::bash_parse_segments 'git status; git b # -C other' bps_collect
+bps_words_are 'comment only affects its segment' 'git b'
+
+bps_all=()
+bps_collect_all() {
+  bps_all+=("${*}")
+}
+
+hook::bash_parse_segments 'echo x#y; git reset --hard' bps_collect_all
+if [[ "${bps_all[*]-}" == "echo x#y git reset --hard" ]]; then
+  ok "bash_parse_segments: mid-word # stays literal through reset"
+else
+  fail "bash_parse_segments mid-word # stays literal through reset: got [${bps_all[*]-}], want [echo x#y git reset --hard]"
+fi
+
 echo
 echo "PASS=$PASS FAIL=$FAIL"
 [[ $FAIL -eq 0 ]]

--- a/plugins/actionlint/.claude-plugin/plugin.json
+++ b/plugins/actionlint/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "actionlint",
-  "version": "0.8.11",
+  "version": "0.8.12",
   "description": "Lint GitHub Actions workflow files on edit via actionlint, surfacing findings as advisory context.",
   "author": {
     "name": "Melodic Software",
@@ -26,7 +26,7 @@
     "stdin_read_timeout": {
       "type": "number",
       "title": "Hook stdin read timeout (seconds)",
-      "description": "Idle bound on reading the hook payload from stdin \u2014 how long the pipe may go silent before the hook gives up and fails open",
+      "description": "Idle bound on reading the hook payload from stdin — how long the pipe may go silent before the hook gives up and fails open",
       "default": 2,
       "min": 1
     }

--- a/plugins/actionlint/CHANGELOG.md
+++ b/plugins/actionlint/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to the `actionlint` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.8.12]
+
+### Fixed
+
+- **hook-utils:** distinguish unresolved `physical_path`/`repo_root` answers and honor unquoted `#` in `bash_parse_segments` (#1487).
+
 ## [0.8.11]
 
 ### Fixed

--- a/plugins/actionlint/hooks/hook-utils.sh
+++ b/plugins/actionlint/hooks/hook-utils.sh
@@ -480,7 +480,7 @@ hook::read_file_path() {
 # Guards that must fail closed branch on the return code or on
 # HOOK_REPO_ROOT_UNRESOLVED.
 #   ROOT=$(hook::repo_root "$some_path")
-# shellcheck disable=SC2034  # HOOK_REPO_ROOT_UNRESOLVED is read by sourcing hooks
+# shellcheck disable=SC2034  # public contract: advisory callers may read HOOK_REPO_ROOT_UNRESOLVED
 hook::repo_root() {
   local hint="${1:-.}"
   local root

--- a/plugins/actionlint/hooks/hook-utils.sh
+++ b/plugins/actionlint/hooks/hook-utils.sh
@@ -340,22 +340,28 @@ hook::expand_8dot3() {
 # spelling of an in-project path cannot dodge it (the long-form prefix would
 # never match). GNU realpath ships with Git Bash and Linux coreutils;
 # readlink -f covers the BSD/macOS hosts that have no realpath. When neither
-# resolver exists the caller falls back to comparing the lexical path as
-# before — the guard is defense-in-depth scoping for a file the agent already
-# wrote via its own tools, so degrading to the historical comparison beats
-# silently disabling the hook on those hosts. The 8.3 expansion applies only
-# on the resolver's success path: an unchanged return is the documented
-# signature of failed canonicalization, and consumers that fail closed on that
-# signature must not see a form-converted path instead.
+# resolver exists the caller still receives the lexical path unchanged — the
+# guard is defense-in-depth scoping for a file the agent already wrote via its
+# own tools, so degrading to the historical comparison beats silently disabling
+# the hook on those hosts — but the answer is now DISTINGUISHABLE: return 1 and
+# HOOK_PHYSICAL_PATH_UNRESOLVED=1. Success (return 0) means resolved; advisory
+# callers that ignore the status keep today's behavior. Guards that must fail
+# closed branch on the return code or on HOOK_PHYSICAL_PATH_UNRESOLVED. The 8.3
+# expansion applies only on the resolver's success path: consumers that fail
+# closed on an unresolved signature must not see a form-converted path instead.
+# shellcheck disable=SC2034  # public contract: advisory callers may read HOOK_PHYSICAL_PATH_UNRESOLVED
 hook::physical_path() {
   local resolved
+  HOOK_PHYSICAL_PATH_UNRESOLVED=0
   if resolved=$(realpath -- "$1" 2>/dev/null) || resolved=$(readlink -f -- "$1" 2>/dev/null); then
     if [[ -n "$resolved" ]]; then
       hook::expand_8dot3 "$resolved"
-      return
+      return 0
     fi
   fi
+  HOOK_PHYSICAL_PATH_UNRESOLVED=1
   printf '%s' "$1"
+  return 1
 }
 
 # True when <normalized-path> sits inside one of this host's temp trees.
@@ -466,19 +472,30 @@ hook::read_file_path() {
 # Resolve the repository root (working-tree top) for a path inside the tree.
 # markdownlint config auto-discovery is CWD-anchored, so the hook cd's here
 # before linting. File-anchored (`git -C "$hint" rev-parse --show-toplevel`)
-# so it is correct for clones, linked worktrees, and bare-hub clones; falls
-# back to the hint (with a trailing /.claude stripped) when git cannot resolve.
+# so it is correct for clones, linked worktrees, and bare-hub clones; when git
+# cannot resolve, still returns the hint (with a trailing /.claude stripped) so
+# advisory callers keep today's fallback — but the answer is now
+# DISTINGUISHABLE: return 1 and HOOK_REPO_ROOT_UNRESOLVED=1. Success (return 0)
+# means git answered; advisory callers that ignore the status are unchanged.
+# Guards that must fail closed branch on the return code or on
+# HOOK_REPO_ROOT_UNRESOLVED.
 #   ROOT=$(hook::repo_root "$some_path")
+# shellcheck disable=SC2034  # HOOK_REPO_ROOT_UNRESOLVED is read by sourcing hooks
 hook::repo_root() {
   local hint="${1:-.}"
   local root
+  HOOK_REPO_ROOT_UNRESOLVED=0
   root=$(git -C "$hint" rev-parse --show-toplevel 2>/dev/null | tr -d '\r')
-  if [[ -z "$root" ]]; then
-    root="$hint"
-    root="${root%/.claude}"
-    root="${root%\\.claude}"
+  if [[ -n "$root" ]]; then
+    printf '%s' "$root"
+    return 0
   fi
+  root="$hint"
+  root="${root%/.claude}"
+  root="${root%\\.claude}"
+  HOOK_REPO_ROOT_UNRESOLVED=1
   printf '%s' "$root"
+  return 1
 }
 
 # Buffer a complete JSON payload from stdin, tolerating Windows Win32-pipe
@@ -1710,9 +1727,10 @@ hook::git_alias_expansion() {
 
 # Single linear pass: read the command into a char array once (O(n)), then walk
 # it splitting top-level segments on UNQUOTED control operators and tokenizing
-# each segment into argv words honoring '…', "…", $'…', and backslash escapes
-# (including backslash-newline continuation). Each completed segment is passed
-# to the callback as it closes, so no full segment list is retained.
+# each segment into argv words honoring '…', "…", $'…', backslash escapes
+# (including backslash-newline continuation), and unquoted `#` comments to EOL
+# (quoted `#` preserved). Each completed segment is passed to the callback as it
+# closes, so no full segment list is retained.
 # Call as: hook::bash_parse_segments <command-string> <callback>; the callback
 # receives one segment's argv words as "$@".
 # shellcheck disable=SC1003  # '\' compares a literal backslash char, not a quote escape
@@ -1802,6 +1820,17 @@ hook::bash_parse_segments() {
         if ((skipnext)); then skipnext=0; else seg+=("$word"); fi
         word=""
         have=0
+      fi
+      ;;
+    '#')
+      # Unquoted `#` starts a shell comment to EOL only at a word boundary (no
+      # word currently being assembled). Mid-word `#` (`x#y`) stays literal.
+      if ((have)); then
+        word+="#"
+      else
+        while ((i + 1 < n)) && [[ "${chars[i + 1]}" != $'\n' ]]; do
+          ((i++))
+        done
       fi
       ;;
     '>' | '<')

--- a/plugins/autonomy/.claude-plugin/plugin.json
+++ b/plugins/autonomy/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "autonomy",
-  "version": "0.16.9",
+  "version": "0.16.10",
   "description": "Governed autonomous agent operation: role-topology, binding-seam, wiring-vs-advisor, telemetry, return-accounting, trigger-dispatch, per-work-class guardrail-matrix, standing-routine-catalog, and design-only runner-charter contracts for climbing the AI-adoption ladder, plus a guided-setup skill that discovers an adopting org's state, writes its schema-versioned binding, wires standards-pinned OTLP emission with a zero-cost file-artifact default, wires human-attested return capture at the task boundary, wires signal adapters with one governed dispatch entrypoint, binds the five-class guardrail matrix to an org's isolation substrates with an in-boundary live-validation probe before recording each fail-closed binding, and stands up standing-routine-catalog classes as scheduled temporal signal adapters behind the one governed queue with free scheduling defaults wired as reviewable changes and each routine's work-class mapping homed on the security surface.",
   "author": {
     "name": "Melodic Software",
@@ -25,7 +25,7 @@
     "lane_stop_gate_enabled": {
       "type": "boolean",
       "title": "lane-stop gate",
-      "description": "Opt an autonomous lane into the deterministic Stop-hook completion gate. Default OFF \u2014 a Stop-blocking hook must never engage for an interactive session. Honored from user or managed settings only (the gate reads those files itself); per-session lanes are armed by the claude-ops lane launcher instead. The env mirror is never authority (#1784).",
+      "description": "Opt an autonomous lane into the deterministic Stop-hook completion gate. Default OFF — a Stop-blocking hook must never engage for an interactive session. Honored from user or managed settings only (the gate reads those files itself); per-session lanes are armed by the claude-ops lane launcher instead. The env mirror is never authority (#1784).",
       "default": false
     },
     "lane_stop_gate_sentinel": {
@@ -43,7 +43,7 @@
     "lane_stop_gate_arm_id": {
       "type": "string",
       "title": "lane-stop gate arm id (launcher-managed)",
-      "description": "Written by the lane launcher at launch: names this session's arm record in the plugin's own data directory (hooks/lane-stop-gate-arm.sh). A capability pointer, never authority by itself \u2014 the gate validates it, honors only a record in its install-derived store, and binds it to the first presenting session. Not set by hand.",
+      "description": "Written by the lane launcher at launch: names this session's arm record in the plugin's own data directory (hooks/lane-stop-gate-arm.sh). A capability pointer, never authority by itself — the gate validates it, honors only a record in its install-derived store, and binds it to the first presenting session. Not set by hand.",
       "default": ""
     },
     "lane_notify_enabled": {
@@ -67,13 +67,13 @@
     "verification_lens_pool": {
       "type": "string",
       "title": "verification lens pool",
-      "description": "Ordered, comma-separated pool of verification lenses the model-adjudicated checker slots draw from \u2014 one distinct lens per slot, in pool order. Tokens come from the closed vocabulary in the verification-topology contract leaf; an unrecognized token is recorded as unresolved and draws no lens, and a pool shorter than a class's model-adjudicated slot count leaves the remaining slots unlensed rather than repeating a lens. The pool contributes to no count: how many checkers a class runs, how they must differ, and whether one must be cross-vendor are floors on the org's security binding, outside this setting's reach.",
+      "description": "Ordered, comma-separated pool of verification lenses the model-adjudicated checker slots draw from — one distinct lens per slot, in pool order. Tokens come from the closed vocabulary in the verification-topology contract leaf; an unrecognized token is recorded as unresolved and draws no lens, and a pool shorter than a class's model-adjudicated slot count leaves the remaining slots unlensed rather than repeating a lens. The pool contributes to no count: how many checkers a class runs, how they must differ, and whether one must be cross-vendor are floors on the org's security binding, outside this setting's reach.",
       "default": "specification,adversarial,contract,regression,evidence"
     },
     "visual_narration_enabled": {
       "type": "boolean",
       "title": "advisory visual narration lane",
-      "description": "Run the advisory visual narration lane: strictly downstream of deterministic detection, it writes a plain-language account of a difference the deterministic layer already found and attaches it to the run record for the human gate. Advisory only \u2014 it emits no verdict, fills no checker slot, is counted by no floor, and never gates a transition; no cell anywhere names it as authority. Default OFF: it is inert without an upstream deterministic comparator, and each narrated artifact is a metered vision-model call.",
+      "description": "Run the advisory visual narration lane: strictly downstream of deterministic detection, it writes a plain-language account of a difference the deterministic layer already found and attaches it to the run record for the human gate. Advisory only — it emits no verdict, fills no checker slot, is counted by no floor, and never gates a transition; no cell anywhere names it as authority. Default OFF: it is inert without an upstream deterministic comparator, and each narrated artifact is a metered vision-model call.",
       "default": false
     }
   }

--- a/plugins/autonomy/CHANGELOG.md
+++ b/plugins/autonomy/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to the `autonomy` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.16.10]
+
+### Fixed
+
+- **hook-utils:** distinguish unresolved `physical_path`/`repo_root` answers and honor unquoted `#` in `bash_parse_segments` (#1487).
+
 ## [0.16.9]
 
 ### Fixed

--- a/plugins/autonomy/hooks/hook-utils.sh
+++ b/plugins/autonomy/hooks/hook-utils.sh
@@ -480,7 +480,7 @@ hook::read_file_path() {
 # Guards that must fail closed branch on the return code or on
 # HOOK_REPO_ROOT_UNRESOLVED.
 #   ROOT=$(hook::repo_root "$some_path")
-# shellcheck disable=SC2034  # HOOK_REPO_ROOT_UNRESOLVED is read by sourcing hooks
+# shellcheck disable=SC2034  # public contract: advisory callers may read HOOK_REPO_ROOT_UNRESOLVED
 hook::repo_root() {
   local hint="${1:-.}"
   local root

--- a/plugins/autonomy/hooks/hook-utils.sh
+++ b/plugins/autonomy/hooks/hook-utils.sh
@@ -340,22 +340,28 @@ hook::expand_8dot3() {
 # spelling of an in-project path cannot dodge it (the long-form prefix would
 # never match). GNU realpath ships with Git Bash and Linux coreutils;
 # readlink -f covers the BSD/macOS hosts that have no realpath. When neither
-# resolver exists the caller falls back to comparing the lexical path as
-# before — the guard is defense-in-depth scoping for a file the agent already
-# wrote via its own tools, so degrading to the historical comparison beats
-# silently disabling the hook on those hosts. The 8.3 expansion applies only
-# on the resolver's success path: an unchanged return is the documented
-# signature of failed canonicalization, and consumers that fail closed on that
-# signature must not see a form-converted path instead.
+# resolver exists the caller still receives the lexical path unchanged — the
+# guard is defense-in-depth scoping for a file the agent already wrote via its
+# own tools, so degrading to the historical comparison beats silently disabling
+# the hook on those hosts — but the answer is now DISTINGUISHABLE: return 1 and
+# HOOK_PHYSICAL_PATH_UNRESOLVED=1. Success (return 0) means resolved; advisory
+# callers that ignore the status keep today's behavior. Guards that must fail
+# closed branch on the return code or on HOOK_PHYSICAL_PATH_UNRESOLVED. The 8.3
+# expansion applies only on the resolver's success path: consumers that fail
+# closed on an unresolved signature must not see a form-converted path instead.
+# shellcheck disable=SC2034  # public contract: advisory callers may read HOOK_PHYSICAL_PATH_UNRESOLVED
 hook::physical_path() {
   local resolved
+  HOOK_PHYSICAL_PATH_UNRESOLVED=0
   if resolved=$(realpath -- "$1" 2>/dev/null) || resolved=$(readlink -f -- "$1" 2>/dev/null); then
     if [[ -n "$resolved" ]]; then
       hook::expand_8dot3 "$resolved"
-      return
+      return 0
     fi
   fi
+  HOOK_PHYSICAL_PATH_UNRESOLVED=1
   printf '%s' "$1"
+  return 1
 }
 
 # True when <normalized-path> sits inside one of this host's temp trees.
@@ -466,19 +472,30 @@ hook::read_file_path() {
 # Resolve the repository root (working-tree top) for a path inside the tree.
 # markdownlint config auto-discovery is CWD-anchored, so the hook cd's here
 # before linting. File-anchored (`git -C "$hint" rev-parse --show-toplevel`)
-# so it is correct for clones, linked worktrees, and bare-hub clones; falls
-# back to the hint (with a trailing /.claude stripped) when git cannot resolve.
+# so it is correct for clones, linked worktrees, and bare-hub clones; when git
+# cannot resolve, still returns the hint (with a trailing /.claude stripped) so
+# advisory callers keep today's fallback — but the answer is now
+# DISTINGUISHABLE: return 1 and HOOK_REPO_ROOT_UNRESOLVED=1. Success (return 0)
+# means git answered; advisory callers that ignore the status are unchanged.
+# Guards that must fail closed branch on the return code or on
+# HOOK_REPO_ROOT_UNRESOLVED.
 #   ROOT=$(hook::repo_root "$some_path")
+# shellcheck disable=SC2034  # HOOK_REPO_ROOT_UNRESOLVED is read by sourcing hooks
 hook::repo_root() {
   local hint="${1:-.}"
   local root
+  HOOK_REPO_ROOT_UNRESOLVED=0
   root=$(git -C "$hint" rev-parse --show-toplevel 2>/dev/null | tr -d '\r')
-  if [[ -z "$root" ]]; then
-    root="$hint"
-    root="${root%/.claude}"
-    root="${root%\\.claude}"
+  if [[ -n "$root" ]]; then
+    printf '%s' "$root"
+    return 0
   fi
+  root="$hint"
+  root="${root%/.claude}"
+  root="${root%\\.claude}"
+  HOOK_REPO_ROOT_UNRESOLVED=1
   printf '%s' "$root"
+  return 1
 }
 
 # Buffer a complete JSON payload from stdin, tolerating Windows Win32-pipe
@@ -1710,9 +1727,10 @@ hook::git_alias_expansion() {
 
 # Single linear pass: read the command into a char array once (O(n)), then walk
 # it splitting top-level segments on UNQUOTED control operators and tokenizing
-# each segment into argv words honoring '…', "…", $'…', and backslash escapes
-# (including backslash-newline continuation). Each completed segment is passed
-# to the callback as it closes, so no full segment list is retained.
+# each segment into argv words honoring '…', "…", $'…', backslash escapes
+# (including backslash-newline continuation), and unquoted `#` comments to EOL
+# (quoted `#` preserved). Each completed segment is passed to the callback as it
+# closes, so no full segment list is retained.
 # Call as: hook::bash_parse_segments <command-string> <callback>; the callback
 # receives one segment's argv words as "$@".
 # shellcheck disable=SC1003  # '\' compares a literal backslash char, not a quote escape
@@ -1802,6 +1820,17 @@ hook::bash_parse_segments() {
         if ((skipnext)); then skipnext=0; else seg+=("$word"); fi
         word=""
         have=0
+      fi
+      ;;
+    '#')
+      # Unquoted `#` starts a shell comment to EOL only at a word boundary (no
+      # word currently being assembled). Mid-word `#` (`x#y`) stays literal.
+      if ((have)); then
+        word+="#"
+      else
+        while ((i + 1 < n)) && [[ "${chars[i + 1]}" != $'\n' ]]; do
+          ((i++))
+        done
       fi
       ;;
     '>' | '<')

--- a/plugins/bash-format/.claude-plugin/plugin.json
+++ b/plugins/bash-format/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "bash-format",
-  "version": "0.7.12",
+  "version": "0.7.13",
   "description": "Auto-format and lint shell scripts on edit via shfmt + ShellCheck, using the consuming repo's own .editorconfig and .shellcheckrc.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/bash-format/CHANGELOG.md
+++ b/plugins/bash-format/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to the `bash-format` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.7.13]
+
+### Fixed
+
+- **hook-utils:** distinguish unresolved `physical_path`/`repo_root` answers and honor unquoted `#` in `bash_parse_segments` (#1487).
+
 ## [0.7.12]
 
 ### Fixed

--- a/plugins/bash-format/hooks/hook-utils.sh
+++ b/plugins/bash-format/hooks/hook-utils.sh
@@ -480,7 +480,7 @@ hook::read_file_path() {
 # Guards that must fail closed branch on the return code or on
 # HOOK_REPO_ROOT_UNRESOLVED.
 #   ROOT=$(hook::repo_root "$some_path")
-# shellcheck disable=SC2034  # HOOK_REPO_ROOT_UNRESOLVED is read by sourcing hooks
+# shellcheck disable=SC2034  # public contract: advisory callers may read HOOK_REPO_ROOT_UNRESOLVED
 hook::repo_root() {
   local hint="${1:-.}"
   local root

--- a/plugins/bash-format/hooks/hook-utils.sh
+++ b/plugins/bash-format/hooks/hook-utils.sh
@@ -340,22 +340,28 @@ hook::expand_8dot3() {
 # spelling of an in-project path cannot dodge it (the long-form prefix would
 # never match). GNU realpath ships with Git Bash and Linux coreutils;
 # readlink -f covers the BSD/macOS hosts that have no realpath. When neither
-# resolver exists the caller falls back to comparing the lexical path as
-# before — the guard is defense-in-depth scoping for a file the agent already
-# wrote via its own tools, so degrading to the historical comparison beats
-# silently disabling the hook on those hosts. The 8.3 expansion applies only
-# on the resolver's success path: an unchanged return is the documented
-# signature of failed canonicalization, and consumers that fail closed on that
-# signature must not see a form-converted path instead.
+# resolver exists the caller still receives the lexical path unchanged — the
+# guard is defense-in-depth scoping for a file the agent already wrote via its
+# own tools, so degrading to the historical comparison beats silently disabling
+# the hook on those hosts — but the answer is now DISTINGUISHABLE: return 1 and
+# HOOK_PHYSICAL_PATH_UNRESOLVED=1. Success (return 0) means resolved; advisory
+# callers that ignore the status keep today's behavior. Guards that must fail
+# closed branch on the return code or on HOOK_PHYSICAL_PATH_UNRESOLVED. The 8.3
+# expansion applies only on the resolver's success path: consumers that fail
+# closed on an unresolved signature must not see a form-converted path instead.
+# shellcheck disable=SC2034  # public contract: advisory callers may read HOOK_PHYSICAL_PATH_UNRESOLVED
 hook::physical_path() {
   local resolved
+  HOOK_PHYSICAL_PATH_UNRESOLVED=0
   if resolved=$(realpath -- "$1" 2>/dev/null) || resolved=$(readlink -f -- "$1" 2>/dev/null); then
     if [[ -n "$resolved" ]]; then
       hook::expand_8dot3 "$resolved"
-      return
+      return 0
     fi
   fi
+  HOOK_PHYSICAL_PATH_UNRESOLVED=1
   printf '%s' "$1"
+  return 1
 }
 
 # True when <normalized-path> sits inside one of this host's temp trees.
@@ -466,19 +472,30 @@ hook::read_file_path() {
 # Resolve the repository root (working-tree top) for a path inside the tree.
 # markdownlint config auto-discovery is CWD-anchored, so the hook cd's here
 # before linting. File-anchored (`git -C "$hint" rev-parse --show-toplevel`)
-# so it is correct for clones, linked worktrees, and bare-hub clones; falls
-# back to the hint (with a trailing /.claude stripped) when git cannot resolve.
+# so it is correct for clones, linked worktrees, and bare-hub clones; when git
+# cannot resolve, still returns the hint (with a trailing /.claude stripped) so
+# advisory callers keep today's fallback — but the answer is now
+# DISTINGUISHABLE: return 1 and HOOK_REPO_ROOT_UNRESOLVED=1. Success (return 0)
+# means git answered; advisory callers that ignore the status are unchanged.
+# Guards that must fail closed branch on the return code or on
+# HOOK_REPO_ROOT_UNRESOLVED.
 #   ROOT=$(hook::repo_root "$some_path")
+# shellcheck disable=SC2034  # HOOK_REPO_ROOT_UNRESOLVED is read by sourcing hooks
 hook::repo_root() {
   local hint="${1:-.}"
   local root
+  HOOK_REPO_ROOT_UNRESOLVED=0
   root=$(git -C "$hint" rev-parse --show-toplevel 2>/dev/null | tr -d '\r')
-  if [[ -z "$root" ]]; then
-    root="$hint"
-    root="${root%/.claude}"
-    root="${root%\\.claude}"
+  if [[ -n "$root" ]]; then
+    printf '%s' "$root"
+    return 0
   fi
+  root="$hint"
+  root="${root%/.claude}"
+  root="${root%\\.claude}"
+  HOOK_REPO_ROOT_UNRESOLVED=1
   printf '%s' "$root"
+  return 1
 }
 
 # Buffer a complete JSON payload from stdin, tolerating Windows Win32-pipe
@@ -1710,9 +1727,10 @@ hook::git_alias_expansion() {
 
 # Single linear pass: read the command into a char array once (O(n)), then walk
 # it splitting top-level segments on UNQUOTED control operators and tokenizing
-# each segment into argv words honoring '…', "…", $'…', and backslash escapes
-# (including backslash-newline continuation). Each completed segment is passed
-# to the callback as it closes, so no full segment list is retained.
+# each segment into argv words honoring '…', "…", $'…', backslash escapes
+# (including backslash-newline continuation), and unquoted `#` comments to EOL
+# (quoted `#` preserved). Each completed segment is passed to the callback as it
+# closes, so no full segment list is retained.
 # Call as: hook::bash_parse_segments <command-string> <callback>; the callback
 # receives one segment's argv words as "$@".
 # shellcheck disable=SC1003  # '\' compares a literal backslash char, not a quote escape
@@ -1802,6 +1820,17 @@ hook::bash_parse_segments() {
         if ((skipnext)); then skipnext=0; else seg+=("$word"); fi
         word=""
         have=0
+      fi
+      ;;
+    '#')
+      # Unquoted `#` starts a shell comment to EOL only at a word boundary (no
+      # word currently being assembled). Mid-word `#` (`x#y`) stays literal.
+      if ((have)); then
+        word+="#"
+      else
+        while ((i + 1 < n)) && [[ "${chars[i + 1]}" != $'\n' ]]; do
+          ((i++))
+        done
       fi
       ;;
     '>' | '<')

--- a/plugins/biome-format/.claude-plugin/plugin.json
+++ b/plugins/biome-format/.claude-plugin/plugin.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "biome-format",
-  "version": "0.6.11",
-  "description": "Auto-format and lint JS/TS/JSX/JSON on edit via Biome, only when a biome.json governs the repo \u2014 using the consuming repo's own Biome config.",
+  "version": "0.6.12",
+  "description": "Auto-format and lint JS/TS/JSX/JSON on edit via Biome, only when a biome.json governs the repo — using the consuming repo's own Biome config.",
   "author": {
     "name": "Melodic Software",
     "email": "info@melodicsoftware.com"

--- a/plugins/biome-format/CHANGELOG.md
+++ b/plugins/biome-format/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to the `biome-format` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.6.12]
+
+### Fixed
+
+- **hook-utils:** distinguish unresolved `physical_path`/`repo_root` answers and honor unquoted `#` in `bash_parse_segments` (#1487).
+
 ## [0.6.11]
 
 ### Fixed

--- a/plugins/biome-format/hooks/hook-utils.sh
+++ b/plugins/biome-format/hooks/hook-utils.sh
@@ -480,7 +480,7 @@ hook::read_file_path() {
 # Guards that must fail closed branch on the return code or on
 # HOOK_REPO_ROOT_UNRESOLVED.
 #   ROOT=$(hook::repo_root "$some_path")
-# shellcheck disable=SC2034  # HOOK_REPO_ROOT_UNRESOLVED is read by sourcing hooks
+# shellcheck disable=SC2034  # public contract: advisory callers may read HOOK_REPO_ROOT_UNRESOLVED
 hook::repo_root() {
   local hint="${1:-.}"
   local root

--- a/plugins/biome-format/hooks/hook-utils.sh
+++ b/plugins/biome-format/hooks/hook-utils.sh
@@ -340,22 +340,28 @@ hook::expand_8dot3() {
 # spelling of an in-project path cannot dodge it (the long-form prefix would
 # never match). GNU realpath ships with Git Bash and Linux coreutils;
 # readlink -f covers the BSD/macOS hosts that have no realpath. When neither
-# resolver exists the caller falls back to comparing the lexical path as
-# before — the guard is defense-in-depth scoping for a file the agent already
-# wrote via its own tools, so degrading to the historical comparison beats
-# silently disabling the hook on those hosts. The 8.3 expansion applies only
-# on the resolver's success path: an unchanged return is the documented
-# signature of failed canonicalization, and consumers that fail closed on that
-# signature must not see a form-converted path instead.
+# resolver exists the caller still receives the lexical path unchanged — the
+# guard is defense-in-depth scoping for a file the agent already wrote via its
+# own tools, so degrading to the historical comparison beats silently disabling
+# the hook on those hosts — but the answer is now DISTINGUISHABLE: return 1 and
+# HOOK_PHYSICAL_PATH_UNRESOLVED=1. Success (return 0) means resolved; advisory
+# callers that ignore the status keep today's behavior. Guards that must fail
+# closed branch on the return code or on HOOK_PHYSICAL_PATH_UNRESOLVED. The 8.3
+# expansion applies only on the resolver's success path: consumers that fail
+# closed on an unresolved signature must not see a form-converted path instead.
+# shellcheck disable=SC2034  # public contract: advisory callers may read HOOK_PHYSICAL_PATH_UNRESOLVED
 hook::physical_path() {
   local resolved
+  HOOK_PHYSICAL_PATH_UNRESOLVED=0
   if resolved=$(realpath -- "$1" 2>/dev/null) || resolved=$(readlink -f -- "$1" 2>/dev/null); then
     if [[ -n "$resolved" ]]; then
       hook::expand_8dot3 "$resolved"
-      return
+      return 0
     fi
   fi
+  HOOK_PHYSICAL_PATH_UNRESOLVED=1
   printf '%s' "$1"
+  return 1
 }
 
 # True when <normalized-path> sits inside one of this host's temp trees.
@@ -466,19 +472,30 @@ hook::read_file_path() {
 # Resolve the repository root (working-tree top) for a path inside the tree.
 # markdownlint config auto-discovery is CWD-anchored, so the hook cd's here
 # before linting. File-anchored (`git -C "$hint" rev-parse --show-toplevel`)
-# so it is correct for clones, linked worktrees, and bare-hub clones; falls
-# back to the hint (with a trailing /.claude stripped) when git cannot resolve.
+# so it is correct for clones, linked worktrees, and bare-hub clones; when git
+# cannot resolve, still returns the hint (with a trailing /.claude stripped) so
+# advisory callers keep today's fallback — but the answer is now
+# DISTINGUISHABLE: return 1 and HOOK_REPO_ROOT_UNRESOLVED=1. Success (return 0)
+# means git answered; advisory callers that ignore the status are unchanged.
+# Guards that must fail closed branch on the return code or on
+# HOOK_REPO_ROOT_UNRESOLVED.
 #   ROOT=$(hook::repo_root "$some_path")
+# shellcheck disable=SC2034  # HOOK_REPO_ROOT_UNRESOLVED is read by sourcing hooks
 hook::repo_root() {
   local hint="${1:-.}"
   local root
+  HOOK_REPO_ROOT_UNRESOLVED=0
   root=$(git -C "$hint" rev-parse --show-toplevel 2>/dev/null | tr -d '\r')
-  if [[ -z "$root" ]]; then
-    root="$hint"
-    root="${root%/.claude}"
-    root="${root%\\.claude}"
+  if [[ -n "$root" ]]; then
+    printf '%s' "$root"
+    return 0
   fi
+  root="$hint"
+  root="${root%/.claude}"
+  root="${root%\\.claude}"
+  HOOK_REPO_ROOT_UNRESOLVED=1
   printf '%s' "$root"
+  return 1
 }
 
 # Buffer a complete JSON payload from stdin, tolerating Windows Win32-pipe
@@ -1710,9 +1727,10 @@ hook::git_alias_expansion() {
 
 # Single linear pass: read the command into a char array once (O(n)), then walk
 # it splitting top-level segments on UNQUOTED control operators and tokenizing
-# each segment into argv words honoring '…', "…", $'…', and backslash escapes
-# (including backslash-newline continuation). Each completed segment is passed
-# to the callback as it closes, so no full segment list is retained.
+# each segment into argv words honoring '…', "…", $'…', backslash escapes
+# (including backslash-newline continuation), and unquoted `#` comments to EOL
+# (quoted `#` preserved). Each completed segment is passed to the callback as it
+# closes, so no full segment list is retained.
 # Call as: hook::bash_parse_segments <command-string> <callback>; the callback
 # receives one segment's argv words as "$@".
 # shellcheck disable=SC1003  # '\' compares a literal backslash char, not a quote escape
@@ -1802,6 +1820,17 @@ hook::bash_parse_segments() {
         if ((skipnext)); then skipnext=0; else seg+=("$word"); fi
         word=""
         have=0
+      fi
+      ;;
+    '#')
+      # Unquoted `#` starts a shell comment to EOL only at a word boundary (no
+      # word currently being assembled). Mid-word `#` (`x#y`) stays literal.
+      if ((have)); then
+        word+="#"
+      else
+        while ((i + 1 < n)) && [[ "${chars[i + 1]}" != $'\n' ]]; do
+          ((i++))
+        done
       fi
       ;;
     '>' | '<')

--- a/plugins/claude-ops/.claude-plugin/plugin.json
+++ b/plugins/claude-ops/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "claude-ops",
-  "version": "0.31.12",
+  "version": "0.31.13",
   "description": "Claude Code operations toolkit. Ten skills: inventory (read-only enumeration of the complete invocable surface \u2014 every built-in CLI command with aliases and hidden/gated status, every bundled skill, and every component of every installed plugin across all marketplaces; reads the shipped binary because upstream publishes no built-in command list, and carries an integrity verdict so a drifted build reports counts as floors rather than silently short totals), audit-install-state (read-only audit of the machine-scope ~/.claude installation directory and ~/.claude.json \u2014 full inventory split into an authored surface and rolled-up bulk trees, product-managed retention vs genuinely unmanaged state, filename-scheme resolution before any process-liveness check, and deliberate/mid-experiment detection; reports, never deletes), audit-performance (read-only slowness-diagnostic capture run at the moment the machine or a session feels slow \u2014 CLI version, retention-sweep health including the silent unparsable-settings pause, a timed census walk of the install tree as a sweep-cost proxy, active-session and plugin-fleet counts, a process census, and a bundled known-performance-issues reference; separates the three documented suspects \u2014 accumulated state, version regression, component bloat \u2014 and routes remediation out; reports, never mutates), observability (read locally captured telemetry \u2014 OTEL store, collector, hook-event JSONL, ccusage \u2014 with trend reports and store pruning), known-issues (search known Claude product GitHub bugs, check service health, maintain a persistent tracked-issue registry), changelog (ingest Claude Code changelog entries and integrate them into the current repo), plugins (bring a machine's plugin fleet current on demand \u2014 marketplace refresh, effective-scope updates including in-repo project/local installs, new-plugin install per policy, scope-divergence detection and explicit convergence), morning-brief (read-only gh-based operator morning view \u2014 queue-label counts, merge-ready PRs, parked decisions with their RECOMMENDED lines, and loop-lane telemetry freshness), lanes (start/restart/stop/status loop lanes as named background Claude Code sessions seeded from canonical prompt files, with per-lane model/effort, a repo-pull + marketplace-refresh launch step, and a consume-restarts action \u2014 an OS-schedulable reader that relaunches stopped lanes whose telemetry carries a restart_request), and a re-runnable setup action that settles where the known-issues registry lives. Plus a family of seven advisory *-audit telemetry-emitter hooks (API errors, config changes, instruction loads, permission denials, pre-compaction, skill usage, tool failures) that emit the shared hook-telemetry envelope, and a reference sink that maps envelopes into the hook-events.jsonl the observability skill reads.",
   "author": {
     "name": "Melodic Software",
@@ -39,7 +39,7 @@
     "skill_usage_scope": {
       "type": "string",
       "title": "Skill-usage log scope",
-      "description": "Where the skill-usage store lives. Valid values: \"repo\" (default \u2014 project tree under the repo root, kept out of git status via a machine-local .git/info/exclude entry), \"user\" (the skill_usage_dir subpath under $HOME, one cross-repo store; rows carry a project field), \"data-dir\" (${CLAUDE_PLUGIN_DATA}/skill-usage/<repo-slug>, plugin-owned and update-safe). The manifest schema has no enum type, so this validates in prose; any other value is treated as \"repo\" with a one-time advisory.",
+      "description": "Where the skill-usage store lives. Valid values: \"repo\" (default — project tree under the repo root, kept out of git status via a machine-local .git/info/exclude entry), \"user\" (the skill_usage_dir subpath under $HOME, one cross-repo store; rows carry a project field), \"data-dir\" (${CLAUDE_PLUGIN_DATA}/skill-usage/<repo-slug>, plugin-owned and update-safe). The manifest schema has no enum type, so this validates in prose; any other value is treated as \"repo\" with a one-time advisory.",
       "default": "repo"
     },
     "skill_usage_git_exclude": {
@@ -51,7 +51,7 @@
     "install_new": {
       "type": "string",
       "title": "New-plugin install policy for the plugins skill's sync action",
-      "description": "Controls what `sync` does with catalog plugins that aren't installed yet. Valid values: \"ask\" (default \u2014 offer them in one batched multi-select prompt), \"all\" (install every one automatically), \"none\" (report only, never install). The manifest schema has no enum type, so this validates in prose, not JSON Schema; any other value is treated as \"ask\".",
+      "description": "Controls what `sync` does with catalog plugins that aren't installed yet. Valid values: \"ask\" (default — offer them in one batched multi-select prompt), \"all\" (install every one automatically), \"none\" (report only, never install). The manifest schema has no enum type, so this validates in prose, not JSON Schema; any other value is treated as \"ask\".",
       "default": "ask"
     },
     "api_error_audit_enabled": {
@@ -105,7 +105,7 @@
     "stdin_read_timeout": {
       "type": "number",
       "title": "Hook stdin read timeout (seconds)",
-      "description": "Idle bound on reading the hook payload from stdin \u2014 how long the pipe may go silent before the hook gives up and fails open",
+      "description": "Idle bound on reading the hook payload from stdin — how long the pipe may go silent before the hook gives up and fails open",
       "default": 2,
       "min": 1
     }

--- a/plugins/claude-ops/CHANGELOG.md
+++ b/plugins/claude-ops/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to the `claude-ops` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.31.13]
+
+### Fixed
+
+- **hook-utils:** distinguish unresolved `physical_path`/`repo_root` answers and honor unquoted `#` in `bash_parse_segments` (#1487).
+
 ## [0.31.12]
 
 ### Fixed

--- a/plugins/claude-ops/hooks/hook-utils.sh
+++ b/plugins/claude-ops/hooks/hook-utils.sh
@@ -480,7 +480,7 @@ hook::read_file_path() {
 # Guards that must fail closed branch on the return code or on
 # HOOK_REPO_ROOT_UNRESOLVED.
 #   ROOT=$(hook::repo_root "$some_path")
-# shellcheck disable=SC2034  # HOOK_REPO_ROOT_UNRESOLVED is read by sourcing hooks
+# shellcheck disable=SC2034  # public contract: advisory callers may read HOOK_REPO_ROOT_UNRESOLVED
 hook::repo_root() {
   local hint="${1:-.}"
   local root

--- a/plugins/claude-ops/hooks/hook-utils.sh
+++ b/plugins/claude-ops/hooks/hook-utils.sh
@@ -340,22 +340,28 @@ hook::expand_8dot3() {
 # spelling of an in-project path cannot dodge it (the long-form prefix would
 # never match). GNU realpath ships with Git Bash and Linux coreutils;
 # readlink -f covers the BSD/macOS hosts that have no realpath. When neither
-# resolver exists the caller falls back to comparing the lexical path as
-# before — the guard is defense-in-depth scoping for a file the agent already
-# wrote via its own tools, so degrading to the historical comparison beats
-# silently disabling the hook on those hosts. The 8.3 expansion applies only
-# on the resolver's success path: an unchanged return is the documented
-# signature of failed canonicalization, and consumers that fail closed on that
-# signature must not see a form-converted path instead.
+# resolver exists the caller still receives the lexical path unchanged — the
+# guard is defense-in-depth scoping for a file the agent already wrote via its
+# own tools, so degrading to the historical comparison beats silently disabling
+# the hook on those hosts — but the answer is now DISTINGUISHABLE: return 1 and
+# HOOK_PHYSICAL_PATH_UNRESOLVED=1. Success (return 0) means resolved; advisory
+# callers that ignore the status keep today's behavior. Guards that must fail
+# closed branch on the return code or on HOOK_PHYSICAL_PATH_UNRESOLVED. The 8.3
+# expansion applies only on the resolver's success path: consumers that fail
+# closed on an unresolved signature must not see a form-converted path instead.
+# shellcheck disable=SC2034  # public contract: advisory callers may read HOOK_PHYSICAL_PATH_UNRESOLVED
 hook::physical_path() {
   local resolved
+  HOOK_PHYSICAL_PATH_UNRESOLVED=0
   if resolved=$(realpath -- "$1" 2>/dev/null) || resolved=$(readlink -f -- "$1" 2>/dev/null); then
     if [[ -n "$resolved" ]]; then
       hook::expand_8dot3 "$resolved"
-      return
+      return 0
     fi
   fi
+  HOOK_PHYSICAL_PATH_UNRESOLVED=1
   printf '%s' "$1"
+  return 1
 }
 
 # True when <normalized-path> sits inside one of this host's temp trees.
@@ -466,19 +472,30 @@ hook::read_file_path() {
 # Resolve the repository root (working-tree top) for a path inside the tree.
 # markdownlint config auto-discovery is CWD-anchored, so the hook cd's here
 # before linting. File-anchored (`git -C "$hint" rev-parse --show-toplevel`)
-# so it is correct for clones, linked worktrees, and bare-hub clones; falls
-# back to the hint (with a trailing /.claude stripped) when git cannot resolve.
+# so it is correct for clones, linked worktrees, and bare-hub clones; when git
+# cannot resolve, still returns the hint (with a trailing /.claude stripped) so
+# advisory callers keep today's fallback — but the answer is now
+# DISTINGUISHABLE: return 1 and HOOK_REPO_ROOT_UNRESOLVED=1. Success (return 0)
+# means git answered; advisory callers that ignore the status are unchanged.
+# Guards that must fail closed branch on the return code or on
+# HOOK_REPO_ROOT_UNRESOLVED.
 #   ROOT=$(hook::repo_root "$some_path")
+# shellcheck disable=SC2034  # HOOK_REPO_ROOT_UNRESOLVED is read by sourcing hooks
 hook::repo_root() {
   local hint="${1:-.}"
   local root
+  HOOK_REPO_ROOT_UNRESOLVED=0
   root=$(git -C "$hint" rev-parse --show-toplevel 2>/dev/null | tr -d '\r')
-  if [[ -z "$root" ]]; then
-    root="$hint"
-    root="${root%/.claude}"
-    root="${root%\\.claude}"
+  if [[ -n "$root" ]]; then
+    printf '%s' "$root"
+    return 0
   fi
+  root="$hint"
+  root="${root%/.claude}"
+  root="${root%\\.claude}"
+  HOOK_REPO_ROOT_UNRESOLVED=1
   printf '%s' "$root"
+  return 1
 }
 
 # Buffer a complete JSON payload from stdin, tolerating Windows Win32-pipe
@@ -1710,9 +1727,10 @@ hook::git_alias_expansion() {
 
 # Single linear pass: read the command into a char array once (O(n)), then walk
 # it splitting top-level segments on UNQUOTED control operators and tokenizing
-# each segment into argv words honoring '…', "…", $'…', and backslash escapes
-# (including backslash-newline continuation). Each completed segment is passed
-# to the callback as it closes, so no full segment list is retained.
+# each segment into argv words honoring '…', "…", $'…', backslash escapes
+# (including backslash-newline continuation), and unquoted `#` comments to EOL
+# (quoted `#` preserved). Each completed segment is passed to the callback as it
+# closes, so no full segment list is retained.
 # Call as: hook::bash_parse_segments <command-string> <callback>; the callback
 # receives one segment's argv words as "$@".
 # shellcheck disable=SC1003  # '\' compares a literal backslash char, not a quote escape
@@ -1802,6 +1820,17 @@ hook::bash_parse_segments() {
         if ((skipnext)); then skipnext=0; else seg+=("$word"); fi
         word=""
         have=0
+      fi
+      ;;
+    '#')
+      # Unquoted `#` starts a shell comment to EOL only at a word boundary (no
+      # word currently being assembled). Mid-word `#` (`x#y`) stays literal.
+      if ((have)); then
+        word+="#"
+      else
+        while ((i + 1 < n)) && [[ "${chars[i + 1]}" != $'\n' ]]; do
+          ((i++))
+        done
       fi
       ;;
     '>' | '<')

--- a/plugins/context-guard/.claude-plugin/plugin.json
+++ b/plugins/context-guard/.claude-plugin/plugin.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "context-guard",
-  "version": "0.7.9",
-  "description": "Per-session context-window observability plus the first shipped consumer: a statusline wrapper tees each session's context_window fields to a per-session snapshot file, a zone resolver classifies usage into smart/acceptable/dumb bands (percentage bands plus window-class token bands, conservative-min combination, zones.json SSOT with shipped defaults), a reader contract fixes how consuming sessions interpret the snapshots, and zone-crossing hooks report once per transition into a worse zone across two channels \u2014 the continuation menu to the operator, who owns that choice, and to the model only the zone determination plus the counter-steer that a zone word is not a decay signal (advisory by default; an optional blocking mode gates new mutating work on a fresh dumb-zone snapshot with handoff-writing exempt), with a PostCompact hook persisting an evidence-degraded marker.",
+  "version": "0.7.10",
+  "description": "Per-session context-window observability plus the first shipped consumer: a statusline wrapper tees each session's context_window fields to a per-session snapshot file, a zone resolver classifies usage into smart/acceptable/dumb bands (percentage bands plus window-class token bands, conservative-min combination, zones.json SSOT with shipped defaults), a reader contract fixes how consuming sessions interpret the snapshots, and zone-crossing hooks report once per transition into a worse zone across two channels — the continuation menu to the operator, who owns that choice, and to the model only the zone determination plus the counter-steer that a zone word is not a decay signal (advisory by default; an optional blocking mode gates new mutating work on a fresh dumb-zone snapshot with handoff-writing exempt), with a PostCompact hook persisting an evidence-degraded marker.",
   "author": {
     "name": "Melodic Software",
     "email": "info@melodicsoftware.com"

--- a/plugins/context-guard/CHANGELOG.md
+++ b/plugins/context-guard/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the `context-guard` plugin.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.10]
+
+### Fixed
+
+- **hook-utils:** distinguish unresolved `physical_path`/`repo_root` answers and honor unquoted `#` in `bash_parse_segments` (#1487).
+
 ## [0.7.9]
 
 ### Fixed

--- a/plugins/context-guard/hooks/hook-utils.sh
+++ b/plugins/context-guard/hooks/hook-utils.sh
@@ -480,7 +480,7 @@ hook::read_file_path() {
 # Guards that must fail closed branch on the return code or on
 # HOOK_REPO_ROOT_UNRESOLVED.
 #   ROOT=$(hook::repo_root "$some_path")
-# shellcheck disable=SC2034  # HOOK_REPO_ROOT_UNRESOLVED is read by sourcing hooks
+# shellcheck disable=SC2034  # public contract: advisory callers may read HOOK_REPO_ROOT_UNRESOLVED
 hook::repo_root() {
   local hint="${1:-.}"
   local root

--- a/plugins/context-guard/hooks/hook-utils.sh
+++ b/plugins/context-guard/hooks/hook-utils.sh
@@ -340,22 +340,28 @@ hook::expand_8dot3() {
 # spelling of an in-project path cannot dodge it (the long-form prefix would
 # never match). GNU realpath ships with Git Bash and Linux coreutils;
 # readlink -f covers the BSD/macOS hosts that have no realpath. When neither
-# resolver exists the caller falls back to comparing the lexical path as
-# before — the guard is defense-in-depth scoping for a file the agent already
-# wrote via its own tools, so degrading to the historical comparison beats
-# silently disabling the hook on those hosts. The 8.3 expansion applies only
-# on the resolver's success path: an unchanged return is the documented
-# signature of failed canonicalization, and consumers that fail closed on that
-# signature must not see a form-converted path instead.
+# resolver exists the caller still receives the lexical path unchanged — the
+# guard is defense-in-depth scoping for a file the agent already wrote via its
+# own tools, so degrading to the historical comparison beats silently disabling
+# the hook on those hosts — but the answer is now DISTINGUISHABLE: return 1 and
+# HOOK_PHYSICAL_PATH_UNRESOLVED=1. Success (return 0) means resolved; advisory
+# callers that ignore the status keep today's behavior. Guards that must fail
+# closed branch on the return code or on HOOK_PHYSICAL_PATH_UNRESOLVED. The 8.3
+# expansion applies only on the resolver's success path: consumers that fail
+# closed on an unresolved signature must not see a form-converted path instead.
+# shellcheck disable=SC2034  # public contract: advisory callers may read HOOK_PHYSICAL_PATH_UNRESOLVED
 hook::physical_path() {
   local resolved
+  HOOK_PHYSICAL_PATH_UNRESOLVED=0
   if resolved=$(realpath -- "$1" 2>/dev/null) || resolved=$(readlink -f -- "$1" 2>/dev/null); then
     if [[ -n "$resolved" ]]; then
       hook::expand_8dot3 "$resolved"
-      return
+      return 0
     fi
   fi
+  HOOK_PHYSICAL_PATH_UNRESOLVED=1
   printf '%s' "$1"
+  return 1
 }
 
 # True when <normalized-path> sits inside one of this host's temp trees.
@@ -466,19 +472,30 @@ hook::read_file_path() {
 # Resolve the repository root (working-tree top) for a path inside the tree.
 # markdownlint config auto-discovery is CWD-anchored, so the hook cd's here
 # before linting. File-anchored (`git -C "$hint" rev-parse --show-toplevel`)
-# so it is correct for clones, linked worktrees, and bare-hub clones; falls
-# back to the hint (with a trailing /.claude stripped) when git cannot resolve.
+# so it is correct for clones, linked worktrees, and bare-hub clones; when git
+# cannot resolve, still returns the hint (with a trailing /.claude stripped) so
+# advisory callers keep today's fallback — but the answer is now
+# DISTINGUISHABLE: return 1 and HOOK_REPO_ROOT_UNRESOLVED=1. Success (return 0)
+# means git answered; advisory callers that ignore the status are unchanged.
+# Guards that must fail closed branch on the return code or on
+# HOOK_REPO_ROOT_UNRESOLVED.
 #   ROOT=$(hook::repo_root "$some_path")
+# shellcheck disable=SC2034  # HOOK_REPO_ROOT_UNRESOLVED is read by sourcing hooks
 hook::repo_root() {
   local hint="${1:-.}"
   local root
+  HOOK_REPO_ROOT_UNRESOLVED=0
   root=$(git -C "$hint" rev-parse --show-toplevel 2>/dev/null | tr -d '\r')
-  if [[ -z "$root" ]]; then
-    root="$hint"
-    root="${root%/.claude}"
-    root="${root%\\.claude}"
+  if [[ -n "$root" ]]; then
+    printf '%s' "$root"
+    return 0
   fi
+  root="$hint"
+  root="${root%/.claude}"
+  root="${root%\\.claude}"
+  HOOK_REPO_ROOT_UNRESOLVED=1
   printf '%s' "$root"
+  return 1
 }
 
 # Buffer a complete JSON payload from stdin, tolerating Windows Win32-pipe
@@ -1710,9 +1727,10 @@ hook::git_alias_expansion() {
 
 # Single linear pass: read the command into a char array once (O(n)), then walk
 # it splitting top-level segments on UNQUOTED control operators and tokenizing
-# each segment into argv words honoring '…', "…", $'…', and backslash escapes
-# (including backslash-newline continuation). Each completed segment is passed
-# to the callback as it closes, so no full segment list is retained.
+# each segment into argv words honoring '…', "…", $'…', backslash escapes
+# (including backslash-newline continuation), and unquoted `#` comments to EOL
+# (quoted `#` preserved). Each completed segment is passed to the callback as it
+# closes, so no full segment list is retained.
 # Call as: hook::bash_parse_segments <command-string> <callback>; the callback
 # receives one segment's argv words as "$@".
 # shellcheck disable=SC1003  # '\' compares a literal backslash char, not a quote escape
@@ -1802,6 +1820,17 @@ hook::bash_parse_segments() {
         if ((skipnext)); then skipnext=0; else seg+=("$word"); fi
         word=""
         have=0
+      fi
+      ;;
+    '#')
+      # Unquoted `#` starts a shell comment to EOL only at a word boundary (no
+      # word currently being assembled). Mid-word `#` (`x#y`) stays literal.
+      if ((have)); then
+        word+="#"
+      else
+        while ((i + 1 < n)) && [[ "${chars[i + 1]}" != $'\n' ]]; do
+          ((i++))
+        done
       fi
       ;;
     '>' | '<')

--- a/plugins/desktop-notification/.claude-plugin/plugin.json
+++ b/plugins/desktop-notification/.claude-plugin/plugin.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "desktop-notification",
-  "version": "0.6.11",
-  "description": "Alert you when Claude Code needs input \u2014 an audible terminal bell, an OSC 9 terminal notification, and an OS-native toast (macOS/Linux) on permission and idle prompts.",
+  "version": "0.6.12",
+  "description": "Alert you when Claude Code needs input — an audible terminal bell, an OSC 9 terminal notification, and an OS-native toast (macOS/Linux) on permission and idle prompts.",
   "author": {
     "name": "Melodic Software",
     "email": "info@melodicsoftware.com"

--- a/plugins/desktop-notification/CHANGELOG.md
+++ b/plugins/desktop-notification/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to the `desktop-notification` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.6.12]
+
+### Fixed
+
+- **hook-utils:** distinguish unresolved `physical_path`/`repo_root` answers and honor unquoted `#` in `bash_parse_segments` (#1487).
+
 ## [0.6.11]
 
 ### Fixed

--- a/plugins/desktop-notification/hooks/hook-utils.sh
+++ b/plugins/desktop-notification/hooks/hook-utils.sh
@@ -480,7 +480,7 @@ hook::read_file_path() {
 # Guards that must fail closed branch on the return code or on
 # HOOK_REPO_ROOT_UNRESOLVED.
 #   ROOT=$(hook::repo_root "$some_path")
-# shellcheck disable=SC2034  # HOOK_REPO_ROOT_UNRESOLVED is read by sourcing hooks
+# shellcheck disable=SC2034  # public contract: advisory callers may read HOOK_REPO_ROOT_UNRESOLVED
 hook::repo_root() {
   local hint="${1:-.}"
   local root

--- a/plugins/desktop-notification/hooks/hook-utils.sh
+++ b/plugins/desktop-notification/hooks/hook-utils.sh
@@ -340,22 +340,28 @@ hook::expand_8dot3() {
 # spelling of an in-project path cannot dodge it (the long-form prefix would
 # never match). GNU realpath ships with Git Bash and Linux coreutils;
 # readlink -f covers the BSD/macOS hosts that have no realpath. When neither
-# resolver exists the caller falls back to comparing the lexical path as
-# before — the guard is defense-in-depth scoping for a file the agent already
-# wrote via its own tools, so degrading to the historical comparison beats
-# silently disabling the hook on those hosts. The 8.3 expansion applies only
-# on the resolver's success path: an unchanged return is the documented
-# signature of failed canonicalization, and consumers that fail closed on that
-# signature must not see a form-converted path instead.
+# resolver exists the caller still receives the lexical path unchanged — the
+# guard is defense-in-depth scoping for a file the agent already wrote via its
+# own tools, so degrading to the historical comparison beats silently disabling
+# the hook on those hosts — but the answer is now DISTINGUISHABLE: return 1 and
+# HOOK_PHYSICAL_PATH_UNRESOLVED=1. Success (return 0) means resolved; advisory
+# callers that ignore the status keep today's behavior. Guards that must fail
+# closed branch on the return code or on HOOK_PHYSICAL_PATH_UNRESOLVED. The 8.3
+# expansion applies only on the resolver's success path: consumers that fail
+# closed on an unresolved signature must not see a form-converted path instead.
+# shellcheck disable=SC2034  # public contract: advisory callers may read HOOK_PHYSICAL_PATH_UNRESOLVED
 hook::physical_path() {
   local resolved
+  HOOK_PHYSICAL_PATH_UNRESOLVED=0
   if resolved=$(realpath -- "$1" 2>/dev/null) || resolved=$(readlink -f -- "$1" 2>/dev/null); then
     if [[ -n "$resolved" ]]; then
       hook::expand_8dot3 "$resolved"
-      return
+      return 0
     fi
   fi
+  HOOK_PHYSICAL_PATH_UNRESOLVED=1
   printf '%s' "$1"
+  return 1
 }
 
 # True when <normalized-path> sits inside one of this host's temp trees.
@@ -466,19 +472,30 @@ hook::read_file_path() {
 # Resolve the repository root (working-tree top) for a path inside the tree.
 # markdownlint config auto-discovery is CWD-anchored, so the hook cd's here
 # before linting. File-anchored (`git -C "$hint" rev-parse --show-toplevel`)
-# so it is correct for clones, linked worktrees, and bare-hub clones; falls
-# back to the hint (with a trailing /.claude stripped) when git cannot resolve.
+# so it is correct for clones, linked worktrees, and bare-hub clones; when git
+# cannot resolve, still returns the hint (with a trailing /.claude stripped) so
+# advisory callers keep today's fallback — but the answer is now
+# DISTINGUISHABLE: return 1 and HOOK_REPO_ROOT_UNRESOLVED=1. Success (return 0)
+# means git answered; advisory callers that ignore the status are unchanged.
+# Guards that must fail closed branch on the return code or on
+# HOOK_REPO_ROOT_UNRESOLVED.
 #   ROOT=$(hook::repo_root "$some_path")
+# shellcheck disable=SC2034  # HOOK_REPO_ROOT_UNRESOLVED is read by sourcing hooks
 hook::repo_root() {
   local hint="${1:-.}"
   local root
+  HOOK_REPO_ROOT_UNRESOLVED=0
   root=$(git -C "$hint" rev-parse --show-toplevel 2>/dev/null | tr -d '\r')
-  if [[ -z "$root" ]]; then
-    root="$hint"
-    root="${root%/.claude}"
-    root="${root%\\.claude}"
+  if [[ -n "$root" ]]; then
+    printf '%s' "$root"
+    return 0
   fi
+  root="$hint"
+  root="${root%/.claude}"
+  root="${root%\\.claude}"
+  HOOK_REPO_ROOT_UNRESOLVED=1
   printf '%s' "$root"
+  return 1
 }
 
 # Buffer a complete JSON payload from stdin, tolerating Windows Win32-pipe
@@ -1710,9 +1727,10 @@ hook::git_alias_expansion() {
 
 # Single linear pass: read the command into a char array once (O(n)), then walk
 # it splitting top-level segments on UNQUOTED control operators and tokenizing
-# each segment into argv words honoring '…', "…", $'…', and backslash escapes
-# (including backslash-newline continuation). Each completed segment is passed
-# to the callback as it closes, so no full segment list is retained.
+# each segment into argv words honoring '…', "…", $'…', backslash escapes
+# (including backslash-newline continuation), and unquoted `#` comments to EOL
+# (quoted `#` preserved). Each completed segment is passed to the callback as it
+# closes, so no full segment list is retained.
 # Call as: hook::bash_parse_segments <command-string> <callback>; the callback
 # receives one segment's argv words as "$@".
 # shellcheck disable=SC1003  # '\' compares a literal backslash char, not a quote escape
@@ -1802,6 +1820,17 @@ hook::bash_parse_segments() {
         if ((skipnext)); then skipnext=0; else seg+=("$word"); fi
         word=""
         have=0
+      fi
+      ;;
+    '#')
+      # Unquoted `#` starts a shell comment to EOL only at a word boundary (no
+      # word currently being assembled). Mid-word `#` (`x#y`) stays literal.
+      if ((have)); then
+        word+="#"
+      else
+        while ((i + 1 < n)) && [[ "${chars[i + 1]}" != $'\n' ]]; do
+          ((i++))
+        done
       fi
       ;;
     '>' | '<')

--- a/plugins/eol-normalizer/.claude-plugin/plugin.json
+++ b/plugins/eol-normalizer/.claude-plugin/plugin.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "eol-normalizer",
-  "version": "0.6.12",
-  "description": "Normalize a written file's working-tree line endings to its .gitattributes eol value on edit \u2014 symmetric CRLF/LF driven by git check-attr, advisory and never blocking.",
+  "version": "0.6.13",
+  "description": "Normalize a written file's working-tree line endings to its .gitattributes eol value on edit — symmetric CRLF/LF driven by git check-attr, advisory and never blocking.",
   "author": {
     "name": "Melodic Software",
     "email": "info@melodicsoftware.com"

--- a/plugins/eol-normalizer/CHANGELOG.md
+++ b/plugins/eol-normalizer/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to the `eol-normalizer` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.6.13]
+
+### Fixed
+
+- **hook-utils:** distinguish unresolved `physical_path`/`repo_root` answers and honor unquoted `#` in `bash_parse_segments` (#1487).
+
 ## [0.6.12]
 
 ### Fixed

--- a/plugins/eol-normalizer/hooks/hook-utils.sh
+++ b/plugins/eol-normalizer/hooks/hook-utils.sh
@@ -480,7 +480,7 @@ hook::read_file_path() {
 # Guards that must fail closed branch on the return code or on
 # HOOK_REPO_ROOT_UNRESOLVED.
 #   ROOT=$(hook::repo_root "$some_path")
-# shellcheck disable=SC2034  # HOOK_REPO_ROOT_UNRESOLVED is read by sourcing hooks
+# shellcheck disable=SC2034  # public contract: advisory callers may read HOOK_REPO_ROOT_UNRESOLVED
 hook::repo_root() {
   local hint="${1:-.}"
   local root

--- a/plugins/eol-normalizer/hooks/hook-utils.sh
+++ b/plugins/eol-normalizer/hooks/hook-utils.sh
@@ -340,22 +340,28 @@ hook::expand_8dot3() {
 # spelling of an in-project path cannot dodge it (the long-form prefix would
 # never match). GNU realpath ships with Git Bash and Linux coreutils;
 # readlink -f covers the BSD/macOS hosts that have no realpath. When neither
-# resolver exists the caller falls back to comparing the lexical path as
-# before — the guard is defense-in-depth scoping for a file the agent already
-# wrote via its own tools, so degrading to the historical comparison beats
-# silently disabling the hook on those hosts. The 8.3 expansion applies only
-# on the resolver's success path: an unchanged return is the documented
-# signature of failed canonicalization, and consumers that fail closed on that
-# signature must not see a form-converted path instead.
+# resolver exists the caller still receives the lexical path unchanged — the
+# guard is defense-in-depth scoping for a file the agent already wrote via its
+# own tools, so degrading to the historical comparison beats silently disabling
+# the hook on those hosts — but the answer is now DISTINGUISHABLE: return 1 and
+# HOOK_PHYSICAL_PATH_UNRESOLVED=1. Success (return 0) means resolved; advisory
+# callers that ignore the status keep today's behavior. Guards that must fail
+# closed branch on the return code or on HOOK_PHYSICAL_PATH_UNRESOLVED. The 8.3
+# expansion applies only on the resolver's success path: consumers that fail
+# closed on an unresolved signature must not see a form-converted path instead.
+# shellcheck disable=SC2034  # public contract: advisory callers may read HOOK_PHYSICAL_PATH_UNRESOLVED
 hook::physical_path() {
   local resolved
+  HOOK_PHYSICAL_PATH_UNRESOLVED=0
   if resolved=$(realpath -- "$1" 2>/dev/null) || resolved=$(readlink -f -- "$1" 2>/dev/null); then
     if [[ -n "$resolved" ]]; then
       hook::expand_8dot3 "$resolved"
-      return
+      return 0
     fi
   fi
+  HOOK_PHYSICAL_PATH_UNRESOLVED=1
   printf '%s' "$1"
+  return 1
 }
 
 # True when <normalized-path> sits inside one of this host's temp trees.
@@ -466,19 +472,30 @@ hook::read_file_path() {
 # Resolve the repository root (working-tree top) for a path inside the tree.
 # markdownlint config auto-discovery is CWD-anchored, so the hook cd's here
 # before linting. File-anchored (`git -C "$hint" rev-parse --show-toplevel`)
-# so it is correct for clones, linked worktrees, and bare-hub clones; falls
-# back to the hint (with a trailing /.claude stripped) when git cannot resolve.
+# so it is correct for clones, linked worktrees, and bare-hub clones; when git
+# cannot resolve, still returns the hint (with a trailing /.claude stripped) so
+# advisory callers keep today's fallback — but the answer is now
+# DISTINGUISHABLE: return 1 and HOOK_REPO_ROOT_UNRESOLVED=1. Success (return 0)
+# means git answered; advisory callers that ignore the status are unchanged.
+# Guards that must fail closed branch on the return code or on
+# HOOK_REPO_ROOT_UNRESOLVED.
 #   ROOT=$(hook::repo_root "$some_path")
+# shellcheck disable=SC2034  # HOOK_REPO_ROOT_UNRESOLVED is read by sourcing hooks
 hook::repo_root() {
   local hint="${1:-.}"
   local root
+  HOOK_REPO_ROOT_UNRESOLVED=0
   root=$(git -C "$hint" rev-parse --show-toplevel 2>/dev/null | tr -d '\r')
-  if [[ -z "$root" ]]; then
-    root="$hint"
-    root="${root%/.claude}"
-    root="${root%\\.claude}"
+  if [[ -n "$root" ]]; then
+    printf '%s' "$root"
+    return 0
   fi
+  root="$hint"
+  root="${root%/.claude}"
+  root="${root%\\.claude}"
+  HOOK_REPO_ROOT_UNRESOLVED=1
   printf '%s' "$root"
+  return 1
 }
 
 # Buffer a complete JSON payload from stdin, tolerating Windows Win32-pipe
@@ -1710,9 +1727,10 @@ hook::git_alias_expansion() {
 
 # Single linear pass: read the command into a char array once (O(n)), then walk
 # it splitting top-level segments on UNQUOTED control operators and tokenizing
-# each segment into argv words honoring '…', "…", $'…', and backslash escapes
-# (including backslash-newline continuation). Each completed segment is passed
-# to the callback as it closes, so no full segment list is retained.
+# each segment into argv words honoring '…', "…", $'…', backslash escapes
+# (including backslash-newline continuation), and unquoted `#` comments to EOL
+# (quoted `#` preserved). Each completed segment is passed to the callback as it
+# closes, so no full segment list is retained.
 # Call as: hook::bash_parse_segments <command-string> <callback>; the callback
 # receives one segment's argv words as "$@".
 # shellcheck disable=SC1003  # '\' compares a literal backslash char, not a quote escape
@@ -1802,6 +1820,17 @@ hook::bash_parse_segments() {
         if ((skipnext)); then skipnext=0; else seg+=("$word"); fi
         word=""
         have=0
+      fi
+      ;;
+    '#')
+      # Unquoted `#` starts a shell comment to EOL only at a word boundary (no
+      # word currently being assembled). Mid-word `#` (`x#y`) stays literal.
+      if ((have)); then
+        word+="#"
+      else
+        while ((i + 1 < n)) && [[ "${chars[i + 1]}" != $'\n' ]]; do
+          ((i++))
+        done
       fi
       ;;
     '>' | '<')

--- a/plugins/go-format/.claude-plugin/plugin.json
+++ b/plugins/go-format/.claude-plugin/plugin.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "go-format",
-  "version": "0.3.12",
-  "description": "Auto-fix Go formatting and import management on edit via goimports \u2014 runs unconditionally (no consumer-config gate), skipping generated files.",
+  "version": "0.3.13",
+  "description": "Auto-fix Go formatting and import management on edit via goimports — runs unconditionally (no consumer-config gate), skipping generated files.",
   "author": {
     "name": "Melodic Software",
     "email": "info@melodicsoftware.com"

--- a/plugins/go-format/CHANGELOG.md
+++ b/plugins/go-format/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to the `go-format` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.3.13]
+
+### Fixed
+
+- **hook-utils:** distinguish unresolved `physical_path`/`repo_root` answers and honor unquoted `#` in `bash_parse_segments` (#1487).
+
 ## [0.3.12]
 
 ### Fixed

--- a/plugins/go-format/hooks/hook-utils.sh
+++ b/plugins/go-format/hooks/hook-utils.sh
@@ -480,7 +480,7 @@ hook::read_file_path() {
 # Guards that must fail closed branch on the return code or on
 # HOOK_REPO_ROOT_UNRESOLVED.
 #   ROOT=$(hook::repo_root "$some_path")
-# shellcheck disable=SC2034  # HOOK_REPO_ROOT_UNRESOLVED is read by sourcing hooks
+# shellcheck disable=SC2034  # public contract: advisory callers may read HOOK_REPO_ROOT_UNRESOLVED
 hook::repo_root() {
   local hint="${1:-.}"
   local root

--- a/plugins/go-format/hooks/hook-utils.sh
+++ b/plugins/go-format/hooks/hook-utils.sh
@@ -340,22 +340,28 @@ hook::expand_8dot3() {
 # spelling of an in-project path cannot dodge it (the long-form prefix would
 # never match). GNU realpath ships with Git Bash and Linux coreutils;
 # readlink -f covers the BSD/macOS hosts that have no realpath. When neither
-# resolver exists the caller falls back to comparing the lexical path as
-# before — the guard is defense-in-depth scoping for a file the agent already
-# wrote via its own tools, so degrading to the historical comparison beats
-# silently disabling the hook on those hosts. The 8.3 expansion applies only
-# on the resolver's success path: an unchanged return is the documented
-# signature of failed canonicalization, and consumers that fail closed on that
-# signature must not see a form-converted path instead.
+# resolver exists the caller still receives the lexical path unchanged — the
+# guard is defense-in-depth scoping for a file the agent already wrote via its
+# own tools, so degrading to the historical comparison beats silently disabling
+# the hook on those hosts — but the answer is now DISTINGUISHABLE: return 1 and
+# HOOK_PHYSICAL_PATH_UNRESOLVED=1. Success (return 0) means resolved; advisory
+# callers that ignore the status keep today's behavior. Guards that must fail
+# closed branch on the return code or on HOOK_PHYSICAL_PATH_UNRESOLVED. The 8.3
+# expansion applies only on the resolver's success path: consumers that fail
+# closed on an unresolved signature must not see a form-converted path instead.
+# shellcheck disable=SC2034  # public contract: advisory callers may read HOOK_PHYSICAL_PATH_UNRESOLVED
 hook::physical_path() {
   local resolved
+  HOOK_PHYSICAL_PATH_UNRESOLVED=0
   if resolved=$(realpath -- "$1" 2>/dev/null) || resolved=$(readlink -f -- "$1" 2>/dev/null); then
     if [[ -n "$resolved" ]]; then
       hook::expand_8dot3 "$resolved"
-      return
+      return 0
     fi
   fi
+  HOOK_PHYSICAL_PATH_UNRESOLVED=1
   printf '%s' "$1"
+  return 1
 }
 
 # True when <normalized-path> sits inside one of this host's temp trees.
@@ -466,19 +472,30 @@ hook::read_file_path() {
 # Resolve the repository root (working-tree top) for a path inside the tree.
 # markdownlint config auto-discovery is CWD-anchored, so the hook cd's here
 # before linting. File-anchored (`git -C "$hint" rev-parse --show-toplevel`)
-# so it is correct for clones, linked worktrees, and bare-hub clones; falls
-# back to the hint (with a trailing /.claude stripped) when git cannot resolve.
+# so it is correct for clones, linked worktrees, and bare-hub clones; when git
+# cannot resolve, still returns the hint (with a trailing /.claude stripped) so
+# advisory callers keep today's fallback — but the answer is now
+# DISTINGUISHABLE: return 1 and HOOK_REPO_ROOT_UNRESOLVED=1. Success (return 0)
+# means git answered; advisory callers that ignore the status are unchanged.
+# Guards that must fail closed branch on the return code or on
+# HOOK_REPO_ROOT_UNRESOLVED.
 #   ROOT=$(hook::repo_root "$some_path")
+# shellcheck disable=SC2034  # HOOK_REPO_ROOT_UNRESOLVED is read by sourcing hooks
 hook::repo_root() {
   local hint="${1:-.}"
   local root
+  HOOK_REPO_ROOT_UNRESOLVED=0
   root=$(git -C "$hint" rev-parse --show-toplevel 2>/dev/null | tr -d '\r')
-  if [[ -z "$root" ]]; then
-    root="$hint"
-    root="${root%/.claude}"
-    root="${root%\\.claude}"
+  if [[ -n "$root" ]]; then
+    printf '%s' "$root"
+    return 0
   fi
+  root="$hint"
+  root="${root%/.claude}"
+  root="${root%\\.claude}"
+  HOOK_REPO_ROOT_UNRESOLVED=1
   printf '%s' "$root"
+  return 1
 }
 
 # Buffer a complete JSON payload from stdin, tolerating Windows Win32-pipe
@@ -1710,9 +1727,10 @@ hook::git_alias_expansion() {
 
 # Single linear pass: read the command into a char array once (O(n)), then walk
 # it splitting top-level segments on UNQUOTED control operators and tokenizing
-# each segment into argv words honoring '…', "…", $'…', and backslash escapes
-# (including backslash-newline continuation). Each completed segment is passed
-# to the callback as it closes, so no full segment list is retained.
+# each segment into argv words honoring '…', "…", $'…', backslash escapes
+# (including backslash-newline continuation), and unquoted `#` comments to EOL
+# (quoted `#` preserved). Each completed segment is passed to the callback as it
+# closes, so no full segment list is retained.
 # Call as: hook::bash_parse_segments <command-string> <callback>; the callback
 # receives one segment's argv words as "$@".
 # shellcheck disable=SC1003  # '\' compares a literal backslash char, not a quote escape
@@ -1802,6 +1820,17 @@ hook::bash_parse_segments() {
         if ((skipnext)); then skipnext=0; else seg+=("$word"); fi
         word=""
         have=0
+      fi
+      ;;
+    '#')
+      # Unquoted `#` starts a shell comment to EOL only at a word boundary (no
+      # word currently being assembled). Mid-word `#` (`x#y`) stays literal.
+      if ((have)); then
+        word+="#"
+      else
+        while ((i + 1 < n)) && [[ "${chars[i + 1]}" != $'\n' ]]; do
+          ((i++))
+        done
       fi
       ;;
     '>' | '<')

--- a/plugins/guardrails/.claude-plugin/plugin.json
+++ b/plugins/guardrails/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "guardrails",
-  "description": "Twelve safety guards that block secret/credential writes, hardcoded machine-specific paths, git hook-bypass attempts, irreversible git operations (force-push, reset --hard, worktree-wide checkout/restore discards), Bash file-write workarounds that circumvent Write/Edit hooks, multi-line `git commit -m` messages (an actual-newline `-m` mangles across shells; single-line `-m` passes), commit subjects and gh pr create titles that violate the repo's tracked team convention (when one is declared in .claude/source-control.md), (advisory) hallucinated CLI flags, (advisory) /plugin:skill references that do not resolve, (advisory) markdown citing a repo path the repo's own history shows was removed, (advisory, opt-in) un-throttled Workflow fan-out that risks burst 529s, and (advisory, opt-in) direct gh pr create calls bypassing this marketplace's own pull-request skill \u2014 each independently toggleable.",
+  "description": "Twelve safety guards that block secret/credential writes, hardcoded machine-specific paths, git hook-bypass attempts, irreversible git operations (force-push, reset --hard, worktree-wide checkout/restore discards), Bash file-write workarounds that circumvent Write/Edit hooks, multi-line `git commit -m` messages (an actual-newline `-m` mangles across shells; single-line `-m` passes), commit subjects and gh pr create titles that violate the repo's tracked team convention (when one is declared in .claude/source-control.md), (advisory) hallucinated CLI flags, (advisory) /plugin:skill references that do not resolve, (advisory) markdown citing a repo path the repo's own history shows was removed, (advisory, opt-in) un-throttled Workflow fan-out that risks burst 529s, and (advisory, opt-in) direct gh pr create calls bypassing this marketplace's own pull-request skill — each independently toggleable.",
   "author": {
     "name": "Melodic Software",
     "email": "info@melodicsoftware.com"
@@ -34,13 +34,13 @@
     "block_no_verify_enabled": {
       "type": "boolean",
       "title": "block-no-verify guard",
-      "description": "Block git hook-bypass attempts (--no-verify, core.hooksPath=, hook-manager env-var disables for a configurable set \u2014 lefthook/husky/pre-commit/simple-git-hooks by default)",
+      "description": "Block git hook-bypass attempts (--no-verify, core.hooksPath=, hook-manager env-var disables for a configurable set — lefthook/husky/pre-commit/simple-git-hooks by default)",
       "default": true
     },
     "block_dangerous_git_enabled": {
       "type": "boolean",
       "title": "block-dangerous-git guard",
-      "description": "Block irreversible git operations (push --force, push --force-with-lease leasing against a value git resolves at push time \u2014 either no expected value, or an expectation that is not an object id of the repository's own hash width \u2014 reset --hard, clean -f, worktree-wide checkout/restore discards)",
+      "description": "Block irreversible git operations (push --force, push --force-with-lease leasing against a value git resolves at push time — either no expected value, or an expectation that is not an object id of the repository's own hash width — reset --hard, clean -f, worktree-wide checkout/restore discards)",
       "default": true
     },
     "block_hook_bypass_enabled": {
@@ -52,7 +52,7 @@
     "block_noncanonical_commit_enabled": {
       "type": "boolean",
       "title": "block-noncanonical-commit guard",
-      "description": "Block `git commit -m` when the message actually contains a newline (multi-line `-m` mangles across shells \u2014 pipe it via `-F -` instead; single-line `-m` passes); --amend, -C/-c, --fixup/--squash, -F <path>, and an in-progress merge/rebase are exempt",
+      "description": "Block `git commit -m` when the message actually contains a newline (multi-line `-m` mangles across shells — pipe it via `-F -` instead; single-line `-m` passes); --amend, -C/-c, --fixup/--squash, -F <path>, and an in-progress merge/rebase are exempt",
       "default": true
     },
     "block_convention_gate_enabled": {
@@ -82,13 +82,13 @@
     "workflow_resilience_check_enabled": {
       "type": "boolean",
       "title": "workflow-resilience-check guard",
-      "description": "Advise on un-throttled Workflow fan-out (never blocks). Default off since 0.20.0: a behavioral-class prose injector, config-disabled per the instruction-economy evidence gate (#2021) \u2014 set true to opt back in",
+      "description": "Advise on un-throttled Workflow fan-out (never blocks). Default off since 0.20.0: a behavioral-class prose injector, config-disabled per the instruction-economy evidence gate (#2021) — set true to opt back in",
       "default": false
     },
     "flag_commit_pr_skill_bypass_enabled": {
       "type": "boolean",
       "title": "flag-commit-pr-skill-bypass guard",
-      "description": "Advise when a direct gh pr create bypasses the source-control pull-request skill (never blocks). Default off since 0.20.0: a behavioral-class prose injector, config-disabled per the instruction-economy evidence gate (#2021) \u2014 set true to opt back in",
+      "description": "Advise when a direct gh pr create bypasses the source-control pull-request skill (never blocks). Default off since 0.20.0: a behavioral-class prose injector, config-disabled per the instruction-economy evidence gate (#2021) — set true to opt back in",
       "default": false
     },
     "cli_flag_verify_bins": {
@@ -124,16 +124,16 @@
     "block_hook_bypass_scratch_roots": {
       "type": "string",
       "title": "block-hook-bypass scratch roots",
-      "description": "Comma-separated ABSOLUTE directories block-hook-bypass exempts as scratch/temp write targets (e.g. /tmp/scratch,/d/jobtmp/session); empty (the default) exempts nothing and leaves the guard's shipped behaviour unchanged. Matching is on the effective stdout target after lexical normalization, at a path-component boundary \u2014 a sibling merely sharing the name prefix, a `..` escape out of a root, and a discard-then-real-file redirect all still block. A quoted or escaped OPERAND is never exempt: the operand is marked so it survives the quote strip and the segment split as one word, and an operand carrying whitespace, `;`, `|`, `&`, `(`, `)`, a newline or a backslash escape exempts nothing. Quotes elsewhere in the command no longer matter. Symlinks are not followed",
+      "description": "Comma-separated ABSOLUTE directories block-hook-bypass exempts as scratch/temp write targets (e.g. /tmp/scratch,/d/jobtmp/session); empty (the default) exempts nothing and leaves the guard's shipped behaviour unchanged. Matching is on the effective stdout target after lexical normalization, at a path-component boundary — a sibling merely sharing the name prefix, a `..` escape out of a root, and a discard-then-real-file redirect all still block. A quoted or escaped OPERAND is never exempt: the operand is marked so it survives the quote strip and the segment split as one word, and an operand carrying whitespace, `;`, `|`, `&`, `(`, `)`, a newline or a backslash escape exempts nothing. Quotes elsewhere in the command no longer matter. Symlinks are not followed",
       "default": ""
     },
     "stdin_read_timeout": {
       "type": "number",
       "title": "Hook stdin read timeout (seconds)",
-      "description": "Idle bound on reading the hook payload from stdin \u2014 how long a silent pipe is tolerated before a blocking guard fails closed",
+      "description": "Idle bound on reading the hook payload from stdin — how long a silent pipe is tolerated before a blocking guard fails closed",
       "default": 2,
       "min": 1
     }
   },
-  "version": "0.28.19"
+  "version": "0.28.20"
 }

--- a/plugins/guardrails/CHANGELOG.md
+++ b/plugins/guardrails/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to the `guardrails` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.28.20]
+
+### Fixed
+
+- **hook-utils:** distinguish unresolved `physical_path`/`repo_root` answers and honor unquoted `#` in `bash_parse_segments` (#1487).
+
 ## [0.28.19]
 
 ### Fixed

--- a/plugins/guardrails/hooks/hook-utils.sh
+++ b/plugins/guardrails/hooks/hook-utils.sh
@@ -480,7 +480,7 @@ hook::read_file_path() {
 # Guards that must fail closed branch on the return code or on
 # HOOK_REPO_ROOT_UNRESOLVED.
 #   ROOT=$(hook::repo_root "$some_path")
-# shellcheck disable=SC2034  # HOOK_REPO_ROOT_UNRESOLVED is read by sourcing hooks
+# shellcheck disable=SC2034  # public contract: advisory callers may read HOOK_REPO_ROOT_UNRESOLVED
 hook::repo_root() {
   local hint="${1:-.}"
   local root

--- a/plugins/guardrails/hooks/hook-utils.sh
+++ b/plugins/guardrails/hooks/hook-utils.sh
@@ -340,22 +340,28 @@ hook::expand_8dot3() {
 # spelling of an in-project path cannot dodge it (the long-form prefix would
 # never match). GNU realpath ships with Git Bash and Linux coreutils;
 # readlink -f covers the BSD/macOS hosts that have no realpath. When neither
-# resolver exists the caller falls back to comparing the lexical path as
-# before — the guard is defense-in-depth scoping for a file the agent already
-# wrote via its own tools, so degrading to the historical comparison beats
-# silently disabling the hook on those hosts. The 8.3 expansion applies only
-# on the resolver's success path: an unchanged return is the documented
-# signature of failed canonicalization, and consumers that fail closed on that
-# signature must not see a form-converted path instead.
+# resolver exists the caller still receives the lexical path unchanged — the
+# guard is defense-in-depth scoping for a file the agent already wrote via its
+# own tools, so degrading to the historical comparison beats silently disabling
+# the hook on those hosts — but the answer is now DISTINGUISHABLE: return 1 and
+# HOOK_PHYSICAL_PATH_UNRESOLVED=1. Success (return 0) means resolved; advisory
+# callers that ignore the status keep today's behavior. Guards that must fail
+# closed branch on the return code or on HOOK_PHYSICAL_PATH_UNRESOLVED. The 8.3
+# expansion applies only on the resolver's success path: consumers that fail
+# closed on an unresolved signature must not see a form-converted path instead.
+# shellcheck disable=SC2034  # public contract: advisory callers may read HOOK_PHYSICAL_PATH_UNRESOLVED
 hook::physical_path() {
   local resolved
+  HOOK_PHYSICAL_PATH_UNRESOLVED=0
   if resolved=$(realpath -- "$1" 2>/dev/null) || resolved=$(readlink -f -- "$1" 2>/dev/null); then
     if [[ -n "$resolved" ]]; then
       hook::expand_8dot3 "$resolved"
-      return
+      return 0
     fi
   fi
+  HOOK_PHYSICAL_PATH_UNRESOLVED=1
   printf '%s' "$1"
+  return 1
 }
 
 # True when <normalized-path> sits inside one of this host's temp trees.
@@ -466,19 +472,30 @@ hook::read_file_path() {
 # Resolve the repository root (working-tree top) for a path inside the tree.
 # markdownlint config auto-discovery is CWD-anchored, so the hook cd's here
 # before linting. File-anchored (`git -C "$hint" rev-parse --show-toplevel`)
-# so it is correct for clones, linked worktrees, and bare-hub clones; falls
-# back to the hint (with a trailing /.claude stripped) when git cannot resolve.
+# so it is correct for clones, linked worktrees, and bare-hub clones; when git
+# cannot resolve, still returns the hint (with a trailing /.claude stripped) so
+# advisory callers keep today's fallback — but the answer is now
+# DISTINGUISHABLE: return 1 and HOOK_REPO_ROOT_UNRESOLVED=1. Success (return 0)
+# means git answered; advisory callers that ignore the status are unchanged.
+# Guards that must fail closed branch on the return code or on
+# HOOK_REPO_ROOT_UNRESOLVED.
 #   ROOT=$(hook::repo_root "$some_path")
+# shellcheck disable=SC2034  # HOOK_REPO_ROOT_UNRESOLVED is read by sourcing hooks
 hook::repo_root() {
   local hint="${1:-.}"
   local root
+  HOOK_REPO_ROOT_UNRESOLVED=0
   root=$(git -C "$hint" rev-parse --show-toplevel 2>/dev/null | tr -d '\r')
-  if [[ -z "$root" ]]; then
-    root="$hint"
-    root="${root%/.claude}"
-    root="${root%\\.claude}"
+  if [[ -n "$root" ]]; then
+    printf '%s' "$root"
+    return 0
   fi
+  root="$hint"
+  root="${root%/.claude}"
+  root="${root%\\.claude}"
+  HOOK_REPO_ROOT_UNRESOLVED=1
   printf '%s' "$root"
+  return 1
 }
 
 # Buffer a complete JSON payload from stdin, tolerating Windows Win32-pipe
@@ -1710,9 +1727,10 @@ hook::git_alias_expansion() {
 
 # Single linear pass: read the command into a char array once (O(n)), then walk
 # it splitting top-level segments on UNQUOTED control operators and tokenizing
-# each segment into argv words honoring '…', "…", $'…', and backslash escapes
-# (including backslash-newline continuation). Each completed segment is passed
-# to the callback as it closes, so no full segment list is retained.
+# each segment into argv words honoring '…', "…", $'…', backslash escapes
+# (including backslash-newline continuation), and unquoted `#` comments to EOL
+# (quoted `#` preserved). Each completed segment is passed to the callback as it
+# closes, so no full segment list is retained.
 # Call as: hook::bash_parse_segments <command-string> <callback>; the callback
 # receives one segment's argv words as "$@".
 # shellcheck disable=SC1003  # '\' compares a literal backslash char, not a quote escape
@@ -1802,6 +1820,17 @@ hook::bash_parse_segments() {
         if ((skipnext)); then skipnext=0; else seg+=("$word"); fi
         word=""
         have=0
+      fi
+      ;;
+    '#')
+      # Unquoted `#` starts a shell comment to EOL only at a word boundary (no
+      # word currently being assembled). Mid-word `#` (`x#y`) stays literal.
+      if ((have)); then
+        word+="#"
+      else
+        while ((i + 1 < n)) && [[ "${chars[i + 1]}" != $'\n' ]]; do
+          ((i++))
+        done
       fi
       ;;
     '>' | '<')

--- a/plugins/markdown-format/.claude-plugin/plugin.json
+++ b/plugins/markdown-format/.claude-plugin/plugin.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "markdown-format",
-  "version": "0.11.14",
-  "description": "Auto-format and lint Markdown on edit via markdownlint-cli2 \u2014 only in repos that carry their own markdownlint config.",
+  "version": "0.11.15",
+  "description": "Auto-format and lint Markdown on edit via markdownlint-cli2 — only in repos that carry their own markdownlint config.",
   "author": {
     "name": "Melodic Software",
     "email": "info@melodicsoftware.com"
@@ -25,7 +25,7 @@
     "markdown_format_lint_gitignored": {
       "type": "boolean",
       "title": "Lint files git ignores",
-      "description": "By default the hook leaves gitignored files alone \u2014 a scratch tier the repo excludes is neither rewritten nor reported on. Set true to bypass THIS HOOK's git check; markdownlint-cli2's own ignores/gitignore config still applies downstream, so a path your markdownlint config also excludes stays untouched.",
+      "description": "By default the hook leaves gitignored files alone — a scratch tier the repo excludes is neither rewritten nor reported on. Set true to bypass THIS HOOK's git check; markdownlint-cli2's own ignores/gitignore config still applies downstream, so a path your markdownlint config also excludes stays untouched.",
       "default": false
     },
     "markdown_format_max_findings": {

--- a/plugins/markdown-format/CHANGELOG.md
+++ b/plugins/markdown-format/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to the `markdown-format` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.11.15]
+
+### Fixed
+
+- **hook-utils:** distinguish unresolved `physical_path`/`repo_root` answers and honor unquoted `#` in `bash_parse_segments` (#1487).
+
 ## [0.11.14]
 
 ### Fixed

--- a/plugins/markdown-format/hooks/hook-utils.sh
+++ b/plugins/markdown-format/hooks/hook-utils.sh
@@ -480,7 +480,7 @@ hook::read_file_path() {
 # Guards that must fail closed branch on the return code or on
 # HOOK_REPO_ROOT_UNRESOLVED.
 #   ROOT=$(hook::repo_root "$some_path")
-# shellcheck disable=SC2034  # HOOK_REPO_ROOT_UNRESOLVED is read by sourcing hooks
+# shellcheck disable=SC2034  # public contract: advisory callers may read HOOK_REPO_ROOT_UNRESOLVED
 hook::repo_root() {
   local hint="${1:-.}"
   local root

--- a/plugins/markdown-format/hooks/hook-utils.sh
+++ b/plugins/markdown-format/hooks/hook-utils.sh
@@ -340,22 +340,28 @@ hook::expand_8dot3() {
 # spelling of an in-project path cannot dodge it (the long-form prefix would
 # never match). GNU realpath ships with Git Bash and Linux coreutils;
 # readlink -f covers the BSD/macOS hosts that have no realpath. When neither
-# resolver exists the caller falls back to comparing the lexical path as
-# before — the guard is defense-in-depth scoping for a file the agent already
-# wrote via its own tools, so degrading to the historical comparison beats
-# silently disabling the hook on those hosts. The 8.3 expansion applies only
-# on the resolver's success path: an unchanged return is the documented
-# signature of failed canonicalization, and consumers that fail closed on that
-# signature must not see a form-converted path instead.
+# resolver exists the caller still receives the lexical path unchanged — the
+# guard is defense-in-depth scoping for a file the agent already wrote via its
+# own tools, so degrading to the historical comparison beats silently disabling
+# the hook on those hosts — but the answer is now DISTINGUISHABLE: return 1 and
+# HOOK_PHYSICAL_PATH_UNRESOLVED=1. Success (return 0) means resolved; advisory
+# callers that ignore the status keep today's behavior. Guards that must fail
+# closed branch on the return code or on HOOK_PHYSICAL_PATH_UNRESOLVED. The 8.3
+# expansion applies only on the resolver's success path: consumers that fail
+# closed on an unresolved signature must not see a form-converted path instead.
+# shellcheck disable=SC2034  # public contract: advisory callers may read HOOK_PHYSICAL_PATH_UNRESOLVED
 hook::physical_path() {
   local resolved
+  HOOK_PHYSICAL_PATH_UNRESOLVED=0
   if resolved=$(realpath -- "$1" 2>/dev/null) || resolved=$(readlink -f -- "$1" 2>/dev/null); then
     if [[ -n "$resolved" ]]; then
       hook::expand_8dot3 "$resolved"
-      return
+      return 0
     fi
   fi
+  HOOK_PHYSICAL_PATH_UNRESOLVED=1
   printf '%s' "$1"
+  return 1
 }
 
 # True when <normalized-path> sits inside one of this host's temp trees.
@@ -466,19 +472,30 @@ hook::read_file_path() {
 # Resolve the repository root (working-tree top) for a path inside the tree.
 # markdownlint config auto-discovery is CWD-anchored, so the hook cd's here
 # before linting. File-anchored (`git -C "$hint" rev-parse --show-toplevel`)
-# so it is correct for clones, linked worktrees, and bare-hub clones; falls
-# back to the hint (with a trailing /.claude stripped) when git cannot resolve.
+# so it is correct for clones, linked worktrees, and bare-hub clones; when git
+# cannot resolve, still returns the hint (with a trailing /.claude stripped) so
+# advisory callers keep today's fallback — but the answer is now
+# DISTINGUISHABLE: return 1 and HOOK_REPO_ROOT_UNRESOLVED=1. Success (return 0)
+# means git answered; advisory callers that ignore the status are unchanged.
+# Guards that must fail closed branch on the return code or on
+# HOOK_REPO_ROOT_UNRESOLVED.
 #   ROOT=$(hook::repo_root "$some_path")
+# shellcheck disable=SC2034  # HOOK_REPO_ROOT_UNRESOLVED is read by sourcing hooks
 hook::repo_root() {
   local hint="${1:-.}"
   local root
+  HOOK_REPO_ROOT_UNRESOLVED=0
   root=$(git -C "$hint" rev-parse --show-toplevel 2>/dev/null | tr -d '\r')
-  if [[ -z "$root" ]]; then
-    root="$hint"
-    root="${root%/.claude}"
-    root="${root%\\.claude}"
+  if [[ -n "$root" ]]; then
+    printf '%s' "$root"
+    return 0
   fi
+  root="$hint"
+  root="${root%/.claude}"
+  root="${root%\\.claude}"
+  HOOK_REPO_ROOT_UNRESOLVED=1
   printf '%s' "$root"
+  return 1
 }
 
 # Buffer a complete JSON payload from stdin, tolerating Windows Win32-pipe
@@ -1710,9 +1727,10 @@ hook::git_alias_expansion() {
 
 # Single linear pass: read the command into a char array once (O(n)), then walk
 # it splitting top-level segments on UNQUOTED control operators and tokenizing
-# each segment into argv words honoring '…', "…", $'…', and backslash escapes
-# (including backslash-newline continuation). Each completed segment is passed
-# to the callback as it closes, so no full segment list is retained.
+# each segment into argv words honoring '…', "…", $'…', backslash escapes
+# (including backslash-newline continuation), and unquoted `#` comments to EOL
+# (quoted `#` preserved). Each completed segment is passed to the callback as it
+# closes, so no full segment list is retained.
 # Call as: hook::bash_parse_segments <command-string> <callback>; the callback
 # receives one segment's argv words as "$@".
 # shellcheck disable=SC1003  # '\' compares a literal backslash char, not a quote escape
@@ -1802,6 +1820,17 @@ hook::bash_parse_segments() {
         if ((skipnext)); then skipnext=0; else seg+=("$word"); fi
         word=""
         have=0
+      fi
+      ;;
+    '#')
+      # Unquoted `#` starts a shell comment to EOL only at a word boundary (no
+      # word currently being assembled). Mid-word `#` (`x#y`) stays literal.
+      if ((have)); then
+        word+="#"
+      else
+        while ((i + 1 < n)) && [[ "${chars[i + 1]}" != $'\n' ]]; do
+          ((i++))
+        done
       fi
       ;;
     '>' | '<')

--- a/plugins/powershell-format/.claude-plugin/plugin.json
+++ b/plugins/powershell-format/.claude-plugin/plugin.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "powershell-format",
-  "version": "0.7.12",
-  "description": "Auto-format and lint PowerShell on edit via PSScriptAnalyzer, only when a PSScriptAnalyzerSettings.psd1 governs the repo \u2014 using the consuming repo's own analyzer settings.",
+  "version": "0.7.13",
+  "description": "Auto-format and lint PowerShell on edit via PSScriptAnalyzer, only when a PSScriptAnalyzerSettings.psd1 governs the repo — using the consuming repo's own analyzer settings.",
   "author": {
     "name": "Melodic Software",
     "email": "info@melodicsoftware.com"

--- a/plugins/powershell-format/CHANGELOG.md
+++ b/plugins/powershell-format/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to the `powershell-format` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.7.13]
+
+### Fixed
+
+- **hook-utils:** distinguish unresolved `physical_path`/`repo_root` answers and honor unquoted `#` in `bash_parse_segments` (#1487).
+
 ## [0.7.12]
 
 ### Fixed

--- a/plugins/powershell-format/hooks/hook-utils.sh
+++ b/plugins/powershell-format/hooks/hook-utils.sh
@@ -480,7 +480,7 @@ hook::read_file_path() {
 # Guards that must fail closed branch on the return code or on
 # HOOK_REPO_ROOT_UNRESOLVED.
 #   ROOT=$(hook::repo_root "$some_path")
-# shellcheck disable=SC2034  # HOOK_REPO_ROOT_UNRESOLVED is read by sourcing hooks
+# shellcheck disable=SC2034  # public contract: advisory callers may read HOOK_REPO_ROOT_UNRESOLVED
 hook::repo_root() {
   local hint="${1:-.}"
   local root

--- a/plugins/powershell-format/hooks/hook-utils.sh
+++ b/plugins/powershell-format/hooks/hook-utils.sh
@@ -340,22 +340,28 @@ hook::expand_8dot3() {
 # spelling of an in-project path cannot dodge it (the long-form prefix would
 # never match). GNU realpath ships with Git Bash and Linux coreutils;
 # readlink -f covers the BSD/macOS hosts that have no realpath. When neither
-# resolver exists the caller falls back to comparing the lexical path as
-# before — the guard is defense-in-depth scoping for a file the agent already
-# wrote via its own tools, so degrading to the historical comparison beats
-# silently disabling the hook on those hosts. The 8.3 expansion applies only
-# on the resolver's success path: an unchanged return is the documented
-# signature of failed canonicalization, and consumers that fail closed on that
-# signature must not see a form-converted path instead.
+# resolver exists the caller still receives the lexical path unchanged — the
+# guard is defense-in-depth scoping for a file the agent already wrote via its
+# own tools, so degrading to the historical comparison beats silently disabling
+# the hook on those hosts — but the answer is now DISTINGUISHABLE: return 1 and
+# HOOK_PHYSICAL_PATH_UNRESOLVED=1. Success (return 0) means resolved; advisory
+# callers that ignore the status keep today's behavior. Guards that must fail
+# closed branch on the return code or on HOOK_PHYSICAL_PATH_UNRESOLVED. The 8.3
+# expansion applies only on the resolver's success path: consumers that fail
+# closed on an unresolved signature must not see a form-converted path instead.
+# shellcheck disable=SC2034  # public contract: advisory callers may read HOOK_PHYSICAL_PATH_UNRESOLVED
 hook::physical_path() {
   local resolved
+  HOOK_PHYSICAL_PATH_UNRESOLVED=0
   if resolved=$(realpath -- "$1" 2>/dev/null) || resolved=$(readlink -f -- "$1" 2>/dev/null); then
     if [[ -n "$resolved" ]]; then
       hook::expand_8dot3 "$resolved"
-      return
+      return 0
     fi
   fi
+  HOOK_PHYSICAL_PATH_UNRESOLVED=1
   printf '%s' "$1"
+  return 1
 }
 
 # True when <normalized-path> sits inside one of this host's temp trees.
@@ -466,19 +472,30 @@ hook::read_file_path() {
 # Resolve the repository root (working-tree top) for a path inside the tree.
 # markdownlint config auto-discovery is CWD-anchored, so the hook cd's here
 # before linting. File-anchored (`git -C "$hint" rev-parse --show-toplevel`)
-# so it is correct for clones, linked worktrees, and bare-hub clones; falls
-# back to the hint (with a trailing /.claude stripped) when git cannot resolve.
+# so it is correct for clones, linked worktrees, and bare-hub clones; when git
+# cannot resolve, still returns the hint (with a trailing /.claude stripped) so
+# advisory callers keep today's fallback — but the answer is now
+# DISTINGUISHABLE: return 1 and HOOK_REPO_ROOT_UNRESOLVED=1. Success (return 0)
+# means git answered; advisory callers that ignore the status are unchanged.
+# Guards that must fail closed branch on the return code or on
+# HOOK_REPO_ROOT_UNRESOLVED.
 #   ROOT=$(hook::repo_root "$some_path")
+# shellcheck disable=SC2034  # HOOK_REPO_ROOT_UNRESOLVED is read by sourcing hooks
 hook::repo_root() {
   local hint="${1:-.}"
   local root
+  HOOK_REPO_ROOT_UNRESOLVED=0
   root=$(git -C "$hint" rev-parse --show-toplevel 2>/dev/null | tr -d '\r')
-  if [[ -z "$root" ]]; then
-    root="$hint"
-    root="${root%/.claude}"
-    root="${root%\\.claude}"
+  if [[ -n "$root" ]]; then
+    printf '%s' "$root"
+    return 0
   fi
+  root="$hint"
+  root="${root%/.claude}"
+  root="${root%\\.claude}"
+  HOOK_REPO_ROOT_UNRESOLVED=1
   printf '%s' "$root"
+  return 1
 }
 
 # Buffer a complete JSON payload from stdin, tolerating Windows Win32-pipe
@@ -1710,9 +1727,10 @@ hook::git_alias_expansion() {
 
 # Single linear pass: read the command into a char array once (O(n)), then walk
 # it splitting top-level segments on UNQUOTED control operators and tokenizing
-# each segment into argv words honoring '…', "…", $'…', and backslash escapes
-# (including backslash-newline continuation). Each completed segment is passed
-# to the callback as it closes, so no full segment list is retained.
+# each segment into argv words honoring '…', "…", $'…', backslash escapes
+# (including backslash-newline continuation), and unquoted `#` comments to EOL
+# (quoted `#` preserved). Each completed segment is passed to the callback as it
+# closes, so no full segment list is retained.
 # Call as: hook::bash_parse_segments <command-string> <callback>; the callback
 # receives one segment's argv words as "$@".
 # shellcheck disable=SC1003  # '\' compares a literal backslash char, not a quote escape
@@ -1802,6 +1820,17 @@ hook::bash_parse_segments() {
         if ((skipnext)); then skipnext=0; else seg+=("$word"); fi
         word=""
         have=0
+      fi
+      ;;
+    '#')
+      # Unquoted `#` starts a shell comment to EOL only at a word boundary (no
+      # word currently being assembled). Mid-word `#` (`x#y`) stays literal.
+      if ((have)); then
+        word+="#"
+      else
+        while ((i + 1 < n)) && [[ "${chars[i + 1]}" != $'\n' ]]; do
+          ((i++))
+        done
       fi
       ;;
     '>' | '<')

--- a/plugins/rate-limit-guard/.claude-plugin/plugin.json
+++ b/plugins/rate-limit-guard/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "rate-limit-guard",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Shared rate-limit guard for loop lanes: a statusline wrapper tees the subscription rate-limit windows to a fixed machine-scope file, a StopFailure hook records rate-limit stops reactively, and a reader contract fixes how consuming sessions pause and resume.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/rate-limit-guard/CHANGELOG.md
+++ b/plugins/rate-limit-guard/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to the `rate-limit-guard` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.7.2]
+
+### Fixed
+
+- **hook-utils:** distinguish unresolved `physical_path`/`repo_root` answers and honor unquoted `#` in `bash_parse_segments` (#1487).
+
 ## [0.7.1]
 
 ### Fixed

--- a/plugins/rate-limit-guard/hooks/hook-utils.sh
+++ b/plugins/rate-limit-guard/hooks/hook-utils.sh
@@ -480,7 +480,7 @@ hook::read_file_path() {
 # Guards that must fail closed branch on the return code or on
 # HOOK_REPO_ROOT_UNRESOLVED.
 #   ROOT=$(hook::repo_root "$some_path")
-# shellcheck disable=SC2034  # HOOK_REPO_ROOT_UNRESOLVED is read by sourcing hooks
+# shellcheck disable=SC2034  # public contract: advisory callers may read HOOK_REPO_ROOT_UNRESOLVED
 hook::repo_root() {
   local hint="${1:-.}"
   local root

--- a/plugins/rate-limit-guard/hooks/hook-utils.sh
+++ b/plugins/rate-limit-guard/hooks/hook-utils.sh
@@ -340,22 +340,28 @@ hook::expand_8dot3() {
 # spelling of an in-project path cannot dodge it (the long-form prefix would
 # never match). GNU realpath ships with Git Bash and Linux coreutils;
 # readlink -f covers the BSD/macOS hosts that have no realpath. When neither
-# resolver exists the caller falls back to comparing the lexical path as
-# before — the guard is defense-in-depth scoping for a file the agent already
-# wrote via its own tools, so degrading to the historical comparison beats
-# silently disabling the hook on those hosts. The 8.3 expansion applies only
-# on the resolver's success path: an unchanged return is the documented
-# signature of failed canonicalization, and consumers that fail closed on that
-# signature must not see a form-converted path instead.
+# resolver exists the caller still receives the lexical path unchanged — the
+# guard is defense-in-depth scoping for a file the agent already wrote via its
+# own tools, so degrading to the historical comparison beats silently disabling
+# the hook on those hosts — but the answer is now DISTINGUISHABLE: return 1 and
+# HOOK_PHYSICAL_PATH_UNRESOLVED=1. Success (return 0) means resolved; advisory
+# callers that ignore the status keep today's behavior. Guards that must fail
+# closed branch on the return code or on HOOK_PHYSICAL_PATH_UNRESOLVED. The 8.3
+# expansion applies only on the resolver's success path: consumers that fail
+# closed on an unresolved signature must not see a form-converted path instead.
+# shellcheck disable=SC2034  # public contract: advisory callers may read HOOK_PHYSICAL_PATH_UNRESOLVED
 hook::physical_path() {
   local resolved
+  HOOK_PHYSICAL_PATH_UNRESOLVED=0
   if resolved=$(realpath -- "$1" 2>/dev/null) || resolved=$(readlink -f -- "$1" 2>/dev/null); then
     if [[ -n "$resolved" ]]; then
       hook::expand_8dot3 "$resolved"
-      return
+      return 0
     fi
   fi
+  HOOK_PHYSICAL_PATH_UNRESOLVED=1
   printf '%s' "$1"
+  return 1
 }
 
 # True when <normalized-path> sits inside one of this host's temp trees.
@@ -466,19 +472,30 @@ hook::read_file_path() {
 # Resolve the repository root (working-tree top) for a path inside the tree.
 # markdownlint config auto-discovery is CWD-anchored, so the hook cd's here
 # before linting. File-anchored (`git -C "$hint" rev-parse --show-toplevel`)
-# so it is correct for clones, linked worktrees, and bare-hub clones; falls
-# back to the hint (with a trailing /.claude stripped) when git cannot resolve.
+# so it is correct for clones, linked worktrees, and bare-hub clones; when git
+# cannot resolve, still returns the hint (with a trailing /.claude stripped) so
+# advisory callers keep today's fallback — but the answer is now
+# DISTINGUISHABLE: return 1 and HOOK_REPO_ROOT_UNRESOLVED=1. Success (return 0)
+# means git answered; advisory callers that ignore the status are unchanged.
+# Guards that must fail closed branch on the return code or on
+# HOOK_REPO_ROOT_UNRESOLVED.
 #   ROOT=$(hook::repo_root "$some_path")
+# shellcheck disable=SC2034  # HOOK_REPO_ROOT_UNRESOLVED is read by sourcing hooks
 hook::repo_root() {
   local hint="${1:-.}"
   local root
+  HOOK_REPO_ROOT_UNRESOLVED=0
   root=$(git -C "$hint" rev-parse --show-toplevel 2>/dev/null | tr -d '\r')
-  if [[ -z "$root" ]]; then
-    root="$hint"
-    root="${root%/.claude}"
-    root="${root%\\.claude}"
+  if [[ -n "$root" ]]; then
+    printf '%s' "$root"
+    return 0
   fi
+  root="$hint"
+  root="${root%/.claude}"
+  root="${root%\\.claude}"
+  HOOK_REPO_ROOT_UNRESOLVED=1
   printf '%s' "$root"
+  return 1
 }
 
 # Buffer a complete JSON payload from stdin, tolerating Windows Win32-pipe
@@ -1710,9 +1727,10 @@ hook::git_alias_expansion() {
 
 # Single linear pass: read the command into a char array once (O(n)), then walk
 # it splitting top-level segments on UNQUOTED control operators and tokenizing
-# each segment into argv words honoring '…', "…", $'…', and backslash escapes
-# (including backslash-newline continuation). Each completed segment is passed
-# to the callback as it closes, so no full segment list is retained.
+# each segment into argv words honoring '…', "…", $'…', backslash escapes
+# (including backslash-newline continuation), and unquoted `#` comments to EOL
+# (quoted `#` preserved). Each completed segment is passed to the callback as it
+# closes, so no full segment list is retained.
 # Call as: hook::bash_parse_segments <command-string> <callback>; the callback
 # receives one segment's argv words as "$@".
 # shellcheck disable=SC1003  # '\' compares a literal backslash char, not a quote escape
@@ -1802,6 +1820,17 @@ hook::bash_parse_segments() {
         if ((skipnext)); then skipnext=0; else seg+=("$word"); fi
         word=""
         have=0
+      fi
+      ;;
+    '#')
+      # Unquoted `#` starts a shell comment to EOL only at a word boundary (no
+      # word currently being assembled). Mid-word `#` (`x#y`) stays literal.
+      if ((have)); then
+        word+="#"
+      else
+        while ((i + 1 < n)) && [[ "${chars[i + 1]}" != $'\n' ]]; do
+          ((i++))
+        done
       fi
       ;;
     '>' | '<')

--- a/plugins/ruff-format/.claude-plugin/plugin.json
+++ b/plugins/ruff-format/.claude-plugin/plugin.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "ruff-format",
-  "version": "0.6.12",
-  "description": "Auto-format and lint Python on edit via Ruff, only when a Ruff config governs the repo \u2014 using the consuming repo's own Ruff config.",
+  "version": "0.6.13",
+  "description": "Auto-format and lint Python on edit via Ruff, only when a Ruff config governs the repo — using the consuming repo's own Ruff config.",
   "author": {
     "name": "Melodic Software",
     "email": "info@melodicsoftware.com"

--- a/plugins/ruff-format/CHANGELOG.md
+++ b/plugins/ruff-format/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to the `ruff-format` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.6.13]
+
+### Fixed
+
+- **hook-utils:** distinguish unresolved `physical_path`/`repo_root` answers and honor unquoted `#` in `bash_parse_segments` (#1487).
+
 ## [0.6.12]
 
 ### Fixed

--- a/plugins/ruff-format/hooks/hook-utils.sh
+++ b/plugins/ruff-format/hooks/hook-utils.sh
@@ -480,7 +480,7 @@ hook::read_file_path() {
 # Guards that must fail closed branch on the return code or on
 # HOOK_REPO_ROOT_UNRESOLVED.
 #   ROOT=$(hook::repo_root "$some_path")
-# shellcheck disable=SC2034  # HOOK_REPO_ROOT_UNRESOLVED is read by sourcing hooks
+# shellcheck disable=SC2034  # public contract: advisory callers may read HOOK_REPO_ROOT_UNRESOLVED
 hook::repo_root() {
   local hint="${1:-.}"
   local root

--- a/plugins/ruff-format/hooks/hook-utils.sh
+++ b/plugins/ruff-format/hooks/hook-utils.sh
@@ -340,22 +340,28 @@ hook::expand_8dot3() {
 # spelling of an in-project path cannot dodge it (the long-form prefix would
 # never match). GNU realpath ships with Git Bash and Linux coreutils;
 # readlink -f covers the BSD/macOS hosts that have no realpath. When neither
-# resolver exists the caller falls back to comparing the lexical path as
-# before — the guard is defense-in-depth scoping for a file the agent already
-# wrote via its own tools, so degrading to the historical comparison beats
-# silently disabling the hook on those hosts. The 8.3 expansion applies only
-# on the resolver's success path: an unchanged return is the documented
-# signature of failed canonicalization, and consumers that fail closed on that
-# signature must not see a form-converted path instead.
+# resolver exists the caller still receives the lexical path unchanged — the
+# guard is defense-in-depth scoping for a file the agent already wrote via its
+# own tools, so degrading to the historical comparison beats silently disabling
+# the hook on those hosts — but the answer is now DISTINGUISHABLE: return 1 and
+# HOOK_PHYSICAL_PATH_UNRESOLVED=1. Success (return 0) means resolved; advisory
+# callers that ignore the status keep today's behavior. Guards that must fail
+# closed branch on the return code or on HOOK_PHYSICAL_PATH_UNRESOLVED. The 8.3
+# expansion applies only on the resolver's success path: consumers that fail
+# closed on an unresolved signature must not see a form-converted path instead.
+# shellcheck disable=SC2034  # public contract: advisory callers may read HOOK_PHYSICAL_PATH_UNRESOLVED
 hook::physical_path() {
   local resolved
+  HOOK_PHYSICAL_PATH_UNRESOLVED=0
   if resolved=$(realpath -- "$1" 2>/dev/null) || resolved=$(readlink -f -- "$1" 2>/dev/null); then
     if [[ -n "$resolved" ]]; then
       hook::expand_8dot3 "$resolved"
-      return
+      return 0
     fi
   fi
+  HOOK_PHYSICAL_PATH_UNRESOLVED=1
   printf '%s' "$1"
+  return 1
 }
 
 # True when <normalized-path> sits inside one of this host's temp trees.
@@ -466,19 +472,30 @@ hook::read_file_path() {
 # Resolve the repository root (working-tree top) for a path inside the tree.
 # markdownlint config auto-discovery is CWD-anchored, so the hook cd's here
 # before linting. File-anchored (`git -C "$hint" rev-parse --show-toplevel`)
-# so it is correct for clones, linked worktrees, and bare-hub clones; falls
-# back to the hint (with a trailing /.claude stripped) when git cannot resolve.
+# so it is correct for clones, linked worktrees, and bare-hub clones; when git
+# cannot resolve, still returns the hint (with a trailing /.claude stripped) so
+# advisory callers keep today's fallback — but the answer is now
+# DISTINGUISHABLE: return 1 and HOOK_REPO_ROOT_UNRESOLVED=1. Success (return 0)
+# means git answered; advisory callers that ignore the status are unchanged.
+# Guards that must fail closed branch on the return code or on
+# HOOK_REPO_ROOT_UNRESOLVED.
 #   ROOT=$(hook::repo_root "$some_path")
+# shellcheck disable=SC2034  # HOOK_REPO_ROOT_UNRESOLVED is read by sourcing hooks
 hook::repo_root() {
   local hint="${1:-.}"
   local root
+  HOOK_REPO_ROOT_UNRESOLVED=0
   root=$(git -C "$hint" rev-parse --show-toplevel 2>/dev/null | tr -d '\r')
-  if [[ -z "$root" ]]; then
-    root="$hint"
-    root="${root%/.claude}"
-    root="${root%\\.claude}"
+  if [[ -n "$root" ]]; then
+    printf '%s' "$root"
+    return 0
   fi
+  root="$hint"
+  root="${root%/.claude}"
+  root="${root%\\.claude}"
+  HOOK_REPO_ROOT_UNRESOLVED=1
   printf '%s' "$root"
+  return 1
 }
 
 # Buffer a complete JSON payload from stdin, tolerating Windows Win32-pipe
@@ -1710,9 +1727,10 @@ hook::git_alias_expansion() {
 
 # Single linear pass: read the command into a char array once (O(n)), then walk
 # it splitting top-level segments on UNQUOTED control operators and tokenizing
-# each segment into argv words honoring '…', "…", $'…', and backslash escapes
-# (including backslash-newline continuation). Each completed segment is passed
-# to the callback as it closes, so no full segment list is retained.
+# each segment into argv words honoring '…', "…", $'…', backslash escapes
+# (including backslash-newline continuation), and unquoted `#` comments to EOL
+# (quoted `#` preserved). Each completed segment is passed to the callback as it
+# closes, so no full segment list is retained.
 # Call as: hook::bash_parse_segments <command-string> <callback>; the callback
 # receives one segment's argv words as "$@".
 # shellcheck disable=SC1003  # '\' compares a literal backslash char, not a quote escape
@@ -1802,6 +1820,17 @@ hook::bash_parse_segments() {
         if ((skipnext)); then skipnext=0; else seg+=("$word"); fi
         word=""
         have=0
+      fi
+      ;;
+    '#')
+      # Unquoted `#` starts a shell comment to EOL only at a word boundary (no
+      # word currently being assembled). Mid-word `#` (`x#y`) stays literal.
+      if ((have)); then
+        word+="#"
+      else
+        while ((i + 1 < n)) && [[ "${chars[i + 1]}" != $'\n' ]]; do
+          ((i++))
+        done
       fi
       ;;
     '>' | '<')

--- a/plugins/source-control/.claude-plugin/plugin.json
+++ b/plugins/source-control/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "source-control",
-  "version": "0.53.21",
+  "version": "0.53.22",
   "description": "Git and GitHub delivery workflow: /commit (Conventional Commits + Co-authored-by trailer via safe heredoc mechanics), /pull-request (prep, create, CI monitoring, review-comment triage, merge, CI-log fetch), /babysit-prs (self-pacing fleet loop \u2014 safe by default; opt-in worker/autopilot tiers add gate-checked merge and thread resolution behind a deterministic Python engine), /babysit-loop (the loop-lane merge lane: a standing or drain loop that invokes babysit-prs per cycle, configured through repo-scoped babysit_loop_* keys on the layered source-control.md seam, with merge authority human-only until the target repo's tracked config adopts the lane, a gate-proven C2-mechanical baseline once adopted, and standing merge-rung raises binding from the team-tracked layer only \u2014 with one named exception, where an invocation line explicitly typing both the autopilot tier keyword and the dedicated raise argument --merge c3-this-run widens that single invocation's merge authority up to C3 behind a fresh independent frontier-tier resolver, while C4-structural and C5-untrusted-provenance stay unconditionally human-merge), /worktree (create, status, cleanup, audit for parallel-session isolation), /setup (check the effective commit-subject / PR-title convention merged across its config layers and the babysit-prs config, or apply \u2014 interview the repo and write the convention config to a chosen layer), and /resolve-conflicts (intent-first merge/rebase conflict resolution with a semantic-conflict sweep \u2014 never --abort). The commit-subject / PR-title convention is configurable via a source-control.md config written by a re-runnable setup skill, layered across a ~/.claude user-global file, the tracked team file, and a gitignored .claude/source-control.local.md personal overlay merged per key; Conventional Commits is the default when no convention is declared.",
   "author": {
     "name": "Melodic Software",
@@ -26,7 +26,7 @@
     "lane_instance": {
       "type": "string",
       "title": "Lane instance id",
-      "description": "Writer identity for this machine's loop-lane telemetry, per the loop-lane convention's lane-instance identity rule. It becomes the suffix of the babysit-loop telemetry sentinel marker (`source-control:babysit-loop@<id>`), so each concurrently running lane instance owns its own comment and none can overwrite another's durable state. Must match ^[a-z0-9][a-z0-9-]{0,31}$, be stable across restarts, and be distinct across concurrent instances; two lanes on one machine each need an explicit value. Absent: the sanitized lowercased hostname. The value appears verbatim in tracker comments \u2014 set an opaque id if a machine name should not be published in a public tracker."
+      "description": "Writer identity for this machine's loop-lane telemetry, per the loop-lane convention's lane-instance identity rule. It becomes the suffix of the babysit-loop telemetry sentinel marker (`source-control:babysit-loop@<id>`), so each concurrently running lane instance owns its own comment and none can overwrite another's durable state. Must match ^[a-z0-9][a-z0-9-]{0,31}$, be stable across restarts, and be distinct across concurrent instances; two lanes on one machine each need an explicit value. Absent: the sanitized lowercased hostname. The value appears verbatim in tracker comments — set an opaque id if a machine name should not be published in a public tracker."
     },
     "pr_body_linkage_gate_enabled": {
       "type": "boolean",
@@ -37,13 +37,13 @@
     "pr_linkage_mcp_gate_enabled": {
       "type": "boolean",
       "title": "pr-linkage-mcp-gate hook",
-      "description": "Block a GitHub MCP create_pull_request/update_pull_request whose PR body would fail the repository's required pr-issue-linkage check \u2014 the MCP-surface sibling of pr-body-linkage-gate, covering cloud/remote sessions that open PRs without the gh CLI. Same policy scope: enforced only in a repository that carries .github/workflows/pr-issue-linkage.yml, and only for the repository the origin remote names.",
+      "description": "Block a GitHub MCP create_pull_request/update_pull_request whose PR body would fail the repository's required pr-issue-linkage check — the MCP-surface sibling of pr-body-linkage-gate, covering cloud/remote sessions that open PRs without the gh CLI. Same policy scope: enforced only in a repository that carries .github/workflows/pr-issue-linkage.yml, and only for the repository the origin remote names.",
       "default": true
     },
     "worktree_create_gate_enabled": {
       "type": "boolean",
       "title": "worktree-create-gate hook",
-      "description": "Redirect a WorktreeCreate away from Claude Code's default location, which may be inside the repository, to the configured worktree_root. Turning this OFF does NOT hand placement back to Claude Code: a WorktreeCreate hook has no 'not applicable' channel \u2014 measured on Claude Code 2.1.228, a non-zero exit and an exit-0-without-a-path both fail the creation \u2014 so `false` makes the gate refuse out loud, and every harness-driven creation path (`claude --worktree`, a subagent with `isolation: \"worktree\"`, a background session) fails with a message naming the real stand-downs. To let Claude Code place worktrees itself, set `worktree.bgIsolation` to `\"none\"` in settings, or disable this plugin. Probe, verbatim harness output and the as-of stamp: `skills/worktree/fixtures/README.md`.",
+      "description": "Redirect a WorktreeCreate away from Claude Code's default location, which may be inside the repository, to the configured worktree_root. Turning this OFF does NOT hand placement back to Claude Code: a WorktreeCreate hook has no 'not applicable' channel — measured on Claude Code 2.1.228, a non-zero exit and an exit-0-without-a-path both fail the creation — so `false` makes the gate refuse out loud, and every harness-driven creation path (`claude --worktree`, a subagent with `isolation: \"worktree\"`, a background session) fails with a message naming the real stand-downs. To let Claude Code place worktrees itself, set `worktree.bgIsolation` to `\"none\"` in settings, or disable this plugin. Probe, verbatim harness output and the as-of stamp: `skills/worktree/fixtures/README.md`.",
       "default": true
     },
     "babysit_watched_owners": {
@@ -56,12 +56,12 @@
       "type": "string",
       "multiple": true,
       "title": "Babysit extra self identities",
-      "description": "Extra GitHub posting identities (e.g. a project bot account) added to your `gh api user` login \u2014 the self set babysit-prs treats as its own: self-comment suppression, same-login classification, readiness-gate classification rows, the merge-gate self-exemption, and the resolve-thread bot-only test (a self-authored reply to a bot thread no longer counts as a disqualifying human participant). Not a discovery filter \u2014 which authors' PRs the queue discovers is `--author`'s job, independent of this set. Absent: your gh login alone."
+      "description": "Extra GitHub posting identities (e.g. a project bot account) added to your `gh api user` login — the self set babysit-prs treats as its own: self-comment suppression, same-login classification, readiness-gate classification rows, the merge-gate self-exemption, and the resolve-thread bot-only test (a self-authored reply to a bot thread no longer counts as a disqualifying human participant). Not a discovery filter — which authors' PRs the queue discovers is `--author`'s job, independent of this set. Absent: your gh login alone."
     },
     "babysit_intended_write_identity": {
       "type": "string",
       "title": "Babysit intended write identity",
-      "description": "The single GitHub login babysit-prs's own writes are intended to land under \u2014 typically the bot posting identity. When a write the orchestrator recorded performing lands under a different `babysit_self_logins` identity (e.g. a bot-token mint failed and the write silently fell back to your personal login), the cycle status surfaces an attribution-drift material finding instead of proceeding silently. Set it to one of your self logins; a value that is not actually a posting identity would flag every write. Absent: the check is dormant."
+      "description": "The single GitHub login babysit-prs's own writes are intended to land under — typically the bot posting identity. When a write the orchestrator recorded performing lands under a different `babysit_self_logins` identity (e.g. a bot-token mint failed and the write silently fell back to your personal login), the cycle status surfaces an attribution-drift material finding instead of proceeding silently. Set it to one of your self logins; a value that is not actually a posting identity would flag every write. Absent: the check is dormant."
     },
     "babysit_default_tier": {
       "type": "string",
@@ -140,7 +140,7 @@
       "type": "string",
       "multiple": true,
       "title": "Babysit approval-downgrade reviewer logins",
-      "description": "AI reviewer logins whose approval is surfaced as a `material` finding instead of `ignored` in the one case the structural approval-downgrade reaches: a review body carrying blocking-looking prose that still parses as an approval verdict (no CRITICAL/IMPORTANT or required-fix marker). Every bot's such approval is downgraded to non-blocking regardless; naming a login opts its own into the more-conservative `material` bucket rather than being ignored. Does not affect a review already in the APPROVED state or a plain clean approval with no blocking-looking prose \u2014 both are ignored regardless. Absent: such approvals are ignored for every bot."
+      "description": "AI reviewer logins whose approval is surfaced as a `material` finding instead of `ignored` in the one case the structural approval-downgrade reaches: a review body carrying blocking-looking prose that still parses as an approval verdict (no CRITICAL/IMPORTANT or required-fix marker). Every bot's such approval is downgraded to non-blocking regardless; naming a login opts its own into the more-conservative `material` bucket rather than being ignored. Does not affect a review already in the APPROVED state or a plain clean approval with no blocking-looking prose — both are ignored regardless. Absent: such approvals are ignored for every bot."
     },
     "babysit_skip_downgrade_logins": {
       "type": "string",
@@ -180,7 +180,7 @@
     "worktree_root": {
       "type": "directory",
       "title": "Worktree root",
-      "description": "External root under which /worktree create places worktrees, as <root>/<owner>-<repo>-<slug> \u2014 a path OUTSIDE every repository (on Windows, the same drive as the repo). Absent: the worktrees/ subdirectory of the plugin data dir, which the skill supplies explicitly rather than reading from the environment (not per-plugin in a Bash-tool subprocess). Deliberately outside the repository tree AND outside repository-discovery roots such as a ghq root, which a checkout-relative default would land inside. Never the in-repo .claude/worktrees/ default, whose nested placement the nesting invariant forbids \u2014 that claim is stated, measured, dated and given an expiry in exactly one place: `skills/worktree/SKILL.md` \u00a7 \"The nesting invariant, verified\"."
+      "description": "External root under which /worktree create places worktrees, as <root>/<owner>-<repo>-<slug> — a path OUTSIDE every repository (on Windows, the same drive as the repo). Absent: the worktrees/ subdirectory of the plugin data dir, which the skill supplies explicitly rather than reading from the environment (not per-plugin in a Bash-tool subprocess). Deliberately outside the repository tree AND outside repository-discovery roots such as a ghq root, which a checkout-relative default would land inside. Never the in-repo .claude/worktrees/ default, whose nested placement the nesting invariant forbids — that claim is stated, measured, dated and given an expiry in exactly one place: `skills/worktree/SKILL.md` § \"The nesting invariant, verified\"."
     },
     "worktree_stale_days": {
       "type": "number",
@@ -210,7 +210,7 @@
     "setup_inference_recency_days": {
       "type": "number",
       "title": "Setup inference recency split (days)",
-      "description": "Boundary for the recency split in /source-control:setup's convention-inference report \u2014 subjects newer than this many days are the 'recent' bucket, weighted as the live convention when its share diverges from the older bucket. Absent: 90.",
+      "description": "Boundary for the recency split in /source-control:setup's convention-inference report — subjects newer than this many days are the 'recent' bucket, weighted as the live convention when its share diverges from the older bucket. Absent: 90.",
       "default": 90,
       "min": 1
     },

--- a/plugins/source-control/CHANGELOG.md
+++ b/plugins/source-control/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to the `source-control` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.53.22]
+
+### Fixed
+
+- **hook-utils:** distinguish unresolved `physical_path`/`repo_root` answers and honor unquoted `#` in `bash_parse_segments` (#1487).
+
 ## [0.53.21]
 
 ### Fixed

--- a/plugins/source-control/hooks/hook-utils.sh
+++ b/plugins/source-control/hooks/hook-utils.sh
@@ -480,7 +480,7 @@ hook::read_file_path() {
 # Guards that must fail closed branch on the return code or on
 # HOOK_REPO_ROOT_UNRESOLVED.
 #   ROOT=$(hook::repo_root "$some_path")
-# shellcheck disable=SC2034  # HOOK_REPO_ROOT_UNRESOLVED is read by sourcing hooks
+# shellcheck disable=SC2034  # public contract: advisory callers may read HOOK_REPO_ROOT_UNRESOLVED
 hook::repo_root() {
   local hint="${1:-.}"
   local root

--- a/plugins/source-control/hooks/hook-utils.sh
+++ b/plugins/source-control/hooks/hook-utils.sh
@@ -340,22 +340,28 @@ hook::expand_8dot3() {
 # spelling of an in-project path cannot dodge it (the long-form prefix would
 # never match). GNU realpath ships with Git Bash and Linux coreutils;
 # readlink -f covers the BSD/macOS hosts that have no realpath. When neither
-# resolver exists the caller falls back to comparing the lexical path as
-# before — the guard is defense-in-depth scoping for a file the agent already
-# wrote via its own tools, so degrading to the historical comparison beats
-# silently disabling the hook on those hosts. The 8.3 expansion applies only
-# on the resolver's success path: an unchanged return is the documented
-# signature of failed canonicalization, and consumers that fail closed on that
-# signature must not see a form-converted path instead.
+# resolver exists the caller still receives the lexical path unchanged — the
+# guard is defense-in-depth scoping for a file the agent already wrote via its
+# own tools, so degrading to the historical comparison beats silently disabling
+# the hook on those hosts — but the answer is now DISTINGUISHABLE: return 1 and
+# HOOK_PHYSICAL_PATH_UNRESOLVED=1. Success (return 0) means resolved; advisory
+# callers that ignore the status keep today's behavior. Guards that must fail
+# closed branch on the return code or on HOOK_PHYSICAL_PATH_UNRESOLVED. The 8.3
+# expansion applies only on the resolver's success path: consumers that fail
+# closed on an unresolved signature must not see a form-converted path instead.
+# shellcheck disable=SC2034  # public contract: advisory callers may read HOOK_PHYSICAL_PATH_UNRESOLVED
 hook::physical_path() {
   local resolved
+  HOOK_PHYSICAL_PATH_UNRESOLVED=0
   if resolved=$(realpath -- "$1" 2>/dev/null) || resolved=$(readlink -f -- "$1" 2>/dev/null); then
     if [[ -n "$resolved" ]]; then
       hook::expand_8dot3 "$resolved"
-      return
+      return 0
     fi
   fi
+  HOOK_PHYSICAL_PATH_UNRESOLVED=1
   printf '%s' "$1"
+  return 1
 }
 
 # True when <normalized-path> sits inside one of this host's temp trees.
@@ -466,19 +472,30 @@ hook::read_file_path() {
 # Resolve the repository root (working-tree top) for a path inside the tree.
 # markdownlint config auto-discovery is CWD-anchored, so the hook cd's here
 # before linting. File-anchored (`git -C "$hint" rev-parse --show-toplevel`)
-# so it is correct for clones, linked worktrees, and bare-hub clones; falls
-# back to the hint (with a trailing /.claude stripped) when git cannot resolve.
+# so it is correct for clones, linked worktrees, and bare-hub clones; when git
+# cannot resolve, still returns the hint (with a trailing /.claude stripped) so
+# advisory callers keep today's fallback — but the answer is now
+# DISTINGUISHABLE: return 1 and HOOK_REPO_ROOT_UNRESOLVED=1. Success (return 0)
+# means git answered; advisory callers that ignore the status are unchanged.
+# Guards that must fail closed branch on the return code or on
+# HOOK_REPO_ROOT_UNRESOLVED.
 #   ROOT=$(hook::repo_root "$some_path")
+# shellcheck disable=SC2034  # HOOK_REPO_ROOT_UNRESOLVED is read by sourcing hooks
 hook::repo_root() {
   local hint="${1:-.}"
   local root
+  HOOK_REPO_ROOT_UNRESOLVED=0
   root=$(git -C "$hint" rev-parse --show-toplevel 2>/dev/null | tr -d '\r')
-  if [[ -z "$root" ]]; then
-    root="$hint"
-    root="${root%/.claude}"
-    root="${root%\\.claude}"
+  if [[ -n "$root" ]]; then
+    printf '%s' "$root"
+    return 0
   fi
+  root="$hint"
+  root="${root%/.claude}"
+  root="${root%\\.claude}"
+  HOOK_REPO_ROOT_UNRESOLVED=1
   printf '%s' "$root"
+  return 1
 }
 
 # Buffer a complete JSON payload from stdin, tolerating Windows Win32-pipe
@@ -1710,9 +1727,10 @@ hook::git_alias_expansion() {
 
 # Single linear pass: read the command into a char array once (O(n)), then walk
 # it splitting top-level segments on UNQUOTED control operators and tokenizing
-# each segment into argv words honoring '…', "…", $'…', and backslash escapes
-# (including backslash-newline continuation). Each completed segment is passed
-# to the callback as it closes, so no full segment list is retained.
+# each segment into argv words honoring '…', "…", $'…', backslash escapes
+# (including backslash-newline continuation), and unquoted `#` comments to EOL
+# (quoted `#` preserved). Each completed segment is passed to the callback as it
+# closes, so no full segment list is retained.
 # Call as: hook::bash_parse_segments <command-string> <callback>; the callback
 # receives one segment's argv words as "$@".
 # shellcheck disable=SC1003  # '\' compares a literal backslash char, not a quote escape
@@ -1802,6 +1820,17 @@ hook::bash_parse_segments() {
         if ((skipnext)); then skipnext=0; else seg+=("$word"); fi
         word=""
         have=0
+      fi
+      ;;
+    '#')
+      # Unquoted `#` starts a shell comment to EOL only at a word boundary (no
+      # word currently being assembled). Mid-word `#` (`x#y`) stays literal.
+      if ((have)); then
+        word+="#"
+      else
+        while ((i + 1 < n)) && [[ "${chars[i + 1]}" != $'\n' ]]; do
+          ((i++))
+        done
       fi
       ;;
     '>' | '<')

--- a/plugins/typos-format/.claude-plugin/plugin.json
+++ b/plugins/typos-format/.claude-plugin/plugin.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "typos-format",
-  "version": "0.6.13",
-  "description": "Spell-check on edit via typos-cli, unconditionally \u2014 report-only by default, honoring the consuming repo's own typos configuration when one is present.",
+  "version": "0.6.14",
+  "description": "Spell-check on edit via typos-cli, unconditionally — report-only by default, honoring the consuming repo's own typos configuration when one is present.",
   "author": {
     "name": "Melodic Software",
     "email": "info@melodicsoftware.com"

--- a/plugins/typos-format/CHANGELOG.md
+++ b/plugins/typos-format/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to the `typos-format` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.6.14]
+
+### Fixed
+
+- **hook-utils:** distinguish unresolved `physical_path`/`repo_root` answers and honor unquoted `#` in `bash_parse_segments` (#1487).
+
 ## [0.6.13]
 
 ### Fixed

--- a/plugins/typos-format/hooks/hook-utils.sh
+++ b/plugins/typos-format/hooks/hook-utils.sh
@@ -480,7 +480,7 @@ hook::read_file_path() {
 # Guards that must fail closed branch on the return code or on
 # HOOK_REPO_ROOT_UNRESOLVED.
 #   ROOT=$(hook::repo_root "$some_path")
-# shellcheck disable=SC2034  # HOOK_REPO_ROOT_UNRESOLVED is read by sourcing hooks
+# shellcheck disable=SC2034  # public contract: advisory callers may read HOOK_REPO_ROOT_UNRESOLVED
 hook::repo_root() {
   local hint="${1:-.}"
   local root

--- a/plugins/typos-format/hooks/hook-utils.sh
+++ b/plugins/typos-format/hooks/hook-utils.sh
@@ -340,22 +340,28 @@ hook::expand_8dot3() {
 # spelling of an in-project path cannot dodge it (the long-form prefix would
 # never match). GNU realpath ships with Git Bash and Linux coreutils;
 # readlink -f covers the BSD/macOS hosts that have no realpath. When neither
-# resolver exists the caller falls back to comparing the lexical path as
-# before — the guard is defense-in-depth scoping for a file the agent already
-# wrote via its own tools, so degrading to the historical comparison beats
-# silently disabling the hook on those hosts. The 8.3 expansion applies only
-# on the resolver's success path: an unchanged return is the documented
-# signature of failed canonicalization, and consumers that fail closed on that
-# signature must not see a form-converted path instead.
+# resolver exists the caller still receives the lexical path unchanged — the
+# guard is defense-in-depth scoping for a file the agent already wrote via its
+# own tools, so degrading to the historical comparison beats silently disabling
+# the hook on those hosts — but the answer is now DISTINGUISHABLE: return 1 and
+# HOOK_PHYSICAL_PATH_UNRESOLVED=1. Success (return 0) means resolved; advisory
+# callers that ignore the status keep today's behavior. Guards that must fail
+# closed branch on the return code or on HOOK_PHYSICAL_PATH_UNRESOLVED. The 8.3
+# expansion applies only on the resolver's success path: consumers that fail
+# closed on an unresolved signature must not see a form-converted path instead.
+# shellcheck disable=SC2034  # public contract: advisory callers may read HOOK_PHYSICAL_PATH_UNRESOLVED
 hook::physical_path() {
   local resolved
+  HOOK_PHYSICAL_PATH_UNRESOLVED=0
   if resolved=$(realpath -- "$1" 2>/dev/null) || resolved=$(readlink -f -- "$1" 2>/dev/null); then
     if [[ -n "$resolved" ]]; then
       hook::expand_8dot3 "$resolved"
-      return
+      return 0
     fi
   fi
+  HOOK_PHYSICAL_PATH_UNRESOLVED=1
   printf '%s' "$1"
+  return 1
 }
 
 # True when <normalized-path> sits inside one of this host's temp trees.
@@ -466,19 +472,30 @@ hook::read_file_path() {
 # Resolve the repository root (working-tree top) for a path inside the tree.
 # markdownlint config auto-discovery is CWD-anchored, so the hook cd's here
 # before linting. File-anchored (`git -C "$hint" rev-parse --show-toplevel`)
-# so it is correct for clones, linked worktrees, and bare-hub clones; falls
-# back to the hint (with a trailing /.claude stripped) when git cannot resolve.
+# so it is correct for clones, linked worktrees, and bare-hub clones; when git
+# cannot resolve, still returns the hint (with a trailing /.claude stripped) so
+# advisory callers keep today's fallback — but the answer is now
+# DISTINGUISHABLE: return 1 and HOOK_REPO_ROOT_UNRESOLVED=1. Success (return 0)
+# means git answered; advisory callers that ignore the status are unchanged.
+# Guards that must fail closed branch on the return code or on
+# HOOK_REPO_ROOT_UNRESOLVED.
 #   ROOT=$(hook::repo_root "$some_path")
+# shellcheck disable=SC2034  # HOOK_REPO_ROOT_UNRESOLVED is read by sourcing hooks
 hook::repo_root() {
   local hint="${1:-.}"
   local root
+  HOOK_REPO_ROOT_UNRESOLVED=0
   root=$(git -C "$hint" rev-parse --show-toplevel 2>/dev/null | tr -d '\r')
-  if [[ -z "$root" ]]; then
-    root="$hint"
-    root="${root%/.claude}"
-    root="${root%\\.claude}"
+  if [[ -n "$root" ]]; then
+    printf '%s' "$root"
+    return 0
   fi
+  root="$hint"
+  root="${root%/.claude}"
+  root="${root%\\.claude}"
+  HOOK_REPO_ROOT_UNRESOLVED=1
   printf '%s' "$root"
+  return 1
 }
 
 # Buffer a complete JSON payload from stdin, tolerating Windows Win32-pipe
@@ -1710,9 +1727,10 @@ hook::git_alias_expansion() {
 
 # Single linear pass: read the command into a char array once (O(n)), then walk
 # it splitting top-level segments on UNQUOTED control operators and tokenizing
-# each segment into argv words honoring '…', "…", $'…', and backslash escapes
-# (including backslash-newline continuation). Each completed segment is passed
-# to the callback as it closes, so no full segment list is retained.
+# each segment into argv words honoring '…', "…", $'…', backslash escapes
+# (including backslash-newline continuation), and unquoted `#` comments to EOL
+# (quoted `#` preserved). Each completed segment is passed to the callback as it
+# closes, so no full segment list is retained.
 # Call as: hook::bash_parse_segments <command-string> <callback>; the callback
 # receives one segment's argv words as "$@".
 # shellcheck disable=SC1003  # '\' compares a literal backslash char, not a quote escape
@@ -1802,6 +1820,17 @@ hook::bash_parse_segments() {
         if ((skipnext)); then skipnext=0; else seg+=("$word"); fi
         word=""
         have=0
+      fi
+      ;;
+    '#')
+      # Unquoted `#` starts a shell comment to EOL only at a word boundary (no
+      # word currently being assembled). Mid-word `#` (`x#y`) stays literal.
+      if ((have)); then
+        word+="#"
+      else
+        while ((i + 1 < n)) && [[ "${chars[i + 1]}" != $'\n' ]]; do
+          ((i++))
+        done
       fi
       ;;
     '>' | '<')


### PR DESCRIPTION
Fixes #1487

## Summary

Shared `hook-utils.sh` helpers no longer answer "I could not determine this" as an indistinguishable success:

- **`hook::physical_path`** — returns `1` and sets `HOOK_PHYSICAL_PATH_UNRESOLVED=1` when neither `realpath` nor `readlink -f` resolves, while still printing the lexical path for advisory callers.
- **`hook::repo_root`** — returns `1` and sets `HOOK_REPO_ROOT_UNRESOLVED=1` when `git rev-parse --show-toplevel` cannot answer, while still printing the hint fallback.
- **`hook::bash_parse_segments`** — unquoted `#` starts a shell comment to EOL; quoted `#` is preserved.

Contract is documented at each helper: **return 0 means resolved**; advisory callers that ignore the status keep today's behavior.

## Tests

`lib/hook-utils.test.sh` covers path-helper failure signals and the `#` comment bypass shape (`git b # -C other-repo`).

## Propagation

Synced via `scripts/sync-hook-utils.sh`; all 16 carrying plugins bumped with changelog entries.

## Related

N/A