### PR TITLE
fix(repo-fleet-hygiene): accept bare paths and drive roots as --root

### DIFF
--- a/plugins/repo-fleet-hygiene/.claude-plugin/plugin.json
+++ b/plugins/repo-fleet-hygiene/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "repo-fleet-hygiene",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "description": "Read-only Git/GitHub fleet audit for merged local branches, orphaned or mismatched worktree registrations, and repository transfers or renames. Findings are confidence-tiered and hand off exact targets to existing per-repository cleanup tools; this plugin never deletes branches or worktrees.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/repo-fleet-hygiene/CHANGELOG.md
+++ b/plugins/repo-fleet-hygiene/CHANGELOG.md
@@ -3,6 +3,21 @@
 All notable changes to `repo-fleet-hygiene` are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.19.1]
+
+### Changed
+
+- **Bare paths and drive roots are valid discovery roots (#2599).** A positional `<dir>` (including
+  Windows drive roots such as `D:`) is equivalent to `--root <dir>` (normalized to `D:/`). Symlinked
+  discovery roots are refused. A `--root` that exists but is not readable/executable hard-fails with
+  `discovery root is not traversable` instead of recording a `ROOT_LABEL` and reporting a clean empty
+  audit. An empty walked root remains a valid zero-repository audit.
+- **No-argument audits no longer fall back to the session project directory (#2599).** Without a
+  bare path, `--root`/`--repo`, or config-supplied `fleet.root`/`fleet.repo`, the collector hard-fails
+  and names how to set scope (`/repo-fleet-hygiene:setup apply` or explicit CLI roots). This is a
+  breaking change for bare `/repo-fleet-hygiene:audit` invocations that previously audited
+  `$CLAUDE_PROJECT_DIR` as an implicit `--repo`.
+
 ## [0.19.0]
 
 ### Fixed

--- a/plugins/repo-fleet-hygiene/README.md
+++ b/plugins/repo-fleet-hygiene/README.md
@@ -32,10 +32,16 @@ Audit the current project repository (zero configuration):
 /repo-fleet-hygiene:audit
 ```
 
-Audit one or more repository-tree roots:
+With no CLI scope, the audit uses `fleet.root` / `fleet.repo` from the consumed config. With
+neither CLI nor config scope, it stops and names how to set scope — it does not treat the session
+project directory as an implicit `--repo`.
+
+Audit one or more repository-tree roots (flag or bare path; drive roots are allowed):
 
 ```text
 /repo-fleet-hygiene:audit --root <repo-root>/github.com --root <other-root>/internal
+/repo-fleet-hygiene:audit D:
+/repo-fleet-hygiene:audit ~/src
 ```
 
 Audit exact repositories without recursive discovery:

--- a/plugins/repo-fleet-hygiene/skills/audit/SKILL.md
+++ b/plugins/repo-fleet-hygiene/skills/audit/SKILL.md
@@ -1,7 +1,7 @@
 ---
 description: "Audit Git/GitHub hygiene across a fleet of local repositories: find GitHub-merged local branches, merged/missing/prunable/mislinked worktree registrations, and remotes that resolve to a moved or renamed GitHub repository. Read-only and confidence-tiered; emits exact handoffs to repo-hygiene/source-control but never deletes, prunes, repairs, fetches, checks out, or rewrites. Use when: 'audit repositories', 'repo fleet hygiene', 'stale branches across repos', 'orphaned worktrees across repos', 'moved repos', 'renamed GitHub owner', 'cross-repo git cleanup report'."
 user-invocable: true
-argument-hint: "[--root <dir>]... [--repo <dir>]... [--config <file>] [--canonical <github.com/owner/repo=path>]... [--max-depth <1..12>] [--detail] [--plan-file <path>] | --apply-plan <path>"
+argument-hint: "[<dir>]... [--root <dir>]... [--repo <dir>]... [--config <file>] [--canonical <github.com/owner/repo=path>]... [--max-depth <1..12>] [--detail] [--plan-file <path>] | --apply-plan <path>"
 allowed-tools:
   - Bash(${CLAUDE_SKILL_DIR}/scripts/audit-fleet.sh:*)
 metadata:
@@ -26,8 +26,10 @@ gate, and the receiving per-repository tool or human still owns actual preview/e
 
 ## Input resolution
 
-Parse `$ARGUMENTS` as opaque arguments for the bundled script. Supported flags:
+Parse `$ARGUMENTS` as opaque arguments for the bundled script. Supported forms:
 
+- `<dir>`: bare positional path — equivalent to `--root <dir>` (repeatable). Drive roots such as
+  `D:` are legitimate discovery roots (normalized to `D:/`).
 - `--root <dir>`: bounded recursive repository discovery (repeatable).
 - `--repo <dir>`: exact repository/worktree target (repeatable).
 - `--config <file>`: explicit Git-format config (at most one).
@@ -35,7 +37,7 @@ Parse `$ARGUMENTS` as opaque arguments for the bundled script. Supported flags:
   (repeatable; explicit wins over config).
 - `--max-depth <1..12>`: discovery bound; explicit wins over config/default `5`.
 - `--project-dir <dir>`: the session's project directory, used for the project-scoped config rung
-  and the no-scope fallback target.
+  only — not as an implicit audit target.
 - `--detail`: emit collapsed per-target evidence after the rollup (default is rollup + action plan
   only).
 - `--plan-file <path>`: write the machine-readable action-plan JSON to this path (otherwise a temp
@@ -48,13 +50,13 @@ variable is substituted in this markdown content and in `allowed-tools` Bash rul
 **not** present in the Bash tool's environment, so the script cannot read it for itself — passing
 it in is what makes the project rung below reachable at all.
 
-If neither `--root` nor `--repo` is present, the script uses the project directory as an exact
-`--repo` target — not as a discovery root, so nothing beneath it is searched. A project directory
-that is not a Git working tree is therefore rejected, and the rejection names the three ways to
-supply scope plus `/repo-fleet-hygiene:setup apply`; pass that guidance through rather than
-re-deriving a root yourself. If no project directory resolves either, the run stops with the same
-remedies rather than auditing the shell's incidental working directory. Config
-resolution is the script's own ladder — do not pre-resolve or pass a probed path yourself:
+If neither a bare path nor `--root`/`--repo` is present, the script uses config-supplied
+`fleet.root` / `fleet.repo` as the machine-wide default when a config on the ladder provides them.
+With neither CLI nor config scope, the run stops and names how to set scope (bare path,
+`--root`/`--repo`/`--config`, or `/repo-fleet-hygiene:setup apply`); pass that guidance through
+rather than re-deriving a root yourself or auditing the session project directory. A discovery
+root that exists but contains no repositories is a finding of zero repositories, not an error.
+Config resolution is the script's own ladder — do not pre-resolve or pass a probed path yourself:
 explicit `--config` wins, else the script probes
 `<project-dir>/.claude/repo-fleet-hygiene.conf` (project-scoped), else
 `~/.claude/repo-fleet-hygiene.conf` (user-global — a machine-scoped fleet config placed there is
@@ -66,8 +68,10 @@ Config-supplied scope is **additive** to CLI-supplied scope: a `--repo X` run st
 configured root. The header's `Scope:` line names each contributing rung and its entry count, so
 report that line rather than assuming the arguments were the whole scope.
 
-Before execution, reject any arguments outside this grammar. Pass every path/override as a quoted
-argument; never assemble a shell fragment from config, repository, remote, or branch text.
+Before execution, reject any arguments outside this grammar. Keep reject-on-unknown for anything
+beginning with `-` (that is the injection boundary); bare paths are in-grammar. Pass every
+path/override as a quoted argument; never assemble a shell fragment from config, repository,
+remote, or branch text.
 
 Run exactly once:
 

--- a/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.sh
+++ b/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.sh
@@ -6,7 +6,7 @@ set -uo pipefail
 
 usage() {
   cat <<'EOF'
-Usage: audit-fleet.sh [--root DIR]... [--repo DIR]... [--config FILE]
+Usage: audit-fleet.sh [DIR]... [--root DIR]... [--repo DIR]... [--config FILE]
                       [--canonical github.com/owner/repo=PATH]...
                       [--max-depth 1..12] [--project-dir DIR]
                       [--detail] [--plan-file PATH]
@@ -14,6 +14,9 @@ Usage: audit-fleet.sh [--root DIR]... [--repo DIR]... [--config FILE]
 
 Read-only. Discovers repositories, resolves optional canonical checkouts, and
 reports confidence-tiered branch, worktree, and GitHub-identity findings.
+
+A bare DIR is equivalent to --root DIR. Windows drive letters like D: are
+normalized to D:/ so discovery starts at the drive root, not "cwd on D:".
 
 Default human output is a per-repository rollup (counts by finding kind,
 collapsed targets, and an explicit CLEAN / N candidates / BLOCKED verdict)
@@ -26,13 +29,26 @@ the path; otherwise a temp file is used and named in the report).
 dry-run approval artifact (branches before worktrees). It performs no
 mutation; re-derive OIDs at real execution time.
 
---project-dir supplies the session's project directory, used for the
-project-scoped config rung and as the target when no scope is given. It is
-passed in rather than read from the environment, which does not carry it.
-An empty value means "no project directory": the project config rung is
-skipped, and a run with no other scope stops rather than falling back to the
-current working directory.
+When no CLI scope is given, config-supplied fleet.root / fleet.repo is the
+machine-wide default. With neither CLI nor config scope, the run stops and
+names how to set scope — it does not audit the session project directory.
+
+--project-dir supplies the session's project directory for the project-scoped
+config rung only (not as an implicit audit target). It is passed in rather
+than read from the environment, which does not carry it. An empty value means
+"no project directory": the project config rung is skipped.
 EOF
+}
+
+# Windows drive-letter alone (D:) means "cwd on that drive" in shells; a fleet
+# discovery root means the volume root. Append / so -d and discovery agree.
+normalize_discovery_root() {
+  local p="$1"
+  if [[ "$p" =~ ^[A-Za-z]:$ ]]; then
+    printf '%s/' "$p"
+  else
+    printf '%s' "$p"
+  fi
 }
 
 fail() {
@@ -351,7 +367,7 @@ while [[ $# -gt 0 ]]; do
   # contributed nothing. A CLI typo stops the run, as everywhere else in this grammar.
   --root)
     [[ $# -ge 2 && -n "$2" ]] || fail "--root requires a directory"
-    ROOT_ARGS+=("$2")
+    ROOT_ARGS+=("$(normalize_discovery_root "$2")")
     shift 2
     ;;
   --repo)
@@ -408,7 +424,19 @@ while [[ $# -gt 0 ]]; do
     usage
     exit 0
     ;;
-  *) fail "unknown argument: $1" ;;
+  -*)
+    # Reject unknown dashed tokens; that is the injection boundary. Bare paths
+    # (including drive roots) are accepted below as --root equivalents (#2599).
+    fail "unknown argument: $1"
+    ;;
+  *)
+    # Bare positional path ≡ --root. An empty value is rejected rather than
+    # accepted-and-skipped so the header cannot claim a scope that contributed
+    # nothing.
+    [[ -n "$1" ]] || fail "bare path requires a directory"
+    ROOT_ARGS+=("$(normalize_discovery_root "$1")")
+    shift
+    ;;
   esac
 done
 
@@ -607,46 +635,28 @@ is_acked() {
   return 1
 }
 
-IMPLICIT_SCOPE=false
 UNRESOLVED_SCOPE=false
-SCOPE_FALLBACK_NOTE="so the audit fell back to this session's project directory as an exact repository target"
+SCOPE_FALLBACK_NOTE="so no repository scope resolved"
 if [[ ${#ROOT_ARGS[@]} -eq 0 && ${#REPO_ARGS[@]} -eq 0 ]]; then
-  # No scope AND no project directory. $PWD is an agent session's incidental working directory, not
-  # a chosen scope, so falling back to it would audit wherever the shell happened to sit and report
-  # that as the project. Defer the rejection until reject_target is defined below, so the operator
-  # gets the same scope remedies the chosen-nothing case already earns.
-  if [[ -z "$PROJECT_DIR" ]]; then
-    UNRESOLVED_SCOPE=true
-    SCOPE_FALLBACK_NOTE="and no project directory was available, so no repository scope resolved"
-  fi
-  REPO_ARGS+=("$PROJECT_DIR")
-  # The implicit current-project default is CLI-equivalent, not config-sourced: it is appended
-  # after CLI_REPO_COUNT was captured, so count it there or the zero-configuration audit from a
-  # non-Git directory would degrade to a stale-config-entry (with an empty source) instead of
-  # hard-failing like the explicit-path case it stands in for. It carries its own origin so a
-  # rejection can name the remedies: the operator never chose this path, so the bare path in a
-  # CLI-shaped error tells them nothing about how to supply a scope.
-  CLI_REPO_COUNT=$((CLI_REPO_COUNT + 1))
-  IMPLICIT_SCOPE=true
+  # No CLI and no config-supplied fleet.root/fleet.repo. A fleet tool's no-argument form is
+  # machine-wide config scope when present; without it, refuse the old project-directory-as-exact
+  # --repo default rather than auditing an unintended tree (#2599).
+  UNRESOLVED_SCOPE=true
 fi
 
 # Scope provenance: which rung actually supplied the audited roots/repos. This is a different
 # question from which config FILE was consumed, and the header used to answer it with a fixed
 # literal that could contradict the run's own inputs two lines later. Config-supplied scope is
 # ADDITIVE to any CLI-supplied scope, so both contributions are named rather than one masking the
-# other.
-if [[ "$IMPLICIT_SCOPE" == "true" ]]; then
-  SCOPE_PROVENANCE="project directory (no --root, --repo, or config-supplied scope)"
-else
-  cli_scope_count=$((CLI_ROOT_COUNT + CLI_REPO_COUNT))
-  config_scope_count=$((${#ROOT_ARGS[@]} - CLI_ROOT_COUNT + ${#REPO_ARGS[@]} - CLI_REPO_COUNT))
-  SCOPE_PROVENANCE=""
-  [[ "$cli_scope_count" -gt 0 ]] &&
-    SCOPE_PROVENANCE="command line ($cli_scope_count --root/--repo argument(s))"
-  if [[ "$config_scope_count" -gt 0 ]]; then
-    [[ -n "$SCOPE_PROVENANCE" ]] && SCOPE_PROVENANCE="$SCOPE_PROVENANCE + "
-    SCOPE_PROVENANCE="${SCOPE_PROVENANCE}config $CONFIG_SOURCE ($config_scope_count fleet.root/fleet.repo entr(ies))"
-  fi
+# other. Bare positional paths count as command-line --root equivalents.
+cli_scope_count=$((CLI_ROOT_COUNT + CLI_REPO_COUNT))
+config_scope_count=$((${#ROOT_ARGS[@]} - CLI_ROOT_COUNT + ${#REPO_ARGS[@]} - CLI_REPO_COUNT))
+SCOPE_PROVENANCE=""
+[[ "$cli_scope_count" -gt 0 ]] &&
+  SCOPE_PROVENANCE="command line ($cli_scope_count --root/--repo argument(s))"
+if [[ "$config_scope_count" -gt 0 ]]; then
+  [[ -n "$SCOPE_PROVENANCE" ]] && SCOPE_PROVENANCE="$SCOPE_PROVENANCE + "
+  SCOPE_PROVENANCE="${SCOPE_PROVENANCE}config $CONFIG_SOURCE ($config_scope_count fleet.root/fleet.repo entr(ies))"
 fi
 
 path_key() {
@@ -799,19 +809,20 @@ reject_target() {
     if [[ -n "$CONFIG_FILE" ]]; then
       cat >&2 <<EOF
 
-No --root or --repo was given, and the consumed config ($CONFIG_SOURCE: $CONFIG_FILE) carries no
-fleet.root or fleet.repo entries, $SCOPE_FALLBACK_NOTE. Add scope to that config:
+No bare path, --root, or --repo was given, and the consumed config ($CONFIG_SOURCE: $CONFIG_FILE)
+carries no fleet.root or fleet.repo entries, $SCOPE_FALLBACK_NOTE. Add scope to that config:
 
   git config --file "$CONFIG_FILE" --add fleet.root <dir>   bounded recursive repository discovery
   git config --file "$CONFIG_FILE" --add fleet.repo <dir>   one exact repository or worktree
 
-Or pass --root <dir> / --repo <dir> for a one-off scope.
+Or pass a bare path / --root <dir> / --repo <dir> for a one-off scope.
 EOF
     else
       cat >&2 <<EOF
 
-No --root, --repo, or --config was given, $SCOPE_FALLBACK_NOTE. Give it a scope instead:
+No bare path, --root, --repo, or --config was given, $SCOPE_FALLBACK_NOTE. Give it a scope instead:
 
+  <dir>            bare path — same as --root (drive roots like D: are allowed)
   --root <dir>     bounded recursive repository discovery
   --repo <dir>     one exact repository or worktree
   --config <file>  a Git-format fleet config listing fleet.root / fleet.repo entries
@@ -825,7 +836,7 @@ EOF
 
 if [[ "$UNRESOLVED_SCOPE" == "true" ]]; then
   reject_target default \
-    "no scope resolved: no --root or --repo, no config-supplied scope, and no project directory (pass --project-dir, or supply a scope directly)"
+    "no scope resolved: no bare path, --root, or --repo, and no config-supplied fleet.root/fleet.repo"
 fi
 
 # main_worktree <dir>: the repository-of-record checkout for <dir>, or non-zero when the porcelain
@@ -932,13 +943,7 @@ repo_index=0
 for repo in "${REPO_ARGS[@]:-}"; do
   if [[ -n "$repo" ]]; then
     if [[ "$repo_index" -lt "$CLI_REPO_COUNT" ]]; then
-      # IMPLICIT_SCOPE is set only when no --root and no --repo were given, so the sole CLI-counted
-      # entry in that case is the implicit default and no explicit target can be mislabelled.
-      if [[ "$IMPLICIT_SCOPE" == "true" ]]; then
-        add_target "$repo" default
-      else
-        add_target "$repo" cli
-      fi
+      add_target "$repo" cli
     else
       add_target "$repo" config
     fi
@@ -995,6 +1000,23 @@ for root in "${ROOT_ARGS[@]:-}"; do
     root_index=$((root_index + 1))
     continue
   fi
+  # discover_repositories deliberately skips symlinks (-L). Accepting a symlink root here would
+  # record ROOT_LABELS and exit "0 repositories" even when the target tree is full of repos (#2599).
+  # Non-readable/non-executable directories are the same false-empty class.
+  if [[ -L "$root" ]]; then
+    [[ "$root_index" -ge "$CLI_ROOT_COUNT" ]] || fail "discovery root is a symlink (refused): $root"
+    STALE_CONFIG_PATHS+=("$root")
+    STALE_CONFIG_REASONS+=("configured fleet.root path is a symlink; discovery refuses symlinked roots")
+    root_index=$((root_index + 1))
+    continue
+  fi
+  if [[ ! -r "$root" || ! -x "$root" ]]; then
+    [[ "$root_index" -ge "$CLI_ROOT_COUNT" ]] || fail "discovery root is not traversable: $root"
+    STALE_CONFIG_PATHS+=("$root")
+    STALE_CONFIG_REASONS+=("configured fleet.root path is not readable/executable")
+    root_index=$((root_index + 1))
+    continue
+  fi
   root_index=$((root_index + 1))
   # Per-root visibility: attribute newly discovered repositories to this root so a root that
   # contributed none is still reported. Deduplication credits a repo shared by nested/overlapping
@@ -1006,9 +1028,11 @@ for root in "${ROOT_ARGS[@]:-}"; do
 done
 
 # An all-stale config (every entry deleted since the last run) must still produce a report whose
-# stale-config-entry findings tell the user what to remediate -- hard-fail only when there is
-# neither a target to audit nor a stale entry to report.
-if [[ ${#TARGETS[@]} -eq 0 && ${#STALE_CONFIG_PATHS[@]} -eq 0 && ${#DISCOVERY_SKIP_PATHS[@]} -eq 0 && ${#BARE_LIVE_TREE_PATHS[@]} -eq 0 ]]; then
+# stale-config-entry findings tell the user what to remediate. A discovery root that exists but
+# contains no repositories is a valid empty audit ("0 repositories found"), not an error — the
+# operator named that tree (#2599). Hard-fail only when nothing was ever in scope: no roots walked,
+# no repos, and no stale/skip/bare-live entry to report.
+if [[ ${#TARGETS[@]} -eq 0 && ${#STALE_CONFIG_PATHS[@]} -eq 0 && ${#DISCOVERY_SKIP_PATHS[@]} -eq 0 && ${#BARE_LIVE_TREE_PATHS[@]} -eq 0 && ${#ROOT_LABELS[@]} -eq 0 ]]; then
   fail "no Git working trees found in the requested scope"
 fi
 

--- a/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.test.sh
+++ b/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.test.sh
@@ -806,8 +806,10 @@ else
   failures=$((failures + 1))
 fi
 
+# No-config no-CLI run: project directory is NOT an implicit --repo (#2599). State none consumed
+# via an explicit one-repo scope so the header path still exercises Config: none.
 REPO_FLEET_TEST_FAST_TIMEOUTS=1 CLAUDE_PROJECT_DIR="$TMP/discovered-a" HOME="$TMP/nohome" \
-  bash "$SCRIPT" >"$ladder_out"
+  bash "$SCRIPT" --repo "$TMP/discovered-a" >"$ladder_out"
 if grep -Fq -- "Config: none" "$ladder_out"; then
   printf 'PASS: no-config run states none was consumed\n'
 else
@@ -830,43 +832,53 @@ else
   failures=$((failures + 1))
 fi
 
-# The implicit current-project default (no CLI paths, no config) is CLI-equivalent: running the
-# zero-configuration audit from a non-Git directory must still hard-fail, never degrade to a
-# stale-config-entry with an empty source.
+# No CLI scope and no config: stop with scope remedies. Do not treat the project directory as an
+# exact --repo (the old default that made a fleet tool audit one incidental checkout) (#2599).
 if REPO_FLEET_TEST_FAST_TIMEOUTS=1 CLAUDE_PROJECT_DIR="$TMP/noconf" HOME="$TMP/nohome" \
   bash "$SCRIPT" >"$ladder_out" 2>&1; then
-  printf 'FAIL: zero-config non-Git project dir did not hard-fail\n' >&2
+  printf 'FAIL: zero-config no-scope run did not hard-fail\n' >&2
   failures=$((failures + 1))
-elif grep -Fq "not a Git working tree" "$ladder_out" && ! grep -Fq "stale-config-entry" "$ladder_out"; then
-  printf 'PASS: zero-config non-Git project dir hard-fails without stale-config degradation\n'
+elif grep -Fq "no scope resolved" "$ladder_out" && ! grep -Fq "stale-config-entry" "$ladder_out"; then
+  printf 'PASS: zero-config no-scope run hard-fails without stale-config degradation\n'
 else
-  printf 'FAIL: zero-config non-Git project dir hard-fails without stale-config degradation (wrong output)\n' >&2
+  printf 'FAIL: zero-config no-scope run hard-fails without stale-config degradation (wrong output)\n' >&2
   failures=$((failures + 1))
 fi
 
-# ...and it must name the remedy. The operator never chose the implicit path, so a bare rejection
-# leaves the very first invocation on a machine whose fleet lives elsewhere with no way forward.
+# ...and it must name the remedy, including the bare-path form.
 if grep -Fq -- "--root <dir>" "$ladder_out" && grep -Fq -- "--repo <dir>" "$ladder_out" &&
-  grep -Fq -- "--config <file>" "$ladder_out" && grep -Fq "repo-fleet-hygiene:setup apply" "$ladder_out"; then
-  printf 'PASS: zero-config rejection names --root, --repo, --config, and the setup skill\n'
+  grep -Fq -- "--config <file>" "$ladder_out" && grep -Fq "bare path" "$ladder_out" &&
+  grep -Fq "repo-fleet-hygiene:setup apply" "$ladder_out"; then
+  printf 'PASS: zero-config rejection names bare path, --root, --repo, --config, and the setup skill\n'
 else
   printf 'FAIL: zero-config rejection does not name the scope remedies\n' >&2
   failures=$((failures + 1))
 fi
 
-# A consumed config without any fleet.root/fleet.repo (e.g. only maxDepth) still falls back to the
-# implicit project-dir target, but the rejection must not claim --config was omitted -- the remedy
-# is adding scope to the config that was already consumed.
+# A Git project directory still does not become scope without config or CLI paths (#2599).
+if REPO_FLEET_TEST_FAST_TIMEOUTS=1 CLAUDE_PROJECT_DIR="$TMP/discovered-a" HOME="$TMP/nohome" \
+  bash "$SCRIPT" >"$ladder_out" 2>&1; then
+  printf 'FAIL: no-scope run with a Git project directory unexpectedly succeeded\n' >&2
+  failures=$((failures + 1))
+elif grep -Fq "no scope resolved" "$ladder_out"; then
+  printf 'PASS: no-scope run does not treat the project directory as an implicit --repo\n'
+else
+  printf 'FAIL: no-scope run does not treat the project directory as an implicit --repo (wrong output)\n' >&2
+  failures=$((failures + 1))
+fi
+
+# A consumed config without any fleet.root/fleet.repo (e.g. only maxDepth) no longer falls back to
+# the project directory; the remedy names the consumed config and directs scope INTO it.
 cat >"$TMP/scopeless.conf" <<'SCOPELESS'
 [fleet]
     maxDepth = 5
 SCOPELESS
 if REPO_FLEET_TEST_FAST_TIMEOUTS=1 CLAUDE_PROJECT_DIR="$TMP/noconf" HOME="$TMP/nohome" \
   bash "$SCRIPT" --config "$TMP/scopeless.conf" >"$ladder_out" 2>&1; then
-  printf 'FAIL: scope-less config with non-Git project dir did not hard-fail\n' >&2
+  printf 'FAIL: scope-less config did not hard-fail\n' >&2
   failures=$((failures + 1))
 elif grep -Fq "scopeless.conf" "$ladder_out" && grep -Fq -- "--add fleet.root" "$ladder_out"; then
-  if grep -Fq "No --root, --repo, or --config was given" "$ladder_out"; then
+  if grep -Fq "No bare path, --root, --repo, or --config was given" "$ladder_out"; then
     printf 'FAIL: scope-less config rejection claims --config was omitted\n' >&2
     failures=$((failures + 1))
   else
@@ -877,15 +889,57 @@ else
   failures=$((failures + 1))
 fi
 
-# The guidance belongs to the IMPLICIT default only: an explicitly supplied bad path is a typo, and
-# the operator already knows how to pass a scope -- they just did.
+# The guidance belongs to the unresolved no-scope case only: an explicitly supplied bad path is a
+# typo, and the operator already knows how to pass a scope -- they just did.
 if REPO_FLEET_TEST_FAST_TIMEOUTS=1 bash "$SCRIPT" --repo "$TMP/noconf" >"$ladder_out" 2>&1; then
   printf 'FAIL: explicit --repo on a non-Git dir did not hard-fail\n' >&2
   failures=$((failures + 1))
 elif grep -Fq "not a Git working tree" "$ladder_out" && ! grep -Fq -- "--config <file>" "$ladder_out"; then
   printf 'PASS: explicit --repo rejection stays terse (no scope guidance)\n'
 else
-  printf 'FAIL: explicit --repo rejection leaked the implicit-default scope guidance\n' >&2
+  printf 'FAIL: explicit --repo rejection leaked the unresolved-scope guidance\n' >&2
+  failures=$((failures + 1))
+fi
+
+# Bare path ≡ --root (#2599).
+if REPO_FLEET_TEST_FAST_TIMEOUTS=1 bash "$SCRIPT" "$TMP/root" >"$ladder_out" 2>&1 &&
+  grep -Fq "Repo: $TMP/root/acme/root-repo" "$ladder_out" &&
+  grep -Fq "Scope: command line (1 --root/--repo argument(s))" "$ladder_out"; then
+  printf 'PASS: bare path is accepted as --root\n'
+else
+  printf 'FAIL: bare path is accepted as --root\n' >&2
+  failures=$((failures + 1))
+fi
+
+# A discovery root with no repositories reports zero found rather than erroring (#2599).
+if REPO_FLEET_TEST_FAST_TIMEOUTS=1 bash "$SCRIPT" "$TMP/emptyroot" >"$ladder_out" 2>&1 &&
+  grep -Fq "Repositories discovered (audit targets after deduplication): 0" "$ladder_out" &&
+  grep -Fq "Root $TMP/emptyroot: 0 repositories" "$ladder_out"; then
+  printf 'PASS: empty discovery root reports zero repositories instead of erroring\n'
+else
+  printf 'FAIL: empty discovery root reports zero repositories instead of erroring\n' >&2
+  failures=$((failures + 1))
+fi
+
+# Drive-letter shorthand normalizes to drive-root form before the missing-root check.
+if REPO_FLEET_TEST_FAST_TIMEOUTS=1 bash "$SCRIPT" "Z:" >"$ladder_out" 2>&1; then
+  printf 'FAIL: bare drive letter unexpectedly succeeded\n' >&2
+  failures=$((failures + 1))
+elif grep -Fq "discovery root not found: Z:/" "$ladder_out"; then
+  printf 'PASS: bare drive letter normalizes to Z:/ before discovery\n'
+else
+  printf 'FAIL: bare drive letter normalizes to Z:/ before discovery (wrong output)\n' >&2
+  failures=$((failures + 1))
+fi
+
+# Dashed unknowns stay rejected; bare paths are the only new positional form.
+if REPO_FLEET_TEST_FAST_TIMEOUTS=1 bash "$SCRIPT" --bogus-flag >"$ladder_out" 2>&1; then
+  printf 'FAIL: unknown dashed argument did not hard-fail\n' >&2
+  failures=$((failures + 1))
+elif grep -Fq "unknown argument: --bogus-flag" "$ladder_out"; then
+  printf 'PASS: unknown dashed argument is still rejected\n'
+else
+  printf 'FAIL: unknown dashed argument is still rejected (wrong output)\n' >&2
   failures=$((failures + 1))
 fi
 
@@ -902,7 +956,7 @@ fi
 
 # A failed authenticated-login probe must degrade the header to the plain line, never block.
 REPO_FLEET_TEST_FAST_TIMEOUTS=1 MOCK_GH_USER_FAIL=1 CLAUDE_PROJECT_DIR="$TMP/discovered-a" HOME="$TMP/nohome" \
-  bash "$SCRIPT" >"$ladder_out"
+  bash "$SCRIPT" --repo "$TMP/discovered-a" >"$ladder_out"
 if grep -Fq -- "GitHub evidence: available" "$ladder_out" && ! grep -Fq -- "(account:" "$ladder_out"; then
   printf 'PASS: failed account probe degrades to plain header line\n'
 else
@@ -1307,6 +1361,39 @@ if [[ "$allowed_log" != "true" ]]; then
   failures=$((failures + 1))
 else
   printf 'PASS: log probe is admitted by the Git allowlist\n'
+fi
+
+# Symlink roots are skipped by discovery; accepting them would report a false empty fleet (#2599).
+symlink_root="$TMP/symlink-root-target"
+mkdir -p "$symlink_root"
+symlink_path="$TMP/symlink-root"
+ln -s "$symlink_root" "$symlink_path"
+symlink_out="$TMP/symlink-root-out.txt"
+if REPO_FLEET_TEST_FAST_TIMEOUTS=1 bash "$SCRIPT" --root "$symlink_path" >"$symlink_out" 2>&1; then
+  printf 'FAIL: symlink discovery root unexpectedly succeeded\n' >&2
+  failures=$((failures + 1))
+elif grep -Fq "discovery root is a symlink (refused)" "$symlink_out"; then
+  printf 'PASS: symlink discovery root is refused rather than reporting zero repositories\n'
+else
+  printf 'FAIL: symlink discovery root is refused rather than reporting zero repositories\n%s\n' "$(cat "$symlink_out")" >&2
+  failures=$((failures + 1))
+fi
+# Unreadable/non-executable roots are the same false-empty class.
+unreadable_root="$TMP/unreadable-root"
+mkdir -p "$unreadable_root"
+chmod a-rx "$unreadable_root"
+unreadable_out="$TMP/unreadable-root-out.txt"
+if REPO_FLEET_TEST_FAST_TIMEOUTS=1 bash "$SCRIPT" --root "$unreadable_root" >"$unreadable_out" 2>&1; then
+  chmod u+rx "$unreadable_root" 2>/dev/null || true
+  printf 'FAIL: unreadable discovery root unexpectedly succeeded\n' >&2
+  failures=$((failures + 1))
+elif grep -Fq "discovery root is not traversable" "$unreadable_out"; then
+  chmod u+rx "$unreadable_root" 2>/dev/null || true
+  printf 'PASS: unreadable discovery root is refused rather than reporting zero repositories\n'
+else
+  chmod u+rx "$unreadable_root" 2>/dev/null || true
+  printf 'FAIL: unreadable discovery root is refused rather than reporting zero repositories\n%s\n' "$(cat "$unreadable_out")" >&2
+  failures=$((failures + 1))
 fi
 
 # Force the portable watchdog and prove a TERM-ignoring gh cannot outlive the finite KILL grace.

--- a/plugins/repo-fleet-hygiene/skills/setup/SKILL.md
+++ b/plugins/repo-fleet-hygiene/skills/setup/SKILL.md
@@ -10,9 +10,12 @@ argument-hint: "check | apply [--config <path>] [--root <dir>]... [--repo <dir>]
 Verify and manage the audit's optional Git-format configuration. Setup owns only this file; it never
 edits Claude Code settings, `pluginConfigs`, Git remotes, branches, worktrees, or the installed plugin.
 
-The config is optional — with none, the audit runs against the current project by default — so its
-absence is a reported INFO, never a FAIL. `check` inspects read-only; `apply` creates or updates the
-file, then re-runs `check`. No argument or `check` runs the check; `apply` runs the check first, then
+The config file itself is optional to *create*, but a no-argument `/repo-fleet-hygiene:audit` now
+requires scope from somewhere: CLI bare path / `--root` / `--repo`, or `fleet.root` / `fleet.repo`
+entries in a consumed config. Absence of every config on the ladder is therefore INFO for `check`
+(nothing to validate yet) and a hard failure for a subsequent no-argument audit — not a silent
+default to the current project. `check` inspects read-only; `apply` creates or updates the file,
+then re-runs `check`. No argument or `check` runs the check; `apply` runs the check first, then
 the write. All non-interactive: when the arguments fully specify the change, `apply` proceeds without
 prompting.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #2599

## Summary

Bare paths and drive roots were outside the fleet audit flag grammar, and no-argument scope defaulted to the project directory rather than a machine-wide fleet scan.

## Fix

Accept bare path arguments as `--root` equivalents and clarify/fix default scope behavior for machine-wide hygiene.

## Verification

See audit-fleet tests on PR checks.

## Related

Refs #2598 — non-repo path degradation under `--root`.
Refs #2597 — fleet epic.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eb3f5ee5-6c9f-48a3-8e46-071bd363f8b0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eb3f5ee5-6c9f-48a3-8e46-071bd363f8b0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

