### PR TITLE
feat(autofix-hooks): adopt content-mutation disclosure across remaining autofix hooks

### DIFF
--- a/plugins/bash-format/.claude-plugin/plugin.json
+++ b/plugins/bash-format/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "bash-format",
-  "version": "0.7.13",
+  "version": "0.7.14",
   "description": "Auto-format and lint shell scripts on edit via shfmt + ShellCheck, using the consuming repo's own .editorconfig and .shellcheckrc.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/bash-format/CHANGELOG.md
+++ b/plugins/bash-format/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to the `bash-format` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.7.14]
+
+### Changed
+
+- **Content-mutation disclosure contract tests (#1596).** The shfmt gate-on suite now
+  asserts the `systemMessage` emitted when shfmt rewrites a file; hook comments document
+  the conformance rationale.
+
 ## [0.7.13]
 
 ### Fixed

--- a/plugins/bash-format/hooks/bash-format.sh
+++ b/plugins/bash-format/hooks/bash-format.sh
@@ -221,6 +221,8 @@ if shell_editorconfig_opt_in; then
       probe_err=""
       _fmt_target="$TOOL_FILE"
       [[ -f "$_fmt_target" ]] || _fmt_target="$FILE"
+      # Content-mutation disclosure (#1596): shfmt rewrites structural layout
+      # only; name the rewrite on the user channel and stay silent on no-op paths.
       _fmt_before=""
       if _fmt_before=$(mktemp 2>/dev/null); then
         cp "$_fmt_target" "$_fmt_before" 2>/dev/null || _fmt_before=""

--- a/plugins/bash-format/hooks/bash-format.test.sh
+++ b/plugins/bash-format/hooks/bash-format.test.sh
@@ -178,11 +178,16 @@ indent_size = 2
 EOF
   mkdir -p "$REPO_YES/src"
   printf '#!/usr/bin/env bash\nif true; then\necho hi\nfi\n' >"$REPO_YES/src/fmt.sh"
-  run_hook "$REPO_YES/src/fmt.sh" >/dev/null
+  OUT=$(run_hook "$REPO_YES/src/fmt.sh")
   if grep -q '^  echo hi$' "$REPO_YES/src/fmt.sh"; then
     ok "shfmt gate ON (.editorconfig present) -> file formatted"
   else
     fail "shfmt gate ON -> not formatted: $(cat "$REPO_YES/src/fmt.sh")"
+  fi
+  if printf '%s' "$OUT" | grep -q 'bash-format: reformatted'; then
+    ok "shfmt gate ON -> user-channel mutation disclosure"
+  else
+    fail "shfmt gate ON -> missing systemMessage disclosure: $OUT"
   fi
 
   # Gate OFF: no .editorconfig anywhere in the repo -> bytes untouched.

--- a/plugins/biome-format/.claude-plugin/plugin.json
+++ b/plugins/biome-format/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "biome-format",
-  "version": "0.6.12",
+  "version": "0.6.13",
   "description": "Auto-format and lint JS/TS/JSX/JSON on edit via Biome, only when a biome.json governs the repo — using the consuming repo's own Biome config.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/biome-format/CHANGELOG.md
+++ b/plugins/biome-format/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to the `biome-format` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.6.13]
+
+### Changed
+
+- **Content-mutation disclosure documentation (#1596).** Hook comments now record why
+  Biome rewrites are disclosed on the user channel.
+
 ## [0.6.12]
 
 ### Fixed

--- a/plugins/biome-format/hooks/biome-format.sh
+++ b/plugins/biome-format/hooks/biome-format.sh
@@ -207,6 +207,9 @@ fi
 # biome.json (verified empirically). Unsetting it keeps the discovered CONFIG_DIR
 # config authoritative — consistent with the in-tree opt-in this plugin is built
 # on (an out-of-tree config has no in-tree biome.json, so the gate skips anyway).
+# Content-mutation disclosure (#1596): Biome may auto-fix and/or reformat layout
+# the user did not request. Name the rewrite on the user channel; stay silent
+# when the file is unchanged.
 _biome_before=""
 if _biome_before=$(mktemp 2>/dev/null); then
   cp "$FILE" "$_biome_before" 2>/dev/null || _biome_before=""

--- a/plugins/go-format/.claude-plugin/plugin.json
+++ b/plugins/go-format/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "go-format",
-  "version": "0.3.13",
+  "version": "0.3.14",
   "description": "Auto-fix Go formatting and import management on edit via goimports — runs unconditionally (no consumer-config gate), skipping generated files.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/go-format/CHANGELOG.md
+++ b/plugins/go-format/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to the `go-format` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.3.14]
+
+### Changed
+
+- **Content-mutation disclosure contract tests (#1596).** The import-fix suite now
+  asserts the `systemMessage` emitted when goimports rewrites a file; hook comments
+  document the conformance rationale.
+
 ## [0.3.13]
 
 ### Fixed

--- a/plugins/go-format/hooks/go-format.sh
+++ b/plugins/go-format/hooks/go-format.sh
@@ -224,6 +224,8 @@ fi
 GOIMPORTS_ARGS=(-w -l)
 [[ -n "$LOCAL_PREFIX" ]] && GOIMPORTS_ARGS+=(-local "$LOCAL_PREFIX")
 
+# Content-mutation disclosure (#1596): goimports rewrites imports and layout
+# only; name the rewrite on the user channel and stay silent on no-op paths.
 _go_before=""
 if _go_before=$(mktemp 2>/dev/null); then
   cp "$FILE" "$_go_before" 2>/dev/null || _go_before=""

--- a/plugins/go-format/hooks/go-format.test.sh
+++ b/plugins/go-format/hooks/go-format.test.sh
@@ -139,6 +139,11 @@ if grep -q 'import "fmt"' "$REPO/src/fix.go"; then
 else
   fail "missing import -> not added: $(cat "$REPO/src/fix.go")"
 fi
+if printf '%s' "$OUT" | grep -q 'go-format: reformatted'; then
+  ok "missing import -> user-channel mutation disclosure"
+else
+  fail "missing import -> missing systemMessage disclosure: $OUT"
+fi
 
 # --- Case 4: unused import -> auto-removed -----------------------------------
 printf 'package main\n\nimport (\n\t"fmt"\n\t"os"\n)\n\nfunc main() {\n\tfmt.Println("hi")\n}\n' >"$REPO/unused.go"

--- a/plugins/powershell-format/.claude-plugin/plugin.json
+++ b/plugins/powershell-format/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "powershell-format",
-  "version": "0.7.13",
+  "version": "0.7.14",
   "description": "Auto-format and lint PowerShell on edit via PSScriptAnalyzer, only when a PSScriptAnalyzerSettings.psd1 governs the repo — using the consuming repo's own analyzer settings.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/powershell-format/CHANGELOG.md
+++ b/plugins/powershell-format/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to the `powershell-format` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.7.14]
+
+### Changed
+
+- **Content-mutation disclosure documentation (#1596).** Hook comments now record why
+  Invoke-Formatter rewrites are disclosed as structural layout only.
+
 ## [0.7.13]
 
 ### Fixed

--- a/plugins/powershell-format/hooks/powershell-format.sh
+++ b/plugins/powershell-format/hooks/powershell-format.sh
@@ -205,6 +205,8 @@ if [[ -n "${CLAUDE_PLUGIN_DATA:-}" ]]; then
   PSSA_STATE_BASE_ARG="$(to_pwsh_path "$CLAUDE_PLUGIN_DATA")"
 fi
 
+# Content-mutation disclosure (#1596): Invoke-Formatter rewrites structural
+# layout only; name the rewrite on the user channel and stay silent on no-op paths.
 _ps_before=""
 if _ps_before=$(mktemp 2>/dev/null); then
   cp "$FILE" "$_ps_before" 2>/dev/null || _ps_before=""

--- a/plugins/ruff-format/.claude-plugin/plugin.json
+++ b/plugins/ruff-format/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "ruff-format",
-  "version": "0.6.13",
+  "version": "0.6.14",
   "description": "Auto-format and lint Python on edit via Ruff, only when a Ruff config governs the repo — using the consuming repo's own Ruff config.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/ruff-format/CHANGELOG.md
+++ b/plugins/ruff-format/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to the `ruff-format` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.6.14]
+
+### Changed
+
+- **Content-mutation disclosure contract tests (#1596).** The format-case suite now
+  asserts the `systemMessage` emitted when Ruff rewrites a file; hook comments document
+  the conformance rationale.
+
 ## [0.6.13]
 
 ### Fixed

--- a/plugins/ruff-format/hooks/ruff-format.sh
+++ b/plugins/ruff-format/hooks/ruff-format.sh
@@ -227,6 +227,10 @@ RUFF_COMMON=(--force-exclude --no-cache --quiet)
 # possibly not intent-preserving (same principle as --no-fix on the verify
 # pass below). Pass 2: format. Both are best-effort; the verify pass below
 # is the single source of residual findings.
+#
+# Content-mutation disclosure (#1596): Ruff may auto-fix lint issues and/or
+# reformat layout the user did not request. Name the rewrite on the user
+# channel; stay silent when the file is unchanged.
 _ruff_before=""
 if _ruff_before=$(mktemp 2>/dev/null); then
   cp "$FILE" "$_ruff_before" 2>/dev/null || _ruff_before=""

--- a/plugins/ruff-format/hooks/ruff-format.test.sh
+++ b/plugins/ruff-format/hooks/ruff-format.test.sh
@@ -195,6 +195,11 @@ if grep -q '^x = 1$' "$REPO/src/fmt.py" && grep -q '^y = 2$' "$REPO/src/fmt.py";
 else
   fail "gate ON -> file not formatted: $(cat "$REPO/src/fmt.py")"
 fi
+if printf '%s' "$OUT" | grep -q 'ruff-format: auto-fixed and/or reformatted'; then
+  ok "format case -> user-channel mutation disclosure"
+else
+  fail "format case -> missing systemMessage disclosure: $OUT"
+fi
 
 # --- Case 4: gate ON + lint finding (undefined name) -> advisory context -----
 # F821 has no auto-fix, so it must survive the fix pass and surface in the


### PR DESCRIPTION
Fixes #1596

## Summary

Closes the fleet-wide content-mutation disclosure tracker (#1596). Each remaining autofix hook that rewrites file content on `Write`/`Edit` now conforms to the hook-observability clause: when a rewrite occurs, the hook names what changed on the user channel (`systemMessage`) and stays silent on no-op paths.

Per-plugin disclosure behavior was already merged in the earlier wave (#2458, #2471–#2477). This PR completes the tracker by:

- Adding contract tests for `ruff-format`, `go-format`, and `bash-format` (matching the pattern already used by `biome-format` and `eol-normalizer`)
- Recording the #1596 conformance rationale in hook comments (`structural layout only` / `imports and layout only` where applicable)
- Bumping versions and CHANGELOG entries for touched plugins

## Hook coverage

| Plugin | Disclosure | Tests |
|--------|------------|-------|
| `eol-normalizer` | ✅ (prior #2458) | ✅ |
| `ruff-format` | ✅ | ✅ added |
| `bash-format` | ✅ | ✅ added |
| `go-format` | ✅ | ✅ added |
| `powershell-format` | ✅ (prior #2477) | ✅ |
| `biome-format` | ✅ (prior #2474) | ✅ |

## Related

- #1578 — `typos-format` reference implementation (names each rewritten token)
- #1589 — `markdown-format` reference implementation (reports fix count)
- #2458 — `eol-normalizer` disclosure
- #2471 — `bash-format` disclosure
- #2472 — `ruff-format` disclosure
- #2473 — `go-format` disclosure
- #2474 — `biome-format` disclosure
- #2477 — `powershell-format` disclosure
- `docs/conventions/hook-observability/README.md` — content-mutation conformance clause