### PR TITLE
fix(machine-health): surface invalid catalog entries in the report

### DIFF
--- a/plugins/machine-health/.claude-plugin/plugin.json
+++ b/plugins/machine-health/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "machine-health",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "Workstation health audit: OS-specific checks (disk, OS updates, security posture, CISA KEV correlation) run from a versioned catalog with trend-aware severity, approval-gated remediations, and dated markdown reports. Windows fully implemented; macOS/Linux scaffolded (report UNKNOWN and stop). Machine state persists in the plugin data directory; the report directory and check catalog are configurable.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/machine-health/CHANGELOG.md
+++ b/plugins/machine-health/CHANGELOG.md
@@ -16,8 +16,12 @@ All notable changes to the `machine-health` plugin are documented here. Format f
   registered. Each rejected entry now synthesizes a schema-valid `UNKNOWN` CheckResult
   (`ran_successfully: false`, error = the assertion message) via
   `New-InvalidCatalogEntryResult` and feeds the normal reporting path. Id stays the
-  entry's kebab-valid `id` when present, else a collision-free synthetic id; category stays
-  the declared value when legal, else `reliability`.
+  entry's kebab-valid `id` when present, else a collision-checked
+  `invalid-catalog-entry-<index>` fallback (against catalog / already-emitted result
+  ids); category stays the declared value when legal, else `reliability`. Id-less
+  overlay rows in `checks.local.jsonc` are retained through `Merge-CatalogOverlay` so
+  they reach the same reporting path. The category vocabulary parity guard covers this
+  helper as a fifth copy alongside the two schemas and two validators.
 
 ## [0.10.1]
 

--- a/plugins/machine-health/CHANGELOG.md
+++ b/plugins/machine-health/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to the `machine-health` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.10.2]
+
+### Fixed
+
+- **Invalid catalog entries now surface as UNKNOWN findings, not silent run-log skips
+  (#2575).** When `Assert-CatalogEntry` rejected an entry, the orchestrator continued
+  (correct for availability) but only wrote `catalog_entry_invalid skip …` to the run
+  log — so `latest.json`, severity counts, the rendered report, and the run delta showed
+  nothing. A registered check with a typo (the field case: `chezmoi-drift` declaring a
+  category outside the enum) was indistinguishable from a check that was never
+  registered. Each rejected entry now synthesizes a schema-valid `UNKNOWN` CheckResult
+  (`ran_successfully: false`, error = the assertion message) via
+  `New-InvalidCatalogEntryResult` and feeds the normal reporting path. Id stays the
+  entry's kebab-valid `id` when present, else a collision-free synthetic id; category stays
+  the declared value when legal, else `reliability`.
+
 ## [0.10.1]
 
 ### Fixed

--- a/plugins/machine-health/skills/audit/scripts/windows/Invoke-MachineHealthCheck.ps1
+++ b/plugins/machine-health/skills/audit/scripts/windows/Invoke-MachineHealthCheck.ps1
@@ -58,6 +58,7 @@ $libRoot = Join-Path $PSScriptRoot 'lib'
 . (Join-Path $libRoot 'Read-HistoryJsonl.ps1')
 . (Join-Path $libRoot 'ConvertFrom-Jsonc.ps1')
 . (Join-Path $libRoot 'Assert-CatalogEntry.ps1')
+. (Join-Path $libRoot 'New-InvalidCatalogEntryResult.ps1')
 . (Join-Path $libRoot 'Get-ApprovalState.ps1')
 . (Join-Path $libRoot 'Invoke-AllowlistedWeb.ps1')
 . (Join-Path $libRoot 'Get-ElevationMatrix.ps1')
@@ -225,8 +226,9 @@ if ($userLoaded -and -not $Force.IsPresent) {
 }
 
 # Load catalog: JSONC parse (comment-aware) + per-entry schema validation.
-# Invalid entries are skipped with a warning so a single typo does not block
-# the orchestrator from running the rest of the catalog.
+# Invalid entries are skipped for dispatch so a single typo does not block the
+# rest of the catalog, but each skip is synthesized as an UNKNOWN CheckResult
+# so the report / latest.json / severity_counts surface it (not only the run log).
 $catalogPath = Join-Path $skillRoot 'catalog\checks.jsonc'
 $catalog = $null
 try {
@@ -258,13 +260,20 @@ if (Test-Path -LiteralPath $overlayPath) {
 }
 
 $validatedChecks = [System.Collections.Generic.List[object]]::new()
+$invalidCatalogResults = [System.Collections.Generic.List[object]]::new()
+$entryIndex = 0
 foreach ($entry in @($catalog.checks)) {
     try {
         [void](Assert-CatalogEntry $entry -Because $catalogPath)
         $validatedChecks.Add($entry)
     } catch {
         Write-MachineHealthLog "catalog_entry_invalid skip $($_.Exception.Message)"
+        $invalidCatalogResults.Add((New-InvalidCatalogEntryResult `
+                    -Entry $entry `
+                    -Index $entryIndex `
+                    -ErrorMessage $_.Exception.Message))
     }
+    $entryIndex++
 }
 
 $windowsChecks = @($validatedChecks | Where-Object {
@@ -377,6 +386,11 @@ $batteryReportPath = Join-Path $logsDir "battery-report-$runStamp.html"
 $ranCheckIds = [System.Collections.Generic.List[string]]::new()
 
 $checkResults = [System.Collections.Generic.List[object]]::new()
+# Surface Assert-CatalogEntry failures through the normal reporting path first
+# so a registered-but-invalid check cannot silently vanish from the report.
+foreach ($invalidResult in $invalidCatalogResults) {
+    $checkResults.Add($invalidResult)
+}
 foreach ($entry in $windowsChecks) {
     $scriptPath = Join-Path $skillRoot $entry.script
     if (-not (Test-Path -LiteralPath $scriptPath)) {

--- a/plugins/machine-health/skills/audit/scripts/windows/Invoke-MachineHealthCheck.ps1
+++ b/plugins/machine-health/skills/audit/scripts/windows/Invoke-MachineHealthCheck.ps1
@@ -261,6 +261,16 @@ if (Test-Path -LiteralPath $overlayPath) {
 
 $validatedChecks = [System.Collections.Generic.List[object]]::new()
 $invalidCatalogResults = [System.Collections.Generic.List[object]]::new()
+# Seed occupied ids so synthetic fallbacks never collide with a real catalog id
+# (e.g. invalid DiskSpace at index 2 vs a custom check named invalid-catalog-entry-2).
+$occupiedResultIds = [System.Collections.Generic.HashSet[string]]::new([StringComparer]::Ordinal)
+foreach ($seedEntry in @($catalog.checks)) {
+    if ($null -eq $seedEntry -or -not $seedEntry.PSObject.Properties['id']) { continue }
+    $seedId = [string]$seedEntry.id
+    if ($seedId -cmatch '^[a-z][a-z0-9-]*[a-z0-9]$') {
+        [void]$occupiedResultIds.Add($seedId)
+    }
+}
 $entryIndex = 0
 foreach ($entry in @($catalog.checks)) {
     try {
@@ -268,10 +278,13 @@ foreach ($entry in @($catalog.checks)) {
         $validatedChecks.Add($entry)
     } catch {
         Write-MachineHealthLog "catalog_entry_invalid skip $($_.Exception.Message)"
-        $invalidCatalogResults.Add((New-InvalidCatalogEntryResult `
-                    -Entry $entry `
-                    -Index $entryIndex `
-                    -ErrorMessage $_.Exception.Message))
+        $invalidResult = New-InvalidCatalogEntryResult `
+            -Entry $entry `
+            -Index $entryIndex `
+            -ErrorMessage $_.Exception.Message `
+            -OccupiedIds @($occupiedResultIds)
+        $invalidCatalogResults.Add($invalidResult)
+        [void]$occupiedResultIds.Add([string]$invalidResult.id)
     }
     $entryIndex++
 }

--- a/plugins/machine-health/skills/audit/scripts/windows/lib/Assert-CatalogEntry.ps1
+++ b/plugins/machine-health/skills/audit/scripts/windows/lib/Assert-CatalogEntry.ps1
@@ -11,9 +11,10 @@ function covers the fields and rules the orchestrator relies on.
 
 Returns $true on success; throws on violation with a message that names the
 offending entry by id (or a stable index when id is missing/invalid).
-Callers typically wrap in try/catch and skip invalid entries with a warning
-so a single typo does not prevent the orchestrator from running the rest
-of the catalog.
+Callers typically wrap in try/catch, continue past the bad entry so a single
+typo does not take down the run, and synthesize an UNKNOWN CheckResult via
+New-InvalidCatalogEntryResult so the skip is visible in the report — not only
+in the run log.
 #>
 
 function Assert-CatalogEntry {

--- a/plugins/machine-health/skills/audit/scripts/windows/lib/Merge-CatalogOverlay.ps1
+++ b/plugins/machine-health/skills/audit/scripts/windows/lib/Merge-CatalogOverlay.ps1
@@ -15,8 +15,9 @@ under the state base: catalog/checks.local.jsonc. Merge semantics:
 
 Entries are never deleted by an overlay -- set "enabled": false or
 "deprecated": true instead. Callers validate each merged entry with
-Assert-CatalogEntry afterwards, so a malformed overlay entry is skipped with
-a warning rather than blocking the run.
+Assert-CatalogEntry afterwards; a malformed overlay entry is not dispatched,
+but the orchestrator synthesizes an UNKNOWN CheckResult so the skip appears
+in the report rather than only in the run log.
 #>
 
 function Merge-CatalogOverlay {

--- a/plugins/machine-health/skills/audit/scripts/windows/lib/Merge-CatalogOverlay.ps1
+++ b/plugins/machine-health/skills/audit/scripts/windows/lib/Merge-CatalogOverlay.ps1
@@ -17,7 +17,9 @@ Entries are never deleted by an overlay -- set "enabled": false or
 "deprecated": true instead. Callers validate each merged entry with
 Assert-CatalogEntry afterwards; a malformed overlay entry is not dispatched,
 but the orchestrator synthesizes an UNKNOWN CheckResult so the skip appears
-in the report rather than only in the run log.
+in the report rather than only in the run log. Overlay entries with a missing
+or blank id cannot be keyed into the merge map; they are appended unchanged so
+New-InvalidCatalogEntryResult can still surface them.
 #>
 
 function Merge-CatalogOverlay {
@@ -44,10 +46,15 @@ function Merge-CatalogOverlay {
         $overlayChecks = @($Overlay.checks)
     }
 
+    # Id-less overlay rows are retained (not dropped) so the orchestrator's
+    # Assert-CatalogEntry loop can emit UNKNOWN findings for them.
+    $idLessOverlayEntries = [System.Collections.Generic.List[object]]::new()
     foreach ($patch in $overlayChecks) {
-        if ($null -eq $patch -or -not $patch.PSObject.Properties['id'] -or
+        if ($null -eq $patch) { continue }
+        if (-not $patch.PSObject.Properties['id'] -or
             [string]::IsNullOrWhiteSpace([string]$patch.id)) {
-            Write-Warning 'Merge-CatalogOverlay: overlay entry without id skipped.'
+            Write-Warning 'Merge-CatalogOverlay: overlay entry without id retained for validation reporting.'
+            $idLessOverlayEntries.Add($patch)
             continue
         }
         $id = [string]$patch.id
@@ -66,5 +73,5 @@ function Merge-CatalogOverlay {
         }
     }
 
-    return @($merged.Values)
+    return @($merged.Values) + @($idLessOverlayEntries)
 }

--- a/plugins/machine-health/skills/audit/scripts/windows/lib/New-InvalidCatalogEntryResult.ps1
+++ b/plugins/machine-health/skills/audit/scripts/windows/lib/New-InvalidCatalogEntryResult.ps1
@@ -1,0 +1,77 @@
+#Requires -Version 7.4
+
+<#
+.SYNOPSIS
+Synthesizes a CheckResult for a catalog entry that failed Assert-CatalogEntry.
+
+.DESCRIPTION
+When the orchestrator continues past one bad catalog entry (so a typo does not
+take down the whole run), the skip must still be visible in the report,
+latest.json, and severity_counts — not only in the run log. This helper builds
+a schema-valid UNKNOWN result for that path:
+
+- id: the entry's id when present and kebab-valid; otherwise catalog-entry-<Index>
+- category: the entry's declared category when it is in the enum; otherwise
+  reliability (the audit's own mechanism failed)
+- severity UNKNOWN, ran_successfully false, error = the Assert-CatalogEntry message
+- summary: "catalog entry invalid, check did not run: <first line of error>"
+#>
+
+. (Join-Path $PSScriptRoot 'Write-HealthResult.ps1')
+
+function New-InvalidCatalogEntryResult {
+    [CmdletBinding()]
+    [OutputType([pscustomobject])]
+    param(
+        [Parameter(Mandatory = $false)] $Entry,
+        [Parameter(Mandatory = $true)] [int] $Index,
+        [Parameter(Mandatory = $true)] [string] $ErrorMessage,
+        [ValidateSet('windows', 'macos', 'linux')] [string] $Os = 'windows'
+    )
+
+    $validCategories = @(
+        'config', 'drivers', 'network', 'power', 'reliability',
+        'security', 'services', 'storage', 'updates'
+    )
+
+    $id = "catalog-entry-$Index"
+    if ($null -ne $Entry -and $null -ne $Entry.PSObject.Properties['id']) {
+        $candidateId = [string]$Entry.id
+        if ($candidateId -cmatch '^[a-z][a-z0-9-]*[a-z0-9]$') {
+            $id = $candidateId
+        }
+    }
+
+    $category = 'reliability'
+    if ($null -ne $Entry -and $null -ne $Entry.PSObject.Properties['category']) {
+        $candidateCategory = [string]$Entry.category
+        if ($candidateCategory -in $validCategories) {
+            $category = $candidateCategory
+        }
+    }
+
+    $needsAdmin = $false
+    if ($null -ne $Entry -and $null -ne $Entry.PSObject.Properties['needs_admin'] -and
+        $Entry.needs_admin -is [bool]) {
+        $needsAdmin = $Entry.needs_admin
+    }
+
+    $firstLine = (($ErrorMessage -split '\r?\n') | Select-Object -First 1)
+    if ([string]::IsNullOrWhiteSpace($firstLine)) {
+        $firstLine = 'Assert-CatalogEntry failed'
+    }
+    $summary = "catalog entry invalid, check did not run: $firstLine"
+    if ($summary.Length -gt 240) {
+        $summary = $summary.Substring(0, 237) + '...'
+    }
+
+    return New-HealthResult `
+        -Id $id `
+        -Category $category `
+        -Os $Os `
+        -Severity 'UNKNOWN' `
+        -Summary $summary `
+        -NeedsAdmin $needsAdmin `
+        -RanSuccessfully $false `
+        -ErrorMessage $ErrorMessage
+}

--- a/plugins/machine-health/skills/audit/scripts/windows/lib/New-InvalidCatalogEntryResult.ps1
+++ b/plugins/machine-health/skills/audit/scripts/windows/lib/New-InvalidCatalogEntryResult.ps1
@@ -10,7 +10,8 @@ take down the whole run), the skip must still be visible in the report,
 latest.json, and severity_counts — not only in the run log. This helper builds
 a schema-valid UNKNOWN result for that path:
 
-- id: the entry's id when present and kebab-valid; otherwise catalog-entry-<Index>
+- id: the entry's id when present and kebab-valid; otherwise a reserved
+  invalid-catalog-entry-<Index> fallback that avoids colliding with OccupiedIds
 - category: the entry's declared category when it is in the enum; otherwise
   reliability (the audit's own mechanism failed)
 - severity UNKNOWN, ran_successfully false, error = the Assert-CatalogEntry message
@@ -26,7 +27,9 @@ function New-InvalidCatalogEntryResult {
         [Parameter(Mandatory = $false)] $Entry,
         [Parameter(Mandatory = $true)] [int] $Index,
         [Parameter(Mandatory = $true)] [string] $ErrorMessage,
-        [ValidateSet('windows', 'macos', 'linux')] [string] $Os = 'windows'
+        [ValidateSet('windows', 'macos', 'linux')] [string] $Os = 'windows',
+        # Catalog / already-emitted result ids the fallback must not reuse.
+        [Parameter(Mandatory = $false)] [AllowEmptyCollection()] [string[]] $OccupiedIds = @()
     )
 
     $validCategories = @(
@@ -34,11 +37,28 @@ function New-InvalidCatalogEntryResult {
         'security', 'services', 'storage', 'updates'
     )
 
-    $id = "catalog-entry-$Index"
+    $occupied = [System.Collections.Generic.HashSet[string]]::new([StringComparer]::Ordinal)
+    foreach ($oid in @($OccupiedIds)) {
+        if (-not [string]::IsNullOrWhiteSpace($oid)) {
+            [void]$occupied.Add([string]$oid)
+        }
+    }
+
+    $id = $null
     if ($null -ne $Entry -and $null -ne $Entry.PSObject.Properties['id']) {
         $candidateId = [string]$Entry.id
         if ($candidateId -cmatch '^[a-z][a-z0-9-]*[a-z0-9]$') {
             $id = $candidateId
+        }
+    }
+    if ($null -eq $id) {
+        # Reserved synthetic namespace: not used by shipped checks. Still collide-
+        # check OccupiedIds so a custom overlay named the same stays unique.
+        $id = "invalid-catalog-entry-$Index"
+        $suffix = 2
+        while ($occupied.Contains($id)) {
+            $id = "invalid-catalog-entry-$Index-$suffix"
+            $suffix++
         }
     }
 

--- a/plugins/machine-health/skills/audit/tests/windows/lib/Assert-CatalogEntry.Tests.ps1
+++ b/plugins/machine-health/skills/audit/tests/windows/lib/Assert-CatalogEntry.Tests.ps1
@@ -158,14 +158,14 @@ Describe 'Catalog integration: catalog/checks.jsonc conforms to schema' -Tag 'in
 Describe 'Category vocabulary: schemas and validators agree' -Tag 'lib' {
     # The category enum lives in four places: checks.schema.json,
     # check-result.schema.json, Assert-CatalogEntry, and Assert-CheckResult.
-    # A value present in a schema but missing from a validator silently
-    # disables every check declaring it (the orchestrator skips entries
-    # Assert-CatalogEntry rejects), and a value present in one validator but
-    # not the other admits an overlay entry whose emitted result is then
-    # rejected - so all four copies are compared exactly, in both directions:
-    # the validators' literal $validCategories sets are extracted from the
-    # AST and matched against the schema enums, and each schema value is also
-    # accepted behaviorally.
+    # A value present in a schema but missing from a validator rejects every
+    # check declaring it (Assert-CatalogEntry fails; the orchestrator then
+    # synthesizes UNKNOWN rather than dispatching), and a value present in one
+    # validator but not the other admits an overlay entry whose emitted result
+    # is then rejected - so all four copies are compared exactly, in both
+    # directions: the validators' literal $validCategories sets are extracted
+    # from the AST and matched against the schema enums, and each schema value
+    # is also accepted behaviorally.
     BeforeAll {
         . (Join-Path $script:LibRoot 'Assert-CheckResult.ps1')
         . (Join-Path $script:LibRoot 'Write-HealthResult.ps1')

--- a/plugins/machine-health/skills/audit/tests/windows/lib/Assert-CatalogEntry.Tests.ps1
+++ b/plugins/machine-health/skills/audit/tests/windows/lib/Assert-CatalogEntry.Tests.ps1
@@ -156,16 +156,18 @@ Describe 'Catalog integration: catalog/checks.jsonc conforms to schema' -Tag 'in
 }
 
 Describe 'Category vocabulary: schemas and validators agree' -Tag 'lib' {
-    # The category enum lives in four places: checks.schema.json,
-    # check-result.schema.json, Assert-CatalogEntry, and Assert-CheckResult.
-    # A value present in a schema but missing from a validator rejects every
-    # check declaring it (Assert-CatalogEntry fails; the orchestrator then
-    # synthesizes UNKNOWN rather than dispatching), and a value present in one
-    # validator but not the other admits an overlay entry whose emitted result
-    # is then rejected - so all four copies are compared exactly, in both
-    # directions: the validators' literal $validCategories sets are extracted
-    # from the AST and matched against the schema enums, and each schema value
-    # is also accepted behaviorally.
+    # The category enum lives in five places: checks.schema.json,
+    # check-result.schema.json, Assert-CatalogEntry, Assert-CheckResult, and
+    # New-InvalidCatalogEntryResult. A value present in a schema but missing
+    # from a validator rejects every check declaring it (Assert-CatalogEntry
+    # fails; the orchestrator then synthesizes UNKNOWN rather than
+    # dispatching), and a value present in one validator but not the other
+    # admits an overlay entry whose emitted result is then rejected - so all
+    # five copies are compared exactly, in both directions: the validators'
+    # literal $validCategories sets are extracted from the AST and matched
+    # against the schema enums, and each schema value is also accepted
+    # behaviorally. The synthetic-result helper is included so an entry that
+    # fails on another field does not silently reclassify as reliability.
     BeforeAll {
         . (Join-Path $script:LibRoot 'Assert-CheckResult.ps1')
         . (Join-Path $script:LibRoot 'Write-HealthResult.ps1')
@@ -210,6 +212,11 @@ Describe 'Category vocabulary: schemas and validators agree' -Tag 'lib' {
 
     It 'Assert-CheckResult accepts exactly the schema-declared set (both directions)' {
         $validatorSet = Get-ValidatorCategorySet (Join-Path $script:LibRoot 'Assert-CheckResult.ps1')
+        ($validatorSet | Sort-Object) | Should -Be ($script:ResultCategories | Sort-Object)
+    }
+
+    It 'New-InvalidCatalogEntryResult accepts exactly the schema-declared set (both directions)' {
+        $validatorSet = Get-ValidatorCategorySet (Join-Path $script:LibRoot 'New-InvalidCatalogEntryResult.ps1')
         ($validatorSet | Sort-Object) | Should -Be ($script:ResultCategories | Sort-Object)
     }
 

--- a/plugins/machine-health/skills/audit/tests/windows/lib/Merge-CatalogOverlay.Tests.ps1
+++ b/plugins/machine-health/skills/audit/tests/windows/lib/Merge-CatalogOverlay.Tests.ps1
@@ -115,13 +115,30 @@ Describe 'Merge-CatalogOverlay' {
     }
 
     Context 'malformed overlay entries' {
-        It 'skips an overlay entry without an id' {
+        It 'retains an overlay entry without an id for validation reporting' {
             $overlay = [pscustomobject]@{
-                checks = @([pscustomobject]@{ enabled = $false })
+                checks = @([pscustomobject]@{ enabled = $false; category = 'storage' })
             }
             $out = Merge-CatalogOverlay -BaseChecks @((New-BaseEntry)) -Overlay $overlay -WarningAction SilentlyContinue
-            @($out).Count | Should -Be 1
+            @($out).Count | Should -Be 2
+            $out[0].id | Should -Be 'disk-space'
             $out[0].enabled | Should -BeTrue
+            $idLess = @($out | Where-Object { -not $_.PSObject.Properties['id'] })
+            @($idLess).Count | Should -Be 1
+            $idLess[0].category | Should -Be 'storage'
+        }
+
+        It 'retains an overlay entry with a blank id' {
+            $overlay = [pscustomobject]@{
+                checks = @([pscustomobject]@{ id = '   '; category = 'network' })
+            }
+            $out = Merge-CatalogOverlay -BaseChecks @((New-BaseEntry)) -Overlay $overlay -WarningAction SilentlyContinue
+            @($out).Count | Should -Be 2
+            $blank = @($out | Where-Object {
+                    $_.PSObject.Properties['id'] -and [string]::IsNullOrWhiteSpace([string]$_.id)
+                })
+            @($blank).Count | Should -Be 1
+            $blank[0].category | Should -Be 'network'
         }
     }
 }

--- a/plugins/machine-health/skills/audit/tests/windows/lib/New-InvalidCatalogEntryResult.Tests.ps1
+++ b/plugins/machine-health/skills/audit/tests/windows/lib/New-InvalidCatalogEntryResult.Tests.ps1
@@ -1,0 +1,180 @@
+#Requires -Version 7.4
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.7.0' }
+<#
+.SYNOPSIS
+Tests for scripts/windows/lib/New-InvalidCatalogEntryResult.ps1.
+
+.DESCRIPTION
+Pins the #2575 contract: an Assert-CatalogEntry failure becomes a schema-valid
+UNKNOWN CheckResult that severity_counts / latest.json / the report can see.
+#>
+
+BeforeAll {
+    $script:TestsRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+    $script:SkillRoot = Split-Path -Parent $script:TestsRoot
+    $script:LibRoot = Join-Path $script:SkillRoot 'scripts\windows\lib'
+    . (Join-Path $script:LibRoot 'Assert-CatalogEntry.ps1')
+    . (Join-Path $script:LibRoot 'Assert-CheckResult.ps1')
+    . (Join-Path $script:LibRoot 'New-InvalidCatalogEntryResult.ps1')
+
+    function New-NearlyValidEntry {
+        param([hashtable] $Overrides = @{})
+        $base = [ordered]@{
+            id               = 'chezmoi-drift'
+            category         = 'config'
+            os               = @('windows')
+            script           = 'scripts/windows/checks/Test-ChezmoiDrift.ps1'
+            severity_rules   = 'references/windows/check-catalog.md#custom'
+            needs_admin      = $false
+            enabled          = $true
+            deprecated       = $false
+            added_on         = '2026-08-01'
+            crash_count      = 0
+            identical_streak = 0
+        }
+        foreach ($k in $Overrides.Keys) { $base[$k] = $Overrides[$k] }
+        return [pscustomobject]$base
+    }
+}
+
+Describe 'New-InvalidCatalogEntryResult' -Tag 'lib' {
+    Context 'id selection' {
+        It 'keeps a kebab-valid entry id' {
+            $entry = New-NearlyValidEntry -Overrides @{ category = 'hairdryers' }
+            $result = New-InvalidCatalogEntryResult -Entry $entry -Index 3 `
+                -ErrorMessage "CatalogEntry 'chezmoi-drift' category 'hairdryers' not in allowed set"
+            $result.id | Should -Be 'chezmoi-drift'
+            { Assert-CheckResult $result } | Should -Not -Throw
+        }
+
+        It 'falls back to catalog-entry-N when id is missing' {
+            $entry = [pscustomobject]@{ category = 'storage' }
+            $result = New-InvalidCatalogEntryResult -Entry $entry -Index 7 `
+                -ErrorMessage 'CatalogEntry is missing required field id'
+            $result.id | Should -Be 'catalog-entry-7'
+            { Assert-CheckResult $result } | Should -Not -Throw
+        }
+
+        It 'falls back to catalog-entry-N when id is not kebab-case' {
+            $entry = New-NearlyValidEntry -Overrides @{ id = 'DiskSpace' }
+            $result = New-InvalidCatalogEntryResult -Entry $entry -Index 2 `
+                -ErrorMessage "CatalogEntry.id 'DiskSpace' is not valid kebab-case"
+            $result.id | Should -Be 'catalog-entry-2'
+            { Assert-CheckResult $result } | Should -Not -Throw
+        }
+
+        It 'handles a null entry' {
+            $result = New-InvalidCatalogEntryResult -Entry $null -Index 0 `
+                -ErrorMessage 'CatalogEntry is null.'
+            $result.id | Should -Be 'catalog-entry-0'
+            $result.category | Should -Be 'reliability'
+            { Assert-CheckResult $result } | Should -Not -Throw
+        }
+    }
+
+    Context 'category fallback' {
+        It 'keeps a legal declared category' {
+            $entry = New-NearlyValidEntry -Overrides @{
+                category = 'security'
+                script   = 'checks/broken.ps1'
+            }
+            $result = New-InvalidCatalogEntryResult -Entry $entry -Index 1 `
+                -ErrorMessage "CatalogEntry 'chezmoi-drift' script path is not scripts/<os>/checks/Name.ps1"
+            $result.category | Should -Be 'security'
+            { Assert-CheckResult $result } | Should -Not -Throw
+        }
+
+        It 'falls back to reliability when category is outside the enum' {
+            # Field instance that motivated #2575 before config was added, and
+            # any future typo: invalid category must not make the synthetic
+            # result itself fail Assert-CheckResult.
+            $entry = New-NearlyValidEntry -Overrides @{ category = 'platform' }
+            $result = New-InvalidCatalogEntryResult -Entry $entry -Index 4 `
+                -ErrorMessage "CatalogEntry 'chezmoi-drift' category 'platform' not in allowed set"
+            $result.category | Should -Be 'reliability'
+            $result.severity | Should -Be 'UNKNOWN'
+            $result.ran_successfully | Should -BeFalse
+            { Assert-CheckResult $result } | Should -Not -Throw
+        }
+    }
+
+    Context 'summary and error contract' {
+        It 'sets ran_successfully false, UNKNOWN severity, and the full error' {
+            $msg = "CatalogEntry 'chezmoi-drift' category 'platform' not in allowed set (checks.jsonc)"
+            $entry = New-NearlyValidEntry -Overrides @{ category = 'platform' }
+            $result = New-InvalidCatalogEntryResult -Entry $entry -Index 0 -ErrorMessage $msg
+            $result.severity | Should -Be 'UNKNOWN'
+            $result.ran_successfully | Should -BeFalse
+            $result.error | Should -Be $msg
+            $result.summary | Should -Match '^catalog entry invalid, check did not run:'
+            $result.summary | Should -BeLike "*$($msg.Split("`n")[0])*"
+            { Assert-CheckResult $result } | Should -Not -Throw
+        }
+
+        It 'truncates summary to 240 chars when the error line is long' {
+            $long = 'x' * 300
+            $result = New-InvalidCatalogEntryResult -Entry $null -Index 9 -ErrorMessage $long
+            $result.summary.Length | Should -BeLessOrEqual 240
+            { Assert-CheckResult $result } | Should -Not -Throw
+        }
+    }
+}
+
+Describe 'Orchestrator invalid-catalog loop contract' -Tag 'lib' {
+    # Mirrors the validation loop in Invoke-MachineHealthCheck.ps1: continue
+    # past bad entries for availability, but collect synthetic UNKNOWN results
+    # for the reporting path.
+    It 'collects UNKNOWN results for invalid entries and keeps valid ones' {
+        $valid = New-NearlyValidEntry -Overrides @{
+            id       = 'disk-space'
+            category = 'storage'
+            script   = 'scripts/windows/checks/Test-DiskHealth.ps1'
+        }
+        $invalidCategory = New-NearlyValidEntry -Overrides @{ category = 'platform' }
+        $invalidId = New-NearlyValidEntry -Overrides @{ id = 'NotKebab' }
+
+        $validatedChecks = [System.Collections.Generic.List[object]]::new()
+        $invalidCatalogResults = [System.Collections.Generic.List[object]]::new()
+        $entryIndex = 0
+        foreach ($entry in @($valid, $invalidCategory, $invalidId)) {
+            try {
+                [void](Assert-CatalogEntry $entry -Because 'unit-test-catalog')
+                $validatedChecks.Add($entry)
+            } catch {
+                $invalidCatalogResults.Add((New-InvalidCatalogEntryResult `
+                            -Entry $entry `
+                            -Index $entryIndex `
+                            -ErrorMessage $_.Exception.Message))
+            }
+            $entryIndex++
+        }
+
+        @($validatedChecks).Count | Should -Be 1
+        $validatedChecks[0].id | Should -Be 'disk-space'
+
+        @($invalidCatalogResults).Count | Should -Be 2
+        $invalidCatalogResults[0].id | Should -Be 'chezmoi-drift'
+        $invalidCatalogResults[0].severity | Should -Be 'UNKNOWN'
+        $invalidCatalogResults[0].category | Should -Be 'reliability'
+        $invalidCatalogResults[1].id | Should -Be 'catalog-entry-2'
+        $invalidCatalogResults[1].severity | Should -Be 'UNKNOWN'
+
+        foreach ($r in $invalidCatalogResults) {
+            { Assert-CheckResult $r } | Should -Not -Throw
+        }
+
+        # Severity counts must include the synthetic UNKNOWNs — the defect was
+        # that a skipped entry contributed nothing here.
+        $severityCounts = @{ OK = 0; INFO = 0; WARN = 0; CRIT = 0; UNKNOWN = 0 }
+        foreach ($r in $invalidCatalogResults) { $severityCounts[$r.severity]++ }
+        $severityCounts.UNKNOWN | Should -Be 2
+    }
+
+    It 'orchestrator catch block calls New-InvalidCatalogEntryResult (wiring pin)' {
+        $orchestrator = Join-Path $script:SkillRoot 'scripts\windows\Invoke-MachineHealthCheck.ps1'
+        $text = Get-Content -LiteralPath $orchestrator -Raw
+        $text | Should -Match 'New-InvalidCatalogEntryResult'
+        $text | Should -Match '\$invalidCatalogResults'
+        $text | Should -Match 'catalog_entry_invalid skip'
+    }
+}

--- a/plugins/machine-health/skills/audit/tests/windows/lib/New-InvalidCatalogEntryResult.Tests.ps1
+++ b/plugins/machine-health/skills/audit/tests/windows/lib/New-InvalidCatalogEntryResult.Tests.ps1
@@ -206,7 +206,7 @@ Describe 'Orchestrator invalid-catalog loop contract' -Tag 'lib' {
             { Assert-CheckResult $r } | Should -Not -Throw
         }
 
-        # Severity counts must include the synthetic UNKNOWNs — the defect was
+        # Severity counts must include the synthetic UNKNOWN findings — the defect was
         # that a skipped entry contributed nothing here.
         $severityCounts = @{ OK = 0; INFO = 0; WARN = 0; CRIT = 0; UNKNOWN = 0 }
         foreach ($r in $invalidCatalogResults) { $severityCounts[$r.severity]++ }

--- a/plugins/machine-health/skills/audit/tests/windows/lib/New-InvalidCatalogEntryResult.Tests.ps1
+++ b/plugins/machine-health/skills/audit/tests/windows/lib/New-InvalidCatalogEntryResult.Tests.ps1
@@ -47,27 +47,49 @@ Describe 'New-InvalidCatalogEntryResult' -Tag 'lib' {
             { Assert-CheckResult $result } | Should -Not -Throw
         }
 
-        It 'falls back to catalog-entry-N when id is missing' {
+        It 'falls back to invalid-catalog-entry-N when id is missing' {
             $entry = [pscustomobject]@{ category = 'storage' }
             $result = New-InvalidCatalogEntryResult -Entry $entry -Index 7 `
                 -ErrorMessage 'CatalogEntry is missing required field id'
-            $result.id | Should -Be 'catalog-entry-7'
+            $result.id | Should -Be 'invalid-catalog-entry-7'
             { Assert-CheckResult $result } | Should -Not -Throw
         }
 
-        It 'falls back to catalog-entry-N when id is not kebab-case' {
+        It 'falls back to invalid-catalog-entry-N when id is not kebab-case' {
             $entry = New-NearlyValidEntry -Overrides @{ id = 'DiskSpace' }
             $result = New-InvalidCatalogEntryResult -Entry $entry -Index 2 `
                 -ErrorMessage "CatalogEntry.id 'DiskSpace' is not valid kebab-case"
-            $result.id | Should -Be 'catalog-entry-2'
+            $result.id | Should -Be 'invalid-catalog-entry-2'
             { Assert-CheckResult $result } | Should -Not -Throw
         }
 
         It 'handles a null entry' {
             $result = New-InvalidCatalogEntryResult -Entry $null -Index 0 `
                 -ErrorMessage 'CatalogEntry is null.'
-            $result.id | Should -Be 'catalog-entry-0'
+            $result.id | Should -Be 'invalid-catalog-entry-0'
             $result.category | Should -Be 'reliability'
+            { Assert-CheckResult $result } | Should -Not -Throw
+        }
+
+        It 'avoids colliding with an occupied fallback id' {
+            $entry = New-NearlyValidEntry -Overrides @{ id = 'DiskSpace' }
+            $result = New-InvalidCatalogEntryResult -Entry $entry -Index 2 `
+                -ErrorMessage "CatalogEntry.id 'DiskSpace' is not valid kebab-case" `
+                -OccupiedIds @('invalid-catalog-entry-2', 'other-check')
+            $result.id | Should -Be 'invalid-catalog-entry-2-2'
+            { Assert-CheckResult $result } | Should -Not -Throw
+        }
+
+        It 'keeps escalating the suffix until the fallback is free' {
+            $entry = [pscustomobject]@{ category = 'storage' }
+            $result = New-InvalidCatalogEntryResult -Entry $entry -Index 2 `
+                -ErrorMessage 'missing id' `
+                -OccupiedIds @(
+                    'invalid-catalog-entry-2',
+                    'invalid-catalog-entry-2-2',
+                    'invalid-catalog-entry-2-3'
+                )
+            $result.id | Should -Be 'invalid-catalog-entry-2-4'
             { Assert-CheckResult $result } | Should -Not -Throw
         }
     }
@@ -132,31 +154,52 @@ Describe 'Orchestrator invalid-catalog loop contract' -Tag 'lib' {
         }
         $invalidCategory = New-NearlyValidEntry -Overrides @{ category = 'platform' }
         $invalidId = New-NearlyValidEntry -Overrides @{ id = 'NotKebab' }
+        # A valid custom check whose id matches the old collision-prone fallback
+        # namespace — synthetic ids must still be unique against it.
+        $occupyingFallback = New-NearlyValidEntry -Overrides @{
+            id       = 'invalid-catalog-entry-2'
+            category = 'storage'
+            script   = 'scripts/windows/checks/Test-DiskHealth.ps1'
+        }
+
+        $catalogEntries = @($valid, $invalidCategory, $invalidId, $occupyingFallback)
+        $occupiedResultIds = [System.Collections.Generic.HashSet[string]]::new([StringComparer]::Ordinal)
+        foreach ($seedEntry in $catalogEntries) {
+            $seedId = [string]$seedEntry.id
+            if ($seedId -cmatch '^[a-z][a-z0-9-]*[a-z0-9]$') {
+                [void]$occupiedResultIds.Add($seedId)
+            }
+        }
 
         $validatedChecks = [System.Collections.Generic.List[object]]::new()
         $invalidCatalogResults = [System.Collections.Generic.List[object]]::new()
         $entryIndex = 0
-        foreach ($entry in @($valid, $invalidCategory, $invalidId)) {
+        foreach ($entry in $catalogEntries) {
             try {
                 [void](Assert-CatalogEntry $entry -Because 'unit-test-catalog')
                 $validatedChecks.Add($entry)
             } catch {
-                $invalidCatalogResults.Add((New-InvalidCatalogEntryResult `
-                            -Entry $entry `
-                            -Index $entryIndex `
-                            -ErrorMessage $_.Exception.Message))
+                $invalidResult = New-InvalidCatalogEntryResult `
+                    -Entry $entry `
+                    -Index $entryIndex `
+                    -ErrorMessage $_.Exception.Message `
+                    -OccupiedIds @($occupiedResultIds)
+                $invalidCatalogResults.Add($invalidResult)
+                [void]$occupiedResultIds.Add([string]$invalidResult.id)
             }
             $entryIndex++
         }
 
-        @($validatedChecks).Count | Should -Be 1
+        @($validatedChecks).Count | Should -Be 2
         $validatedChecks[0].id | Should -Be 'disk-space'
+        $validatedChecks[1].id | Should -Be 'invalid-catalog-entry-2'
 
         @($invalidCatalogResults).Count | Should -Be 2
         $invalidCatalogResults[0].id | Should -Be 'chezmoi-drift'
         $invalidCatalogResults[0].severity | Should -Be 'UNKNOWN'
         $invalidCatalogResults[0].category | Should -Be 'reliability'
-        $invalidCatalogResults[1].id | Should -Be 'catalog-entry-2'
+        # Index 2 would have been invalid-catalog-entry-2, but that id is taken.
+        $invalidCatalogResults[1].id | Should -Be 'invalid-catalog-entry-2-2'
         $invalidCatalogResults[1].severity | Should -Be 'UNKNOWN'
 
         foreach ($r in $invalidCatalogResults) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #2575

## Summary

Invalid catalog entries were skipped with only a run-log line, so a registered-but-invalid check was indistinguishable from an unregistered one in the report / `latest.json` / severity counts.

## Fix

Surface invalid catalog entries in the rendered report and machine-readable outputs (not only the run log).

## Verification

See branch CI / machine-health tests on the PR checks.

## Related

Refs #2576 — NOT_IMPLEMENTED docs category mismatch (related defect class).
Refs #2574 — `config` category vocabulary work.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eb3f5ee5-6c9f-48a3-8e46-071bd363f8b0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eb3f5ee5-6c9f-48a3-8e46-071bd363f8b0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

