### PR TITLE
docs(disk-hygiene): document max-depth and confirmed-large-scan flags

### DIFF
--- a/plugins/disk-hygiene/.claude-plugin/plugin.json
+++ b/plugins/disk-hygiene/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "disk-hygiene",
-  "version": "0.17.9",
+  "version": "0.17.10",
   "description": "Context-aware disk hygiene for arbitrary directory trees: inventories orphaned and temporary artifacts, classifies evidence into review tiers, and offers exact-path cleanup only after a fresh safety preview and explicit per-tier approval. The target is read-only by default; OS-managed paths, links and mount points, VCS-tracked content, changed entries, and live-handle uncertainty fail closed.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/disk-hygiene/CHANGELOG.md
+++ b/plugins/disk-hygiene/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to the `disk-hygiene` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.17.10]
+
+### Fixed
+
+- **Document the real clean-skill argument surface (#2589).** The Arguments
+  section omitted `--max-depth` and `--confirmed-large-scan` (and related
+  flags the engine accepts), which undercut the bounded-first large-target
+  workflow the skill body requires.
+
 ## [0.17.9]
 
 ### Fixed

--- a/plugins/disk-hygiene/skills/clean/SKILL.md
+++ b/plugins/disk-hygiene/skills/clean/SKILL.md
@@ -1,6 +1,6 @@
 ---
 description: "Audit an arbitrary directory tree for orphaned, temporary, stale-lock, failed-write, partial-download, and empty leftover artifacts; classify evidence into confidence tiers; and optionally remove exact validated paths after explicit per-tier approval. Read-only by default and manual-only. Use when: 'audit this directory', 'find orphaned files', 'what junk can I clean up', 'reclaim disk space', 'find temp or lock leftovers', 'clean up my home directory'. Skip when: repository cache/build cleanup belongs to repo-hygiene, a product has its own prune/GC command, or the target is an OS-managed root."
-argument-hint: "[--execute] [--policy <policy.json>] <target-directory>"
+argument-hint: "[--execute] [--policy <policy.json>] [--max-depth <N>] [--confirmed-large-scan] <target-directory>"
 user-invocable: true
 disable-model-invocation: true
 hooks:
@@ -36,11 +36,18 @@ filename pattern is a discovery hint, never proof that an entry is junk. Read
 
 ## Arguments and boundaries
 
-Parse `$ARGUMENTS` as optional `--execute`, optional `--policy <file>`, and one target directory.
+Parse `$ARGUMENTS` as the complete user-facing surface: optional `--execute`, optional
+`--policy <file>`, optional `--max-depth <N>`, optional `--confirmed-large-scan`, and one target
+directory. Remaining engine flags (`--output`, `--project-dir`, `--data-root` on scan;
+`--snapshot`, `--plan`, `--report`, `--confirm-tier`, `--approval-token`, `--paths` on the other
+subcommands) are supplied by this skill's command templates, not typed by the user.
 `--execute` means "deletion may be offered" on every platform — the gated engine lane where the
 platform supports it, the manual handoff elsewhere; it is not approval. (Deliberate semantic
 unification, not a restatement: the flag previously read as engine-lane-only, which left the
-manual lane's gate ambiguous — consumer sessions read it both ways.) With no target, ask once. Reject an
+manual lane's gate ambiguous — consumer sessions read it both ways.) `--max-depth <N>` bounds a
+scan to depth N (preferred for large targets); `--confirmed-large-scan` opts into an unbounded
+full walk after the human clears the [confirmation gate](#confirmation-gate)'s scan-scope row.
+With no target, ask once. Reject an
 OS-managed root, a non-root mount target, a protected shell-folder root or descendant, a missing
 directory, a symlink, or a Windows reparse point. A whole-volume root that is not OS-managed (a
 Windows Dev Drive) is no longer rejected outright — it is a valid target, but as a known-large root


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #2589

## Summary

The clean skill's argument-surface docs omitted `--max-depth` and `--confirmed-large-scan` even though the engine accepts them and the skill body depends on the bounded-first workflow.

## Fix

Documented the real argument surface in `plugins/disk-hygiene/skills/clean/SKILL.md`, including `--max-depth`, `--confirmed-large-scan`, and related required flags.

## Verification

- Docs-only change; no engine behavior change
- Flag names cross-checked against the skill body / engine usage

## Related

Refs #2615 — PowerShell `2>&1` false-positive redirect (serial disk-hygiene follow-up).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eb3f5ee5-6c9f-48a3-8e46-071bd363f8b0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eb3f5ee5-6c9f-48a3-8e46-071bd363f8b0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

