### PR TITLE
docs: explain CI exec-bit=failure and the Windows filemode trap in AGENTS.md (#2584)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,11 +26,13 @@ mean to commit.
 CI's `hygiene` lane fails with `exec-bit=failure` when a tracked file whose
 first two bytes are `#!` — any shebang file, not just `.sh` — sits in the git
 index at mode `100644`. Fix each file the lane's error annotation names, then
-commit the mode change:
+commit with the **plain form** — no pathspec after `git commit`:
 
 ```shell
 chmod +x -- <path>
 git update-index --chmod=+x -- <path>
+git commit          # NOT `git commit -- <path>`; see below
+git ls-tree HEAD -- <path>   # confirm 100755 was recorded
 ```
 
 The defect is invisible on Windows, where it is usually introduced: an NTFS
@@ -39,12 +41,18 @@ clone gets `core.filemode=false`, so git ignores worktree permission bits —
 `100644`, and `git status` / `git diff` show nothing wrong afterward. The bad
 mode first surfaces as the red CI lane; locally it is visible only via
 `git ls-files --stage -- <path>`. `git update-index --chmod=+x` writes the
-index entry directly and works regardless of `core.filemode`; the `chmod`
-keeps the worktree in agreement so a later `git add` cannot revert the entry
-where filemode is honored. Committing through the source-control plugin's
-commit skill applies this fix automatically
-(`plugins/source-control/skills/commit/scripts/exec-bit-check.sh`, reasoning
-in [its reference](plugins/source-control/skills/commit/reference/exec-bit.md))
+index entry directly and works regardless of `core.filemode` — but the
+pathspec commit form (`git commit -- <path>`, git's `--only` mode) rebuilds
+the named entries from the working tree, where the `chmod` is invisible under
+`core.filemode=false`, and silently records `100644` again; only the plain
+index commit preserves the fix. "Stage explicit paths" above is not in
+tension: it constrains `git add`, which keeps a corrected entry — only the
+pathspec *commit* form discards it. Committing through the source-control
+plugin's commit skill handles all of this automatically
+(`plugins/source-control/skills/commit/scripts/exec-bit-check.sh`; reasoning
+in [its reference](plugins/source-control/skills/commit/reference/exec-bit.md),
+the pathspec interaction in
+[pathspec-commits.md](plugins/source-control/skills/commit/reference/pathspec-commits.md))
 — the trap bites commits made without it.
 
 ## Pull requests

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,32 @@ Stage the specific files a change touches. Never `git add -A` or `git add .`:
 a blanket stage can sweep in synced, generated, or unrelated files you did not
 mean to commit.
 
+## CI `exec-bit=failure`: set a new script's exec bit in the index
+
+CI's `hygiene` lane fails with `exec-bit=failure` when a tracked file whose
+first two bytes are `#!` — any shebang file, not just `.sh` — sits in the git
+index at mode `100644`. Fix each file the lane's error annotation names, then
+commit the mode change:
+
+```shell
+chmod +x -- <path>
+git update-index --chmod=+x -- <path>
+```
+
+The defect is invisible on Windows, where it is usually introduced: an NTFS
+clone gets `core.filemode=false`, so git ignores worktree permission bits —
+`chmod +x` alone never reaches the index, every newly added file stages as
+`100644`, and `git status` / `git diff` show nothing wrong afterward. The bad
+mode first surfaces as the red CI lane; locally it is visible only via
+`git ls-files --stage -- <path>`. `git update-index --chmod=+x` writes the
+index entry directly and works regardless of `core.filemode`; the `chmod`
+keeps the worktree in agreement so a later `git add` cannot revert the entry
+where filemode is honored. Committing through the source-control plugin's
+commit skill applies this fix automatically
+(`plugins/source-control/skills/commit/scripts/exec-bit-check.sh`, reasoning
+in [its reference](plugins/source-control/skills/commit/reference/exec-bit.md))
+— the trap bites commits made without it.
+
 ## Pull requests
 
 - Title pull requests with [Conventional Commits](https://www.conventionalcommits.org/).


### PR DESCRIPTION
Closes #2584

## Summary

Documents the Windows/git trap behind CI's `exec-bit=failure` in `AGENTS.md`: under `core.filemode=false` (every NTFS clone), `chmod +x` never reaches the index, so a newly added shebang file commits as `100644` and nothing looks wrong locally until the `hygiene` lane goes red. Two PRs hit this in one day (#2583 here, melodic-software/dotfiles#479).

## Fix

Adds an `AGENTS.md` section, placed with the existing commit-mechanics rule ("Stage explicit paths"), that:

- leads with the literal symptom string `exec-bit=failure` so a search from the red lane lands on it;
- gives the two-line fix (`chmod +x` + `git update-index --chmod=+x`), which writes the index entry regardless of `core.filemode`;
- explains why the defect is invisible locally on Windows and how to see it (`git ls-files --stage`);
- points at the source-control commit skill's existing `exec-bit-check.sh` and its `reference/exec-bit.md` for depth — the trap bites only commits made without that skill.

Deliberately documentation, not a new gate: the defect is already enforced fail-closed by the hygiene lane (whose per-file annotation prints the exact fix command) and auto-fixed at commit time by the commit skill; a third gate would duplicate the same CI round or introduce local git hooks, a mechanism this repo does not use. Rationale in #2584.

## Verification

Mechanism verified empirically on a Windows/Git Bash box before documenting: fresh `git init` sets `core.filemode=false`; `chmod +x` + `git add` stages `100644`; `git update-index --chmod=+x` flips the entry to `100755`; a later `git add` of content edits preserves `100755`. The exec-bit action source at the pinned SHA (`ci-workflows` `c265418`) confirms the check is shebang-based and extension-agnostic, and mode-gated on `100644`.

Local gates on the change: `markdownlint-cli2 AGENTS.md` (0 errors), `typos` (clean), `editorconfig-checker` (clean), `lychee --offline` (relative link OK), `gitleaks git` (no leaks), `scripts/affected-tests.sh` (no suites selected — every changed file is a recorded no-suite class).

## Related

- Refs #2583 — this repo's occurrence (rate-limit-guard bench harness scripts)
- Refs melodic-software/dotfiles#479 — same-day occurrence in a sibling repo
- Refs #2569 / #2571 — the hook-portability gate precedent weighed (and distinguished) in the document-vs-enforce call

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aac8xjCjMxFsXGHCXKHY4W
