### PR TITLE
docs(knowledge): add citation-shape owner doc for tracked citations

### DIFF
--- a/plugins/knowledge/.claude-plugin/plugin.json
+++ b/plugins/knowledge/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "knowledge",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "Ingest external knowledge into durable, synthesized artifacts. Ships a book-distillation pipeline (PDF/EPUB into concept-organized, author-attributed skill reference files), a YouTube pipeline (watch, transcript, link harvest, and repo-applicability synthesis), a course-digest pipeline (extract and synthesize online video courses \u2014 Dometrain, Teachable \u2014 into repo-applicable recommendations), a docpage-digest pipeline (single online documentation page into a verified knowledge slice with dual verification \u2014 one cross-vendor verifier \u2014 and an interview handoff), and a map-corpus pipeline (multi-resource corpus into a classified link map, deterministic node manifests, gate-verified relevance inventory, and an approved queue of docpage-digest runs), plus a re-runnable setup action; a configurable library directory governs where synthesized artifacts land in the consuming repo.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/knowledge/CHANGELOG.md
+++ b/plugins/knowledge/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to the `knowledge` plugin are recorded here. The `version` i
 `.claude-plugin/plugin.json` is the delivery vehicle — a consumer receives a change
 only after that version increases.
 
+## [0.12.1]
+
+### Added
+
+- **Owner doc for the tracked citation shape** (`reference/citation-shape.md`): URL + retrieval
+  date (ISO 8601, UTC) + `sha256:<hex64>` over raw snapshot bytes, with inline and structured
+  forms, an optional node-id sub-resource anchor, and a drift rule (new fetch = new citation;
+  never edit a hash in place). Pays down the Brief-captured debt `map-corpus` recorded ("that
+  citation shape still needs an owner doc before a second skill emits it") — the skill's
+  cite-never-copy gotcha now points at the owner doc instead of naming the debt.
+
 ## [0.12.0]
 
 ### Added

--- a/plugins/knowledge/reference/citation-shape.md
+++ b/plugins/knowledge/reference/citation-shape.md
@@ -1,0 +1,62 @@
+# Tracked citation shape
+
+This document owns the citation shape that `knowledge` skills use whenever a TRACKED output
+refers to fetched external content. The rule it serves: **tracked outputs cite, never copy** —
+the verbatim snapshot stays in the untracked work slice; only the citation crosses into anything
+committed.
+
+Any `knowledge` skill emitting tracked citations conforms to this shape. Skill-internal hashes
+(node span hashes, slug hashes) remain owned by their skill's own format docs; this document
+owns only the citation that leaves the slice.
+
+## Shape
+
+A citation names exactly three facts, none optional:
+
+1. **URL** — the canonical fetched URL, after the emitting skill's URL normalization. Cite the
+   channel actually fetched (e.g. a site's raw-markdown channel, a raw file URL), not a prettier
+   equivalent that serves different bytes.
+2. **Retrieval date** — ISO 8601 calendar date (UTC) of the fetch that produced the snapshot,
+   e.g. `2026-08-14`.
+3. **Content hash** — `sha256:<hex64>` over the raw snapshot bytes exactly as fetched, before
+   any decoding, normalization, or extraction.
+
+### Inline form (prose)
+
+> `<URL>` (retrieved `<YYYY-MM-DD>`, `sha256:<hex64>`)
+
+### Structured form (JSON/YAML artifacts)
+
+```json
+{
+  "url": "https://example.org/page.md",
+  "retrieved": "2026-08-14",
+  "sha256": "<hex64>"
+}
+```
+
+Field names `url`, `retrieved`, `sha256` are fixed. The hash value matches the emitting skill's
+snapshot-level hash (`snapshot_sha256` in map-corpus inventories and queues) so a citation is
+checkable against its slice without re-fetching.
+
+## Sub-resource anchors (optional extension)
+
+A citation MAY narrow to a region of the resource by appending the emitting skill's
+deterministic node id (e.g. map-corpus `n0007-05b0396b`, whose trailing 8 hex are the first 8 of
+the node's span hash). The anchor never replaces the three required facts; a reader with only
+the base citation can still verify the whole resource. Node-id semantics stay owned by the
+emitting skill's manifest format doc.
+
+## Drift
+
+A citation asserts what WAS fetched, not what the URL serves now. On re-fetch, a differing hash
+means upstream drift: record the new fetch as a new citation (new date, new hash) and note the
+drift; never edit the old citation's hash in place and never silently re-snapshot over the slice
+the old citation points into.
+
+## Non-goals
+
+- Not a bibliography or attribution format — licensing attribution follows the source's license
+  terms separately.
+- Not an archival guarantee — the snapshot bytes live in an untracked slice on the machine that
+  fetched them; the hash makes any surviving copy verifiable, it does not promise one survives.

--- a/plugins/knowledge/reference/citation-shape.md
+++ b/plugins/knowledge/reference/citation-shape.md
@@ -5,9 +5,12 @@ refers to fetched external content. The rule it serves: **tracked outputs cite, 
 the verbatim snapshot stays in the untracked work slice; only the citation crosses into anything
 committed.
 
-Any `knowledge` skill emitting tracked citations conforms to this shape. Skill-internal hashes
-(node span hashes, slug hashes) remain owned by their skill's own format docs; this document
-owns only the citation that leaves the slice.
+Any `knowledge` skill adopting the cite-never-copy rule conforms to this shape for the
+citations it emits into tracked outputs. One shipped emitter predates this contract and does
+not yet conform: `youtube-digest`'s staged `research/sources.md` records URLs without retrieval
+dates or hashes — a known, not-yet-migrated exception; migrating it is a separate decision, not
+implied by this document. Skill-internal hashes (node span hashes, slug hashes) remain owned by
+their skill's own format docs; this document owns only the citation that leaves the slice.
 
 ## Shape
 
@@ -41,11 +44,25 @@ checkable against its slice without re-fetching.
 
 ## Sub-resource anchors (optional extension)
 
-A citation MAY narrow to a region of the resource by appending the emitting skill's
-deterministic node id (e.g. map-corpus `n0007-05b0396b`, whose trailing 8 hex are the first 8 of
-the node's span hash). The anchor never replaces the three required facts; a reader with only
-the base citation can still verify the whole resource. Node-id semantics stay owned by the
-emitting skill's manifest format doc.
+A citation MAY narrow to a region of the resource with the emitting skill's deterministic node
+id (e.g. map-corpus `n0007-05b0396b`, whose trailing 8 hex are the first 8 of the node's span
+hash). Serialization is fixed so independent emitters converge:
+
+- **Inline form** — a fourth comma-separated element inside the parentheses, keyword `node`:
+
+  > `<URL>` (retrieved `<YYYY-MM-DD>`, `sha256:<hex64>`, node `<node-id>`)
+
+- **Structured form** — an optional `node` field beside the three required fields:
+
+  ```json
+  { "url": "…", "retrieved": "…", "sha256": "…", "node": "n0007-05b0396b" }
+  ```
+
+Never a URL fragment — `<URL>#<node-id>` would corrupt the `url` field's identity (fragments
+are dropped by the canonical-URL rule) and suggest the anchor resolves in a browser, which it
+does not. The anchor never replaces the three required facts; a reader with only the base
+citation can still verify the whole resource. Node-id semantics stay owned by the emitting
+skill's manifest format doc.
 
 ## Drift
 

--- a/plugins/knowledge/skills/map-corpus/SKILL.md
+++ b/plugins/knowledge/skills/map-corpus/SKILL.md
@@ -197,5 +197,5 @@ Emit a continuation prompt when pausing mid-pipeline (slug, first unticked phase
 - **Two-level nesting is a hard bound.** `<epic>/<slug>/` — deeper is a major topic-docs contract
   change adopted fleet-wide, not a local choice.
 - **Tracked outputs cite, never copy.** URL + retrieval date + content hash only; the verbatim
-  snapshot lives in the untracked slice. That citation shape still needs an owner doc before a
-  second skill emits it (Brief captured assumption).
+  snapshot lives in the untracked slice. The citation shape is owned by
+  [`reference/citation-shape.md`](../../reference/citation-shape.md) at the plugin root.

--- a/plugins/knowledge/skills/map-corpus/SKILL.md
+++ b/plugins/knowledge/skills/map-corpus/SKILL.md
@@ -198,4 +198,4 @@ Emit a continuation prompt when pausing mid-pipeline (slug, first unticked phase
   change adopted fleet-wide, not a local choice.
 - **Tracked outputs cite, never copy.** URL + retrieval date + content hash only; the verbatim
   snapshot lives in the untracked slice. The citation shape is owned by
-  [`reference/citation-shape.md`](../../reference/citation-shape.md) at the plugin root.
+  `${CLAUDE_PLUGIN_ROOT}/reference/citation-shape.md` at the plugin root.


### PR DESCRIPTION
No related issue: pays down the Brief-captured citation-shape doc debt recorded in map-corpus (shipped in #2614); no tracker item was filed for it.

## Summary

- Adds `plugins/knowledge/reference/citation-shape.md` — the owner doc for the tracked citation shape the knowledge skills emit: URL + retrieval date (ISO 8601, UTC) + `sha256:<hex64>` over raw snapshot bytes, with inline and structured forms, an optional node-id sub-resource anchor, and a drift rule (a new fetch is a new citation; a hash is never edited in place).
- Points `map-corpus`'s cite-never-copy gotcha at the owner doc instead of naming the debt ("that citation shape still needs an owner doc before a second skill emits it").
- Bumps the `knowledge` plugin 0.12.0 → 0.12.1 with a CHANGELOG entry.

Docs-only; `plugins/knowledge/skills/docpage-digest/` untouched.

## Test plan

- `markdownlint-cli2` over the three changed/added markdown files: 0 errors.
- Relative link from `map-corpus/SKILL.md` to `../../reference/citation-shape.md` resolves in-tree.
- No shebang files added; no exec-bit changes.

## Related

Refs #2614 — map-corpus shipped carrying the citation-shape owner-doc debt this PR pays down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QK29DYZWiYRTxwoSz4hQns
