### PR TITLE
fix(machine-health): use legal category in NOT_IMPLEMENTED docs

### DIFF
--- a/plugins/machine-health/.claude-plugin/plugin.json
+++ b/plugins/machine-health/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "machine-health",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Workstation health audit: OS-specific checks (disk, OS updates, security posture, CISA KEV correlation) run from a versioned catalog with trend-aware severity, approval-gated remediations, and dated markdown reports. Windows fully implemented; macOS/Linux scaffolded (report UNKNOWN and stop). Machine state persists in the plugin data directory; the report directory and check catalog are configurable.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/machine-health/CHANGELOG.md
+++ b/plugins/machine-health/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to the `machine-health` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.10.1]
+
+### Fixed
+
+- **NOT_IMPLEMENTED scaffold docs use a legal check category (#2576).** Linux/macOS
+  `NOT_IMPLEMENTED.md` instructed `category: "platform"`, which is outside the
+  check-result schema enum and would be rejected by `Assert-CheckResult`. Both
+  docs now use `reliability`.
+
 ## [0.10.0]
 
 ### Added

--- a/plugins/machine-health/skills/audit/references/linux/NOT_IMPLEMENTED.md
+++ b/plugins/machine-health/skills/audit/references/linux/NOT_IMPLEMENTED.md
@@ -8,7 +8,7 @@ Scaffolding placeholder. When `machine-health` is invoked on a Linux host, the s
 2. Load `references/shared/*.md` for semantics, schema, and discovery guidance.
 3. Read this file; note `scripts/linux/NOT_IMPLEMENTED.md` is also present.
 4. Produce a single-check report:
-   - `id: "os-support"`, `category: "platform"`, `severity: "UNKNOWN"`.
+   - `id: "os-support"`, `category: "reliability"`, `severity: "UNKNOWN"`.
    - `summary: "Linux support is scaffolded but not yet implemented."`
    - `commands`: one-liner pointing at this file for porting guidance.
 5. Exit cleanly. No process spawned against Windows scripts. No install attempts. No network calls.

--- a/plugins/machine-health/skills/audit/references/macos/NOT_IMPLEMENTED.md
+++ b/plugins/machine-health/skills/audit/references/macos/NOT_IMPLEMENTED.md
@@ -8,7 +8,7 @@ Scaffolding placeholder. When `machine-health` is invoked on a macOS host, the s
 2. Load `references/shared/*.md` for semantics, schema, and discovery guidance.
 3. Read this file; note `scripts/macos/NOT_IMPLEMENTED.md` is also present.
 4. Produce a single-check report:
-   - `id: "os-support"`, `category: "platform"`, `severity: "UNKNOWN"`.
+   - `id: "os-support"`, `category: "reliability"`, `severity: "UNKNOWN"`.
    - `summary: "macOS support is scaffolded but not yet implemented."`
    - `commands`: one-liner pointing at this file for porting guidance.
 5. Exit cleanly. No process spawned against Windows scripts. No install attempts. No network calls.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #2576

## Summary

Linux/macOS `NOT_IMPLEMENTED` reference docs instructed scaffolded check results to use `category: "platform"`, which is outside the check-result schema enum and would be rejected by `Assert-CheckResult`.

## Fix

Changed both docs to use `category: "reliability"` (a legal enum value), matching the locked Wave-1 decision to fix the docs rather than expand the schema.

## Verification

- Diff limited to `plugins/machine-health/skills/audit/references/{linux,macos}/NOT_IMPLEMENTED.md`
- Schema enum unchanged; docs now agree with `check-result.schema.json`

## Related

Refs #2575 — related silent invalid-category class (catalog skip vs report surfacing), handled separately.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eb3f5ee5-6c9f-48a3-8e46-071bd363f8b0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eb3f5ee5-6c9f-48a3-8e46-071bd363f8b0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

