### PR TITLE
fix(disk-hygiene): do not flag PowerShell 2>&1 as file redirect

### DIFF
--- a/plugins/disk-hygiene/.claude-plugin/plugin.json
+++ b/plugins/disk-hygiene/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "disk-hygiene",
-  "version": "0.17.10",
+  "version": "0.17.11",
   "description": "Context-aware disk hygiene for arbitrary directory trees: inventories orphaned and temporary artifacts, classifies evidence into review tiers, and offers exact-path cleanup only after a fresh safety preview and explicit per-tier approval. The target is read-only by default; OS-managed paths, links and mount points, VCS-tracked content, changed entries, and live-handle uncertainty fail closed.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/disk-hygiene/CHANGELOG.md
+++ b/plugins/disk-hygiene/CHANGELOG.md
@@ -3,6 +3,19 @@
 All notable changes to the `disk-hygiene` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.17.11]
+
+### Fixed
+
+- **PowerShell stream merges (`2>&1`, `*>&1`) are no longer flagged as file-overwriting
+  redirection (#2615).** `_POWERSHELL_OUTPUT_REDIRECT` matched the `>` inside `2>&1` because
+  its lookaround only excluded adjacent `<`, `>`, and `=`. In PowerShell `>&` is only ever a
+  stream merge and never designates a file, so ordinary diagnostic commands that capture
+  combined output were prompting as mutations — approval-fatigue noise that blunts real
+  deletion prompts, especially once the belt stays armed for the rest of the session (#2591).
+  The detector now also excludes a following `&`; `2>out.txt` and `'data' > file` still
+  prompt.
+
 ## [0.17.10]
 
 ### Fixed

--- a/plugins/disk-hygiene/skills/clean/scripts/destructive_guard.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/destructive_guard.py
@@ -968,7 +968,9 @@ _POWERSHELL_MUTATION_WORDS = re.compile(
 _POWERSHELL_NEW_ITEM_FORCE = re.compile(
     r"(?i)(?<![\w./\\-])new-item(?![\w-]).*-force\b"
 )
-_POWERSHELL_OUTPUT_REDIRECT = re.compile(r"(?<![<>])>(?![=>])")
+# Exclude stream merges (`2>&1`, `1>&2`, `*>&1`): in PowerShell `>&` only merges
+# streams and never designates a file. File redirects like `2>out.txt` still match.
+_POWERSHELL_OUTPUT_REDIRECT = re.compile(r"(?<![<>])>(?![=>&])")
 _POWERSHELL_DOTNET_DELETE = re.compile(r"(?i)(::\s*delete|\.\s*delete\s*\()")
 # robocopy is an executable normally invocable by full path
 # (C:\Windows\System32\robocopy.exe), so unlike the cmdlet word list its

--- a/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
@@ -4574,6 +4574,7 @@ class GuardTests(unittest.TestCase):
             "Out-File C:/tmp/file.txt -Force",
             "New-Item C:/tmp/file.txt -ItemType File -Force",
             "'data' > C:/tmp/file.txt",
+            "Get-ChildItem C:/tmp 2>out.txt",
         ):
             result = self.run_guard_powershell(command)
             assert result is not None, command
@@ -4582,6 +4583,17 @@ class GuardTests(unittest.TestCase):
                 result["hookSpecificOutput"]["permissionDecision"],
                 command,
             )
+
+    def test_powershell_stream_merges_are_not_file_redirects(self) -> None:
+        """#2615: `2>&1` / `*>&1` merge streams; they must not prompt as file redirects."""
+        for command in (
+            "bash plugins/disk-hygiene/skills/clean/scripts/hygiene.test.sh 2>&1 | Select-Object -Last 8",
+            "git status --short 2>&1",
+            "Get-ChildItem C:/tmp 1>&2",
+            "Get-ChildItem C:/tmp *>&1",
+            "Get-ChildItem C:/tmp 2>&1 | Select-Object -First 1",
+        ):
+            self.assertIsNone(self.run_guard_powershell(command), command)
 
     def test_powershell_bare_name_mentions_defer_but_engine_identity_denies(self) -> None:
         """F6 (#1112): mentions defer via the invocation classifier; a command


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #2615

## Summary

The disk-hygiene PowerShell belt treated `2>&1` stream merges as file-overwriting redirects because `_POWERSHELL_OUTPUT_REDIRECT` matched the `>` in `2>&1`.

## Fix

Exclude PowerShell stream-merge redirections (`N>&M`) from the file-overwrite detector. Add regression coverage.

## Verification

See branch CI / local destructive_guard / hygiene tests on the PR checks.

## Related

Refs #2589 — argument-surface docs (serial disk-hygiene lane).
Refs #2591 / #2618 — belt lifetime (later wave).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eb3f5ee5-6c9f-48a3-8e46-071bd363f8b0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eb3f5ee5-6c9f-48a3-8e46-071bd363f8b0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

