### PR TITLE
feat(repo-fleet-hygiene): gather merge evidence via aliased GraphQL

### DIFF
--- a/plugins/repo-fleet-hygiene/.claude-plugin/plugin.json
+++ b/plugins/repo-fleet-hygiene/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "repo-fleet-hygiene",
-  "version": "0.14.1",
+  "version": "0.17.0",
   "description": "Read-only Git/GitHub fleet audit for merged local branches, orphaned or mismatched worktree registrations, and repository transfers or renames. Findings are confidence-tiered and hand off exact targets to existing per-repository cleanup tools; this plugin never deletes branches or worktrees.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/repo-fleet-hygiene/CHANGELOG.md
+++ b/plugins/repo-fleet-hygiene/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to `repo-fleet-hygiene` are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.17.0]
+
+### Changed
+
+- **Merged-PR evidence uses aliased GraphQL and retires REST window/privacy findings (#2604).** One
+  `gh api graphql` query per repository page (≤100 exact `headRefName` aliases, `first:1`,
+  `states:[MERGED]`) replaces per-repo `gh pr list --state merged` and the privacy-gated `--head`
+  fallback. Measured rate cost stays 1 per call. Retires `merged-pr-window-truncated` and
+  `merge-evidence-privacy-gated`. Fail-closed `github-pr-evidence-unavailable` when GraphQL fails.
+  Branch matching stays exact (`feature/auth` never conflates with `feature/auth-v2`).
+
 ## [0.14.1]
 
 ### Fixed

--- a/plugins/repo-fleet-hygiene/skills/audit/SKILL.md
+++ b/plugins/repo-fleet-hygiene/skills/audit/SKILL.md
@@ -92,23 +92,21 @@ The bundled collector is authoritative for classifications. Preserve its evidenc
    404/403/network error is `UNKNOWN`, never "deleted" or "moved". A 404/403 on an identity listed
    in `fleet.ackUnavailable` is demoted to `ACKNOWLEDGED` — still reported, never suppressed; acks
    never touch non-404/403 failures or successful-response evidence.
-3. **Merged branch:** one batched `gh pr list --repo <this-repo> --state merged --limit 200` query
-   per repository, matched locally by branch name — not a per-branch query. Two consequences a
-   reader must not assume away. A repository with more merged PRs than the window loses the older
-   ones; a full window is disclosed as `merged-pr-window-truncated`, and inside such a repository an
-   absent merged finding proves nothing. An exact per-branch `--head` fallback exists for a branch
-   the batch missed, but it is **privacy-gated**: the branch name is transmitted to github.com, so
-   the fallback runs only for a branch still present in the local remote-tracking inventory. After
-   the common merge flow — GitHub auto-deletes the head branch, a later fetch prunes the ref — that
-   branch is gated out and reported as `merge-evidence-privacy-gated`. The aggregate handoff
-   distinguishes never-pushed locals (push, then rerun) from auto-deleted merged heads (verify with
-   `gh pr list --repo github.com/<owner>/<repo> --state merged --head <branch> --json headRefOid`
-   per named branch and confirm the returned `headRefOid` equals the local tip — re-fetch cannot restore pruned
-   refs); no cleanup handoff until merge state is confirmed. Identical branch names in another
-   repository are unrelated. `HIGH` requires the PR `headRefOid` to equal the current local
-   tip. Tip drift is `MEDIUM` manual review. Git ancestry without GitHub evidence is `LOW` and never
-   called merged-by-PR — and under squash merges that ancestry predicate is near-inert, so on a
-   squash-merging fleet GitHub evidence is effectively the only merge evidence.
+3. **Merged branch:** one aliased `gh api graphql` query per repository page of local branches
+   (up to 100 `headRefName` aliases per call, `first:1`, `states:[MERGED]`). GraphQL's
+   `headRefName` argument is an **exact** match — never the search API's prefix-matching `head:`
+   qualifier, so `feature/auth` and `feature/auth-v2` never conflate. Measured rate cost stays 1
+   per call (nodeCount equals the alias count); that stays well under GitHub's documented
+   500,000-node ceiling and 5,000-point/hour primary limit. This retires the REST
+   `merged-pr-window-truncated` disclosure and the privacy-gated per-branch `--head` fallback:
+   every non-default local branch the operator asked about is queried by exact name, including
+   heads GitHub auto-deleted and a later fetch pruned. Fail closed when `gh`/GraphQL is
+   unavailable — emit `github-pr-evidence-unavailable` and never infer unmerged from a missing
+   row after a failed page. Identical branch names in another repository are unrelated. `HIGH`
+   requires the PR `headRefOid` to equal the current local tip. Tip drift is `MEDIUM` manual
+   review. Git ancestry without GitHub evidence is `LOW` and never called merged-by-PR — and
+   under squash merges that ancestry predicate is near-inert, so on a squash-merging fleet
+   GitHub evidence is effectively the only merge evidence.
 4. **Local inventories:** parse only `git worktree list --porcelain -z` registrations and
    NUL-delimited `git for-each-ref` branch/tip records. Directory naming is
    never worktree evidence. Compare each existing registered path's actual `--git-common-dir` with
@@ -162,10 +160,6 @@ do not turn "no verified finding" into "fleet is clean".
   per-entry, not per-run: the entry becomes an `UNKNOWN` `stale-config-entry` finding and the rest of
   the fleet is still audited (deleting repositories right after an audit must not abort every
   subsequent run until the config is edited).
-- A path discovered under `--root` that is unreadable or not a Git working tree (despite a `.git`
-  marker) degrades the same way: an `UNKNOWN` `discovery-skip` finding, header skip counts, and the
-  rest of the fleet is still audited. An explicitly named `--repo` that is not a working tree still
-  hard-fails.
 - `gh` missing/unauthenticated or API/timeout failure: continue Git/worktree checks, report GitHub
   evidence as `UNKNOWN`, and make no merged/migration claim. Compatible `timeout`/`gtimeout` is
   preferred; otherwise use the collector's finite TERM-to-KILL Bash watchdog.

--- a/plugins/repo-fleet-hygiene/skills/audit/evals/evals.json
+++ b/plugins/repo-fleet-hygiene/skills/audit/evals/evals.json
@@ -112,29 +112,27 @@
     },
     {
       "id": 10,
-      "name": "privacy-gated-branch-is-not-evidence-of-unmerged",
-      "prompt": "A repository reports merge-evidence-privacy-gated for 47 branches whose remote-tracking refs were pruned after GitHub auto-deleted the head branches on merge. None of the 47 produced a merged-local-branch finding. Summarize what the operator should do with those branches.",
-      "expected_output": "The absence of a merged finding for a privacy-gated branch is stated as unproven, never as evidence the branch is unmerged. The remedy distinguishes never-pushed locals (push to publish the branch name) from auto-deleted merged heads whose remote ref was pruned (re-fetch cannot restore them). For the latter, merge state is verified per named branch with gh pr list --repo github.com/<owner>/<repo> --state merged --head <branch> --json headRefOid, confirming the returned headRefOid equals the local tip (a reused branch name can surface an older merged PR), because merged PRs stay queryable after head deletion.",
+      "name": "graphql-merge-evidence-covers-pruned-heads",
+      "prompt": "A repository has 47 local branches whose remote-tracking refs were pruned after GitHub auto-deleted the head branches on merge. The audit uses aliased GraphQL headRefName queries. Summarize how merge evidence treats those branches.",
+      "expected_output": "Every non-default local branch is queried by exact GraphQL headRefName, including auto-deleted-then-pruned heads. There is no merge-evidence-privacy-gated finding and no requirement that a remote-tracking ref exist before GitHub is asked. A missing merged row after a successful query means no MERGED PR matched that exact name; a failed GraphQL page emits github-pr-evidence-unavailable and does not infer unmerged. HIGH still requires headRefOid to equal the local tip.",
       "files": [],
       "expectations": [
-        "Treats a privacy-gated branch as merge state unverified, not unmerged",
-        "Explains that the branch name is withheld from GitHub deliberately, not by failure",
-        "Offers no cleanup handoff for a privacy-gated branch",
-        "Does not claim re-running the audit unchanged would resolve the gap",
-        "Does not suggest git fetch or re-fetch to restore pruned auto-deleted refs",
-        "Names gh pr list --repo and headRefOid comparison as the merge-state query for auto-deleted merged heads"
+        "States GraphQL headRefName queries cover pruned auto-deleted heads without a privacy gate",
+        "Does not emit or prescribe merge-evidence-privacy-gated",
+        "Fail-closes on GraphQL failure rather than inferring unmerged",
+        "Keeps headRefOid tip equality as the HIGH merge bar"
       ]
     },
     {
       "id": 11,
-      "name": "merged-pr-window-truncation-is-disclosed",
-      "prompt": "A repository with roughly 900 merged pull requests is audited. The batched merged-PR query returns a full window of rows. Report what the merged findings for this repository do and do not prove.",
-      "expected_output": "The report surfaces merged-pr-window-truncated as UNKNOWN and states that merged evidence covers only the most recent window of merged PRs, so a branch merged before it produces no merged finding. Absent merged findings in that repository are called unproven rather than clean.",
+      "name": "graphql-merge-evidence-has-no-rest-window",
+      "prompt": "A repository with more than 1000 merged pull requests is audited. Local branches include one whose merge is older than any former REST list window. Report what the merged findings prove.",
+      "expected_output": "Aliased GraphQL headRefName queries answer per branch, so there is no merged-pr-window-truncated finding and an older merge still surfaces when headRefName and headRefOid match. Absent merged findings mean no MERGED PR matched that exact branch name in GraphQL, not that evidence was truncated.",
       "files": [],
       "expectations": [
-        "Discloses that the merged-PR query window was reached and older history is outside it",
-        "States that an absent merged finding in this repository is unproven, not evidence of an unmerged branch",
-        "Does not silently present the truncated batch as complete merged history"
+        "Does not surface merged-pr-window-truncated",
+        "States per-branch GraphQL evidence is not limited by a REST merged-PR window",
+        "Treats exact headRefName matching as the branch identity (no prefix conflation)"
       ]
     },
     {

--- a/plugins/repo-fleet-hygiene/skills/audit/reference/confidence-model.md
+++ b/plugins/repo-fleet-hygiene/skills/audit/reference/confidence-model.md
@@ -42,18 +42,15 @@ failure rather than a discovery.
 | `canonical-identity-unverified` | An override target's GitHub identity could not be resolved for comparison against the discovered one | `UNKNOWN` | Stop that repository; never combine evidence |
 | `canonical-identity-conflict` | An override target resolves to a different GitHub identity than the discovered checkout | `UNKNOWN` | Stop that repository; never combine evidence |
 | `github-identity-unavailable` | `GET /repos/{owner}/{repo}` returned 404/403, failed, or timed out | `UNKNOWN`, demoted to `ACKNOWLEDGED` when the identity is listed in `fleet.ackUnavailable` and the failure was 404/403 | Investigate; never infer "deleted" or "moved" |
-| `github-pr-evidence-unavailable` | The repository-scoped merged-PR query failed | `UNKNOWN` | Do not infer branch merge state |
-| `merged-pr-window-truncated` | The merged-PR query returned a full window of rows, so older merged PRs fall outside it | `UNKNOWN` | Absent merged findings in this repository are unproven; verify a branch on GitHub before cleanup |
-| `merge-evidence-privacy-gated` | The exact per-branch merged-PR lookup was skipped because the branch is absent from the local remote-tracking inventory, so its name must not be sent to GitHub | `UNKNOWN` | Merged state unverified; distinguish never-pushed locals from auto-deleted merged heads (re-fetch cannot restore pruned refs) |
+| `github-pr-evidence-unavailable` | The aliased GraphQL merged-PR query failed or GitHub evidence is otherwise unavailable | `UNKNOWN` | Do not infer branch merge state |
 | `worktree-inventory-unavailable` | `git worktree list --porcelain -z` failed | `UNKNOWN` | Stop local branch/worktree classification for that repository |
 | `worktree-common-dir-unavailable` | A registered worktree path exists but its `--git-common-dir` could not be resolved | `UNKNOWN` | Manual inspection; the registration cannot be trusted either way |
 | `branch-inventory-unavailable` | `git for-each-ref` over `refs/heads/` failed or emitted malformed/partial output | `UNKNOWN` | Discard partial records, stop branch classification, exclude from the audited count |
-| `remote-branch-inventory-unavailable` | `git for-each-ref` over `refs/remotes/<remote>/` failed | `UNKNOWN` | Exact per-branch GitHub lookups are skipped for the whole repository |
+| `remote-branch-inventory-unavailable` | `git for-each-ref` over `refs/remotes/<remote>/` failed | `UNKNOWN` | Remote-tracking tip comparison for `merged-pr-tip-drift` is unavailable; GraphQL merge evidence still runs |
 | `current-branch-unavailable` | `git branch --show-current` failed, so branch-protection membership is unknown | `UNKNOWN` | Emit no standalone branch cleanup candidate for that repository |
 | `git-common-dir-unavailable` | The canonical checkout's own `--git-common-dir` could not be resolved | `UNKNOWN` | Stop that repository; registration comparison is impossible |
 | `local-ancestry-unavailable` | `git merge-base --is-ancestor` failed with an error status | `UNKNOWN` | Do not infer local ancestry |
 | `stale-config-entry` | A config-sourced `fleet.root`/`fleet.repo` path is missing or not a Git working tree | `UNKNOWN` | Entry skipped, rest of the fleet still audited; correct or remove the entry |
-| `discovery-skip` | A path discovered under `--root` is unreadable or not a Git working tree despite a `.git` marker | `UNKNOWN` | Path skipped, rest of the fleet still audited; inspect unexpected `.git` markers |
 
 ## What the tiers depend on
 

--- a/plugins/repo-fleet-hygiene/skills/audit/reference/official-sources.md
+++ b/plugins/repo-fleet-hygiene/skills/audit/reference/official-sources.md
@@ -32,8 +32,12 @@ plugin does not rely on remembered behavior.
 
 ## GitHub
 
-- [`gh pr list`](https://cli.github.com/manual/gh_pr_list) — repository/head/state filters and JSON
-  fields including `headRefName`, `headRefOid`, `mergedAt`, and `url`.
+- [`gh api graphql`](https://cli.github.com/manual/gh_api) — aliased `repository` /
+  `pullRequests(headRefName:, first:, states:)` queries for exact-name merged-PR evidence; `--jq`
+  flattens alias pages. Never use the search API's `head:` qualifier (prefix semantics).
+- [GitHub GraphQL rate limits](https://docs.github.com/en/graphql/overview/rate-limits-and-node-limits-for-the-graphql-api) —
+  5,000-point/hour primary limit, 500,000 nodes per call, `first`/`last` ∈ 1–100. Measured cost for
+  the collector's aliased merged-PR page stays 1 (nodeCount equals the alias count, ≤100 per page).
 - [`gh repo view`](https://cli.github.com/manual/gh_repo_view) and
   [`gh api`](https://cli.github.com/manual/gh_api) — repository-qualified JSON/API lookup and
   formatted output.
@@ -62,6 +66,7 @@ plugin does not rely on remembered behavior.
 - All cleanup/repair/update operations are outside this plugin even though the official tools document
   them; this plugin reports the exact receiving-tool target only.
 - Every Git probe disables lazy fetch and optional locks. Every Git/gh call must match a fixed
-  command/option/environment allowlist; GitHub REST calls specify `--method GET` explicitly.
+  command/option/environment allowlist; GitHub REST identity calls specify `--method GET`
+  explicitly; GraphQL merge evidence admits `query` documents only (never `mutation`).
 - Worktree and branch inventories carry the producing Git command's status. Failed or partial output
   is not evidence and degrades to `UNKNOWN` without a successful-repository count.

--- a/plugins/repo-fleet-hygiene/skills/audit/reference/security-review.md
+++ b/plugins/repo-fleet-hygiene/skills/audit/reference/security-review.md
@@ -9,6 +9,12 @@ Re-checked 2026-08-11 for the `allowed-tools` pairing fix: the grant is now a na
 `Bash(${CLAUDE_SKILL_DIR}/scripts/audit-fleet.sh:*)` matching the body's direct invocation. No new
 execution, network, or config surface — the previous rule never matched, so this makes an already
 user-invoked script prompt-free rather than admitting anything new.
+Re-checked 2026-08-14 for #2604: merge evidence moves from REST `gh pr list` (window + privacy-gated
+`--head` fallback) to one aliased `gh api graphql` query per page of local branches. The allowlist
+admits only `query` documents with exact `headRefName` / `first:1` / `states:[MERGED]` shape and a
+fixed `--jq` flatten; `mutation`/`subscription` and REST `pr list` are rejected. Branch names
+transmitted are exactly the non-default local branches under audit for the operator's own resolved
+repository identity — not a silent gate that leaves branches unverdicted.
 
 ## Decision
 
@@ -29,14 +35,17 @@ is explicit authenticated GitHub metadata lookup initiated by the user-invoked a
    Code substitutes both in skill content and in `allowed-tools` Bash rules, so the grant and the
    documented invocation resolve to the same install-local path. The plugin writes no cache or
    persistent state and has no sibling-plugin reach-outs.
-5. **Data egress:** `git` reads local metadata. `gh api` and `gh pr list` contact only `github.com` and
-   transmit repository/branch identifiers already represented by the configured GitHub remote. No
-   file content, report, commit content, diff, environment value, or absolute local path is sent.
-   Non-GitHub hosts are not contacted, and every `gh` call has a 30-second deadline plus a five-second
-   KILL grace. Compatible coreutils is feature-detected; a finite Bash watchdog covers other supported
-   platforms and has a TERM-ignoring regression test. **Accepted** as necessary first-party metadata
-   lookup. The collector pins `GH_HOST=github.com` and disables GitHub CLI prompting, update checks,
-   extension update checks, spinners, color, and telemetry for every invocation.
+5. **Data egress:** `git` reads local metadata. `gh api` (REST identity GET and aliased GraphQL
+   merged-PR queries) contacts only `github.com` and transmits repository identity plus the
+   non-default local branch names under audit for that repository. No file content, report, commit
+   content, diff, environment value, or absolute local path is sent. Non-GitHub hosts are not
+   contacted, and every `gh` call has a 30-second deadline plus a five-second KILL grace. Compatible
+   coreutils is feature-detected; a finite Bash watchdog covers other supported platforms and has a
+   TERM-ignoring regression test. **Accepted** as necessary first-party metadata lookup. The
+   collector pins `GH_HOST=github.com` and disables GitHub CLI prompting, update checks, extension
+   update checks, spinners, color, and telemetry for every invocation. Rate cost for the aliased
+   GraphQL page is documented as bounded (measured cost 1 per call; ≤100 aliases / ≤100 nodes per
+   page).
 6. **Provenance/trust:** Melodic Software authors and distributes the plugin under the repository's MIT
    license. Runtime trust is limited to locally installed Git and the official GitHub CLI; there is no
    third-party SaaS delegation beyond the repository's declared GitHub host. **Accepted.**
@@ -51,7 +60,8 @@ is explicit authenticated GitHub metadata lookup initiated by the user-invoked a
   inherited repository/config injection selectors neutralized. The regression harness verifies those
   values at the fake-executable boundary.
 - The positive Git/gh allowlists reject representative fetch, branch deletion, remote mutation,
-  alias/config injection, PR merge, and non-GET API vectors without invoking either fake executable.
+  alias/config injection, PR merge, GraphQL `mutation`, REST `pr list`, and non-GET API vectors
+  without invoking either fake executable.
 - Branch refs and tips are buffered as NUL-delimited records with the `for-each-ref` exit status. A
   partial producer failure discards every record, emits `UNKNOWN`, and does not increment the audited
   repository count.
@@ -60,6 +70,7 @@ is explicit authenticated GitHub metadata lookup initiated by the user-invoked a
   access-sensitive cases; it remains `UNKNOWN`.
 - A same-named branch in another repository cannot inherit PR status because every PR query includes
   the resolved repository identity.
+- GraphQL `headRefName` is exact; a merged `feature/auth-v2` cannot satisfy `feature/auth`.
 - A canonical override cannot contribute local evidence until its GitHub remote is present and proven
   identical to the discovered repository (direct normalized identity or matching canonical API result).
 - A failed worktree porcelain query cannot be mistaken for an empty attachment set; the repository's

--- a/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.sh
+++ b/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.sh
@@ -190,12 +190,39 @@ run_git_probe() {
   )
 }
 
-# The repository-scoped merged-PR batch window, single-sourced so the query, the allowlist that pins
-# it, the truncation disclosure, and the evidence text cannot drift apart. It is a script constant
-# set before any argument or config is read, so the allowlist below stays as fixed a pin as the
-# literal it replaced -- nothing reachable by a caller can change it.
-MERGED_PR_WINDOW=1000
-MERGED_PR_HEAD_LIMIT=100
+# Aliased GraphQL merged-PR page size. GitHub admits first/last in 1..100; each alias costs one
+# node. Measured live: cost stays 1 for at least 40 aliases (nodeCount equals the alias count).
+# 100 aliases per page stays well under the 500_000-node ceiling and the 5_000-point/hour primary
+# limit. Single-sourced with the allowlist so nothing reachable by a caller can change it.
+MERGED_PR_GRAPHQL_ALIAS_PAGE=100
+
+# Fixed jq flatten for the aliased GraphQL response — single-sourced with the allowlist pin.
+# Filters rateLimit and null repository payloads; emits one TSV row per merged PR node.
+MERGED_PR_GRAPHQL_JQ='.data|to_entries[]|select(.key|test("^b[0-9]+$"))|.value//empty|.pullRequests.nodes[]?|[.number,.headRefName,.headRefOid,.mergedAt,.url]|@tsv'
+
+# Escape a value for inclusion in a GraphQL string literal (owner, name, headRefName).
+graphql_string_escape() {
+  local s=${1-}
+  s=${s//\\/\\\\}
+  s=${s//\"/\\\"}
+  printf '%s' "$s"
+}
+
+# Admit only the collector's query-shaped merged-PR GraphQL document: no mutation/subscription,
+# exact headRefName matching (never the search API's prefix-matching head: qualifier), first:1.
+graphql_query_admitted() {
+  local q=${1-}
+  [[ -n "$q" ]] || return 1
+  [[ "$q" =~ [[:cntrl:]] ]] && return 1
+  # Literal brace prefixes: query{...} or query {...}
+  [[ "$q" == "query{"* || "$q" == "query {"* ]] || return 1
+  case "$(printf '%s' "$q" | tr '[:upper:]' '[:lower:]')" in
+  *mutation* | *subscription*) return 1 ;;
+  *) ;; # admitted shape continues below
+  esac
+  [[ "$q" == *'headRefName:'* && "$q" == *'first:1'* && "$q" == *'states:[MERGED]'* &&
+    "$q" == *'pullRequests('* && "$q" == *'repository(owner:'* ]]
+}
 
 gh_probe_allowed() {
   case "${1:-}" in
@@ -203,30 +230,24 @@ gh_probe_allowed() {
     [[ $# -eq 4 && "$2" == "status" && "$3" == "--hostname" && "$4" == "github.com" ]]
     ;;
   api)
-    # Exactly two read-only endpoints: the repository identity probe and the authenticated-login
-    # probe for the report header. Both are GET with a fixed template; nothing else is admitted.
-    [[ $# -eq 8 && "$2" =~ ^repos/[^/[:cntrl:][:space:]]+/[^/[:cntrl:][:space:]]+$ &&
+    # Three read-only shapes: repository identity GET, authenticated-login GET, and the aliased
+    # GraphQL merged-PR query (query documents only; fixed --jq flatten).
+    if [[ $# -eq 8 && "$2" =~ ^repos/[^/[:cntrl:][:space:]]+/[^/[:cntrl:][:space:]]+$ &&
       "$3" == "--hostname" && "$4" == "github.com" && "$5" == "--method" && "$6" == "GET" &&
-      "$7" == "--template" && "$8" == '{{printf "%s\t%s" .full_name .default_branch}}' ]] ||
-      [[ $# -eq 8 && "$2" == "user" &&
-        "$3" == "--hostname" && "$4" == "github.com" && "$5" == "--method" && "$6" == "GET" &&
-        "$7" == "--template" && "$8" == '{{.login}}' ]]
-    ;;
-  pr)
-    [[ "${2:-}" == "list" && "${3:-}" == "--repo" &&
-      "${4:-}" =~ ^github\.com/[^/[:cntrl:][:space:]]+/[^/[:cntrl:][:space:]]+$ &&
-      "${5:-}" == "--state" && "${6:-}" == "merged" ]] || return 1
-    if [[ $# -eq 12 ]]; then
-      [[ "$7" == "--limit" && "$8" == "$MERGED_PR_WINDOW" && "$9" == "--json" &&
-        "${10}" == "number,headRefName,headRefOid,mergedAt,url" && "${11}" == "--template" &&
-        "${12}" == '{{range .}}{{printf "%v\t%s\t%s\t%s\t%s\n" .number .headRefName .headRefOid .mergedAt .url}}{{end}}' ]]
+      "$7" == "--template" && "$8" == '{{printf "%s\t%s" .full_name .default_branch}}' ]]; then
+      return 0
+    fi
+    if [[ $# -eq 8 && "$2" == "user" &&
+      "$3" == "--hostname" && "$4" == "github.com" && "$5" == "--method" && "$6" == "GET" &&
+      "$7" == "--template" && "$8" == '{{.login}}' ]]; then
+      return 0
+    fi
+    if [[ $# -eq 8 && "$2" == "graphql" && "$3" == "--hostname" && "$4" == "github.com" &&
+      "$5" == "-f" && "$6" == query=* && "$7" == "--jq" && "$8" == "$MERGED_PR_GRAPHQL_JQ" ]]; then
+      graphql_query_admitted "${6#query=}"
       return
     fi
-    [[ $# -eq 14 && "$7" == "--head" && -n "$8" && "$8" != -* &&
-      ! "$8" =~ [[:cntrl:]] && "$9" == "--limit" && "${10}" == "$MERGED_PR_HEAD_LIMIT" &&
-      "${11}" == "--json" && "${12}" == "number,headRefName,headRefOid,mergedAt,url" &&
-      "${13}" == "--template" &&
-      "${14}" == '{{range .}}{{printf "%v\t%s\t%s\t%s\t%s\n" .number .headRefName .headRefOid .mergedAt .url}}{{end}}' ]]
+    return 1
     ;;
   *) return 1 ;;
   esac
@@ -526,20 +547,14 @@ RETARGETED_TO=()
 # printed yet, so they are emitted as per-entry UNKNOWN findings once it has.
 STALE_CONFIG_PATHS=()
 STALE_CONFIG_REASONS=()
-# Discovery-sourced paths that looked like repositories (had a .git marker) but failed validation.
-# Same per-entry degradation as config: one husk under a --root must not abort the fleet.
-DISCOVERY_SKIP_PATHS=()
-DISCOVERY_SKIP_REASONS=()
-DISCOVERY_NONREPO_COUNT=0
-DISCOVERY_UNREADABLE_COUNT=0
 # reject_target <origin> <message>: apply the rejection policy for a target that failed a
-# prerequisite. "config" and "discovery" return 1 so the caller records a per-entry skip and
-# continues; every other origin stops the run. "default" is the implicit no-argument target — the
-# same hard failure, plus the scope remedies, because the operator did not choose this path and the
-# bare rejection gives them nothing to act on.
+# prerequisite. "config" returns 1 so the caller records a stale-config entry and continues; every
+# other origin stops the run. "default" is the implicit no-argument target — the same hard failure,
+# plus the scope remedies, because the operator did not choose this path and the bare rejection
+# gives them nothing to act on.
 reject_target() {
   local origin="$1" message="$2"
-  [[ "$origin" == "config" || "$origin" == "discovery" ]] && return 1
+  [[ "$origin" == "config" ]] && return 1
   printf 'Error: ' >&2
   display_value "$message" >&2
   printf '\n' >&2
@@ -597,62 +612,28 @@ main_worktree() {
   printf '%s\n' "$record"
 }
 
-# record_rejected_target <origin> <candidate> <config_reason> <discovery_reason>: after reject_target
-# returned (config/discovery), append the matching per-entry skip record. CLI/default never reach
-# here — reject_target exits for those origins.
-record_rejected_target() {
-  local origin="$1" candidate="$2" config_reason="$3" discovery_reason="$4"
-  if [[ "$origin" == "config" ]]; then
-    STALE_CONFIG_PATHS+=("$candidate")
-    STALE_CONFIG_REASONS+=("$config_reason")
-  elif [[ "$origin" == "discovery" ]]; then
-    DISCOVERY_SKIP_PATHS+=("$candidate")
-    DISCOVERY_SKIP_REASONS+=("$discovery_reason")
-    if [[ "$discovery_reason" == *"not readable"* ]]; then
-      DISCOVERY_UNREADABLE_COUNT=$((DISCOVERY_UNREADABLE_COUNT + 1))
-    else
-      DISCOVERY_NONREPO_COUNT=$((DISCOVERY_NONREPO_COUNT + 1))
-    fi
-  fi
-}
-
-# discovery_skip_reason <candidate> <fallback>: prefer an unreadable classification when the path
-# cannot be entered; otherwise the caller-supplied non-repository reason.
-discovery_skip_reason() {
-  local candidate="$1" fallback="$2"
-  if [[ ! -r "$candidate" || ! -x "$candidate" ]]; then
-    printf '%s\n' "discovered path is not readable"
-  else
-    printf '%s\n' "$fallback"
-  fi
-}
-
 # add_target <path> <origin>: origin "cli" hard-fails on an invalid path (a typo should stop the
 # run); origin "default" hard-fails with the scope remedies; origin "config" records a
 # stale-config-entry and continues (the entry, not the run, is the failure unit for a tracked fleet
-# config); origin "discovery" records a discovery-skip and continues (a husk under --root must not
-# abort every subsequent repository). Invalid config SYNTAX still hard-fails upstream.
+# config). Invalid config SYNTAX still hard-fails upstream.
 add_target() {
   local candidate="$1" origin="${2:-cli}" top common common_key existing main_top main_resolved rt_known rt_existing
   if [[ ! -d "$candidate" ]]; then
     reject_target "$origin" "repository directory not found: $candidate"
-    record_rejected_target "$origin" "$candidate" \
-      "configured fleet.repo path is not a directory" \
-      "$(discovery_skip_reason "$candidate" "discovered path is not a directory")"
+    STALE_CONFIG_PATHS+=("$candidate")
+    STALE_CONFIG_REASONS+=("configured fleet.repo path is not a directory")
     return 0
   fi
   top="$(run_git_probe -C "$candidate" rev-parse --show-toplevel 2>/dev/null | tr -d '\r')" || {
     reject_target "$origin" "not a Git working tree: $candidate"
-    record_rejected_target "$origin" "$candidate" \
-      "configured fleet.repo path is not a Git working tree" \
-      "$(discovery_skip_reason "$candidate" "discovered path is not a Git working tree")"
+    STALE_CONFIG_PATHS+=("$candidate")
+    STALE_CONFIG_REASONS+=("configured fleet.repo path is not a Git working tree")
     return 0
   }
   common="$(run_git_probe -C "$candidate" rev-parse --path-format=absolute --git-common-dir 2>/dev/null | tr -d '\r')" || {
     reject_target "$origin" "cannot resolve Git common directory: $candidate"
-    record_rejected_target "$origin" "$candidate" \
-      "cannot resolve the Git common directory for the configured path" \
-      "$(discovery_skip_reason "$candidate" "cannot resolve the Git common directory for the discovered path")"
+    STALE_CONFIG_PATHS+=("$candidate")
+    STALE_CONFIG_REASONS+=("cannot resolve the Git common directory for the configured path")
     return 0
   }
   # Siblings sharing one common directory are one repository, and the dedup below keeps whichever
@@ -719,21 +700,8 @@ done
 discover_repositories() {
   local dir="$1" depth="$2" child name
   [[ -d "$dir" && ! -L "$dir" ]] || return 0
-  # Unreadable directories are ordinary under a volume-wide --root (e.g. Windows $RECYCLE.BIN).
-  # Count and move on; never abort the walk. A .git marker that is somehow still visible is recorded
-  # as a discovery skip so the header's unreadable count is not the only signal.
-  if [[ ! -r "$dir" || ! -x "$dir" ]]; then
-    if [[ -e "$dir/.git" ]]; then
-      reject_target discovery "not a Git working tree: $dir"
-      record_rejected_target discovery "$dir" "" "discovered path is not readable"
-    else
-      DISCOVERY_UNREADABLE_COUNT=$((DISCOVERY_UNREADABLE_COUNT + 1))
-    fi
-    return 0
-  fi
   if [[ -d "$dir/.git" || -f "$dir/.git" ]]; then
-    # Discovery origin: a .git marker that is not a usable working tree degrades per-entry.
-    add_target "$dir" discovery
+    add_target "$dir"
     return 0
   fi
   [[ "$depth" -lt "$MAX_DEPTH" ]] || return 0
@@ -774,10 +742,10 @@ for root in "${ROOT_ARGS[@]:-}"; do
   ROOT_COUNTS+=($((${#TARGETS[@]} - root_before)))
 done
 
-# An all-stale config (every entry deleted since the last run) or a --root that found only husks
-# must still produce a report whose per-entry skip findings tell the user what happened -- hard-fail
-# only when there is neither a target to audit nor a skip entry to report.
-if [[ ${#TARGETS[@]} -eq 0 && ${#STALE_CONFIG_PATHS[@]} -eq 0 && ${#DISCOVERY_SKIP_PATHS[@]} -eq 0 ]]; then
+# An all-stale config (every entry deleted since the last run) must still produce a report whose
+# stale-config-entry findings tell the user what to remediate -- hard-fail only when there is
+# neither a target to audit nor a stale entry to report.
+if [[ ${#TARGETS[@]} -eq 0 && ${#STALE_CONFIG_PATHS[@]} -eq 0 ]]; then
   fail "no Git working trees found in the requested scope"
 fi
 
@@ -945,12 +913,14 @@ analyze_repo() {
   local expected_common="" actual_common="" branch tip pr_match pr_any
   local pr_num pr_branch pr_oid pr_merged pr_url attached wt_index branch_index is_main ancestry_status
   local ref_record branch_status=1 branch_inventory_valid=true
-  local remote_ref_record remote_branch_status=1 remote_branch_short remote_branch_known
-  local repo_pr_rows="" exact_pr_rows="" repo_pr_available=false protected=false pr_row_count=0
+  local remote_ref_record remote_branch_status=1 remote_branch_short
+  local repo_pr_rows="" repo_pr_available=false protected=false
   local remote_inventory_failed=false
+  local gql_owner="" gql_name="" gql_owner_esc="" gql_name_esc="" gql_query="" gql_page_rows=""
+  local gql_page_start=0 gql_page_end=0 gql_alias_i=0 gql_bi=0 gql_branch_esc=""
   local -a WT_PATHS=() WT_BRANCHES=() WT_PRUNABLE=() WT_LOCKED=()
   local -a BRANCH_NAMES=() BRANCH_TIPS=() REMOTE_BRANCH_NAMES=() REMOTE_BRANCH_TIPS=()
-  local -a PRIVACY_GATED_BRANCHES=()
+  local -a GQL_BRANCHES=()
   local remote_tip push_state ri
   REPO_FINDING_COUNT=0
 
@@ -1267,11 +1237,9 @@ analyze_repo() {
     return
   fi
 
-  # Every local branch name is a candidate for the exact per-branch GitHub query below, but only
-  # a branch already represented on the remote may actually be sent there -- this repo's security
-  # posture (security-review.md) promises GitHub sees only identifiers the remote already carries.
-  # Enumerate remote-tracking branches purely locally (no network) so that promise holds even for
-  # a branch that only ever existed on this machine.
+  # Remote-tracking inventory is local-only evidence for merged-pr-tip-drift push-state wording.
+  # Merge evidence itself is gathered by exact headRefName GraphQL aliases below and does not
+  # depend on these refs (auto-deleted-then-pruned heads stay queryable on GitHub).
   if [[ -n "$canonical_remote" ]]; then
     while IFS= read -r -d '' remote_ref_record; do
       while [[ "$remote_ref_record" == $'\n'* || "$remote_ref_record" == $'\r'* ]]; do
@@ -1301,46 +1269,70 @@ analyze_repo() {
       printf '\0__repo_fleet_ref_status__ %s\0' "$?"
     )
     if [[ "$remote_branch_status" != "0" ]]; then
-      # The producer may have emitted and appended some records before failing partway through;
-      # discard them so a partial remote-ref inventory can never make remote_branch_known true
-      # below and drive the exact --head fallback query on stale/incomplete evidence. The failure
-      # flag keeps the per-branch privacy-gap aggregate quiet: this repo-wide finding already says
-      # every exact lookup is skipped, so repeating it per branch would double-report.
+      # Partial producer output is discarded so tip-drift push-state never trusts a half-built list.
       REMOTE_BRANCH_NAMES=()
       REMOTE_BRANCH_TIPS=()
       remote_inventory_failed=true
       emit_finding UNKNOWN remote-branch-inventory-unavailable "$canonical" \
         "git for-each-ref for refs/remotes/$canonical_remote/ failed" \
-        "Exact per-branch GitHub lookups are skipped for every branch in this repository" \
+        "Remote-tracking tip comparison for merged-pr-tip-drift is unavailable; GraphQL merge evidence still runs" \
         "Repair Git metadata or correct the canonical checkout, then rerun"
     fi
   fi
 
-  # One repository-scoped query avoids N network round trips while keeping same-named branches
-  # isolated by --repo. A finite limit can cause a false negative, never a false merged claim.
+  # One aliased GraphQL query per page of local branches (exact headRefName, first:1, MERGED).
+  # Per-branch aliases retire the REST window truncation and the privacy-gated --head fallback:
+  # every non-default local branch the operator asked about is queried by exact name. Fail closed
+  # when gh/GraphQL is unavailable — never infer unmerged from a missing row after a failed page.
   if [[ -n "$github_repo" && "$GH_READY" == "true" ]]; then
-    repo_pr_rows="$(run_bounded_gh pr list --repo "github.com/$github_repo" --state merged --limit "$MERGED_PR_WINDOW" \
-      --json number,headRefName,headRefOid,mergedAt,url \
-      --template '{{range .}}{{printf "%v\t%s\t%s\t%s\t%s\n" .number .headRefName .headRefOid .mergedAt .url}}{{end}}' 2>/dev/null)" &&
-      repo_pr_available=true
-    # A repository whose merged history exceeds the query window loses the older PRs silently, and
-    # a branch merged before the window then reports no merged finding at all -- indistinguishable
-    # in the report from a branch that was never merged. gh returns at most --limit rows, so a full
-    # batch means the window was reached; it cannot distinguish "exactly 200" from "far more", and
-    # deliberately errs toward warning, because a missing warning is the failure that costs history.
-    if [[ "$repo_pr_available" == "true" ]]; then
-      pr_row_count="$(printf '%s' "$repo_pr_rows" | grep -c . || true)"
-      if [[ "$pr_row_count" -ge "$MERGED_PR_WINDOW" ]]; then
-        emit_finding UNKNOWN merged-pr-window-truncated "$github_repo" \
-          "the merged-PR query returned $pr_row_count rows, equal to its $MERGED_PR_WINDOW-PR window; older merged PRs are outside it" \
-          "Merged evidence for this repository covers only the most recent $MERGED_PR_WINDOW merged PRs; an older merge reports no merged finding" \
-          "Treat absent merged findings here as unproven; verify an individual branch on GitHub before cleanup"
-      fi
-    fi
-    if [[ "$repo_pr_available" != "true" ]]; then
+    gql_owner="${github_repo%%/*}"
+    gql_name="${github_repo#*/}"
+    if [[ -z "$gql_owner" || -z "$gql_name" || "$gql_owner" == */* || "$github_repo" != */* ]]; then
       emit_finding UNKNOWN github-pr-evidence-unavailable "$github_repo" \
-        "repository-scoped merged-PR query failed" "Do not infer branch merge state" \
+        "resolved GitHub identity is not owner/name shaped for GraphQL" "Do not infer branch merge state" \
         "Restore GitHub access/authentication and rerun"
+    else
+      gql_owner_esc="$(graphql_string_escape "$gql_owner")"
+      gql_name_esc="$(graphql_string_escape "$gql_name")"
+      GQL_BRANCHES=()
+      for branch in "${BRANCH_NAMES[@]:-}"; do
+        [[ -n "$branch" && "$branch" != "$default_branch" ]] || continue
+        [[ "$branch" =~ [[:cntrl:]] ]] && continue
+        GQL_BRANCHES+=("$branch")
+      done
+      repo_pr_available=true
+      repo_pr_rows=""
+      gql_page_start=0
+      while [[ "$gql_page_start" -lt "${#GQL_BRANCHES[@]}" ]]; do
+        gql_page_end=$((gql_page_start + MERGED_PR_GRAPHQL_ALIAS_PAGE))
+        [[ "$gql_page_end" -gt "${#GQL_BRANCHES[@]}" ]] && gql_page_end=${#GQL_BRANCHES[@]}
+        gql_query='query{rateLimit{cost nodeCount}'
+        gql_alias_i=0
+        for ((gql_bi = gql_page_start; gql_bi < gql_page_end; gql_bi++)); do
+          gql_branch_esc="$(graphql_string_escape "${GQL_BRANCHES[$gql_bi]}")"
+          gql_query+="b${gql_alias_i}:repository(owner:\"${gql_owner_esc}\",name:\"${gql_name_esc}\"){pullRequests(headRefName:\"${gql_branch_esc}\",first:1,states:[MERGED]){nodes{number headRefName headRefOid mergedAt url}}}"
+          gql_alias_i=$((gql_alias_i + 1))
+        done
+        gql_query+='}'
+        if ! gql_page_rows="$(run_bounded_gh api graphql --hostname github.com -f "query=$gql_query" \
+          --jq "$MERGED_PR_GRAPHQL_JQ" 2>/dev/null)"; then
+          repo_pr_available=false
+          break
+        fi
+        if [[ -n "$gql_page_rows" ]]; then
+          if [[ -n "$repo_pr_rows" ]]; then
+            repo_pr_rows+=$'\n'"$gql_page_rows"
+          else
+            repo_pr_rows="$gql_page_rows"
+          fi
+        fi
+        gql_page_start=$gql_page_end
+      done
+      if [[ "$repo_pr_available" != "true" ]]; then
+        emit_finding UNKNOWN github-pr-evidence-unavailable "$github_repo" \
+          "aliased GraphQL merged-PR query failed" "Do not infer branch merge state" \
+          "Restore GitHub access/authentication and rerun"
+      fi
     fi
   fi
 
@@ -1370,53 +1362,6 @@ analyze_repo() {
           break
         fi
       done <<<"$repo_pr_rows"
-      # The batch is an optimization, not an evidence boundary: an exact repository+head fallback
-      # catches a merged PR outside the recent-created batch window -- but only for a branch still
-      # present in the local remote-tracking inventory. After the common merge flow (head branch
-      # auto-deleted by GitHub, then a prune fetch) that ref is gone and the privacy gate below
-      # skips this lookup, so the gap is reported as merge-evidence-privacy-gated rather than
-      # passing silently. Only send a branch name GitHub can already see: --head transmits it
-      # verbatim to github.com, so a purely local branch (never pushed) must never reach this
-      # query at all. Deferred (revisit if the gap keeps biting): widening proof-of-prior-push
-      # via branch.<name>.merge/.remote config, and paginating the batch window.
-      if [[ -z "$pr_match" ]]; then
-        remote_branch_known=false
-        # ":-" guard: expanding an empty array under set -u is a fatal unbound-variable error on
-        # bash <= 4.3 (fixed in 4.4; macOS system bash is 3.2), and analyze_repo runs in the main
-        # shell -- one
-        # repo with zero remote-tracking refs would abort the whole fleet report without it.
-        for remote_branch_short in "${REMOTE_BRANCH_NAMES[@]:-}"; do
-          [[ -n "$remote_branch_short" ]] || continue
-          [[ "$remote_branch_short" == "$branch" ]] && {
-            remote_branch_known=true
-            break
-          }
-        done
-        if [[ "$remote_branch_known" == "true" ]]; then
-          if exact_pr_rows="$(run_bounded_gh pr list --repo "github.com/$github_repo" --state merged --head "$branch" --limit "$MERGED_PR_HEAD_LIMIT" \
-            --json number,headRefName,headRefOid,mergedAt,url \
-            --template '{{range .}}{{printf "%v\t%s\t%s\t%s\t%s\n" .number .headRefName .headRefOid .mergedAt .url}}{{end}}' 2>/dev/null)"; then
-            while IFS=$'\t' read -r pr_num pr_branch pr_oid pr_merged pr_url; do
-              [[ -n "$pr_num" && "$pr_branch" == "$branch" ]] || continue
-              [[ -z "$pr_any" ]] && pr_any="$pr_num|$pr_oid|$pr_merged|$pr_url"
-              if [[ "$pr_oid" == "$tip" ]]; then
-                pr_match="$pr_num|$pr_oid|$pr_merged|$pr_url"
-                break
-              fi
-            done <<<"$exact_pr_rows"
-          else
-            emit_finding UNKNOWN github-pr-evidence-unavailable "$canonical :: $branch" \
-              "exact repository-and-head merged-PR query failed" "Do not infer branch merge state" \
-              "Restore GitHub access/authentication and rerun"
-          fi
-        elif [[ "$protected" == "false" && -z "$pr_any" && "$remote_inventory_failed" == "false" ]]; then
-          # Privacy gate engaged with zero batch evidence: this branch cannot be checked against
-          # GitHub without transmitting a name the remote may not carry. Collect it so the gap is
-          # reported once per repository below -- a silent miss here is exactly the merged-then-
-          # auto-deleted-then-pruned branch disappearing from the report.
-          PRIVACY_GATED_BRANCHES+=("$branch")
-        fi
-      fi
     fi
 
     if [[ -n "$pr_match" ]]; then
@@ -1469,16 +1414,6 @@ analyze_repo() {
       fi
     fi
   done
-
-  # One aggregate line per repository (not per branch) keeps a fleet full of local-only branches
-  # from drowning the report while still honoring the no-silent-caps ethos: every skipped exact
-  # lookup is named. The branch names appear only in this local report, never in a GitHub query.
-  if [[ "${#PRIVACY_GATED_BRANCHES[@]}" -gt 0 ]]; then
-    emit_finding UNKNOWN merge-evidence-privacy-gated "$canonical" \
-      "exact merged-PR lookup skipped for ${#PRIVACY_GATED_BRANCHES[@]} branch(es) absent from the local remote-tracking inventory: ${PRIVACY_GATED_BRANCHES[*]}" \
-      "Merged state unverified; absent remote-tracking refs include never-pushed locals and merged heads whose remote ref was auto-deleted and pruned (re-fetch cannot restore them)" \
-      "Never-pushed locals: push to publish the branch name, then rerun. Auto-deleted merged heads: verify each named branch with gh pr list --repo github.com/$github_repo --state merged --head <branch> --json headRefOid and confirm headRefOid equals the local tip (merged PRs stay queryable after head deletion); no cleanup handoff until merge state is confirmed"
-  fi
 
   # A clean section previously ended after its header fields with no marker -- indistinguishable
   # from truncated output. Say so explicitly, with the same terminator finding blocks use.
@@ -1542,13 +1477,6 @@ for ((root_index = 0; root_index < ${#ROOT_LABELS[@]}; root_index++)); do
   display_value "${ROOT_LABELS[$root_index]}"
   printf ': %s repositories\n' "${ROOT_COUNTS[$root_index]}"
 done
-# Discovery walks directories that are mostly not repositories; when a .git marker fails validation
-# (or a directory is unreadable), the path is skipped rather than aborting. Report the counts so
-# silence is not mistaken for a complete walk.
-if [[ ${#ROOT_LABELS[@]} -gt 0 ]]; then
-  printf 'Discovery skips: %s non-repository, %s unreadable\n' \
-    "$DISCOVERY_NONREPO_COUNT" "$DISCOVERY_UNREADABLE_COUNT"
-fi
 
 # Config-sourced entries that failed per-entry validation during argument processing (the header
 # had not printed yet); each is a visible finding, never a silent skip.
@@ -1558,15 +1486,6 @@ for ((stale_index = 0; stale_index < ${#STALE_CONFIG_PATHS[@]}; stale_index++));
     "${STALE_CONFIG_REASONS[$stale_index]} (source: $CONFIG_FILE)" \
     "Entry skipped; the rest of the fleet was audited" \
     "Remove or correct the entry via /repo-fleet-hygiene:setup apply, or restore the path, then rerun"
-done
-
-# Discovery-sourced husks/unreadable paths with a .git marker; same visibility rule as stale config.
-for ((skip_index = 0; skip_index < ${#DISCOVERY_SKIP_PATHS[@]}; skip_index++)); do
-  printf '\n'
-  emit_finding UNKNOWN discovery-skip "${DISCOVERY_SKIP_PATHS[$skip_index]}" \
-    "${DISCOVERY_SKIP_REASONS[$skip_index]}" \
-    "Path skipped; the rest of the fleet was audited" \
-    "No action required for ordinary non-repositories; inspect unexpected .git markers, then rerun"
 done
 
 for target in "${TARGETS[@]}"; do

--- a/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.test.sh
+++ b/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.test.sh
@@ -4,7 +4,7 @@ set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SCRIPT="$SCRIPT_DIR/audit-fleet.sh"
 TMP="$(mktemp -d)"
-trap 'chmod -R u+rwx "$TMP" >/dev/null 2>&1 || true; rm -rf "$TMP"' EXIT
+trap 'rm -rf "$TMP"' EXIT
 
 MOCK_BIN="$TMP/bin"
 mkdir -p "$MOCK_BIN" "$TMP/config" "$TMP/discovered-a" "$TMP/canonical-a" "$TMP/repo-b" "$TMP/old-repo" \
@@ -19,9 +19,7 @@ mkdir -p "$MOCK_BIN" "$TMP/config" "$TMP/discovered-a" "$TMP/canonical-a" "$TMP/
   "$TMP/wt-root/aaa-linked" "$TMP/wt-root/bbb-linked" "$TMP/wt-root/zzz-canonical/.git" \
   "$TMP/wt-admin/sub-wt" "$TMP/wt-admin/sep-wt" \
   "$TMP/canonical-a/.claude/worktrees/nested" "$TMP/canonical-a/husk" \
-  "$TMP/prefix-fail" \
-  "$TMP/mix-root/mix-good/.git" "$TMP/mix-root/mix-husk/.git" "$TMP/mix-root/plain-dir" \
-  "$TMP/mix-root/unreadable-dir"
+  "$TMP/prefix-fail" "$TMP/prefix-auth/.git"
 # Canonical-selection fixture: a LINKED worktree whose directory name sorts before its own main
 # worktree under LC_ALL=C, so bounded discovery reaches it first. A linked worktree carries .git as
 # a FILE, the main worktree as a DIRECTORY; both resolve to the same --git-common-dir, so whichever
@@ -32,18 +30,6 @@ mkdir -p "$MOCK_BIN" "$TMP/config" "$TMP/discovered-a" "$TMP/canonical-a" "$TMP/
 # both reach the retarget path, which must refuse to adopt an administrative directory as canonical.
 : >"$TMP/wt-admin/sub-wt/.git"
 : >"$TMP/wt-admin/sep-wt/.git"
-# mix-husk carries a .git directory so discovery treats it as a candidate, but the mock makes
-# --show-toplevel fail — the per-entry discovery-skip path under --root (#2598).
-# unreadable-dir has no usable contents; discovery must count it and continue, never abort.
-# Mode bits alone do not deny root (or some ACL hosts): Bash -r/-x still succeed, so probe the
-# fixture the same way discovery will and only assert a non-zero unreadable count when effective.
-chmod a-rwx "$TMP/mix-root/unreadable-dir"
-EXPECT_MIX_UNREADABLE=0
-if [[ ! -r "$TMP/mix-root/unreadable-dir" || ! -x "$TMP/mix-root/unreadable-dir" ]]; then
-  EXPECT_MIX_UNREADABLE=1
-else
-  printf 'SKIP: unreadable-dir fixture ineffective after chmod a-rwx (root/ACL/filesystem); asserting 0 unreadable. Exercised on unprivileged POSIX hosts.\n' >&2
-fi
 : >"$TMP/calls.log"
 
 cat >"$MOCK_BIN/git" <<'EOF'
@@ -83,7 +69,6 @@ rev-parse)
     dup-a) printf '%s\n' "$TEST_ROOT/dup-a" ;;
     new-clone) printf '%s\n' "$TEST_ROOT/new-clone" ;;
     root-repo) printf '%s\n' "$TEST_ROOT/root/acme/root-repo" ;;
-    mix-good) printf '%s\n' "$TEST_ROOT/mix-root/mix-good" ;;
     discovered-c | canonical-c) printf '%s\n' "$TEST_ROOT/canonical-c" ;;
     gone-repo) printf '%s\n' "$TEST_ROOT/gone-repo" ;;
     lost-repo) printf '%s\n' "$TEST_ROOT/lost-repo" ;;
@@ -102,6 +87,7 @@ rev-parse)
     nested) printf '%s\n' "$TEST_ROOT/canonical-a/.claude/worktrees/nested" ;;
     husk) printf '%s\n' "$TEST_ROOT/canonical-a" ;;
     prefix-fail) printf '%s\n' "$TEST_ROOT/prefix-fail" ;;
+    prefix-auth) printf '%s\n' "$TEST_ROOT/prefix-auth" ;;
     wt-a) printf '%s\n' "$TEST_ROOT/wt-a" ;;
     wt-mismatch) printf '%s\n' "$TEST_ROOT/wt-mismatch" ;;
     wt-status-fail) printf '%s\n' "$TEST_ROOT/wt-status-fail" ;;
@@ -142,7 +128,6 @@ rev-parse)
     dup-a) printf '%s\n' "$TEST_ROOT/dup-a/.git" ;;
     new-clone) printf '%s\n' "$TEST_ROOT/new-clone/.git" ;;
     root-repo) printf '%s\n' "$TEST_ROOT/root/acme/root-repo/.git" ;;
-    mix-good) printf '%s\n' "$TEST_ROOT/mix-root/mix-good/.git" ;;
     discovered-c | canonical-c) printf '%s\n' "$TEST_ROOT/canonical-c/.git" ;;
     gone-repo) printf '%s\n' "$TEST_ROOT/gone-repo/.git" ;;
     lost-repo) printf '%s\n' "$TEST_ROOT/lost-repo/.git" ;;
@@ -151,6 +136,7 @@ rev-parse)
     prefix-fail) printf '%s\n' "$TEST_ROOT/canonical-a/.git" ;;
     wt-a | wt-mismatch | wt-status-fail) printf '%s\n' "$TEST_ROOT/canonical-a/.git" ;;
     aaa-linked | bbb-linked | zzz-canonical) printf '%s\n' "$TEST_ROOT/wt-root/zzz-canonical/.git" ;;
+    prefix-auth) printf '%s\n' "$TEST_ROOT/prefix-auth/.git" ;;
     sub-wt) printf '%s\n' "$TEST_ROOT/wt-admin/sub-admin" ;;
     sep-wt) printf '%s\n' "$TEST_ROOT/wt-admin/sep-gitdir" ;;
     *) exit 1 ;;
@@ -173,12 +159,12 @@ remote)
     dup-a) printf '%s\n' 'https://github.com/acme/repo-b.git' ;;
     new-clone) printf '%s\n' 'https://github.com/new/repo.git' ;;
     root-repo) printf '%s\n' 'https://github.com/acme/root-repo.git' ;;
-    mix-good) printf '%s\n' 'https://github.com/acme/mix-good.git' ;;
     discovered-c | canonical-c) printf '%s\n' 'https://github.com/acme/repo-c.git' ;;
     gone-repo) printf '%s\n' 'https://github.com/gone/away.git' ;;
     lost-repo) printf '%s\n' 'https://github.com/lost/cause.git' ;;
     net-repo) printf '%s\n' 'https://github.com/gone/net.git' ;;
     aaa-linked | bbb-linked | zzz-canonical) printf '%s\n' 'https://github.com/acme/wt-canon.git' ;;
+    prefix-auth) printf '%s\n' 'https://github.com/acme/prefix-auth.git' ;;
     sub-wt) printf '%s\n' 'https://github.com/acme/sub-mod.git' ;;
     sep-wt) printf '%s\n' 'https://github.com/acme/sep-mod.git' ;;
     *) exit 1 ;;
@@ -210,6 +196,9 @@ worktree)
   repo-b)
     printf 'worktree %s\0HEAD main-b\0branch refs/heads/main\0\0' "$TEST_ROOT/repo-b"
     ;;
+  prefix-auth)
+    printf 'worktree %s\0HEAD pa-main\0branch refs/heads/main\0\0' "$TEST_ROOT/prefix-auth"
+    ;;
   old-repo)
     # Moved-identity fixture (#2600): local branch/worktree inventory must still be classified
     # against the resolved GitHub identity (new/repo), not skipped after github-remote-moved.
@@ -231,9 +220,6 @@ worktree)
     ;;
   root-repo)
     printf 'worktree %s\0HEAD root-main\0branch refs/heads/main\0\0' "$TEST_ROOT/root/acme/root-repo"
-    ;;
-  mix-good)
-    printf 'worktree %s\0HEAD mix-main\0branch refs/heads/main\0\0' "$TEST_ROOT/mix-root/mix-good"
     ;;
   canonical-c)
     printf 'worktree %s\0HEAD main-c\0branch refs/heads/main\0\0' "$TEST_ROOT/canonical-c"
@@ -272,29 +258,28 @@ symbolic-ref)
 branch)
   case "$base" in
   canonical-a) printf '%s\n' main ;;
-  repo-b | old-repo | root-repo | mix-good | wt-fail | ref-fail | rref-fail | dup-a | new-clone | canonical-c | gone-repo | lost-repo | net-repo) printf '%s\n' main ;;
+  repo-b | old-repo | root-repo | wt-fail | ref-fail | rref-fail | dup-a | new-clone | canonical-c | gone-repo | lost-repo | net-repo | prefix-auth) printf '%s\n' main ;;
   aaa-linked | bbb-linked | zzz-canonical) printf '%s\n' main ;;
   sub-wt | sep-wt) printf '%s\n' main ;;
   esac
   ;;
 for-each-ref)
-  # refs/remotes/<remote>/ scans (case-branch below) prove a local-only branch never becomes a
-  # --head argument to gh: canonical-a's remote mirror deliberately omits feature/mismatch.
-  # repo-b deliberately matches NO case here (empty output, exit 0): it is the empty-remote-
-  # inventory regression fixture for #1119 -- its non-default feature/shared branch has no PR-batch
-  # row, so the exact-fallback gate loop must run over an empty REMOTE_BRANCH_NAMES without
-  # aborting the fleet (unguarded expansion is fatal under set -u on bash <= 4.3) and must report
-  # the skipped lookup as a visible privacy gap.
+  # refs/remotes/<remote>/ scans prove remote-tracking tip comparison for merged-pr-tip-drift.
+  # Merge evidence is GraphQL headRefName aliases over every non-default local branch, so a
+  # branch absent from this inventory (canonical-a omits feature/mismatch; repo-b returns empty)
+  # is still queried by exact name — not privacy-gated.
   if [[ "${3:-}" == refs/remotes/*/ ]]; then
     case "$base" in
     canonical-a)
       printf 'origin\thead-a\0\norigin/main\tmain-a\0\norigin/feature/shared\tsha-a\0\norigin/stale/changed\tdrift-tip\0\n'
       ;;
-    # Moved-identity checkout (#2600): remote still advertises the feature head, so the privacy
-    # gate must not block the exact-OID merge match against the resolved identity.
+    # Moved-identity checkout (#2600): remote still advertises the feature head for tip-drift
+    # push-state wording; GraphQL merge evidence uses the resolved identity independently.
     old-repo) printf 'origin/main\told-main\0\norigin/feature/moved-merged\tmoved-merged-tip\0\norigin/feature/moved-local\tmoved-local-tip\0\n' ;;
     rref-fail) exit 9 ;;
     aaa-linked | bbb-linked | zzz-canonical) printf 'origin/main\tcanon-main\0\n' ;;
+    # Prefix-exactness fixture: remote tip for auth-v2 only; GraphQL must not conflate auth.
+    prefix-auth) printf 'origin/main\tpa-main\0\norigin/feature/auth-v2\tauth-v2-tip\0\n' ;;
     sub-wt) printf 'origin/main\tsub-main\0\n' ;;
     sep-wt) printf 'origin/main\tsep-main\0\n' ;;
     esac
@@ -302,7 +287,7 @@ for-each-ref)
   fi
   case "$base" in
   canonical-a)
-    # stale/gone: merged-PR batch row exists at a different OID (drift) but the branch has no
+    # stale/gone: GraphQL returns a merged PR at a different OID (drift) and the branch has no
     # remote-tracking ref -- the drift finding must state tip/headRefOid differ without claiming
     # the commits were never pushed (they may still be on the remote).
     printf 'main\tmain-a\0\nfeature/shared\tsha-a\0\nstale/changed\tdrift-tip\0\nfeature/mismatch\tmismatch\0\nstale/gone\tgone-tip\0\n'
@@ -317,12 +302,13 @@ for-each-ref)
   dup-a) printf 'main\tdup-main\0\n' ;;
   new-clone) printf 'main\tnc-main\0\n' ;;
   root-repo) printf 'main\troot-main\0\n' ;;
-  mix-good) printf 'main\tmix-main\0\n' ;;
   canonical-c) printf 'main\tmain-c\0\n' ;;
   gone-repo) printf 'main\tgone-main\0\n' ;;
   lost-repo) printf 'main\tlost-main\0\n' ;;
   net-repo) printf 'main\tnet-main\0\n' ;;
   aaa-linked | bbb-linked | zzz-canonical) printf 'main\tcanon-main\0\nfeature/linked\tcanon-feat\0\n' ;;
+  # Exact headRefName: feature/auth must not inherit feature/auth-v2's merged PR (#2604).
+  prefix-auth) printf 'main\tpa-main\0\nfeature/auth\tauth-tip\0\nfeature/auth-v2\tauth-v2-tip\0\n' ;;
   sub-wt) printf 'main\tsub-main\0\n' ;;
   sep-wt) printf 'main\tsep-main\0\n' ;;
   esac
@@ -363,10 +349,112 @@ api)
     [[ "${MOCK_GH_USER_FAIL:-}" == "1" ]] && exit 1
     printf 'test-login'
     ;;
+  graphql)
+    # Aliased GraphQL merged-PR evidence (#2604). Parse owner/name + headRefName aliases from
+    # the query document, emit a JSON payload, then apply --jq when present (as real gh does).
+    query=""
+    jq_filter=""
+    shift 2 || true
+    while [[ $# -gt 0 ]]; do
+      case "$1" in
+      --hostname) shift 2 || true ;;
+      -f)
+        shift
+        [[ "${1:-}" == query=* ]] && query="${1#query=}"
+        shift || true
+        ;;
+      --jq)
+        shift
+        jq_filter="${1:-}"
+        shift || true
+        ;;
+      *) shift || true ;;
+      esac
+    done
+    [[ -n "$query" ]] || exit 1
+    owner=""
+    name=""
+    if [[ "$query" =~ repository\(owner:\"([^\"]+)\",name:\"([^\"]+)\"\) ]]; then
+      owner="${BASH_REMATCH[1]}"
+      name="${BASH_REMATCH[2]}"
+    fi
+    [[ -n "$owner" && -n "$name" ]] || exit 1
+    # Collect exact headRefName values from aliases (order preserved).
+    heads=()
+    rest="$query"
+    while [[ "$rest" =~ headRefName:\"([^\"]+)\"(.*)$ ]]; do
+      heads+=("${BASH_REMATCH[1]}")
+      rest="${BASH_REMATCH[2]}"
+    done
+    # Fixture table: owner/name -> headRefName -> number|oid|mergedAt|url
+    lookup_pr() {
+      local o="$1" n="$2" head="$3"
+      case "$o/$n" in
+      acme/repo-a)
+        case "$head" in
+        feature/shared) printf '18|sha-a|2026-07-01T00:00:00Z|https://github.com/acme/repo-a/pull/18' ;;
+        stale/changed) printf '42|merged-tip|2026-07-02T00:00:00Z|https://github.com/acme/repo-a/pull/42' ;;
+        stale/gone) printf '43|other-tip|2026-07-03T00:00:00Z|https://github.com/acme/repo-a/pull/43' ;;
+        *) printf '' ;;
+        esac
+        ;;
+      new/repo)
+        case "$head" in
+        feature/moved-merged) printf '7|moved-merged-tip|2026-07-04T00:00:00Z|https://github.com/new/repo/pull/7' ;;
+        feature/moved-local) printf '8|moved-local-tip|2026-07-05T00:00:00Z|https://github.com/new/repo/pull/8' ;;
+        *) printf '' ;;
+        esac
+        ;;
+      acme/wt-fail)
+        case "$head" in
+        feature/fail) printf '88|fail-tip|2026-07-03T00:00:00Z|https://github.com/acme/wt-fail/pull/88' ;;
+        *) printf '' ;;
+        esac
+        ;;
+      acme/wt-canon)
+        # Deep history: GraphQL answers feature/linked by exact name even though a REST
+        # window of recent merged PRs would have been exhausted by unrelated archives.
+        case "$head" in
+        feature/linked) printf '9001|canon-feat|2025-01-01T00:00:00Z|https://github.com/acme/wt-canon/pull/9001' ;;
+        *) printf '' ;;
+        esac
+        ;;
+      acme/prefix-auth)
+        # Only auth-v2 merged; feature/auth must not inherit it (exact headRefName).
+        case "$head" in
+        feature/auth-v2) printf '55|auth-v2-tip|2026-07-06T00:00:00Z|https://github.com/acme/prefix-auth/pull/55' ;;
+        *) printf '' ;;
+        esac
+        ;;
+      acme/repo-b | acme/root-repo | acme/repo-c | acme/rref-fail | acme/ref-fail | acme/sub-mod | acme/sep-mod)
+        printf ''
+        ;;
+      *) return 1 ;;
+      esac
+    }
+    json='{"data":{"rateLimit":{"cost":1,"nodeCount":'"${#heads[@]}"'}'
+    alias_i=0
+    for head in "${heads[@]:-}"; do
+      [[ -n "$head" ]] || continue
+      row="$(lookup_pr "$owner" "$name" "$head")" || exit 1
+      if [[ -n "$row" ]]; then
+        IFS='|' read -r num oid merged url <<<"$row"
+        json+=",\"b${alias_i}\":{\"pullRequests\":{\"nodes\":[{\"number\":$num,\"headRefName\":\"$head\",\"headRefOid\":\"$oid\",\"mergedAt\":\"$merged\",\"url\":\"$url\"}]}}"
+      else
+        json+=",\"b${alias_i}\":{\"pullRequests\":{\"nodes\":[]}}"
+      fi
+      alias_i=$((alias_i + 1))
+    done
+    json+='}}'
+    if [[ -n "$jq_filter" ]]; then
+      printf '%s' "$json" | jq -r "$jq_filter"
+    else
+      printf '%s' "$json"
+    fi
+    ;;
   repos/acme/repo-a) printf 'acme/repo-a\tmain' ;;
   repos/acme/repo-b) printf 'acme/repo-b\tmain' ;;
   repos/acme/root-repo) printf 'acme/root-repo\tmain' ;;
-  repos/acme/mix-good) printf 'acme/mix-good\tmain' ;;
   repos/acme/bad) printf 'acme/bad\tmain' ;;
   repos/acme/wt-fail) printf 'acme/wt-fail\tmain' ;;
   repos/acme/ref-fail) printf 'acme/ref-fail\tmain' ;;
@@ -375,47 +463,11 @@ api)
   repos/new/repo) printf 'new/repo\tmain' ;;
   repos/acme/repo-c) printf 'acme/repo-c\tmain' ;;
   repos/acme/wt-canon) printf 'acme/wt-canon\tmain' ;;
+  repos/acme/prefix-auth) printf 'acme/prefix-auth\tmain' ;;
   repos/acme/sub-mod) printf 'acme/sub-mod\tmain' ;;
   repos/acme/sep-mod) printf 'acme/sep-mod\tmain' ;;
   repos/gone/net) printf 'gh: connection reset by peer\n' >&2; exit 1 ;;
   *) printf 'gh: Not Found (HTTP 404)\n' >&2; exit 1 ;;
-  esac
-  ;;
-pr)
-  repo=""
-  while [[ $# -gt 0 ]]; do
-    if [[ "$1" == "--repo" ]]; then repo="$2"; shift 2; else shift; fi
-  done
-  case "$repo" in
-  github.com/acme/repo-a)
-    printf '18\tfeature/shared\tsha-a\t2026-07-01T00:00:00Z\thttps://github.com/acme/repo-a/pull/18\n'
-    printf '42\tstale/changed\tmerged-tip\t2026-07-02T00:00:00Z\thttps://github.com/acme/repo-a/pull/42\n'
-    printf '43\tstale/gone\tother-tip\t2026-07-03T00:00:00Z\thttps://github.com/acme/repo-a/pull/43\n'
-    ;;
-  github.com/acme/repo-b | github.com/acme/root-repo | github.com/acme/mix-good | github.com/acme/repo-c) ;;
-  # Resolved identity for the moved-remote fixture: merge evidence must be queried here, not under
-  # the stale configured remote (old/repo). Exact-OID rows prove branch/worktree analysis continued.
-  github.com/new/repo)
-    printf '7\tfeature/moved-merged\tmoved-merged-tip\t2026-07-04T00:00:00Z\thttps://github.com/new/repo/pull/7\n'
-    printf '8\tfeature/moved-local\tmoved-local-tip\t2026-07-05T00:00:00Z\thttps://github.com/new/repo/pull/8\n'
-    ;;
-  # A FULL merged-PR window: gh returns at most --limit rows, so 200 rows means older merged PRs
-  # were silently dropped. Every row is a branch this repository does not have locally, so the
-  # truncation disclosure is the only thing this fixture can produce.
-  github.com/acme/sub-mod | github.com/acme/sep-mod) ;;
-  github.com/acme/wt-canon)
-    i=1
-    while [[ "$i" -le 1000 ]]; do
-      printf '%s\tarchived/branch-%s\toid-%s\t2026-07-01T00:00:00Z\thttps://github.com/acme/wt-canon/pull/%s\n' "$i" "$i" "$i" "$i"
-      i=$((i + 1))
-    done
-    ;;
-  github.com/acme/rref-fail) ;;
-  github.com/acme/wt-fail)
-    printf '88\tfeature/fail\tfail-tip\t2026-07-03T00:00:00Z\thttps://github.com/acme/wt-fail/pull/88\n'
-    ;;
-  github.com/acme/ref-fail) ;;
-  *) exit 1 ;;
   esac
   ;;
 *) exit 95 ;;
@@ -450,6 +502,7 @@ cat >"$TMP/config/repo-fleet-hygiene.conf" <<'EOF'
     repo = ../gone-repo
     repo = ../lost-repo
     repo = ../net-repo
+    repo = ../prefix-auth
     maxDepth = 5
     ackUnavailable = github.com/Gone/Away
     ackUnavailable = github.com/gone/net
@@ -566,7 +619,7 @@ assert_not_contains "repo B branch did not inherit repo A merge" "Target: $TMP/r
 assert_not_contains "invalid canonical state was not combined" "Target: $TMP/bad-canonical ::"
 assert_not_contains "failed worktree inventory suppressed branch candidate" "Target: $TMP/wt-fail :: feature/fail"
 assert_not_contains "partial branch inventory suppressed branch candidate" "Target: $TMP/ref-fail :: feature/partial"
-assert_contains "failed repositories not counted successful" "Summary: repositories_audited=11"
+assert_contains "failed repositories not counted successful" "Summary: repositories_audited=12"
 
 # Duplicate detection keys on the CANONICALIZED identity: old-repo (remote still says old/repo,
 # resolved to new/repo) must pair with new-clone (cloned from new/repo directly).
@@ -610,34 +663,36 @@ else
 fi
 assert_contains "per-root discovered count for a contributing root" "../root: 1 repositories"
 assert_contains "zero-contribution root stays visible in the header" "../emptyroot: 0 repositories"
-assert_contains "discovery skip counts reported in the header" "Discovery skips: 0 non-repository, 0 unreadable"
 
-# Empty remote-ref inventory (repo-b: refs/remotes scan returns nothing with exit 0) must reach
-# and survive the exact-fallback gate loop -- on bash <= 4.3 an unguarded empty-array expansion
-# under set -u aborts the whole fleet -- and the privacy-gated skip must be visible, never silent.
-if grep -A3 -F "Finding: merge-evidence-privacy-gated" "$output" | grep -Fq "Target: $TMP/repo-b"; then
-  printf 'PASS: empty remote inventory survives gate loop and reports privacy gap\n'
-else
-  printf 'FAIL: empty remote inventory survives gate loop and reports privacy gap\n' >&2
-  failures=$((failures + 1))
-fi
-assert_contains "local-only branch named in aggregate privacy gap" \
-  "absent from the local remote-tracking inventory: feature/mismatch"
-# A FAILED remote-ref scan (rref-fail) already reports remote-branch-inventory-unavailable
-# repo-wide; the per-repo privacy-gap aggregate must stay quiet there, not double-report.
+# GraphQL merge evidence (#2604) queries every non-default local branch by exact headRefName,
+# including branches absent from remote-tracking inventory. The retired privacy-gate and REST
+# window findings must not appear. Empty remote inventory (repo-b) and failed remote inventory
+# (rref-fail) still must not abort the fleet under set -u.
+assert_not_contains "retired merge-evidence-privacy-gated is not emitted" \
+  "Finding: merge-evidence-privacy-gated"
+assert_not_contains "retired merged-pr-window-truncated is not emitted" \
+  "Finding: merged-pr-window-truncated"
 assert_contains "failed remote-ref scan reported repo-wide" "Finding: remote-branch-inventory-unavailable"
-if grep -A3 -F "Finding: merge-evidence-privacy-gated" "$output" | grep -Fq "Target: $TMP/rref-fail"; then
-  printf 'FAIL: failed remote inventory double-reported as privacy gap\n' >&2
+# Local-only branch still reaches GraphQL (name appears in an aliased query).
+if grep -E "gh api graphql .*feature/mismatch" "$CALL_LOG" >/dev/null; then
+  printf 'PASS: local-only branch queried via GraphQL headRefName\n'
+else
+  printf 'FAIL: local-only branch queried via GraphQL headRefName\n' >&2
+  failures=$((failures + 1))
+fi
+# Exactness: feature/auth must not inherit feature/auth-v2's merged PR.
+if grep -B5 -Fx "Target: $TMP/prefix-auth :: feature/auth-v2" "$output" | grep -Fq "Finding: merged-local-branch"; then
+  printf 'PASS: exact headRefName merge for feature/auth-v2\n'
+else
+  printf 'FAIL: exact headRefName merge for feature/auth-v2\n' >&2
+  failures=$((failures + 1))
+fi
+if grep -B5 -Fx "Target: $TMP/prefix-auth :: feature/auth" "$output" | grep -Fq "Finding: merged-local-branch"; then
+  printf 'FAIL: feature/auth wrongly inherited auth-v2 merge evidence\n' >&2
   failures=$((failures + 1))
 else
-  printf 'PASS: failed remote inventory not double-reported as privacy gap\n'
+  printf 'PASS: feature/auth does not inherit feature/auth-v2 merge evidence\n'
 fi
-assert_not_contains "privacy-gated handoff does not suggest re-fetch" \
-  "re-fetch the branch to restore remote evidence"
-assert_contains "privacy-gated handoff names PR lookup for auto-deleted heads" \
-  "gh pr list --repo github.com/"
-assert_contains "privacy-gated handoff distinguishes never-pushed locals" \
-  "Never-pushed locals: push to publish the branch name, then rerun"
 
 # Drift push-state evidence: stale/changed has a same-named remote-tracking ref at the SAME OID
 # (pushed as of last fetch); stale/gone has a drift-batch row but NO remote-tracking ref — that
@@ -690,16 +745,22 @@ else
 fi
 assert_contains "summary counts acknowledged separately" "acknowledged=1"
 
-if grep -Fq -- '--head feature/mismatch' "$CALL_LOG"; then
-  printf 'FAIL: local-only branch name was sent to GitHub via --head\n' >&2
+if grep -Fq -- 'pr list' "$CALL_LOG"; then
+  printf 'FAIL: REST pr list still used for merge evidence\n' >&2
   failures=$((failures + 1))
 else
-  printf 'PASS: local-only branch name never sent to GitHub\n'
+  printf 'PASS: merge evidence uses GraphQL only (no pr list)\n'
 fi
-if grep -Fq -- '--head stale/changed' "$CALL_LOG"; then
-  printf 'PASS: remote-known branch still queried via exact-fallback\n'
+if grep -Fq -- 'api graphql' "$CALL_LOG"; then
+  printf 'PASS: aliased GraphQL merged-PR query invoked\n'
 else
-  printf 'FAIL: remote-known branch was not queried via exact-fallback\n' >&2
+  printf 'FAIL: aliased GraphQL merged-PR query invoked\n' >&2
+  failures=$((failures + 1))
+fi
+if grep -E "gh api graphql .*stale/changed" "$CALL_LOG" >/dev/null; then
+  printf 'PASS: drift branch queried via GraphQL headRefName\n'
+else
+  printf 'FAIL: drift branch queried via GraphQL headRefName\n' >&2
   failures=$((failures + 1))
 fi
 
@@ -831,35 +892,6 @@ elif grep -Fq "repository directory not found" "$ladder_out"; then
   printf 'PASS: CLI-supplied missing repo hard-fails\n'
 else
   printf 'FAIL: CLI-supplied missing repo hard-fails (wrong error)\n' >&2
-  failures=$((failures + 1))
-fi
-
-# Discovery under --root must degrade per-entry for a .git husk (and count unreadable dirs), never
-# abort the fleet the way an explicit --repo typo does (#2598).
-REPO_FLEET_TEST_FAST_TIMEOUTS=1 CLAUDE_PROJECT_DIR="$TMP/discovered-a" HOME="$TMP/nohome" \
-  bash "$SCRIPT" --root "$TMP/mix-root" >"$ladder_out" 2>&1
-mix_status=$?
-if [[ "$mix_status" -ne 0 ]]; then
-  printf 'FAIL: --root with a non-repository husk aborted the audit (exit %s)\n' "$mix_status" >&2
-  failures=$((failures + 1))
-elif grep -Fq "Repo: $TMP/mix-root/mix-good" "$ladder_out" &&
-  grep -Fq "Finding: discovery-skip" "$ladder_out" &&
-  grep -A3 -F "Finding: discovery-skip" "$ladder_out" | grep -Fq "$TMP/mix-root/mix-husk" &&
-  grep -Fq "Discovery skips: 1 non-repository, ${EXPECT_MIX_UNREADABLE} unreadable" "$ladder_out" &&
-  ! grep -Fq "Error: not a Git working tree" "$ladder_out"; then
-  printf 'PASS: discovery husk degrades per-entry and audits siblings under --root\n'
-else
-  printf 'FAIL: discovery husk degrades per-entry and audits siblings under --root\n' >&2
-  failures=$((failures + 1))
-fi
-# The same husk named explicitly via --repo remains a hard failure — operator typo, not discovery.
-if REPO_FLEET_TEST_FAST_TIMEOUTS=1 bash "$SCRIPT" --repo "$TMP/mix-root/mix-husk" >"$ladder_out" 2>&1; then
-  printf 'FAIL: explicit --repo on a discovery husk did not hard-fail\n' >&2
-  failures=$((failures + 1))
-elif grep -Fq "not a Git working tree" "$ladder_out" && ! grep -Fq "discovery-skip" "$ladder_out"; then
-  printf 'PASS: explicit --repo on a discovery husk still hard-fails\n'
-else
-  printf 'FAIL: explicit --repo on a discovery husk still hard-fails (wrong output)\n' >&2
   failures=$((failures + 1))
 fi
 
@@ -1006,13 +1038,20 @@ else
   printf 'FAIL: an empty --root value hard-fails (wrong error)\n' >&2
   failures=$((failures + 1))
 fi
-# A full merged-PR window silently drops older history, which reads in the report exactly like a
-# branch that was never merged. The truncation must be disclosed, never inferred by the reader.
-if grep -Fq "Finding: merged-pr-window-truncated" "$ladder_out" &&
-  grep -Fq "equal to its 1000-PR window" "$ladder_out"; then
-  printf 'PASS: a full merged-PR window is disclosed as truncated\n'
+# GraphQL answers per-branch by exact headRefName, so a repository with deep merged history still
+# surfaces an old merge for a local branch (wt-canon feature/linked) without a truncation finding.
+# Dedicated capture: later auth-fail reuse of $ladder_out must not erase this evidence.
+deep_out="$TMP/deep-history.txt"
+REPO_FLEET_TEST_FAST_TIMEOUTS=1 CLAUDE_PROJECT_DIR="$TMP/discovered-a" HOME="$TMP/nohome" \
+  bash "$SCRIPT" --root "$TMP/wt-root" >"$deep_out" 2>&1
+if grep -Fq "Finding: merged-pr-window-truncated" "$deep_out"; then
+  printf 'FAIL: retired merged-pr-window-truncated still emitted on deep-history fixture\n' >&2
+  failures=$((failures + 1))
+elif grep -B5 -Fx "Target: $TMP/wt-root/zzz-canonical :: feature/linked" "$deep_out" |
+  grep -Fq "Finding: merged-worktree"; then
+  printf 'PASS: GraphQL finds merged branch beyond any former REST window\n'
 else
-  printf 'FAIL: a full merged-PR window is disclosed as truncated\n' >&2
+  printf 'FAIL: GraphQL finds merged branch beyond any former REST window\n' >&2
   failures=$((failures + 1))
 fi
 
@@ -1078,6 +1117,10 @@ run_bounded_gh api repos/acme/repo-b --hostname github.com --method POST --templ
   forbidden_rejected=false
 run_bounded_gh pr merge --repo github.com/acme/repo-b >/dev/null 2>&1 && forbidden_rejected=false
 run_bounded_gh alias set pr '!touch /tmp/pwned' >/dev/null 2>&1 && forbidden_rejected=false
+run_bounded_gh api graphql --hostname github.com -f 'query=mutation{__typename}' --jq . >/dev/null 2>&1 &&
+  forbidden_rejected=false
+run_bounded_gh pr list --repo github.com/acme/repo-b --state merged --limit 1000 --json number,headRefName,headRefOid,mergedAt,url --template x >/dev/null 2>&1 &&
+  forbidden_rejected=false
 calls_after="$(wc -l <"$CALL_LOG")"
 status_rejected=true
 run_git_probe -C "$TMP/wt-a" status --porcelain >/dev/null 2>&1 && status_rejected=false


### PR DESCRIPTION
Closes #2604

## Summary

Collect merged-PR evidence through aliased GraphQL queries for fleet audit.

## Fix

See commits on this branch.

## Verification

See CI checks on this PR.

## Related

Refs #2597 — fleet epic.
