### PR TITLE
feat(repo-fleet-hygiene): report merged remote branches still on origin

### DIFF
--- a/plugins/repo-fleet-hygiene/.claude-plugin/plugin.json
+++ b/plugins/repo-fleet-hygiene/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "repo-fleet-hygiene",
-  "version": "0.19.2",
+  "version": "0.20.0",
   "description": "Machine-wide Git/GitHub repository discovery, evidence rollup, and action-plan handoff to the per-repository cleanup owners. The current audit is read-only and confidence-tiered; this plugin never deletes branches or worktrees.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/repo-fleet-hygiene/CHANGELOG.md
+++ b/plugins/repo-fleet-hygiene/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to `repo-fleet-hygiene` are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.20.0]
+
+### Added
+
+- **`merged-remote-branch` findings for heads still on origin after merge (#2607).** When
+  `delete_branch_on_merge` is not enabled (or a remote head survived), the collector reports merged
+  remote branches that remain on the configured remote and hands off exact cleanup guidance.
+  Enabling GitHub auto-delete remains complementary and is not changed by this release.
+
+### Fixed
+
+- **`merged-remote-branch` requires live remote proof for HIGH (#2607 review).** A last-fetched
+  remote-tracking tip match alone does not prove the head still exists after merge-and-auto-delete
+  without a pruning fetch. The collector now runs allowlisted `git ls-remote --heads` before HIGH;
+  probe failure demotes to MEDIUM (cached observation); empty ls-remote emits no finding.
+
 ## [0.19.2]
 
 ### Changed

--- a/plugins/repo-fleet-hygiene/README.md
+++ b/plugins/repo-fleet-hygiene/README.md
@@ -8,6 +8,9 @@ owners or reimplement their cleanup decisions.
 The currently shipped audit reports:
 
 - local branches whose matching GitHub pull request is merged;
+- remote-tracking heads that still exist on origin after a GitHub merge (where
+  `delete_branch_on_merge` is not enabled or was blocked — enabling that setting is complementary,
+  not a substitute for this visibility, and this plugin never changes repository settings);
 - merged-PR, missing, prunable, or administratively mismatched worktree registrations; and
 - GitHub repositories whose configured remote resolves to a different owner or name.
 

--- a/plugins/repo-fleet-hygiene/skills/audit/SKILL.md
+++ b/plugins/repo-fleet-hygiene/skills/audit/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: "Coordinate Git/GitHub hygiene across a machine-wide fleet: discover canonical repositories, collect and roll up cross-repository evidence, and hand an action plan to repo-hygiene/source-control, which own per-repository cleanup. The current collector is read-only and emits detailed exact handoffs; it never deletes, prunes, repairs, fetches, checks out, or rewrites. Use when: 'audit repositories', 'repo fleet hygiene', 'stale branches across repos', 'orphaned worktrees across repos', 'moved repos', 'renamed GitHub owner', 'cross-repo git cleanup report'."
+description: "Coordinate Git/GitHub hygiene across a machine-wide fleet: discover canonical repositories, collect and roll up cross-repository evidence (including merged remote-tracking heads still on origin), and hand an action plan to repo-hygiene/source-control, which own per-repository cleanup. The current collector is read-only and emits detailed exact handoffs; it never deletes, prunes, repairs, fetches, checks out, or rewrites. Use when: 'audit repositories', 'repo fleet hygiene', 'stale branches across repos', 'orphaned worktrees across repos', 'merged remote branches', 'moved repos', 'renamed GitHub owner', 'cross-repo git cleanup report'."
 user-invocable: true
 argument-hint: "[--root <dir>]... [--repo <dir>]... [--config <file>] [--canonical <github.com/owner/repo=path>]... [--max-depth <1..12>] [--detail] [--plan-file <path>] | --apply-plan <path>"
 allowed-tools:
@@ -123,7 +123,18 @@ The bundled collector is authoritative for classifications. Preserve its evidenc
    review. Git ancestry without GitHub evidence is `LOW` and never called merged-by-PR — and
    under squash merges that ancestry predicate is near-inert, so on a squash-merging fleet
    GitHub evidence is effectively the only merge evidence.
-4. **Local inventories:** parse only `git worktree list --porcelain -z` registrations and
+4. **Merged remote branch:** after local classification, the same merged-PR rows are matched
+   against each remote-tracking tip under the selected remote. When `headRefOid` equals that tip
+   and the branch is not the default, probe live existence with
+   `git ls-remote --heads <remote> refs/heads/<branch>`. A matching tip → `HIGH`
+   `merged-remote-branch` (remote head still present after merge — unset or blocked
+   `delete_branch_on_merge`). ls-remote failure → `MEDIUM` cached observation (may be stale after a
+   prune-less fetch). Empty ls-remote → no finding (head already gone upstream). Remote-only heads
+   (local already deleted) are included. The handoff is an optional `git push --delete --dry-run`
+   preview naming the remote and branch; this skill never runs it and never calls org-admin APIs to
+   flip repository settings. Enabling `delete_branch_on_merge` is complementary (it stops the class
+   accruing) and is **not** a substitute for this fleet visibility.
+5. **Local inventories:** parse only `git worktree list --porcelain -z` registrations and
    NUL-delimited `git for-each-ref` branch/tip records. Directory naming is
    never worktree evidence. Compare each existing registered path's actual `--git-common-dir` with
    the canonical checkout's expected common dir. A mismatch is `HIGH` evidence of an administrative
@@ -134,8 +145,9 @@ The bundled collector is authoritative for classifications. Preserve its evidenc
    verdict. If either inventory command fails or emits malformed/partial output, discard it, emit `UNKNOWN`,
    stop local branch/worktree classification, and do not count that repository as successfully
    audited; an empty/failed inventory never means no branches are attached.
-5. **Protection:** current/default/worktree-attached branches are never emitted as standalone branch
-   cleanup candidates. A merged worktree is routed to worktree dry-run first.
+6. **Protection:** current/default/worktree-attached branches are never emitted as standalone branch
+   cleanup candidates. A merged worktree is routed to worktree dry-run first. `merged-remote-branch`
+   is independent of local attachment — it describes the remote ref.
 
 Every emitted finding kind, both confidence axes, and the merge-strategy and
 `gc.worktreePruneExpire` dependencies the tiers rest on:
@@ -236,6 +248,7 @@ issues merge:
 | Finding | Handoff (not executed here) |
 |---|---|
 | `merged-local-branch` | Run `/repo-hygiene:clean git` in the named canonical repository |
+| `merged-remote-branch` | Optional preview only: `git push --delete --dry-run <remote> <branch>` in the canonical repository (never executed here). Enabling GitHub `delete_branch_on_merge` is complementary and owned by the repository's settings automation — this audit does not change it |
 | `merged-worktree`, `prunable-worktree`, `missing-worktree` | Run `/source-control:worktree cleanup --dry-run` in the canonical repository |
 | `worktree-status-handoff` | Run `/source-control:worktree status` in the canonical repository (stranded-work axis); use cleanup `--dry-run` only after Work is safe. If `source-control` is not installed, name the listed worktree targets and the missing collaborator — emit no porcelain-based substitute verdict |
 | `worktree-admin-mismatch` | Manual inspection; `git worktree repair` is an option only after validating which administrative directory is authoritative |

--- a/plugins/repo-fleet-hygiene/skills/audit/evals/evals.json
+++ b/plugins/repo-fleet-hygiene/skills/audit/evals/evals.json
@@ -173,6 +173,20 @@
         "Names the #2608 rollup and #2609 consumer as unshipped contracts",
         "Keeps branch and worktree cleanup with the per-repository owners and their confirmation gates"
       ]
+    },
+    {
+      "id": 15,
+      "name": "merged-remote-branch-is-optional-preview-not-settings-mutation",
+      "prompt": "A fleet audit finds origin/feature/cleanup still present after PR #44 MERGED with headRefOid equal to the remote-tracking tip. delete_branch_on_merge is off in this org's Pulumi-managed settings. What should the report do?",
+      "expected_output": "After matching the MERGED PR headRefOid to the last-fetched remote-tracking tip, confirm the head still exists with ls-remote. Matching tip → HIGH merged-remote-branch with an optional git push --delete --dry-run preview handoff, separate from local cleanup. State that enabling delete_branch_on_merge is complementary and not a substitute for this visibility. Do not call org-admin APIs or change repository settings from the audit. If ls-remote fails, report MEDIUM as a cached observation; if ls-remote is empty, emit no finding.",
+      "files": [],
+      "expectations": [
+        "Requires ls-remote confirmation (or demotes to MEDIUM) before treating a remote-tracking tip as live HIGH evidence",
+        "Emits merged-remote-branch from GitHub MERGED PR evidence matched to the remote tip when live existence is proven",
+        "Offers only an optional dry-run preview handoff, never inline remote deletion",
+        "Treats delete_branch_on_merge as complementary documentation, not something the audit flips",
+        "Does not call org-admin APIs to change repository settings"
+      ]
     }
   ]
 }

--- a/plugins/repo-fleet-hygiene/skills/audit/reference/confidence-model.md
+++ b/plugins/repo-fleet-hygiene/skills/audit/reference/confidence-model.md
@@ -26,6 +26,7 @@ failure rather than a discovery.
 | `merged-local-branch` | GitHub `MERGED` PR for this repository + branch and `headRefOid` equals local tip; branch is not current/default/worktree-attached | `HIGH` | Candidate handoff to `/repo-hygiene:clean git` |
 | `merged-worktree` | Same merged-PR/tip evidence, branch is attached to a non-main registered worktree | `HIGH` | Candidate handoff to `/source-control:worktree cleanup --dry-run` first |
 | `merged-pr-tip-drift` | GitHub merged PR exists, but local tip differs from every returned `headRefOid` | `MEDIUM` | Manual review; never delete from this evidence |
+| `merged-remote-branch` | GitHub `MERGED` PR for this repository + branch and `headRefOid` equals the last-fetched remote-tracking tip, **and** `git ls-remote --heads` confirms the same tip still exists on the remote (so `delete_branch_on_merge` was not enabled or was blocked). When ls-remote fails, the same cached match is reported at `MEDIUM` as an unverified local remote-tracking observation. Empty ls-remote (head already deleted upstream) emits no finding. | `HIGH` when ls-remote confirms; `MEDIUM` when ls-remote fails | Optional `git push --delete --dry-run` preview handoff; separate from local cleanup. Enabling GitHub `delete_branch_on_merge` is complementary (stops the class accruing), not a substitute for this finding — never changed by this audit |
 | `local-ancestry-only` | Local tip is an ancestor of the remote-tracking default branch, with no matching GitHub merged PR evidence | `LOW` | Informational only |
 | `prunable-worktree` | Git porcelain marks the registration `prunable` | `HIGH` | Candidate dry-run handoff; no inline prune |
 | `missing-worktree` | Registered path is absent but Git has not marked it prunable under its current expiry policy | `MEDIUM` | Manual review/dry-run handoff |
@@ -47,7 +48,7 @@ failure rather than a discovery.
 | `worktree-inventory-unavailable` | `git worktree list --porcelain -z` failed | `UNKNOWN` | Stop local branch/worktree classification for that repository |
 | `worktree-common-dir-unavailable` | A registered worktree path exists but its `--git-common-dir` could not be resolved | `UNKNOWN` | Manual inspection; the registration cannot be trusted either way |
 | `branch-inventory-unavailable` | `git for-each-ref` over `refs/heads/` failed or emitted malformed/partial output | `UNKNOWN` | Discard partial records, stop branch classification, exclude from the audited count |
-| `remote-branch-inventory-unavailable` | `git for-each-ref` over `refs/remotes/<remote>/` failed | `UNKNOWN` | Exact per-branch GitHub lookups are skipped for the whole repository |
+| `remote-branch-inventory-unavailable` | `git for-each-ref` over `refs/remotes/<remote>/` failed | `UNKNOWN` | Remote-tracking tip comparison for `merged-pr-tip-drift` is unavailable; GraphQL merge evidence still runs |
 | `current-branch-unavailable` | `git branch --show-current` failed, so branch-protection membership is unknown | `UNKNOWN` | Emit no standalone branch cleanup candidate for that repository |
 | `git-common-dir-unavailable` | The canonical checkout's own `--git-common-dir` could not be resolved | `UNKNOWN` | Stop that repository; registration comparison is impossible |
 | `local-ancestry-unavailable` | `git merge-base --is-ancestor` failed with an error status | `UNKNOWN` | Do not infer local ancestry |
@@ -79,8 +80,9 @@ not a difference in evidence strength.
 
 1. A protection condition wins over a branch candidate classification.
 2. A merged worktree routes through worktree cleanup before branch cleanup.
-3. Administrative mismatch wins over ordinary worktree status because the path cannot be trusted.
-4. A stronger confidence tier never authorizes mutation inside this plugin.
+3. `merged-remote-branch` is independent of local attachment: it describes the remote ref.
+4. Administrative mismatch wins over ordinary worktree status because the path cannot be trusted.
+5. A stronger confidence tier never authorizes mutation inside this plugin.
 
 ## Presentation rollup
 

--- a/plugins/repo-fleet-hygiene/skills/audit/reference/official-sources.md
+++ b/plugins/repo-fleet-hygiene/skills/audit/reference/official-sources.md
@@ -60,7 +60,12 @@ plugin does not rely on remembered behavior.
 
 - Git porcelain/common-dir facts establish local registration and linkage; directory naming never does.
 - GitHub merged state is repository-qualified, and the PR head OID must match the local tip before a
-  high-confidence handoff.
+  high-confidence local/worktree handoff — or the remote-tracking tip before a high-confidence
+  `merged-remote-branch` handoff. HIGH for that kind also requires `git ls-remote --heads` to confirm
+  the tip still exists on the remote; a last-fetched remote-tracking match alone is only MEDIUM when
+  the probe fails, and emits nothing when the remote head is already gone. A remaining remote head
+  after merge is evidence that `delete_branch_on_merge` was not enabled or was blocked; enabling that
+  setting is complementary and outside this plugin's mutation boundary.
 - A successful old-identity lookup whose canonical `full_name` differs establishes transfer/rename;
   a 403/404 does not distinguish access, deletion, or absence and remains unknown.
 - All cleanup/repair/update operations are outside this plugin even though the official tools document

--- a/plugins/repo-fleet-hygiene/skills/audit/reference/security-review.md
+++ b/plugins/repo-fleet-hygiene/skills/audit/reference/security-review.md
@@ -15,6 +15,13 @@ admits only `query` documents with exact `headRefName` / `first:1` / `states:[ME
 fixed `--jq` flatten; `mutation`/`subscription` and REST `pr list` are rejected. Branch names
 transmitted are exactly the non-default local branches under audit for the operator's own resolved
 repository identity — not a silent gate that leaves branches unverdicted.
+Re-checked 2026-08-15 for #2607 (`merged-remote-branch`): reuses the same aliased GraphQL
+merged-PR evidence, also querying remote-only head names from the local remote-tracking inventory.
+Live HIGH confidence additionally requires allowlisted `git ls-remote --heads <remote>
+refs/heads/<branch>` (read-only; empty result suppresses the finding; probe failure demotes to
+MEDIUM). No new API endpoints, no mutation allowlist entries (`git push` remains rejected), and no
+org-admin repository-settings writes — `delete_branch_on_merge` is named in evidence/handoff prose
+only.
 
 ## Decision
 

--- a/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.sh
+++ b/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.sh
@@ -187,6 +187,14 @@ git_probe_allowed() {
       [[ "$6" == "refs/heads/" ]] && return 0
       [[ "$6" == refs/remotes/*/ && ! "$6" =~ [[:cntrl:][:space:]] ]]
       ;;
+    ls-remote)
+      # Read-only live remote probe: prove a named head still exists upstream without fetch/prune.
+      remote="${5:-}"
+      ref="${6:-}"
+      [[ $# -eq 6 && "$4" == "--heads" && -n "$remote" && "$remote" != -* &&
+        ! "$remote" =~ [[:cntrl:][:space:]] && "$ref" == refs/heads/* &&
+        ! "$ref" =~ [[:cntrl:][:space:]] ]]
+      ;;
     merge-base)
       ref="${6:-}"
       [[ $# -eq 6 && "$4" == "--is-ancestor" && -n "${5:-}" && "${5:-}" != -* &&
@@ -1808,6 +1816,17 @@ analyze_repo() {
         [[ "$branch" =~ [[:cntrl:]] ]] && continue
         GQL_BRANCHES+=("$branch")
       done
+      # Remote-only heads (local already deleted) still need exact headRefName GraphQL rows
+      # for merged-remote-branch classification.
+      for remote_branch_short in "${REMOTE_BRANCH_NAMES[@]:-}"; do
+        [[ -n "$remote_branch_short" && "$remote_branch_short" != "$default_branch" ]] || continue
+        [[ "$remote_branch_short" =~ [[:cntrl:]] ]] && continue
+        already=false
+        for existing in "${GQL_BRANCHES[@]:-}"; do
+          [[ "$existing" == "$remote_branch_short" ]] && { already=true; break; }
+        done
+        [[ "$already" == "true" ]] || GQL_BRANCHES+=("$remote_branch_short")
+      done
       repo_pr_available=true
       repo_pr_rows=""
       gql_page_start=0
@@ -1922,6 +1941,60 @@ analyze_repo() {
       fi
     fi
   done
+
+  # Merged remote branches that still exist on the remote are a distinct class from local cleanup:
+  # delete_branch_on_merge was off (or blocked), so the head ref remains on origin after merge.
+  # Match GraphQL merged-PR rows against the REMOTE tip (not the local tip). This also catches
+  # remote-only heads (local already deleted). A last-fetched remote-tracking tip alone is not
+  # live proof — after merge-and-auto-delete without a pruning fetch the cached ref can linger —
+  # so HIGH requires ls-remote to confirm the head still exists at the matched tip. When
+  # ls-remote fails, report the cached observation at MEDIUM. Empty ls-remote means the remote
+  # head is gone; emit nothing. Enabling GitHub delete_branch_on_merge is complementary and is
+  # never a substitute for this visibility; this collector never changes that setting.
+  if [[ "$repo_pr_available" == "true" && "$remote_inventory_failed" == "false" && -n "$canonical_remote" ]]; then
+    for ((ri = 0; ri < ${#REMOTE_BRANCH_NAMES[@]}; ri++)); do
+      remote_branch_short="${REMOTE_BRANCH_NAMES[$ri]}"
+      remote_tip="${REMOTE_BRANCH_TIPS[$ri]}"
+      [[ -n "$remote_branch_short" && -n "$remote_tip" ]] || continue
+      [[ "$remote_branch_short" == "$default_branch" ]] && continue
+      pr_match=""
+      while IFS=$'\t' read -r pr_num pr_branch pr_oid pr_merged pr_url; do
+        [[ -n "$pr_num" ]] || continue
+        [[ "$pr_branch" == "$remote_branch_short" ]] || continue
+        if [[ "$pr_oid" == "$remote_tip" ]]; then
+          pr_match="$pr_num|$pr_oid|$pr_merged|$pr_url"
+          break
+        fi
+      done <<<"$repo_pr_rows"
+      if [[ -n "$pr_match" ]]; then
+        IFS='|' read -r pr_num pr_oid pr_merged pr_url <<<"$pr_match"
+        live_out=""
+        live_status=0
+        live_out="$(run_git_probe -C "$canonical" ls-remote --heads "$canonical_remote" \
+          "refs/heads/$remote_branch_short" 2>/dev/null)" || live_status=$?
+        live_oid=""
+        if [[ "$live_status" -eq 0 && -n "$live_out" ]]; then
+          live_oid="${live_out%%[[:space:]]*}"
+          live_oid="${live_oid%%$'\t'*}"
+        fi
+        if [[ "$live_status" -eq 0 && -n "$live_oid" && "$live_oid" == "$remote_tip" ]]; then
+          emit_finding HIGH merged-remote-branch "$canonical :: $canonical_remote/$remote_branch_short" \
+            "GitHub PR #$pr_num MERGED; headRefOid $pr_oid equals last-fetched $canonical_remote/$remote_branch_short tip ($pr_url); ls-remote confirmed refs/heads/$remote_branch_short still at $live_oid (delete_branch_on_merge not enabled or blocked for this repository)" \
+            "Optional remote-branch deletion preview; separate from local branch/worktree cleanup" \
+            "Preview only: git -C $canonical push --delete --dry-run $canonical_remote $remote_branch_short. Enabling GitHub delete_branch_on_merge is complementary (stops this class accruing) and is not a substitute for this finding; change that setting in the repository's settings-owning automation, never via an org-admin API call from this audit"
+        elif [[ "$live_status" -eq 0 ]]; then
+          # Empty or tip-mismatched ls-remote: remote head is gone or moved; do not blame
+          # delete_branch_on_merge on a stale local remote-tracking observation.
+          :
+        else
+          emit_finding MEDIUM merged-remote-branch "$canonical :: $canonical_remote/$remote_branch_short" \
+            "GitHub PR #$pr_num MERGED; headRefOid $pr_oid equals last-fetched $canonical_remote/$remote_branch_short tip ($pr_url); current remote existence could not be verified (ls-remote failed) — may be a stale local remote-tracking observation after a prune-less fetch" \
+            "Optional remote-branch deletion preview; separate from local branch/worktree cleanup" \
+            "Preview only: git -C $canonical push --delete --dry-run $canonical_remote $remote_branch_short. Re-verify with ls-remote or a pruning fetch before acting. Enabling GitHub delete_branch_on_merge is complementary (stops this class accruing) and is not a substitute for this finding; change that setting in the repository's settings-owning automation, never via an org-admin API call from this audit"
+        fi
+      fi
+    done
+  fi
 
   REPOS_AUDITED=$((REPOS_AUDITED + 1))
   mark_repo_counted

--- a/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.test.sh
+++ b/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.test.sh
@@ -271,7 +271,7 @@ for-each-ref)
   if [[ "${3:-}" == refs/remotes/*/ ]]; then
     case "$base" in
     canonical-a)
-      printf 'origin\thead-a\0\norigin/main\tmain-a\0\norigin/feature/shared\tsha-a\0\norigin/stale/changed\tdrift-tip\0\n'
+      printf 'origin\thead-a\0\norigin/main\tmain-a\0\norigin/feature/shared\tsha-a\0\norigin/stale/changed\tdrift-tip\0\norigin/feature/remote-only\tremote-only-tip\0\norigin/feature/stale-cached\tstale-cached-tip\0\norigin/feature/ls-fail\tls-fail-tip\0\n'
       ;;
     # Moved-identity checkout (#2600): remote still advertises the feature head for tip-drift
     # push-state wording; GraphQL merge evidence uses the resolved identity independently.
@@ -311,6 +311,22 @@ for-each-ref)
   prefix-auth) printf 'main\tpa-main\0\nfeature/auth\tauth-tip\0\nfeature/auth-v2\tauth-v2-tip\0\n' ;;
   sub-wt) printf 'main\tsub-main\0\n' ;;
   sep-wt) printf 'main\tsep-main\0\n' ;;
+  esac
+  ;;
+ls-remote)
+  # Live remote existence probe for merged-remote-branch HIGH confidence. Default: echo the
+  # matching tip. feature/stale-cached is present only in the local remote-tracking inventory
+  # (auto-deleted upstream); ls-remote returns empty. feature/ls-fail forces a probe error → MEDIUM.
+  [[ "${1:-}" == "--heads" && -n "${2:-}" && -n "${3:-}" ]] || exit 96
+  case "${3:-}" in
+  refs/heads/feature/stale-cached) exit 0 ;;
+  refs/heads/feature/ls-fail) exit 7 ;;
+  refs/heads/feature/remote-only) printf 'remote-only-tip\trefs/heads/feature/remote-only\n' ;;
+  refs/heads/feature/shared) printf 'sha-a\trefs/heads/feature/shared\n' ;;
+  refs/heads/feature/moved-local) printf 'moved-local-tip\trefs/heads/feature/moved-local\n' ;;
+  refs/heads/feature/moved-merged) printf 'moved-merged-tip\trefs/heads/feature/moved-merged\n' ;;
+  refs/heads/*) exit 0 ;;
+  *) exit 96 ;;
   esac
   ;;
 merge-base) exit 1 ;;
@@ -395,6 +411,9 @@ api)
         feature/shared) printf '18|sha-a|2026-07-01T00:00:00Z|https://github.com/acme/repo-a/pull/18' ;;
         stale/changed) printf '42|merged-tip|2026-07-02T00:00:00Z|https://github.com/acme/repo-a/pull/42' ;;
         stale/gone) printf '43|other-tip|2026-07-03T00:00:00Z|https://github.com/acme/repo-a/pull/43' ;;
+        feature/remote-only) printf '44|remote-only-tip|2026-07-04T00:00:00Z|https://github.com/acme/repo-a/pull/44' ;;
+        feature/stale-cached) printf '45|stale-cached-tip|2026-07-05T00:00:00Z|https://github.com/acme/repo-a/pull/45' ;;
+        feature/ls-fail) printf '46|ls-fail-tip|2026-07-06T00:00:00Z|https://github.com/acme/repo-a/pull/46' ;;
         *) printf '' ;;
         esac
         ;;
@@ -603,6 +622,41 @@ assert_kind_targets "moved-remote still emits merged-worktree on resolved identi
   merged-worktree "old-repo :: feature/moved-merged" "new-clone"
 assert_kind_targets "moved-remote still emits merged-local-branch on resolved identity" \
   merged-local-branch "old-repo :: feature/moved-local" "new-clone"
+
+# #2607: remote heads that still exist after a MERGED PR are a distinct finding from local cleanup.
+assert_contains "merged remote-tracking head is reported" "Finding: merged-remote-branch"
+assert_kind_targets "remote-only merged head is reported without a local branch" \
+  merged-remote-branch "canonical-a :: origin/feature/remote-only" "stale/changed"
+assert_kind_targets "matching remote tip for an attached branch still emits merged-remote-branch" \
+  merged-remote-branch "canonical-a :: origin/feature/shared" "stale/changed"
+assert_not_contains "tip-drift remote tip is not a merged-remote-branch candidate" \
+  "Target: $TMP/canonical-a :: origin/stale/changed"
+assert_contains "merged-remote-branch handoff is dry-run preview only" \
+  "push --delete --dry-run origin feature/remote-only"
+assert_contains "merged-remote-branch names delete_branch_on_merge as complementary" \
+  "Enabling GitHub delete_branch_on_merge is complementary"
+assert_kind_targets "moved-remote still emits merged-remote-branch on resolved identity" \
+  merged-remote-branch "old-repo :: origin/feature/moved-local" "new-clone"
+# ls-remote proof → HIGH; empty ls-remote (auto-deleted upstream) → no finding; probe fail → MEDIUM.
+if grep -A6 -F "Target: $TMP/canonical-a :: origin/feature/remote-only" "$output" |
+  grep -Fq "Confidence: HIGH"; then
+  printf 'PASS: ls-remote-confirmed merged-remote-branch is HIGH\n'
+else
+  printf 'FAIL: ls-remote-confirmed merged-remote-branch is HIGH\n' >&2
+  failures=$((failures + 1))
+fi
+assert_contains "HIGH evidence names ls-remote confirmation" "ls-remote confirmed refs/heads/feature/remote-only"
+assert_not_contains "auto-deleted upstream is not reported as merged-remote-branch" \
+  "origin/feature/stale-cached"
+if grep -A6 -F "Target: $TMP/canonical-a :: origin/feature/ls-fail" "$output" |
+  grep -Fq "Confidence: MEDIUM"; then
+  printf 'PASS: ls-remote failure demotes merged-remote-branch to MEDIUM\n'
+else
+  printf 'FAIL: ls-remote failure demotes merged-remote-branch to MEDIUM\n' >&2
+  failures=$((failures + 1))
+fi
+assert_contains "MEDIUM evidence names unverified remote existence" \
+  "current remote existence could not be verified (ls-remote failed)"
 if [[ "$status_handoff_evidence" == *"$TMP/wt-old"* ]]; then
   printf 'PASS: moved-remote worktree still named for status handoff\n'
 else
@@ -1127,6 +1181,7 @@ else
   failures=$((failures + 1))
 fi
 assert_not_contains_file "no merged claim without GitHub evidence" "Finding: merged-local-branch" "$ladder_out"
+assert_not_contains_file "no merged-remote claim without GitHub evidence" "Finding: merged-remote-branch" "$ladder_out"
 
 # The tier table is the contract a consumer tiers decisions on, and it silently fell to covering
 # half the emitted kinds. Assert set equality in BOTH directions instead: a new emit_finding kind
@@ -1329,6 +1384,8 @@ run_git_probe -c alias.remote='!touch /tmp/pwned' remote >/dev/null 2>&1 && forb
 run_git_probe -C "$TMP/repo-b" branch -D main >/dev/null 2>&1 && forbidden_rejected=false
 run_git_probe -C "$TMP/repo-b" remote set-url origin https://example.invalid >/dev/null 2>&1 &&
   forbidden_rejected=false
+run_git_probe -C "$TMP/repo-b" push --delete --dry-run origin feature/x >/dev/null 2>&1 &&
+  forbidden_rejected=false
 run_git_probe config --file "$TMP/config/repo-fleet-hygiene.conf" --get-regexp -z '.*' >/dev/null 2>&1 &&
   forbidden_rejected=false
 run_bounded_gh api repos/acme/repo-b --hostname github.com --method POST --template x >/dev/null 2>&1 &&
@@ -1344,6 +1401,9 @@ status_rejected=true
 run_git_probe -C "$TMP/wt-a" status --porcelain >/dev/null 2>&1 && status_rejected=false
 allowed_log=true
 run_git_probe -C "$TMP/wt-a" log -1 --format=%ct HEAD >/dev/null 2>&1 || allowed_log=false
+allowed_ls_remote=true
+run_git_probe -C "$TMP/canonical-a" ls-remote --heads origin refs/heads/feature/shared >/dev/null 2>&1 ||
+  allowed_ls_remote=false
 if [[ "$forbidden_rejected" != "true" || "$calls_before" != "$calls_after" ]]; then
   printf 'FAIL: exact command allowlist admitted a forbidden Git/gh vector\n' >&2
   failures=$((failures + 1))
@@ -1361,6 +1421,13 @@ if [[ "$allowed_log" != "true" ]]; then
   failures=$((failures + 1))
 else
   printf 'PASS: log probe is admitted by the Git allowlist\n'
+fi
+
+if [[ "$allowed_ls_remote" != "true" ]]; then
+  printf 'FAIL: ls-remote --heads probe was not admitted by the Git allowlist\n' >&2
+  failures=$((failures + 1))
+else
+  printf 'PASS: ls-remote --heads probe is admitted by the Git allowlist\n'
 fi
 
 # Symlink roots are skipped by discovery; accepting them would report a false empty fleet (#2599).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #2607

## Summary

Nothing in the plugin fleet cleaned up or even reported merged remote branches that remain on origin when `delete_branch_on_merge` is not enabled.

## Fix

Add merged-remote-branch findings (gh-based evidence) and handoff guidance. Enabling GitHub `delete_branch_on_merge` remains complementary and is not changed by this PR.

## Verification

See collector tests on PR checks.

## Related

Refs #2597 — fleet epic.
Refs #2604 — GraphQL merge evidence (related).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eb3f5ee5-6c9f-48a3-8e46-071bd363f8b0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eb3f5ee5-6c9f-48a3-8e46-071bd363f8b0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

