### PR TITLE
feat(disk-hygiene): prioritize tidiness over reclaimable bytes in reports

### DIFF
--- a/plugins/disk-hygiene/.claude-plugin/plugin.json
+++ b/plugins/disk-hygiene/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "disk-hygiene",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "description": "Context-aware disk hygiene for arbitrary directory trees: inventories orphaned and temporary artifacts, classifies evidence into review tiers, and offers exact-path cleanup only after a fresh safety preview and explicit per-tier approval. The target is read-only by default; OS-managed paths, links and mount points, VCS-tracked content, changed entries, and live-handle uncertainty fail closed.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/disk-hygiene/CHANGELOG.md
+++ b/plugins/disk-hygiene/CHANGELOG.md
@@ -3,6 +3,27 @@
 All notable changes to the `disk-hygiene` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.19.0]
+
+### Fixed
+
+- **Empty-directory counting is linear in inventory size (#2590).** Snapshot finalization
+  precomputes parent paths once instead of scanning the full inventory per directory, so the
+  tidiness metric stays tractable near the 250,000-entry limit.
+- **Scan-error directories are not counted as empty (#2590).** When `os.scandir` fails, the
+  directory is recorded as not-walked (unknown) and excluded from `empty_directory_count`, so a
+  coverage gap is not reported as empty residue.
+
+### Changed
+
+- **Reporting is tidiness-first; reclaimable bytes are secondary (#2590).** Skill guidance,
+  scan/preview/apply report fields, and the approval table now lead with provenance, what an
+  entry is, why it is removable, and risk. Empty directories stay first-class and rankable via
+  snapshot `empty_directory_count`, preview `empty_directory` / `empty_directories`, and apply
+  `paths_removed` / `empty_directories_removed`. Byte totals remain available but no longer
+  frame the run. Plan candidates require `provenance` and `risk` alongside the existing
+  evidence fields.
+
 ## [0.18.0]
 
 ### Added

--- a/plugins/disk-hygiene/README.md
+++ b/plugins/disk-hygiene/README.md
@@ -3,7 +3,8 @@
 `/disk-hygiene:clean` audits an arbitrary directory tree for abandoned temporary files, stale locks,
 failed atomic-write remnants, empty leftovers, and similar disk residue. It is a context-aware audit,
 not a static delete list: bundled patterns are discovery hints only, and every finding needs evidence
-that it is not work product.
+that it is not work product. Safe tidiness is the primary objective; reclaimable bytes are a
+secondary signal, so zero-byte and empty-directory residue stay visible in reports.
 
 The default lane is read-only. Cleanup is available only through a fresh, exact-path preview followed
 by explicit approval of one confidence tier. The engine then rechecks every candidate before removing
@@ -15,6 +16,10 @@ unvalidated tree.
 - The side-effecting skill is manual-only (`disable-model-invocation: true`). Automated, scheduled,
   remote, or otherwise unattended sessions audit and stop.
 - Confidence controls report ordering, never authorization. High, medium, and low each require a
+  separate approval naming every path. Per-entry reports lead with provenance, what the entry is,
+  why it is removable, and risk; logical byte counts are secondary and do not drop empty
+  directories from the ranking.
+- Filesystem roots, mount targets, OS-managed roots on every Windows volume, user shell-folder roots,
   separate approval naming every path and its logical byte count.
 - Filesystem roots, mount targets, OS-managed roots on every Windows volume (unless addressed only
   via `--root-children` with an explicit child selection), user shell-folder roots,
@@ -33,9 +38,9 @@ unvalidated tree.
 - Deletion walks the validated snapshot bottom-up. New entries are not traversed; they make the
   directory non-empty and therefore skipped. After captured children are removed, a directory is
   reopened with `O_NOFOLLOW`, checked empty through its descriptor, and matched by device, inode, and
-  type immediately before descriptor-relative `rmdir`. The report separates removed, locked, changed,
-  protected, needs-elevation, and unverified outcomes and records logical bytes plus observed
-  free-space delta.
+  type immediately before descriptor-relative `rmdir`. The report leads with tidiness outcomes
+  (paths removed, empty directories cleared, skips) and records logical / reclaimable bytes plus
+  observed free-space delta as secondary figures.
 
 The execution lane is Linux-only. It reads the current mount namespace from `/proc/self/mountinfo`,
 re-discovers protections and Git state, opens every parent through `O_NOFOLLOW` directory descriptors,

--- a/plugins/disk-hygiene/skills/clean/SKILL.md
+++ b/plugins/disk-hygiene/skills/clean/SKILL.md
@@ -31,7 +31,8 @@ metadata:
 # Disk hygiene
 
 Audit first; mutate only after a fresh deterministic preview and explicit approval of one tier. A
-filename pattern is a discovery hint, never proof that an entry is junk. Read
+filename pattern is a discovery hint, never proof that an entry is junk. **Safe tidiness is the
+primary objective; reclaimed bytes are secondary.** Read
 [the safety model](reference/safety-model.md) before the optional execution lane.
 
 ## Arguments and boundaries
@@ -212,7 +213,8 @@ For each hinted or suspicious entry, inspect enough neighboring content and meta
 
 ## 3. Classify and report
 
-Confidence is report priority, not permission:
+Safe tidiness leads; reclaimed space follows. Confidence is report priority, not permission — and
+byte size is never a ranking key:
 
 | Tier | Minimum evidence | Default outcome |
 |---|---|---|
@@ -220,9 +222,25 @@ Confidence is report priority, not permission:
 | Medium | Likely disposable, but one ownership/provenance fact is indirect | Review, then optionally offer its own approval |
 | Low | Name/age-only, conflicting signals, resumable or user-content possibility | Keep unless the human separately reviews and approves exact paths |
 
-Report every finding with path, logical bytes, tier, evidence, owner/native-GC result, why it is not
-work product, and disposition. Separately list protected, locked, needs-elevation, unverified, and
-coverage-gap entries. Empty directories are not inherently junk.
+Report every finding with these fields, in this order — size last:
+
+1. **Provenance** — where it came from, resolved from evidence (a manifest, a config's own
+   contents, an owning repository's source, a documented naming contract), never guessed from the
+   name alone.
+2. **What it is** — intent / role of the entry (`reason` in engine plans).
+3. **Why removable** — why it is not work product, plus owner / native-GC result.
+4. **Risk** — what could go wrong if it is removed (and why that risk is acceptable at this tier).
+5. Path, tier, evidence, disposition.
+6. Logical / reclaimable bytes as a **secondary** signal only.
+
+Separately list protected, locked, needs-elevation, unverified, and coverage-gap entries.
+
+**Empty directories are first-class findings.** They are not inherently junk, but zero-byte residue
+must stay visible and rankable: never drop an empty directory from investigation or from the report
+because it reclaims nothing. Prefer ranking by tier, location sensitivity (for example volume-root
+or home-root orphans), and provenance strength over byte totals. The snapshot's
+`empty_directory_count` and each preview candidate's `empty_directory` flag exist so empty dirs do
+not disappear under byte-centric roll-ups.
 
 An entry's `logical_size` is reclaimable local bytes only when its `size_qualifiers` is empty.
 Exclude every qualified entry from any reclaimable-bytes total and state the qualified bytes
@@ -233,7 +251,8 @@ so `logical_size` is `null` rather than `0` — except on the target's own recor
 partial walked sum alongside a `not-walked` qualifier, so read that number as a floor. Prefer the
 snapshot's `target_reclaimable_local_bytes` (and preview/apply `reclaimable_local_bytes*`) over summing
 `logical_size` yourself — folding qualified or unknown sizes into a total claims space that
-deleting the path would never return.
+deleting the path would never return. Never treat a low or zero reclaimable-byte figure as a reason
+to skip a finding that otherwise clears the evidence bar.
 
 ## 4. Build one exact-tier plan
 
@@ -247,9 +266,11 @@ Only when `--execute` was requested, write `<run-dir>/plan-<tier>.json`; never m
     {
       "path": "relative/exact.tmp",
       "tier": "high",
+      "provenance": "documented atomic-write staging name; owner process absent",
       "reason": "failed atomic-write staging file",
       "evidence": ["documented name shape", "owner process absent"],
       "why_not_work_product": "generated staging bytes with no durable consumer",
+      "risk": "low — regenerable staging residue; no live consumer",
       "owner": "unmanaged"
     }
   ]
@@ -275,10 +296,11 @@ handles from current state rather than trusting snapshot annotations. It also pr
 directory-descriptor prerequisites. Windows and macOS return `execution-platform-unsupported`. Any
 blocker means no approval prompt and no deletion. Fix nothing behind the gate; rescan.
 
-When status is `ready-for-explicit-approval`, show a table naming every path, the single tier, logical
-bytes, and the preview's approval token, then pass the [confirmation gate](#confirmation-gate) — the
-approval must name **exactly that tier and list**. Process another tier only with a new plan, preview,
-and question.
+When status is `ready-for-explicit-approval`, show a table naming every path with provenance, what
+it is, why removable, risk, empty-directory flag when set, the single tier, and only then logical /
+reclaimable bytes, plus the preview's approval token — then pass the
+[confirmation gate](#confirmation-gate) — the approval must name **exactly that tier and list**.
+Process another tier only with a new plan, preview, and question.
 
 ## 6. Apply only the confirmed preview
 
@@ -354,9 +376,11 @@ approved list. Engine invocations from PowerShell stay hard-denied. The plugin-l
 argument, so the unset-default hook-drop that once made it inert on a default install is gone.
 `Bash|PowerShell` PreToolUse hooks fire for the PowerShell tool. See `reference/safety-model.md`.
 
-Summarize removed paths, logical bytes removed, observed free-space delta, and every skip grouped by
+Summarize tidiness outcomes first: paths removed, empty directories cleared
+(`empty_directories_removed` / `paths_removed`), remaining coverage gaps, and every skip grouped by
 `locked`, `changed-or-link`, `protected`, `needs-elevation`, `handle-state-unverified`, or
-`delete-failed`. Do not claim the observed free-space delta is exact: concurrent disk activity,
+`delete-failed`. Report reclaimable bytes removed and observed free-space delta **after** those
+tidiness figures. Do not claim the observed free-space delta is exact: concurrent disk activity,
 sparse files, hard links, compression, and delayed allocation affect it.
 
 ## Gotchas

--- a/plugins/disk-hygiene/skills/clean/evals/evals.json
+++ b/plugins/disk-hygiene/skills/clean/evals/evals.json
@@ -10,7 +10,7 @@
       "expectations": [
         "Runs hygiene.py scan and does not run apply",
         "Treats filename patterns as discovery hints rather than cleanup verdicts",
-        "Reports evidence, ownership, work-product analysis, protected items, and coverage gaps"
+        "Reports provenance, intent, why-removable, risk, ownership, work-product analysis, protected items, and coverage gaps — with bytes secondary"
       ]
     },
     {
@@ -131,6 +131,18 @@
         "Does not reject the non-OS volume root outright; treats it as a valid but known-large target",
         "Honors large-target-confirmation-required (non-os-volume-root): bounds with --max-depth or confirms with --confirmed-large-scan only after asking the user",
         "Still denies a genuine OS-managed root outright and never fabricates the large-scan confirmation"
+      ]
+    },
+    {
+      "id": 12,
+      "name": "empty-directories-remain-first-class-tidiness-findings",
+      "prompt": "/disk-hygiene:clean C:\\ — four empty orphan directories at the volume root total 0 bytes; a 4.8 GB cache sits beside them. Rank by reclaimable bytes.",
+      "expected_output": "Reports tidiness-first: empty directories stay visible and rankable with required provenance, intent, why-removable, and risk fields; size is secondary. Does not dismiss zero-byte residue because target_reclaimable_local_bytes would ignore them.",
+      "files": [],
+      "expectations": [
+        "Treats safe tidiness as the primary objective and reclaimable bytes as secondary",
+        "Keeps empty/zero-byte directories visible in the report and does not rank solely by bytes",
+        "Requires per-entry provenance, what-it-is, why-removable, and risk before proposing removal"
       ]
     }
   ]

--- a/plugins/disk-hygiene/skills/clean/scripts/hygiene.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/hygiene.py
@@ -765,6 +765,101 @@ def reclaimable_local_bytes(entries: list[dict[str, Any]]) -> int:
     return total
 
 
+def entry_is_empty_directory(
+    entry: dict[str, Any],
+    inventory: dict[str, dict[str, Any]] | list[dict[str, Any]] | set[str] | None = None,
+    *,
+    parents_with_children: set[str] | None = None,
+    unknown_paths: set[str] | None = None,
+) -> bool:
+    """True when a walked directory has no inventoried descendants.
+
+    Truncated (`not-walked`) directories are unknown, not empty — their
+    `logical_size` is null. A walked parent whose only children were cut off by
+    `--max-depth` can still show `logical_size` 0; requiring no snapshot
+    descendants keeps that case out of the empty-directory tidiness count so
+    zero-byte residue stays visible without mislabeling uninventoried trees.
+    Directories whose scandir failed (or that appear in ``unknown_paths``) are
+    likewise unknown: a coverage gap is not empty residue.
+    """
+    if entry.get("kind") != "directory":
+        return False
+    qualifiers = entry.get("size_qualifiers") or []
+    if "not-walked" in qualifiers:
+        return False
+    if entry.get("logical_size") != 0:
+        return False
+    relative = entry.get("path")
+    if not isinstance(relative, str) or not relative:
+        return False
+    if unknown_paths and relative in unknown_paths:
+        return False
+    if parents_with_children is not None:
+        return relative not in parents_with_children
+    if inventory is None:
+        paths: Iterable[str] = ()
+    elif isinstance(inventory, dict):
+        paths = inventory
+    elif isinstance(inventory, set):
+        paths = inventory
+    else:
+        paths = (
+            item["path"]
+            for item in inventory
+            if isinstance(item, dict) and isinstance(item.get("path"), str)
+        )
+    prefix = relative + "/"
+    return not any(path.startswith(prefix) for path in paths)
+
+
+def inventory_parent_paths(paths: Iterable[str]) -> set[str]:
+    """Return every inventory path that has at least one inventoried descendant.
+
+    Built in one linear pass over ``paths`` so empty-directory counting stays
+    O(entries) rather than O(directories × entries).
+    """
+    parents: set[str] = set()
+    for path in paths:
+        if not isinstance(path, str) or "/" not in path:
+            continue
+        parent = path.rsplit("/", 1)[0]
+        while parent:
+            if parent in parents:
+                break
+            parents.add(parent)
+            if "/" not in parent:
+                break
+            parent = parent.rsplit("/", 1)[0]
+    return parents
+
+
+def empty_directory_count(
+    entries: list[dict[str, Any]],
+    *,
+    error_paths: Iterable[str] | None = None,
+) -> int:
+    """Count walked empty directories in a snapshot inventory.
+
+    ``error_paths`` are scan-error relatives that must not count as empty even
+    when they were recorded with ``logical_size`` 0 and no descendants.
+    """
+    by_path = {
+        entry["path"]: entry
+        for entry in entries
+        if isinstance(entry, dict) and isinstance(entry.get("path"), str)
+    }
+    parents_with_children = inventory_parent_paths(by_path)
+    unknown = {path for path in (error_paths or ()) if isinstance(path, str) and path}
+    return sum(
+        1
+        for entry in by_path.values()
+        if entry_is_empty_directory(
+            entry,
+            parents_with_children=parents_with_children,
+            unknown_paths=unknown,
+        )
+    )
+
 def discover_enclosing_git(target: Path) -> tuple[list[Path], list[str]]:
     marker_root = next(
         (
@@ -1166,7 +1261,7 @@ def scan_tree(
     else:
         allowed_root_children = {name.casefold() for name in root_children}
 
-    def visit(directory: Path, depth: int = 1) -> int:
+    def visit(directory: Path, depth: int = 1) -> int | None:
         total = 0
         try:
             with os.scandir(directory) as iterator:
@@ -1175,7 +1270,8 @@ def scan_tree(
             errors.append(
                 {"path": directory.relative_to(target).as_posix(), "error": str(exc)}
             )
-            return 0
+            # Unknown coverage — not an empty directory. Caller marks not-walked.
+            return None
         for child in children:
             path = Path(child.path)
             # Root-children mode never walks the volume root as a whole: only
@@ -1221,6 +1317,9 @@ def scan_tree(
                         truncated.append(relative)
                     else:
                         subtotal = visit(path, depth + 1)
+                        if subtotal is None:
+                            # scandir failed inside this child: unknown, not empty.
+                            walked = False
                     data = metadata(path, kind, subtotal, walked=walked)
                     # Truncated children contribute unknown, not zero: adding
                     # null as 0 was what made a truncated subtree look empty.
@@ -1254,6 +1353,9 @@ def scan_tree(
         return total
 
     total_size = visit(target)
+    if total_size is None:
+        total_size = 0
+        truncated.append(".")
     repositories = sorted(set(repositories))
     annotate_tracked(entries, target, repositories, truncated, repo_errors)
     reclaimable = reclaimable_local_bytes(entries)
@@ -1265,6 +1367,11 @@ def scan_tree(
         target_identity["size_qualifiers"] = sorted(
             set(target_identity["size_qualifiers"] + ["not-walked"])
         )
+    error_paths = {
+        item["path"]
+        for item in errors
+        if isinstance(item, dict) and isinstance(item.get("path"), str)
+    }
     payload: dict[str, Any] = {
         "schema_version": SCHEMA_VERSION,
         "engine": "disk-hygiene-python-1",
@@ -1275,6 +1382,9 @@ def scan_tree(
         "target_identity": target_identity,
         "target_logical_bytes": total_size,
         "target_reclaimable_local_bytes": reclaimable,
+        "empty_directory_count": empty_directory_count(
+            entries, error_paths=error_paths
+        ),
         "policy": policy,
         "repositories": [str(repo) for repo in repositories],
         "repository_errors": repo_errors,
@@ -1438,9 +1548,11 @@ def validate_plan(
         required = {
             "path",
             "tier",
+            "provenance",
             "reason",
             "evidence",
             "why_not_work_product",
+            "risk",
             "owner",
         }
         if not required.issubset(candidate):
@@ -1463,6 +1575,11 @@ def validate_plan(
         ):
             raise HygieneError(f"candidate paths overlap: {relative}")
         seen.append(pure)
+        if (
+            not isinstance(candidate["provenance"], str)
+            or not candidate["provenance"].strip()
+        ):
+            raise HygieneError(f"candidate needs provenance: {relative}")
         if not isinstance(candidate["reason"], str) or not candidate["reason"].strip():
             raise HygieneError(f"candidate needs a reason: {relative}")
         if (
@@ -1470,6 +1587,8 @@ def validate_plan(
             or not candidate["why_not_work_product"].strip()
         ):
             raise HygieneError(f"candidate needs work-product analysis: {relative}")
+        if not isinstance(candidate["risk"], str) or not candidate["risk"].strip():
+            raise HygieneError(f"candidate needs a risk assessment: {relative}")
         if (
             not isinstance(candidate["evidence"], list)
             or not candidate["evidence"]
@@ -1996,6 +2115,7 @@ def preview(snapshot: dict[str, Any], plan: dict[str, Any]) -> dict[str, Any]:
                     )
                 )
         blockers = sorted(set(blockers))
+        candidate_entry = entries[relative]
         logical_bytes = sum(
             entry_logical_file_bytes(entries[name]) for name in expected_paths
         )
@@ -2008,6 +2128,11 @@ def preview(snapshot: dict[str, Any], plan: dict[str, Any]) -> dict[str, Any]:
             {
                 "path": relative,
                 "tier": plan["tier"],
+                "provenance": candidate["provenance"],
+                "reason": candidate["reason"],
+                "why_not_work_product": candidate["why_not_work_product"],
+                "risk": candidate["risk"],
+                "empty_directory": entry_is_empty_directory(candidate_entry, entries),
                 "logical_bytes": logical_bytes,
                 "reclaimable_local_bytes": reclaimable_bytes,
                 "handle_state": state,
@@ -2021,12 +2146,17 @@ def preview(snapshot: dict[str, Any], plan: dict[str, Any]) -> dict[str, Any]:
         "tier": plan["tier"],
         "target": str(target),
         "candidates": results,
+        "empty_directories": sum(1 for item in results if item["empty_directory"]),
         "logical_bytes": sum(item["logical_bytes"] for item in results),
         "reclaimable_local_bytes": sum(
             item["reclaimable_local_bytes"] for item in results
         ),
         "approval_token": None if blocked else approval_token(snapshot, plan),
-        "warning": "Approval is valid only for this tier, exact plan, and snapshot. Re-preview after any change.",
+        "warning": (
+            "Safe tidiness is the primary objective; reclaimable bytes are "
+            "secondary. Approval is valid only for this tier, exact plan, and "
+            "snapshot. Re-preview after any change."
+        ),
     }
     return payload
 
@@ -2286,6 +2416,8 @@ def apply_plan(snapshot: dict[str, Any], plan: dict[str, Any]) -> dict[str, Any]
                 }
                 for item in candidates
             ],
+            "paths_removed": 0,
+            "empty_directories_removed": 0,
             "logical_bytes_removed": 0,
             "reclaimable_local_bytes_removed": 0,
             "observed_free_space_delta_bytes": 0,
@@ -2306,6 +2438,8 @@ def apply_plan(snapshot: dict[str, Any], plan: dict[str, Any]) -> dict[str, Any]
                 }
                 for item in candidates
             ],
+            "paths_removed": 0,
+            "empty_directories_removed": 0,
             "logical_bytes_removed": 0,
             "reclaimable_local_bytes_removed": 0,
             "observed_free_space_delta_bytes": 0,
@@ -2417,6 +2551,7 @@ def apply_plan(snapshot: dict[str, Any], plan: dict[str, Any]) -> dict[str, Any]
             removed.append(
                 {
                     "path": relative,
+                    "empty_directory": entry_is_empty_directory(entry, entries),
                     "logical_bytes": logical,
                     "reclaimable_local_bytes": reclaimable,
                 }
@@ -2429,6 +2564,10 @@ def apply_plan(snapshot: dict[str, Any], plan: dict[str, Any]) -> dict[str, Any]
         "target": str(target),
         "removed": removed,
         "skipped": skipped,
+        "paths_removed": len(removed),
+        "empty_directories_removed": sum(
+            1 for item in removed if item["empty_directory"]
+        ),
         "logical_bytes_removed": logical_removed,
         "reclaimable_local_bytes_removed": reclaimable_removed,
         "observed_free_space_delta_bytes": after - before,
@@ -2688,6 +2827,7 @@ def main(argv: list[str] | None = None) -> int:
                     "snapshot": str(output_path),
                     "entries": len(snapshot["entries"]),
                     "hinted_entries": hinted,
+                    "empty_directory_count": snapshot["empty_directory_count"],
                     "target_logical_bytes": snapshot["target_logical_bytes"],
                     "target_reclaimable_local_bytes": snapshot[
                         "target_reclaimable_local_bytes"
@@ -2697,7 +2837,11 @@ def main(argv: list[str] | None = None) -> int:
                     "policy_sources": policy["policy_sources"],
                     "os_autoclean": advisory,
                     "note": (
-                        "Hints are discovery signals, never cleanup verdicts. "
+                        "Safe tidiness is the primary objective; reclaimable "
+                        "bytes are a secondary signal. empty_directory_count "
+                        "names walked empty directories (logical_size 0, not "
+                        "truncated) so zero-byte residue stays visible. Hints "
+                        "are discovery signals, never cleanup verdicts. "
                         "target_reclaimable_local_bytes excludes every entry "
                         "whose size_qualifiers is non-empty (cloud-placeholder, "
                         "hardlinked, sparse, not-walked); target_logical_bytes "

--- a/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
@@ -45,9 +45,11 @@ def candidate(path: str, tier: str = "high") -> dict[str, object]:
     return {
         "path": path,
         "tier": tier,
+        "provenance": "fixture convention documents this as abandoned atomic-write staging",
         "reason": "fixture provenance identifies an abandoned atomic-write temporary",
         "evidence": ["name matches fixture convention", "owner process is absent"],
         "why_not_work_product": "fixture content is generated and has no durable consumer",
+        "risk": "low — fixture residue with no live consumer",
         "owner": "unmanaged",
     }
 
@@ -418,10 +420,110 @@ class HygieneTests(unittest.TestCase):
             # A genuinely empty walked directory still reports 0 with no qualifier.
             self.assertEqual(0, entries["empty"]["logical_size"])
             self.assertEqual([], entries["empty"]["size_qualifiers"])
+            self.assertTrue(hygiene.entry_is_empty_directory(entries["empty"], entries))
+            self.assertFalse(
+                hygiene.entry_is_empty_directory(entries["deep/sub"], entries)
+            )
+            # Parent of a truncated child can show logical_size 0; inventory
+            # descendants keep it out of the empty-directory tidiness count.
+            self.assertFalse(hygiene.entry_is_empty_directory(entries["deep"], entries))
+            self.assertEqual(1, snapshot["empty_directory_count"])
             self.assertEqual(
                 entries["visible.tmp"]["logical_size"],
                 snapshot["target_reclaimable_local_bytes"],
             )
+
+    def test_empty_directory_count_is_linear_and_excludes_error_paths(self) -> None:
+        # Many sibling empty directories must not require a full inventory scan each.
+        entries = [
+            {
+                "path": f"d{i:04d}",
+                "kind": "directory",
+                "logical_size": 0,
+                "size_qualifiers": [],
+            }
+            for i in range(200)
+        ]
+        entries.append(
+            {
+                "path": "parent",
+                "kind": "directory",
+                "logical_size": 0,
+                "size_qualifiers": [],
+            }
+        )
+        entries.append(
+            {
+                "path": "parent/child",
+                "kind": "file",
+                "logical_size": 1,
+                "size_qualifiers": [],
+            }
+        )
+        entries.append(
+            {
+                "path": "unreadable",
+                "kind": "directory",
+                "logical_size": 0,
+                "size_qualifiers": [],
+            }
+        )
+        self.assertEqual(
+            200,
+            hygiene.empty_directory_count(
+                entries, error_paths={"unreadable"}
+            ),
+        )
+        parents = hygiene.inventory_parent_paths(
+            entry["path"] for entry in entries if isinstance(entry.get("path"), str)
+        )
+        self.assertIn("parent", parents)
+        self.assertNotIn("unreadable", parents)
+
+    def test_plan_requires_provenance_and_risk_for_tidiness_reporting(self) -> None:
+        entry = {"kind": "file", "logical_size": 1, "size_qualifiers": []}
+        base = candidate("orphan.tmp")
+        for missing in ("provenance", "risk"):
+            broken = dict(base)
+            del broken[missing]
+            plan = {"version": 1, "tier": "high", "candidates": [broken]}
+            with self.assertRaisesRegex(hygiene.HygieneError, missing):
+                hygiene.validate_plan(plan, {"orphan.tmp": entry})
+
+    def test_preview_surfaces_tidiness_fields_and_empty_directory_flag(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary) / "target"
+            root.mkdir()
+            (root / "orphan-empty").mkdir()
+            (root / "keep.txt").write_text("work", encoding="utf-8")
+            snapshot = hygiene.scan_tree(root.resolve(), hygiene.load_policy(None))
+            self.assertEqual(1, snapshot["empty_directory_count"])
+            plan = {
+                "version": 1,
+                "tier": "high",
+                "candidates": [candidate("orphan-empty")],
+            }
+            with (
+                mock.patch.object(hygiene, "execution_blockers", return_value=[]),
+                mock.patch.object(hygiene, "hard_protection", return_value=[]),
+                mock.patch.object(hygiene, "tracked_blocker", return_value=None),
+                mock.patch.object(
+                    hygiene, "linux_mount_points", return_value=(set(), None)
+                ),
+                mock.patch.object(
+                    hygiene, "handle_state", return_value=("clear", None)
+                ),
+            ):
+                preview = hygiene.preview(snapshot, plan)
+            self.assertEqual("ready-for-explicit-approval", preview["status"])
+            item = preview["candidates"][0]
+            self.assertTrue(item["empty_directory"])
+            self.assertEqual(1, preview["empty_directories"])
+            self.assertEqual(0, item["logical_bytes"])
+            self.assertEqual(0, item["reclaimable_local_bytes"])
+            self.assertEqual(candidate("orphan-empty")["provenance"], item["provenance"])
+            self.assertEqual(candidate("orphan-empty")["risk"], item["risk"])
+            self.assertIn("Safe tidiness is the primary objective", preview["warning"])
 
     def test_hard_linked_names_are_qualified_and_excluded_from_reclaimable(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
@@ -1736,8 +1838,45 @@ class HygieneTests(unittest.TestCase):
                 {"candidate/nested/captured.tmp", "candidate/nested", "candidate"},
                 {item["path"] for item in report["removed"]},
             )
+            self.assertEqual(3, report["paths_removed"])
+            self.assertEqual(0, report["empty_directories_removed"])
             self.assertFalse((root / "candidate").exists())
             self.assertEqual("work product", untouched.read_text(encoding="utf-8"))
+
+    @unittest.skipUnless(
+        hygiene.os_key() == "linux", "descriptor-relative removal is Linux-only"
+    )
+    def test_apply_report_counts_empty_directory_tidiness_outcomes(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary) / "target"
+            root.mkdir()
+            (root / "orphan-empty").mkdir()
+            (root / "keep.txt").write_text("work product", encoding="utf-8")
+            snapshot = hygiene.scan_tree(root.resolve(), hygiene.load_policy(None))
+            plan = {
+                "version": 1,
+                "tier": "high",
+                "candidates": [candidate("orphan-empty")],
+            }
+            with (
+                mock.patch.object(hygiene, "execution_blockers", return_value=[]),
+                mock.patch.object(hygiene, "hard_protection", return_value=[]),
+                mock.patch.object(hygiene, "tracked_blocker", return_value=None),
+                mock.patch.object(
+                    hygiene, "linux_mount_points", return_value=(set(), None)
+                ),
+                mock.patch.object(
+                    hygiene, "handle_state", return_value=("clear", None)
+                ),
+            ):
+                report = hygiene.apply_plan(snapshot, plan)
+            self.assertEqual("completed", report["status"])
+            self.assertEqual(1, report["paths_removed"])
+            self.assertEqual(1, report["empty_directories_removed"])
+            self.assertTrue(report["removed"][0]["empty_directory"])
+            self.assertEqual(0, report["reclaimable_local_bytes_removed"])
+            self.assertFalse((root / "orphan-empty").exists())
+            self.assertEqual("work product", (root / "keep.txt").read_text(encoding="utf-8"))
 
 
     def test_scan_max_depth_truncates_and_preview_blocks_planning(self) -> None:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #2590

## Summary

Disk-hygiene reporting was organized around reclaimable bytes, so empty/zero-byte directories effectively dropped out — inverting the operator goal of safe tidiness.

## Fix

Make tidiness/provenance the primary reporting frame; keep bytes as a secondary signal so empty residue remains visible and actionable.

## Verification

See PR checks / plugin tests.

## Related

Refs #2588 — root-children mode (related volume-root cleanup workflow).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eb3f5ee5-6c9f-48a3-8e46-071bd363f8b0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eb3f5ee5-6c9f-48a3-8e46-071bd363f8b0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

