### PR TITLE
docs: document same-version plugin cache drift (#2061)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ consumers without editing the plugin itself.
 
 Browse and manage with `/plugin`. To refresh after updates: `/plugin marketplace update melodic-software`.
 
+When you consume this repo from a local `directory` source, the install cache keys on semver
+`version`, not commit — so several commits under one version leave early installs on a stale
+snapshot and `plugin update` can report "already at the latest version" while SHA lags. See
+[`docs/MIGRATION-PLAYBOOK.md`](docs/MIGRATION-PLAYBOOK.md) ("Same-version commit drift") and
+[#2061](https://github.com/melodic-software/claude-code-plugins/issues/2061).
+
 ### Enable plugin suggestions for an organization
 
 Some catalog entries declare `relevance` signals so Claude Code can suggest the plugin when a

--- a/docs/MIGRATION-PLAYBOOK.md
+++ b/docs/MIGRATION-PLAYBOOK.md
@@ -397,6 +397,34 @@ Separate **plugin-owned** logic from **consumer-owned** extension points:
   what shifted. A bump that adds a new trust surface additionally re-triggers the plugin-acceptance
   security review below.
 
+### Same-version commit drift (directory-source marketplaces)
+
+For a marketplace registered with a `directory` source (a local clone or a repo-relative path in
+checked-in settings), the installed plugin cache is keyed by the **semver `version` in
+`plugin.json`**, not by the git commit SHA. Claude Code records the commit at install time in
+`installed_plugins.json`, but the cache directory name is only `<version>` — so a later commit under
+the same version does not replace the snapshot.
+
+That bites the normal PR shape here: a branch lands several commits under one version bump (review
+fixes before merge, audit follow-ups, and the like). Whoever installed on the branch's first commit
+keeps that snapshot until the version changes. Every later commit under the same version is invisible
+to installed sessions — including corrections that would otherwise be live after merge.
+
+`claude plugin update <name>@<marketplace>` compares **version numbers only**. When the marketplace
+ref and the cache both read `0.7.0`, `update` reports success ("already at the latest version") and
+copies nothing — a false green that confirms the wrong state while the recorded SHA lags the source.
+
+**Workarounds (until upstream fixes this — [melodic-software/claude-code-plugins#2061](https://github.com/melodic-software/claude-code-plugins/issues/2061)):**
+
+- **Force a fresh snapshot:** `claude plugin uninstall <name>@<marketplace>` then `install` again,
+  then `enable` — `uninstall` drops enabled state, so skipping `enable` leaves the plugin silently
+  absent rather than silently stale.
+- **Ship a version bump** when the merged result must reach consumers — the only delivery vehicle for
+  marketplace installs (see bullets above).
+- **Local iteration:** `claude --plugin-dir ./plugins/<name>` loads the working tree and takes
+  session precedence over the cached install (see "Local development loop" below) — no reinstall
+  needed for same-session edits after `/reload-plugins`.
+
 ## Persistence, configuration & external integration
 
 A skill is a markdown prompt (plus optional scripts), not a compiled runtime — so ports / adapters /

--- a/plugins/claude-ops/skills/plugins/context/gotchas.md
+++ b/plugins/claude-ops/skills/plugins/context/gotchas.md
@@ -4,6 +4,18 @@ Failure modes this skill is specifically built to avoid, and what breaks if the 
 bypassed. Underlying facts are in [scope-semantics.md](scope-semantics.md) — this file is the
 "here's what goes wrong" companion, not a restatement.
 
+## Same-version commit drift on `directory`-source marketplaces — `update` can false-green
+
+For a marketplace registered from a local `directory` source, the install cache is keyed by semver
+`version`, not commit SHA — so several commits under one version (the normal reviewed-PR shape)
+leave early installers on the first snapshot. `claude plugin update <name>@<marketplace>` compares
+versions only: when both sides read `0.7.0` it reports "already at the latest version" and refreshes
+nothing, even when `installed_plugins.json`'s recorded SHA lags the checkout. Workarounds:
+`uninstall` → `install` → `enable`; bump `plugin.json` `version` to deliver; or iterate with
+`--plugin-dir` (see [MIGRATION-PLAYBOOK.md](https://github.com/melodic-software/claude-code-plugins/blob/main/docs/MIGRATION-PLAYBOOK.md)
+"Same-version commit drift"). Upstream fix tracked in
+[melodic-software/claude-code-plugins#2061](https://github.com/melodic-software/claude-code-plugins/issues/2061).
+
 ## `claude plugin update <name>` (bare) fails "Plugin not found" — always pass the full id
 
 **Verified empirically** (`claude plugin update <name> -s user` → `Plugin "<name>" not found`;

--- a/plugins/claude-ops/skills/plugins/context/gotchas.md
+++ b/plugins/claude-ops/skills/plugins/context/gotchas.md
@@ -4,18 +4,6 @@ Failure modes this skill is specifically built to avoid, and what breaks if the 
 bypassed. Underlying facts are in [scope-semantics.md](scope-semantics.md) — this file is the
 "here's what goes wrong" companion, not a restatement.
 
-## Same-version commit drift on `directory`-source marketplaces — `update` can false-green
-
-For a marketplace registered from a local `directory` source, the install cache is keyed by semver
-`version`, not commit SHA — so several commits under one version (the normal reviewed-PR shape)
-leave early installers on the first snapshot. `claude plugin update <name>@<marketplace>` compares
-versions only: when both sides read `0.7.0` it reports "already at the latest version" and refreshes
-nothing, even when `installed_plugins.json`'s recorded SHA lags the checkout. Workarounds:
-`uninstall` → `install` → `enable`; bump `plugin.json` `version` to deliver; or iterate with
-`--plugin-dir` (see [MIGRATION-PLAYBOOK.md](https://github.com/melodic-software/claude-code-plugins/blob/main/docs/MIGRATION-PLAYBOOK.md)
-"Same-version commit drift"). Upstream fix tracked in
-[melodic-software/claude-code-plugins#2061](https://github.com/melodic-software/claude-code-plugins/issues/2061).
-
 ## `claude plugin update <name>` (bare) fails "Plugin not found" — always pass the full id
 
 **Verified empirically** (`claude plugin update <name> -s user` → `Plugin "<name>" not found`;


### PR DESCRIPTION
No linked issue

## Summary

Document the directory-source marketplace failure mode where the plugin install cache keys on semver version rather than commit SHA, so multiple commits under one version leave early installs on a stale snapshot and `plugin update` can false-green. Adds workarounds and links upstream tracking issue #2061.

## Fix

- `docs/MIGRATION-PLAYBOOK.md` — Same-version commit drift subsection + workarounds
- `README.md` — short marketplace pointer

## Verification

- Docs review against #2061 songwriting 0.7.0 case
- markdownlint on touched docs

## Related

Refs #2061 — docs mitigation only; issue stays open for upstream Claude Code fix (Class C / product).