### PR TITLE
fix(guardrails): repo-context chokepoint for block-noncanonical-commit (#1500, #1553)

### DIFF
--- a/plugins/guardrails/.claude-plugin/plugin.json
+++ b/plugins/guardrails/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "guardrails",
-  "description": "Twelve safety guards that block secret/credential writes, hardcoded machine-specific paths, git hook-bypass attempts, irreversible git operations (force-push, reset --hard, worktree-wide checkout/restore discards), Bash file-write workarounds that circumvent Write/Edit hooks, multi-line `git commit -m` messages (an actual-newline `-m` mangles across shells; single-line `-m` passes), commit subjects and gh pr create titles that violate the repo's tracked team convention (when one is declared in .claude/source-control.md), (advisory) hallucinated CLI flags, (advisory) /plugin:skill references that do not resolve, (advisory) markdown citing a repo path the repo's own history shows was removed, (advisory, opt-in) un-throttled Workflow fan-out that risks burst 529s, and (advisory, opt-in) direct gh pr create calls bypassing this marketplace's own pull-request skill — each independently toggleable.",
+  "description": "Twelve safety guards that block secret/credential writes, hardcoded machine-specific paths, git hook-bypass attempts, irreversible git operations (force-push, reset --hard, worktree-wide checkout/restore discards), Bash file-write workarounds that circumvent Write/Edit hooks, multi-line `git commit -m` messages (an actual-newline `-m` mangles across shells; single-line `-m` passes), commit subjects and gh pr create titles that violate the repo's tracked team convention (when one is declared in .claude/source-control.md), (advisory) hallucinated CLI flags, (advisory) /plugin:skill references that do not resolve, (advisory) markdown citing a repo path the repo's own history shows was removed, (advisory, opt-in) un-throttled Workflow fan-out that risks burst 529s, and (advisory, opt-in) direct gh pr create calls bypassing this marketplace's own pull-request skill \u2014 each independently toggleable.",
   "author": {
     "name": "Melodic Software",
     "email": "info@melodicsoftware.com"
@@ -34,13 +34,13 @@
     "block_no_verify_enabled": {
       "type": "boolean",
       "title": "block-no-verify guard",
-      "description": "Block git hook-bypass attempts (--no-verify, core.hooksPath=, hook-manager env-var disables for a configurable set — lefthook/husky/pre-commit/simple-git-hooks by default)",
+      "description": "Block git hook-bypass attempts (--no-verify, core.hooksPath=, hook-manager env-var disables for a configurable set \u2014 lefthook/husky/pre-commit/simple-git-hooks by default)",
       "default": true
     },
     "block_dangerous_git_enabled": {
       "type": "boolean",
       "title": "block-dangerous-git guard",
-      "description": "Block irreversible git operations (push --force, push --force-with-lease leasing against a value git resolves at push time — either no expected value, or an expectation that is not an object id of the repository's own hash width — reset --hard, clean -f, worktree-wide checkout/restore discards)",
+      "description": "Block irreversible git operations (push --force, push --force-with-lease leasing against a value git resolves at push time \u2014 either no expected value, or an expectation that is not an object id of the repository's own hash width \u2014 reset --hard, clean -f, worktree-wide checkout/restore discards)",
       "default": true
     },
     "block_hook_bypass_enabled": {
@@ -52,7 +52,7 @@
     "block_noncanonical_commit_enabled": {
       "type": "boolean",
       "title": "block-noncanonical-commit guard",
-      "description": "Block `git commit -m` when the message actually contains a newline (multi-line `-m` mangles across shells — pipe it via `-F -` instead; single-line `-m` passes); --amend, -C/-c, --fixup/--squash, -F <path>, and an in-progress merge/rebase are exempt",
+      "description": "Block `git commit -m` when the message actually contains a newline (multi-line `-m` mangles across shells \u2014 pipe it via `-F -` instead; single-line `-m` passes); --amend, -C/-c, --fixup/--squash, -F <path>, and an in-progress merge/rebase are exempt",
       "default": true
     },
     "block_convention_gate_enabled": {
@@ -82,13 +82,13 @@
     "workflow_resilience_check_enabled": {
       "type": "boolean",
       "title": "workflow-resilience-check guard",
-      "description": "Advise on un-throttled Workflow fan-out (never blocks). Default off since 0.20.0: a behavioral-class prose injector, config-disabled per the instruction-economy evidence gate (#2021) — set true to opt back in",
+      "description": "Advise on un-throttled Workflow fan-out (never blocks). Default off since 0.20.0: a behavioral-class prose injector, config-disabled per the instruction-economy evidence gate (#2021) \u2014 set true to opt back in",
       "default": false
     },
     "flag_commit_pr_skill_bypass_enabled": {
       "type": "boolean",
       "title": "flag-commit-pr-skill-bypass guard",
-      "description": "Advise when a direct gh pr create bypasses the source-control pull-request skill (never blocks). Default off since 0.20.0: a behavioral-class prose injector, config-disabled per the instruction-economy evidence gate (#2021) — set true to opt back in",
+      "description": "Advise when a direct gh pr create bypasses the source-control pull-request skill (never blocks). Default off since 0.20.0: a behavioral-class prose injector, config-disabled per the instruction-economy evidence gate (#2021) \u2014 set true to opt back in",
       "default": false
     },
     "cli_flag_verify_bins": {
@@ -124,16 +124,16 @@
     "block_hook_bypass_scratch_roots": {
       "type": "string",
       "title": "block-hook-bypass scratch roots",
-      "description": "Comma-separated ABSOLUTE directories block-hook-bypass exempts as scratch/temp write targets (e.g. /tmp/scratch,/d/jobtmp/session); empty (the default) exempts nothing and leaves the guard's shipped behaviour unchanged. Matching is on the effective stdout target after lexical normalization, at a path-component boundary — a sibling merely sharing the name prefix, a `..` escape out of a root, and a discard-then-real-file redirect all still block. A quoted or escaped OPERAND is never exempt: the operand is marked so it survives the quote strip and the segment split as one word, and an operand carrying whitespace, `;`, `|`, `&`, `(`, `)`, a newline or a backslash escape exempts nothing. Quotes elsewhere in the command no longer matter. Symlinks are not followed",
+      "description": "Comma-separated ABSOLUTE directories block-hook-bypass exempts as scratch/temp write targets (e.g. /tmp/scratch,/d/jobtmp/session); empty (the default) exempts nothing and leaves the guard's shipped behaviour unchanged. Matching is on the effective stdout target after lexical normalization, at a path-component boundary \u2014 a sibling merely sharing the name prefix, a `..` escape out of a root, and a discard-then-real-file redirect all still block. A quoted or escaped OPERAND is never exempt: the operand is marked so it survives the quote strip and the segment split as one word, and an operand carrying whitespace, `;`, `|`, `&`, `(`, `)`, a newline or a backslash escape exempts nothing. Quotes elsewhere in the command no longer matter. Symlinks are not followed",
       "default": ""
     },
     "stdin_read_timeout": {
       "type": "number",
       "title": "Hook stdin read timeout (seconds)",
-      "description": "Idle bound on reading the hook payload from stdin — how long a silent pipe is tolerated before a blocking guard fails closed",
+      "description": "Idle bound on reading the hook payload from stdin \u2014 how long a silent pipe is tolerated before a blocking guard fails closed",
       "default": 2,
       "min": 1
     }
   },
-  "version": "0.28.20"
+  "version": "0.28.21"
 }

--- a/plugins/guardrails/CHANGELOG.md
+++ b/plugins/guardrails/CHANGELOG.md
@@ -19,13 +19,6 @@ All notable changes to the `guardrails` plugin are documented here. Format follo
   continues with the literal composed directory. Acceptance rows added for the #1553
   reproducer, R8-2, R8-3, and F3.
 
-### Changed
-
-- **Docs:** actionable `/plugin configure` guidance now uses the marketplace-qualified form
-  (`<plugin>@melodic-software`; generated option blocks use `@<marketplace>`) per
-  [`docs/extensibility-contract-smoke-tests.md`](../../docs/extensibility-contract-smoke-tests.md)
-  Test E (#1360). Targetless references to the flow stay unqualified.
-
 ## [0.28.20]
 
 ### Fixed

--- a/plugins/guardrails/CHANGELOG.md
+++ b/plugins/guardrails/CHANGELOG.md
@@ -3,6 +3,29 @@
 All notable changes to the `guardrails` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.28.21]
+
+### Fixed
+
+- **`block-noncanonical-commit` binds repo-context through one `repo_git_probe` chokepoint
+  ([#1500](https://github.com/melodic-software/claude-code-plugins/issues/1500),
+  [#1553](https://github.com/melodic-software/claude-code-plugins/issues/1553)).**
+  Every git subprocess question now runs as `git -C <dir> <locating globals…> <args…>`,
+  cached under `%q`-encoded keys so argv boundaries cannot collide.
+  `HOOK_EFFECTIVE_LOCATING` propagates `--git-dir` / `--work-tree` / `--namespace`
+  across `!` hops (cleared on pure-discovery outer hops and when an inner frame carries
+  `-C`); path composition via `alias_launch_dir` / `HOOK_EFFECTIVE_BASE` stays separate
+  from alias lookup. No outer fail-closed when git cannot resolve a work tree — the walk
+  continues with the literal composed directory. Acceptance rows added for the #1553
+  reproducer, R8-2, R8-3, and F3.
+
+### Changed
+
+- **Docs:** actionable `/plugin configure` guidance now uses the marketplace-qualified form
+  (`<plugin>@melodic-software`; generated option blocks use `@<marketplace>`) per
+  [`docs/extensibility-contract-smoke-tests.md`](../../docs/extensibility-contract-smoke-tests.md)
+  Test E (#1360). Targetless references to the flow stay unqualified.
+
 ## [0.28.20]
 
 ### Fixed

--- a/plugins/guardrails/hooks/block-noncanonical-commit.sh
+++ b/plugins/guardrails/hooks/block-noncanonical-commit.sh
@@ -391,6 +391,9 @@ collect_locating_globals() {
   return 0
 }
 
+# Called from walk_argv below; ShellCheck 0.11 SC2329 does not always see
+# nested bash function calls through the alias-expansion walk.
+# shellcheck disable=SC2329
 set_probe_locating() {
   local -a inherited=()
   if ((${#HOOK_EFFECTIVE_LOCATING[@]})) && ((HOOK_FRAME_PREFIX_HAS_C == 0)); then
@@ -405,6 +408,7 @@ set_probe_locating() {
   fi
 }
 
+# shellcheck disable=SC2329
 shell_alias_inherited_locating() {
   if ((${#locating_globals[@]})); then
     HOOK_EFFECTIVE_LOCATING=("${HOOK_PROBE_LOCATING[@]}")

--- a/plugins/guardrails/hooks/block-noncanonical-commit.sh
+++ b/plugins/guardrails/hooks/block-noncanonical-commit.sh
@@ -49,7 +49,7 @@
 # Per-repo/per-user allow-list: the `block_noncanonical_commit_allow` userConfig
 # option is a comma-separated list of form tokens (currently just
 # "message-flag", which allows `-m` even with a newline in the message). Set it
-# with `/plugin configure guardrails` or headless via `claude plugin install
+# with `/plugin configure guardrails@melodic-software` or headless via `claude plugin install
 # --config`; read from the CLAUDE_PLUGIN_OPTION_BLOCK_NONCANONICAL_COMMIT_ALLOW
 # process mirror. Kill switch: `block_noncanonical_commit_enabled` set to false.
 #
@@ -275,56 +275,74 @@ explicit_git_dir() { explicit_global git-dir "$@"; }
 # Separate calls per field (never one `--show-toplevel --show-prefix` call split
 # on a newline) keep an interior newline in one field from being read as the
 # boundary into the next.
-# Call as: git_rev_parse_field <dir> <path-flag> [locating-global...]
+# Repository questions share one chokepoint (#1500/#1553): every `git` subprocess
+# runs as `git -C <dir> <HOOK_PROBE_LOCATING…> <args…>`, cached under a key of
+# %q-encoded words so argv boundaries cannot collide. `HOOK_EFFECTIVE_LOCATING`
+# is the locating globals inherited across `!` hops (--git-dir/--work-tree/
+# `--namespace` only; `-C` stays in effective_dir). It is cleared on a
+# pure-discovery `!` hop whose outer prefix carries no locating globals, and
+# merged with each frame's own prefix globals in git's last-wins order.
+HOOK_EFFECTIVE_LOCATING=()
+HOOK_PROBE_LOCATING=()
+HOOK_FRAME_PREFIX_HAS_C=0
+declare -A _repo_git_probe_cache=()
 HOOK_REV_PARSE_FIELD=""
+HOOK_REPO_GIT_PROBE_OUT=""
+
+# Call as: repo_git_probe <dir> <git-arg>… — sets HOOK_REPO_GIT_PROBE_OUT.
 # shellcheck disable=SC2329  # reached via the hook::bash_parse_segments callback chain
-git_rev_parse_field() {
-  local dir="$1" flag="$2" out
-  shift 2
-  # No errexit here (`set -uo pipefail` only, no `-e`), so git's nonzero exit on a
-  # non-repo does not abort the subshell before `printf` — the sentinel is always
-  # emitted, and an empty git answer frames to "".
+repo_git_probe() {
+  local dir="$1" key q a out
+  shift
+  printf -v q '%q' "$dir"
+  key="$q"
+  for a in ${HOOK_PROBE_LOCATING[@]+"${HOOK_PROBE_LOCATING[@]}"} "$@"; do
+    printf -v q '%q' "$a"
+    key+=$'\n'"$q"
+  done
+  if [[ -n "${_repo_git_probe_cache[$key]+x}" ]]; then
+    HOOK_REPO_GIT_PROBE_OUT="${_repo_git_probe_cache[$key]}"
+    return 0
+  fi
   out=$(
-    git -C "$dir" "$@" rev-parse "$flag" 2>/dev/null
+    git -C "$dir" ${HOOK_PROBE_LOCATING[@]+"${HOOK_PROBE_LOCATING[@]}"} "$@" 2>/dev/null
     printf 'x'
   )
-  out="${out%x}"     # drop the sentinel, keeping any real trailing byte
-  out="${out%$'\n'}" # git's single bare-LF line terminator (see od note above)
-  HOOK_REV_PARSE_FIELD="$out"
+  out="${out%x}"
+  out="${out%$'\n'}"
+  _repo_git_probe_cache["$key"]="$out"
+  HOOK_REPO_GIT_PROBE_OUT="$out"
 }
 
-# Call as: alias_launch_dir <dir> [locating-global...]
+# Call as: git_rev_parse_field <dir> <path-flag>
+# shellcheck disable=SC2329  # reached via the hook::bash_parse_segments callback chain
+git_rev_parse_field() {
+  local dir="$1" flag="$2"
+  repo_git_probe "$dir" rev-parse "$flag"
+  HOOK_REV_PARSE_FIELD="$HOOK_REPO_GIT_PROBE_OUT"
+}
+
+# Call as: alias_launch_dir <dir> <frame-locating-nglob>
 declare -A _alias_launch_dir=()
 HOOK_ALIAS_LAUNCH_DIR=""
 # shellcheck disable=SC2329  # reached via the hook::bash_parse_segments callback chain
 alias_launch_dir() {
-  local dir="$1" key q toplevel prefix nglob a
-  shift
-  nglob=$#
-  # Key each argv word %q-encoded, never joined with `$*`: a value-carrying
-  # locating global (`--git-dir 'X --work-tree'`) would otherwise flatten to the
-  # same space-joined string as a differently-bounded argv (`--git-dir X
-  # --work-tree`), and the shared global cache would hand the second segment the
-  # first's answer — a wrong repository, decided fail-open. %q makes each word's
-  # bytes (spaces, newlines) unable to shift a field boundary.
+  local dir="$1" key q toplevel prefix frame_nglob="$2" a
   printf -v q '%q' "$dir"
   key="$q"
-  for a in "$@"; do
+  for a in ${HOOK_PROBE_LOCATING[@]+"${HOOK_PROBE_LOCATING[@]}"}; do
     printf -v q '%q' "$a"
     key+=$'\n'"$q"
   done
   if [[ -z "${_alias_launch_dir[$key]+x}" ]]; then
-    # Each field is read byte-exact (git_rev_parse_field) — the top level may
-    # contain, or end in, a newline. The prefix call is skipped when the toplevel
-    # is empty (git could not answer).
-    git_rev_parse_field "$dir" --show-toplevel "$@"
+    git_rev_parse_field "$dir" --show-toplevel
     toplevel="$HOOK_REV_PARSE_FIELD"
     if [[ -z "$toplevel" ]]; then
       _alias_launch_dir["$key"]=""
     else
-      git_rev_parse_field "$dir" --show-prefix "$@"
+      git_rev_parse_field "$dir" --show-prefix
       prefix="$HOOK_REV_PARSE_FIELD"
-      if [[ -n "$prefix" || $nglob -eq 0 ]]; then
+      if [[ -n "$prefix" || frame_nglob -eq 0 ]]; then
         _alias_launch_dir["$key"]="$toplevel"
       else
         _alias_launch_dir["$key"]="$dir"
@@ -371,6 +389,28 @@ collect_locating_globals() {
     esac
   done
   return 0
+}
+
+set_probe_locating() {
+  local -a inherited=()
+  if ((${#HOOK_EFFECTIVE_LOCATING[@]})) && ((HOOK_FRAME_PREFIX_HAS_C == 0)); then
+    inherited=("${HOOK_EFFECTIVE_LOCATING[@]}")
+  fi
+  HOOK_PROBE_LOCATING=()
+  if ((${#inherited[@]})); then
+    HOOK_PROBE_LOCATING=("${inherited[@]}")
+  fi
+  if ((${#locating_globals[@]})); then
+    HOOK_PROBE_LOCATING+=("${locating_globals[@]}")
+  fi
+}
+
+shell_alias_inherited_locating() {
+  if ((${#locating_globals[@]})); then
+    HOOK_EFFECTIVE_LOCATING=("${HOOK_PROBE_LOCATING[@]}")
+  else
+    HOOK_EFFECTIVE_LOCATING=()
+  fi
 }
 
 # The base is HOOK_EFFECTIVE_BASE, not the payload cwd directly, because a `!`
@@ -458,7 +498,9 @@ sequencer_in_progress() {
     # --absolute-git-dir, not --git-dir: the latter answers relative to the repo,
     # which would resolve against the HOOK's cwd here and silently miss every
     # sequencer file.
-    dir=$(git -C "$repo" rev-parse --absolute-git-dir 2>/dev/null) || return 1
+    repo_git_probe "$repo" rev-parse --absolute-git-dir
+    dir="$HOOK_REPO_GIT_PROBE_OUT"
+    [[ -n "$dir" ]] || return 1
   fi
   [[ -n "$dir" ]] || return 1
   for f in MERGE_HEAD CHERRY_PICK_HEAD REVERT_HEAD rebase-merge rebase-apply; do
@@ -480,17 +522,18 @@ HOOK_PERSISTED_ALIAS_EXPS=()
 # shellcheck disable=SC2329  # reached via the hook::bash_parse_segments callback chain
 persisted_alias_expansions() {
   local dir="$1" sub="$2" key plain cmd q a
-  shift 2
   printf -v q '%q' "$dir"
   key="$q"$'\n'"$sub"
-  for a in "$@"; do
+  for a in ${HOOK_PROBE_LOCATING[@]+"${HOOK_PROBE_LOCATING[@]}"}; do
     printf -v q '%q' "$a"
     key+=$'\n'"$q"
   done
   if [[ -z "${_persisted_alias_plain[$key]+x}" ]]; then
-    _persisted_alias_plain["$key"]=$(git -C "$dir" "$@" config --get "alias.$sub" 2>/dev/null)
+    repo_git_probe "$dir" config --get "alias.$sub"
+    _persisted_alias_plain["$key"]="$HOOK_REPO_GIT_PROBE_OUT"
     if [[ -z "${_persisted_alias_plain[$key]}" ]]; then
-      _persisted_alias_command["$key"]=$(git -C "$dir" "$@" config --get "alias.$sub.command" 2>/dev/null)
+      repo_git_probe "$dir" config --get "alias.$sub.command"
+      _persisted_alias_command["$key"]="$HOOK_REPO_GIT_PROBE_OUT"
     else
       _persisted_alias_command["$key"]=""
     fi
@@ -638,8 +681,15 @@ check_segment() {
   # finite distinct alias keys guarantee termination. Terminating is not the same as
   # tractable — the walk branches per hop, and alias_reexpand_admit is what keeps
   # its cost proportional to the chain's length.
-  local exp reparse a alias_rc s seen_hit=0 saved_base=""
+  local exp reparse a alias_rc s seen_hit=0 saved_base="" saved_locating=()
   local -a expw=() saved_seen=() saved_shell_seen=() nextw=()
+  HOOK_FRAME_PREFIX_HAS_C=0
+  local pf
+  for ((pf = gi; pf < sub_idx; pf++)); do
+    [[ "${w[pf]}" == "-C" ]] && HOOK_FRAME_PREFIX_HAS_C=1 && break
+  done
+  collect_locating_globals "${w[@]:gi:sub_idx-gi}"
+  set_probe_locating
   hook::git_alias_expansion "$sub"
   alias_rc=$?
   if ((alias_rc == 2)); then
@@ -693,14 +743,16 @@ check_segment() {
           reparse="${exp#!}"
           for a in "${w[@]:sub_idx+1}"; do reparse+=" $(printf '%q' "$a")"; done
           [[ -n "$seg_dir" ]] || seg_dir="$(effective_dir ${wrapper_cd[@]+"${wrapper_cd[@]}"} "${w[@]:gi:sub_idx-gi}")"
-          collect_locating_globals "${w[@]:gi:sub_idx-gi}"
-          alias_launch_dir "$seg_dir" ${locating_globals[@]+"${locating_globals[@]}"} ||
+          alias_launch_dir "$seg_dir" ${#locating_globals[@]} ||
             HOOK_ALIAS_LAUNCH_DIR="$seg_dir"
           HOOK_ALIAS_SEEN=()
+          saved_locating=(${HOOK_EFFECTIVE_LOCATING[@]+"${HOOK_EFFECTIVE_LOCATING[@]}"})
+          shell_alias_inherited_locating
           HOOK_EFFECTIVE_BASE="$HOOK_ALIAS_LAUNCH_DIR"
           alias_reexpand_admit shell "$reparse" &&
             hook::bash_parse_segments "$reparse" check_segment
           HOOK_EFFECTIVE_BASE="$saved_base"
+          HOOK_EFFECTIVE_LOCATING=(${saved_locating[@]+"${saved_locating[@]}"})
           HOOK_ALIAS_SEEN=(${saved_seen[@]+"${saved_seen[@]}"} "$sub")
         else
           hook::env_s_split "$exp"
@@ -718,8 +770,7 @@ check_segment() {
     if ((inline_alias_handled == 0)) && [[ "$sub" != "commit" ]]; then
       local pexp
       [[ -n "$seg_dir" ]] || seg_dir="$(effective_dir ${wrapper_cd[@]+"${wrapper_cd[@]}"} "${w[@]:gi:sub_idx-gi}")"
-      collect_locating_globals "${w[@]:gi:sub_idx-gi}"
-      persisted_alias_expansions "$seg_dir" "$sub" ${locating_globals[@]+"${locating_globals[@]}"}
+      persisted_alias_expansions "$seg_dir" "$sub"
       for pexp in ${HOOK_PERSISTED_ALIAS_EXPS[@]+"${HOOK_PERSISTED_ALIAS_EXPS[@]}"}; do
         [[ -n "$pexp" ]] || continue
         if [[ "$pexp" == '!'* ]]; then
@@ -746,8 +797,7 @@ check_segment() {
           # the directory forever (`-C .`) never repeats a key, so termination
           # there rests on the fail-closed traversal budget, not on this set.
           local pkey pseen_hit=0
-          collect_locating_globals "${w[@]:gi:sub_idx-gi}"
-          alias_launch_dir "$seg_dir" ${locating_globals[@]+"${locating_globals[@]}"} ||
+          alias_launch_dir "$seg_dir" ${#locating_globals[@]} ||
             HOOK_ALIAS_LAUNCH_DIR="$seg_dir"
           pkey="$HOOK_ALIAS_LAUNCH_DIR"$'\n'"$sub="$'\n'"$pexp"
           for s in ${HOOK_SHELL_ALIAS_SEEN[@]+"${HOOK_SHELL_ALIAS_SEEN[@]}"}; do
@@ -762,10 +812,13 @@ check_segment() {
             preparse="${pexp#!}"
             for pa in "${w[@]:sub_idx+1}"; do preparse+=" $(printf '%q' "$pa")"; done
             HOOK_ALIAS_SEEN=()
+            saved_locating=(${HOOK_EFFECTIVE_LOCATING[@]+"${HOOK_EFFECTIVE_LOCATING[@]}"})
+            shell_alias_inherited_locating
             HOOK_EFFECTIVE_BASE="$HOOK_ALIAS_LAUNCH_DIR"
             alias_reexpand_admit shell "$preparse" &&
               hook::bash_parse_segments "$preparse" check_segment
             HOOK_EFFECTIVE_BASE="$saved_base"
+            HOOK_EFFECTIVE_LOCATING=(${saved_locating[@]+"${saved_locating[@]}"})
             HOOK_ALIAS_SEEN=(${saved_seen[@]+"${saved_seen[@]}"} "$sub")
           fi
         else
@@ -917,6 +970,9 @@ HOOK_SHELL_ALIAS_SEEN=()
 # level, then each `!` reparse's own repository as the walk descends (effective_dir).
 # Save/restored alongside the seen-sets, so sibling segments start from the cwd.
 HOOK_EFFECTIVE_BASE="${HOOK_CWD:-${CLAUDE_PROJECT_DIR:-.}}"
+HOOK_EFFECTIVE_LOCATING=()
+HOOK_PROBE_LOCATING=()
+HOOK_FRAME_PREFIX_HAS_C=0
 
 # The alias-traversal bounds (alias_reexpand_admit). Both are invocation-wide and
 # deliberately NOT save/restored: a state analyzed anywhere is analyzed, and the

--- a/plugins/guardrails/hooks/block-noncanonical-commit.test.sh
+++ b/plugins/guardrails/hooks/block-noncanonical-commit.test.sh
@@ -1166,6 +1166,36 @@ if [[ -d "$GLOB/repo/.git" ]]; then
   fi
 fi
 
+# --- repo-context chokepoint (#1500 / #1553) ----------------------------------
+CHOKE="$TEST_TMPDIR/choke"
+mkdir -p "$CHOKE/outside"
+nested_repo "$CHOKE/repo"
+if [[ -d "$CHOKE/repo/.git" ]]; then
+  git -C "$CHOKE/repo" config alias.a b
+  git -C "$CHOKE/repo" config alias.b $'commit --allow-empty -m "x\ny"'
+  choke_run() {
+    local label="$1" cmd="$2" want="$3" rc
+    MSYS_NO_PATHCONV=1 jq -n --arg c "$cmd" --arg d "$CHOKE/outside" \
+      '{tool_name:"Bash",tool_input:{command:$c},cwd:$d}' |
+      timeout "$HANG_GUARD_SECS" bash "$HOOK" >/dev/null 2>&1
+    rc=$?
+    ((rc == 124)) && bad "$label: HUNG" && return
+    assert_exit "$label" "$want" "$rc"
+  }
+  choke_run "#1553: persisted chain under locating globals (blocked)" \
+    "git --git-dir=$CHOKE/repo/.git --work-tree=$CHOKE/repo --git-dir=$CHOKE/repo/.git a" 2
+  choke_run "R8-2: inline alias into persisted multi-line -m (blocked)" \
+    "git --git-dir=$CHOKE/repo/.git --work-tree=$CHOKE/repo -c alias.a=b a" 2
+  choke_run "R8-3: ! body establishes repo via -C, canonical -F - (allowed)" \
+    "git -c alias.a='!git -C $CHOKE/repo commit --allow-empty -F -' a" 0
+  choke_run "R8-3 twin: same shape with multi-line -m (blocked)" \
+    "git -c alias.a='!git -C $CHOKE/repo commit --allow-empty -m \"x${NL}y\"' a" 2
+  choke_run "F3: --git-dir/--work-tree ! alias to canonical commit (allowed)" \
+    "git --git-dir=$CHOKE/repo/.git --work-tree=$CHOKE/repo -c alias.a='!git commit -F -' a" 0
+  choke_run "F3 twin: same outer shape with multi-line -m in body (blocked)" \
+    "git --git-dir=$CHOKE/repo/.git --work-tree=$CHOKE/repo -c alias.a='!git commit -m \"x${NL}y\"' a" 2
+fi
+
 # --- explicit locating globals: a `!` body launches where the CALLER stands ----
 # git chdirs a `!` body to the work-tree top level only when the caller's
 # directory is INSIDE the effective work tree. With `--git-dir`/`--work-tree`


### PR DESCRIPTION
Closes #1500
Closes #1553

## Summary

Single repo-context chokepoint in `block-noncanonical-commit`: every git question goes through `repo_git_probe` with per-frame locating globals; path composition stays separate from alias lookup.

## Fix

- `repo_git_probe` seam with `%q` cache keys
- `HOOK_EFFECTIVE_LOCATING` across `!` hops (cleared on pure-discovery / inner `-C`)
- No outer fail-closed
- Acceptance tests for #1553 / R8-2 / R8-3 / F3
- guardrails version bump

## Verification

```bash
bash plugins/guardrails/hooks/block-noncanonical-commit.test.sh
```
passed: 213 failed: 0

## Related

Refs #1486 — cd-following still out of scope. Refs #1469 — sibling-guard port deferred.