### PR TITLE
fix(ci): fetch the base ref with full history so the scope check has a merge base

### DIFF
--- a/scripts/verify-security-review-evidence.sh
+++ b/scripts/verify-security-review-evidence.sh
@@ -155,7 +155,13 @@ main() {
   fi
 
   local base_ref="${GITHUB_BASE_REF:-main}"
-  git fetch origin "$base_ref" --depth=1 >/dev/null 2>&1 || true
+  # Never `--depth=1` here. The scope check below diffs `origin/<base>...HEAD`,
+  # and a three-dot diff needs a merge base — a shallow fetch truncates the base
+  # ref to a lone commit and kills it for every branch not sitting on the base's
+  # current tip, so the guard dies with "no merge base" instead of evaluating.
+  # The workflow checks out with fetch-depth: 0, so this is a normal fetch
+  # against an already-complete clone, not a cost regression.
+  git fetch origin "$base_ref" >/dev/null 2>&1 || true
   # A command substitution keeps `set -e` live for the helper (no `||`
   # suppression), so a genuine fault inside it still aborts the guard — while
   # the in-scope decision travels on stdout, where it cannot be confused with

--- a/scripts/verify-security-review-evidence.sh.test.sh
+++ b/scripts/verify-security-review-evidence.sh.test.sh
@@ -207,6 +207,56 @@ else
     "the catch-all branch is gone; an unexpected verdict could fall through as a pass"
 fi
 
+# A shallow base-ref fetch destroys the merge base the scope check's three-dot
+# diff needs, so the guard dies with "no merge base" for every branch not on the
+# base's current tip. Static guard first, then the behaviour it protects.
+# shellcheck disable=SC2016  # as above, the regex matches a LITERAL "$base_ref"
+# in the guard's source; expanding it here would search for this test's own var.
+if grep -qE '^[[:space:]]*git fetch origin "\$base_ref".*--depth' "$GUARD_SCRIPT"; then
+  fail "the base ref is fetched with full history, not shallow" \
+    "found a --depth fetch; a three-dot diff against a truncated base ref has no merge base and the guard errors instead of evaluating scope"
+else
+  pass "the base ref is fetched with full history, not shallow"
+fi
+
+MERGE_BASE_TMP="$(mktemp -d)"
+trap 'rm -rf "$MERGE_BASE_TMP"' EXIT
+
+# `&&`-chained rather than `set -e`: enabling errexit anywhere in this file
+# switches on SC2310 for every pre-existing function-in-a-condition above.
+# The PR branch forks, then main advances past it — the ordinary case.
+if ! (
+  export GIT_AUTHOR_NAME=t GIT_AUTHOR_EMAIL=t@t &&
+    export GIT_COMMITTER_NAME=t GIT_COMMITTER_EMAIL=t@t &&
+    git init -q -b main "$MERGE_BASE_TMP/origin" &&
+    cd "$MERGE_BASE_TMP/origin" &&
+    echo one > f && git add f && git commit -qm one &&
+    git clone -q "$MERGE_BASE_TMP/origin" "$MERGE_BASE_TMP/work" &&
+    cd "$MERGE_BASE_TMP/work" && git checkout -qb pr &&
+    echo pr > g && git add g && git commit -qm pr &&
+    cd "$MERGE_BASE_TMP/origin" && echo two > f && git commit -qam two
+) >/dev/null 2>&1; then
+  fail "merge-base fixture builds" "could not construct the behind-main fixture repository"
+fi
+
+cd "$MERGE_BASE_TMP/work" || exit 1
+git fetch origin main >/dev/null 2>&1
+if git diff --name-only origin/main...HEAD >/dev/null 2>&1; then
+  pass "a full base-ref fetch leaves a usable merge base for a branch behind main"
+else
+  fail "a full base-ref fetch leaves a usable merge base for a branch behind main" \
+    "three-dot diff failed even with full history — the scope check could never run"
+fi
+
+git fetch origin main --depth=1 >/dev/null 2>&1
+if git diff --name-only origin/main...HEAD >/dev/null 2>&1; then
+  fail "the regression this guards is real: a shallow base-ref fetch breaks the three-dot diff" \
+    "the shallow fetch did NOT break the diff, so this test no longer pins anything — re-derive it against the current git before trusting the static guard above"
+else
+  pass "the regression this guards is real: a shallow base-ref fetch breaks the three-dot diff"
+fi
+cd "$SCRIPT_DIR" || exit 1
+
 if [[ "$FAILED" -eq 0 ]]; then
   printf '\nAll checks passed.\n'
   exit 0


### PR DESCRIPTION
## Summary

`scripts/verify-security-review-evidence.sh` fetched the base ref shallow and then asked for a
three-dot diff against it:

```bash
git fetch origin "$base_ref" --depth=1 >/dev/null 2>&1 || true
# ...
git diff --name-only origin/<base>...HEAD
```

A three-dot diff needs a merge base. `--depth=1` truncates the base ref to a lone commit, so any
branch not sitting on the base's current tip dies with `fatal: origin/main...HEAD: no merge base`
before the scope check can run. At this repo's merge rate that is most PRs more than a few minutes
old.

Observed on #2539: deterministic across two independent runs (`31655807987`, jobs `94310219602` and
`94312908610`), branch seven commits behind main.

The failure is fail-closed — correct, and clearly deliberate in the script's comments — but the guard
never reaches the evidence check it exists to perform, and goes red on PRs it has nothing to say
about.

**Fix:** drop `--depth=1`. `.github/workflows/claude-security-review.yml` already checks out with
`fetch-depth: 0`, so this is a normal fetch against an already-complete clone, not a cost regression.
Nothing about the fail-closed posture changes.

**Not done here:** defending against being called from a genuinely shallow clone
(`--is-shallow-repository` → `--unshallow`). The only caller checks out full history, so that would
be scaffolding for a case that does not exist. Raised as a question in #2553 rather than built.

## Test plan

- `scripts/verify-security-review-evidence.sh.test.sh` — all checks pass, including two new ones:
  - a **static** guard that fails if a `--depth` fetch of the base ref is reintroduced;
  - a **behavioural** test building a behind-main fixture repo and asserting *both* directions — the
    full fetch yields a working three-dot diff, and the shallow fetch breaks it. The second
    assertion fails loudly if the regression ever stops being real, so the test cannot start passing
    vacuously and leave the static guard unexamined.
- `scripts/affected-tests.sh --run` — 1 suite selected, passes.
- `shellcheck` with the repo's `.shellcheckrc`: **exit 0**, matching the pre-change baseline
  (verified by stashing and re-running). The fixture chains with `&&` rather than `set -e` because
  enabling errexit anywhere in that file switches on SC2310 for every pre-existing
  function-in-a-condition above it; the one new `SC2016` carries the same disable directive and
  rationale the file already uses two blocks earlier.
- `editorconfig-checker` clean; no file-mode changes.

## Related

Closes #2553

Found while shipping #2539, where this gate went red on a docs-only change with no finding of its
own.
