### PR TITLE
fix(skill-quality): allow static gates on non-git plugin trees

### DIFF
--- a/plugins/skill-quality/.claude-plugin/plugin.json
+++ b/plugins/skill-quality/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "skill-quality",
-  "version": "0.15.9",
+  "version": "0.15.10",
   "description": "Skill-authoring QA tooling: a static contract checker that runs twenty-two deterministic checks over a Claude Code skill (frontmatter, per-skill listing-entry cap, trigger-keyword preservation, line caps, broken internal refs, markdownlint, gotchas surface, evals presence, precompute opportunity, injection shell-declaration, fresh-eyes declaration conformance), a shared skill-listing budget reporter across a set of skills, and a bundled evals.json schema plus a deterministic eval-quality lint (duplicate case identities, missing fixtures, empty or vague grading criteria, set-coverage warnings). Runs against any repo's skills directory via the convention-resolution ladder \u2014 no baked layout.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/skill-quality/CHANGELOG.md
+++ b/plugins/skill-quality/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to the `skill-quality` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.15.10]
+
+### Fixed
+
+- **Static gates run against non-git plugin-cache installs (#2619).** `check-skill.sh` and
+  `check-listing-budget.sh` no longer exit 2 with `Error: not in a git repo` when cwd is outside
+  a git repository. Marketplace cache trees are plain directories; with
+  `CHECK_SKILL_SKILLS_ROOT` (or `CLAUDE_PROJECT_DIR`, or an explicit listing-budget root) the
+  non-git checks still run. Git-backed checks (3/8/9/13) skip with a note. Exit 2 remains only
+  when no skills root can be resolved at all.
+
 ## [0.15.9]
 
 ### Changed

--- a/plugins/skill-quality/README.md
+++ b/plugins/skill-quality/README.md
@@ -101,8 +101,10 @@ stands alone.
 
 ## Requirements
 
-- A git repository — several checks read `git show HEAD:` / `git ls-files`; outside a repo the script
-  exits 2.
+- A skills root — via `CHECK_SKILL_SKILLS_ROOT`, `CLAUDE_PROJECT_DIR`, or a git repository
+  (last-resort default `.claude/skills`). Git-backed checks (trigger preservation, vendor
+  identity, stale metadata, committed artifacts) skip with a note outside a repo so
+  marketplace plugin-cache installs (plain trees) still run the rest of the gate.
 - `npx` (Node) is optional; without it the markdownlint check downgrades to a warning and the other
   twenty-one still gate.
 

--- a/plugins/skill-quality/scripts/check-listing-budget.sh
+++ b/plugins/skill-quality/scripts/check-listing-budget.sh
@@ -60,11 +60,15 @@
 #
 # No args: resolves ONE root via the same convention ladder as check-skill.sh
 #   (CHECK_SKILL_SKILLS_ROOT, then ${CLAUDE_PROJECT_DIR}/.claude/skills, then
-#   <git-root>/.claude/skills) — the shape a single consumer project has. A
-#   resolved root that does not exist is reported as "no skills root found".
+#   <git-root>/.claude/skills when cwd is inside a git repo) — the shape a
+#   single consumer project has. Outside a git repo with no override, that is
+#   an environment error (exit 2) naming the missing root, not a silent skip.
+#   A resolved root that does not exist is reported as "no skills root found".
 # One or more args: EVERY explicit root must exist — a missing one is an
 #   environment error (exit 2), never a silent skip, because skipping it
 #   would omit a whole plugin subtree and report a falsely low aggregate.
+#   Explicit roots do not require a git repository (plugin-cache installs are
+#   plain directory trees).
 # One or more args: each is scanned as an independent skills root and every
 #   skill under every root is pooled into ONE shared aggregate. This is how a
 #   consumer who installs multiple plugins actually experiences the listing
@@ -121,10 +125,14 @@ if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
   exit 0
 fi
 
+# Git is optional. Explicit skill-root args (and CHECK_SKILL_SKILLS_ROOT /
+# CLAUDE_PROJECT_DIR) work against plain directory trees such as marketplace
+# plugin-cache installs. The git toplevel is only the last-resort default root
+# when no args and no override are supplied.
 REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null | tr -d '\r')"
-if [[ -z "$REPO_ROOT" || ! -d "$REPO_ROOT" ]]; then
-  printf 'Error: not in a git repo\n' >&2
-  exit 2
+HAVE_GIT=0
+if [[ -n "$REPO_ROOT" && -d "$REPO_ROOT" ]]; then
+  HAVE_GIT=1
 fi
 
 # `skill-frontmatter.sh` is deliberately NOT sourced any more. Its helpers are
@@ -208,11 +216,21 @@ else
     SINGLE_ROOT="$CHECK_SKILL_SKILLS_ROOT"
   elif [[ -n "${CLAUDE_PROJECT_DIR:-}" ]]; then
     SINGLE_ROOT="$CLAUDE_PROJECT_DIR/.claude/skills"
-  else
+  elif [[ "$HAVE_GIT" == 1 ]]; then
     SINGLE_ROOT="$REPO_ROOT/.claude/skills"
+  else
+    printf 'Error: not in a git repo and no skills root set — set CHECK_SKILL_SKILLS_ROOT (or CLAUDE_PROJECT_DIR), pass an explicit skills root, or run from inside a git repository\n' >&2
+    exit 2
   fi
   if [[ "$SINGLE_ROOT" != /* && ! "$SINGLE_ROOT" =~ ^[A-Za-z]:[\\/] ]]; then
-    SINGLE_ROOT="${CLAUDE_PROJECT_DIR:-$REPO_ROOT}/$SINGLE_ROOT"
+    if [[ -n "${CLAUDE_PROJECT_DIR:-}" ]]; then
+      SINGLE_ROOT="$CLAUDE_PROJECT_DIR/$SINGLE_ROOT"
+    elif [[ "$HAVE_GIT" == 1 ]]; then
+      SINGLE_ROOT="$REPO_ROOT/$SINGLE_ROOT"
+    else
+      printf 'Error: relative skills root %s needs CLAUDE_PROJECT_DIR or a git repository to anchor against\n' "$SINGLE_ROOT" >&2
+      exit 2
+    fi
   fi
   ROOTS=("$SINGLE_ROOT")
 fi

--- a/plugins/skill-quality/scripts/check-listing-budget.test.sh
+++ b/plugins/skill-quality/scripts/check-listing-budget.test.sh
@@ -477,6 +477,55 @@ else
   fail "200-file corpus took ${perf_elapsed}s or miscounted (bound 30s): $out"
 fi
 
+# 20. Non-git plugin-cache tree: explicit root still reports (issue #2619).
+#     Marketplace installs are plain dirs; an explicit skills root must not
+#     abort with "not in a git repo" just because cwd has no .git.
+CACHE_TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP" "$CACHE_TMP"' EXIT
+CACHE_SKILLS="$CACHE_TMP/marketplace/some-plugin/1.0.0/skills"
+make_skill "$CACHE_SKILLS" cache-skill "A cache-install fixture description."
+out="$(
+  cd "$CACHE_TMP" &&
+    env -u GIT_DIR -u GIT_WORK_TREE -u GIT_COMMON_DIR -u GIT_PREFIX \
+      bash "$SUT" "$CACHE_SKILLS" 2>&1
+)"
+rc=$?
+if [[ $rc -eq 0 ]] &&
+  grep -q 'CHECK-LISTING-BUDGET: OK' <<<"$out" &&
+  ! grep -q 'Error: not in a git repo' <<<"$out"; then
+  pass "non-git plugin-cache tree: listing-budget reports over an explicit root"
+else
+  fail "non-git explicit root should report OK without git (rc=$rc): $out"
+fi
+
+# 20b. Outside git with no args and no override is still an environment error.
+out="$(
+  cd "$CACHE_TMP" &&
+    env -u GIT_DIR -u GIT_WORK_TREE -u GIT_COMMON_DIR -u GIT_PREFIX \
+      -u CHECK_SKILL_SKILLS_ROOT -u CLAUDE_PROJECT_DIR \
+      bash "$SUT" 2>&1
+)"
+rc=$?
+if [[ $rc -eq 2 ]] && grep -q 'no skills root set' <<<"$out"; then
+  pass "outside git with no args/override still exits 2 naming the missing root"
+else
+  fail "outside git with no args should exit 2 (rc=$rc): $out"
+fi
+
+# 20c. CHECK_SKILL_SKILLS_ROOT from a non-git cwd still resolves (no-args form).
+out="$(
+  cd "$CACHE_TMP" &&
+    env -u GIT_DIR -u GIT_WORK_TREE -u GIT_COMMON_DIR -u GIT_PREFIX \
+      CHECK_SKILL_SKILLS_ROOT="$CACHE_SKILLS" \
+      bash "$SUT" 2>&1
+)"
+rc=$?
+if [[ $rc -eq 0 ]] && grep -q 'CHECK-LISTING-BUDGET: OK' <<<"$out"; then
+  pass "non-git no-args form honors CHECK_SKILL_SKILLS_ROOT"
+else
+  fail "non-git CHECK_SKILL_SKILLS_ROOT should report OK (rc=$rc): $out"
+fi
+
 if [[ $fails -ne 0 ]]; then
   printf '%d assertion(s) failed\n' "$fails" >&2
   exit 1

--- a/plugins/skill-quality/scripts/check-listing-budget.test.sh
+++ b/plugins/skill-quality/scripts/check-listing-budget.test.sh
@@ -477,7 +477,7 @@ else
   fail "200-file corpus took ${perf_elapsed}s or miscounted (bound 30s): $out"
 fi
 
-# 20. Non-git plugin-cache tree: explicit root still reports (issue #2619).
+# 20. Non-git plugin-cache tree: explicit root still reports.
 #     Marketplace installs are plain dirs; an explicit skills root must not
 #     abort with "not in a git repo" just because cwd has no .git.
 CACHE_TMP="$(mktemp -d)"

--- a/plugins/skill-quality/scripts/check-skill.sh
+++ b/plugins/skill-quality/scripts/check-skill.sh
@@ -19,14 +19,19 @@
 # Skills root resolution (first hit wins):
 #   1. CHECK_SKILL_SKILLS_ROOT env var (explicit override)
 #   2. ${CLAUDE_PROJECT_DIR}/.claude/skills (plugin runtime)
-#   3. <git-root>/.claude/skills (default)
+#   3. <git-root>/.claude/skills (default, when cwd is inside a git repo)
+#
+# A git repository is OPTIONAL. Marketplace plugin-cache installs are plain
+# directory trees (no .git). When cwd is not inside a git repo, set
+# CHECK_SKILL_SKILLS_ROOT (or CLAUDE_PROJECT_DIR) and the non-git checks still
+# run; git-backed checks (3, 8, 9, 13) skip with a note.
 #
 # Base ref for the git-backed diff checks (3, 8, 9):
 #   CHECK_SKILL_BASE_REF (default HEAD). These checks diff the WORKING TREE
 #   against this ref, so the default catches an uncommitted rewrite. For a
 #   post-commit audit (where HEAD == tree hides an already-committed change),
 #   run on a clean tree with CHECK_SKILL_BASE_REF pointing before the change
-#   (e.g. HEAD^ or a merge-base).
+#   (e.g. HEAD^ or a merge-base). Ignored when not in a git repo.
 #
 # NOT covered here: the SHARED listing budget (skillListingBudgetFraction) that
 # every loaded skill draws from together, a different cross-skill limit from
@@ -78,8 +83,11 @@
 #
 # Notes (static, git-diff-based design):
 #   - Checks 3/8/9 diff the working tree against CHECK_SKILL_BASE_REF (default
-#     HEAD). The default catches an uncommitted rewrite; a post-commit audit
-#     sets the base ref before the change and runs on a clean tree (see above).
+#     HEAD) when a git repo is available. Outside a repo (plugin-cache install)
+#     those checks — and check 13's committed-artifact scan — skip with a note;
+#     every other check still runs. The default catches an uncommitted rewrite;
+#     a post-commit audit sets the base ref before the change and runs on a
+#     clean tree (see above).
 #   - Frontmatter must open with `---` on line 1; content before the fence is
 #     not treated as frontmatter.
 #   - A block-scalar `description: |` / `>-` is unfolded before checks 2/3/12,
@@ -122,9 +130,8 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-# Git is optional. Marketplace plugin-cache installs are plain directories; with
-# CHECK_SKILL_SKILLS_ROOT or CLAUDE_PROJECT_DIR the non-git checks still run.
-# Git-backed checks (3/8/9/13) skip with a note when there is no repository.
+# Git is optional. Plugin-cache installs are plain trees; non-git checks still
+# run when CHECK_SKILL_SKILLS_ROOT (or CLAUDE_PROJECT_DIR) points at them.
 REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null | tr -d '\r')"
 HAVE_GIT=0
 if [[ -n "$REPO_ROOT" && -d "$REPO_ROOT" ]]; then
@@ -136,6 +143,7 @@ source "$SCRIPT_DIR/skill-frontmatter.sh"
 
 # Base ref for the git-backed diff checks (3, 8, 9) — see the header. Default
 # HEAD (uncommitted-rewrite case); an explicit ref enables a post-commit audit.
+# Validated only when a git repo is present; ignored otherwise.
 BASE_REF="${CHECK_SKILL_BASE_REF:-HEAD}"
 if [[ "$HAVE_GIT" == 1 && "$BASE_REF" != "HEAD" ]] &&
   ! git -C "$REPO_ROOT" rev-parse --verify --quiet "$BASE_REF^{commit}" >/dev/null 2>&1; then
@@ -147,6 +155,8 @@ SKILL_NAME="${1:?Usage: check-skill.sh [--require-evals] <skill-name>}"
 
 # Resolve the skills root without baking a repo layout (convention-resolution
 # ladder): explicit override, then plugin project dir, then git-root default.
+# Outside a git repo the git-root step is unavailable — require an explicit
+# root (or CLAUDE_PROJECT_DIR) rather than aborting solely for missing VCS.
 if [[ -n "${CHECK_SKILL_SKILLS_ROOT:-}" ]]; then
   SKILLS_ROOT="$CHECK_SKILL_SKILLS_ROOT"
 elif [[ -n "${CLAUDE_PROJECT_DIR:-}" ]]; then
@@ -180,7 +190,8 @@ SKILL_MD="$SKILL_DIR/SKILL.md"
 # the conventional .claude/skills. Ask git for the prefix rather than
 # string-stripping REPO_ROOT — on Git Bash `git rev-parse` and `pwd` can differ
 # in drive-letter case / slash form, which would silently break the strip.
-# Empty when the skill dir is outside the repo (git-backed checks then no-op).
+# Empty when not in a git repo, or when the skill dir is outside the repo
+# (git-backed checks then no-op).
 SKILL_REL=""
 if [[ "$HAVE_GIT" == 1 ]]; then
   SKILL_REL="$(git -C "$SKILL_DIR" rev-parse --show-prefix 2>/dev/null | tr -d '\r')"
@@ -335,7 +346,7 @@ fi
 # --- Check 3: trigger-keyword preservation vs HEAD -------------------------
 
 if [[ "$HAVE_GIT" != 1 ]]; then
-  note "trigger-keyword preservation (check 3) skipped — not in a git repository"
+  note "not in a git repo — trigger-keyword preservation (check 3) skipped"
 elif git -C "$REPO_ROOT" cat-file -e "$BASE_REF:$SKILL_REL/SKILL.md" 2>/dev/null; then
   BASE_FM_3="$(git -C "$REPO_ROOT" show "$BASE_REF:$SKILL_REL/SKILL.md" 2>/dev/null | skill_frontmatter::extract)"
   BASE_TRIG="$(fm_listing_triggers "$BASE_FM_3")"
@@ -461,7 +472,7 @@ while IFS= read -r ref; do
     fi
     resolve_base="$PLUGIN_DIR"
   fi
-  if git -C "$REPO_ROOT" check-ignore -q "$resolve_base/$check_ref" 2>/dev/null; then
+  if [[ "$HAVE_GIT" == 1 ]] && git -C "$REPO_ROOT" check-ignore -q "$resolve_base/$check_ref" 2>/dev/null; then
     note "check-5 skip (gitignored runtime path): $check_ref"
     continue
   fi
@@ -566,8 +577,11 @@ fi
 
 # Only meaningful when the skill has a HEAD baseline: a brand-new vendored skill
 # staged before a pre-commit run has no prior vendor/ to preserve, so its staged
-# files must not read as "changed vs HEAD".
-if [[ -d "$SKILL_DIR/vendor" ]] && git -C "$REPO_ROOT" cat-file -e "$BASE_REF:$SKILL_REL/SKILL.md" 2>/dev/null; then
+# files must not read as "changed vs HEAD". Outside a git repo there is no
+# baseline to compare — skip rather than abort the whole gate.
+if [[ "$HAVE_GIT" != 1 ]]; then
+  [[ -d "$SKILL_DIR/vendor" ]] && note "not in a git repo — vendor byte-identity (check 8) skipped"
+elif [[ -d "$SKILL_DIR/vendor" ]] && git -C "$REPO_ROOT" cat-file -e "$BASE_REF:$SKILL_REL/SKILL.md" 2>/dev/null; then
   if git -C "$REPO_ROOT" diff --quiet "$BASE_REF" -- "$SKILL_REL/vendor/" 2>/dev/null; then
     note "vendor/ unchanged vs $BASE_REF"
   else
@@ -590,7 +604,9 @@ fi
 
 # --- Check 9: stale-tracking metadata keys preserved vs HEAD ---------------
 
-if git -C "$REPO_ROOT" cat-file -e "$BASE_REF:$SKILL_REL/SKILL.md" 2>/dev/null; then
+if [[ "$HAVE_GIT" != 1 ]]; then
+  note "not in a git repo — stale-tracking metadata (check 9) skipped"
+elif git -C "$REPO_ROOT" cat-file -e "$BASE_REF:$SKILL_REL/SKILL.md" 2>/dev/null; then
   BASE_FM="$(git -C "$REPO_ROOT" show "$BASE_REF:$SKILL_REL/SKILL.md" 2>/dev/null | skill_frontmatter::extract)"
   for key in upstream-version synced upstream-sha; do
     if grep -qE "^[[:space:]]*$key:" <<<"$BASE_FM"; then
@@ -644,7 +660,7 @@ fi
 # --- Check 13: no committed cache/build artifacts ----------------------------
 
 if [[ "$HAVE_GIT" != 1 ]]; then
-  note "committed-artifact scan (check 13) skipped — not in a git repository"
+  note "not in a git repo — committed-artifact scan (check 13) skipped"
 else
   CACHE_HITS="$(git -C "$REPO_ROOT" ls-files "$SKILL_REL" 2>/dev/null | grep -E '__pycache__|\.pyc$|/node_modules/' || true)"
   if [[ -n "$CACHE_HITS" ]]; then

--- a/plugins/skill-quality/scripts/check-skill.sh
+++ b/plugins/skill-quality/scripts/check-skill.sh
@@ -122,10 +122,13 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+# Git is optional. Marketplace plugin-cache installs are plain directories; with
+# CHECK_SKILL_SKILLS_ROOT or CLAUDE_PROJECT_DIR the non-git checks still run.
+# Git-backed checks (3/8/9/13) skip with a note when there is no repository.
 REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null | tr -d '\r')"
-if [[ -z "$REPO_ROOT" || ! -d "$REPO_ROOT" ]]; then
-  printf 'Error: not in a git repo\n' >&2
-  exit 2
+HAVE_GIT=0
+if [[ -n "$REPO_ROOT" && -d "$REPO_ROOT" ]]; then
+  HAVE_GIT=1
 fi
 
 # shellcheck source=./skill-frontmatter.sh
@@ -134,7 +137,7 @@ source "$SCRIPT_DIR/skill-frontmatter.sh"
 # Base ref for the git-backed diff checks (3, 8, 9) — see the header. Default
 # HEAD (uncommitted-rewrite case); an explicit ref enables a post-commit audit.
 BASE_REF="${CHECK_SKILL_BASE_REF:-HEAD}"
-if [[ "$BASE_REF" != "HEAD" ]] &&
+if [[ "$HAVE_GIT" == 1 && "$BASE_REF" != "HEAD" ]] &&
   ! git -C "$REPO_ROOT" rev-parse --verify --quiet "$BASE_REF^{commit}" >/dev/null 2>&1; then
   printf 'Error: CHECK_SKILL_BASE_REF=%s is not a valid commit\n' "$BASE_REF" >&2
   exit 2
@@ -148,15 +151,25 @@ if [[ -n "${CHECK_SKILL_SKILLS_ROOT:-}" ]]; then
   SKILLS_ROOT="$CHECK_SKILL_SKILLS_ROOT"
 elif [[ -n "${CLAUDE_PROJECT_DIR:-}" ]]; then
   SKILLS_ROOT="$CLAUDE_PROJECT_DIR/.claude/skills"
-else
+elif [[ "$HAVE_GIT" == 1 ]]; then
   SKILLS_ROOT="$REPO_ROOT/.claude/skills"
+else
+  printf 'Error: not in a git repo and no skills root set — set CHECK_SKILL_SKILLS_ROOT (or CLAUDE_PROJECT_DIR), or run from inside a git repository\n' >&2
+  exit 2
 fi
 
 # Anchor a relative skills root to the project root. The setup action persists a
 # project-relative path; if the skill is invoked from a subdirectory a relative
 # root would otherwise resolve against the cwd and miss the skills.
 if [[ "$SKILLS_ROOT" != /* && ! "$SKILLS_ROOT" =~ ^[A-Za-z]:[\\/] ]]; then
-  SKILLS_ROOT="${CLAUDE_PROJECT_DIR:-$REPO_ROOT}/$SKILLS_ROOT"
+  if [[ -n "${CLAUDE_PROJECT_DIR:-}" ]]; then
+    SKILLS_ROOT="$CLAUDE_PROJECT_DIR/$SKILLS_ROOT"
+  elif [[ "$HAVE_GIT" == 1 ]]; then
+    SKILLS_ROOT="$REPO_ROOT/$SKILLS_ROOT"
+  else
+    printf 'Error: relative skills root %s needs CLAUDE_PROJECT_DIR or a git repository to anchor against\n' "$SKILLS_ROOT" >&2
+    exit 2
+  fi
 fi
 
 SKILL_DIR="$SKILLS_ROOT/$SKILL_NAME"
@@ -168,8 +181,11 @@ SKILL_MD="$SKILL_DIR/SKILL.md"
 # string-stripping REPO_ROOT — on Git Bash `git rev-parse` and `pwd` can differ
 # in drive-letter case / slash form, which would silently break the strip.
 # Empty when the skill dir is outside the repo (git-backed checks then no-op).
-SKILL_REL="$(git -C "$SKILL_DIR" rev-parse --show-prefix 2>/dev/null | tr -d '\r')"
-SKILL_REL="${SKILL_REL%/}"
+SKILL_REL=""
+if [[ "$HAVE_GIT" == 1 ]]; then
+  SKILL_REL="$(git -C "$SKILL_DIR" rev-parse --show-prefix 2>/dev/null | tr -d '\r')"
+  SKILL_REL="${SKILL_REL%/}"
+fi
 
 # Tunables (listing description cap; SKILL.md line caps; vendor sync age).
 DESC_CHAR_CAP=1536
@@ -318,7 +334,9 @@ fi
 
 # --- Check 3: trigger-keyword preservation vs HEAD -------------------------
 
-if git -C "$REPO_ROOT" cat-file -e "$BASE_REF:$SKILL_REL/SKILL.md" 2>/dev/null; then
+if [[ "$HAVE_GIT" != 1 ]]; then
+  note "trigger-keyword preservation (check 3) skipped — not in a git repository"
+elif git -C "$REPO_ROOT" cat-file -e "$BASE_REF:$SKILL_REL/SKILL.md" 2>/dev/null; then
   BASE_FM_3="$(git -C "$REPO_ROOT" show "$BASE_REF:$SKILL_REL/SKILL.md" 2>/dev/null | skill_frontmatter::extract)"
   BASE_TRIG="$(fm_listing_triggers "$BASE_FM_3")"
   CUR_TRIG="$(printf '%s\n%s\n' "$CUR_DESC" "$CUR_WTU" | skill_frontmatter::extract_triggers)"
@@ -625,9 +643,13 @@ fi
 
 # --- Check 13: no committed cache/build artifacts ----------------------------
 
-CACHE_HITS="$(git -C "$REPO_ROOT" ls-files "$SKILL_REL" 2>/dev/null | grep -E '__pycache__|\.pyc$|/node_modules/' || true)"
-if [[ -n "$CACHE_HITS" ]]; then
-  err "committed cache/build artifact(s) under the skill dir: $(printf '%s' "$CACHE_HITS" | head -3 | tr '\n' ' ')"
+if [[ "$HAVE_GIT" != 1 ]]; then
+  note "committed-artifact scan (check 13) skipped — not in a git repository"
+else
+  CACHE_HITS="$(git -C "$REPO_ROOT" ls-files "$SKILL_REL" 2>/dev/null | grep -E '__pycache__|\.pyc$|/node_modules/' || true)"
+  if [[ -n "$CACHE_HITS" ]]; then
+    err "committed cache/build artifact(s) under the skill dir: $(printf '%s' "$CACHE_HITS" | head -3 | tr '\n' ' ')"
+  fi
 fi
 
 # --- Check 14: evals/evals.json presence -------------------------------------

--- a/plugins/skill-quality/scripts/check-skill.test.sh
+++ b/plugins/skill-quality/scripts/check-skill.test.sh
@@ -2516,6 +2516,63 @@ else
   fail "CHECK_SKILL_REQUIRE_EVALS=1 should fail without evals (rc=$rc): $out"
 fi
 
+# 46. Non-git plugin-cache tree: static gates still run (issue #2619).
+#     Marketplace installs are plain dirs with no .git. Point
+#     CHECK_SKILL_SKILLS_ROOT at a cache-shaped skills root from a cwd that is
+#     not inside any git repository — must not exit 2 with "not in a git repo".
+CACHE_TMP="$(mktemp -d)"
+# Nested trap: remove cache fixture after the outer TMP trap still fires.
+trap 'rm -rf "$TMP" "$CACHE_TMP"' EXIT
+CACHE_SKILLS="$CACHE_TMP/marketplace/disk-hygiene/0.17.9/skills"
+mkdir -p "$CACHE_SKILLS/clean"
+cat >"$CACHE_SKILLS/clean/SKILL.md" <<'EOF'
+---
+description: "Clean disk. Use when: 'disk full' or 'clean cache'."
+---
+
+## Purpose
+
+Fixture skill shaped like a marketplace cache install (no .git).
+
+## Gotchas
+
+None known.
+EOF
+# Isolate from ambient git: empty GIT_DIR would still walk parents; run from
+# the non-git cache tree itself with GIT_DIR unset.
+out="$(
+  cd "$CACHE_TMP" &&
+    env -u GIT_DIR -u GIT_WORK_TREE -u GIT_COMMON_DIR -u GIT_PREFIX \
+      CHECK_SKILL_SKILLS_ROOT="$CACHE_SKILLS" CHECK_SKILL_SKIP_MARKDOWNLINT=1 \
+      bash "$SUT" clean 2>&1
+)"
+rc=$?
+if [[ $rc -eq 0 ]] &&
+  grep -q 'PASS' <<<"$out" &&
+  ! grep -q 'Error: not in a git repo' <<<"$out" &&
+  grep -q 'trigger-keyword preservation (check 3) skipped' <<<"$out" &&
+  grep -q 'committed-artifact scan (check 13) skipped' <<<"$out"; then
+  pass "non-git plugin-cache tree: check-skill runs and skips git-backed checks"
+else
+  fail "non-git plugin-cache tree should PASS with git checks skipped (rc=$rc): $out"
+fi
+
+# 46b. Outside a git repo with no skills root is still an environment error —
+#      degrade only when a root is resolvable, never silently invent one.
+out="$(
+  cd "$CACHE_TMP" &&
+    env -u GIT_DIR -u GIT_WORK_TREE -u GIT_COMMON_DIR -u GIT_PREFIX \
+      -u CHECK_SKILL_SKILLS_ROOT -u CLAUDE_PROJECT_DIR \
+      CHECK_SKILL_SKIP_MARKDOWNLINT=1 \
+      bash "$SUT" clean 2>&1
+)"
+rc=$?
+if [[ $rc -eq 2 ]] && grep -q 'no skills root set' <<<"$out"; then
+  pass "outside git with no skills root still exits 2 naming the missing root"
+else
+  fail "outside git with no skills root should exit 2 (rc=$rc): $out"
+fi
+
 if [[ $fails -ne 0 ]]; then
   printf '%d assertion(s) failed\n' "$fails" >&2
   exit 1

--- a/plugins/skill-quality/scripts/check-skill.test.sh
+++ b/plugins/skill-quality/scripts/check-skill.test.sh
@@ -2516,7 +2516,7 @@ else
   fail "CHECK_SKILL_REQUIRE_EVALS=1 should fail without evals (rc=$rc): $out"
 fi
 
-# 46. Non-git plugin-cache tree: static gates still run (issue #2619).
+# 46. Non-git plugin-cache tree: static gates still run.
 #     Marketplace installs are plain dirs with no .git. Point
 #     CHECK_SKILL_SKILLS_ROOT at a cache-shaped skills root from a cwd that is
 #     not inside any git repository — must not exit 2 with "not in a git repo".

--- a/plugins/skill-quality/skills/check/SKILL.md
+++ b/plugins/skill-quality/skills/check/SKILL.md
@@ -156,9 +156,12 @@ silent skip or a coerced-to-zero budget.
 
 ## Gotchas
 
-- The script needs a git repository — several checks (trigger-keyword preservation, vendor
-  byte-identity, committed-artifact scan) read `git show HEAD:` / `git ls-files`. Outside a repo it
-  exits 2 (env error).
+- A git repository is optional. Git-backed checks (trigger-keyword preservation, vendor
+  byte-identity, stale-tracking metadata, committed-artifact scan) skip with a note when cwd
+  is outside a repo — marketplace plugin-cache installs are plain trees. Set
+  `CHECK_SKILL_SKILLS_ROOT` (or `CLAUDE_PROJECT_DIR`) so the non-git checks still resolve a
+  skills root; without either and without a git toplevel, the script exits 2 naming the
+  missing root.
 - `check-skill.sh` runs `npx markdownlint-cli2` for check 6; when `npx` is absent that check downgrades
   to a WARN rather than failing, so a run on a machine without Node still gates on the other twenty.
 - **Check 6 defers to the repo's markdownlint config — run it from inside that repo.** `markdownlint-cli2`

--- a/plugins/skill-quality/skills/check/evals/evals.json
+++ b/plugins/skill-quality/skills/check/evals/evals.json
@@ -64,14 +64,14 @@
     },
     {
       "id": 6,
-      "name": "outside-git-repo-is-env-error-not-silent-pass",
-      "prompt": "Run the skill-quality check from a working directory that is not inside any git repository. What happens?",
-      "expected_output": "The checker resolves the repo root via `git rev-parse --show-toplevel` BEFORE it resolves the skills root, so invoking it from outside any git repository finds no toplevel and the script exits 2 with an environment error ('not in a git repo') rather than silently passing. The skill reports the environment error, not a clean PASS.",
+      "name": "outside-git-repo-degrades-not-aborts",
+      "prompt": "Run the skill-quality check from a working directory that is not inside any git repository, pointed at a marketplace plugin-cache skills root via CHECK_SKILL_SKILLS_ROOT. What happens?",
+      "expected_output": "The checker does NOT abort with exit 2 'not in a git repo'. With CHECK_SKILL_SKILLS_ROOT set, non-git checks still run against the cache tree; git-backed checks (3 trigger-preservation, 8 vendor, 9 stale-metadata, 13 committed artifacts) skip with a note. Only when neither a skills root override nor CLAUDE_PROJECT_DIR nor a git toplevel is available does the script exit 2 naming the missing skills root.",
       "files": [],
       "expectations": [
-        "Output explains the checker exits 2 (environment error) when it is invoked from outside any git repository",
-        "Output does NOT characterize the run as a clean PASS when it is run outside a git repo",
-        "Output attributes the exit-2 gate to the git repo-root detection that runs before skills-root resolution, not to a skills directory merely living outside the repo"
+        "Output explains that a plugin-cache / non-git tree still runs the static gate when CHECK_SKILL_SKILLS_ROOT (or CLAUDE_PROJECT_DIR) is set",
+        "Output explains that git-backed checks skip with a note rather than aborting the whole gate",
+        "Output does NOT claim the checker exits 2 solely because cwd is outside a git repository when a skills root is resolvable"
       ]
     },
     {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #2619

## Summary

`skill-quality` static gates exited 2 with `Error: not in a git repo` against marketplace plugin-cache installs (plain dirs), so `plugin-quality:audit` could not run its required skill-quality step on installed plugins.

## Fix

Make git optional in `check-skill.sh` and `check-listing-budget.sh`. When `CHECK_SKILL_SKILLS_ROOT` / `CLAUDE_PROJECT_DIR` / explicit roots resolve, non-git checks still run; git-backed checks skip with notes. Exit 2 only when no skills root can be resolved.

## Verification

- `bash plugins/skill-quality/scripts/check-skill.test.sh` → all assertions passed
- `bash plugins/skill-quality/scripts/check-listing-budget.test.sh` → all assertions passed

## Related

Refs #2618 — hit during disk-hygiene:clean post-use audit.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eb3f5ee5-6c9f-48a3-8e46-071bd363f8b0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eb3f5ee5-6c9f-48a3-8e46-071bd363f8b0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

