### PR TITLE
fix(disk-hygiene): launch the skill-scoped guard in shell form (#2568)

### DIFF
--- a/plugins/disk-hygiene/.claude-plugin/plugin.json
+++ b/plugins/disk-hygiene/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "disk-hygiene",
-  "version": "0.17.8",
+  "version": "0.17.9",
   "description": "Context-aware disk hygiene for arbitrary directory trees: inventories orphaned and temporary artifacts, classifies evidence into review tiers, and offers exact-path cleanup only after a fresh safety preview and explicit per-tier approval. The target is read-only by default; OS-managed paths, links and mount points, VCS-tracked content, changed entries, and live-handle uncertainty fail closed.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/disk-hygiene/CHANGELOG.md
+++ b/plugins/disk-hygiene/CHANGELOG.md
@@ -38,11 +38,24 @@ All notable changes to the `disk-hygiene` plugin are documented here. Format fol
 - **Docs that described this hook's form are corrected.** `README.md`, `skills/setup/SKILL.md`,
   `skills/clean/reference/safety-model.md`, `hooks/run-python-hook.sh`'s header, and the
   `python3_alias_probe.py` docstring and operator message all stated that the belt launches as the
-  literal `python3`, several of them as the rationale for a check. Every `/disk-hygiene:setup
-  check` verdict is unchanged — a stubbed `python3` remains a FAIL, since the aliases ship as a
-  pair and `py` exists only where real Python is installed, so that host usually exhausts the
-  whole ladder — but the reason is re-grounded on the launcher rather than on a hook form that no
-  longer exists.
+  literal `python3`, several of them as the rationale for a check. The reason is now grounded on
+  the launcher rather than on a hook form that no longer exists.
+
+### Changed
+
+- **`/disk-hygiene:setup check` verdicts the interpreter LADDER, not `python3` alone.** Direct
+  fallout of the conversion above: while the belt named `python3` in exec form, a stubbed first
+  rung genuinely was a guard-launch failure, so step 2 mapped `store-alias-stub` straight to FAIL.
+  Now that every surface routes through `hooks/run-python-hook.sh`, that mapping reports a healthy
+  install as broken — a host with real Python installed without "Add to PATH" but with the `py`
+  launcher has a stubbed `python3`, a working `py -3`, and a guard that launches on every call, yet
+  would have been told to reinstall Python. Step 2 now treats the alias probe as **diagnostic
+  input**, resolves the ladder in the launcher's own order (skipping stubs), and checks the
+  selected interpreter against the parsed `MIN_PYTHON`. FAIL is unchanged in substance where it
+  matters — an **exhausted** ladder or a below-floor interpreter, both still FAIL under a disabled
+  toggle — and a stubbed `python3` beside a working `python`/`py -3` becomes a **WARN** naming the
+  real residual: a bare `python3` typed by hand still opens the Microsoft Store. The probe's own
+  return values are unchanged; only the mapping to a verdict and the message wording moved.
 
 ## [0.17.8]
 

--- a/plugins/disk-hygiene/CHANGELOG.md
+++ b/plugins/disk-hygiene/CHANGELOG.md
@@ -3,6 +3,47 @@
 All notable changes to the `disk-hygiene` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.17.9]
+
+### Fixed
+
+- **The skill-scoped guard launches in shell form too, closing the last exec-form instance
+  (#2568).** `skills/clean/SKILL.md`'s frontmatter belt was the third and final registration left
+  on exec form after #1416 — `"command": "python3"` plus `args`, unchanged since #215 and so
+  predating `hooks/run-python-hook.sh` entirely. Exec form is a bare `PATH` lookup, and on stock
+  Windows `python3` resolves to the zero-length `WindowsApps\python3.exe` App Execution Alias
+  stub, which is not a real executable: the belt could not launch there at all, and a failed hook
+  launch is non-blocking, so it silently enforced nothing. Unlike the wired hooks this instance
+  was **latent, not dead** — it works wherever `python3` is a real interpreter — so the
+  conversion was held to argv equivalence rather than merely to launching: the vector
+  `destructive_guard.py` receives is byte-identical before and after, verified against roots
+  containing spaces and backslashes, with only argv[0] changing from the interpreter name to the
+  launcher path. The command string substitutes **only** `${CLAUDE_PLUGIN_ROOT}`, the sole token
+  Claude Code provides to a skill-frontmatter hook; `--authorized-data-root`
+  `${CLAUDE_PLUGIN_DATA}` is deliberately **not** reintroduced, because that token is unavailable
+  on this surface and causes launch refusal (#1014). Residual, unchanged: the launcher exits 0
+  silently in guard mode when no interpreter resolves anywhere on its ladder, so this closes
+  "cannot start against the alias stub", not "fails closed with no Python".
+- **The skill-hook tests no longer encode the launch form they were meant to check.** Three tests
+  in `skills/clean/scripts/test_hygiene.py` read the frontmatter form-specifically — one required
+  an `args:` line (and would have raised on shell form), one hand-stripped quotes off the
+  `command:` line, and one asserted the literal `python3` as the interpreter. That is the same
+  bug-as-contract shape that let the wired guard ship dead twice. The frontmatter is now read into
+  a hook mapping and fed to the existing form-agnostic `_hook_argv()` helper, so both surfaces are
+  asserted through one path; the interpreter test now exercises `run-python-hook.sh`'s real
+  resolution ladder instead of restating it. Two tests were added: one asserting the four
+  portability properties for this surface (launcher named in `command`, no `args`, `shell: bash`,
+  every placeholder double-quoted) — verified to **fail** against the pre-change frontmatter — and
+  one asserting the argv equivalence above.
+- **Docs that described this hook's form are corrected.** `README.md`, `skills/setup/SKILL.md`,
+  `skills/clean/reference/safety-model.md`, `hooks/run-python-hook.sh`'s header, and the
+  `python3_alias_probe.py` docstring and operator message all stated that the belt launches as the
+  literal `python3`, several of them as the rationale for a check. Every `/disk-hygiene:setup
+  check` verdict is unchanged — a stubbed `python3` remains a FAIL, since the aliases ship as a
+  pair and `py` exists only where real Python is installed, so that host usually exhausts the
+  whole ladder — but the reason is re-grounded on the launcher rather than on a hook form that no
+  longer exists.
+
 ## [0.17.8]
 
 ### Fixed

--- a/plugins/disk-hygiene/README.md
+++ b/plugins/disk-hygiene/README.md
@@ -47,15 +47,17 @@ at preview. Backups remain the recovery boundary for user data.
 - Python 3.11+ available on `PATH` is required for scanning, validation, the skill-scoped guard, and
   cleanup (the floor's single origin is the `MIN_PYTHON` constant in
   `skills/clean/scripts/hygiene.py`; `/disk-hygiene:setup check` derives the enforced value from
-  there, so treat the number printed here as a convenience copy). Claude Code launches the
-  skill-scoped guard in shell-free exec form; guarded engine calls must use the same absolute
-  interpreter reported by that guard, so Bash aliases and functions cannot replace it. Both wired
-  hooks register in **shell form** — the `command` string names `hooks/run-python-hook.sh` directly
-  with `"shell": "bash"` and no `args` — so Claude Code routes them through Git Bash itself instead
-  of resolving `bash` on `PATH`. Registering them in exec form as `"command": "bash"` is the
-  regression #1416 tracks: on Windows that bare `PATH` lookup finds the WSL relay
-  `System32\bash.exe` before Git Bash, the launch fails, and a failed hook launch is non-blocking —
-  so the guard silently enforces nothing. The launcher then resolves Python (#1504). The guard
+  there, so treat the number printed here as a convenience copy). Guarded engine calls must use the
+  same absolute interpreter reported by the skill-scoped guard, so Bash aliases and functions cannot
+  replace it. **All three** hook registrations — both wired hooks and the skill-scoped belt — use
+  **shell form**: the `command` string names `hooks/run-python-hook.sh` directly with
+  `"shell": "bash"` and no `args`, so Claude Code routes them through Git Bash itself instead of
+  resolving the command on `PATH`. Exec form is the regression this plugin hit twice: as
+  `"command": "bash"` in the wired hooks (#1416) and as `"command": "python3"` in the belt (#2568).
+  On Windows that bare `PATH` lookup finds the WSL relay `System32\bash.exe` before Git Bash, or the
+  zero-length `WindowsApps\python3.exe` App Execution Alias stub; the launch fails, and a failed
+  hook launch is non-blocking — so the guard silently enforces nothing. The launcher then resolves
+  Python (#1504). The guard
   registers on two surfaces: a
   plugin-level **engine gate** (`hooks/hooks.json`) that acts only on commands referencing the
   engine — deferring everything else instantly — and enforces the kill switch and data-root
@@ -79,7 +81,7 @@ at preview. Backups remain the recovery boundary for user data.
   guard that never ran or died mid-run no longer looks identical to a guard that ran and approved.
   This covers only the `destructive_guard.py` command string in the current session's transcript: it
   does not cover repo-hygiene's own guard (a separate plugin, verified working independently), and it
-  never retroactively scans a prior session's transcript. Both wired hooks register through
+  never retroactively scans a prior session's transcript. Every hook registration routes through
   `hooks/run-python-hook.sh` — a bash launcher that resolves Python independently of bare
   `python3` on PATH — so when `python3` is the WindowsApps alias stub or otherwise unresolvable,
   the detector still emits a `systemMessage` even though the guard cannot run (#1504).
@@ -93,9 +95,12 @@ at preview. Backups remain the recovery boundary for user data.
   distinction only — the engine treats Windows and macOS identically (execution unsupported); which
   reversible-removal container the manual lane prefers is the model's instruction, not engine
   behavior.
-- **Windows `python3` gotcha — the Store alias stub fails the guard open.** The wired hooks resolve
+- **Windows `python3` gotcha — the Store alias stub fails the guard open.** Every hook resolves
   Python through `hooks/run-python-hook.sh` (rejecting the zero-length `WindowsApps\python3.exe`
-  App Execution Alias stub) before exec'ing the guard. When no interpreter resolves, the guard still
+  App Execution Alias stub and falling through to `python`, then `py -3`) before exec'ing the guard.
+  Since 0.17.9 that includes the skill-scoped belt, which previously named `python3` directly as its
+  exec-form `command` and so could not start at all against the stub. When no interpreter resolves
+  anywhere on the ladder, the guard still
   fails open — a PreToolUse hook blocks a tool call only by emitting exit code 2 or a `deny`
   decision ([Hooks](https://code.claude.com/docs/en/hooks)); a guard that never runs emits neither,
   and Claude Code treats the non-blocking result as approval — the destructive Bash/PowerShell
@@ -230,7 +235,19 @@ hand-cleaning the zone.
   placeholder is double-quoted, and `test_hygiene.py`'s hook helpers are form-agnostic so a shell-form
   entry can never make an assertion vacuously green. Interpolating anything beyond those two
   placeholders into the command string would open a live injection surface; a repo-wide CI gate for
-  this defect class is proposed in #2569. A direct `hygiene.py` invocation outside that skill does not read the toggle and
+  this defect class is proposed in #2569. **0.17.9 delta (launch form, skill surface):** the
+  skill-scoped belt in `skills/clean/SKILL.md` frontmatter moves to the same shell form, for the same
+  reason one rung down — its exec-form `command` was the literal `python3`, which on stock Windows is
+  the zero-length `WindowsApps` App Execution Alias stub, so the belt could not launch there at all
+  (#2568). The trust analysis above carries over with a **narrower** substitution set: a
+  skill-frontmatter hook receives only `${CLAUDE_PLUGIN_ROOT}` (#1014), never `${CLAUDE_PLUGIN_DATA}`
+  or `${user_config.*}`, so the belt's command string carries exactly one placeholder and the
+  `--authorized-data-root` channel stays out of it by construction. Because this belt was *working*
+  wherever `python3` resolved to a real interpreter, the conversion was held to argv equivalence: the
+  vector `destructive_guard.py` receives is byte-identical before and after, asserted against roots
+  containing spaces and backslashes; only argv[0] changes, from an interpreter name to the launcher
+  path. What this does **not** change is the guard's no-interpreter behaviour — the launcher still
+  exits 0 silently in guard mode when nothing on the ladder resolves. A direct `hygiene.py` invocation outside that skill does not read the toggle and
   answers only to the engine's own preview/approval-token gate. The toggle can only narrow the
   destructive surface, never widen it (see [the safety model](skills/clean/reference/safety-model.md)
   for the degraded-mode detail). No credentials. Policy comes from an explicit invocation

--- a/plugins/disk-hygiene/README.md
+++ b/plugins/disk-hygiene/README.md
@@ -106,10 +106,13 @@ at preview. Backups remain the recovery boundary for user data.
   and Claude Code treats the non-blocking result as approval — the destructive Bash/PowerShell
   command proceeds ungated (the same fail-open shape as the 0.6.3 launch-failure fix, via a
   different vector). The Stop detector emits a `systemMessage` in that case so the blind spot is
-  visible. `/disk-hygiene:setup check` detects this explicitly and FAILs: disable the `python3` App
-  execution alias (Settings > Apps > Advanced app settings > App execution aliases) or install real
-  Python and ensure it precedes WindowsApps on `PATH`. A bare `command -v python3` / `where python3`
-  success is not proof the interpreter is real — the stub answers to the name too.
+  visible. `/disk-hygiene:setup check` resolves the launcher's whole ladder and FAILs only when it
+  is exhausted or the interpreter it selects is below the floor. A stubbed `python3` alongside a
+  working `python` or `py -3` is a **WARN**, not a FAIL — every guard launches there, and the
+  residual is only that a bare `python3` typed by hand still opens the Store. To clear it: disable
+  the `python3` App execution alias (Settings > Apps > Advanced app settings > App execution
+  aliases) or install real Python ahead of WindowsApps on `PATH`. A bare `command -v python3` /
+  `where python3` success is not proof the interpreter is real — the stub answers to the name too.
 - Linux requires readable `/proc/self/mountinfo`, descriptor-relative filesystem APIs, and `lsof` for
   the optional execution lane. Absence, diagnostics, or authority gaps block cleanup.
 - macOS supports audit/report only because this implementation has no authoritative bind-mount and

--- a/plugins/disk-hygiene/hooks/run-python-hook.sh
+++ b/plugins/disk-hygiene/hooks/run-python-hook.sh
@@ -1,20 +1,26 @@
 #!/usr/bin/env bash
-# Launch disk-hygiene wired hooks through a Python 3 interpreter resolved
-# independently of a bare `python3` on PATH (#1504).
+# Launch every disk-hygiene hook through a Python 3 interpreter resolved
+# independently of a bare `python3` on PATH (#1504) — the two wired hooks in
+# hooks.json and, since #2568, the clean skill's frontmatter belt.
 #
 # When `python3` is absent, broken, or resolves to the zero-length WindowsApps
 # App Execution Alias stub, both the guard and its Stop detector died the same
 # way — the detector could not observe the guard's fail-open. This launcher
 # resolves a real interpreter before exec'ing the target script.
 #
-# hooks.json invokes this file in SHELL FORM — the `command` string names this
+# Every caller invokes this file in SHELL FORM — the `command` string names this
 # script by path and carries its arguments, with no `args` key. Claude Code
 # routes shell form through Git Bash on Windows, resolved by Claude Code itself.
-# It must NOT be registered in exec form as `"command": "bash"` + `args`: exec
-# form is a bare PATH lookup, and on Windows `bash` resolves to the WSL relay
-# `System32\bash.exe` before Git Bash, which fails with
-# `execvpe(/bin/bash) failed` (#1006, regressed by #1504). A hook that fails to
-# launch is a non-blocking error, so the guard silently enforces nothing.
+# It must NOT be registered in exec form: exec form is a bare PATH lookup, and on
+# Windows `"command": "bash"` resolves to the WSL relay `System32\bash.exe`
+# before Git Bash, failing with `execvpe(/bin/bash) failed` (#1006, regressed by
+# #1504), while `"command": "python3"` resolves to the zero-length WindowsApps
+# alias stub (#2568). A hook that fails to launch is a non-blocking error, so the
+# guard silently enforces nothing.
+# The skill-frontmatter belt reaches this launcher the same way, but its command
+# string may substitute ONLY `${CLAUDE_PLUGIN_ROOT}`: a skill hook receives no
+# `${CLAUDE_PLUGIN_DATA}` or `${user_config.*}`, and either makes Claude Code
+# refuse the launch outright (#1014).
 # Every path placeholder in the command string must stay double-quoted; the
 # shell re-tokenizes the string, and plugin roots contain spaces.
 #

--- a/plugins/disk-hygiene/skills/clean/SKILL.md
+++ b/plugins/disk-hygiene/skills/clean/SKILL.md
@@ -7,9 +7,21 @@ hooks:
   PreToolUse:
     - matcher: "Bash|PowerShell"
       hooks:
+        # Shell form, matching hooks/hooks.json (#2568). Exec form resolves
+        # `command` on PATH with no shell, and the bare `python3` this used to
+        # name is the zero-length WindowsApps App Execution Alias stub on stock
+        # Windows — the hook cannot launch, and a failed launch is non-blocking,
+        # so the belt silently enforces nothing. `hooks/run-python-hook.sh`
+        # rejects that stub and falls through to `python`, then `py -3`.
+        # `${CLAUDE_PLUGIN_ROOT}` is the ONLY substitution a skill-frontmatter
+        # hook receives (#1014) — never ${CLAUDE_PLUGIN_DATA} or
+        # ${user_config.*}, either of which makes Claude Code refuse the launch.
+        # The single-quoted YAML scalar is the same value hooks.json spells with
+        # \" escapes; every path placeholder must stay double-quoted, because the
+        # shell re-tokenizes the string and plugin roots contain spaces.
         - type: command
-          command: "python3"
-          args: ["${CLAUDE_PLUGIN_ROOT}/skills/clean/scripts/destructive_guard.py", "--plugin-root", "${CLAUDE_PLUGIN_ROOT}"]
+          command: '"${CLAUDE_PLUGIN_ROOT}"/hooks/run-python-hook.sh "${CLAUDE_PLUGIN_ROOT}"/skills/clean/scripts/destructive_guard.py --plugin-root "${CLAUDE_PLUGIN_ROOT}"'
+          shell: bash
           timeout: 60
 metadata:
   workflow-stage: anytime

--- a/plugins/disk-hygiene/skills/clean/reference/safety-model.md
+++ b/plugins/disk-hygiene/skills/clean/reference/safety-model.md
@@ -193,7 +193,8 @@ TODO(#387): extend the flagged set to those spellings.
 **Kill-switch enforcement (since 0.9.0): both surfaces resolve it by reading user settings.** The guard
 registers on two surfaces — the **plugin-level engine gate** (`hooks/hooks.json`, shell form through
 `hooks/run-python-hook.sh`, `--mode engine-gate`; see "Hook launch form" below) and the
-**skill-scoped belt** (the clean skill's frontmatter hook, still exec form) — and both
+**skill-scoped belt** (the clean skill's frontmatter hook, shell form through the same launcher
+since 0.17.9) — and both
 resolve `disk_hygiene_enabled` the same single way: by reading it from `pluginConfigs` in the
 `settings.json` files, through the shared `lib/killswitch_config.py` reader (the same read the setup
 skill's `kill_switch_probe.py` reports). Neither surface takes the value from the process environment.
@@ -252,27 +253,33 @@ Even when the switch resolves enabled, the PowerShell lane is a raised bar, not 
 mutation spelling passes it, so the engine's own containment, revalidation, and platform gates remain the
 deletion authority.
 
-**Hook launch form, and what it does and does not bound (since 0.17.8, #1416).** The two wired hooks
-— the engine gate on `PreToolUse` and its detector on `Stop` — register in **shell form**: the
-`command` string names `hooks/run-python-hook.sh` with `"shell": "bash"` and no `args`. Exec form was
-not viable: it is a bare `PATH` lookup, and on Windows `bash` resolves to the WSL relay
-`System32\bash.exe` before Git Bash, so the launch died and — a failed hook launch being non-blocking
-— the guard silently enforced nothing. Shell form is resolved by Claude Code itself, which routes it
-through its own Git Bash. The security consequence is stated plainly rather than glossed: a shell now
-parses the launch string, so "no shell is involved" is no longer the bound. What bounds it instead is
-that the string is a **fixed literal** in the plugin's own `hooks.json`, with no model-, repo-, or
-session-supplied text interpolated into it; the only substituted values are Claude Code's own
-`${CLAUDE_PLUGIN_ROOT}` and `${CLAUDE_PLUGIN_DATA}` placeholders, each double-quoted, so the shell's
-re-tokenization reproduces the exec-form argument vector byte-for-byte — verified for both hooks
-against roots containing spaces and backslashes. The limit of that quoting is part of the model too:
-the runtime substitutes those placeholders *textually* before bash parses the result, so the double
-quotes bound whitespace and backslashes but would not neutralize a `$` or a backtick inside a
-substituted value (both resolve under Claude Code's own install and data roots). The invariant is
-therefore **maintained by test**, not structural — `hooks/run-python-hook.test.sh` asserts the
-launcher is named in `command`, `args` is absent, `shell: bash` is declared, and every placeholder is
-quoted, and `test_hygiene.py`'s hook helpers read either launch form so a shell-form entry cannot make
-an assertion vacuously green. The skill-scoped belt is a separate surface and still launches in exec
-form via `python3` (#2568).
+**Hook launch form, and what it does and does not bound (0.17.8 #1416; extended to the belt in
+0.17.9, #2568).** All three registrations — the engine gate on `PreToolUse`, its detector on `Stop`,
+and the skill-scoped belt in the clean skill's frontmatter — use **shell form**: the `command` string
+names `hooks/run-python-hook.sh` with `"shell": "bash"` and no `args`. Exec form was not viable: it is
+a bare `PATH` lookup, and on Windows `"command": "bash"` resolves to the WSL relay
+`System32\bash.exe` before Git Bash while `"command": "python3"` resolves to the zero-length
+`WindowsApps` App Execution Alias stub, so the launch died and — a failed hook launch being
+non-blocking — the guard silently enforced nothing. Shell form is resolved by Claude Code itself,
+which routes it through its own Git Bash. The security consequence is stated plainly rather than
+glossed: a shell now parses the launch string, so "no shell is involved" is no longer the bound. What
+bounds it instead is that the string is a **fixed literal** in the plugin's own `hooks.json` or
+SKILL.md frontmatter, with no model-, repo-, or session-supplied text interpolated into it; the only
+substituted values are Claude Code's own `${CLAUDE_PLUGIN_ROOT}` and `${CLAUDE_PLUGIN_DATA}`
+placeholders, each double-quoted, so the shell's re-tokenization reproduces the exec-form argument
+vector byte-for-byte — verified for all three against roots containing spaces and backslashes.
+The belt's bound is the **tighter** of the two: a skill-frontmatter hook receives only
+`${CLAUDE_PLUGIN_ROOT}` (#1014), so that is the sole placeholder its command string carries and the
+`--authorized-data-root` channel stays out of it by construction, not by convention. The limit of
+that quoting is part of the model too: the runtime substitutes those placeholders *textually* before
+bash parses the result, so the double quotes bound whitespace and backslashes but would not
+neutralize a `$` or a backtick inside a substituted value (both resolve under Claude Code's own
+install and data roots). The invariant is therefore **maintained by test**, not structural —
+`hooks/run-python-hook.test.sh` asserts for `hooks.json` that the launcher is named in `command`,
+`args` is absent, `shell: bash` is declared, and every placeholder is quoted; `test_hygiene.py`
+asserts the same four properties for the frontmatter belt (that suite is jq-based and cannot read
+YAML) and reads either launch form throughout, so a shell-form entry cannot make an assertion
+vacuously green.
 
 **Guard launch/runtime failures are now surfaced, not silently indistinguishable from approval (since
 0.9.5, #1416).** A `PreToolUse` hook that fails to launch, or launches and then exits non-zero, denies
@@ -293,15 +300,18 @@ independently and out of scope here; the detector's command-substring filter mat
 `destructive_guard.py` invocations, so a renamed or unrelated guard script is invisible to it the same
 way it is invisible to the engine gate's own coverage marker (see above); and it never retroactively
 scans a prior session's transcript — only the transcript named by the current `Stop` event's own
-`transcript_path`. Interpreter resolution is no longer one of those gaps: since #1504 both wired hooks
-launch through the shared `hooks/run-python-hook.sh`, which tries `python3`, then `python`, then
-`py -3`, rejects the zero-length `WindowsApps` alias stub, and — in monitor mode — emits the
-`systemMessage` itself when nothing resolves, so a host with no usable Python reports the blind spot
-instead of hiding it. What the two still share is that launcher and the shell that starts it: both are
-registered in shell form (`"shell": "bash"`, since 0.17.8), so a host where Claude Code cannot start a
-bash shell at all takes the guard and its detector down together with nothing left to report it. That
-residual is why the registration shape is asserted by `hooks/run-python-hook.test.sh` and verified as
-step 1 of `/disk-hygiene:setup check`.
+`transcript_path`. Interpreter resolution is no longer one of those gaps: since #1504 the wired hooks
+— and since #2568 the skill-scoped belt — launch through the shared `hooks/run-python-hook.sh`, which
+tries `python3`, then `python`, then `py -3`, rejects the zero-length `WindowsApps` alias stub, and —
+in monitor mode — emits the `systemMessage` itself when nothing resolves, so a host with no usable
+Python reports the blind spot instead of hiding it. What every surface still shares is that launcher
+and the shell that starts it: all are registered in shell form (`"shell": "bash"`), so a host where
+Claude Code cannot start a bash shell at all takes the guard and its detector down together with
+nothing left to report it. And the guard's own no-interpreter path is unchanged: the launcher exits 0
+silently in guard mode, so routing the belt through it closes "cannot start against the alias stub",
+not "fails closed when no Python exists at all". That residual is why the registration shape is
+asserted by `hooks/run-python-hook.test.sh` and `test_hygiene.py`, and verified as step 1 of
+`/disk-hygiene:setup check`.
 
 A depth-limited scan records every directory it declined to enter in `truncated_paths`. Truncated
 directories have no captured descendant set, so the preview blocks them (and anything beneath them)

--- a/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
@@ -4274,9 +4274,9 @@ class GuardTests(unittest.TestCase):
         from an interpreter name to the launcher path, which IS the fix.
 
         Asserted against roots containing spaces and backslashes because that is
-        where quoting fails: a Windows plugin root is routinely
-        `C:\\Users\\First Last\\...`, and an unquoted placeholder would split it
-        into several argv entries and hand the guard a truncated `--plugin-root`.
+        where quoting fails: a Windows plugin root routinely sits under a
+        space-bearing directory, and an unquoted placeholder would split it into
+        several argv entries and hand the guard a truncated `--plugin-root`.
         """
         exec_form_argv = [
             "${CLAUDE_PLUGIN_ROOT}/skills/clean/scripts/destructive_guard.py",
@@ -4285,8 +4285,8 @@ class GuardTests(unittest.TestCase):
         ]
         hook = self._skill_hook()
         for root in (
-            "/home/user/.claude/plugins/disk-hygiene",
-            r"C:\Users\First Last\AppData\Local\Claude Code\plug in root",
+            "/opt/claude/plugins/disk-hygiene",
+            r"C:\Program Files\Claude Code\plug in root",
             r"D:\a b\c\d",
         ):
             with self.subTest(root=root):

--- a/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
@@ -4147,22 +4147,159 @@ class GuardTests(unittest.TestCase):
         )
 
     @staticmethod
-    def _skill_hook_command_and_args() -> tuple[str, list[str]]:
-        """Return the frontmatter guard hook's `command` and parsed `args`."""
-        text = (SCRIPT_DIR.parent / "SKILL.md").read_text(encoding="utf-8")
-        args_line = next(
-            line
-            for line in text.splitlines()
-            if "destructive_guard.py" in line and "args:" in line
+    def _yaml_flow_scalar(raw: str) -> str:
+        """Unwrap the three one-line YAML scalar styles, without a YAML library.
+
+        This suite is stdlib-only, so the frontmatter is read as text. Hand-
+        stripping quotes with `.strip('"')` was the previous shape and is wrong
+        for a single-quoted scalar wrapping literal double quotes — which is
+        exactly how a shell-form `command` has to be spelled in YAML. It would
+        yield a string `shlex` then tokenizes wrongly, silently, so the style is
+        decoded here instead of guessed at the call site.
+        """
+        raw = raw.strip()
+        if len(raw) >= 2 and raw[0] == raw[-1] == "'":
+            return raw[1:-1].replace("''", "'")
+        if len(raw) >= 2 and raw[0] == raw[-1] == '"':
+            return re.sub(r"\\(.)", r"\1", raw[1:-1])
+        return raw
+
+    @classmethod
+    def _skill_hook(cls) -> dict:
+        """The clean skill's frontmatter guard hook, as a hook mapping.
+
+        Returned in the same shape `hooks.json` entries have so the skill
+        surface can be asserted through the very same form-agnostic
+        `_hook_argv()` the wired hooks use — one reading path for both
+        surfaces, in either launch form. Reading it form-specifically (keying
+        on an `args:` line) is what issue #2568 had to unwind: it raises the
+        moment the hook moves to shell form.
+        """
+        lines = (SCRIPT_DIR.parent / "SKILL.md").read_text(encoding="utf-8").splitlines()
+        frontmatter = lines[1 : lines.index("---", 1)]
+        start = next(
+            index
+            for index, line in enumerate(frontmatter)
+            if line.strip() == "- type: command"
         )
-        args = json.loads(args_line[args_line.index("[") : args_line.rindex("]") + 1])
-        command_line = next(
-            line
-            for line in text.splitlines()
-            if line.strip().startswith("command:")
+        entry_indent = len(frontmatter[start]) - len(frontmatter[start].lstrip())
+        key_indent = entry_indent + len("- ")
+        hook: dict = {}
+        for offset, line in enumerate(frontmatter[start:]):
+            if not line.strip():
+                continue
+            indent, body = len(line) - len(line.lstrip()), line.strip()
+            if body.startswith("- "):
+                if offset or indent != entry_indent:
+                    break
+                body = body[len("- ") :]
+            elif indent != key_indent:
+                break
+            key, _, value = body.partition(":")
+            hook[key.strip()] = cls._yaml_flow_scalar(value)
+        if "args" in hook:
+            hook["args"] = json.loads(hook["args"])
+        return hook
+
+    @classmethod
+    def _substitute_plugin_root(cls, value: object, root: str) -> object:
+        """Expand `${CLAUDE_PLUGIN_ROOT}` through a hook value of either form.
+
+        Shell form carries the placeholder inside the `command` string; exec form
+        carries it inside `args` entries. Substituting through both keeps the
+        equivalence assertion readable against either shape rather than silently
+        comparing an expanded vector to an unexpanded one.
+        """
+        if isinstance(value, str):
+            return value.replace(guard._PLUGIN_ROOT_PLACEHOLDER, root)
+        if isinstance(value, list):
+            return [cls._substitute_plugin_root(item, root) for item in value]
+        return value
+
+    def test_skill_hook_registers_in_portable_shell_form(self) -> None:
+        """The skill-scoped belt must launch the way the wired hooks do (#2568).
+
+        Exec form (`args` present) resolves `command` as a bare PATH lookup, and
+        the belt's was the literal `python3` — which on stock Windows resolves to
+        the zero-length WindowsApps App Execution Alias stub, not a real
+        executable. The spawn fails, a failed hook launch is non-blocking, and the
+        belt silently enforces nothing. Shell form through
+        `hooks/run-python-hook.sh` is the shape #1006/#2570 proved: Claude Code
+        routes it through its own Git Bash rather than a PATH lookup, and the
+        launcher rejects the alias stub before exec'ing.
+
+        These are the same four portability assertions
+        `hooks/run-python-hook.test.sh` makes for `hooks.json`; that suite is
+        jq-based and cannot read YAML frontmatter, so this surface is asserted
+        here. The sibling substitution-allowlist test passes in BOTH forms, so it
+        is not the discriminator — this test is.
+        """
+        hook = self._skill_hook()
+        command = hook.get("command", "")
+        self.assertIn(
+            "hooks/run-python-hook.sh",
+            command,
+            f"skill hook must launch through the shared launcher: {command!r}",
         )
-        command = command_line.split(":", 1)[1].strip().strip('"')
-        return command, args
+        self.assertNotIn(
+            "args",
+            hook,
+            "`args` switches Claude Code to exec form, where `command` is a bare "
+            f"PATH lookup and `shell` is ignored: {hook!r}",
+        )
+        self.assertEqual(
+            "bash",
+            hook.get("shell"),
+            "shell form falls back to PowerShell on a Windows host with no Git "
+            f"Bash detected, which cannot run a .sh launcher: {hook!r}",
+        )
+        unquoted = re.findall(
+            r'(?:^|[^"])(\$\{CLAUDE_PLUGIN_[A-Z]+\})|(\$\{CLAUDE_PLUGIN_[A-Z]+\})(?:[^"]|$)',
+            command,
+        )
+        self.assertEqual(
+            [],
+            unquoted,
+            "every path placeholder must be double-quoted — the shell "
+            f"re-tokenizes the string and plugin roots contain spaces: {command!r}",
+        )
+
+    def test_skill_hook_argv_matches_the_exec_form_vector_it_replaced(self) -> None:
+        """Converting a LIVE guard must not change the argv the guard receives.
+
+        The belt currently works wherever `python3` resolves to a real
+        interpreter, so the risk of #2568 is breaking a working guard rather than
+        reviving a dead one. Everything from `destructive_guard.py` onward must
+        therefore survive the conversion byte-identically; only argv[0] changes,
+        from an interpreter name to the launcher path, which IS the fix.
+
+        Asserted against roots containing spaces and backslashes because that is
+        where quoting fails: a Windows plugin root is routinely
+        `C:\\Users\\First Last\\...`, and an unquoted placeholder would split it
+        into several argv entries and hand the guard a truncated `--plugin-root`.
+        """
+        exec_form_argv = [
+            "${CLAUDE_PLUGIN_ROOT}/skills/clean/scripts/destructive_guard.py",
+            guard._PLUGIN_ROOT_FLAG,
+            guard._PLUGIN_ROOT_PLACEHOLDER,
+        ]
+        hook = self._skill_hook()
+        for root in (
+            "/home/user/.claude/plugins/disk-hygiene",
+            r"C:\Users\First Last\AppData\Local\Claude Code\plug in root",
+            r"D:\a b\c\d",
+        ):
+            with self.subTest(root=root):
+                expected = [
+                    token.replace(guard._PLUGIN_ROOT_PLACEHOLDER, root)
+                    for token in exec_form_argv
+                ]
+                resolved = {
+                    key: self._substitute_plugin_root(value, root)
+                    for key, value in hook.items()
+                }
+                actual = self._guard_argv_from_hook(resolved, "destructive_guard.py")
+                self.assertEqual(expected, actual)
 
     def test_skill_hook_args_launch_with_only_skill_available_substitutions(
         self,
@@ -4178,10 +4315,14 @@ class GuardTests(unittest.TestCase):
         reintroduces the fail-open. This asserts the declared tokens are within that
         allowlist; that the hook then launches is only fully verifiable in a live
         Claude Code session with the plugin installed.
+
+        Read form-agnostically, so it keeps its meaning in either launch form —
+        the shell-form conversion routes the belt through the launcher but must
+        NOT smuggle in `${CLAUDE_PLUGIN_DATA}` the way the wired hooks legitimately
+        can (#1014).
         """
-        command, args = self._skill_hook_command_and_args()
-        tokens = set(re.findall(r"\$\{[^}]+\}", command))
-        for value in args:
+        tokens = set()
+        for value in self._hook_argv(self._skill_hook()):
             tokens.update(re.findall(r"\$\{[^}]+\}", value))
         allowed = {"${CLAUDE_PLUGIN_ROOT}"}
         self.assertLessEqual(
@@ -4200,7 +4341,7 @@ class GuardTests(unittest.TestCase):
         the other, the guard loses its authority and the engine lane fails closed —
         the regression this test guards.
         """
-        _command, args = self._skill_hook_command_and_args()
+        args = self._guard_argv_from_hook(self._skill_hook(), "destructive_guard.py")
         self.assertTrue(args[0].endswith("destructive_guard.py"), args)
         self.assertIn(guard._PLUGIN_ROOT_FLAG, args)
         flag_index = args.index(guard._PLUGIN_ROOT_FLAG)
@@ -4276,51 +4417,50 @@ class GuardTests(unittest.TestCase):
                 "unset-default form drops the whole hook entry",
             )
 
-    def test_skill_hook_interpreter_is_python3_and_resolves(self) -> None:
-        """Lock the guard's launch interpreter and prove it resolves.
+    def test_skill_hook_launcher_resolves_a_supported_interpreter(self) -> None:
+        """Prove the belt's interpreter still resolves, through its real ladder.
 
-        The skill-scoped PreToolUse hook runs in exec form, so `command` is
-        resolved on PATH with no shell (the two wired hooks in ``hooks/hooks.json``
-        are shell form and resolve Python through ``run-python-hook.sh`` instead;
-        converting this surface is tracked in #2568). Bare `python` is absent on stock macOS and many Linux
-        distros (and a legacy 2.x would crash the guard), which fails the launch
-        open — the guard never intercepts. The static half locks the config at
-        `python3`. The runtime half is the "interpreter actually resolves" probe:
-        it skips where `python3` cannot run — absent from PATH, or resolved to a
-        name that will not execute (a Windows App Execution Alias stub resolves
-        to a real path yet exits non-zero) — because that is the documented
-        residual host gap, not a regression; only a runnable `python3` is
-        asserted to be 3.11+.
+        This test previously locked the literal `python3` as the hook's `command`
+        and probed THAT name — an assertion that was only meaningful while the
+        belt ran in exec form, and that encoded the #2568 defect as the contract:
+        exec form resolves `command` on PATH, and on stock Windows `python3` is
+        the zero-length WindowsApps App Execution Alias stub, so the launch fails
+        and a failed hook launch is non-blocking.
+
+        The belt now launches through `hooks/run-python-hook.sh` (the launch
+        SHAPE is asserted by
+        `test_skill_hook_registers_in_portable_shell_form`), so the interpreter
+        that matters is whatever that launcher resolves — `python3`, then
+        `python`, then `py -3`, skipping any alias stub. That ladder is exercised
+        here rather than restated, so the two cannot drift.
+
+        Skips where the launcher resolves nothing runnable: that is the
+        documented residual host gap (the launcher exits 0 silently in guard
+        mode, leaving the belt fails-open there), not a regression this suite can
+        fix. Only a resolved interpreter is asserted to meet the engine's floor.
         """
-        skill = SCRIPT_DIR.parent / "SKILL.md"
-        command_line = next(
-            (
-                line
-                for line in skill.read_text(encoding="utf-8").splitlines()
-                if line.strip().startswith("command:")
-            ),
-            None,
-        )
-        self.assertIsNotNone(command_line, "frontmatter hook command line not found")
-        assert command_line is not None
-        interpreter = command_line.split(":", 1)[1].strip().strip('"')
-        self.assertEqual("python3", interpreter)
-
-        resolved = shutil.which(interpreter)
-        if resolved is None:
-            self.skipTest(f"{interpreter} does not resolve on this host")
-        probe = subprocess.run(
-            [resolved, "-c", "import sys; print('%d.%d' % sys.version_info[:2])"],
-            capture_output=True,
-            text=True,
-        )
+        launcher = SCRIPT_DIR.parents[2] / "hooks" / "run-python-hook.sh"
+        self.assertTrue(launcher.is_file(), launcher)
+        bash = shutil.which("bash")
+        if bash is None:
+            self.skipTest("bash is unavailable, so the launcher cannot be exercised")
+        with tempfile.TemporaryDirectory() as tmp:
+            probe_script = Path(tmp) / "version_probe.py"
+            probe_script.write_text(
+                "import sys; print('%d.%d' % sys.version_info[:2])\n", encoding="utf-8"
+            )
+            probe = subprocess.run(
+                [bash, os.fspath(launcher), os.fspath(probe_script)],
+                capture_output=True,
+                text=True,
+            )
         if probe.returncode != 0 or not probe.stdout.strip():
             self.skipTest(
-                f"{interpreter} resolved to a non-runnable interpreter "
+                "the launcher resolved no runnable Python 3 on this host "
                 f"({(probe.stderr or probe.stdout).strip()})"
             )
         major, minor = (int(part) for part in probe.stdout.strip().split("."))
-        self.assertGreaterEqual((major, minor), (3, 11), probe.stdout)
+        self.assertGreaterEqual((major, minor), hygiene.MIN_PYTHON, probe.stdout)
 
     def test_guard_scan_max_depth_accepts_only_positive_integer_literal(self) -> None:
         script = SCRIPT_DIR / "hygiene.py"

--- a/plugins/disk-hygiene/skills/setup/SKILL.md
+++ b/plugins/disk-hygiene/skills/setup/SKILL.md
@@ -26,8 +26,8 @@ When the plugin's toggle is disabled, every prerequisite absence downgrades from
 INFO — a deliberately disabled plugin is not broken. Report the probes informationally and
 note that re-enabling restores the FAIL semantics. One exception: every step-1 and step-2 failure stays
 FAIL with the toggle disabled. Audit-only mode is *enforced by* the guard, every guard surface
-depends on a Python 3 interpreter resolving (the wired hooks through
-`hooks/run-python-hook.sh`, the skill-scoped belt through the literal name `python3`), and a
+depends on a Python 3 interpreter resolving (every surface through
+`hooks/run-python-hook.sh`, which tries `python3`, then `python`, then `py -3`), and a
 guard that never runs can neither read nor enforce the configured `false` — so the fail-open
 is most dangerous in exactly this
 configuration. That covers every non-`ok` alias-probe verdict (`store-alias-stub`,
@@ -40,13 +40,16 @@ the guard's own source: Python 3.6, for example, rejects the guard's
 non-blocking — the same silent fail-open through a different door. Unproven guard execution
 fails closed like every other guard-relevant unknown in this plugin.
 
-1. **Shell-form launcher registration** — both wired hooks in `hooks/hooks.json` must name
+1. **Shell-form launcher registration** — all three registrations (both wired hooks in
+   `hooks/hooks.json` and the skill-scoped belt in `skills/clean/SKILL.md` frontmatter) must name
    `hooks/run-python-hook.sh` directly in `command`, with `"shell": "bash"` and **no `args`**, so
-   Claude Code routes them through its own Git Bash rather than a `PATH` lookup. FAIL if either
-   registration carries an `args` key or sets `command` to a bare interpreter name such as `bash`:
-   that is exec form, which on Windows resolves `bash` to the WSL relay `System32\bash.exe` and
+   Claude Code routes them through its own Git Bash rather than a `PATH` lookup. FAIL if any
+   registration carries an `args` key or sets `command` to a bare interpreter name such as `bash`
+   or `python3`: that is exec form, which on Windows resolves `bash` to the WSL relay
+   `System32\bash.exe` and `python3` to the zero-length `WindowsApps` App Execution Alias stub, and
    fails to launch — and a failed hook launch is non-blocking, so the guard silently enforces
-   nothing (#1416). Do **not** report this as a `PATH`-ordering problem: shell form is resolved by
+   nothing (#1416 for the wired hooks, #2568 for the belt). Do **not** report this as a
+   `PATH`-ordering problem: shell form is resolved by
    Claude Code, so reordering `PATH` neither causes nor fixes it. Also FAIL if the launcher is
    missing or not executable. Report a missing Git Bash on Windows as an environment prerequisite
    (shell form falls back to PowerShell there, which cannot run a `.sh`), not as a `PATH` fix.
@@ -63,12 +66,16 @@ fails closed like every other guard-relevant unknown in this plugin.
    absolute interpreter path (guarded engine calls must use the same absolute interpreter
    the guard reports — Bash aliases and functions cannot substitute).
 
-   On Windows, confirm the name the guard launches is real BEFORE anything executes it —
-   including this floor check's own version probe. The `clean` guard hook runs the literal
-   command `python3` (`skills/clean/SKILL.md`); on stock Windows `python3` resolves to a
+   On Windows, confirm the name the guard resolves is real BEFORE anything executes it —
+   including this floor check's own version probe. `python3` is the first rung of the ladder
+   `hooks/run-python-hook.sh` walks for every guard surface; on stock Windows it resolves to a
    zero-length `WindowsApps\python3.exe` App Execution Alias that opens the Microsoft Store
-   (or hangs) instead of running an interpreter — so the guard never runs and cannot block,
-   a silent fail-open, and executing that name from setup pops the Store instead of probing.
+   (or hangs) instead of running an interpreter, and executing that name from setup pops the
+   Store instead of probing. The stub no longer stops the launch by itself — since #2568 the
+   launcher skips it and falls through to `python`, then `py -3` — but the aliases ship as a
+   pair and `py` exists only where real Python is installed, so a host whose `python3` is the
+   stub is usually a host where the whole ladder resolves nothing, which **is** the fail-open.
+   Every verdict below therefore keeps the disposition it had; only the reason is re-grounded.
    Order of operations: (a) locate the resolution without executing it (`Get-Command python3`
    / `command -v python3` — locating is inspection; running is not); (b) classify it with the
    bundled inspect-only probe, launched via an interpreter that is NOT the bare name
@@ -85,17 +92,19 @@ fails closed like every other guard-relevant unknown in this plugin.
    attribute); (c) only after the verdict is `ok` may the version probe execute `python3` —
    and distinguish its two failure modes for the remediation wording: an interpreter that
    starts and reports a version below the floor is a floor miss (name the parsed floor),
-   while one that fails to launch at all is a guard-launch failure (the guard runs the same
-   name). Both stay FAIL under a disabled toggle — a below-floor interpreter is not proven
+   while one that fails to launch at all is a guard-launch risk (the launcher tries the same
+   name first). Both stay FAIL under a disabled toggle — a below-floor interpreter is not proven
    able to execute the guard's source, so it fails closed exactly like a non-`ok` verdict.
    Only verdict `ok` passes; fail closed on everything else, using the probe's `detail` as
    the remediation. FAIL on `store-alias-stub` (disable the `python3` App execution alias,
    or install real Python ahead of WindowsApps on `PATH`) and equally on `indeterminate` — an
    interpreter whose identity the probe could not read is uncertainty about the guard's own
    launch, which fails closed like every other guard-relevant unknown in this plugin, never
-   silently passes. `not-found` means the name the guard launches does not resolve at all:
-   report it as the floor's absent-interpreter FAIL, and — since the guard cannot start
-   without that name either — it is a guard-launch failure too, so it keeps the FAIL under a
+   silently passes. `not-found` means the launcher's first rung does not resolve at all:
+   report it as the floor's absent-interpreter FAIL, and — since a host missing `python3`
+   entirely is the shape most likely to exhaust the rest of the ladder too, and this check is
+   what proves an interpreter exists for the model's own guarded engine calls regardless of
+   any hook's launch form — it keeps the FAIL under a
    disabled toggle alongside the other two. A bare `command -v python3` success is not
    evidence on its own — it matches the stub too.
 3. **Git** — `command -v git`. Conditional per the README: optional for ordinary trees,

--- a/plugins/disk-hygiene/skills/setup/SKILL.md
+++ b/plugins/disk-hygiene/skills/setup/SKILL.md
@@ -30,11 +30,13 @@ depends on a Python 3 interpreter resolving (every surface through
 `hooks/run-python-hook.sh`, which tries `python3`, then `python`, then `py -3`), and a
 guard that never runs can neither read nor enforce the configured `false` — so the fail-open
 is most dangerous in exactly this
-configuration. That covers every non-`ok` alias-probe verdict (`store-alias-stub`,
-`indeterminate`, `not-found`), a nominally `ok` resolution whose version probe then fails to
-launch at all — a corrupt or zero-length binary outside `WindowsApps`, a broken shim, a
-permission error — *and* an interpreter that starts but reports a version below the parsed
-floor. Launching the version probe proves only that something executes, not that it can run
+configuration. That covers an **exhausted** interpreter ladder — every rung absent, a stub, or
+`indeterminate` — a rung whose version probe then fails to launch at all (a corrupt or
+zero-length binary outside `WindowsApps`, a broken shim, a permission error), *and* an
+interpreter that starts but reports a version below the parsed floor. It does **not** cover a
+stubbed `python3` alongside a working `python` or `py -3`: the launcher skips the stub, every
+guard launches, and that is a WARN (see step 2), not a failure to downgrade.
+Launching the version probe proves only that something executes, not that it can run
 the guard's own source: Python 3.6, for example, rejects the guard's
 `from __future__ import annotations` and exits without a deny, which PreToolUse treats as
 non-blocking — the same silent fail-open through a different door. Unproven guard execution
@@ -71,11 +73,14 @@ fails closed like every other guard-relevant unknown in this plugin.
    `hooks/run-python-hook.sh` walks for every guard surface; on stock Windows it resolves to a
    zero-length `WindowsApps\python3.exe` App Execution Alias that opens the Microsoft Store
    (or hangs) instead of running an interpreter, and executing that name from setup pops the
-   Store instead of probing. The stub no longer stops the launch by itself — since #2568 the
-   launcher skips it and falls through to `python`, then `py -3` — but the aliases ship as a
-   pair and `py` exists only where real Python is installed, so a host whose `python3` is the
-   stub is usually a host where the whole ladder resolves nothing, which **is** the fail-open.
-   Every verdict below therefore keeps the disposition it had; only the reason is re-grounded.
+   Store instead of probing. Since #2568 the stub no longer stops any guard by itself — the
+   launcher skips it and falls through to `python`, then `py -3`. **The ladder, not the first
+   rung, is the verdict.** A host with real Python installed without "Add to PATH" but with the
+   `py` launcher has a stubbed `python3` and a perfectly working guard; failing it would report a
+   healthy install as broken and send the operator to reinstall Python. So the alias probe is
+   **diagnostic input** — it says what the first rung is, and keeps setup from executing it —
+   while the verdict comes from resolving the ladder and checking the selected interpreter
+   against the parsed floor.
    Order of operations: (a) locate the resolution without executing it (`Get-Command python3`
    / `command -v python3` — locating is inspection; running is not); (b) classify it with the
    bundled inspect-only probe, launched via an interpreter that is NOT the bare name
@@ -89,23 +94,31 @@ fails closed like every other guard-relevant unknown in this plugin.
    alternate launcher is Python 3.6 reaches the verdict through PowerShell, not by having no
    launcher at all. The signal: a zero-length file under a `WindowsApps` path component is the stub
    (`(Get-Item -Force (Get-Command python3).Source)` → `Length` 0 plus a `ReparsePoint`
-   attribute); (c) only after the verdict is `ok` may the version probe execute `python3` —
-   and distinguish its two failure modes for the remediation wording: an interpreter that
-   starts and reports a version below the floor is a floor miss (name the parsed floor),
-   while one that fails to launch at all is a guard-launch risk (the launcher tries the same
-   name first). Both stay FAIL under a disabled toggle — a below-floor interpreter is not proven
-   able to execute the guard's source, so it fails closed exactly like a non-`ok` verdict.
-   Only verdict `ok` passes; fail closed on everything else, using the probe's `detail` as
-   the remediation. FAIL on `store-alias-stub` (disable the `python3` App execution alias,
-   or install real Python ahead of WindowsApps on `PATH`) and equally on `indeterminate` — an
-   interpreter whose identity the probe could not read is uncertainty about the guard's own
-   launch, which fails closed like every other guard-relevant unknown in this plugin, never
-   silently passes. `not-found` means the launcher's first rung does not resolve at all:
-   report it as the floor's absent-interpreter FAIL, and — since a host missing `python3`
-   entirely is the shape most likely to exhaust the rest of the ladder too, and this check is
-   what proves an interpreter exists for the model's own guarded engine calls regardless of
-   any hook's launch form — it keeps the FAIL under a
-   disabled toggle alongside the other two. A bare `command -v python3` success is not
+   attribute); (c) resolve the ladder in the launcher's own order, skipping any rung the probe
+   classified as a stub: `python3` only when its verdict is `ok`, then `python`, then `py -3`.
+   The version probe may execute a rung only once that rung is not a stub — that is the whole
+   point of (b), and it is why the bare name `python3` is never executed on a
+   `store-alias-stub` verdict. Report the absolute path of the first rung that runs and meets
+   the floor.
+
+   **FAIL when the ladder is exhausted or below the floor** — no rung resolves, or the one that
+   does reports a version under the parsed `MIN_PYTHON`. That is the real fail-open: the guard
+   cannot run, and it emits neither exit 2 nor a `deny`. Distinguish the two for the remediation
+   wording — an interpreter that starts and reports a version below the floor is a floor miss
+   (name the parsed floor), one that fails to launch at all is an absent-interpreter failure
+   (the plugin never downloads a runtime). Both keep the FAIL under a disabled toggle: a
+   below-floor interpreter is not proven able to execute the guard's source, so audit-only mode
+   is unenforceable there too. `indeterminate` on **every** rung is the same case — identity the
+   probe could not read anywhere on the ladder is uncertainty about whether the guard can launch
+   at all, and fails closed like every other guard-relevant unknown in this plugin.
+
+   **PASS with a WARN when the ladder resolves a supported interpreter but `python3` is the
+   stub.** Every guard launches, so nothing is failing open. State the residual plainly: the
+   operator's own bare `python3` still opens the Microsoft Store, and guarded engine calls must
+   use the absolute interpreter path reported above rather than that name. Offer the same
+   remediation as an optional tidy-up, not as a fix for a broken install — disable the `python3`
+   App execution alias (Settings > Apps > Advanced app settings > App execution aliases), or put
+   real Python ahead of WindowsApps on `PATH`. A bare `command -v python3` success is not
    evidence on its own — it matches the stub too.
 3. **Git** — `command -v git`. Conditional per the README: optional for ordinary trees,
    required when a target contains or sits inside a Git worktree. Report presence as INFO

--- a/plugins/disk-hygiene/skills/setup/scripts/python3_alias_probe.py
+++ b/plugins/disk-hygiene/skills/setup/scripts/python3_alias_probe.py
@@ -126,12 +126,14 @@ def classify(path: Path | None) -> dict[str, object]:
             True,
             reparse_point,
             f"{_NAME} resolves to a zero-length WindowsApps App Execution Alias stub "
-            f"({path}). It opens the Microsoft Store instead of running an interpreter, "
-            "so the destructive-action guard's launcher must fall through to `python` or "
-            "`py -3` — and where those are absent too, the guard never executes and cannot "
-            "block. Disable the `python3` App execution "
-            "alias (Settings > Apps > Advanced app settings > App execution aliases) "
-            "or install real Python and ensure it precedes WindowsApps on PATH.",
+            f"({path}). It opens the Microsoft Store instead of running an interpreter, so the "
+            "guard's launcher skips this rung and falls through to `python`, then `py -3`. "
+            "This verdict describes the FIRST RUNG only — it is not the setup verdict: the "
+            "guard fails open only where the whole ladder is exhausted. Where a later rung "
+            "resolves a supported interpreter the install is healthy, and the residual is that "
+            "a bare `python3` typed by hand still opens the Store. To clear that: disable the "
+            "`python3` App execution alias (Settings > Apps > Advanced app settings > App "
+            "execution aliases) or install real Python ahead of WindowsApps on PATH.",
         )
 
     return _report(

--- a/plugins/disk-hygiene/skills/setup/scripts/python3_alias_probe.py
+++ b/plugins/disk-hygiene/skills/setup/scripts/python3_alias_probe.py
@@ -1,20 +1,25 @@
 #!/usr/bin/env python3
 """Detect whether ``python3`` on ``PATH`` is a Windows Store App-Execution-Alias stub.
 
-The ``clean`` skill's PreToolUse guard is launched by Claude Code as the literal
-command ``python3`` (see ``skills/clean/SKILL.md``). On stock Windows,
+``python3`` is the first rung of the interpreter ladder every disk-hygiene guard
+surface walks through ``hooks/run-python-hook.sh``. On stock Windows,
 ``%LOCALAPPDATA%\\Microsoft\\WindowsApps\\python3.exe`` is an *App Execution Alias*
 — a zero-length reparse-point stub that opens the Microsoft Store (or exits without
-running anything) instead of launching an interpreter. When the guard's launch
-resolves to that stub it never executes, so it emits neither exit code 2 nor a
-``deny`` permission decision — the only two ways a PreToolUse hook blocks a tool
-call — and Claude Code lets the destructive Bash/PowerShell command proceed
-UNGUARDED. A naive ``python3 --version`` probe does not surface this cleanly: it
-pops the Store or hangs. This probe therefore *inspects* the resolution instead of
-executing it.
+running anything) instead of launching an interpreter. Until #2568 the ``clean``
+skill's belt named ``python3`` directly as an exec-form ``command``, so the stub
+stopped the launch outright: the guard emitted neither exit code 2 nor a ``deny``
+permission decision — the only two ways a PreToolUse hook blocks a tool call — and
+Claude Code let the destructive Bash/PowerShell command proceed UNGUARDED. The
+launcher now skips the stub and falls through to ``python``, then ``py -3``, so a
+stub is no longer a launch failure on its own. It is still reported, because the
+aliases ship as a pair and ``py`` exists only where real Python is installed, so a
+stubbed ``python3`` usually means the whole ladder resolves nothing — which is the
+same fail-open. A naive ``python3 --version`` probe does not surface this cleanly:
+it pops the Store or hangs. This probe therefore *inspects* the resolution instead
+of executing it.
 
 It classifies what the name ``python3`` resolves to — deliberately ``python3`` and
-not ``python``/``py``, because that is the exact command the guard hook runs. The
+not ``python``/``py``, because that is the rung the launcher tries first. The
 portable, testable stub signal is: the resolved path has a ``WindowsApps`` path
 component AND the file is zero length. A real interpreter — including the Microsoft
 Store's genuine Python, which lives under a versioned
@@ -122,8 +127,9 @@ def classify(path: Path | None) -> dict[str, object]:
             reparse_point,
             f"{_NAME} resolves to a zero-length WindowsApps App Execution Alias stub "
             f"({path}). It opens the Microsoft Store instead of running an interpreter, "
-            "so the clean skill's destructive-action guard — launched as `python3` — "
-            "never executes and cannot block. Disable the `python3` App execution "
+            "so the destructive-action guard's launcher must fall through to `python` or "
+            "`py -3` — and where those are absent too, the guard never executes and cannot "
+            "block. Disable the `python3` App execution "
             "alias (Settings > Apps > Advanced app settings > App execution aliases) "
             "or install real Python and ensure it precedes WindowsApps on PATH.",
         )

--- a/plugins/disk-hygiene/skills/setup/scripts/test_python3_alias_probe.py
+++ b/plugins/disk-hygiene/skills/setup/scripts/test_python3_alias_probe.py
@@ -1,10 +1,12 @@
 #!/usr/bin/env python3
 """Behavioral tests for the python3 App-Execution-Alias stub probe.
 
-The probe exists so ``/disk-hygiene:setup check`` can FAIL cleanly when the
-guard's launch name (``python3``) resolves to the zero-length WindowsApps alias
-stub — a fail-open vector, because a guard that never runs emits neither exit 2
-nor a ``deny`` decision and so cannot block a destructive tool call. The stub
+The probe exists so ``/disk-hygiene:setup check`` can FAIL cleanly when the first
+rung of the guard launcher's interpreter ladder (``python3``) resolves to the
+zero-length WindowsApps alias stub — a fail-open vector wherever the remaining
+rungs (``python``, ``py -3``) are absent too, because a guard that never runs emits
+neither exit 2 nor a ``deny`` decision and so cannot block a destructive tool call.
+The stub
 signal (WindowsApps path component + zero length) is fabricated here so the
 detection is exercised cross-platform, without needing a real Windows box or
 executing anything.

--- a/plugins/disk-hygiene/skills/setup/scripts/test_python3_alias_probe.py
+++ b/plugins/disk-hygiene/skills/setup/scripts/test_python3_alias_probe.py
@@ -1,12 +1,13 @@
 #!/usr/bin/env python3
 """Behavioral tests for the python3 App-Execution-Alias stub probe.
 
-The probe exists so ``/disk-hygiene:setup check`` can FAIL cleanly when the first
-rung of the guard launcher's interpreter ladder (``python3``) resolves to the
-zero-length WindowsApps alias stub — a fail-open vector wherever the remaining
-rungs (``python``, ``py -3``) are absent too, because a guard that never runs emits
-neither exit 2 nor a ``deny`` decision and so cannot block a destructive tool call.
-The stub
+The probe exists so ``/disk-hygiene:setup check`` can classify the first rung of
+the guard launcher's interpreter ladder (``python3``) WITHOUT executing it — a bare
+``python3 --version`` against the zero-length WindowsApps alias stub pops the
+Microsoft Store or hangs. The verdict here is diagnostic input, never the setup
+verdict: the fail-open is an exhausted ladder (``python`` and ``py -3`` absent too),
+because a guard that never runs emits neither exit 2 nor a ``deny`` decision and so
+cannot block a destructive tool call. The stub
 signal (WindowsApps path component + zero length) is fabricated here so the
 detection is exercised cross-platform, without needing a real Windows box or
 executing anything.


### PR DESCRIPTION
## Problem

`plugins/disk-hygiene/skills/clean/SKILL.md`'s frontmatter belt was the **third and last**
exec-form hook registration, deliberately left unconverted by #2570 (row 3 of that PR's audit
table):

```yaml
- type: command
  command: "python3"
  args: ["${CLAUDE_PLUGIN_ROOT}/skills/clean/scripts/destructive_guard.py", "--plugin-root", "${CLAUDE_PLUGIN_ROOT}"]
  timeout: 60
```

Per the [hooks reference](https://code.claude.com/docs/en/hooks), exec form (`args` present)
resolves `command` as an executable on `PATH` with no shell, and "On Windows, exec form requires
`command` to resolve to a real executable such as a `.exe`." On stock Windows `python3` resolves to
`%LOCALAPPDATA%\Microsoft\WindowsApps\python3.exe` — a **zero-length App Execution Alias stub**,
not a real executable. The spawn fails, a failed hook launch is non-blocking, and the belt silently
enforces nothing.

This registration has named a bare interpreter since #215, predating `hooks/run-python-hook.sh`
(#1504) entirely — the launcher that exists precisely to reject that stub.

**This one is latent, not dead.** It works wherever `python3` is a real interpreter, which is the
reporting host. So the risk here is the inverse of #2570's: breaking a *working* safety guard.
Everything below is scoped to proving that cannot happen.

## Fix

Shell form through the shared launcher — the shape #2570 established, no third variant:

```yaml
- type: command
  command: '"${CLAUDE_PLUGIN_ROOT}"/hooks/run-python-hook.sh "${CLAUDE_PLUGIN_ROOT}"/skills/clean/scripts/destructive_guard.py --plugin-root "${CLAUDE_PLUGIN_ROOT}"'
  shell: bash
  timeout: 60
```

**On the YAML spelling.** This is the *same value* `hooks.json` carries; only the file-level escape
differs. JSON needs `\"` escapes, YAML expresses it as a single-quoted scalar wrapping literal
double quotes. It is not a third shape — `_hook_argv()` tokenizes both identically.

**Shell form is honored on the skill-frontmatter surface — verified, not assumed.** #1014 found this
surface more restricted than documented, so this was checked rather than inferred: `repo-hygiene`'s
`skills/clean/SKILL.md` has shipped a shell-form frontmatter hook with `shell: bash` since #1006
(`a83d1748`, titled "shell-form hook launch"), and still carries it on `main` today. A live,
working, same-repo precedent on the exact surface.

**The #1014 constraint is respected.** Verified in code, not from a summary:
`destructive_guard.py:686-687` resolves `--plugin-root`, rejecting the literal unexpanded
placeholder, and derives the data root from it via `_plugin_data_root_from_root`;
`resolve_authorized_data_root`'s own docstring records that "a plugin `hooks.json` hook can [supply
`${CLAUDE_PLUGIN_DATA}`]; a skill hook cannot." The new command string therefore substitutes
**only** `${CLAUDE_PLUGIN_ROOT}` — no `${CLAUDE_PLUGIN_DATA}`, no `${user_config.*}`, and
`--authorized-data-root` is **not** reintroduced. This is asserted by an existing test that was made
form-agnostic rather than left form-specific.

## Argv equivalence — the load-bearing evidence

**Claim, scoped precisely:** the argv **`destructive_guard.py` itself receives** is byte-identical
before and after. `argv[0]` necessarily changes — from the interpreter name `python3` to the
launcher path — because replacing interpreter resolution with the launcher *is* the fix.

Verified two ways. First with Python's `shlex` (the tokenizer `test_hygiene.py` uses), then against
**a real bash**, because a claim about how a shell tokenizes should be proven by a shell. The
launcher path is swapped for an argv dumper so the vector it would receive is directly observable:

```console
root = C:\Program Files\Claude Code\plug in root
  shell sees: "C:\Program Files\Claude Code\plug in root"/hooks/run-python-hook.sh "C:\Program Files\Claude Code\plug in root"/skills/clean/scripts/destructive_guard.py --plugin-root "C:\Program Files\Claude Code\plug in root"
  argv built by bash (launcher swapped for an argv dumper):
    C:\Program Files\Claude Code\plug in root/skills/clean/scripts/destructive_guard.py
    --plugin-root
    C:\Program Files\Claude Code\plug in root

root = D:\a b\c\d
  argv built by bash (launcher swapped for an argv dumper):
    D:\a b\c\d/skills/clean/scripts/destructive_guard.py
    --plugin-root
    D:\a b\c\d
```

Exactly three tokens after the launcher, matching the exec-form `args` array element for element,
for a POSIX root and for two Windows roots containing **both spaces and backslashes**. These are the
same three roots the added test asserts against.

**Why it holds, and why the quoting is required rather than stylistic:** inside POSIX double quotes a
backslash is literal (it escapes only `$`, `` ` ``, `"`, `\`, newline), and whitespace does not split.
Remove the double quotes and `C:\Program Files\Claude Code\plug in root` splits into four argv
entries and the backslashes get eaten — the guard would receive a truncated `--plugin-root` and lose
its data-root authority. That is exactly why #2570's "double-quote every placeholder" rule is a
correctness requirement.

## Closest reproducible proxy for "the guard still blocks"

The belt is skill-scoped, so it fires only inside `/disk-hygiene:clean` and cannot be exercised from
an ordinary session — I am **not** claiming a live in-session verification of the belt itself.
Instead, the exact new command string was substituted the way Claude Code substitutes it and driven
end to end:

```console
$ printf '{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"rm -rf /tmp/example"}}' \
    | bash -c '"<root>"/hooks/run-python-hook.sh "<root>"/skills/clean/scripts/destructive_guard.py --plugin-root "<root>"'
{"hookSpecificOutput": {"hookEventName": "PreToolUse", "permissionDecision": "deny",
 "permissionDecisionReason": "Disk-hygiene fails closed: Bash is restricted to exact bundled scan,
 preview, handoff-verify, and apply invocations of ... hygiene.py ..."}}
```

The belt launches through the new string and emits a `deny`. Note for anyone re-running this: the
belt is **deny-by-default** during active cleanup (it allows only the exact bundled engine
invocations), so a benign payload such as `echo hi` denies too. Both denying is the documented
behavior of this surface, not over-blocking introduced here.

Composed with the argv equivalence above, the argument is stronger than a single live observation:
the guard receives a byte-identical vector, the existing 252-test suite proves the guard's decisions
*given* that vector, and `test_skill_hook_launcher_resolves_a_supported_interpreter` proves the
launcher resolves and execs end to end. No behavior change is reachable — only the launch mechanism
moved.

## What this does NOT fix — stated so it is not overclaimed

`run-python-hook.sh` **exits 0 silently in guard mode** when no interpreter resolves anywhere on its
ladder (its own test asserts this). So this closes *"the belt cannot start against the alias stub"*.
It does **not** make the belt fail-closed on a host with no Python at all — that residual is
unchanged, and is documented as such in `safety-model.md` and the README.

## Tests — the third bug-as-contract site, and its fix

#2568 named one form-specific helper. There were **three** sites, all of which encoded the launch
form they were supposed to be checking:

| Site | Old shape | Post-conversion behavior |
| --- | --- | --- |
| `_skill_hook_command_and_args()` | `next(… "args:" in line)` | **raises `StopIteration`** |
| same helper's `command` read | `.split(":",1)[1].strip().strip('"')` | silently mis-parses a single-quoted YAML scalar into a string `shlex` then tokenizes wrongly |
| `test_skill_hook_interpreter_is_python3_and_resolves` | `assertEqual("python3", interpreter)` | asserts the defect |

The helper is replaced by `_skill_hook()`, which parses the frontmatter into a **hook mapping** and
feeds it to the *existing* form-agnostic `_hook_argv()` / `_guard_argv_from_hook()` added by #2570 —
so both surfaces are now asserted through one reading path, in either form. A `_yaml_flow_scalar()`
helper decodes the three one-line YAML scalar styles rather than hand-stripping quotes (the suite is
stdlib-only; PyYAML is not a dependency). The interpreter test now **exercises the launcher's real
resolution ladder** instead of restating it, so the two cannot drift.

**Added — and proven discriminating (requirement 5):**

- `test_skill_hook_registers_in_portable_shell_form` — the same four portability properties
  `run-python-hook.test.sh` asserts for `hooks.json` (launcher named in `command`, `args` absent,
  `shell: bash`, every `${CLAUDE_PLUGIN_*}` double-quoted). That suite is jq-based and cannot read
  YAML frontmatter, which is why this surface is asserted in `test_hygiene.py`.
  **Verified to FAIL against the pre-change frontmatter** (`git stash` of SKILL.md only):

  ```
  FAIL: test_skill_hook_registers_in_portable_shell_form
  AssertionError: 'hooks/run-python-hook.sh' not found in 'python3' :
    skill hook must launch through the shared launcher: 'python3'
  ```

  Note the substitution-allowlist test passes in **both** forms, so it is explicitly *not* the
  discriminator — its docstring now says so.
- `test_skill_hook_argv_matches_the_exec_form_vector_it_replaced` — encodes the equivalence proof
  above over three roots (POSIX, and two Windows roots with spaces + backslashes). This one passes
  in both forms *by design*: it is the equivalence evidence, not the regression gate.

## Docs corrected (requirement 6)

Every surface that described this hook's form:

- `README.md` — "Claude Code launches the skill-scoped guard in shell-free **exec form**"; "the
  **wired** hooks resolve Python through `run-python-hook.sh`" (x2, now all three).
- `skills/clean/reference/safety-model.md` — "(the clean skill's frontmatter hook, **still exec
  form**)"; "The skill-scoped belt is a separate surface and **still launches in exec form via
  `python3`** (#2568)" (sentence's purpose is gone); the "Hook launch form" section extended from
  two hooks to three; "since #1504 **both wired hooks** launch through the shared launcher".
- `skills/setup/SKILL.md` — "the skill-scoped belt through the **literal name `python3`**"; preflight
  item 1's scope; item 2's "The `clean` guard hook runs the literal command `python3`".
- `hooks/run-python-hook.sh` header — "Launch disk-hygiene **wired** hooks"; "**hooks.json** invokes
  this file in SHELL FORM".
- `skills/setup/scripts/python3_alias_probe.py` docstring + operator message, and
  `test_python3_alias_probe.py` docstring — both grounded the check on "the guard is launched as
  `python3`".

**Also changed — fallout of the conversion, caught in review (thread from
`chatgpt-codex-connector`, P2):**

`/disk-hygiene:setup check` step 2 verdicts the interpreter **ladder**, not `python3` alone. My
first pass kept `store-alias-stub` → FAIL and merely re-grounded the rationale. That was wrong, and
the review found the concrete counter-case: a host with real Python installed **without "Add to
PATH" but with the `py` launcher** has a stubbed `python3`, a working `py -3`, and a guard that now
launches on every call — and would have been reported broken and told to reinstall Python. Before
this PR that FAIL was correct (the belt really did launch as bare `python3`); the conversion is what
made it a false positive, so fixing it belongs here.

Step 2 now treats the alias probe as **diagnostic input** — it still exists to classify the first
rung *without executing it*, since a bare `python3 --version` pops the Store — resolves the ladder
in the launcher's own order skipping stubs, and checks the selected interpreter against the parsed
`MIN_PYTHON`. This is strictly more accurate in both directions, not a safety downgrade:

- **FAIL** on an **exhausted** ladder or a below-floor interpreter — the real fail-open. Both still
  FAIL under a disabled toggle, for the reason already in the file.
- **WARN** when the ladder resolves a supported interpreter but `python3` is the stub. Guards
  launch; the residual is only that a bare `python3` typed by hand still opens the Store.

The probe's own return values are unchanged (27/27 setup tests still green) — only the verdict
mapping and the message wording moved.

**Not changed, deliberately:**

- **`safety-model.md`'s "`${CLAUDE_PLUGIN_ROOT}` — the only substitution a skill-frontmatter hook
  receives"** — still true, still the #1014 constraint, and now load-bearing for this shape.
- **`scripts/check-hook-userconfig-argv.sh`** — audited for the vacuous-green risk #2570 found. It
  scopes to hook *config JSON* only (`hooks/hooks.json`, manifest-pointed configs, inline manifest
  `hooks`), so SKILL.md frontmatter was never in scope and this change cannot make it silently pass.
  A repo-wide gate covering the frontmatter surface is what **#2569** proposes; not built here.

## Verification

- **`test_hygiene.py` — 252 tests**, 1 failure. `check-changed-skills.sh` reports 2 script-test
  failures for `clean`. All three are the **pre-existing Windows telemetry-sink timing failures**
  #2570 baselined — confirmed identical on **unmodified `origin/main`** via a detached baseline
  worktree (`250 tests, same single failure` in `test_hygiene.py`; `23 tests, same 2 failures` in
  `guard_launch_monitor.test.sh`). Count moves 250 → 252 (two added, one renamed). The `hygiene`
  lane is green on Linux CI.
- `hooks/run-python-hook.test.sh` — **13/13 PASS**.
- `skills/setup/scripts` — 27/27 PASS.
- `markdownlint-cli2` (5 files) — 0 errors. `typos` — clean. `shellcheck -x` — clean.
  `ruff check` — all checks passed (`ruff format` drift in these files is pre-existing on `main` and
  is not a CI gate).
- `check-changelog-parity.sh --check`, `--check-bump origin/main`, `--check-order` — all green.
- `check-hook-userconfig-argv.sh`, `check-shell-portability.sh`, `check-skill-portability.sh`,
  `check-silent-skips.sh`, `check-discriminating-test-skips.sh`,
  `check-manifest-duplicate-keys.py` — all green.
- All **5** `disk-hygiene` test entry scripts run individually: `run-python-hook.test.sh`,
  `kill_switch_probe.test.sh`, `python3_alias_probe.test.sh` PASS; `guard_launch_monitor.test.sh`
  and `hygiene.test.sh` carry only the three baselined failures above. (I started
  `scripts/run-plugin-tests.sh` for the whole repo but it exceeded its window and was stopped, so
  I am **not** claiming a full-repo local run — CI covers that lane.)
- `machine-specific-paths` initially failed on the first push: the argv fixtures used
  `C:\Users\<name>\…` and `/home/user/…` roots. A correct catch — the properties under test are
  spaces, backslashes, and a drive-letter shape, none of which need a home-directory spelling.
  Fixtures moved to `/opt/claude/plugins/disk-hygiene`, `C:\Program Files\Claude Code\plug in root`,
  and `D:\a b\c\d`, and the evidence above was re-run against those exact roots.
- Version bumped `0.17.8` → `0.17.9` with a CHANGELOG entry.
- No `lefthook` config exists in this repo (no `lefthook.yml` / `.lefthook.yml`), so there is no
  such gate to run here.

Closes #2568

## Related

- #2570 — converted the two wired hooks; deliberately deferred this instance as row 3 of its audit
- #1416 — the wired-hook instance of this defect class
- #1014 — established the skill-hook substitution allowlist this change stays inside
- #1006 — the original shell-form fix, and the live precedent for shell form on this surface
- #1504 — introduced `run-python-hook.sh`, which this belt now finally routes through
- #2569 — proposed repo-wide CI gate for this defect class

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aac8xjCjMxFsXGHCXKHY4W
