### PR TITLE
feat(skill-quality): ratchet evals presence for changed skills (#530 stage 1)

### DIFF
--- a/plugins/skill-quality/.claude-plugin/plugin.json
+++ b/plugins/skill-quality/.claude-plugin/plugin.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "skill-quality",
-  "version": "0.15.6",
-  "description": "Skill-authoring QA tooling: a static contract checker that runs twenty-two deterministic checks over a Claude Code skill (frontmatter, per-skill listing-entry cap, trigger-keyword preservation, line caps, broken internal refs, markdownlint, gotchas surface, evals presence, precompute opportunity, injection shell-declaration, fresh-eyes declaration conformance), a shared skill-listing budget reporter across a set of skills, and a bundled evals.json schema plus a deterministic eval-quality lint (duplicate case identities, missing fixtures, empty or vague grading criteria, set-coverage warnings). Runs against any repo's skills directory via the convention-resolution ladder — no baked layout.",
+  "version": "0.15.8",
+  "description": "Skill-authoring QA tooling: a static contract checker that runs twenty-two deterministic checks over a Claude Code skill (frontmatter, per-skill listing-entry cap, trigger-keyword preservation, line caps, broken internal refs, markdownlint, gotchas surface, evals presence, precompute opportunity, injection shell-declaration, fresh-eyes declaration conformance), a shared skill-listing budget reporter across a set of skills, and a bundled evals.json schema plus a deterministic eval-quality lint (duplicate case identities, missing fixtures, empty or vague grading criteria, set-coverage warnings). Runs against any repo's skills directory via the convention-resolution ladder \u2014 no baked layout.",
   "author": {
     "name": "Melodic Software",
     "email": "info@melodicsoftware.com"

--- a/plugins/skill-quality/CHANGELOG.md
+++ b/plugins/skill-quality/CHANGELOG.md
@@ -12,6 +12,17 @@ All notable changes to the `skill-quality` plugin are documented here. Format fo
   [`docs/extensibility-contract-smoke-tests.md`](../../docs/extensibility-contract-smoke-tests.md)
   Test E (#1360). Targetless references to the flow stay unqualified.
 
+## [0.15.7]
+
+### Added
+
+- **Evals-presence ratchet for changed skills (#530 stage 1).** `check-skill.sh` accepts
+  `--require-evals` (or `CHECK_SKILL_REQUIRE_EVALS=1`) and FAILs when `evals/evals.json` is
+  missing for any skill shape. `check-changed-skills.sh` forwards that flag when a PR's
+  changed set includes a new or modified `SKILL.md`, so untouched legacy skills stay green
+  until edited. Default ad-hoc check behavior remains WARN-only for action-router-shaped
+  skills.
+
 ## [0.15.6]
 
 ### Changed

--- a/plugins/skill-quality/CHANGELOG.md
+++ b/plugins/skill-quality/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to the `skill-quality` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.15.8]
+
+### Changed
+
+- **Docs:** actionable `/plugin configure` guidance now uses the marketplace-qualified form
+  (`<plugin>@melodic-software`; generated option blocks use `@<marketplace>`) per
+  [`docs/extensibility-contract-smoke-tests.md`](../../docs/extensibility-contract-smoke-tests.md)
+  Test E (#1360). Targetless references to the flow stay unqualified.
+
+
 ## [0.15.6]
 
 ### Changed

--- a/plugins/skill-quality/CHANGELOG.md
+++ b/plugins/skill-quality/CHANGELOG.md
@@ -12,7 +12,6 @@ All notable changes to the `skill-quality` plugin are documented here. Format fo
   [`docs/extensibility-contract-smoke-tests.md`](../../docs/extensibility-contract-smoke-tests.md)
   Test E (#1360). Targetless references to the flow stay unqualified.
 
-
 ## [0.15.6]
 
 ### Changed

--- a/plugins/skill-quality/README.md
+++ b/plugins/skill-quality/README.md
@@ -123,7 +123,7 @@ reads it from.
 Three supported routes, in the order most people want them:
 
 1. **Interactively** — Claude Code prompts for declared options when you enable the
-   plugin. To change them later: `/plugin configure skill-quality@<marketplace>`.
+   plugin. To change them later: `/plugin configure skill-quality`.
 2. **Headless, at install time** — repeat `--config` for each option. Replace
    `<marketplace>` with the marketplace you installed this plugin from:
 

--- a/plugins/skill-quality/README.md
+++ b/plugins/skill-quality/README.md
@@ -32,7 +32,8 @@ phrase, which quietly degrades a skill's auto-invocation. Check 3 compares the t
 - `scripts/*.test.sh` pass where present.
 - Vendored `vendor/` byte-identical vs `HEAD`; stale-tracking metadata keys preserved; sync age.
 - Gotchas surface present; `description` carries `Use when` phrasing; no committed cache artifacts;
-  action-router skills ship `evals/evals.json`; companion spoke dirs are referenced.
+  action-router skills without evals WARN (FAIL with `--require-evals` for any shape); companion spoke
+  dirs are referenced.
 - Precompute opportunity (advisory) — a fenced shell block gathers read-only context the skill could
   inline at load time via [`!` injection](https://code.claude.com/docs/en/skills#inject-dynamic-context)
   instead of a per-invocation tool call.
@@ -122,7 +123,7 @@ reads it from.
 Three supported routes, in the order most people want them:
 
 1. **Interactively** — Claude Code prompts for declared options when you enable the
-   plugin. To change them later: `/plugin configure skill-quality`.
+   plugin. To change them later: `/plugin configure skill-quality@<marketplace>`.
 2. **Headless, at install time** — repeat `--config` for each option. Replace
    `<marketplace>` with the marketplace you installed this plugin from:
 

--- a/plugins/skill-quality/scripts/check-skill.sh
+++ b/plugins/skill-quality/scripts/check-skill.sh
@@ -9,8 +9,12 @@
 # Exit 0 = all checks pass; 1 = one or more check failures; 2 = usage/env error.
 #
 # Usage:
-#   bash check-skill.sh <skill-name>
+#   bash check-skill.sh [--require-evals] <skill-name>
 #   bash check-skill.sh --help
+#
+# --require-evals (or CHECK_SKILL_REQUIRE_EVALS=1) FAILs when evals/evals.json
+# is absent for any skill shape. Without it, check 14 WARNs only on
+# action-router-shaped skills — the legacy fleet posture.
 #
 # Skills root resolution (first hit wins):
 #   1. CHECK_SKILL_SKILLS_ROOT env var (explicit override)
@@ -53,7 +57,8 @@
 #  11. Gotchas surface present (WARN; inline `## Gotchas` or context|reference/gotchas.md)
 #  12. description carries "Use when" trigger phrasing, single-quoted (WARN)
 #  13. No committed cache/build artifacts (__pycache__, *.pyc, node_modules) (FAIL)
-#  14. Action-router-shaped skill ships evals/evals.json (WARN)
+#  14. evals/evals.json presence (WARN for action-router shape; FAIL with
+#      --require-evals / CHECK_SKILL_REQUIRE_EVALS=1 for any shape)
 #  15. Companion spoke dirs referenced from SKILL.md (WARN; orphan-spoke direction)
 #  16. metadata.category present (INFO only)
 #  17. Vendor-backed: metadata.synced not older than 180 days (WARN)
@@ -92,10 +97,30 @@ usage() {
   sed -n '2,38p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
 }
 
-if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
-  usage
-  exit 0
-fi
+REQUIRE_EVALS="${CHECK_SKILL_REQUIRE_EVALS:-0}"
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+  --help | -h)
+    usage
+    exit 0
+    ;;
+  --require-evals)
+    REQUIRE_EVALS=1
+    shift
+    ;;
+  --)
+    shift
+    break
+    ;;
+  -*)
+    printf 'Error: unknown option: %s\n' "$1" >&2
+    exit 2
+    ;;
+  *)
+    break
+    ;;
+  esac
+done
 
 REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null | tr -d '\r')"
 if [[ -z "$REPO_ROOT" || ! -d "$REPO_ROOT" ]]; then
@@ -115,7 +140,7 @@ if [[ "$BASE_REF" != "HEAD" ]] &&
   exit 2
 fi
 
-SKILL_NAME="${1:?Usage: check-skill.sh <skill-name>}"
+SKILL_NAME="${1:?Usage: check-skill.sh [--require-evals] <skill-name>}"
 
 # Resolve the skills root without baking a repo layout (convention-resolution
 # ladder): explicit override, then plugin project dir, then git-root default.
@@ -605,10 +630,17 @@ if [[ -n "$CACHE_HITS" ]]; then
   err "committed cache/build artifact(s) under the skill dir: $(printf '%s' "$CACHE_HITS" | head -3 | tr '\n' ' ')"
 fi
 
-# --- Check 14: action-router shape without evals ------------------------------
+# --- Check 14: evals/evals.json presence -------------------------------------
+# Legacy fleet: action-router shape without evals WARNs (evals warranted, not
+# mandatory). Changed-skill CI passes --require-evals so any touched SKILL.md
+# must ship evals/evals.json regardless of shape.
 
-if grep -qE '^##+[[:space:]]+Actions?([^[:alnum:]_]|$)' "$SKILL_MD" && [[ ! -f "$SKILL_DIR/evals/evals.json" ]]; then
-  warn "action-router-shaped skill with no evals/evals.json — check whether the skill warrants triggering evals"
+if [[ ! -f "$SKILL_DIR/evals/evals.json" ]]; then
+  if [[ "$REQUIRE_EVALS" == "1" ]]; then
+    err "skill ships no evals/evals.json — required when the skill is new or its SKILL.md changed"
+  elif grep -qE '^##+[[:space:]]+Actions?([^[:alnum:]_]|$)' "$SKILL_MD"; then
+    warn "action-router-shaped skill with no evals/evals.json — check whether the skill warrants triggering evals"
+  fi
 fi
 
 # --- Check 15: companion spoke dirs referenced from the hub -------------------

--- a/plugins/skill-quality/scripts/check-skill.test.sh
+++ b/plugins/skill-quality/scripts/check-skill.test.sh
@@ -63,6 +63,12 @@ run() {
       bash "$SUT" "$@")
 }
 
+run_require_evals() {
+  (cd "$TMP" &&
+    CHECK_SKILL_SKILLS_ROOT="$SKILLS" CHECK_SKILL_SKIP_MARKDOWNLINT=1 \
+      bash "$SUT" --require-evals "$@")
+}
+
 # 1. --help exits 0.
 if run --help >/dev/null 2>&1; then
   pass "--help exits 0"
@@ -2445,6 +2451,69 @@ if [[ $rc -eq 1 ]] &&
   pass "a ref no sibling hosts keeps the plain broken-internal-ref message"
 else
   fail "unhosted ref should keep the broken-internal-ref message (rc=$rc): $out"
+fi
+
+# 42. --require-evals FAILs on any shape without evals/evals.json.
+make_skill no-evals '---
+description: "A plain skill. Use when: '"'"'checking evals presence'"'"'."
+---
+
+## Purpose
+
+Not action-router-shaped.
+
+## Gotchas
+
+None known.
+'
+out="$(run_require_evals no-evals 2>&1)"
+rc=$?
+if [[ $rc -eq 1 ]] && grep -q 'skill ships no evals/evals.json' <<<"$out"; then
+  pass "--require-evals fails when evals/evals.json is absent"
+else
+  fail "--require-evals should fail without evals (rc=$rc): $out"
+fi
+
+# 43. Without --require-evals, a non-action-router skill without evals stays green.
+out="$(run no-evals 2>&1)"
+rc=$?
+if [[ $rc -eq 0 ]] && ! grep -q 'skill ships no evals/evals.json' <<<"$out"; then
+  pass "legacy fleet: non-action-router without evals passes without --require-evals"
+else
+  fail "non-action-router without evals should pass without --require-evals (rc=$rc): $out"
+fi
+
+# 44. --require-evals on a new skill (no base-ref SKILL.md) still FAILs.
+git -C "$TMP" add -A && git -C "$TMP" commit -qm base >/dev/null
+make_skill brand-new '---
+description: "A brand-new skill. Use when: '"'"'checking new-skill evals'"'"'."
+---
+
+## Purpose
+
+New-skill ratchet fixture.
+
+## Gotchas
+
+None known.
+'
+out="$(cd "$TMP" && CHECK_SKILL_SKILLS_ROOT="$SKILLS" CHECK_SKILL_SKIP_MARKDOWNLINT=1 \
+  CHECK_SKILL_BASE_REF=HEAD bash "$SUT" --require-evals brand-new 2>&1)"
+rc=$?
+if [[ $rc -eq 1 ]] && grep -q 'skill ships no evals/evals.json' <<<"$out"; then
+  pass "--require-evals fails for a new skill without evals"
+else
+  fail "new skill without evals should fail under --require-evals (rc=$rc): $out"
+fi
+
+# 45. CHECK_SKILL_REQUIRE_EVALS=1 env mirrors --require-evals.
+out="$(cd "$TMP" && CHECK_SKILL_SKILLS_ROOT="$SKILLS" CHECK_SKILL_SKIP_MARKDOWNLINT=1 \
+  CHECK_SKILL_REQUIRE_EVALS=1 bash "$SUT" no-evals 2>&1)"
+rc=$?
+if [[ $rc -eq 1 ]] && grep -q 'skill ships no evals/evals.json' <<<"$out"; then
+  pass "CHECK_SKILL_REQUIRE_EVALS=1 mirrors --require-evals"
+else
+  fail "CHECK_SKILL_REQUIRE_EVALS=1 should fail without evals (rc=$rc): $out"
 fi
 
 if [[ $fails -ne 0 ]]; then

--- a/scripts/check-changed-skills.sh
+++ b/scripts/check-changed-skills.sh
@@ -7,6 +7,10 @@
 # skill-quality static contract gate (plugins/skill-quality/scripts/check-skill.sh
 # — trigger-keyword preservation vs the base ref, frontmatter, listing-budget
 # and line caps, broken internal refs, evals presence, committed artifacts).
+# When a changed skill's SKILL.md is new or modified vs <base-ref>, the checker
+# is invoked with --require-evals so a missing evals/evals.json FAILs for any
+# shape; untouched legacy skills and non-SKILL.md-only touches keep the legacy
+# WARN-only posture.
 # Any FAIL fails this gate. It replaces the work lane's manual high-blast-radius
 # skill-diff read with a deterministic check, and is the first lane to invoke the
 # otherwise-uninvoked skill-quality checker.
@@ -62,10 +66,14 @@ for skill_dir in "${changed[@]}"; do
   skill_name="${skill_dir##*/}" # <skill>
   checked=$((checked + 1))
   printf '=== %s ===\n' "$skill_dir"
+  require_evals_args=()
+  if git diff --name-only "$BASE" -- "$skill_dir/SKILL.md" | grep -q .; then
+    require_evals_args=(--require-evals)
+  fi
   if CHECK_SKILL_SKILLS_ROOT="$PWD/$skills_root" \
     CHECK_SKILL_BASE_REF="$BASE" \
     CHECK_SKILL_SKIP_MARKDOWNLINT=1 \
-    bash "$CHECKER" "$skill_name"; then
+    bash "$CHECKER" "${require_evals_args[@]}" "$skill_name"; then
     :
   else
     failed=$((failed + 1))

--- a/scripts/check-changed-skills.test.sh
+++ b/scripts/check-changed-skills.test.sh
@@ -28,8 +28,10 @@ ok() {
 STUB="$(mktemp)"
 cat >"$STUB" <<'EOF'
 #!/usr/bin/env bash
-printf 'name=%s root=%s base=%s\n' "$1" "$CHECK_SKILL_SKILLS_ROOT" "$CHECK_SKILL_BASE_REF" >>"$CHECK_LOG"
-[[ "$1" == "bad" ]] && exit 1
+printf 'args=%s root=%s base=%s\n' "$*" "$CHECK_SKILL_SKILLS_ROOT" "$CHECK_SKILL_BASE_REF" >>"$CHECK_LOG"
+for arg in "$@"; do
+  [[ "$arg" == "bad" ]] && exit 1
+done
 exit 0
 EOF
 chmod +x "$STUB"
@@ -115,7 +117,7 @@ b="$(base_sha "$r")"
 add_skill "$r" p1 alpha SKILL.md # touch two paths in one skill
 add_skill "$r" p1 alpha vendor/tool/SKILL.md
 run "$r" "$b" >/dev/null 2>&1
-n="$(grep -c "name=alpha" "$r/checklog" 2>/dev/null || echo 0)"
+n="$(grep -c "args=.*alpha" "$r/checklog" 2>/dev/null || echo 0)"
 if [[ "$n" == "1" ]]; then
   ok "vendor subtree maps to owning skill, checked once"
 else
@@ -130,8 +132,8 @@ commit_all "$r" base >/dev/null
 b="$(base_sha "$r")"
 add_skill "$r" p2 beta SKILL.md
 run "$r" "$b" >/dev/null 2>&1
-if grep -q "name=beta root=$r/plugins/p2/skills base=$b" "$r/checklog" 2>/dev/null; then
-  ok "checker receives skill name, skills root, and base ref"
+if grep -q "args=--require-evals beta root=$r/plugins/p2/skills base=$b" "$r/checklog" 2>/dev/null; then
+  ok "checker receives skill name, skills root, base ref, and --require-evals on SKILL.md change"
 else
   fail "env passthrough wrong, got: $(cat "$r/checklog" 2>/dev/null)"
 fi
@@ -181,6 +183,144 @@ if [[ "$rc" -eq 2 ]]; then
   ok "missing checker exits 2 (fail closed)"
 else
   fail "missing checker should exit 2, got $rc"
+fi
+rm -rf "$r"
+
+# --- SKILL.md change forwards --require-evals to the checker ----------------
+r="$(mk_repo)"
+add_skill "$r" p1 alpha
+commit_all "$r" base >/dev/null
+b="$(base_sha "$r")"
+add_skill "$r" p1 alpha SKILL.md
+run "$r" "$b" >/dev/null 2>&1
+if grep -q 'args=--require-evals alpha ' "$r/checklog" 2>/dev/null; then
+  ok "SKILL.md change forwards --require-evals"
+else
+  fail "SKILL.md change should forward --require-evals, got: $(cat "$r/checklog" 2>/dev/null)"
+fi
+rm -rf "$r"
+
+# --- a non-SKILL.md touch does not forward --require-evals ------------------
+r="$(mk_repo)"
+add_skill "$r" p1 alpha
+add_skill "$r" p1 alpha context/note.md
+commit_all "$r" base >/dev/null
+b="$(base_sha "$r")"
+printf 'updated\n' >"$r/plugins/p1/skills/alpha/context/note.md"
+run "$r" "$b" >/dev/null 2>&1
+if grep -q 'args=alpha ' "$r/checklog" 2>/dev/null &&
+  ! grep -q 'args=--require-evals alpha ' "$r/checklog" 2>/dev/null; then
+  ok "non-SKILL.md touch does not forward --require-evals"
+else
+  fail "context-only change should not forward --require-evals, got: $(cat "$r/checklog" 2>/dev/null)"
+fi
+rm -rf "$r"
+
+# --- integration: a new skill without evals fails the gate ------------------
+r="$(mk_repo)"
+mkdir -p "$r/plugins/skill-quality/scripts"
+cp "$SELF_DIR/../plugins/skill-quality/scripts/check-skill.sh" "$r/plugins/skill-quality/scripts/"
+cp "$SELF_DIR/../plugins/skill-quality/scripts/skill-frontmatter.sh" "$r/plugins/skill-quality/scripts/"
+chmod +x "$r/plugins/skill-quality/scripts/"*.sh
+printf 'base\n' >"$r/README.md"
+commit_all "$r" base >/dev/null
+b="$(base_sha "$r")"
+mkdir -p "$r/plugins/p1/skills/newbie"
+cat >"$r/plugins/p1/skills/newbie/SKILL.md" <<'EOF'
+---
+description: "A new skill. Use when: 'testing the evals ratchet'."
+---
+
+## Purpose
+
+Fixture for the evals-presence ratchet.
+
+## Gotchas
+
+None known.
+EOF
+git -C "$r" add plugins/p1/skills/newbie/SKILL.md
+if (cd "$r" && CHECK_SKILL_BIN="$r/plugins/skill-quality/scripts/check-skill.sh" \
+  bash scripts/check-changed-skills.sh "$b") >/dev/null 2>&1; then
+  fail "new skill without evals should fail the changed-skill gate"
+else
+  ok "new skill without evals fails the changed-skill gate"
+fi
+rm -rf "$r"
+
+# --- integration: a touched legacy skill without evals fails the gate --------
+r="$(mk_repo)"
+mkdir -p "$r/plugins/skill-quality/scripts"
+cp "$SELF_DIR/../plugins/skill-quality/scripts/check-skill.sh" "$r/plugins/skill-quality/scripts/"
+cp "$SELF_DIR/../plugins/skill-quality/scripts/skill-frontmatter.sh" "$r/plugins/skill-quality/scripts/"
+chmod +x "$r/plugins/skill-quality/scripts/"*.sh
+mkdir -p "$r/plugins/p1/skills/legacy"
+cat >"$r/plugins/p1/skills/legacy/SKILL.md" <<'EOF'
+---
+description: "A legacy skill. Use when: 'testing the evals ratchet'."
+---
+
+## Purpose
+
+Fixture for the evals-presence ratchet.
+
+## Gotchas
+
+None known.
+EOF
+commit_all "$r" base >/dev/null
+b="$(base_sha "$r")"
+printf '\n## Notes\n\nTouched for the ratchet test.\n' >>"$r/plugins/p1/skills/legacy/SKILL.md"
+if (cd "$r" && CHECK_SKILL_BIN="$r/plugins/skill-quality/scripts/check-skill.sh" \
+  bash scripts/check-changed-skills.sh "$b") >/dev/null 2>&1; then
+  fail "touched legacy skill without evals should fail the changed-skill gate"
+else
+  ok "touched legacy skill without evals fails the changed-skill gate"
+fi
+rm -rf "$r"
+
+# --- integration: a touched legacy skill with evals passes the gate --------
+r="$(mk_repo)"
+mkdir -p "$r/plugins/skill-quality/scripts"
+cp "$SELF_DIR/../plugins/skill-quality/scripts/check-skill.sh" "$r/plugins/skill-quality/scripts/"
+cp "$SELF_DIR/../plugins/skill-quality/scripts/skill-frontmatter.sh" "$r/plugins/skill-quality/scripts/"
+chmod +x "$r/plugins/skill-quality/scripts/"*.sh
+mkdir -p "$r/plugins/p1/skills/legacy/evals"
+cat >"$r/plugins/p1/skills/legacy/SKILL.md" <<'EOF'
+---
+description: "A legacy skill. Use when: 'testing the evals ratchet'."
+---
+
+## Purpose
+
+Fixture for the evals-presence ratchet.
+
+## Gotchas
+
+None known.
+EOF
+cat >"$r/plugins/p1/skills/legacy/evals/evals.json" <<'EOF'
+{
+  "skill_name": "legacy",
+  "evals": [
+    {
+      "id": "1",
+      "name": "happy-path",
+      "prompt": "run legacy",
+      "expected_output": "Runs the legacy skill.",
+      "expectations": ["Output routes to the legacy skill"]
+    }
+  ]
+}
+EOF
+commit_all "$r" base >/dev/null
+b="$(base_sha "$r")"
+printf '\n## Notes\n\nTouched for the ratchet test.\n' >>"$r/plugins/p1/skills/legacy/SKILL.md"
+if (cd "$r" && CHECK_SKILL_BIN="$r/plugins/skill-quality/scripts/check-skill.sh" \
+  bash scripts/check-changed-skills.sh "$b") >/dev/null 2>&1; then
+  ok "touched legacy skill with evals passes the changed-skill gate"
+else
+  fail "touched legacy skill with evals should pass the changed-skill gate"
 fi
 rm -rf "$r"
 


### PR DESCRIPTION
No linked issue

## Summary

Promotes missing `evals/evals.json` from WARN to FAIL for skills a PR touches when `SKILL.md` is new or modified (stage-1 ratchet under #530).

## Fix

- `check-skill.sh` `--require-evals` / `CHECK_SKILL_REQUIRE_EVALS=1` fails on missing evals for any skill shape
- Default remains WARN-only for action-router-shaped skills
- `check-changed-skills.sh` forwards `--require-evals` when SKILL.md changed vs PR base
- Self-tests for new-skill and touched-legacy paths
- skill-quality version bump + options docs sync

## Verification

- scripts/check-changed-skills.test.sh
- plugins/skill-quality/scripts/check-skill.test.sh
- python3 scripts/sync-plugin-options-docs.py --check

## Related

Refs #530 — stage-1 evals-presence ratchet; stages 2–5 remain on the umbrella.