### PR TITLE
feat(machine-health): add config check category for declared-configuration drift (#2574)

### DIFF
--- a/plugins/machine-health/.claude-plugin/plugin.json
+++ b/plugins/machine-health/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "machine-health",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "description": "Workstation health audit: OS-specific checks (disk, OS updates, security posture, CISA KEV correlation) run from a versioned catalog with trend-aware severity, approval-gated remediations, and dated markdown reports. Windows fully implemented; macOS/Linux scaffolded (report UNKNOWN and stop). Machine state persists in the plugin data directory; the report directory and check catalog are configurable.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/machine-health/CHANGELOG.md
+++ b/plugins/machine-health/CHANGELOG.md
@@ -3,6 +3,24 @@
 All notable changes to the `machine-health` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.10.0]
+
+### Added
+
+- **`config` check category: a home for declared-configuration drift checks.** The category
+  vocabulary (`drivers`, `network`, `power`, `reliability`, `security`, `services`, `storage`,
+  `updates`) named machine subsystems and had no member for checks that compare declared
+  configuration — dotfiles, curated package manifests, infrastructure-as-code — against live
+  machine state. The first real overlay check of that shape (`chezmoi-drift`,
+  melodic-software/dotfiles) shipped as `"category": "config"`, which `Assert-CatalogEntry`
+  rejected; the orchestrator skipped the entry with only a run-log line, so the check silently
+  never ran, and the interim fix mislabeled it `reliability` — a vocabulary for crash and
+  stability telemetry, not configuration integrity. `config` is now a legal value in all four
+  places the vocabulary lives: `catalog/schemas/checks.schema.json`,
+  `catalog/schemas/check-result.schema.json`, `Assert-CatalogEntry`, and `Assert-CheckResult`.
+  A new parity test pins the four copies together so a category added to a schema but not a
+  validator (or vice versa) fails the suite instead of silently disabling checks.
+
 ## [0.9.1]
 
 ### Changed

--- a/plugins/machine-health/skills/audit/catalog/schemas/check-result.schema.json
+++ b/plugins/machine-health/skills/audit/catalog/schemas/check-result.schema.json
@@ -29,7 +29,7 @@
     },
     "category": {
       "type": "string",
-      "enum": ["drivers", "network", "power", "reliability", "security", "services", "storage", "updates"],
+      "enum": ["config", "drivers", "network", "power", "reliability", "security", "services", "storage", "updates"],
       "description": "High-level grouping used for report layout and severity_counts aggregation."
     },
     "os": {

--- a/plugins/machine-health/skills/audit/catalog/schemas/checks.schema.json
+++ b/plugins/machine-health/skills/audit/catalog/schemas/checks.schema.json
@@ -37,7 +37,7 @@
         },
         "category": {
           "type": "string",
-          "enum": ["drivers", "network", "power", "reliability", "security", "services", "storage", "updates"]
+          "enum": ["config", "drivers", "network", "power", "reliability", "security", "services", "storage", "updates"]
         },
         "os": {
           "type": "array",

--- a/plugins/machine-health/skills/audit/scripts/windows/lib/Assert-CatalogEntry.ps1
+++ b/plugins/machine-health/skills/audit/scripts/windows/lib/Assert-CatalogEntry.ps1
@@ -48,7 +48,7 @@ function Assert-CatalogEntry {
     }
 
     $validCategories = @(
-        'drivers', 'network', 'power', 'reliability',
+        'config', 'drivers', 'network', 'power', 'reliability',
         'security', 'services', 'storage', 'updates'
     )
     if ($Entry.category -notin $validCategories) {

--- a/plugins/machine-health/skills/audit/scripts/windows/lib/Assert-CheckResult.ps1
+++ b/plugins/machine-health/skills/audit/scripts/windows/lib/Assert-CheckResult.ps1
@@ -58,7 +58,7 @@ function Assert-CheckResult {
     }
 
     $validCategories = @(
-        'drivers', 'network', 'power', 'reliability',
+        'config', 'drivers', 'network', 'power', 'reliability',
         'security', 'services', 'storage', 'updates'
     )
     $category = & $getField 'category'

--- a/plugins/machine-health/skills/audit/tests/windows/lib/Assert-CatalogEntry.Tests.ps1
+++ b/plugins/machine-health/skills/audit/tests/windows/lib/Assert-CatalogEntry.Tests.ps1
@@ -60,6 +60,11 @@ Describe 'Assert-CatalogEntry' -Tag 'lib' {
             $entry = New-ValidEntry -Overrides @{ cadence = 'monthly' }
             Assert-CatalogEntry $entry | Should -BeTrue
         }
+
+        It 'accepts the config category (declared-configuration drift checks)' {
+            $entry = New-ValidEntry -Overrides @{ category = 'config' }
+            Assert-CatalogEntry $entry | Should -BeTrue
+        }
     }
 
     Context 'invalid entries' {
@@ -146,6 +151,45 @@ Describe 'Catalog integration: catalog/checks.jsonc conforms to schema' -Tag 'in
         foreach ($entry in $script:Catalog.checks) {
             $expectedPath = Join-Path $script:SkillRoot $entry.script
             Test-Path -LiteralPath $expectedPath | Should -BeTrue -Because "$($entry.id) -> $expectedPath"
+        }
+    }
+}
+
+Describe 'Category vocabulary: schemas and validators agree' -Tag 'lib' {
+    # The category enum lives in four places: checks.schema.json,
+    # check-result.schema.json, Assert-CatalogEntry, and Assert-CheckResult.
+    # A value present in a schema but missing from a validator silently
+    # disables every check declaring it (the orchestrator skips entries
+    # Assert-CatalogEntry rejects), so the four copies are pinned together.
+    BeforeAll {
+        . (Join-Path $script:LibRoot 'Assert-CheckResult.ps1')
+        . (Join-Path $script:LibRoot 'Write-HealthResult.ps1')
+        $schemasRoot = Join-Path $script:SkillRoot 'catalog\schemas'
+        $checksSchema = Get-Content -LiteralPath (Join-Path $schemasRoot 'checks.schema.json') -Raw |
+            ConvertFrom-Json
+        $resultSchema = Get-Content -LiteralPath (Join-Path $schemasRoot 'check-result.schema.json') -Raw |
+            ConvertFrom-Json
+        $script:CatalogCategories = @($checksSchema.'$defs'.CheckEntry.properties.category.enum)
+        $script:ResultCategories = @($resultSchema.properties.category.enum)
+    }
+
+    It 'the two schemas declare the same category set' {
+        $script:CatalogCategories | Should -Be $script:ResultCategories
+    }
+
+    It 'Assert-CatalogEntry accepts every schema-declared category' {
+        $script:CatalogCategories.Count | Should -BeGreaterThan 0
+        foreach ($cat in $script:CatalogCategories) {
+            $entry = New-ValidEntry -Overrides @{ category = $cat }
+            Assert-CatalogEntry $entry -Because "schema category '$cat'" | Should -BeTrue
+        }
+    }
+
+    It 'Assert-CheckResult accepts every schema-declared category' {
+        foreach ($cat in $script:ResultCategories) {
+            $result = New-HealthResult -Id 'parity-probe' -Category $cat -Os 'windows' `
+                -Severity 'OK' -Summary 'category parity probe'
+            Assert-CheckResult $result -Because "schema category '$cat'" | Should -BeTrue
         }
     }
 }

--- a/plugins/machine-health/skills/audit/tests/windows/lib/Assert-CatalogEntry.Tests.ps1
+++ b/plugins/machine-health/skills/audit/tests/windows/lib/Assert-CatalogEntry.Tests.ps1
@@ -160,7 +160,12 @@ Describe 'Category vocabulary: schemas and validators agree' -Tag 'lib' {
     # check-result.schema.json, Assert-CatalogEntry, and Assert-CheckResult.
     # A value present in a schema but missing from a validator silently
     # disables every check declaring it (the orchestrator skips entries
-    # Assert-CatalogEntry rejects), so the four copies are pinned together.
+    # Assert-CatalogEntry rejects), and a value present in one validator but
+    # not the other admits an overlay entry whose emitted result is then
+    # rejected - so all four copies are compared exactly, in both directions:
+    # the validators' literal $validCategories sets are extracted from the
+    # AST and matched against the schema enums, and each schema value is also
+    # accepted behaviorally.
     BeforeAll {
         . (Join-Path $script:LibRoot 'Assert-CheckResult.ps1')
         . (Join-Path $script:LibRoot 'Write-HealthResult.ps1')
@@ -171,10 +176,41 @@ Describe 'Category vocabulary: schemas and validators agree' -Tag 'lib' {
             ConvertFrom-Json
         $script:CatalogCategories = @($checksSchema.'$defs'.CheckEntry.properties.category.enum)
         $script:ResultCategories = @($resultSchema.properties.category.enum)
+
+        function Get-ValidatorCategorySet {
+            param([Parameter(Mandatory)] [string] $Path)
+            $ast = [System.Management.Automation.Language.Parser]::ParseFile(
+                $Path, [ref]$null, [ref]$null)
+            $assignments = @($ast.FindAll({
+                        param($node)
+                        $node -is [System.Management.Automation.Language.AssignmentStatementAst] -and
+                        $node.Left.Extent.Text -eq '$validCategories'
+                    }, $true))
+            if ($assignments.Count -ne 1) {
+                throw "Expected exactly one `$validCategories assignment in $Path, found $($assignments.Count)."
+            }
+            $right = $assignments[0].Right
+            $expr = if ($right -is [System.Management.Automation.Language.PipelineAst]) {
+                $right.GetPureExpression()
+            } else {
+                $right.Expression
+            }
+            @($expr.SafeGetValue())
+        }
     }
 
     It 'the two schemas declare the same category set' {
         $script:CatalogCategories | Should -Be $script:ResultCategories
+    }
+
+    It 'Assert-CatalogEntry accepts exactly the schema-declared set (both directions)' {
+        $validatorSet = Get-ValidatorCategorySet (Join-Path $script:LibRoot 'Assert-CatalogEntry.ps1')
+        ($validatorSet | Sort-Object) | Should -Be ($script:CatalogCategories | Sort-Object)
+    }
+
+    It 'Assert-CheckResult accepts exactly the schema-declared set (both directions)' {
+        $validatorSet = Get-ValidatorCategorySet (Join-Path $script:LibRoot 'Assert-CheckResult.ps1')
+        ($validatorSet | Sort-Object) | Should -Be ($script:ResultCategories | Sort-Object)
     }
 
     It 'Assert-CatalogEntry accepts every schema-declared category' {

--- a/plugins/machine-health/skills/audit/tests/windows/lib/Write-HealthResult.Tests.ps1
+++ b/plugins/machine-health/skills/audit/tests/windows/lib/Write-HealthResult.Tests.ps1
@@ -159,6 +159,13 @@ Describe 'Write-HealthResult' -Tag 'lib' {
             $bad = [pscustomobject]@{ id = 'x'; category = 'storage' }
             { $bad | Write-HealthResult } | Should -Throw -ExpectedMessage '*missing required field*'
         }
+
+        It 'accepts the config category at emit time' {
+            $cfg = New-HealthResult -Id 'chezmoi-drift' -Category 'config' -Os 'windows' `
+                -Severity 'OK' -Summary 'declared configuration matches live state'
+            $out = $cfg | Write-HealthResult
+            ($out | ConvertFrom-Json).category | Should -Be 'config'
+        }
     }
 
     Context '-Human mode' {


### PR DESCRIPTION
## The gap

The machine-health check-category vocabulary — `drivers`, `network`, `power`, `reliability`, `security`, `services`, `storage`, `updates` — names machine subsystems and has no member for **configuration-integrity checks**: checks that compare declared configuration (dotfiles, curated package manifests, IaC) against live machine state.

It has already bitten in production. The first overlay check of that shape (`chezmoi-drift`, registered through this plugin's documented catalog-overlay seam in `melodic-software/dotfiles`) shipped as `"category": "config"`; `Assert-CatalogEntry` rejected it, the orchestrator skipped the entry with only a `catalog_entry_invalid skip` run-log line, and the check silently never ran until melodic-software/dotfiles#472 found it. That PR's interim fix retagged it `reliability` and flagged the retag as a judgement call — the closest *legal* value, not the *right* one — naming a `config` category upstream as the clean end state. This PR is that contribution.

## Why a new category, not an existing one

Audited the vocabulary against the shipped catalog before adding a member:

- `updates` is a pending-update backlog (`windows-update`, `winget-upgrades`, `sdk-versions`) — drift from declared config is not a pending update
- `reliability` is crash/stability telemetry (`event-log-errors`, `reliability`, `scheduled-tasks`) — drift is not a stability signal
- the rest name the subsystem they probe (`security`, `services`, `storage`, `network`, `power`, `drivers`)

Nothing in the set means "the machine's state has diverged from what its configuration declares." `config` follows the vocabulary's existing form (short lowercase subject noun) and gives the drift-check family a truthful report grouping.

## What changed

The vocabulary lives in four places; all four gain `config`:

- `catalog/schemas/checks.schema.json` — `CheckEntry.category` enum
- `catalog/schemas/check-result.schema.json` — `category` enum
- `scripts/windows/lib/Assert-CatalogEntry.ps1` — `$validCategories`
- `scripts/windows/lib/Assert-CheckResult.ps1` — `$validCategories`

Plus:

- **Red-first regression tests.** `Assert-CatalogEntry.Tests.ps1`: a `config` catalog entry passes; `Write-HealthResult.Tests.ps1`: a `config` result passes emit-time validation. Both were run against the pre-change validators first and failed with exactly the production failure mode:

  ```text
  [-] accepts the config category (declared-configuration drift checks)
      RuntimeException: CatalogEntry 'disk-space' category 'config' not in allowed set.
  [-] accepts the config category at emit time
      RuntimeException: CheckResult.category 'config' not in allowed set (Write-HealthResult emit).
  ```

- **A vocabulary-parity test** (`Category vocabulary: schemas and validators agree`) pinning the four copies together: the two schema enums must be identical, and every schema-declared category must be accepted by `Assert-CatalogEntry` and `Assert-CheckResult`. A value added to a schema but not a validator — the shape of drift that silently disables checks — now fails the suite.
- `CHANGELOG.md` `[0.10.0]` entry; `plugin.json` `0.9.1 → 0.10.0`.

No check changes category in this PR: no shipped check is configuration-integrity-shaped. The first consumer is the dotfiles overlay (below).

## Merge ordering with the dotfiles consumer

The follow-up PR melodic-software/dotfiles#482 (closing melodic-software/dotfiles#481) flips `chezmoi-drift` from the `reliability` workaround to `config`. **This PR must merge and ship first, and the installed plugin on the consuming machine must be updated to >= 0.10.0, before that PR merges/applies** — it carries a `do-not-merge` label until the installed plugin satisfies that floor. The overlay is validated by the *installed* plugin; against an older install, `config` is out-of-enum and the entry goes back to being silently skipped — the exact dead-check bug dotfiles#472 fixed. This PR has no dependency in the other direction and is safe to merge on its own.

## Out of scope, filed separately

- #2575 — the silent per-entry skip itself (a registered-but-invalid check is invisible in the report; proposal: synthesize an `UNKNOWN` result so it costs a report line every week instead of nothing forever). That is the change that would have caught this class in the first place.
- #2576 — `references/{linux,macos}/NOT_IMPLEMENTED.md` instruct `category: "platform"`, also out-of-enum.

## Verification

- Full machine-health Pester suite (`tests/Invoke-MachineHealthTests.ps1`): **389 passed, 0 failed, 1 skipped** (pre-existing skip)
- `scripts/check-changelog-parity.sh --check`, `--check-bump origin/main`, `--check-order`: pass
- `scripts/affected-tests.sh --allow-unmapped --run`: no shell suites map to the changed `.ps1` files (Pester covers them; run above)
- `Invoke-ScriptAnalyzer` on the four changed `.ps1` files: one pre-existing warning (`PSUseShouldProcessForStateChangingFunctions` on the existing `New-ValidEntry` test helper), nothing introduced
- markdownlint-cli2 + typos on `CHANGELOG.md`: clean
- `check-jsonschema` on `plugin.json` against the plugin-manifest schema: ok

## Related

- Closes #2574

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aac8xjCjMxFsXGHCXKHY4W
