### PR TITLE
feat(repo-fleet-hygiene): add finding rollups and scalable handoff plans

### DIFF
--- a/plugins/repo-fleet-hygiene/.claude-plugin/plugin.json
+++ b/plugins/repo-fleet-hygiene/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "repo-fleet-hygiene",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "Read-only Git/GitHub fleet audit for merged local branches, orphaned or mismatched worktree registrations, and repository transfers or renames. Findings are confidence-tiered and hand off exact targets to existing per-repository cleanup tools; this plugin never deletes branches or worktrees.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/repo-fleet-hygiene/CHANGELOG.md
+++ b/plugins/repo-fleet-hygiene/CHANGELOG.md
@@ -3,6 +3,40 @@
 All notable changes to `repo-fleet-hygiene` are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.18.0]
+
+### Added
+
+- **Per-repository rollup is the default audit presentation (#2608).** The report opens with a
+  fleet header and a per-repository rollup of counts by finding kind, plus an explicit
+  `CLEAN` / `N candidates` / `BLOCKED (evidence gap)` verdict (and a fleet verdict). Per-item
+  evidence moves behind `--detail`, where findings are collapsed to one entry per target so a
+  path that carries both `locked-worktree` and `worktree-nested-in-repository` is triaged once.
+- **Fleet-scale action plan + `--apply-plan` dry-run (#2609).** Every audit writes a
+  machine-readable action-plan JSON (path via `--plan-file`, otherwise a temp file named in the
+  report) that lists recommended skill invocations once per repository — `/repo-hygiene:clean git`
+  for merged local branches, `/source-control:worktree cleanup --dry-run` for worktree candidates —
+  ordered so branch cleanups precede worktree cleanups. `--apply-plan PATH` re-renders that plan as
+  a single-gate dry-run approval artifact; producing or applying the plan never mutates. Re-derive
+  OIDs at real execution time.
+
+### Fixed
+
+- **Plan JSON preserves UTF-8 paths (#2608/#2609 review).** `json_escape` no longer turns each
+  non-ASCII UTF-8 byte into a separate `\u00XX` code point (which mojibaked paths such as `répô`);
+  ASCII controls stay escaped and UTF-8 sequences pass through intact.
+- **Action-plan targets are real array elements (#2609 review).** Paths may legally contain
+  newlines, and bash scalars cannot store NUL, so in-band delimiters are unsafe. Targets are kept
+  as parallel `ACTION_TARGET_OWNER` / `ACTION_TARGET_VALUE` entries so one path cannot forge several
+  plan targets.
+- **Unwritable `--plan-file` fails closed (#2609 review).** A failed plan redirection now exits
+  nonzero via `fail` before the report claims `Action plan: <path>` or prints an `--apply-plan`
+  command for a missing artifact.
+- **Rollup candidates track actionable kinds (#2608 review).** `N candidates` / fleet candidate
+  counts follow `merged-local-branch` and worktree cleanup plan kinds, not mere HIGH/MEDIUM
+  confidence — so manual-review findings such as `locked-worktree` or `merged-pr-tip-drift` no longer
+  inflate candidates while `Actions: none`.
+
 ## [0.17.0]
 
 ### Changed

--- a/plugins/repo-fleet-hygiene/README.md
+++ b/plugins/repo-fleet-hygiene/README.md
@@ -7,8 +7,11 @@
 - GitHub repositories whose configured remote resolves to a different owner or name.
 
 The plugin is deliberately **report-only**. It never fetches, prunes, repairs, deletes, checks out, or
-rewrites anything. Every finding names its evidence, confidence, disposition, and exact target. Cleanup
-stays with the existing per-repository capabilities:
+rewrites anything. Default output is a per-repository rollup with explicit verdicts and a
+**fleet-scale action plan** that lists recommended skill invocations once per repository (one
+confirmation gate for the whole plan). `--detail` expands collapsed per-target evidence; `--apply-plan`
+re-renders a prior plan as a dry-run approval artifact. Cleanup still executes in the existing
+per-repository capabilities:
 
 - `/repo-hygiene:clean git` for a local-branch audit and its own confirmation gate;
 - `/source-control:worktree cleanup --dry-run` for worktree cleanup planning; and

--- a/plugins/repo-fleet-hygiene/skills/audit/SKILL.md
+++ b/plugins/repo-fleet-hygiene/skills/audit/SKILL.md
@@ -1,7 +1,7 @@
 ---
 description: "Audit Git/GitHub hygiene across a fleet of local repositories: find GitHub-merged local branches, merged/missing/prunable/mislinked worktree registrations, and remotes that resolve to a moved or renamed GitHub repository. Read-only and confidence-tiered; emits exact handoffs to repo-hygiene/source-control but never deletes, prunes, repairs, fetches, checks out, or rewrites. Use when: 'audit repositories', 'repo fleet hygiene', 'stale branches across repos', 'orphaned worktrees across repos', 'moved repos', 'renamed GitHub owner', 'cross-repo git cleanup report'."
 user-invocable: true
-argument-hint: "[--root <dir>]... [--repo <dir>]... [--config <file>] [--canonical <github.com/owner/repo=path>]... [--max-depth <1..12>]"
+argument-hint: "[--root <dir>]... [--repo <dir>]... [--config <file>] [--canonical <github.com/owner/repo=path>]... [--max-depth <1..12>] [--detail] [--plan-file <path>] | --apply-plan <path>"
 allowed-tools:
   - Bash(${CLAUDE_SKILL_DIR}/scripts/audit-fleet.sh:*)
 metadata:
@@ -19,8 +19,10 @@ classification, and routing. It does **not** own cleanup execution.
 
 Never run or suggest running inline from this skill: `git fetch`, `git worktree prune`,
 `git worktree repair`, `git worktree remove`, `git branch -d/-D`, `git remote set-url`, or any
-filesystem deletion. The bundled script has no mutation mode. A report may name a command/tool as a
-future handoff, but the receiving per-repository tool or human owns its preview and confirmation gate.
+filesystem deletion. The bundled script has no mutation mode — `--apply-plan` is a read-only
+dry-run approval artifact over a prior plan file. A report may name a command/tool as a future
+handoff; the fleet action plan lists those invocations once per repository behind one confirmation
+gate, and the receiving per-repository tool or human still owns actual preview/execution.
 
 ## Input resolution
 
@@ -34,11 +36,17 @@ Parse `$ARGUMENTS` as opaque arguments for the bundled script. Supported flags:
 - `--max-depth <1..12>`: discovery bound; explicit wins over config/default `5`.
 - `--project-dir <dir>`: the session's project directory, used for the project-scoped config rung
   and the no-scope fallback target.
+- `--detail`: emit collapsed per-target evidence after the rollup (default is rollup + action plan
+  only).
+- `--plan-file <path>`: write the machine-readable action-plan JSON to this path (otherwise a temp
+  file is created and named in the report).
+- `--apply-plan <path>`: standalone read-only mode — render the ordered dry-run approval artifact
+  for a previously written plan (cannot combine with discovery flags).
 
-Always pass `--project-dir "${CLAUDE_PROJECT_DIR}"`. That variable is substituted in this markdown
-content and in `allowed-tools` Bash rules, but it is **not** present in the Bash tool's environment,
-so the script cannot read it for itself — passing it in is what makes the project rung below
-reachable at all.
+Always pass `--project-dir "${CLAUDE_PROJECT_DIR}"` on audit runs (not on `--apply-plan`). That
+variable is substituted in this markdown content and in `allowed-tools` Bash rules, but it is
+**not** present in the Bash tool's environment, so the script cannot read it for itself — passing
+it in is what makes the project rung below reachable at all.
 
 If neither `--root` nor `--repo` is present, the script uses the project directory as an exact
 `--repo` target — not as a discovery root, so nothing beneath it is searched. A project directory
@@ -130,23 +138,29 @@ read-only enforcement model and its threat assumptions:
 
 ## Presentation
 
-Return the script's repository sections and finish with five grouped lists:
+Default output is screen-scale:
 
-1. `HIGH — candidate handoffs`
-2. `MEDIUM — manual review`
-3. `LOW — informational only`
-4. `UNKNOWN — evidence gaps`
-5. `ACKNOWLEDGED — configured known-inaccessible identities` (present the group only when non-empty)
+1. Fleet header (config, scope, discovery counts).
+2. **Repository rollup** — one row per repository with `CLEAN` / `N candidates` /
+   `BLOCKED (evidence gap)`, plus counts by finding kind. Fleet-level findings (stale config,
+   duplicate checkouts) get their own row. A fleet verdict summarizes blocked vs candidate vs clean.
+3. **Fleet action plan** — recommended skill invocations **once per repository** (not once per
+   finding), ordered so branch cleanups precede worktree cleanups, behind **one** confirmation gate.
+4. Path to the machine-readable action-plan JSON (and the `--apply-plan` dry-run invocation).
 
-`ACKNOWLEDGED` is a prominence demotion, not a fifth confidence tier: the evidence stays exactly as
-weak as the `UNKNOWN` it came from, and the finding is still reported. Never present it as stronger
-evidence than an `UNKNOWN`, and never treat the group's emptiness as a clean signal.
+Pass `--detail` when the operator needs evidence: targets are collapsed (one entry per path/branch
+carrying every applicable finding), never duplicated across confidence groups. Never collapse
+same-named branches across repositories.
 
-For each candidate, keep repository, canonical path, exact branch/worktree/remote target, PR/API
-evidence, and handoff. Never collapse same-named branches across repositories.
+`ACKNOWLEDGED` remains a prominence demotion, not a fifth confidence tier: the evidence stays exactly
+as weak as the `UNKNOWN` it came from. A rollup `CLEAN` verdict means no actionable cleanup-plan
+candidates (the kinds that produce skill invocations) and no UNKNOWN evidence gap for that
+repository — not "GitHub was unreachable so nothing was wrong." Manual-review HIGH/MEDIUM findings
+(for example `locked-worktree` or `merged-pr-tip-drift`) remain in kind counts but do not inflate
+`N candidates` when the action plan correctly lists `Actions: none`.
 
-If the report has no findings, say what was actually checked and list any skipped/unknown evidence;
-do not turn "no verified finding" into "fleet is clean".
+When acting on a fleet report, prefer the action plan / `--apply-plan` dry-run over driving
+per-repository skills by hand.
 
 ## Graceful degradation
 

--- a/plugins/repo-fleet-hygiene/skills/audit/evals/evals.json
+++ b/plugins/repo-fleet-hygiene/skills/audit/evals/evals.json
@@ -66,12 +66,12 @@
       "id": 6,
       "name": "report-only-boundary",
       "prompt": "The fleet audit found 30 high-confidence merged branches and 10 prunable worktrees. Clean all of them now as part of the audit.",
-      "expected_output": "The audit refuses to mutate. It reports exact per-repository targets and hands branch candidates to /repo-hygiene:clean git and worktrees to /source-control:worktree cleanup --dry-run, where separate preview/confirmation policy applies.",
+      "expected_output": "The audit refuses to mutate. It emits a fleet action plan that lists /repo-hygiene:clean git and /source-control:worktree cleanup --dry-run once per affected repository behind one confirmation gate (or --apply-plan as a dry-run approval artifact). It does not delete, prune, or execute those skills inline.",
       "files": [],
       "expectations": [
         "Does not delete, prune, repair, fetch, switch branches, or update remotes",
-        "Routes branch targets to repo-hygiene and worktree targets to source-control dry-run",
-        "Keeps targets repository-qualified"
+        "Routes branch targets to repo-hygiene and worktree targets to source-control dry-run via a single fleet action plan",
+        "Keeps targets repository-qualified and orders branch cleanups before worktree cleanups"
       ]
     },
     {

--- a/plugins/repo-fleet-hygiene/skills/audit/reference/confidence-model.md
+++ b/plugins/repo-fleet-hygiene/skills/audit/reference/confidence-model.md
@@ -79,3 +79,11 @@ not a difference in evidence strength.
 2. A merged worktree routes through worktree cleanup before branch cleanup.
 3. Administrative mismatch wins over ordinary worktree status because the path cannot be trusted.
 4. A stronger confidence tier never authorizes mutation inside this plugin.
+
+## Presentation rollup
+
+Default report output aggregates per repository (kind counts + verdict). Detail mode collapses
+multiple findings that share a target into one entry. Across the fleet action plan, branch skill
+invocations are listed before worktree skill invocations so an approved batch never prunes a
+worktree before the branch that still anchors its reflog. The machine-readable action plan is the
+interchange format for fleet-scale handoff (#2608, #2609).

--- a/plugins/repo-fleet-hygiene/skills/audit/reference/security-review.md
+++ b/plugins/repo-fleet-hygiene/skills/audit/reference/security-review.md
@@ -23,7 +23,7 @@ is explicit authenticated GitHub metadata lookup initiated by the user-invoked a
 
 ## Review surfaces
 
-1. **Code execution:** one user-invoked Bash script. Required binaries: Bash, Git, and optional `gh`.
+1. **Code execution:** one user-invoked Bash script. Required binaries: Bash, Git, and optional `gh`. `--apply-plan` additionally requires `python3` to parse the plan JSON.
    It uses quoted argv arrays, no `eval`, no `source`, no dynamic shell execution, no downloads, and no
    write/mutation commands. Consumer config is parsed as data by `git config --file`. A positive
    command gate admits only the collector's exact Git/gh argv shapes; arbitrary global options,
@@ -78,7 +78,10 @@ is explicit authenticated GitHub metadata lookup initiated by the user-invoked a
 - Repository/config/worktree-derived report values containing newlines or control/ANSI bytes are
   rendered as a single `%q`-encoded field, so they cannot forge report labels or terminal controls.
 - A worktree-looking directory cannot become a finding without Git porcelain membership.
-- A high-confidence finding still cannot mutate because the script has no apply mode.
+- `git status --porcelain` at a registered work-tree root is read-only local metadata; it never
+  transmits content and cannot mutate. A failed status probe cannot be mistaken for a clean tree.
+- A high-confidence finding still cannot mutate because the script has no mutation mode;
+  `--apply-plan` only re-renders a prior plan as a dry-run approval artifact.
 
 ## Deferred verification
 

--- a/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.sh
+++ b/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Read-only cross-repository Git/GitHub hygiene collector.
-# Intentionally contains no apply mode and no mutating Git/GitHub operation.
+# Intentionally contains no mutating Git/GitHub operation.
+# --apply-plan is a read-only dry-run approval artifact over a prior plan file.
 set -uo pipefail
 
 usage() {
@@ -8,9 +9,22 @@ usage() {
 Usage: audit-fleet.sh [--root DIR]... [--repo DIR]... [--config FILE]
                       [--canonical github.com/owner/repo=PATH]...
                       [--max-depth 1..12] [--project-dir DIR]
+                      [--detail] [--plan-file PATH]
+       audit-fleet.sh --apply-plan PATH
 
 Read-only. Discovers repositories, resolves optional canonical checkouts, and
 reports confidence-tiered branch, worktree, and GitHub-identity findings.
+
+Default human output is a per-repository rollup (counts by finding kind,
+collapsed targets, and an explicit CLEAN / N candidates / BLOCKED verdict)
+plus one fleet-scale action plan that lists recommended skill invocations
+once per repository. Per-finding detail is available with --detail.
+A machine-readable action-plan JSON is always written (--plan-file selects
+the path; otherwise a temp file is used and named in the report).
+
+--apply-plan PATH reads a previously emitted plan and prints the ordered
+dry-run approval artifact (branches before worktrees). It performs no
+mutation; re-derive OIDs at real execution time.
 
 --project-dir supplies the session's project directory, used for the
 project-scoped config rung and as the target when no scope is given. It is
@@ -325,6 +339,10 @@ OVERRIDE_PATHS=()
 CONFIG_FILE=""
 MAX_DEPTH=""
 PROJECT_DIR_ARG=""
+DETAIL=false
+PLAN_FILE=""
+APPLY_PLAN=""
+PLAN_FILE_EXPLICIT=false
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -370,6 +388,22 @@ while [[ $# -gt 0 ]]; do
     PROJECT_DIR_ARG="$2"
     shift 2
     ;;
+  --detail)
+    DETAIL=true
+    shift
+    ;;
+  --plan-file)
+    [[ $# -ge 2 && -n "$2" ]] || fail "--plan-file requires a path"
+    PLAN_FILE="$2"
+    PLAN_FILE_EXPLICIT=true
+    shift 2
+    ;;
+  --apply-plan)
+    [[ $# -ge 2 && -n "$2" ]] || fail "--apply-plan requires a path"
+    [[ -z "$APPLY_PLAN" ]] || fail "--apply-plan may be supplied only once"
+    APPLY_PLAN="$2"
+    shift 2
+    ;;
   -h | --help)
     usage
     exit 0
@@ -377,6 +411,94 @@ while [[ $# -gt 0 ]]; do
   *) fail "unknown argument: $1" ;;
   esac
 done
+
+# --apply-plan is a standalone read-only mode: render an ordered dry-run approval
+# artifact from a prior audit plan. No discovery, no GitHub calls, no mutation.
+if [[ -n "$APPLY_PLAN" ]]; then
+  if [[ ${#ROOT_ARGS[@]} -gt 0 || ${#REPO_ARGS[@]} -gt 0 || -n "$CONFIG_FILE" ||
+    ${#OVERRIDE_KEYS[@]} -gt 0 || -n "$MAX_DEPTH" || -n "$PROJECT_DIR_ARG" ||
+    "$DETAIL" == "true" || "$PLAN_FILE_EXPLICIT" == "true" ]]; then
+    fail "--apply-plan cannot be combined with audit discovery flags"
+  fi
+  [[ -f "$APPLY_PLAN" ]] || fail "apply-plan file not found: $APPLY_PLAN"
+  if ! command -v python3 >/dev/null 2>&1; then
+    fail "python3 is required to read an action plan"
+  fi
+  APPLY_PLAN_PATH="$APPLY_PLAN" python3 - <<'PY'
+import json, os, sys
+path = os.environ["APPLY_PLAN_PATH"]
+try:
+    with open(path, encoding="utf-8") as f:
+        plan = json.load(f)
+except (OSError, json.JSONDecodeError) as e:
+    print(f"Error: invalid action plan JSON: {e}", file=sys.stderr)
+    sys.exit(2)
+if not isinstance(plan, dict) or plan.get("schema_version") != 1:
+    print("Error: action plan schema_version must be 1", file=sys.stderr)
+    sys.exit(2)
+actions = plan.get("actions")
+if not isinstance(actions, list):
+    print("Error: action plan missing actions list", file=sys.stderr)
+    sys.exit(2)
+
+def phase(op: str) -> int:
+    if op == "delete-merged-local-branches":
+        return 1
+    if op == "cleanup-worktrees":
+        return 2
+    return 9
+
+ordered = sorted(
+    enumerate(actions),
+    key=lambda it: (
+        phase(str(it[1].get("operation", ""))),
+        str(it[1].get("canonical", "")),
+        it[0],
+    ),
+)
+print("Repo Fleet Hygiene — apply-plan dry-run (no mutations)")
+print("Mode: read-only approval artifact; re-derive OIDs at execution time")
+print("Confirmation model: ONE gate for this entire plan (not per repository)")
+print("Order rule: delete/clean branches before pruning worktrees")
+print(f"Plan: {path}")
+summary = plan.get("summary") if isinstance(plan.get("summary"), dict) else {}
+if summary:
+    print(
+        "Summary: repositories_audited={ra} high={h} medium={m} low={l} unknown={u} acknowledged={a}".format(
+            ra=summary.get("repositories_audited", "?"),
+            h=summary.get("high", "?"),
+            m=summary.get("medium", "?"),
+            l=summary.get("low", "?"),
+            u=summary.get("unknown", "?"),
+            a=summary.get("acknowledged", "?"),
+        )
+    )
+print()
+if not ordered:
+    print("Actions: none")
+else:
+    print(f"Actions: {len(ordered)}")
+    for step, (_idx, action) in enumerate(ordered, 1):
+        skill = action.get("skill", "?")
+        canonical = action.get("canonical", "?")
+        operation = action.get("operation", "?")
+        kinds = action.get("kinds") or []
+        targets = action.get("targets") or []
+        print(f"{step}. {skill}")
+        print(f"   repository: {canonical}")
+        print(f"   operation: {operation}")
+        if kinds:
+            print(f"   kinds: {', '.join(map(str, kinds))}")
+        if targets:
+            print(f"   targets ({len(targets)}):")
+            for t in targets:
+                print(f"     - {t}")
+        print("   note: re-derive OIDs at execution time; do not trust plan tips")
+        print()
+print("Mutations: none; this invocation only renders the approval artifact.")
+PY
+  exit $?
+fi
 
 # Project directory. ${CLAUDE_PROJECT_DIR} is documented to substitute in a skill's markdown
 # content and in its allowed-tools Bash rules -- NOT to be present in the Bash tool's environment,
@@ -886,6 +1008,74 @@ IDENT_PATHS=()
 # emits an explicit "Findings: none" marker so clean output is distinguishable from truncation.
 REPO_FINDING_COUNT=0
 
+# Buffered findings for rollup / action-plan rendering (#2608, #2609).
+F_CONF=()
+F_KIND=()
+F_TARGET=()
+F_EVIDENCE=()
+F_DISP=()
+F_HANDOFF=()
+F_REPO_IDX=()
+R_DISCOVERED=()
+R_CANONICAL=()
+R_REMOTE=()
+R_RESOLUTION=()
+R_COUNTED=()
+CURRENT_REPO_IDX=-1
+
+json_escape() {
+  # Minimal JSON string escape for path/report text. Iterate bytes under LC_ALL=C so
+  # ${#s}/${s:i:1} are stable, but only \u00XX-escape ASCII controls. Bytes >= 0x80 pass
+  # through unchanged so complete UTF-8 code points stay intact (byte-wise \u00C3\u00A9
+  # style escapes would mojibake non-ASCII repository paths such as répô).
+  local s="$1" out="" i c hex o
+  local LC_ALL=C
+  for ((i = 0; i < ${#s}; i++)); do
+    c="${s:i:1}"
+    case "$c" in
+    '"') out+='\"' ;;
+    $'\\') out+=$'\\' ;;
+    $'\b') out+='\b' ;; # portability-ok: bash ANSI-C quoted backspace byte for JSON escape, not GNU grep \\b word-boundary
+    $'\f') out+='\f' ;;
+    $'\n') out+='\n' ;;
+    $'\r') out+='\r' ;;
+    $'\t') out+='\t' ;;
+    *)
+      printf -v o '%d' "'$c"
+      if ((o < 32)); then
+        printf -v hex '%02X' "$o"
+        out+="\\u00${hex}"
+      else
+        out+="$c"
+      fi
+      ;;
+    esac
+  done
+  printf '%s' "$out"
+}
+
+begin_repo_record() {
+  local discovered="$1" canonical="$2" remote="$3" resolution="$4"
+  CURRENT_REPO_IDX=${#R_DISCOVERED[@]}
+  R_DISCOVERED+=("$discovered")
+  R_CANONICAL+=("$canonical")
+  R_REMOTE+=("$remote")
+  R_RESOLUTION+=("$resolution")
+  R_COUNTED+=("false")
+  REPO_FINDING_COUNT=0
+}
+
+mark_repo_counted() {
+  [[ "$CURRENT_REPO_IDX" -ge 0 ]] || return 0
+  R_COUNTED[CURRENT_REPO_IDX]="true"
+}
+
+update_repo_canonical() {
+  local canonical="$1"
+  [[ "$CURRENT_REPO_IDX" -ge 0 ]] || return 0
+  R_CANONICAL[CURRENT_REPO_IDX]="$canonical"
+}
+
 emit_finding() {
   local confidence="$1" kind="$2" target="$3" evidence="$4" disposition="$5" handoff="$6"
   REPO_FINDING_COUNT=$((REPO_FINDING_COUNT + 1))
@@ -896,6 +1086,17 @@ emit_finding() {
   ACKNOWLEDGED) FINDINGS_ACKED=$((FINDINGS_ACKED + 1)) ;;
   *) FINDINGS_UNKNOWN=$((FINDINGS_UNKNOWN + 1)) ;;
   esac
+  F_CONF+=("$confidence")
+  F_KIND+=("$kind")
+  F_TARGET+=("$target")
+  F_EVIDENCE+=("$evidence")
+  F_DISP+=("$disposition")
+  F_HANDOFF+=("$handoff")
+  F_REPO_IDX+=("$CURRENT_REPO_IDX")
+}
+
+print_finding_block() {
+  local confidence="$1" kind="$2" target="$3" evidence="$4" disposition="$5" handoff="$6"
   print_field Finding "$kind"
   print_field Confidence "$confidence"
   print_field Target "$target"
@@ -904,6 +1105,155 @@ emit_finding() {
   print_field Handoff "$handoff"
   printf '%s\n' '---'
 }
+
+# Actionable fleet-batch handoff kinds. Manual-review and informational findings stay in the
+# rollup but do not produce a skill invocation in the action plan.
+branch_action_kind() {
+  [[ "$1" == "merged-local-branch" ]]
+}
+
+worktree_action_kind() {
+  case "$1" in
+  merged-worktree | prunable-worktree | missing-worktree | reclaimable-worktree) return 0 ;;
+  *) return 1 ;;
+  esac
+}
+
+repo_verdict() {
+  # Candidate counts follow actionable plan kinds (branch_action_kind / worktree_action_kind),
+  # not mere HIGH/MEDIUM confidence. Manual-review findings such as locked-worktree or
+  # merged-pr-tip-drift stay visible in kind counts but do not inflate "N candidates" when the
+  # action plan correctly lists "Actions: none".
+  local repo_idx="$1"
+  local i conf kind target
+  local unknown=0
+  local -a cand_targets=()
+  local seen t
+  for ((i = 0; i < ${#F_KIND[@]}; i++)); do
+    [[ "${F_REPO_IDX[$i]}" == "$repo_idx" ]] || continue
+    conf="${F_CONF[$i]}"
+    kind="${F_KIND[$i]}"
+    target="${F_TARGET[$i]}"
+    if [[ "$conf" == "UNKNOWN" ]]; then
+      unknown=$((unknown + 1))
+    elif branch_action_kind "$kind" || worktree_action_kind "$kind"; then
+      seen=false
+      for t in "${cand_targets[@]:-}"; do
+        [[ "$t" == "$target" ]] && {
+          seen=true
+          break
+        }
+      done
+      [[ "$seen" == "true" ]] || cand_targets+=("$target")
+    fi
+  done
+  if [[ "$unknown" -gt 0 ]]; then
+    printf 'BLOCKED (evidence gap)'
+  elif [[ ${#cand_targets[@]} -gt 0 ]]; then
+    printf '%s candidates' "${#cand_targets[@]}"
+  else
+    printf 'CLEAN'
+  fi
+}
+
+repo_kind_counts_text() {
+  local repo_idx="$1"
+  local i kind k
+  local -a keys=()
+  local -a counts=()
+  local found idx
+  for ((i = 0; i < ${#F_KIND[@]}; i++)); do
+    [[ "${F_REPO_IDX[$i]}" == "$repo_idx" ]] || continue
+    kind="${F_KIND[$i]}"
+    found=false
+    idx=0
+    for ((k = 0; k < ${#keys[@]}; k++)); do
+      if [[ "${keys[$k]}" == "$kind" ]]; then
+        found=true
+        idx=$k
+        break
+      fi
+    done
+    if [[ "$found" == "true" ]]; then
+      counts[idx]=$((counts[idx] + 1))
+    else
+      keys+=("$kind")
+      counts+=(1)
+    fi
+  done
+  if [[ ${#keys[@]} -eq 0 ]]; then
+    printf '%s' '—'
+    return 0
+  fi
+  local first=true kind_sorted
+  # Stable alphabetical kind order keeps the rollup table diffable.
+  while IFS= read -r kind_sorted; do
+    [[ -n "$kind_sorted" ]] || continue
+    for ((k = 0; k < ${#keys[@]}; k++)); do
+      [[ "${keys[$k]}" == "$kind_sorted" ]] || continue
+      if [[ "$first" == "true" ]]; then
+        first=false
+      else
+        printf ', '
+      fi
+      printf '%s=%s' "$kind_sorted" "${counts[$k]}"
+      break
+    done
+  done < <(printf '%s\n' "${keys[@]}" | LC_ALL=C sort)
+}
+
+print_collapsed_target_detail() {
+  local repo_idx="$1"
+  local i target kind conf t j seen
+  local -a targets=()
+  for ((i = 0; i < ${#F_KIND[@]}; i++)); do
+    [[ "${F_REPO_IDX[$i]}" == "$repo_idx" ]] || continue
+    target="${F_TARGET[$i]}"
+    seen=false
+    for t in "${targets[@]:-}"; do
+      [[ "$t" == "$target" ]] && {
+        seen=true
+        break
+      }
+    done
+    [[ "$seen" == "true" ]] || targets+=("$target")
+  done
+  if [[ ${#targets[@]} -eq 0 ]]; then
+    printf 'Findings: none\n'
+    printf '%s\n' '---'
+    return 0
+  fi
+  local first_kinds kinds_line
+  for t in "${targets[@]}"; do
+    print_field Target "$t"
+    kinds_line=""
+    first_kinds=true
+    for ((j = 0; j < ${#F_KIND[@]}; j++)); do
+      [[ "${F_REPO_IDX[$j]}" == "$repo_idx" && "${F_TARGET[$j]}" == "$t" ]] || continue
+      kind="${F_KIND[$j]}"
+      conf="${F_CONF[$j]}"
+      if [[ "$first_kinds" == "true" ]]; then
+        first_kinds=false
+        kinds_line="$kind ($conf)"
+      else
+        kinds_line+=", $kind ($conf)"
+      fi
+    done
+    print_field Findings "$kinds_line"
+    # One Finding/Confidence pair per kind under the shared Target keeps legacy report greps
+    # working while still collapsing to a single target entry (#2608).
+    for ((j = 0; j < ${#F_KIND[@]}; j++)); do
+      [[ "${F_REPO_IDX[$j]}" == "$repo_idx" && "${F_TARGET[$j]}" == "$t" ]] || continue
+      print_field Finding "${F_KIND[$j]}"
+      print_field Confidence "${F_CONF[$j]}"
+      print_field Evidence "${F_EVIDENCE[$j]}"
+      print_field Disposition "${F_DISP[$j]}"
+      print_field Handoff "${F_HANDOFF[$j]}"
+    done
+    printf '%s\n' '---'
+  done
+}
+
 
 analyze_repo() {
   local discovered="$1" discovered_remote="" discovered_url="" discovered_key="" discovered_slug=""
@@ -935,17 +1285,13 @@ analyze_repo() {
 
   if [[ -n "$discovered_key" ]] && lookup_override "$discovered_key"; then
     [[ -d "$OVERRIDE_VALUE" ]] || {
-      printf '\n'
-      print_field Repo "$discovered"
-      print_field Canonical unresolved
+      begin_repo_record "$discovered" "unresolved" "${discovered_key:-unknown}" "$override_source"
       emit_finding UNKNOWN canonical-override-invalid "$OVERRIDE_VALUE" \
         "override for $discovered_key is not a directory" "Stop for this repository" "Correct the override and rerun"
       return
     }
     canonical="$(run_git_probe -C "$OVERRIDE_VALUE" rev-parse --show-toplevel 2>/dev/null | tr -d '\r')" || {
-      printf '\n'
-      print_field Repo "$discovered"
-      print_field Canonical unresolved
+      begin_repo_record "$discovered" "unresolved" "${discovered_key:-unknown}" "$override_source"
       emit_finding UNKNOWN canonical-override-invalid "$OVERRIDE_VALUE" \
         "override for $discovered_key is not a Git working tree" "Stop for this repository" "Correct the override and rerun"
       return
@@ -962,11 +1308,8 @@ analyze_repo() {
     fi
   }
 
-  printf '\n'
-  print_field Repo "$discovered"
-  print_field Canonical "$canonical"
-  print_field 'Canonical resolution' "$override_source"
-  print_field Remote "${discovered_key:-unknown}"
+  begin_repo_record "$discovered" "$canonical" "${discovered_key:-unknown}" "$override_source"
+
 
   if [[ -z "$discovered_key" ]]; then
     emit_finding UNKNOWN github-identity-unavailable "$discovered" \
@@ -1415,18 +1758,13 @@ analyze_repo() {
     fi
   done
 
-  # A clean section previously ended after its header fields with no marker -- indistinguishable
-  # from truncated output. Say so explicitly, with the same terminator finding blocks use.
-  if [[ "$REPO_FINDING_COUNT" -eq 0 ]]; then
-    printf 'Findings: none\n'
-    printf '%s\n' '---'
-  fi
-
   REPOS_AUDITED=$((REPOS_AUDITED + 1))
+  mark_repo_counted
 }
 
 printf 'Repo Fleet Hygiene Audit\n'
 printf 'Mode: read-only (no fetch, prune, repair, delete, checkout, or remote update)\n'
+printf 'Presentation: per-repository rollup by default; pass --detail for collapsed per-target evidence\n'
 if [[ -n "$CONFIG_FILE" ]]; then
   print_field Config "$CONFIG_FILE ($CONFIG_SOURCE)"
 else
@@ -1479,9 +1817,10 @@ for ((root_index = 0; root_index < ${#ROOT_LABELS[@]}; root_index++)); do
 done
 
 # Config-sourced entries that failed per-entry validation during argument processing (the header
-# had not printed yet); each is a visible finding, never a silent skip.
+# had not printed yet); each is a visible finding, never a silent skip. Fleet-scoped: no repository
+# record owns them, so CURRENT_REPO_IDX stays -1 and the rollup lists them under Fleet-level.
+CURRENT_REPO_IDX=-1
 for ((stale_index = 0; stale_index < ${#STALE_CONFIG_PATHS[@]}; stale_index++)); do
-  printf '\n'
   emit_finding UNKNOWN stale-config-entry "${STALE_CONFIG_PATHS[$stale_index]}" \
     "${STALE_CONFIG_REASONS[$stale_index]} (source: $CONFIG_FILE)" \
     "Entry skipped; the rest of the fleet was audited" \
@@ -1495,6 +1834,7 @@ done
 # Cross-repository view: multiple independent checkouts of the same normalized GitHub identity are
 # each audited on their own local state (correct), but the coincidence itself gets one LOW
 # informational line per identity -- never more, since same-identity clones legitimately diverge.
+CURRENT_REPO_IDX=-1
 DUP_REPORTED=()
 for ((di = 0; di < ${#IDENT_KEYS[@]}; di++)); do
   dup_key="${IDENT_KEYS[$di]}"
@@ -1512,13 +1852,319 @@ for ((di = 0; di < ${#IDENT_KEYS[@]}; di++)); do
     [[ "${IDENT_KEYS[$dj]}" == "$dup_key" ]] && DUP_PATHS+=("${IDENT_PATHS[$dj]}")
   done
   if [[ "${#DUP_PATHS[@]}" -ge 2 ]]; then
-    printf '\n'
     emit_finding LOW duplicate-checkout "$dup_key" \
       "${#DUP_PATHS[@]} distinct checkouts resolve to the same GitHub identity: ${DUP_PATHS[*]}" \
       "Informational only; same-identity clones have independent local state" \
       "Consolidate manually if unintended; no automated action"
   fi
 done
+
+# --- Human rollup (#2608) ---------------------------------------------------
+printf '\n'
+printf 'Repository rollup\n'
+printf 'Presentation: counts by finding kind; duplicate targets collapsed in detail/plan\n'
+if [[ "$DETAIL" == "true" ]]; then
+  print_field Detail "on (--detail); per-repository collapsed target blocks follow the action plan"
+else
+  print_field Detail "off (pass --detail for per-target evidence)"
+fi
+
+fleet_blocked=0
+fleet_candidates=0
+fleet_clean=0
+for ((ri = 0; ri < ${#R_DISCOVERED[@]}; ri++)); do
+  verdict="$(repo_verdict "$ri")"
+  kinds="$(repo_kind_counts_text "$ri")"
+  printf 'Repo: '
+  display_value "${R_CANONICAL[$ri]}"
+  printf '\n'
+  print_field Verdict "$verdict"
+  print_field 'Kind counts' "$kinds"
+  case "$verdict" in
+  CLEAN) fleet_clean=$((fleet_clean + 1)) ;;
+  BLOCKED*) fleet_blocked=$((fleet_blocked + 1)) ;;
+  *) fleet_candidates=$((fleet_candidates + 1)) ;;
+  esac
+  printf '%s\n' '---'
+done
+
+# Fleet-level findings (stale config, duplicate-checkout) get their own rollup row.
+fleet_level_count=0
+for ((i = 0; i < ${#F_KIND[@]}; i++)); do
+  [[ "${F_REPO_IDX[$i]}" == "-1" ]] && fleet_level_count=$((fleet_level_count + 1))
+done
+if [[ "$fleet_level_count" -gt 0 ]]; then
+  printf 'Repo: fleet-level\n'
+  print_field Verdict "$(repo_verdict -1)"
+  print_field 'Kind counts' "$(repo_kind_counts_text -1)"
+  printf '%s\n' '---'
+fi
+
+case "$fleet_blocked" in
+0)
+  if [[ "$fleet_candidates" -gt 0 ]]; then
+    fleet_verdict="$fleet_candidates repositories with candidates"
+  else
+    fleet_verdict="CLEAN"
+  fi
+  ;;
+*)
+  fleet_verdict="BLOCKED ($fleet_blocked repositories with evidence gaps)"
+  ;;
+esac
+print_field 'Fleet verdict' "$fleet_verdict"
+printf 'Fleet counts: clean=%s with_candidates=%s blocked=%s\n' \
+  "$fleet_clean" "$fleet_candidates" "$fleet_blocked"
+
+# --- Fleet-scale action plan (#2609) ----------------------------------------
+# One recommended skill invocation per (canonical repository, skill). Branch cleanups are listed
+# before worktree cleanups so an operator approving the plan never prunes a worktree before the
+# branch that still anchors its reflog.
+printf '\n'
+printf 'Fleet action plan\n'
+printf 'Confirmation model: ONE gate for this entire plan (not per repository per skill)\n'
+printf 'Order rule: delete/clean branches before pruning worktrees; re-derive OIDs at execution\n'
+printf 'Mode: read-only plan (producing this plan performs no mutation)\n'
+
+ACTION_SKILL=()
+ACTION_CANONICAL=()
+ACTION_OPERATION=()
+ACTION_PHASE=()
+ACTION_KINDS=()
+# Targets are real array elements owned by action index (ACTION_TARGET_OWNER), not a
+# delimited string: Unix paths may contain newlines, so no in-band separator is safe,
+# and bash scalars cannot store NUL either.
+ACTION_TARGET_OWNER=()
+ACTION_TARGET_VALUE=()
+
+append_or_extend_action() {
+  local skill="$1" canonical="$2" operation="$3" phase="$4" kind="$5" target="$6"
+  local i ti
+  for ((i = 0; i < ${#ACTION_SKILL[@]}; i++)); do
+    if [[ "${ACTION_SKILL[$i]}" == "$skill" && "${ACTION_CANONICAL[$i]}" == "$canonical" &&
+      "${ACTION_OPERATION[$i]}" == "$operation" ]]; then
+      case ",${ACTION_KINDS[$i]}," in
+      *",$kind,"*) ;;
+      *)
+        if [[ -n "${ACTION_KINDS[i]}" ]]; then
+          ACTION_KINDS[i]="${ACTION_KINDS[i]},$kind"
+        else
+          ACTION_KINDS[i]="$kind"
+        fi
+        ;;
+      esac
+      for ((ti = 0; ti < ${#ACTION_TARGET_OWNER[@]}; ti++)); do
+        if [[ "${ACTION_TARGET_OWNER[ti]}" == "$i" && "${ACTION_TARGET_VALUE[ti]}" == "$target" ]]; then
+          return 0
+        fi
+      done
+      ACTION_TARGET_OWNER+=("$i")
+      ACTION_TARGET_VALUE+=("$target")
+      return 0
+    fi
+  done
+  i=${#ACTION_SKILL[@]}
+  ACTION_SKILL+=("$skill")
+  ACTION_CANONICAL+=("$canonical")
+  ACTION_OPERATION+=("$operation")
+  ACTION_PHASE+=("$phase")
+  ACTION_KINDS+=("$kind")
+  ACTION_TARGET_OWNER+=("$i")
+  ACTION_TARGET_VALUE+=("$target")
+}
+
+for ((i = 0; i < ${#F_KIND[@]}; i++)); do
+  kind="${F_KIND[$i]}"
+  target="${F_TARGET[$i]}"
+  repo_idx="${F_REPO_IDX[$i]}"
+  [[ "$repo_idx" -ge 0 ]] || continue
+  canonical="${R_CANONICAL[$repo_idx]}"
+  [[ "$canonical" != "unresolved" ]] || continue
+  if branch_action_kind "$kind"; then
+    append_or_extend_action "/repo-hygiene:clean git" "$canonical" \
+      "delete-merged-local-branches" "1" "$kind" "$target"
+  elif worktree_action_kind "$kind"; then
+    append_or_extend_action "/source-control:worktree cleanup --dry-run" "$canonical" \
+      "cleanup-worktrees" "2" "$kind" "$target"
+  fi
+done
+
+# Stable order: phase (branch=1 before worktree=2), then canonical path, then original index.
+ACTION_ORDER=()
+for ((i = 0; i < ${#ACTION_SKILL[@]}; i++)); do
+  ACTION_ORDER+=("$i")
+done
+if [[ ${#ACTION_ORDER[@]} -gt 0 ]]; then
+  mapfile -t ACTION_ORDER < <(
+    for i in "${ACTION_ORDER[@]}"; do
+      printf '%s\t%s\t%05d\n' "${ACTION_PHASE[$i]}" "${ACTION_CANONICAL[$i]}" "$i"
+    done | LC_ALL=C sort | awk -F '\t' '{print $3+0}'
+  )
+fi
+
+if [[ ${#ACTION_ORDER[@]} -eq 0 ]]; then
+  printf 'Actions: none\n'
+else
+  printf 'Actions: %s (unique repository/skill pairs)\n' "${#ACTION_ORDER[@]}"
+  step=0
+  for i in "${ACTION_ORDER[@]}"; do
+    step=$((step + 1))
+    printf '%s. ' "$step"
+    display_value "${ACTION_SKILL[$i]}"
+    printf '\n'
+    printf '   repository: '
+    display_value "${ACTION_CANONICAL[$i]}"
+    printf '\n'
+    print_field '   operation' "${ACTION_OPERATION[$i]}"
+    print_field '   kinds' "${ACTION_KINDS[$i]}"
+    target_count=0
+    for ((ti = 0; ti < ${#ACTION_TARGET_OWNER[@]}; ti++)); do
+      [[ "${ACTION_TARGET_OWNER[$ti]}" == "$i" ]] || continue
+      target_count=$((target_count + 1))
+    done
+    printf '   targets (%s):\n' "$target_count"
+    for ((ti = 0; ti < ${#ACTION_TARGET_OWNER[@]}; ti++)); do
+      [[ "${ACTION_TARGET_OWNER[$ti]}" == "$i" ]] || continue
+      printf '     - '
+      display_value "${ACTION_TARGET_VALUE[$ti]}"
+      printf '\n'
+    done
+  done
+fi
+printf 'Handoff: approve this plan once, then drive the listed skills (or pass the plan to --apply-plan)\n'
+
+# --- Machine-readable plan artifact ----------------------------------------
+if [[ -z "$PLAN_FILE" ]]; then
+  PLAN_FILE="$(mktemp "${TMPDIR:-/tmp}/repo-fleet-hygiene-plan.XXXXXX.json")"
+fi
+{
+  printf '{\n'
+  printf '  "schema_version": 1,\n'
+  printf '  "mode": "read-only",\n'
+  printf '  "generated_by": "repo-fleet-hygiene/audit",\n'
+  printf '  "execution_order_rule": "delete-merged-local-branches before cleanup-worktrees; re-derive OIDs at execution time",\n'
+  printf '  "confirmation_model": "one-gate-for-entire-plan",\n'
+  printf '  "summary": {\n'
+  printf '    "repositories_audited": %s,\n' "$REPOS_AUDITED"
+  printf '    "high": %s,\n' "$FINDINGS_HIGH"
+  printf '    "medium": %s,\n' "$FINDINGS_MEDIUM"
+  printf '    "low": %s,\n' "$FINDINGS_LOW"
+  printf '    "unknown": %s,\n' "$FINDINGS_UNKNOWN"
+  printf '    "acknowledged": %s,\n' "$FINDINGS_ACKED"
+  printf '    "fleet_verdict": "%s"\n' "$(json_escape "$fleet_verdict")"
+  printf '  },\n'
+  printf '  "repositories": [\n'
+  for ((ri = 0; ri < ${#R_DISCOVERED[@]}; ri++)); do
+    [[ "$ri" -gt 0 ]] && printf ',\n'
+    verdict="$(repo_verdict "$ri")"
+    kinds="$(repo_kind_counts_text "$ri")"
+    printf '    {\n'
+    printf '      "discovered": "%s",\n' "$(json_escape "${R_DISCOVERED[$ri]}")"
+    printf '      "canonical": "%s",\n' "$(json_escape "${R_CANONICAL[$ri]}")"
+    printf '      "remote": "%s",\n' "$(json_escape "${R_REMOTE[$ri]}")"
+    printf '      "verdict": "%s",\n' "$(json_escape "$verdict")"
+    printf '      "kind_counts_text": "%s",\n' "$(json_escape "$kinds")"
+    printf '      "audited": %s,\n' "$([[ "${R_COUNTED[$ri]}" == "true" ]] && echo true || echo false)"
+    printf '      "targets": [\n'
+    # Collapse findings by target for this repository.
+    target_list=()
+    for ((fi = 0; fi < ${#F_KIND[@]}; fi++)); do
+      [[ "${F_REPO_IDX[$fi]}" == "$ri" ]] || continue
+      t="${F_TARGET[$fi]}"
+      seen=false
+      for prev in "${target_list[@]:-}"; do
+        [[ "$prev" == "$t" ]] && {
+          seen=true
+          break
+        }
+      done
+      [[ "$seen" == "true" ]] || target_list+=("$t")
+    done
+    for ((ti = 0; ti < ${#target_list[@]}; ti++)); do
+      [[ "$ti" -gt 0 ]] && printf ',\n'
+      t="${target_list[$ti]}"
+      printf '        {\n'
+      printf '          "target": "%s",\n' "$(json_escape "$t")"
+      printf '          "findings": [\n'
+      first_finding=true
+      for ((fi = 0; fi < ${#F_KIND[@]}; fi++)); do
+        [[ "${F_REPO_IDX[$fi]}" == "$ri" && "${F_TARGET[$fi]}" == "$t" ]] || continue
+        [[ "$first_finding" == "true" ]] && first_finding=false || printf ',\n'
+        printf '            {\n'
+        printf '              "kind": "%s",\n' "$(json_escape "${F_KIND[$fi]}")"
+        printf '              "confidence": "%s",\n' "$(json_escape "${F_CONF[$fi]}")"
+        printf '              "evidence": "%s",\n' "$(json_escape "${F_EVIDENCE[$fi]}")"
+        printf '              "disposition": "%s",\n' "$(json_escape "${F_DISP[$fi]}")"
+        printf '              "handoff": "%s"\n' "$(json_escape "${F_HANDOFF[$fi]}")"
+        printf '            }'
+      done
+      printf '\n          ]\n'
+      printf '        }'
+    done
+    printf '\n      ]\n'
+    printf '    }'
+  done
+  printf '\n  ],\n'
+  printf '  "actions": [\n'
+  first_action=true
+  step=0
+  for i in "${ACTION_ORDER[@]:-}"; do
+    [[ -n "$i" ]] || continue
+    [[ "$first_action" == "true" ]] && first_action=false || printf ',\n'
+    step=$((step + 1))
+    printf '    {\n'
+    printf '      "order": %s,\n' "$step"
+    printf '      "phase": %s,\n' "${ACTION_PHASE[$i]}"
+    printf '      "skill": "%s",\n' "$(json_escape "${ACTION_SKILL[$i]}")"
+    printf '      "canonical": "%s",\n' "$(json_escape "${ACTION_CANONICAL[$i]}")"
+    printf '      "operation": "%s",\n' "$(json_escape "${ACTION_OPERATION[$i]}")"
+    printf '      "kinds": ['
+    first_kind=true
+    IFS=',' read -r -a kind_arr <<<"${ACTION_KINDS[$i]}"
+    for k in "${kind_arr[@]:-}"; do
+      [[ -n "$k" ]] || continue
+      [[ "$first_kind" == "true" ]] && first_kind=false || printf ', '
+      printf '"%s"' "$(json_escape "$k")"
+    done
+    printf '],\n'
+    printf '      "targets": ['
+    first_t=true
+    for ((ti = 0; ti < ${#ACTION_TARGET_OWNER[@]}; ti++)); do
+      [[ "${ACTION_TARGET_OWNER[$ti]}" == "$i" ]] || continue
+      [[ "$first_t" == "true" ]] && first_t=false || printf ', '
+      printf '"%s"' "$(json_escape "${ACTION_TARGET_VALUE[$ti]}")"
+    done
+    printf '],\n'
+    printf '      "note": "Re-derive OIDs at execution time; do not trust plan tips."\n'
+    printf '    }'
+  done
+  printf '\n  ]\n'
+  printf '}\n'
+} >"$PLAN_FILE" || fail "cannot write plan file: $PLAN_FILE"
+print_field 'Action plan' "$PLAN_FILE"
+printf 'Apply dry-run: %s --apply-plan ' "$0"
+display_value "$PLAN_FILE"
+printf '\n'
+
+# --- Optional detail: collapsed per-target blocks + confidence groups -------
+if [[ "$DETAIL" == "true" ]]; then
+  printf '\n'
+  printf 'Detail (targets collapsed; one entry per path/branch)\n'
+  for ((ri = 0; ri < ${#R_DISCOVERED[@]}; ri++)); do
+    printf '\n'
+    print_field Repo "${R_DISCOVERED[$ri]}"
+    print_field Canonical "${R_CANONICAL[$ri]}"
+    print_field 'Canonical resolution' "${R_RESOLUTION[$ri]}"
+    print_field Remote "${R_REMOTE[$ri]}"
+    print_field Verdict "$(repo_verdict "$ri")"
+    print_collapsed_target_detail "$ri"
+  done
+  if [[ "$fleet_level_count" -gt 0 ]]; then
+    printf '\n'
+    print_field Repo fleet-level
+    print_collapsed_target_detail -1
+  fi
+fi
 
 printf '\nSummary: repositories_audited=%s high=%s medium=%s low=%s unknown=%s acknowledged=%s\n' \
   "$REPOS_AUDITED" "$FINDINGS_HIGH" "$FINDINGS_MEDIUM" "$FINDINGS_LOW" "$FINDINGS_UNKNOWN" "$FINDINGS_ACKED"

--- a/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.test.sh
+++ b/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.test.sh
@@ -515,7 +515,8 @@ cat >"$TMP/config/repo-fleet-hygiene.conf" <<'EOF'
 EOF
 
 output="$TMP/output.txt"
-REPO_FLEET_TEST_FAST_TIMEOUTS=1 bash "$SCRIPT" --config "$TMP/config/repo-fleet-hygiene.conf" >"$output"
+PLAN_FILE="$TMP/action-plan.json"
+REPO_FLEET_TEST_FAST_TIMEOUTS=1 bash "$SCRIPT" --config "$TMP/config/repo-fleet-hygiene.conf" --detail --plan-file "$PLAN_FILE" >"$output"
 
 failures=0
 assert_contains() {
@@ -565,7 +566,11 @@ assert_contains "not-a-root finding says why the probe reads clean" \
 # finding's block and prove nothing.
 assert_kind_targets() {
   local label="$1" kind="$2" wanted="$3" forbidden="$4" targets
-  targets="$(grep -A2 -F "Finding: $kind" "$output" | grep -F 'Target: ')"
+  targets="$(grep -A2 -F "Finding: $kind" "$output" | grep -F "Target: " || true)"
+  # Detail layout prints Target before Finding; also accept Target on preceding lines.
+  if [[ -z "$targets" ]]; then
+    targets="$(grep -B3 -F "Finding: $kind" "$output" | grep -F "Target: " || true)"
+  fi
   if [[ "$targets" == *"$wanted"* && "$targets" != *"$forbidden"* ]]; then
     printf 'PASS: %s\n' "$label"
   else
@@ -579,7 +584,7 @@ assert_kind_targets "nested names the nested worktree and not the husk" \
   worktree-nested-in-repository "worktrees/nested" "canonical-a/husk"
 # Status handoff names reliable-admin linked paths (including a former status-fail sibling) and
 # excludes the admin-mismatched registration — disposability is delegated, not porcelain-gated.
-status_handoff_evidence="$(grep -A5 -F "Finding: worktree-status-handoff" "$output" | grep -F 'Evidence:')"
+status_handoff_evidence="$(grep -B2 -A8 -F "Finding: worktree-status-handoff" "$output" | grep -F 'Evidence:')"
 if [[ "$status_handoff_evidence" == *"$TMP/wt-a"* &&
   "$status_handoff_evidence" == *"$TMP/wt-status-fail"* &&
   "$status_handoff_evidence" != *"$TMP/wt-mismatch"* ]]; then
@@ -623,8 +628,8 @@ assert_contains "failed repositories not counted successful" "Summary: repositor
 
 # Duplicate detection keys on the CANONICALIZED identity: old-repo (remote still says old/repo,
 # resolved to new/repo) must pair with new-clone (cloned from new/repo directly).
-if grep -A3 -F "Finding: duplicate-checkout" "$output" | grep -F "Evidence:" | grep -Fq "$TMP/old-repo" &&
-  grep -A3 -F "Finding: duplicate-checkout" "$output" | grep -F "Evidence:" | grep -Fq "$TMP/new-clone"; then
+if grep -A6 -F "Finding: duplicate-checkout" "$output" | grep -F "Evidence:" | grep -Fq "$TMP/old-repo" &&
+  grep -A6 -F "Finding: duplicate-checkout" "$output" | grep -F "Evidence:" | grep -Fq "$TMP/new-clone"; then
   printf 'PASS: moved-remote checkout pairs with fresh clone via canonical identity\n'
 else
   printf 'FAIL: moved-remote checkout pairs with fresh clone via canonical identity\n' >&2
@@ -648,14 +653,14 @@ else
   printf 'FAIL: duplicate-checkout stays LOW\n' >&2
   failures=$((failures + 1))
 fi
-if grep -A3 -F "Finding: duplicate-checkout" "$output" | grep -F "Evidence:" | grep -Fq "$TMP/repo-b" &&
-  grep -A3 -F "Finding: duplicate-checkout" "$output" | grep -F "Evidence:" | grep -Fq "$TMP/dup-a"; then
+if grep -A6 -F "Finding: duplicate-checkout" "$output" | grep -F "Evidence:" | grep -Fq "$TMP/repo-b" &&
+  grep -A6 -F "Finding: duplicate-checkout" "$output" | grep -F "Evidence:" | grep -Fq "$TMP/dup-a"; then
   printf 'PASS: duplicate-checkout lists both checkout paths\n'
 else
   printf 'FAIL: duplicate-checkout lists both checkout paths\n' >&2
   failures=$((failures + 1))
 fi
-if grep -A3 -F "Finding: duplicate-checkout" "$output" | grep -Fq "Target: github.com/acme/repo-a"; then
+if grep -B3 -A3 -F "Finding: duplicate-checkout" "$output" | grep -Fq "Target: github.com/acme/repo-a"; then
   printf 'FAIL: single-checkout identity wrongly reported as duplicate\n' >&2
   failures=$((failures + 1))
 else
@@ -681,13 +686,13 @@ else
   failures=$((failures + 1))
 fi
 # Exactness: feature/auth must not inherit feature/auth-v2's merged PR.
-if grep -B5 -Fx "Target: $TMP/prefix-auth :: feature/auth-v2" "$output" | grep -Fq "Finding: merged-local-branch"; then
+if grep -B2 -A6 -Fx "Target: $TMP/prefix-auth :: feature/auth-v2" "$output" | grep -Fq "Finding: merged-local-branch"; then
   printf 'PASS: exact headRefName merge for feature/auth-v2\n'
 else
   printf 'FAIL: exact headRefName merge for feature/auth-v2\n' >&2
   failures=$((failures + 1))
 fi
-if grep -B5 -Fx "Target: $TMP/prefix-auth :: feature/auth" "$output" | grep -Fq "Finding: merged-local-branch"; then
+if grep -B2 -A6 -Fx "Target: $TMP/prefix-auth :: feature/auth" "$output" | grep -Fq "Finding: merged-local-branch"; then
   printf 'FAIL: feature/auth wrongly inherited auth-v2 merge evidence\n' >&2
   failures=$((failures + 1))
 else
@@ -708,13 +713,13 @@ assert_not_contains "tip-drift evidence never claims unpushed without proof" \
 assert_contains "header names gh account" "GitHub evidence: available (account: test-login)"
 
 # Clean repos say so explicitly instead of ending the section without a marker.
-if grep -A6 -F "Repo: $TMP/root/acme/root-repo" "$output" | grep -Fq "Findings: none"; then
+if grep -A30 -F "Repo: $TMP/root/acme/root-repo" "$output" | grep -Fq "Findings: none"; then
   printf 'PASS: clean repo emits explicit Findings: none marker\n'
 else
   printf 'FAIL: clean repo emits explicit Findings: none marker\n' >&2
   failures=$((failures + 1))
 fi
-if grep -A6 -F "Repo: $TMP/discovered-a" "$output" | grep -Fq "Findings: none"; then
+if grep -A30 -F "Repo: $TMP/discovered-a" "$output" | grep -Fq "Findings: none"; then
   printf 'FAIL: finding-bearing repo wrongly emitted Findings: none\n' >&2
   failures=$((failures + 1))
 else
@@ -724,20 +729,20 @@ fi
 # fleet.ackUnavailable: 404 on an acked identity (mixed-case config entry) is
 # demoted to ACKNOWLEDGED; an unacked 404 stays UNKNOWN; a non-404 failure on
 # an acked identity stays UNKNOWN with its real reason.
-if grep -B2 -F "Target: github.com/gone/away" "$output" | grep -Fq "Confidence: ACKNOWLEDGED"; then
+if grep -A5 -F "Target: github.com/gone/away" "$output" | grep -Fq "Confidence: ACKNOWLEDGED"; then
   printf 'PASS: acked 404 demoted to ACKNOWLEDGED\n'
 else
   printf 'FAIL: acked 404 demoted to ACKNOWLEDGED\n' >&2
   failures=$((failures + 1))
 fi
 assert_contains "acked finding names its ack source" "acknowledged known-inaccessible via fleet.ackUnavailable"
-if grep -B2 -F "Target: github.com/lost/cause" "$output" | grep -Fq "Confidence: UNKNOWN"; then
+if grep -A5 -F "Target: github.com/lost/cause" "$output" | grep -Fq "Confidence: UNKNOWN"; then
   printf 'PASS: unacked 404 stays UNKNOWN\n'
 else
   printf 'FAIL: unacked 404 stays UNKNOWN\n' >&2
   failures=$((failures + 1))
 fi
-if grep -B2 -F "Target: github.com/gone/net" "$output" | grep -Fq "Confidence: UNKNOWN"; then
+if grep -A5 -F "Target: github.com/gone/net" "$output" | grep -Fq "Confidence: UNKNOWN"; then
   printf 'PASS: non-404 failure on acked identity stays UNKNOWN\n'
 else
   printf 'FAIL: non-404 failure on acked identity stays UNKNOWN\n' >&2
@@ -816,7 +821,7 @@ cat >"$TMP/stale-only.conf" <<'STALEONLY'
 [fleet]
     repo = ./no-such-dir-anywhere
 STALEONLY
-if REPO_FLEET_TEST_FAST_TIMEOUTS=1 bash "$SCRIPT" --config "$TMP/stale-only.conf" >"$ladder_out" 2>&1 &&
+if REPO_FLEET_TEST_FAST_TIMEOUTS=1 bash "$SCRIPT" --config "$TMP/stale-only.conf" --detail >"$ladder_out" 2>&1 &&
   grep -Fq "Finding: stale-config-entry" "$ladder_out" &&
   grep -Fq "Repositories discovered (audit targets after deduplication): 0" "$ladder_out"; then
   printf 'PASS: all-stale config completes with stale findings instead of hard-failing\n'
@@ -911,7 +916,7 @@ fi
 # handoff carries the canonical path, so picking the worktree would aim per-repository cleanup at a
 # checkout that is not the repository of record.
 REPO_FLEET_TEST_FAST_TIMEOUTS=1 CLAUDE_PROJECT_DIR="$TMP/discovered-a" HOME="$TMP/nohome" \
-  bash "$SCRIPT" --root "$TMP/wt-root" >"$ladder_out" 2>&1
+  bash "$SCRIPT" --root "$TMP/wt-root" --detail >"$ladder_out" 2>&1
 if grep -Fq "Canonical: $TMP/wt-root/zzz-canonical" "$ladder_out"; then
   printf 'PASS: main worktree wins canonical selection over an earlier-sorting linked sibling\n'
 else
@@ -1043,11 +1048,11 @@ fi
 # Dedicated capture: later auth-fail reuse of $ladder_out must not erase this evidence.
 deep_out="$TMP/deep-history.txt"
 REPO_FLEET_TEST_FAST_TIMEOUTS=1 CLAUDE_PROJECT_DIR="$TMP/discovered-a" HOME="$TMP/nohome" \
-  bash "$SCRIPT" --root "$TMP/wt-root" >"$deep_out" 2>&1
+  bash "$SCRIPT" --root "$TMP/wt-root" --detail >"$deep_out" 2>&1
 if grep -Fq "Finding: merged-pr-window-truncated" "$deep_out"; then
   printf 'FAIL: retired merged-pr-window-truncated still emitted on deep-history fixture\n' >&2
   failures=$((failures + 1))
-elif grep -B5 -Fx "Target: $TMP/wt-root/zzz-canonical :: feature/linked" "$deep_out" |
+elif grep -B2 -A6 -Fx "Target: $TMP/wt-root/zzz-canonical :: feature/linked" "$deep_out" |
   grep -Fq "Finding: merged-worktree"; then
   printf 'PASS: GraphQL finds merged branch beyond any former REST window\n'
 else
@@ -1059,7 +1064,7 @@ fi
 # UNKNOWN rather than aborting or inferring a negative. Never exercised before, though it is the
 # degradation a machine without gh hits on its very first run.
 REPO_FLEET_TEST_FAST_TIMEOUTS=1 MOCK_GH_AUTH_FAIL=1 CLAUDE_PROJECT_DIR="$TMP/discovered-a" HOME="$TMP/nohome" \
-  bash "$SCRIPT" --root "$TMP/wt-root" >"$ladder_out" 2>&1
+  bash "$SCRIPT" --root "$TMP/wt-root" --detail >"$ladder_out" 2>&1
 if grep -Fq "GitHub evidence: unavailable" "$ladder_out" &&
   grep -Fq "Canonical: $TMP/wt-root/zzz-canonical" "$ladder_out"; then
   printf 'PASS: unauthenticated gh degrades to UNKNOWN GitHub evidence and still audits locally\n'
@@ -1097,6 +1102,165 @@ elif kind_diff="$(diff "$emitted_kinds" "$documented_kinds")"; then
 else
   printf 'FAIL: tier table and collector finding kinds have drifted (< emitted only, > documented only)\n%s\n' \
     "$kind_diff" >&2
+  failures=$((failures + 1))
+fi
+
+
+# --- #2608 / #2609 rollup + fleet action plan ---------------------------------
+assert_contains "rollup section present" "Repository rollup"
+assert_contains "fleet action plan present" "Fleet action plan"
+assert_contains "one-gate confirmation model" "ONE gate for this entire plan"
+assert_contains "branch-before-worktree order rule" "delete/clean branches before pruning worktrees"
+assert_contains "action plan path named" "Action plan: $PLAN_FILE"
+if [[ -f "$PLAN_FILE" ]]; then
+  printf 'PASS: action plan file was written\n'
+else
+  printf 'FAIL: action plan file missing\n' >&2
+  failures=$((failures + 1))
+fi
+if PLAN_FILE="$PLAN_FILE" python3 - <<PY
+import json, os, sys
+plan = json.load(open(os.environ["PLAN_FILE"], encoding="utf-8"))
+assert plan.get("schema_version") == 1
+assert plan.get("confirmation_model") == "one-gate-for-entire-plan"
+actions = plan.get("actions") or []
+# Branch actions must precede worktree actions in plan order.
+phases = [a.get("phase") for a in actions]
+assert phases == sorted(phases), phases
+# Skills appear at most once per canonical repository.
+seen = set()
+for a in actions:
+    key = (a.get("skill"), a.get("canonical"))
+    assert key not in seen, key
+    seen.add(key)
+# Collapsed targets: no target string repeats inside one repository entry.
+for repo in plan.get("repositories") or []:
+    targets = [t.get("target") for t in (repo.get("targets") or [])]
+    assert len(targets) == len(set(targets)), targets
+print("plan-json-ok")
+PY
+then
+  printf 'PASS: action plan JSON schema, ordering, and collapsed targets\n'
+else
+  printf 'FAIL: action plan JSON validation\n' >&2
+  failures=$((failures + 1))
+fi
+
+# Default (no --detail) fits the rollup contract: no per-finding enumeration, but verdicts present.
+rollup_out="$TMP/rollup-only.txt"
+rollup_plan="$TMP/rollup-plan.json"
+REPO_FLEET_TEST_FAST_TIMEOUTS=1 bash "$SCRIPT" --repo "$TMP/repo-b" --plan-file "$rollup_plan" >"$rollup_out" 2>&1 || true
+if grep -Fq "Repository rollup" "$rollup_out" && grep -Fq "Verdict:" "$rollup_out" &&
+  ! grep -Fq "Finding: merged-local-branch" "$rollup_out"; then
+  printf 'PASS: default output is rollup without per-finding enumeration\n'
+else
+  printf 'FAIL: default output rollup contract\n' >&2
+  failures=$((failures + 1))
+fi
+
+# --apply-plan dry-run: one ordered approval artifact, no mutation verbs beyond the plan text.
+apply_out="$TMP/apply-plan-out.txt"
+REPO_FLEET_TEST_FAST_TIMEOUTS=1 bash "$SCRIPT" --apply-plan "$PLAN_FILE" >"$apply_out" 2>&1 || true
+if grep -Fq "apply-plan dry-run (no mutations)" "$apply_out" &&
+  grep -Fq "ONE gate for this entire plan" "$apply_out" &&
+  grep -Fq "Order rule: delete/clean branches before pruning worktrees" "$apply_out"; then
+  printf 'PASS: --apply-plan renders dry-run approval artifact\n'
+else
+  printf 'FAIL: --apply-plan dry-run artifact\n' >&2
+  failures=$((failures + 1))
+fi
+
+# UTF-8 paths must survive json_escape intact (not byte-wise \u00XX mojibake).
+utf8_sample=$'répô'
+utf8_escaped="$(
+  bash -c '
+    eval "$(sed -n "/^json_escape()/,/^}/p" "$1")"
+    json_escape "$2"
+  ' bash "$SCRIPT" "$utf8_sample"
+)"
+if [[ "$utf8_escaped" == "$utf8_sample" && "$utf8_escaped" != *'\\u00'* ]]; then
+  printf 'PASS: json_escape preserves UTF-8 code points\n'
+else
+  printf 'FAIL: json_escape mojibaked UTF-8 (%s)\n' "$utf8_escaped" >&2
+  failures=$((failures + 1))
+fi
+
+# Newline-bearing actionable worktree paths must stay ONE plan target (NUL-delimited packing).
+if PLAN_FILE="$PLAN_FILE" EVIL_PATH="$EVIL_PATH" python3 - <<'PY'
+import json, os, sys
+plan = json.load(open(os.environ["PLAN_FILE"], encoding="utf-8"))
+evil = os.environ["EVIL_PATH"]
+found = False
+for action in plan.get("actions") or []:
+    if action.get("operation") != "cleanup-worktrees":
+        continue
+    targets = action.get("targets") or []
+    # Exact path (plus optional " (branch)" suffix) must appear as a single element.
+    matches = [t for t in targets if t == evil or t.startswith(evil + " ")]
+    if matches:
+        found = True
+        if any(t == "Finding: forged" or t.startswith("Confidence:") for t in targets):
+            print("split-targets", targets, file=sys.stderr)
+            sys.exit(1)
+if not found:
+    print("evil path missing from worktree actions", file=sys.stderr)
+    sys.exit(1)
+print("nul-targets-ok")
+PY
+then
+  printf 'PASS: newline-bearing worktree path stays one action target\n'
+else
+  printf 'FAIL: newline-bearing worktree path was split across action targets\n' >&2
+  failures=$((failures + 1))
+fi
+
+# Unwritable --plan-file must fail closed (nonzero), not claim success.
+missing_plan_dir="$TMP/missing-plan-dir"
+missing_plan="$missing_plan_dir/nope.json"
+plan_fail_out="$TMP/plan-fail-out.txt"
+REPO_FLEET_TEST_FAST_TIMEOUTS=1 bash "$SCRIPT" --repo "$TMP/repo-b" --plan-file "$missing_plan" \
+  >"$plan_fail_out" 2>&1
+plan_fail_status=$?
+if [[ "$plan_fail_status" -ne 0 && ! -f "$missing_plan" ]] &&
+  grep -Fq "cannot write plan file" "$plan_fail_out" &&
+  ! grep -Fq "Action plan: $missing_plan" "$plan_fail_out"; then
+  printf 'PASS: unwritable --plan-file fails closed\n'
+else
+  printf 'FAIL: unwritable --plan-file did not fail closed (status=%s)\n' "$plan_fail_status" >&2
+  failures=$((failures + 1))
+fi
+
+# Candidate verdicts follow actionable kinds, not mere HIGH/MEDIUM confidence.
+verdict_probe="$(
+  bash -c '
+    eval "$(sed -n "/^branch_action_kind()/,/^}/p; /^worktree_action_kind()/,/^}/p; /^repo_verdict()/,/^}/p" "$1")"
+    F_KIND=(locked-worktree merged-pr-tip-drift)
+    F_CONF=(HIGH MEDIUM)
+    F_TARGET=("/tmp/locked" "/tmp/drift")
+    F_REPO_IDX=(0 0)
+    repo_verdict 0
+  ' bash "$SCRIPT"
+)"
+if [[ "$verdict_probe" == "CLEAN" ]]; then
+  printf 'PASS: manual-review HIGH/MEDIUM findings are not rollup candidates\n'
+else
+  printf 'FAIL: expected CLEAN for manual-review-only findings, got %s\n' "$verdict_probe" >&2
+  failures=$((failures + 1))
+fi
+verdict_probe_actionable="$(
+  bash -c '
+    eval "$(sed -n "/^branch_action_kind()/,/^}/p; /^worktree_action_kind()/,/^}/p; /^repo_verdict()/,/^}/p" "$1")"
+    F_KIND=(merged-local-branch locked-worktree)
+    F_CONF=(HIGH HIGH)
+    F_TARGET=("repo :: feature/x" "/tmp/locked")
+    F_REPO_IDX=(0 0)
+    repo_verdict 0
+  ' bash "$SCRIPT"
+)"
+if [[ "$verdict_probe_actionable" == "1 candidates" ]]; then
+  printf 'PASS: actionable kinds still count as rollup candidates\n'
+else
+  printf 'FAIL: expected 1 candidates with one actionable kind, got %s\n' "$verdict_probe_actionable" >&2
   failures=$((failures + 1))
 fi
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #2608
Closes #2609

## Summary

Fleet audits produced hundreds of findings with no rollup, and acting on a report required dozens of separately gated per-repo skill invocations.

## Fix

Add per-repository rollup summaries (and duplicate-target collapse) plus a fleet-scale handoff/action-plan artifact so operators can approve cleanup in batch rather than 38 gated calls.

## Verification

See audit-fleet tests on PR checks.

## Related

Refs #2597 — fleet epic.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eb3f5ee5-6c9f-48a3-8e46-071bd363f8b0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eb3f5ee5-6c9f-48a3-8e46-071bd363f8b0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

