### PR TITLE
fix(repo-fleet-hygiene): degrade non-repo paths under --root

### DIFF
--- a/plugins/repo-fleet-hygiene/.claude-plugin/plugin.json
+++ b/plugins/repo-fleet-hygiene/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "repo-fleet-hygiene",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "Read-only Git/GitHub fleet audit for merged local branches, orphaned or mismatched worktree registrations, and repository transfers or renames. Findings are confidence-tiered and hand off exact targets to existing per-repository cleanup tools; this plugin never deletes branches or worktrees.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/repo-fleet-hygiene/CHANGELOG.md
+++ b/plugins/repo-fleet-hygiene/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to `repo-fleet-hygiene` are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.14.1]
+
+### Fixed
+
+- **Discovery husks under `--root` no longer abort the fleet (#2598).** A path discovered beneath a
+  `--root` that is unreadable or not a Git working tree (despite a `.git` marker) now degrades
+  per-entry like a stale config entry: the audit continues, the header reports
+  `Discovery skips: N non-repository, M unreadable`, and each `.git` husk becomes an `UNKNOWN`
+  `discovery-skip` finding. An explicitly supplied `--repo` that is not a working tree still
+  hard-fails. SKILL.md graceful degradation and the confidence-model tier table updated to match.
+
 ## [0.14.0]
 
 ### Changed

--- a/plugins/repo-fleet-hygiene/skills/audit/SKILL.md
+++ b/plugins/repo-fleet-hygiene/skills/audit/SKILL.md
@@ -162,6 +162,10 @@ do not turn "no verified finding" into "fleet is clean".
   per-entry, not per-run: the entry becomes an `UNKNOWN` `stale-config-entry` finding and the rest of
   the fleet is still audited (deleting repositories right after an audit must not abort every
   subsequent run until the config is edited).
+- A path discovered under `--root` that is unreadable or not a Git working tree (despite a `.git`
+  marker) degrades the same way: an `UNKNOWN` `discovery-skip` finding, header skip counts, and the
+  rest of the fleet is still audited. An explicitly named `--repo` that is not a working tree still
+  hard-fails.
 - `gh` missing/unauthenticated or API/timeout failure: continue Git/worktree checks, report GitHub
   evidence as `UNKNOWN`, and make no merged/migration claim. Compatible `timeout`/`gtimeout` is
   preferred; otherwise use the collector's finite TERM-to-KILL Bash watchdog.

--- a/plugins/repo-fleet-hygiene/skills/audit/reference/confidence-model.md
+++ b/plugins/repo-fleet-hygiene/skills/audit/reference/confidence-model.md
@@ -53,6 +53,7 @@ failure rather than a discovery.
 | `git-common-dir-unavailable` | The canonical checkout's own `--git-common-dir` could not be resolved | `UNKNOWN` | Stop that repository; registration comparison is impossible |
 | `local-ancestry-unavailable` | `git merge-base --is-ancestor` failed with an error status | `UNKNOWN` | Do not infer local ancestry |
 | `stale-config-entry` | A config-sourced `fleet.root`/`fleet.repo` path is missing or not a Git working tree | `UNKNOWN` | Entry skipped, rest of the fleet still audited; correct or remove the entry |
+| `discovery-skip` | A path discovered under `--root` is unreadable or not a Git working tree despite a `.git` marker | `UNKNOWN` | Path skipped, rest of the fleet still audited; inspect unexpected `.git` markers |
 
 ## What the tiers depend on
 

--- a/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.sh
+++ b/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.sh
@@ -526,14 +526,20 @@ RETARGETED_TO=()
 # printed yet, so they are emitted as per-entry UNKNOWN findings once it has.
 STALE_CONFIG_PATHS=()
 STALE_CONFIG_REASONS=()
+# Discovery-sourced paths that looked like repositories (had a .git marker) but failed validation.
+# Same per-entry degradation as config: one husk under a --root must not abort the fleet.
+DISCOVERY_SKIP_PATHS=()
+DISCOVERY_SKIP_REASONS=()
+DISCOVERY_NONREPO_COUNT=0
+DISCOVERY_UNREADABLE_COUNT=0
 # reject_target <origin> <message>: apply the rejection policy for a target that failed a
-# prerequisite. "config" returns 1 so the caller records a stale-config entry and continues; every
-# other origin stops the run. "default" is the implicit no-argument target — the same hard failure,
-# plus the scope remedies, because the operator did not choose this path and the bare rejection
-# gives them nothing to act on.
+# prerequisite. "config" and "discovery" return 1 so the caller records a per-entry skip and
+# continues; every other origin stops the run. "default" is the implicit no-argument target — the
+# same hard failure, plus the scope remedies, because the operator did not choose this path and the
+# bare rejection gives them nothing to act on.
 reject_target() {
   local origin="$1" message="$2"
-  [[ "$origin" == "config" ]] && return 1
+  [[ "$origin" == "config" || "$origin" == "discovery" ]] && return 1
   printf 'Error: ' >&2
   display_value "$message" >&2
   printf '\n' >&2
@@ -591,28 +597,62 @@ main_worktree() {
   printf '%s\n' "$record"
 }
 
+# record_rejected_target <origin> <candidate> <config_reason> <discovery_reason>: after reject_target
+# returned (config/discovery), append the matching per-entry skip record. CLI/default never reach
+# here — reject_target exits for those origins.
+record_rejected_target() {
+  local origin="$1" candidate="$2" config_reason="$3" discovery_reason="$4"
+  if [[ "$origin" == "config" ]]; then
+    STALE_CONFIG_PATHS+=("$candidate")
+    STALE_CONFIG_REASONS+=("$config_reason")
+  elif [[ "$origin" == "discovery" ]]; then
+    DISCOVERY_SKIP_PATHS+=("$candidate")
+    DISCOVERY_SKIP_REASONS+=("$discovery_reason")
+    if [[ "$discovery_reason" == *"not readable"* ]]; then
+      DISCOVERY_UNREADABLE_COUNT=$((DISCOVERY_UNREADABLE_COUNT + 1))
+    else
+      DISCOVERY_NONREPO_COUNT=$((DISCOVERY_NONREPO_COUNT + 1))
+    fi
+  fi
+}
+
+# discovery_skip_reason <candidate> <fallback>: prefer an unreadable classification when the path
+# cannot be entered; otherwise the caller-supplied non-repository reason.
+discovery_skip_reason() {
+  local candidate="$1" fallback="$2"
+  if [[ ! -r "$candidate" || ! -x "$candidate" ]]; then
+    printf '%s\n' "discovered path is not readable"
+  else
+    printf '%s\n' "$fallback"
+  fi
+}
+
 # add_target <path> <origin>: origin "cli" hard-fails on an invalid path (a typo should stop the
 # run); origin "default" hard-fails with the scope remedies; origin "config" records a
 # stale-config-entry and continues (the entry, not the run, is the failure unit for a tracked fleet
-# config). Invalid config SYNTAX still hard-fails upstream.
+# config); origin "discovery" records a discovery-skip and continues (a husk under --root must not
+# abort every subsequent repository). Invalid config SYNTAX still hard-fails upstream.
 add_target() {
   local candidate="$1" origin="${2:-cli}" top common common_key existing main_top main_resolved rt_known rt_existing
   if [[ ! -d "$candidate" ]]; then
     reject_target "$origin" "repository directory not found: $candidate"
-    STALE_CONFIG_PATHS+=("$candidate")
-    STALE_CONFIG_REASONS+=("configured fleet.repo path is not a directory")
+    record_rejected_target "$origin" "$candidate" \
+      "configured fleet.repo path is not a directory" \
+      "$(discovery_skip_reason "$candidate" "discovered path is not a directory")"
     return 0
   fi
   top="$(run_git_probe -C "$candidate" rev-parse --show-toplevel 2>/dev/null | tr -d '\r')" || {
     reject_target "$origin" "not a Git working tree: $candidate"
-    STALE_CONFIG_PATHS+=("$candidate")
-    STALE_CONFIG_REASONS+=("configured fleet.repo path is not a Git working tree")
+    record_rejected_target "$origin" "$candidate" \
+      "configured fleet.repo path is not a Git working tree" \
+      "$(discovery_skip_reason "$candidate" "discovered path is not a Git working tree")"
     return 0
   }
   common="$(run_git_probe -C "$candidate" rev-parse --path-format=absolute --git-common-dir 2>/dev/null | tr -d '\r')" || {
     reject_target "$origin" "cannot resolve Git common directory: $candidate"
-    STALE_CONFIG_PATHS+=("$candidate")
-    STALE_CONFIG_REASONS+=("cannot resolve the Git common directory for the configured path")
+    record_rejected_target "$origin" "$candidate" \
+      "cannot resolve the Git common directory for the configured path" \
+      "$(discovery_skip_reason "$candidate" "cannot resolve the Git common directory for the discovered path")"
     return 0
   }
   # Siblings sharing one common directory are one repository, and the dedup below keeps whichever
@@ -679,8 +719,21 @@ done
 discover_repositories() {
   local dir="$1" depth="$2" child name
   [[ -d "$dir" && ! -L "$dir" ]] || return 0
+  # Unreadable directories are ordinary under a volume-wide --root (e.g. Windows $RECYCLE.BIN).
+  # Count and move on; never abort the walk. A .git marker that is somehow still visible is recorded
+  # as a discovery skip so the header's unreadable count is not the only signal.
+  if [[ ! -r "$dir" || ! -x "$dir" ]]; then
+    if [[ -e "$dir/.git" ]]; then
+      reject_target discovery "not a Git working tree: $dir"
+      record_rejected_target discovery "$dir" "" "discovered path is not readable"
+    else
+      DISCOVERY_UNREADABLE_COUNT=$((DISCOVERY_UNREADABLE_COUNT + 1))
+    fi
+    return 0
+  fi
   if [[ -d "$dir/.git" || -f "$dir/.git" ]]; then
-    add_target "$dir"
+    # Discovery origin: a .git marker that is not a usable working tree degrades per-entry.
+    add_target "$dir" discovery
     return 0
   fi
   [[ "$depth" -lt "$MAX_DEPTH" ]] || return 0
@@ -721,10 +774,10 @@ for root in "${ROOT_ARGS[@]:-}"; do
   ROOT_COUNTS+=($((${#TARGETS[@]} - root_before)))
 done
 
-# An all-stale config (every entry deleted since the last run) must still produce a report whose
-# stale-config-entry findings tell the user what to remediate -- hard-fail only when there is
-# neither a target to audit nor a stale entry to report.
-if [[ ${#TARGETS[@]} -eq 0 && ${#STALE_CONFIG_PATHS[@]} -eq 0 ]]; then
+# An all-stale config (every entry deleted since the last run) or a --root that found only husks
+# must still produce a report whose per-entry skip findings tell the user what happened -- hard-fail
+# only when there is neither a target to audit nor a skip entry to report.
+if [[ ${#TARGETS[@]} -eq 0 && ${#STALE_CONFIG_PATHS[@]} -eq 0 && ${#DISCOVERY_SKIP_PATHS[@]} -eq 0 ]]; then
   fail "no Git working trees found in the requested scope"
 fi
 
@@ -1489,6 +1542,13 @@ for ((root_index = 0; root_index < ${#ROOT_LABELS[@]}; root_index++)); do
   display_value "${ROOT_LABELS[$root_index]}"
   printf ': %s repositories\n' "${ROOT_COUNTS[$root_index]}"
 done
+# Discovery walks directories that are mostly not repositories; when a .git marker fails validation
+# (or a directory is unreadable), the path is skipped rather than aborting. Report the counts so
+# silence is not mistaken for a complete walk.
+if [[ ${#ROOT_LABELS[@]} -gt 0 ]]; then
+  printf 'Discovery skips: %s non-repository, %s unreadable\n' \
+    "$DISCOVERY_NONREPO_COUNT" "$DISCOVERY_UNREADABLE_COUNT"
+fi
 
 # Config-sourced entries that failed per-entry validation during argument processing (the header
 # had not printed yet); each is a visible finding, never a silent skip.
@@ -1498,6 +1558,15 @@ for ((stale_index = 0; stale_index < ${#STALE_CONFIG_PATHS[@]}; stale_index++));
     "${STALE_CONFIG_REASONS[$stale_index]} (source: $CONFIG_FILE)" \
     "Entry skipped; the rest of the fleet was audited" \
     "Remove or correct the entry via /repo-fleet-hygiene:setup apply, or restore the path, then rerun"
+done
+
+# Discovery-sourced husks/unreadable paths with a .git marker; same visibility rule as stale config.
+for ((skip_index = 0; skip_index < ${#DISCOVERY_SKIP_PATHS[@]}; skip_index++)); do
+  printf '\n'
+  emit_finding UNKNOWN discovery-skip "${DISCOVERY_SKIP_PATHS[$skip_index]}" \
+    "${DISCOVERY_SKIP_REASONS[$skip_index]}" \
+    "Path skipped; the rest of the fleet was audited" \
+    "No action required for ordinary non-repositories; inspect unexpected .git markers, then rerun"
 done
 
 for target in "${TARGETS[@]}"; do

--- a/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.test.sh
+++ b/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.test.sh
@@ -4,7 +4,7 @@ set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SCRIPT="$SCRIPT_DIR/audit-fleet.sh"
 TMP="$(mktemp -d)"
-trap 'rm -rf "$TMP"' EXIT
+trap 'chmod -R u+rwx "$TMP" >/dev/null 2>&1 || true; rm -rf "$TMP"' EXIT
 
 MOCK_BIN="$TMP/bin"
 mkdir -p "$MOCK_BIN" "$TMP/config" "$TMP/discovered-a" "$TMP/canonical-a" "$TMP/repo-b" "$TMP/old-repo" \
@@ -19,7 +19,9 @@ mkdir -p "$MOCK_BIN" "$TMP/config" "$TMP/discovered-a" "$TMP/canonical-a" "$TMP/
   "$TMP/wt-root/aaa-linked" "$TMP/wt-root/bbb-linked" "$TMP/wt-root/zzz-canonical/.git" \
   "$TMP/wt-admin/sub-wt" "$TMP/wt-admin/sep-wt" \
   "$TMP/canonical-a/.claude/worktrees/nested" "$TMP/canonical-a/husk" \
-  "$TMP/prefix-fail"
+  "$TMP/prefix-fail" \
+  "$TMP/mix-root/mix-good/.git" "$TMP/mix-root/mix-husk/.git" "$TMP/mix-root/plain-dir" \
+  "$TMP/mix-root/unreadable-dir"
 # Canonical-selection fixture: a LINKED worktree whose directory name sorts before its own main
 # worktree under LC_ALL=C, so bounded discovery reaches it first. A linked worktree carries .git as
 # a FILE, the main worktree as a DIRECTORY; both resolve to the same --git-common-dir, so whichever
@@ -30,6 +32,18 @@ mkdir -p "$MOCK_BIN" "$TMP/config" "$TMP/discovered-a" "$TMP/canonical-a" "$TMP/
 # both reach the retarget path, which must refuse to adopt an administrative directory as canonical.
 : >"$TMP/wt-admin/sub-wt/.git"
 : >"$TMP/wt-admin/sep-wt/.git"
+# mix-husk carries a .git directory so discovery treats it as a candidate, but the mock makes
+# --show-toplevel fail — the per-entry discovery-skip path under --root (#2598).
+# unreadable-dir has no usable contents; discovery must count it and continue, never abort.
+# Mode bits alone do not deny root (or some ACL hosts): Bash -r/-x still succeed, so probe the
+# fixture the same way discovery will and only assert a non-zero unreadable count when effective.
+chmod a-rwx "$TMP/mix-root/unreadable-dir"
+EXPECT_MIX_UNREADABLE=0
+if [[ ! -r "$TMP/mix-root/unreadable-dir" || ! -x "$TMP/mix-root/unreadable-dir" ]]; then
+  EXPECT_MIX_UNREADABLE=1
+else
+  printf 'SKIP: unreadable-dir fixture ineffective after chmod a-rwx (root/ACL/filesystem); asserting 0 unreadable. Exercised on unprivileged POSIX hosts.\n' >&2
+fi
 : >"$TMP/calls.log"
 
 cat >"$MOCK_BIN/git" <<'EOF'
@@ -69,6 +83,7 @@ rev-parse)
     dup-a) printf '%s\n' "$TEST_ROOT/dup-a" ;;
     new-clone) printf '%s\n' "$TEST_ROOT/new-clone" ;;
     root-repo) printf '%s\n' "$TEST_ROOT/root/acme/root-repo" ;;
+    mix-good) printf '%s\n' "$TEST_ROOT/mix-root/mix-good" ;;
     discovered-c | canonical-c) printf '%s\n' "$TEST_ROOT/canonical-c" ;;
     gone-repo) printf '%s\n' "$TEST_ROOT/gone-repo" ;;
     lost-repo) printf '%s\n' "$TEST_ROOT/lost-repo" ;;
@@ -127,6 +142,7 @@ rev-parse)
     dup-a) printf '%s\n' "$TEST_ROOT/dup-a/.git" ;;
     new-clone) printf '%s\n' "$TEST_ROOT/new-clone/.git" ;;
     root-repo) printf '%s\n' "$TEST_ROOT/root/acme/root-repo/.git" ;;
+    mix-good) printf '%s\n' "$TEST_ROOT/mix-root/mix-good/.git" ;;
     discovered-c | canonical-c) printf '%s\n' "$TEST_ROOT/canonical-c/.git" ;;
     gone-repo) printf '%s\n' "$TEST_ROOT/gone-repo/.git" ;;
     lost-repo) printf '%s\n' "$TEST_ROOT/lost-repo/.git" ;;
@@ -157,6 +173,7 @@ remote)
     dup-a) printf '%s\n' 'https://github.com/acme/repo-b.git' ;;
     new-clone) printf '%s\n' 'https://github.com/new/repo.git' ;;
     root-repo) printf '%s\n' 'https://github.com/acme/root-repo.git' ;;
+    mix-good) printf '%s\n' 'https://github.com/acme/mix-good.git' ;;
     discovered-c | canonical-c) printf '%s\n' 'https://github.com/acme/repo-c.git' ;;
     gone-repo) printf '%s\n' 'https://github.com/gone/away.git' ;;
     lost-repo) printf '%s\n' 'https://github.com/lost/cause.git' ;;
@@ -215,6 +232,9 @@ worktree)
   root-repo)
     printf 'worktree %s\0HEAD root-main\0branch refs/heads/main\0\0' "$TEST_ROOT/root/acme/root-repo"
     ;;
+  mix-good)
+    printf 'worktree %s\0HEAD mix-main\0branch refs/heads/main\0\0' "$TEST_ROOT/mix-root/mix-good"
+    ;;
   canonical-c)
     printf 'worktree %s\0HEAD main-c\0branch refs/heads/main\0\0' "$TEST_ROOT/canonical-c"
     ;;
@@ -252,7 +272,7 @@ symbolic-ref)
 branch)
   case "$base" in
   canonical-a) printf '%s\n' main ;;
-  repo-b | old-repo | root-repo | wt-fail | ref-fail | rref-fail | dup-a | new-clone | canonical-c | gone-repo | lost-repo | net-repo) printf '%s\n' main ;;
+  repo-b | old-repo | root-repo | mix-good | wt-fail | ref-fail | rref-fail | dup-a | new-clone | canonical-c | gone-repo | lost-repo | net-repo) printf '%s\n' main ;;
   aaa-linked | bbb-linked | zzz-canonical) printf '%s\n' main ;;
   sub-wt | sep-wt) printf '%s\n' main ;;
   esac
@@ -297,6 +317,7 @@ for-each-ref)
   dup-a) printf 'main\tdup-main\0\n' ;;
   new-clone) printf 'main\tnc-main\0\n' ;;
   root-repo) printf 'main\troot-main\0\n' ;;
+  mix-good) printf 'main\tmix-main\0\n' ;;
   canonical-c) printf 'main\tmain-c\0\n' ;;
   gone-repo) printf 'main\tgone-main\0\n' ;;
   lost-repo) printf 'main\tlost-main\0\n' ;;
@@ -345,6 +366,7 @@ api)
   repos/acme/repo-a) printf 'acme/repo-a\tmain' ;;
   repos/acme/repo-b) printf 'acme/repo-b\tmain' ;;
   repos/acme/root-repo) printf 'acme/root-repo\tmain' ;;
+  repos/acme/mix-good) printf 'acme/mix-good\tmain' ;;
   repos/acme/bad) printf 'acme/bad\tmain' ;;
   repos/acme/wt-fail) printf 'acme/wt-fail\tmain' ;;
   repos/acme/ref-fail) printf 'acme/ref-fail\tmain' ;;
@@ -370,7 +392,7 @@ pr)
     printf '42\tstale/changed\tmerged-tip\t2026-07-02T00:00:00Z\thttps://github.com/acme/repo-a/pull/42\n'
     printf '43\tstale/gone\tother-tip\t2026-07-03T00:00:00Z\thttps://github.com/acme/repo-a/pull/43\n'
     ;;
-  github.com/acme/repo-b | github.com/acme/root-repo | github.com/acme/repo-c) ;;
+  github.com/acme/repo-b | github.com/acme/root-repo | github.com/acme/mix-good | github.com/acme/repo-c) ;;
   # Resolved identity for the moved-remote fixture: merge evidence must be queried here, not under
   # the stale configured remote (old/repo). Exact-OID rows prove branch/worktree analysis continued.
   github.com/new/repo)
@@ -588,6 +610,7 @@ else
 fi
 assert_contains "per-root discovered count for a contributing root" "../root: 1 repositories"
 assert_contains "zero-contribution root stays visible in the header" "../emptyroot: 0 repositories"
+assert_contains "discovery skip counts reported in the header" "Discovery skips: 0 non-repository, 0 unreadable"
 
 # Empty remote-ref inventory (repo-b: refs/remotes scan returns nothing with exit 0) must reach
 # and survive the exact-fallback gate loop -- on bash <= 4.3 an unguarded empty-array expansion
@@ -808,6 +831,35 @@ elif grep -Fq "repository directory not found" "$ladder_out"; then
   printf 'PASS: CLI-supplied missing repo hard-fails\n'
 else
   printf 'FAIL: CLI-supplied missing repo hard-fails (wrong error)\n' >&2
+  failures=$((failures + 1))
+fi
+
+# Discovery under --root must degrade per-entry for a .git husk (and count unreadable dirs), never
+# abort the fleet the way an explicit --repo typo does (#2598).
+REPO_FLEET_TEST_FAST_TIMEOUTS=1 CLAUDE_PROJECT_DIR="$TMP/discovered-a" HOME="$TMP/nohome" \
+  bash "$SCRIPT" --root "$TMP/mix-root" >"$ladder_out" 2>&1
+mix_status=$?
+if [[ "$mix_status" -ne 0 ]]; then
+  printf 'FAIL: --root with a non-repository husk aborted the audit (exit %s)\n' "$mix_status" >&2
+  failures=$((failures + 1))
+elif grep -Fq "Repo: $TMP/mix-root/mix-good" "$ladder_out" &&
+  grep -Fq "Finding: discovery-skip" "$ladder_out" &&
+  grep -A3 -F "Finding: discovery-skip" "$ladder_out" | grep -Fq "$TMP/mix-root/mix-husk" &&
+  grep -Fq "Discovery skips: 1 non-repository, ${EXPECT_MIX_UNREADABLE} unreadable" "$ladder_out" &&
+  ! grep -Fq "Error: not a Git working tree" "$ladder_out"; then
+  printf 'PASS: discovery husk degrades per-entry and audits siblings under --root\n'
+else
+  printf 'FAIL: discovery husk degrades per-entry and audits siblings under --root\n' >&2
+  failures=$((failures + 1))
+fi
+# The same husk named explicitly via --repo remains a hard failure — operator typo, not discovery.
+if REPO_FLEET_TEST_FAST_TIMEOUTS=1 bash "$SCRIPT" --repo "$TMP/mix-root/mix-husk" >"$ladder_out" 2>&1; then
+  printf 'FAIL: explicit --repo on a discovery husk did not hard-fail\n' >&2
+  failures=$((failures + 1))
+elif grep -Fq "not a Git working tree" "$ladder_out" && ! grep -Fq "discovery-skip" "$ladder_out"; then
+  printf 'PASS: explicit --repo on a discovery husk still hard-fails\n'
+else
+  printf 'FAIL: explicit --repo on a discovery husk still hard-fails (wrong output)\n' >&2
   failures=$((failures + 1))
 fi
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #2598

## Summary

A single non-repository or unreadable path under `--root` aborted the entire fleet audit, making realistic trees (e.g. a drive root) unusable.

## Fix

Degrade discovery-sourced non-repo / unreadable paths per-entry (continue the audit; surface skip/unknown) instead of hard-failing the run.

## Verification

See `audit-fleet.test.sh` on PR checks.

## Related

Refs #2597 — fleet hygiene epic.
Refs #2602 — bare-with-live-tree anomaly (related silent omission class).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eb3f5ee5-6c9f-48a3-8e46-071bd363f8b0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eb3f5ee5-6c9f-48a3-8e46-071bd363f8b0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

