### PR TITLE
fix(disk-hygiene): launch wired hooks through bash Python resolver (#1504)

### DIFF
--- a/plugins/disk-hygiene/.claude-plugin/plugin.json
+++ b/plugins/disk-hygiene/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "disk-hygiene",
-  "version": "0.17.5",
+  "version": "0.17.6",
   "description": "Context-aware disk hygiene for arbitrary directory trees: inventories orphaned and temporary artifacts, classifies evidence into review tiers, and offers exact-path cleanup only after a fresh safety preview and explicit per-tier approval. The target is read-only by default; OS-managed paths, links and mount points, VCS-tracked content, changed entries, and live-handle uncertainty fail closed.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/disk-hygiene/CHANGELOG.md
+++ b/plugins/disk-hygiene/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to the `disk-hygiene` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.17.6]
+
+### Fixed
+
+- **Wired hooks launch through a bash Python resolver (#1504).** Both `hooks/hooks.json`
+  registrations now invoke `hooks/run-python-hook.sh`, which resolves a real Python 3
+  interpreter (rejecting the zero-length WindowsApps `python3` alias stub) before exec'ing
+  the guard or the Stop detector. When no interpreter resolves, the guard still fails open
+  (exit 0) and the detector emits a `systemMessage` on stdout — so the blind spot the
+  detector exists to surface is visible even when bare `python3` cannot run.
+
 ## [0.17.5]
 
 ### Added

--- a/plugins/disk-hygiene/README.md
+++ b/plugins/disk-hygiene/README.md
@@ -49,7 +49,9 @@ at preview. Backups remain the recovery boundary for user data.
   `skills/clean/scripts/hygiene.py`; `/disk-hygiene:setup check` derives the enforced value from
   there, so treat the number printed here as a convenience copy). Claude Code launches the guard in
   shell-free exec form; guarded engine calls must use the same absolute interpreter reported by that
-  guard, so Bash aliases and functions cannot replace it. The guard registers on two surfaces: a
+  guard, so Bash aliases and functions cannot replace it. Both wired hooks register as `bash`
+  invoking `hooks/run-python-hook.sh`, so `bash` must resolve on `PATH` (Git Bash on Windows) before
+  the launcher can resolve Python (#1504). The guard registers on two surfaces: a
   plugin-level **engine gate** (`hooks/hooks.json`) that acts only on commands referencing the
   engine — deferring everything else instantly — and enforces the kill switch and data-root
   authority; and the skill-scoped **belt** inside the `clean` skill's context, which adds the

--- a/plugins/disk-hygiene/README.md
+++ b/plugins/disk-hygiene/README.md
@@ -72,10 +72,10 @@ at preview. Backups remain the recovery boundary for user data.
   guard that never ran or died mid-run no longer looks identical to a guard that ran and approved.
   This covers only the `destructive_guard.py` command string in the current session's transcript: it
   does not cover repo-hygiene's own guard (a separate plugin, verified working independently), and it
-  never retroactively scans a prior session's transcript. It is also wired with the same literal
-  `python3` command as the guard it watches, so the interpreter-resolution failure below — the
-  WindowsApps alias stub, or a missing/broken `python3` — takes the detector down with the guard and
-  goes unreported (#1504).
+  never retroactively scans a prior session's transcript. Both wired hooks register through
+  `hooks/run-python-hook.sh` — a bash launcher that resolves Python independently of bare
+  `python3` on PATH — so when `python3` is the WindowsApps alias stub or otherwise unresolvable,
+  the detector still emits a `systemMessage` even though the guard cannot run (#1504).
 - Git is optional for ordinary trees. If a target contains or sits inside a Git worktree, Git becomes
   required so tracked content can be proven safe; otherwise cleanup for that subtree is blocked.
 - Windows has the full **audit** lane (Python 3.11's `lstat` reparse metadata plus Win32 APIs
@@ -86,18 +86,18 @@ at preview. Backups remain the recovery boundary for user data.
   distinction only — the engine treats Windows and macOS identically (execution unsupported); which
   reversible-removal container the manual lane prefers is the model's instruction, not engine
   behavior.
-- **Windows `python3` gotcha — the Store alias stub fails the guard open.** The `clean` guard hook
-  launches the literal command `python3`. On stock Windows that name resolves to a zero-length
-  `WindowsApps\python3.exe` App Execution Alias — a reparse stub that opens the Microsoft Store (or
-  exits) instead of running an interpreter, so the guard process never starts. A PreToolUse hook
-  blocks a tool call only by emitting exit code 2 or a `deny` decision ([Hooks](https://code.claude.com/docs/en/hooks));
-  a guard that never runs emits neither, and Claude Code treats the non-blocking result as approval —
-  the destructive Bash/PowerShell command proceeds ungated (the same fail-open shape as the 0.6.3
-  launch-failure fix, via a different vector). `/disk-hygiene:setup check` detects this explicitly and
-  FAILs: disable the `python3` App execution alias (Settings > Apps > Advanced app settings > App
-  execution aliases) or install real Python and ensure it precedes WindowsApps on `PATH`. A bare
-  `command -v python3` / `where python3` success is not proof the interpreter is real — the stub
-  answers to the name too.
+- **Windows `python3` gotcha — the Store alias stub fails the guard open.** The wired hooks resolve
+  Python through `hooks/run-python-hook.sh` (rejecting the zero-length `WindowsApps\python3.exe`
+  App Execution Alias stub) before exec'ing the guard. When no interpreter resolves, the guard still
+  fails open — a PreToolUse hook blocks a tool call only by emitting exit code 2 or a `deny`
+  decision ([Hooks](https://code.claude.com/docs/en/hooks)); a guard that never runs emits neither,
+  and Claude Code treats the non-blocking result as approval — the destructive Bash/PowerShell
+  command proceeds ungated (the same fail-open shape as the 0.6.3 launch-failure fix, via a
+  different vector). The Stop detector emits a `systemMessage` in that case so the blind spot is
+  visible. `/disk-hygiene:setup check` detects this explicitly and FAILs: disable the `python3` App
+  execution alias (Settings > Apps > Advanced app settings > App execution aliases) or install real
+  Python and ensure it precedes WindowsApps on `PATH`. A bare `command -v python3` / `where python3`
+  success is not proof the interpreter is real — the stub answers to the name too.
 - Linux requires readable `/proc/self/mountinfo`, descriptor-relative filesystem APIs, and `lsof` for
   the optional execution lane. Absence, diagnostics, or authority gaps block cleanup.
 - macOS supports audit/report only because this implementation has no authoritative bind-mount and

--- a/plugins/disk-hygiene/hooks/hooks.json
+++ b/plugins/disk-hygiene/hooks/hooks.json
@@ -6,8 +6,9 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3",
+            "command": "bash",
             "args": [
+              "${CLAUDE_PLUGIN_ROOT}/hooks/run-python-hook.sh",
               "${CLAUDE_PLUGIN_ROOT}/skills/clean/scripts/destructive_guard.py",
               "--mode",
               "engine-gate",
@@ -26,8 +27,9 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3",
+            "command": "bash",
             "args": [
+              "${CLAUDE_PLUGIN_ROOT}/hooks/run-python-hook.sh",
               "${CLAUDE_PLUGIN_ROOT}/skills/clean/scripts/guard_launch_monitor.py",
               "--data-root",
               "${CLAUDE_PLUGIN_DATA}"

--- a/plugins/disk-hygiene/hooks/run-python-hook.sh
+++ b/plugins/disk-hygiene/hooks/run-python-hook.sh
@@ -67,7 +67,7 @@ resolve_python3() {
 
   if command -v py >/dev/null 2>&1; then
     resolved="$(py -3 -c 'import sys; print(sys.executable)' 2>/dev/null)" || return 1
-    if [[ -n "$resolved" ]] && "$resolved" -c 'import sys; raise SystemExit(0 if sys.version_info >= (3, 11) else 1)' 2>/dev/null; then
+    if [[ -n "$resolved" ]] && "$resolved" -c "$PYTHON_VERSION_PROBE" 2>/dev/null; then
       printf '%s' "$resolved"
       return 0
     fi

--- a/plugins/disk-hygiene/hooks/run-python-hook.sh
+++ b/plugins/disk-hygiene/hooks/run-python-hook.sh
@@ -22,6 +22,7 @@ MODE=unknown
 case "$SCRIPT" in
 *guard_launch_monitor.py*) MODE=monitor ;;
 *destructive_guard.py*) MODE=guard ;;
+*) ;;
 esac
 
 # Portable WindowsApps path-component check (case-insensitive).
@@ -48,7 +49,7 @@ resolve_python3() {
     if _is_store_alias_stub "$resolved"; then
       continue
     fi
-    if "$resolved" -c 'import sys; sys.exit(0)' 2>/dev/null; then
+    if "$resolved" -c 'import sys; raise SystemExit(0 if sys.version_info >= (3, 11) else 1)' 2>/dev/null; then
       printf '%s' "$resolved"
       return 0
     fi
@@ -56,7 +57,7 @@ resolve_python3() {
 
   if command -v py >/dev/null 2>&1; then
     resolved="$(py -3 -c 'import sys; print(sys.executable)' 2>/dev/null)" || return 1
-    if [[ -n "$resolved" ]] && "$resolved" -c 'import sys; sys.exit(0)' 2>/dev/null; then
+    if [[ -n "$resolved" ]] && "$resolved" -c 'import sys; raise SystemExit(0 if sys.version_info >= (3, 11) else 1)' 2>/dev/null; then
       printf '%s' "$resolved"
       return 0
     fi

--- a/plugins/disk-hygiene/hooks/run-python-hook.sh
+++ b/plugins/disk-hygiene/hooks/run-python-hook.sh
@@ -15,6 +15,16 @@
 #   * destructive_guard.py — exit 0 silently (existing PreToolUse fail-open).
 set -uo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ENGINE="$SCRIPT_DIR/../skills/clean/scripts/hygiene.py"
+MIN_PYTHON_MAJOR="$(sed -n 's/^MIN_PYTHON = (\([0-9]*\), \([0-9]*\)).*/\1/p' "$ENGINE")"
+MIN_PYTHON_MINOR="$(sed -n 's/^MIN_PYTHON = (\([0-9]*\), \([0-9]*\)).*/\2/p' "$ENGINE")"
+if [[ -z "$MIN_PYTHON_MAJOR" || -z "$MIN_PYTHON_MINOR" ]]; then
+  MIN_PYTHON_MAJOR=3
+  MIN_PYTHON_MINOR=11
+fi
+PYTHON_VERSION_PROBE="import sys; raise SystemExit(0 if sys.version_info >= ($MIN_PYTHON_MAJOR, $MIN_PYTHON_MINOR) else 1)"
+
 SCRIPT="${1:-}"
 shift || true
 
@@ -49,7 +59,7 @@ resolve_python3() {
     if _is_store_alias_stub "$resolved"; then
       continue
     fi
-    if "$resolved" -c 'import sys; raise SystemExit(0 if sys.version_info >= (3, 11) else 1)' 2>/dev/null; then
+    if "$resolved" -c "$PYTHON_VERSION_PROBE" 2>/dev/null; then
       printf '%s' "$resolved"
       return 0
     fi

--- a/plugins/disk-hygiene/hooks/run-python-hook.sh
+++ b/plugins/disk-hygiene/hooks/run-python-hook.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Launch disk-hygiene wired hooks through a Python 3 interpreter resolved
+# independently of a bare `python3` on PATH (#1504).
+#
+# Claude Code registers plugin hooks in exec form: the `command` field is
+# resolved on PATH with no shell. When `python3` is absent, broken, or resolves
+# to the zero-length WindowsApps App Execution Alias stub, both the guard and its
+# Stop detector died the same way — the detector could not observe the guard's
+# fail-open. This launcher is registered as `bash` (available in Git Bash on
+# Windows) and resolves a real interpreter before exec'ing the target script.
+#
+# When no interpreter resolves:
+#   * guard_launch_monitor.py — emit a once-per-run systemMessage on stdout
+#     (the detector's only output channel) so the operator sees the blind spot.
+#   * destructive_guard.py — exit 0 silently (existing PreToolUse fail-open).
+set -uo pipefail
+
+SCRIPT="${1:-}"
+shift || true
+
+MODE=unknown
+case "$SCRIPT" in
+*guard_launch_monitor.py*) MODE=monitor ;;
+*destructive_guard.py*) MODE=guard ;;
+esac
+
+# Portable WindowsApps path-component check (case-insensitive).
+_under_windowsapps() {
+  local path_lower
+  path_lower="$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')"
+  [[ "$path_lower" == *windowsapps* ]]
+}
+
+# True when `path` names a zero-length Windows App Execution Alias stub.
+_is_store_alias_stub() {
+  local path="$1"
+  [[ -f "$path" ]] || return 1
+  [[ -s "$path" ]] && return 1
+  _under_windowsapps "$path"
+}
+
+# Echo a runnable Python 3 interpreter path, or return 1.
+resolve_python3() {
+  local candidate resolved
+
+  for candidate in python3 python; do
+    resolved="$(command -v "$candidate" 2>/dev/null)" || continue
+    if _is_store_alias_stub "$resolved"; then
+      continue
+    fi
+    if "$resolved" -c 'import sys; sys.exit(0)' 2>/dev/null; then
+      printf '%s' "$resolved"
+      return 0
+    fi
+  done
+
+  if command -v py >/dev/null 2>&1; then
+    resolved="$(py -3 -c 'import sys; print(sys.executable)' 2>/dev/null)" || return 1
+    if [[ -n "$resolved" ]] && "$resolved" -c 'import sys; sys.exit(0)' 2>/dev/null; then
+      printf '%s' "$resolved"
+      return 0
+    fi
+  fi
+
+  return 1
+}
+
+PYTHON=""
+if ! PYTHON="$(resolve_python3)"; then
+  PYTHON=""
+fi
+
+if [[ -z "$PYTHON" ]]; then
+  if [[ "$MODE" == "monitor" ]]; then
+    printf '%s\n' \
+      '{"systemMessage":"disk-hygiene: destructive guard could not launch — no Python 3 interpreter resolved on this host (python3 missing or is a Windows App Execution Alias stub). Destructive Bash/PowerShell commands may have proceeded unguarded."}'
+  fi
+  exit 0
+fi
+
+exec "$PYTHON" "$SCRIPT" "$@"

--- a/plugins/disk-hygiene/hooks/run-python-hook.test.sh
+++ b/plugins/disk-hygiene/hooks/run-python-hook.test.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# Contract tests for the disk-hygiene Python hook launcher (#1504).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LAUNCHER="$SCRIPT_DIR/run-python-hook.sh"
+
+pass() { printf 'PASS: %s\n' "$1"; }
+fail() { printf 'FAIL: %s\n' "$1" >&2; exit 1; }
+
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    pass "$label"
+  else
+    fail "$label (expected '$expected', got '$actual')"
+  fi
+}
+
+assert_contains() {
+  local label="$1" needle="$2" haystack="$3"
+  if [[ "$haystack" == *"$needle"* ]]; then
+    pass "$label"
+  else
+    fail "$label (missing '$needle' in output)"
+  fi
+}
+
+# --- launcher is executable and hooks.json wires bash + this script ---
+HOOKS_JSON="$SCRIPT_DIR/hooks.json"
+if ! command -v jq >/dev/null 2>&1; then
+  echo "SKIP: jq required" >&2
+  exit 0
+fi
+
+for hook_name in destructive_guard.py guard_launch_monitor.py; do
+  command_line="$(jq -r --arg target "$hook_name" '
+    .hooks | to_entries[] | .value[]? | .hooks[]? |
+    select(.args[]? | contains($target)) | .command
+  ' "$HOOKS_JSON" | head -n1)"
+  assert_eq "hooks.json command for $hook_name is bash" "bash" "$command_line"
+  launcher_arg="$(jq -r --arg target "$hook_name" '
+    .hooks | to_entries[] | .value[]? | .hooks[]? |
+    select(.args[]? | contains($target)) | .args[0]
+  ' "$HOOKS_JSON" | head -n1)"
+  assert_contains "hooks.json args[0] for $hook_name is the launcher" "run-python-hook.sh" "$launcher_arg"
+done
+
+# --- monitor mode without python emits systemMessage JSON ---
+FAKE_BIN="$(mktemp -d)"
+trap 'rm -rf "$FAKE_BIN"' EXIT
+printf '#!/usr/bin/env bash\nexit 127\n' >"$FAKE_BIN/nopy"
+chmod +x "$FAKE_BIN/nopy"
+cat >"$FAKE_BIN/python3" <<'EOF'
+#!/usr/bin/env bash
+exit 127
+EOF
+chmod +x "$FAKE_BIN/python3"
+cat >"$FAKE_BIN/python" <<'EOF'
+#!/usr/bin/env bash
+exit 127
+EOF
+chmod +x "$FAKE_BIN/python"
+
+MONITOR_OUT="$(
+  PATH="$FAKE_BIN:$PATH" bash "$LAUNCHER" \
+    "$SCRIPT_DIR/../skills/clean/scripts/guard_launch_monitor.py" \
+    --data-root /tmp/disk-hygiene-test 2>/dev/null || true
+)"
+assert_contains "monitor mode warns when python is unavailable" "systemMessage" "$MONITOR_OUT"
+assert_contains "monitor mode names the guard" "destructive guard" "$MONITOR_OUT"
+
+# --- guard mode without python is silent success ---
+GUARD_RC=0
+PATH="$FAKE_BIN:$PATH" bash "$LAUNCHER" \
+  "$SCRIPT_DIR/../skills/clean/scripts/destructive_guard.py" \
+  --mode engine-gate >/dev/null 2>&1 || GUARD_RC=$?
+assert_eq "guard mode exits 0 when python is unavailable" "0" "$GUARD_RC"
+
+# --- happy path execs the target script when python is available ---
+if command -v python3 >/dev/null 2>&1 &&
+  python3 -c 'import sys; sys.exit(0)' 2>/dev/null; then
+  VERSION_OUT="$(
+    bash "$LAUNCHER" -c 'import sys; print(sys.version_info[0])' 2>/dev/null || true
+  )"
+  # `-c` is consumed by bash launcher as SCRIPT; use a tiny helper instead.
+  HELPER="$(mktemp --suffix=.py)"
+  printf 'import sys\nprint("launcher-ok")\n' >"$HELPER"
+  HELPER_OUT="$(bash "$LAUNCHER" "$HELPER" 2>/dev/null || true)"
+  rm -f "$HELPER"
+  assert_eq "launcher runs python script on happy path" "launcher-ok" "${HELPER_OUT//$'\r'/}"
+else
+  echo "SKIP: runnable python3 not available for happy-path probe" >&2
+fi
+
+pass "all run-python-hook contract checks"

--- a/plugins/disk-hygiene/hooks/run-python-hook.test.sh
+++ b/plugins/disk-hygiene/hooks/run-python-hook.test.sh
@@ -4,6 +4,13 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 LAUNCHER="$SCRIPT_DIR/run-python-hook.sh"
+ENGINE="$SCRIPT_DIR/../skills/clean/scripts/hygiene.py"
+FLOOR="$(sed -n 's/^MIN_PYTHON = (\([0-9]*\), \([0-9]*\)).*/\1.\2/p' "$ENGINE")"
+if [[ -z "$FLOOR" ]]; then
+  echo "FAIL: could not parse MIN_PYTHON from $ENGINE" >&2
+  exit 1
+fi
+PYTHON_VERSION_PROBE="import sys; floor = tuple(int(part) for part in '$FLOOR'.split('.')); raise SystemExit(0 if sys.version_info >= floor else 1)"
 
 pass() { printf 'PASS: %s\n' "$1"; }
 fail() { printf 'FAIL: %s\n' "$1" >&2; exit 1; }
@@ -79,7 +86,7 @@ assert_eq "guard mode exits 0 when python is unavailable" "0" "$GUARD_RC"
 
 # --- happy path execs the target script when python is available ---
 if command -v python3 >/dev/null 2>&1 &&
-  python3 -c 'import sys; raise SystemExit(0 if sys.version_info >= (3, 11) else 1)' 2>/dev/null; then
+  python3 -c "$PYTHON_VERSION_PROBE" 2>/dev/null; then
   HELPER="$(mktemp --suffix=.py)"
   printf 'import sys\nprint("launcher-ok")\n' >"$HELPER"
   HELPER_OUT="$(bash "$LAUNCHER" "$HELPER" 2>/dev/null || true)"

--- a/plugins/disk-hygiene/hooks/run-python-hook.test.sh
+++ b/plugins/disk-hygiene/hooks/run-python-hook.test.sh
@@ -79,11 +79,7 @@ assert_eq "guard mode exits 0 when python is unavailable" "0" "$GUARD_RC"
 
 # --- happy path execs the target script when python is available ---
 if command -v python3 >/dev/null 2>&1 &&
-  python3 -c 'import sys; sys.exit(0)' 2>/dev/null; then
-  VERSION_OUT="$(
-    bash "$LAUNCHER" -c 'import sys; print(sys.version_info[0])' 2>/dev/null || true
-  )"
-  # `-c` is consumed by bash launcher as SCRIPT; use a tiny helper instead.
+  python3 -c 'import sys; raise SystemExit(0 if sys.version_info >= (3, 11) else 1)' 2>/dev/null; then
   HELPER="$(mktemp --suffix=.py)"
   printf 'import sys\nprint("launcher-ok")\n' >"$HELPER"
   HELPER_OUT="$(bash "$LAUNCHER" "$HELPER" 2>/dev/null || true)"

--- a/plugins/disk-hygiene/skills/setup/SKILL.md
+++ b/plugins/disk-hygiene/skills/setup/SKILL.md
@@ -24,7 +24,7 @@ report a PASS/FAIL/INFO table with one remediation line per FAIL.
 
 When the plugin's toggle is disabled, every prerequisite absence downgrades from FAIL to
 INFO — a deliberately disabled plugin is not broken. Report the probes informationally and
-note that re-enabling restores the FAIL semantics. One exception: every step-1 failure stays
+note that re-enabling restores the FAIL semantics. One exception: every step-1 and step-2 failure stays
 FAIL with the toggle disabled. Audit-only mode is *enforced by* the guard, both guard surfaces
 launch through the literal name `python3`, and a guard that never runs can neither read nor
 enforce the configured `false` — so the fail-open is most dangerous in exactly this
@@ -38,7 +38,12 @@ the guard's own source: Python 3.6, for example, rejects the guard's
 non-blocking — the same silent fail-open through a different door. Unproven guard execution
 fails closed like every other guard-relevant unknown in this plugin.
 
-1. **Python floor on `PATH`** — the interpreter used by scanning, validation, the
+1. **Bash launcher on `PATH`** — both wired hooks in `hooks/hooks.json` register as the literal
+   command `bash` before `hooks/run-python-hook.sh` resolves Python. FAIL if `command -v bash` is
+   empty; on Windows ensure Git Bash (or another real `bash.exe`) precedes stub paths on `PATH`.
+   When bash is missing, neither the guard nor the Stop detector can launch — the same blind spot
+   the launcher exists to surface.
+2. **Python floor on `PATH`** — the interpreter used by scanning, validation, the
    guard, and cleanup. (The guard registers on two surfaces: a plugin-level engine gate
    that acts only on engine-referencing commands, and the skill-scoped belt inside the
    `clean` skill's context. Both register unconditionally and resolve the kill switch by
@@ -86,10 +91,10 @@ fails closed like every other guard-relevant unknown in this plugin.
    without that name either — it is a guard-launch failure too, so it keeps the FAIL under a
    disabled toggle alongside the other two. A bare `command -v python3` success is not
    evidence on its own — it matches the stub too.
-2. **Git** — `command -v git`. Conditional per the README: optional for ordinary trees,
+3. **Git** — `command -v git`. Conditional per the README: optional for ordinary trees,
    required when a target contains or sits inside a Git worktree. Report presence as INFO
    with that conditionality stated; absence is only a FAIL for worktree-containing targets.
-3. **Platform posture** — detect the current OS family and report its documented lane per
+4. **Platform posture** — detect the current OS family and report its documented lane per
    the README, keeping the audit and execution lanes visibly separate: Windows (full
    **audit** — `lstat` reparse + Win32, never UAC; engine **execution unsupported** —
    `preview` reports `execution-platform-unsupported` as a per-candidate blocker, removal is
@@ -98,9 +103,9 @@ fails closed like every other guard-relevant unknown in this plugin.
    `/proc/self/mountinfo` is readable — `lsof` needed only for that optional execution
    lane, absent `lsof` is INFO with the reduced-capability note), macOS (audit/report
    only by design; manual Trash handoff only under `--execute` — INFO, not a defect).
-4. **Execution kill switch** — resolve the effective `disk_hygiene_enabled` value
+5. **Execution kill switch** — resolve the effective `disk_hygiene_enabled` value
    deterministically; never present an assumed value as the configured one. Run the bundled
-   probe with the step-1 interpreter:
+   probe with the step-2 interpreter:
    `"<python>" "${CLAUDE_PLUGIN_ROOT}/skills/setup/scripts/kill_switch_probe.py"`
    and report its `effective` value together with its `source` (`configured` vs `default`).
    When the probe says `degraded: true`, report that the configured value could not be read
@@ -109,7 +114,7 @@ fails closed like every other guard-relevant unknown in this plugin.
    to a boolean that contradicts the probe, report the discrepancy instead of silently
    preferring either channel (the probe sees user settings only; managed settings or a
    `--settings` flag can carry a value the probe cannot see).
-5. **Plugin registration** — INFO: confirm the plugin is enabled for this project
+6. **Plugin registration** — INFO: confirm the plugin is enabled for this project
    (`/plugin` → Installed) rather than parsing settings files.
 
 ## `apply` (idempotent)


### PR DESCRIPTION
Fixes #1504

## Summary

Both wired `disk-hygiene` hooks now register as `bash` invoking `hooks/run-python-hook.sh`, which resolves a real Python 3 interpreter (rejecting the zero-length WindowsApps `python3` alias stub) before exec'ing the target script. When no interpreter resolves, the guard still fails open (exit 0) and the Stop detector emits a `systemMessage` on stdout.

## Related

- #1465 — disclosed the blind spot this change closes
- #1416 — guard-launch monitor that benefits from independent launcher
