### PR TITLE
feat(disk-hygiene): add root-children mode for OS volume roots

### DIFF
--- a/plugins/disk-hygiene/.claude-plugin/plugin.json
+++ b/plugins/disk-hygiene/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "disk-hygiene",
-  "version": "0.17.11",
+  "version": "0.18.0",
   "description": "Context-aware disk hygiene for arbitrary directory trees: inventories orphaned and temporary artifacts, classifies evidence into review tiers, and offers exact-path cleanup only after a fresh safety preview and explicit per-tier approval. The target is read-only by default; OS-managed paths, links and mount points, VCS-tracked content, changed entries, and live-handle uncertainty fail closed.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/disk-hygiene/CHANGELOG.md
+++ b/plugins/disk-hygiene/CHANGELOG.md
@@ -3,6 +3,20 @@
 All notable changes to the `disk-hygiene` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.18.0]
+
+### Added
+
+- **Root-children mode for OS-managed volume roots (#2588).** Targeting `C:\` or `/` without a new
+  flag still fails closed — nothing walks an OS-managed root as a whole. With `--root-children` the
+  engine enumerates that root's immediate entries only, hard-excludes OS-owned / hidden / system /
+  reparse / mount / protected-shell-folder / non-directory names (preferring more exclusions when
+  ambiguous), and returns `root-children-selection-required` until the operator names one or more
+  admitted directories via repeatable `--root-child <name>`. Selected children are audited into one
+  snapshot and one report; the volume root's own files and every skipped entry are never inventoried.
+  Documented in `skills/clean/SKILL.md` Arguments, the confirmation gate, the scan template, and
+  `reference/safety-model.md`. The skill-scoped guard accepts the new scan flags.
+
 ## [0.17.11]
 
 ### Fixed

--- a/plugins/disk-hygiene/CHANGELOG.md
+++ b/plugins/disk-hygiene/CHANGELOG.md
@@ -17,6 +17,16 @@ All notable changes to the `disk-hygiene` plugin are documented here. Format fol
   Documented in `skills/clean/SKILL.md` Arguments, the confirmation gate, the scan template, and
   `reference/safety-model.md`. The skill-scoped guard accepts the new scan flags.
 
+### Fixed
+
+- **Linux OS-provisioned root directories are excluded from root-children admission (#2588).** The
+  Linux allowlist now matches the Windows/macOS posture for conventional OS roots (`home`, `root`,
+  `tmp`, `opt`, `srv`, `media`, `mnt`, and the existing `bin`/`boot`/… set), so `/tmp` and `/home`
+  are not reported as admitted audit targets.
+- **Root-child selection preserves exact basenames on case-sensitive hosts (#2588).** On Linux,
+  `--root-child Cache` resolves only to `Cache`, not a case-folded sibling such as `cache`, and the
+  scan filter keeps that exact name. Windows and macOS remain case-insensitive.
+
 ## [0.17.11]
 
 ### Fixed

--- a/plugins/disk-hygiene/README.md
+++ b/plugins/disk-hygiene/README.md
@@ -16,7 +16,8 @@ unvalidated tree.
   remote, or otherwise unattended sessions audit and stop.
 - Confidence controls report ordering, never authorization. High, medium, and low each require a
   separate approval naming every path and its logical byte count.
-- Filesystem roots, mount targets, OS-managed roots on every Windows volume, user shell-folder roots,
+- Filesystem roots, mount targets, OS-managed roots on every Windows volume (unless addressed only
+  via `--root-children` with an explicit child selection), user shell-folder roots,
   VCS metadata/tracked content, mount points (including Linux bind mounts), every Windows reparse
   point, symlinks, entries changed since the scan, and paths outside the target are hard stops. These
   predicates cannot be disabled by policy.

--- a/plugins/disk-hygiene/skills/clean/SKILL.md
+++ b/plugins/disk-hygiene/skills/clean/SKILL.md
@@ -37,22 +37,31 @@ filename pattern is a discovery hint, never proof that an entry is junk. Read
 ## Arguments and boundaries
 
 Parse `$ARGUMENTS` as the complete user-facing surface: optional `--execute`, optional
-`--policy <file>`, optional `--max-depth <N>`, optional `--confirmed-large-scan`, and one target
-directory. Remaining engine flags (`--output`, `--project-dir`, `--data-root` on scan;
-`--snapshot`, `--plan`, `--report`, `--confirm-tier`, `--approval-token`, `--paths` on the other
-subcommands) are supplied by this skill's command templates, not typed by the user.
+`--policy <file>`, optional `--max-depth <N>`, optional `--confirmed-large-scan`, optional
+`--root-children` with zero or more `--root-child <name>`, and one target directory. Remaining
+engine flags (`--output`, `--project-dir`, `--data-root` on scan; `--snapshot`, `--plan`,
+`--report`, `--confirm-tier`, `--approval-token`, `--paths` on the other subcommands) are supplied
+by this skill's command templates, not typed by the user.
 `--execute` means "deletion may be offered" on every platform — the gated engine lane where the
 platform supports it, the manual handoff elsewhere; it is not approval. (Deliberate semantic
 unification, not a restatement: the flag previously read as engine-lane-only, which left the
 manual lane's gate ambiguous — consumer sessions read it both ways.) `--max-depth <N>` bounds a
 scan to depth N (preferred for large targets); `--confirmed-large-scan` opts into an unbounded
 full walk after the human clears the [confirmation gate](#confirmation-gate)'s scan-scope row.
-With no target, ask once. Reject an
-OS-managed root, a non-root mount target, a protected shell-folder root or descendant, a missing
-directory, a symlink, or a Windows reparse point. A whole-volume root that is not OS-managed (a
-Windows Dev Drive) is no longer rejected outright — it is a valid target, but as a known-large root
-it is gated like a home target (see step 1): the scan returns `large-target-confirmation-required`
-unless bounded with `--max-depth` or confirmed with `--confirmed-large-scan`.
+`--root-children` is the only way to address an OS-managed volume root (for example `C:\` or `/`):
+it never walks that root recursively. Without `--root-child` names the engine returns
+`root-children-selection-required` listing admitted immediate directories (OS-owned, hidden,
+system, reparse, mount, protected-shell-folder, and non-directory entries are withheld). With one
+or more explicit `--root-child <name>` flags — after the human clears the confirmation gate's
+root-children row — it audits only those admitted children into one snapshot. A general "clean
+everything" is not selection. With no target, ask once. Reject an
+OS-managed root (unless `--root-children`), a non-root mount target, a protected shell-folder root
+or descendant, a missing directory, a symlink, or a Windows reparse point. A whole-volume root that
+is not OS-managed (a Windows Dev Drive) is no longer rejected outright — it is a valid target, but
+as a known-large root it is gated like a home target (see step 1): the scan returns
+`large-target-confirmation-required` unless bounded with `--max-depth` or confirmed with
+`--confirmed-large-scan`. `--root-children` is invalid on a non-OS volume root or a non-volume
+target; scan those without the flag.
 
 - Use `/repo-hygiene:clean` for one repository's caches, build output, Git metadata, or tree reset.
 - For git worktree checkouts (e.g. under a `.worktrees/` directory), hand off to
@@ -91,9 +100,10 @@ unless bounded with `--max-depth` or confirmed with `--confirmed-large-scan`.
 ## Confirmation gate
 
 Every question this skill asks passes this gate — the no-target prompt above, the large-scan
-confirmation in §1, the removal approval in §5, and the unsupported-platform handoff in §6. One
-surface rule and one floor cover all four. What a valid answer must *name* is per question, because
-a target prompt has no tier or path list to name and cannot be held to a bar built for one.
+confirmation in §1, the root-children selection for an OS-managed volume root, the removal approval
+in §5, and the unsupported-platform handoff in §6. One surface rule and one floor cover all five.
+What a valid answer must *name* is per question, because a target prompt has no tier or path list to
+name and cannot be held to a bar built for one.
 
 **Question surface.** Prefer `AskUserQuestion`: its answer is the user's own and cannot be
 fabricated. It is not always usable, in two distinct ways — a bare-name `permissions.deny` rule or a
@@ -115,6 +125,7 @@ naming what the question never presented cannot be met.
 |---|---|
 | Target selection (no target given) | one directory, which must then clear every rejection in "Arguments and boundaries" |
 | Scan scope (`--confirmed-large-scan`, §1) | that target and a deliberate unbounded full walk of it |
+| Root-children selection (`--root-children`, §1) | one or more admitted immediate child directory names just listed — never "everything" or the volume root itself |
 | Removal approval (§5) and manual handoff (§6) | exactly the one tier and the exact path list just shown |
 
 ## 1. Create a read-only snapshot
@@ -126,7 +137,8 @@ stay there, never in the target or `${CLAUDE_PLUGIN_ROOT}`. Run:
 "<hook-python>" "${CLAUDE_PLUGIN_ROOT}/skills/clean/scripts/hygiene.py" scan \
   --target "<target>" --output "<run-dir>/snapshot.json" [--policy "<policy.json>"] \
   --project-dir "${CLAUDE_PROJECT_DIR}" --data-root "${CLAUDE_PLUGIN_DATA}" \
-  [--max-depth <N>] [--confirmed-large-scan]
+  [--max-depth <N>] [--confirmed-large-scan] \
+  [--root-children [--root-child <name>]...]
 ```
 
 The guard validates `--data-root` against the plugin data directory it derives from
@@ -140,11 +152,16 @@ For a large root (a home directory, anything whose recursive walk could exceed t
 cap), start with a bounded pass: add `--max-depth 1` to inventory the target's loose files and
 immediate children, then fan out deeper scans per subtree that the evidence justifies. The engine
 backs this with a deterministic gate: a scan whose target resolves to the user home directory or a
-non-OS volume root (a Windows Dev Drive — an OS-managed root is denied outright and never reaches
-this gate) and carries neither `--max-depth` nor `--confirmed-large-scan` returns
+non-OS volume root (a Windows Dev Drive — an OS-managed root still cannot be walked as a whole, and
+reaches the engine only via `--root-children`) and carries neither `--max-depth` nor
+`--confirmed-large-scan` returns
 `large-target-confirmation-required` (after a cheap top-level probe, not a full walk) instead of the
 unbounded traversal, so a forgotten bound never becomes an accidental whole-volume scan. `--max-depth`
 is the preferred bounded response.
+When the target is an OS-managed volume root, first run with `--root-children` alone, present the
+`admitted_children` list through the [confirmation gate](#confirmation-gate)'s root-children row,
+then re-run with the same flag plus each chosen `--root-child <name>` — one run directory, one
+snapshot, one report covers every selected subtree. Never invent the selection.
 Reserve `--confirmed-large-scan` for a deliberate full walk the human has confirmed — pass the
 [confirmation gate](#confirmation-gate)'s scan-scope row first, the same standing before an
 expensive step that the apply lane demands before a destructive one; a general "clean my home

--- a/plugins/disk-hygiene/skills/clean/reference/safety-model.md
+++ b/plugins/disk-hygiene/skills/clean/reference/safety-model.md
@@ -22,11 +22,13 @@ whether an exact plan is mechanically eligible. Neither layer may weaken the oth
 ## Non-overridable checks
 
 - target containment; an OS-managed root (per `system_roots()` — the OS drive holding an existing
-  Windows install / `Program Files` / `ProgramData`, or `/` holding `/bin`, `/etc`, …) is denied,
-  while a non-OS volume root (a Windows Dev Drive: a drive root carrying only the per-volume metadata
-  every volume has and no OS-install marker) is a valid target rather than blanket-denied — but as a
-  known-large root it is routed through the large-target scan gate below (bound or confirm), and
-  deletion stays gated by the preview and per-tier approval;
+  Windows install / `Program Files` / `ProgramData`, or `/` holding `/bin`, `/etc`, …) is denied as
+  a recursive walk target, while `--root-children` may address that same root only as a listing of
+  immediate non-OS child directories with explicit `--root-child` selection (never a whole-root
+  walk); a non-OS volume root (a Windows Dev Drive: a drive root carrying only the per-volume
+  metadata every volume has and no OS-install marker) is a valid target rather than blanket-denied
+  — but as a known-large root it is routed through the large-target scan gate below (bound or
+  confirm), and deletion stays gated by the preview and per-tier approval;
 - the audit root itself is never a removal candidate; no protected shell-folder root, OS
   registry/profile hive, VCS metadata or tracked file;
 - no symlink, Windows reparse traversal, non-root mount target, nested mount, or Linux bind mount

--- a/plugins/disk-hygiene/skills/clean/scripts/destructive_guard.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/destructive_guard.py
@@ -881,17 +881,46 @@ def classify_exact_engine_command(command: str, authority: str | None) -> str | 
             or not _argument(tokens[6])
         ):
             return None
-        # --confirmed-large-scan is the sole valueless scan flag; strip at most
-        # one so the remainder is the pure flag/value-pair grammar every other
-        # optional follows.
+        # --confirmed-large-scan and --root-children are the valueless scan
+        # flags; strip at most one of each so the remainder is the pure
+        # flag/value-pair grammar every other optional follows. --root-child
+        # is repeatable (one basename per occurrence) and is stripped next.
         optionals = list(tokens[7:])
         confirmed = optionals.count("--confirmed-large-scan")
         if confirmed > 1:
             return None
         if confirmed:
             optionals.remove("--confirmed-large-scan")
-        if len(optionals) not in {0, 2, 4, 6, 8} or not _consume_optional_pairs(
-            optionals,
+        root_children = optionals.count("--root-children")
+        if root_children > 1:
+            return None
+        if root_children:
+            optionals.remove("--root-children")
+        root_child_names: list[str] = []
+        remaining: list[str] = []
+        index = 0
+        while index < len(optionals):
+            if optionals[index] == "--root-child":
+                if index + 1 >= len(optionals) or not _argument(optionals[index + 1]):
+                    return None
+                name = optionals[index + 1]
+                # Immediate basename only — no separators, no . / ..
+                if (
+                    "/" in name
+                    or "\\" in name
+                    or name in {".", ".."}
+                    or not name
+                ):
+                    return None
+                root_child_names.append(name)
+                index += 2
+                continue
+            remaining.append(optionals[index])
+            index += 1
+        if root_child_names and not root_children:
+            return None
+        if len(remaining) not in {0, 2, 4, 6, 8} or not _consume_optional_pairs(
+            remaining,
             frozenset({"--policy", "--project-dir", "--data-root", "--max-depth"}),
             authority,
         ):

--- a/plugins/disk-hygiene/skills/clean/scripts/hygiene.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/hygiene.py
@@ -28,6 +28,8 @@ MAX_SNAPSHOT_ENTRIES = 250_000
 TIERS = {"high", "medium", "low"}
 VCS_NAMES = {".git", ".hg", ".svn"}
 FILE_ATTRIBUTE_REPARSE_POINT = 0x0400
+FILE_ATTRIBUTE_HIDDEN = 0x2
+FILE_ATTRIBUTE_SYSTEM = 0x4
 # "The bytes are not here." Each of these marks a name whose content lives in a
 # provider's cloud rather than on this disk, so its st_size is a REMOTE byte
 # count while local occupancy is roughly zero — and deleting it propagates the
@@ -82,6 +84,17 @@ WINDOWS_PER_VOLUME_METADATA = {
     "System Volume Information",
 }
 WINDOWS_VOLUME_SYSTEM_NAMES = WINDOWS_OS_DRIVE_MARKERS | WINDOWS_PER_VOLUME_METADATA
+# Well-known OS-provisioned volume-root directory names that are not always in
+# WINDOWS_VOLUME_SYSTEM_NAMES / system_roots(), but are never the user-created
+# residue root-children mode exists to reach. Prefer excluding when ambiguous
+# (#2588).
+WINDOWS_OS_ROOT_EXTRA_NAMES = {
+    "Users",
+    "PerfLogs",
+    "inetpub",
+    "XboxGames",
+    "Windows.old",
+}
 PLUGIN_ROOT = Path(__file__).resolve().parents[3]
 BASELINE_POLICY = (
     Path(__file__).resolve().parents[1] / "reference" / "baseline-policy.json"
@@ -921,8 +934,190 @@ def top_level_entry_count(target: Path) -> tuple[int | None, str | None]:
         return None, str(exc)
 
 
+def volume_root_os_owned_names(
+    platform_key: str | None = None,
+) -> set[str]:
+    """Basenames the volume-root guard treats as OS-owned at a drive/FS root."""
+    current = platform_key or os_key()
+    if current == "windows":
+        return {
+            name.casefold()
+            for name in (
+                WINDOWS_VOLUME_SYSTEM_NAMES
+                | WINDOWS_OS_ROOT_EXTRA_NAMES
+                | {Path(value).name for value in (
+                    os.environ.get("SystemRoot"),
+                    os.environ.get("ProgramFiles"),
+                    os.environ.get("ProgramFiles(x86)"),
+                    os.environ.get("ProgramData"),
+                ) if value}
+            )
+        }
+    if current == "macos":
+        return {
+            name.casefold()
+            for name in (
+                "System",
+                "Library",
+                "Applications",
+                "private",
+                "Volumes",
+                "cores",
+                "usr",
+                "bin",
+                "sbin",
+                "etc",
+                "dev",
+                "tmp",
+                "var",
+            )
+        }
+    return {
+        name.casefold()
+        for name in (
+            "bin",
+            "boot",
+            "dev",
+            "etc",
+            "lib",
+            "lib64",
+            "proc",
+            "run",
+            "sbin",
+            "sys",
+            "usr",
+            "var",
+            "lost+found",
+        )
+    }
+
+
+def root_child_skip_reason(
+    path: Path,
+    *,
+    exact_names: set[str],
+    known_linux_mounts: set[Path] | None = None,
+    os_owned_names: set[str] | None = None,
+) -> str | None:
+    """Why an immediate volume-root entry must not be offered or audited.
+
+    Mirrors the volume-root guard's exclusion spirit (OS-owned / hidden /
+    system / reparse) and fails closed on anything ambiguous (#2588). Root
+    files are never candidates — only directories can be selected.
+    """
+    try:
+        info = path.lstat()
+    except OSError as exc:
+        return f"unreadable:{exc}"
+    if is_linkish_stat(info):
+        return "symlink-junction-or-reparse-point"
+    if is_cloud_placeholder_stat(info):
+        return "cloud-placeholder"
+    if not stat.S_ISDIR(info.st_mode):
+        return "not-a-directory"
+    name = path.name
+    if name in {".", ".."} or not name:
+        return "invalid-name"
+    if name.startswith("."):
+        return "hidden"
+    folded = name.casefold()
+    owned = os_owned_names if os_owned_names is not None else volume_root_os_owned_names()
+    if folded in owned:
+        return "os-owned"
+    # Windows metadata / upgrade residue often uses a $-prefix outside the
+    # static marker set ($SysReset, $WinREAgent, $WINDOWS.~BT, …).
+    if name.startswith("$"):
+        return "os-owned"
+    attributes = int(getattr(info, "st_file_attributes", 0) or 0)
+    if attributes & FILE_ATTRIBUTE_HIDDEN:
+        return "hidden"
+    if attributes & FILE_ATTRIBUTE_SYSTEM:
+        return "system"
+    if has_protected_name(path, exact_names):
+        return "baseline-protected-name"
+    mounted, mount_error = mount_state(path, known_linux_mounts)
+    if mount_error:
+        return "mount-state-unverified"
+    if mounted:
+        return "nested-mount-point"
+    for root in system_roots():
+        if path.absolute() == root.absolute() or is_within(path.absolute(), root.absolute()):
+            return "os-owned"
+    return None
+
+
+def enumerate_root_children(
+    target: Path,
+    policy: dict[str, Any],
+    known_linux_mounts: set[Path] | None = None,
+) -> tuple[list[dict[str, str]], list[dict[str, str]]]:
+    """List immediate volume-root entries into admitted vs skipped buckets.
+
+    Enumerates the root once and never recurses. Admitted entries are
+    directories that cleared every root-children exclusion; skipped entries
+    carry the reason they were withheld.
+    """
+    exact_names = set(policy["protected_exact_names"])
+    os_owned = volume_root_os_owned_names()
+    admitted: list[dict[str, str]] = []
+    skipped: list[dict[str, str]] = []
+    try:
+        with os.scandir(target) as iterator:
+            children = sorted(iterator, key=lambda entry: entry.name.casefold())
+    except OSError as exc:
+        raise HygieneError(f"cannot enumerate volume root: {exc}") from exc
+    for child in children:
+        path = Path(child.path)
+        reason = root_child_skip_reason(
+            path,
+            exact_names=exact_names,
+            known_linux_mounts=known_linux_mounts,
+            os_owned_names=os_owned,
+        )
+        if reason is None:
+            admitted.append({"name": child.name, "path": str(path)})
+        else:
+            skipped.append({"name": child.name, "path": str(path), "reason": reason})
+    return admitted, skipped
+
+
+def normalize_root_child_selection(
+    selected: list[str], admitted: list[dict[str, str]]
+) -> list[str]:
+    """Map a human selection onto admitted basenames; reject anything else."""
+    if not selected:
+        raise HygieneError(
+            "--root-children requires an explicit --root-child selection; "
+            "a general clean-everything request is not selection"
+        )
+    by_fold = {item["name"].casefold(): item["name"] for item in admitted}
+    resolved: list[str] = []
+    seen: set[str] = set()
+    for raw in selected:
+        if not raw or raw in {".", ".."} or "/" in raw or "\\" in raw:
+            raise HygieneError(
+                f"--root-child must be an immediate basename, not a path: {raw!r}"
+            )
+        key = raw.casefold()
+        if key not in by_fold:
+            raise HygieneError(
+                f"--root-child {raw!r} is not an admitted immediate child directory "
+                "of the OS-managed volume root"
+            )
+        canonical = by_fold[key]
+        if canonical.casefold() in seen:
+            continue
+        seen.add(canonical.casefold())
+        resolved.append(canonical)
+    return resolved
+
+
 def scan_tree(
-    target: Path, policy: dict[str, Any], max_depth: int | None = None
+    target: Path,
+    policy: dict[str, Any],
+    max_depth: int | None = None,
+    *,
+    root_children: list[str] | None = None,
 ) -> dict[str, Any]:
     entries: list[dict[str, Any]] = []
     errors: list[dict[str, str]] = []
@@ -932,6 +1127,11 @@ def scan_tree(
     known_mounts, mount_error = linux_mount_points()
     if mount_error:
         errors.append({"path": ".", "error": mount_error})
+    allowed_root_children = (
+        {name.casefold() for name in root_children}
+        if root_children is not None
+        else None
+    )
 
     def visit(directory: Path, depth: int = 1) -> int:
         total = 0
@@ -945,6 +1145,16 @@ def scan_tree(
             return 0
         for child in children:
             path = Path(child.path)
+            # Root-children mode never walks the volume root as a whole: only
+            # explicitly selected immediate directories are entered, and the
+            # root's own files / excluded siblings are never inventoried.
+            if (
+                allowed_root_children is not None
+                and depth == 1
+                and directory == target
+                and child.name.casefold() not in allowed_root_children
+            ):
+                continue
             relative = path.relative_to(target).as_posix()
             protections = hard_protection(path, target, exact_names, known_mounts)
             if path.name.casefold() in VCS_NAMES:
@@ -1019,7 +1229,7 @@ def scan_tree(
         target_identity["size_qualifiers"] = sorted(
             set(target_identity["size_qualifiers"] + ["not-walked"])
         )
-    return {
+    payload: dict[str, Any] = {
         "schema_version": SCHEMA_VERSION,
         "engine": "disk-hygiene-python-1",
         "session_nonce": secrets.token_hex(16),
@@ -1037,6 +1247,10 @@ def scan_tree(
         "truncated_paths": sorted(truncated),
         "entries": sorted(entries, key=lambda entry: entry["path"]),
     }
+    if root_children is not None:
+        payload["root_children_mode"] = True
+        payload["root_children_selected"] = list(root_children)
+    return payload
 
 
 def annotate_tracked(
@@ -1604,6 +1818,10 @@ def resolve_snapshot_target(snapshot: dict[str, Any]) -> tuple[Path, set[Path]]:
     a directory's mtime and size flip whenever any direct child is added or
     removed, so any unrelated write into a live target during the approval
     window would otherwise abort the run.
+
+    Root-children mode is the sole exception to the OS-managed-root veto: the
+    snapshot target is the volume root, but the inventory only covers explicitly
+    selected immediate children — never a recursive walk of the root itself.
     """
     if (
         snapshot.get("schema_version") != SCHEMA_VERSION
@@ -1618,8 +1836,19 @@ def resolve_snapshot_target(snapshot: dict[str, Any]) -> tuple[Path, set[Path]]:
     target_mounted, target_mount_error = mount_state(target, known_mounts)
     if mount_error or target_mount_error:
         raise HygieneError("snapshot target mount state is unverified")
-    if is_os_managed_target(target):
+    root_children_mode = bool(snapshot.get("root_children_mode"))
+    if is_os_managed_target(target) and not root_children_mode:
         raise HygieneError("snapshot target is now an OS-managed root")
+    if root_children_mode:
+        if not is_volume_root(target) or not is_os_managed_target(target):
+            raise HygieneError(
+                "root-children snapshot target must remain an OS-managed volume root"
+            )
+        selected = snapshot.get("root_children_selected")
+        if not isinstance(selected, list) or not selected:
+            raise HygieneError("root-children snapshot is missing its selection")
+        if any(not isinstance(name, str) or not name for name in selected):
+            raise HygieneError("root-children snapshot selection is invalid")
     if target_mounted and not is_volume_root(target):
         raise HygieneError("snapshot target is a mount point")
     if has_protected_path_component(target, baseline_protected_names()):
@@ -1650,6 +1879,11 @@ def preview(snapshot: dict[str, Any], plan: dict[str, Any]) -> dict[str, Any]:
         snapshot.get("policy", {}).get("protected_exact_names", [])
     )
     globs = snapshot_protection_globs(snapshot)
+    selected_root_children = {
+        name.casefold()
+        for name in snapshot.get("root_children_selected", [])
+        if isinstance(name, str)
+    }
     results = []
     blocked = False
     for candidate in candidates:
@@ -1661,6 +1895,10 @@ def preview(snapshot: dict[str, Any], plan: dict[str, Any]) -> dict[str, Any]:
             blockers.append("native-managed-report-only")
         if overlaps_truncated(relative, truncated_paths):
             blockers.append("truncated-not-inventoried")
+        if snapshot.get("root_children_mode"):
+            parts = PurePosixPath(relative).parts
+            if not parts or parts[0].casefold() not in selected_root_children:
+                blockers.append("outside-root-children-selection")
         expected_paths = subtree_names(relative, entries)
         if "truncated-not-inventoried" in blockers:
             # A truncated candidate is already hard-blocked from planning above;
@@ -2158,6 +2396,25 @@ def build_parser() -> argparse.ArgumentParser:
     scan.add_argument("--data-root")
     scan.add_argument("--max-depth", type=int)
     scan.add_argument("--confirmed-large-scan", action="store_true")
+    scan.add_argument(
+        "--root-children",
+        action="store_true",
+        help=(
+            "admit an OS-managed volume root only as a listing of immediate "
+            "non-OS child directories; requires explicit --root-child selection "
+            "before any subtree is audited"
+        ),
+    )
+    scan.add_argument(
+        "--root-child",
+        action="append",
+        default=[],
+        metavar="NAME",
+        help=(
+            "immediate child directory basename to audit under --root-children; "
+            "repeatable; never inferred"
+        ),
+    )
     for name in ("preview", "apply"):
         command = subparsers.add_parser(name)
         command.add_argument("--snapshot", required=True)
@@ -2201,7 +2458,21 @@ def main(argv: list[str] | None = None) -> int:
             mounted, target_mount_error = mount_state(target, known_mounts)
             if mount_error or target_mount_error:
                 raise HygieneError("target mount state is unverified")
-            if is_os_managed_target(target):
+            root_children_mode = bool(args.root_children)
+            selected_root_children = list(args.root_child or [])
+            if selected_root_children and not root_children_mode:
+                raise HygieneError("--root-child requires --root-children")
+            if root_children_mode:
+                if not is_volume_root(target):
+                    raise HygieneError(
+                        "--root-children requires a volume-root target"
+                    )
+                if not is_os_managed_target(target):
+                    raise HygieneError(
+                        "--root-children is only valid for an OS-managed volume root; "
+                        "scan a non-OS volume root without this flag"
+                    )
+            elif is_os_managed_target(target):
                 raise HygieneError("OS-managed roots are not valid audit targets")
             if mounted and not is_volume_root(target):
                 raise HygieneError("mount points are not valid audit targets")
@@ -2221,6 +2492,107 @@ def main(argv: list[str] | None = None) -> int:
                 raise HygieneError("--max-depth must be a positive integer")
             output_path = state_output_path(Path(args.output))
             advisory = os_autoclean_advisory(target)
+            if root_children_mode:
+                admitted, skipped = enumerate_root_children(
+                    target, policy, known_mounts
+                )
+                if not selected_root_children:
+                    return emit(
+                        {
+                            "status": "root-children-selection-required",
+                            "target": str(target),
+                            "admitted_children": admitted,
+                            "skipped_children": skipped,
+                            "os_autoclean": advisory,
+                            "note": (
+                                "OS-managed volume roots are never walked as a "
+                                "whole. Re-run with --root-children and one or "
+                                "more explicit --root-child NAME flags naming "
+                                "admitted immediate directories; a general "
+                                "'clean everything' is not selection."
+                            ),
+                        },
+                        5,
+                    )
+                resolved_children = normalize_root_child_selection(
+                    selected_root_children, admitted
+                )
+                # Each selected child is its own audit target for large-scan
+                # gating: a home directory selected under the volume root still
+                # requires a bound or confirmation.
+                child_large_reasons: list[str] = []
+                for child_name in resolved_children:
+                    child_path = target / child_name
+                    child_large_reasons.extend(
+                        f"{child_name}:{reason}"
+                        for reason in large_scan_reasons(child_path)
+                    )
+                if (
+                    child_large_reasons
+                    and args.max_depth is None
+                    and not args.confirmed_large_scan
+                ):
+                    return emit(
+                        {
+                            "status": "large-target-confirmation-required",
+                            "target": str(target),
+                            "root_children_selected": resolved_children,
+                            "large_target_reasons": sorted(set(child_large_reasons)),
+                            "os_autoclean": advisory,
+                            "note": (
+                                "A selected root child is a known-large scan "
+                                "root; re-run with --max-depth N (preferred) or, "
+                                "only after the human confirms a full walk, "
+                                "--confirmed-large-scan."
+                            ),
+                        },
+                        5,
+                    )
+                try:
+                    snapshot = scan_tree(
+                        target,
+                        policy,
+                        args.max_depth,
+                        root_children=resolved_children,
+                    )
+                except HygieneError as exc:
+                    return emit(
+                        {
+                            "status": "invalid-or-blocked",
+                            "error": str(exc),
+                            "os_autoclean": advisory,
+                        },
+                        2,
+                    )
+                snapshot["root_children_skipped"] = skipped
+                write_json(output_path, snapshot)
+                hinted = sum(1 for entry in snapshot["entries"] if entry["hints"])
+                return emit(
+                    {
+                        "status": "scan-complete",
+                        "target": str(target),
+                        "root_children_mode": True,
+                        "root_children_selected": resolved_children,
+                        "snapshot": str(output_path),
+                        "entries": len(snapshot["entries"]),
+                        "hinted_entries": hinted,
+                        "target_logical_bytes": snapshot["target_logical_bytes"],
+                        "target_reclaimable_local_bytes": snapshot[
+                            "target_reclaimable_local_bytes"
+                        ],
+                        "truncated_paths": snapshot["truncated_paths"],
+                        "errors": snapshot["errors"],
+                        "policy_sources": policy["policy_sources"],
+                        "os_autoclean": advisory,
+                        "note": (
+                            "Root-children mode inventoried only the selected "
+                            "immediate directories; the volume root itself and "
+                            "every skipped OS-owned/hidden/system/reparse entry "
+                            "were never walked. Hints are discovery signals, "
+                            "never cleanup verdicts."
+                        ),
+                    }
+                )
             large_reasons = large_scan_reasons(target)
             if (
                 large_reasons

--- a/plugins/disk-hygiene/skills/clean/scripts/hygiene.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/hygiene.py
@@ -979,15 +979,22 @@ def volume_root_os_owned_names(
             "boot",
             "dev",
             "etc",
+            "home",
             "lib",
             "lib64",
+            "lost+found",
+            "media",
+            "mnt",
+            "opt",
             "proc",
+            "root",
             "run",
             "sbin",
+            "srv",
             "sys",
+            "tmp",
             "usr",
             "var",
-            "lost+found",
         )
     }
 
@@ -1081,8 +1088,23 @@ def enumerate_root_children(
     return admitted, skipped
 
 
+def root_child_names_case_sensitive(platform_key: str | None = None) -> bool:
+    """Whether root-child selection must preserve exact basenames.
+
+    Linux volume roots are case-sensitive; collapsing `/Cache` and `/cache` into
+    one casefolded key would let `--root-child Cache` inventory the wrong sibling
+    (or both). Windows and macOS volume roots are case-insensitive, so casefold
+    matching remains the operator-friendly path there.
+    """
+    current = platform_key or os_key()
+    return current == "linux"
+
+
 def normalize_root_child_selection(
-    selected: list[str], admitted: list[dict[str, str]]
+    selected: list[str],
+    admitted: list[dict[str, str]],
+    *,
+    case_sensitive: bool | None = None,
 ) -> list[str]:
     """Map a human selection onto admitted basenames; reject anything else."""
     if not selected:
@@ -1090,7 +1112,15 @@ def normalize_root_child_selection(
             "--root-children requires an explicit --root-child selection; "
             "a general clean-everything request is not selection"
         )
-    by_fold = {item["name"].casefold(): item["name"] for item in admitted}
+    sensitive = (
+        root_child_names_case_sensitive()
+        if case_sensitive is None
+        else case_sensitive
+    )
+    if sensitive:
+        by_name = {item["name"]: item["name"] for item in admitted}
+    else:
+        by_name = {item["name"].casefold(): item["name"] for item in admitted}
     resolved: list[str] = []
     seen: set[str] = set()
     for raw in selected:
@@ -1098,16 +1128,17 @@ def normalize_root_child_selection(
             raise HygieneError(
                 f"--root-child must be an immediate basename, not a path: {raw!r}"
             )
-        key = raw.casefold()
-        if key not in by_fold:
+        key = raw if sensitive else raw.casefold()
+        if key not in by_name:
             raise HygieneError(
                 f"--root-child {raw!r} is not an admitted immediate child directory "
                 "of the OS-managed volume root"
             )
-        canonical = by_fold[key]
-        if canonical.casefold() in seen:
+        canonical = by_name[key]
+        seen_key = canonical if sensitive else canonical.casefold()
+        if seen_key in seen:
             continue
-        seen.add(canonical.casefold())
+        seen.add(seen_key)
         resolved.append(canonical)
     return resolved
 
@@ -1127,11 +1158,13 @@ def scan_tree(
     known_mounts, mount_error = linux_mount_points()
     if mount_error:
         errors.append({"path": ".", "error": mount_error})
-    allowed_root_children = (
-        {name.casefold() for name in root_children}
-        if root_children is not None
-        else None
-    )
+    root_children_sensitive = root_child_names_case_sensitive()
+    if root_children is None:
+        allowed_root_children: set[str] | None = None
+    elif root_children_sensitive:
+        allowed_root_children = set(root_children)
+    else:
+        allowed_root_children = {name.casefold() for name in root_children}
 
     def visit(directory: Path, depth: int = 1) -> int:
         total = 0
@@ -1148,11 +1181,14 @@ def scan_tree(
             # Root-children mode never walks the volume root as a whole: only
             # explicitly selected immediate directories are entered, and the
             # root's own files / excluded siblings are never inventoried.
+            child_key = (
+                child.name if root_children_sensitive else child.name.casefold()
+            )
             if (
                 allowed_root_children is not None
                 and depth == 1
                 and directory == target
-                and child.name.casefold() not in allowed_root_children
+                and child_key not in allowed_root_children
             ):
                 continue
             relative = path.relative_to(target).as_posix()
@@ -1879,11 +1915,25 @@ def preview(snapshot: dict[str, Any], plan: dict[str, Any]) -> dict[str, Any]:
         snapshot.get("policy", {}).get("protected_exact_names", [])
     )
     globs = snapshot_protection_globs(snapshot)
-    selected_root_children = {
-        name.casefold()
-        for name in snapshot.get("root_children_selected", [])
-        if isinstance(name, str)
-    }
+    if root_child_names_case_sensitive(snapshot.get("platform")):
+        selected_root_children = {
+            name
+            for name in snapshot.get("root_children_selected", [])
+            if isinstance(name, str)
+        }
+
+        def root_child_key(name: str) -> str:
+            return name
+    else:
+        selected_root_children = {
+            name.casefold()
+            for name in snapshot.get("root_children_selected", [])
+            if isinstance(name, str)
+        }
+
+        def root_child_key(name: str) -> str:
+            return name.casefold()
+
     results = []
     blocked = False
     for candidate in candidates:
@@ -1897,7 +1947,7 @@ def preview(snapshot: dict[str, Any], plan: dict[str, Any]) -> dict[str, Any]:
             blockers.append("truncated-not-inventoried")
         if snapshot.get("root_children_mode"):
             parts = PurePosixPath(relative).parts
-            if not parts or parts[0].casefold() not in selected_root_children:
+            if not parts or root_child_key(parts[0]) not in selected_root_children:
                 blockers.append("outside-root-children-selection")
         expected_paths = subtree_names(relative, entries)
         if "truncated-not-inventoried" in blockers:

--- a/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
@@ -878,6 +878,266 @@ class HygieneTests(unittest.TestCase):
             self.assertIn("OS-managed roots", payload["error"])
             self.assertFalse((data_root / "snapshot.json").exists())
 
+    def _os_managed_volume_root_patches(self, target: Path | None = None) -> list[object]:
+        def is_target(path: Path) -> bool:
+            if target is None:
+                return True
+            try:
+                return Path(path).resolve() == target.resolve()
+            except OSError:
+                return False
+
+        def mount_state(path: Path, *args: object, **kwargs: object) -> tuple[bool, None]:
+            return (is_target(path), None)
+
+        return [
+            mock.patch.object(
+                hygiene, "is_volume_root", side_effect=lambda path: is_target(path)
+            ),
+            mock.patch.object(
+                hygiene,
+                "is_os_managed_target",
+                side_effect=lambda path, roots=None, markers=None: is_target(path),
+            ),
+            mock.patch.object(hygiene, "mount_state", side_effect=mount_state),
+            mock.patch.object(hygiene, "system_roots", return_value=[]),
+            mock.patch.object(
+                hygiene,
+                "volume_root_os_owned_names",
+                return_value={
+                    name.casefold()
+                    for name in (
+                        "Windows",
+                        "Program Files",
+                        "Program Files (x86)",
+                        "ProgramData",
+                        "Recovery",
+                        "$Recycle.Bin",
+                        "System Volume Information",
+                        "Users",
+                        "PerfLogs",
+                    )
+                },
+            ),
+        ]
+
+    def test_root_children_without_selection_lists_admitted_only(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            base = Path(temporary)
+            target = base / "os-root"
+            data_root = base / "plugin-data"
+            target.mkdir()
+            data_root.mkdir()
+            (target / "builds").mkdir()
+            (target / "tmp").mkdir()
+            (target / "orphan.tmp").write_text("x", encoding="utf-8")
+            (target / ".hidden").mkdir()
+            (target / "Windows").mkdir()
+            (target / "$SysReset").mkdir()
+            (target / "Documents").mkdir()
+            link = target / "junction-like"
+            link.symlink_to(target / "builds", target_is_directory=True)
+            code, payload = self._scan_target(
+                target,
+                data_root,
+                self._os_managed_volume_root_patches(target),
+                extra_args=["--root-children"],
+            )
+            self.assertEqual(5, code)
+            self.assertEqual("root-children-selection-required", payload["status"])
+            admitted = {item["name"] for item in payload["admitted_children"]}
+            self.assertEqual({"builds", "tmp"}, admitted)
+            skipped = {item["name"]: item["reason"] for item in payload["skipped_children"]}
+            self.assertEqual("not-a-directory", skipped["orphan.tmp"])
+            self.assertEqual("hidden", skipped[".hidden"])
+            self.assertEqual("os-owned", skipped["Windows"])
+            self.assertEqual("os-owned", skipped["$SysReset"])
+            self.assertEqual("baseline-protected-name", skipped["Documents"])
+            self.assertEqual(
+                "symlink-junction-or-reparse-point", skipped["junction-like"]
+            )
+            self.assertFalse((data_root / "snapshot.json").exists())
+
+    def test_root_children_scans_only_selected_admitted_directories(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            base = Path(temporary)
+            target = base / "os-root"
+            data_root = base / "plugin-data"
+            target.mkdir()
+            data_root.mkdir()
+            (target / "builds").mkdir()
+            (target / "builds" / "orphan.tmp").write_text("left", encoding="utf-8")
+            (target / "tmp").mkdir()
+            (target / "tmp" / "keep.tmp").write_text("right", encoding="utf-8")
+            (target / "ccxp").mkdir()
+            (target / "ccxp" / "skip.tmp").write_text("nope", encoding="utf-8")
+            (target / "Windows").mkdir()
+            (target / "Windows" / "system.tmp").write_text("os", encoding="utf-8")
+            (target / "root-only.tmp").write_text("never", encoding="utf-8")
+            code, payload = self._scan_target(
+                target,
+                data_root,
+                self._os_managed_volume_root_patches(target),
+                extra_args=[
+                    "--root-children",
+                    "--root-child",
+                    "builds",
+                    "--root-child",
+                    "tmp",
+                ],
+            )
+            self.assertEqual(0, code)
+            self.assertEqual("scan-complete", payload["status"])
+            self.assertTrue(payload["root_children_mode"])
+            self.assertEqual(["builds", "tmp"], payload["root_children_selected"])
+            snapshot = json.loads(
+                (data_root / "snapshot.json").read_text(encoding="utf-8")
+            )
+            paths = {entry["path"] for entry in snapshot["entries"]}
+            self.assertIn("builds", paths)
+            self.assertIn("builds/orphan.tmp", paths)
+            self.assertIn("tmp", paths)
+            self.assertIn("tmp/keep.tmp", paths)
+            self.assertNotIn("ccxp", paths)
+            self.assertNotIn("ccxp/skip.tmp", paths)
+            self.assertNotIn("Windows", paths)
+            self.assertNotIn("Windows/system.tmp", paths)
+            self.assertNotIn("root-only.tmp", paths)
+            self.assertTrue(snapshot["root_children_mode"])
+            self.assertEqual(["builds", "tmp"], snapshot["root_children_selected"])
+
+    def test_root_children_rejects_unadmitted_or_path_selection(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            base = Path(temporary)
+            target = base / "os-root"
+            data_root = base / "plugin-data"
+            target.mkdir()
+            data_root.mkdir()
+            (target / "builds").mkdir()
+            (target / "Windows").mkdir()
+            code, payload = self._scan_target(
+                target,
+                data_root,
+                self._os_managed_volume_root_patches(target),
+                extra_args=["--root-children", "--root-child", "Windows"],
+            )
+            self.assertEqual(2, code)
+            self.assertIn("not an admitted immediate child", payload["error"])
+            code, payload = self._scan_target(
+                target,
+                data_root,
+                self._os_managed_volume_root_patches(target),
+                extra_args=["--root-children", "--root-child", "builds/nested"],
+            )
+            self.assertEqual(2, code)
+            self.assertIn("immediate basename", payload["error"])
+
+    def test_root_children_flag_requires_os_managed_volume_root(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            base = Path(temporary)
+            target = base / "ordinary"
+            data_root = base / "plugin-data"
+            target.mkdir()
+            data_root.mkdir()
+            (target / "builds").mkdir()
+            code, payload = self._scan_target(
+                target,
+                data_root,
+                [
+                    mock.patch.object(hygiene, "is_volume_root", return_value=False),
+                    mock.patch.object(
+                        hygiene, "is_os_managed_target", return_value=False
+                    ),
+                    mock.patch.object(
+                        hygiene, "mount_state", return_value=(False, None)
+                    ),
+                ],
+                extra_args=["--root-children"],
+            )
+            self.assertEqual(2, code)
+            self.assertIn("volume-root target", payload["error"])
+            code, payload = self._scan_target(
+                target,
+                data_root,
+                self._non_os_volume_root_patches(),
+                extra_args=["--root-children"],
+            )
+            self.assertEqual(2, code)
+            self.assertIn("only valid for an OS-managed volume root", payload["error"])
+
+    def test_root_child_requires_root_children_flag(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            base = Path(temporary)
+            target = base / "ordinary"
+            data_root = base / "plugin-data"
+            target.mkdir()
+            data_root.mkdir()
+            code, payload = self._scan_target(
+                target,
+                data_root,
+                [
+                    mock.patch.object(
+                        hygiene, "is_os_managed_target", return_value=False
+                    ),
+                    mock.patch.object(hygiene, "is_volume_root", return_value=False),
+                    mock.patch.object(
+                        hygiene, "mount_state", return_value=(False, None)
+                    ),
+                ],
+                extra_args=["--root-child", "builds"],
+            )
+            self.assertEqual(2, code)
+            self.assertIn("--root-child requires --root-children", payload["error"])
+
+    def test_preview_allows_root_children_os_managed_snapshot(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary) / "os-root"
+            child = root / "builds"
+            child.mkdir(parents=True)
+            (child / "orphan.tmp").write_text("x", encoding="utf-8")
+            snapshot = hygiene.scan_tree(
+                root.resolve(),
+                hygiene.load_policy(None),
+                root_children=["builds"],
+            )
+            snapshot["root_children_skipped"] = []
+            plan = {
+                "version": 1,
+                "tier": "high",
+                "candidates": [candidate("builds/orphan.tmp")],
+            }
+            target = root.resolve()
+
+            def is_target(path: Path) -> bool:
+                try:
+                    return Path(path).resolve() == target
+                except OSError:
+                    return False
+
+            with (
+                mock.patch.object(
+                    hygiene, "is_volume_root", side_effect=is_target
+                ),
+                mock.patch.object(
+                    hygiene,
+                    "is_os_managed_target",
+                    side_effect=lambda path, roots=None, markers=None: is_target(path),
+                ),
+                mock.patch.object(
+                    hygiene,
+                    "mount_state",
+                    side_effect=lambda path, *a, **k: (is_target(path), None),
+                ),
+                mock.patch.object(hygiene, "system_roots", return_value=[]),
+            ):
+                result = hygiene.preview(snapshot, plan)
+            self.assertEqual("ready-for-explicit-approval", result["status"])
+            self.assertEqual("high", result["tier"])
+            self.assertEqual(
+                ["builds/orphan.tmp"],
+                [item["path"] for item in result["candidates"]],
+            )
+
     def test_scan_rejects_non_root_mount_point(self) -> None:
         # A mount point that is not a volume root (a nested or bind mount as the
         # target) stays hard-blocked — the real cross-boundary danger, unchanged.
@@ -4492,6 +4752,36 @@ class GuardTests(unittest.TestCase):
         denied = (
             f"{base} --confirmed-large-scan --confirmed-large-scan",
             f"{base} --confirmed-large-scan v",
+        )
+        for command in allowed:
+            self.assertEqual(
+                "allow",
+                self.run_guard(command)["hookSpecificOutput"]["permissionDecision"],
+                command,
+            )
+        for command in denied:
+            self.assertEqual(
+                "deny",
+                self.run_guard(command)["hookSpecificOutput"]["permissionDecision"],
+                command,
+            )
+
+    def test_guard_scan_accepts_root_children_selection_flags(self) -> None:
+        script = SCRIPT_DIR / "hygiene.py"
+        base = f'"{self.python_command()}" "{script}" scan --target t --output s'
+        allowed = (
+            f"{base} --root-children",
+            f"{base} --root-children --root-child builds",
+            f"{base} --root-children --root-child builds --root-child tmp",
+            f"{base} --root-children --root-child builds --max-depth 1",
+            f"{base} --confirmed-large-scan --root-children --root-child builds",
+        )
+        denied = (
+            f"{base} --root-child builds",
+            f"{base} --root-children --root-children",
+            f"{base} --root-children --root-child builds/nested",
+            f"{base} --root-children --root-child ..",
+            f"{base} --root-children --root-child",
         )
         for command in allowed:
             self.assertEqual(

--- a/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
@@ -1032,6 +1032,80 @@ class HygieneTests(unittest.TestCase):
             self.assertEqual(2, code)
             self.assertIn("immediate basename", payload["error"])
 
+    def test_linux_volume_root_os_owned_includes_conventional_roots(self) -> None:
+        owned = hygiene.volume_root_os_owned_names("linux")
+        for name in (
+            "bin",
+            "boot",
+            "home",
+            "media",
+            "mnt",
+            "opt",
+            "root",
+            "srv",
+            "tmp",
+            "usr",
+            "var",
+        ):
+            self.assertIn(name.casefold(), owned)
+
+    def test_root_children_skips_linux_os_owned_names(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            base = Path(temporary)
+            target = base / "os-root"
+            data_root = base / "plugin-data"
+            target.mkdir()
+            data_root.mkdir()
+            (target / "builds").mkdir()
+            (target / "tmp").mkdir()
+            (target / "home").mkdir()
+            (target / "opt").mkdir()
+            (target / "srv").mkdir()
+            (target / "root").mkdir()
+            patches = [
+                mock.patch.object(hygiene, "is_volume_root", return_value=True),
+                mock.patch.object(hygiene, "is_os_managed_target", return_value=True),
+                mock.patch.object(hygiene, "os_key", return_value="linux"),
+                mock.patch.object(
+                    hygiene, "mount_state", return_value=(False, None)
+                ),
+                mock.patch.object(hygiene, "system_roots", return_value=[]),
+                mock.patch.object(
+                    hygiene, "linux_mount_points", return_value=(set(), None)
+                ),
+            ]
+            code, payload = self._scan_target(
+                target,
+                data_root,
+                patches,
+                extra_args=["--root-children"],
+            )
+            self.assertEqual(5, code)
+            admitted = {item["name"] for item in payload["admitted_children"]}
+            self.assertEqual({"builds"}, admitted)
+            skipped = {item["name"]: item["reason"] for item in payload["skipped_children"]}
+            for name in ("tmp", "home", "opt", "srv", "root"):
+                self.assertEqual("os-owned", skipped[name])
+
+    def test_root_child_selection_is_exact_on_case_sensitive_hosts(self) -> None:
+        admitted = [
+            {"name": "Cache", "path": "/Cache"},
+            {"name": "cache", "path": "/cache"},
+            {"name": "builds", "path": "/builds"},
+        ]
+        resolved = hygiene.normalize_root_child_selection(
+            ["Cache"], admitted, case_sensitive=True
+        )
+        self.assertEqual(["Cache"], resolved)
+        with self.assertRaises(hygiene.HygieneError):
+            hygiene.normalize_root_child_selection(
+                ["CACHE"], admitted, case_sensitive=True
+            )
+        folded = hygiene.normalize_root_child_selection(
+            ["CACHE"], [{"name": "Cache", "path": "/Cache"}], case_sensitive=False
+        )
+        self.assertEqual(["Cache"], folded)
+
     def test_root_children_flag_requires_os_managed_volume_root(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
             base = Path(temporary)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #2588

## Summary

`/disk-hygiene:clean` rejected OS-managed volume roots outright, leaving no supported path to audit user-created directories sitting at the volume root.

## Fix

Add an explicitly bounded root-children mode that enumerates only immediate root entries, skips OS-owned/hidden/system/reparse entries, and audits admitted children without walking the whole volume.

## Verification

See PR checks / plugin tests.

## Related

Refs #2590 — tidiness-first reporting.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eb3f5ee5-6c9f-48a3-8e46-071bd363f8b0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eb3f5ee5-6c9f-48a3-8e46-071bd363f8b0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

