### PR TITLE
fix(claude): register the session-start hook and install enabled plugins

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -16,11 +16,12 @@
 # Tools with no in-repo manifest are pinned in the VERSION PINS block below.
 #
 # Idempotent by design: every step checks before it installs, so re-runs on
-# session resume cost seconds. Required steps (Node, npm ci, ruff) fail the
-# session start when they break; best-effort steps warn and continue, because
-# a hygiene binary being briefly unreachable should not block a session. The
-# cloud proxy only reliably allows GitHub release-asset downloads for repos
-# attached to the session, so every GitHub-release install is best-effort.
+# session resume cost seconds. Required steps (Node, npm ci, hash-locked Python
+# CI deps) fail the session start when they break; best-effort steps warn and
+# continue, because a hygiene binary being briefly unreachable should not block
+# a session. The cloud proxy only reliably allows GitHub release-asset downloads
+# for repos attached to the session, so every GitHub-release install is
+# best-effort.
 set -euo pipefail
 
 if [[ "${CLAUDE_CODE_REMOTE:-}" != "true" ]]; then
@@ -103,10 +104,117 @@ if [[ ! -f node_modules/.package-lock.json || package-lock.json -nt node_modules
   npm ci --no-audit --no-fund
 fi
 
-# --- ruff (required) -----------------------------------------------------------
-# The same hash-locked install CI's plugin-gate lane runs; a satisfied install
-# is a fast no-op. Wheel hashes in the requirements file are Linux-x64 only,
-# which matches the cloud VM.
+# --- Plugins (best effort) -----------------------------------------------------
+# .claude/settings.json declares this repo as its own marketplace through a
+# relative `directory` source and enables the full catalog. Cloud sessions do
+# install plugins declared in project settings at session start, but only from a
+# marketplace source that path can resolve; a checkout-relative `directory`
+# source is documented as a development source, and sessions in fact arrive with
+# an empty plugin registry — no plugin skill loaded and every `/plugin` command
+# unknown. Registering the checkout by absolute path and installing the enabled
+# set repairs that while keeping the property the directory source exists for:
+# a session exercises the plugin code on the current branch, not published main.
+#
+# Never `claude plugin marketplace remove` here. That subcommand deletes the
+# marketplace's entry from .claude/settings.json, so a hook that used it to
+# force a re-add would silently mutate tracked repository config.
+#
+# Best effort by design: a plugin that fails to install costs that plugin's
+# skills, not the session. Idempotent — installed plugins are skipped, so a
+# resume re-run costs one `claude plugin list` call.
+claude_bin="$repo_root/node_modules/.bin/claude"
+marketplace_name="melodic-software"
+if [[ -x "$claude_bin" ]] && command -v jq >/dev/null 2>&1; then
+  if ! "$claude_bin" plugin marketplace list --json 2>/dev/null |
+    jq -e --arg n "$marketplace_name" 'any(.[]; .name == $n)' >/dev/null; then
+    "$claude_bin" plugin marketplace add "$repo_root" --scope user >/dev/null ||
+      echo "session-start: warning: could not register the $marketplace_name marketplace" >&2
+  fi
+
+  # Enabled-and-not-yet-installed, computed from the tracked settings file so the
+  # hook can never drift from the catalog the repo actually enables.
+  mapfile -t wanted < <(
+    jq -r --arg n "$marketplace_name" \
+      '.enabledPlugins // {} | to_entries[]
+       | select(.value == true and (.key | endswith("@" + $n))) | .key' \
+      .claude/settings.json 2>/dev/null
+  )
+  mapfile -t have < <("$claude_bin" plugin list --json 2>/dev/null | jq -r '.[].id' 2>/dev/null)
+
+  # A directory-source install cache is keyed by the semver in plugin.json, not
+  # by commit, so a later commit under the same version never replaces the
+  # snapshot and `plugin update` false-greens on the version compare — see
+  # "Same-version commit drift" in docs/MIGRATION-PLAYBOOK.md and #2061. On a
+  # resume after the checkout advanced, a presence check alone would therefore
+  # keep serving the skills and hooks of whatever commit installed first, which
+  # defeats the reason this repo uses a directory source at all. Compare the SHA
+  # recorded at install time against HEAD and refresh only the plugins whose own
+  # directory actually changed between them, so the common resume stays cheap.
+  #
+  # Uncommitted edits to a plugin are out of scope here and stay that way: the
+  # playbook's answer for that loop is `claude --plugin-dir ./plugins/<name>`,
+  # which takes session precedence over the cached install.
+  plugins_registry="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/plugins/installed_plugins.json"
+  head_sha="$(git rev-parse HEAD 2>/dev/null || true)"
+  needs_refresh() {
+    # needs_refresh <plugin-id> — true when the cached snapshot predates a
+    # change to that plugin's directory in this checkout.
+    local id="$1" name="${1%@*}" recorded
+    [[ -n "$head_sha" && -f "$plugins_registry" ]] || return 1
+    recorded="$(jq -r --arg id "$id" \
+      '(.plugins[$id] // []) | map(select(.scope == "user")) | .[0].gitCommitSha // ""' \
+      "$plugins_registry" 2>/dev/null)"
+    [[ -n "$recorded" && "$recorded" != "$head_sha" ]] || return 1
+    # A commit this clone doesn't have (shallow fetch, force-push): refresh
+    # rather than guess that the snapshot is current.
+    git cat-file -e "${recorded}^{commit}" 2>/dev/null || return 0
+    ! git diff --quiet "$recorded" HEAD -- "plugins/$name" 2>/dev/null
+  }
+
+  installed=0
+  refreshed=0
+  failed=0
+  for id in "${wanted[@]}"; do
+    [[ -n "$id" ]] || continue
+    if [[ " ${have[*]} " == *" $id "* ]]; then
+      # shellcheck disable=SC2310  # the return status IS the verdict
+      needs_refresh "$id" || continue
+      # `uninstall` drops enabled state, so re-enable explicitly or the plugin
+      # goes silently absent instead of silently stale.
+      if "$claude_bin" plugin uninstall "$id" >/dev/null 2>&1 &&
+        "$claude_bin" plugin install "$id" --scope user -y >/dev/null 2>&1 &&
+        "$claude_bin" plugin enable "$id" --scope user >/dev/null 2>&1; then
+        refreshed=$((refreshed + 1))
+      else
+        failed=$((failed + 1))
+        echo "session-start: warning: plugin refresh failed: $id" >&2
+      fi
+      continue
+    fi
+    if "$claude_bin" plugin install "$id" --scope user -y >/dev/null 2>&1; then
+      installed=$((installed + 1))
+    else
+      failed=$((failed + 1))
+      echo "session-start: warning: plugin install failed: $id" >&2
+    fi
+  done
+  echo "session-start: plugins ${#wanted[@]} enabled, $installed newly installed, $refreshed refreshed, $failed failed"
+else
+  echo "session-start: warning: claude CLI or jq unavailable; plugins will not load" >&2
+fi
+
+# --- Python CI deps (required) -------------------------------------------------
+# The same hash-locked install CI's plugin-gate lane runs; a satisfied install is
+# a fast no-op. --require-hashes is the integrity control that catches a resolved
+# wheel whose digest is not in the lockfile — including a genuine supply-chain
+# compromise — so a failure here stays fatal via `set -e`. Do not swallow stderr
+# or fall back to an unpinned install: that would convert the one tampering
+# signal into a warning easy to lose among bootstrap log lines.
+#
+# `.github/requirements-ci.txt` carries ABI-specific hashes for both the CI
+# interpreter (cp314) and the cloud VM system Python (cp311; #2657 / #2654), so
+# the locked install succeeds on either without an interpreter-mismatch skip.
+# pip rather than uv: uv's PyPI fetches time out against this VM's egress proxy.
 python3 -m pip install --user --quiet --only-binary=:all: --require-hashes \
   --requirement .github/requirements-ci.txt
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,6 +3,19 @@
   "env": {
     "HOOK_TELEMETRY_SINK": ".claude/hooks/hook-telemetry-sink.sh"
   },
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh\""
+          }
+        ]
+      }
+    ]
+  },
   "worktree": {
     "baseRef": "head"
   },

--- a/docs/CLOUD-SESSIONS.md
+++ b/docs/CLOUD-SESSIONS.md
@@ -147,10 +147,11 @@ the optional `gh` setup-script one-liner from above). The repo side:
 |---|---|---|
 | Node | `.node-version` (via the VM's nvm) | required — CI pins a major the VM image doesn't ship |
 | claude CLI + Biome | root `package-lock.json` (`npm ci`) | required |
-| ruff | `.github/requirements-ci.txt` (hash-locked) | required |
+| ruff, pytest, pyyaml | `.github/requirements-ci.txt` (hash-locked) | required — `--require-hashes` fails closed |
 | shellcheck, actionlint, typos, editorconfig-checker, gitleaks | pinned in the hook (GitHub release binaries) | best effort — warns and continues |
 | markdownlint-cli2, check-jsonschema | pinned in the hook (npm -g / uv tool) | best effort |
 | full git history + `origin/main` | `git fetch` | best effort — the base-ref diff gates need it |
+| the enabled plugin catalog | `enabledPlugins` in `.claude/settings.json` | best effort — a plugin that fails to install costs its skills, not the session |
 
 Best-effort rather than required, deliberately: the plugin contract suites SKIP visibly when an
 optional tool is absent and CI remains the enforcing gate, while a required install failure would
@@ -168,16 +169,46 @@ Playwright. `gh`, `pwsh`, and `lychee` are likewise on-demand.
 ### Plugins in sessions on this repo
 
 Being the marketplace doesn't make this repo's plugins active in a session — plugins load only
-when a marketplace is declared and plugins are enabled. `.claude/settings.json` does both, which
-is the documented path for cloud sessions (see
+when a marketplace is declared, enabled, **and installed**. `.claude/settings.json` declares and
+enables; the session-start hook installs (see
 [Discover and install plugins](https://code.claude.com/docs/en/discover-plugins) and
 [extraKnownMarketplaces / enabledPlugins](https://code.claude.com/docs/en/settings#plugin-settings)):
 
 - `extraKnownMarketplaces` declares this repo as its own marketplace via a `directory` source
-  with a relative path, which
-  [resolves against the repository's checkout](https://code.claude.com/docs/en/plugin-marketplaces#relative-paths)
-  — cloud sessions install from the clone at session start; local collaborators are prompted
-  once they trust the folder.
+  with a relative path, so a session exercises the plugin code on the current branch rather than
+  published `main`. Local collaborators are prompted once they trust the folder.
+- **A declared marketplace is gated on workspace trust, and cloud sessions arrive untrusted.**
+  [What runs before you trust a folder](https://code.claude.com/docs/en/permissions#what-runs-before-you-trust-a-folder)
+  groups `extraKnownMarketplaces` entries with the content that needs *this exact folder* trusted,
+  while hooks and the `env` block are used whether or not it is. Observed on 2026-08-15: a cloud
+  session on this repo had `projects["<repo-root>"].hasTrustDialogAccepted` set to `false` in
+  `~/.claude.json`, an empty `~/.claude/plugins/installed_plugins.json`, no plugin skill loaded
+  and every `/plugin` command unknown — while the same settings file's `env` block *had* applied.
+  That is exactly the split the table predicts, and it is why
+  [what carries over](https://code.claude.com/docs/en/cloud-environments#what-carries-over-from-your-setup)
+  promising plugins "installed at session start from the marketplace you declared" did not hold
+  here. A hook is the durable fix precisely because hooks run untrusted.
+- Being a `directory` source may compound it —
+  [that source is documented for development only](https://code.claude.com/docs/en/settings#extraknownmarketplaces)
+  and the carry-over note qualifies install-at-session-start with "requires network access to reach
+  the marketplace source". The two candidates were not separated, because the trust gate alone
+  accounts for the symptom and the hook makes both moot.
+- The hook therefore registers the checkout by absolute path and installs the enabled set
+  explicitly. It never calls `claude plugin marketplace remove`, which deletes the marketplace's
+  entry from `.claude/settings.json` and would have the hook mutate tracked config.
+- On resume it also repairs [same-version commit drift](MIGRATION-PLAYBOOK.md): because a
+  directory-source cache is keyed by the semver in `plugin.json` rather than the commit, a
+  presence check alone would keep serving whichever commit installed first. The hook compares the
+  `gitCommitSha` recorded at install time against `HEAD` and forces the documented
+  uninstall/install/enable cycle for the plugins whose own directory changed between the two, so
+  the usual resume stays cheap. Uncommitted edits are out of scope by design — use
+  `claude --plugin-dir ./plugins/<name>`, which takes session precedence over the cached install.
+- **Consumer repos** should declare the marketplace with a `github` source —
+  `{"source": "github", "repo": "melodic-software/claude-code-plugins"}` — since the relative
+  `directory` source is specific to this repo, whose reason to exist is validating in-flight
+  plugin changes. Declaring it is necessary but, per the trust gate above, not sufficient in a
+  cloud session; verify in a fresh session and add the same install-on-start hook if the catalog
+  does not load.
 - `enabledPlugins` turns on the whole catalog, so this repo dogfoods everything it publishes and a
   regression in any plugin surfaces here first. The trade is context: every enabled plugin adds
   per-turn cost, so a *consumer* repo should enable only the plugins it needs rather than copying
@@ -210,6 +241,11 @@ Both exist in cloud sessions and don't conflict — they serve different callers
   set (verified against the `chore: sync standards components` history on 2026-07-30), so its
   Node pin updates arrive via sync. `.claude/settings.json` and the hook script itself are
   repo-owned.
+- `.github/requirements-ci.txt` is hash-locked. The lockfile carries ABI-specific hashes for both
+  the CI interpreter (cp314 / 3.14) and the cloud VM system Python (cp311 / 3.11; #2657), so the
+  SessionStart hook always installs with `--require-hashes` and a digest mismatch stays fatal —
+  no interpreter-mismatch skip, no unpinned fallback. Installs use `pip` rather than `uv`, whose
+  PyPI fetches time out against the VM's egress proxy.
 - The hook's own version pins exist only because those tools have no in-repo manifest; the cloud
   proxy blocks the GitHub API and `releases/latest` redirects, so the hook can't self-resolve
   "latest". Each GitHub-release asset also carries a pinned SHA-256 the hook verifies before


### PR DESCRIPTION
No linked issue

## Summary

Cloud sessions on this repo started with zero plugins loaded and no bootstrap at all: every `/plugin` command unknown, no plugin skill available, an empty `~/.claude/plugins/installed_plugins.json`, and none of the CI-parity tooling `.claude/hooks/session-start.sh` exists to provide. Three independent causes, all fixed here.

## Fix

**1. The SessionStart hook was never registered.** `.claude/settings.json` had no `hooks` key. The script has carried a header comment claiming it was registered since it was added in 39fe757, and `docs/CLOUD-SESSIONS.md` documented the registration, but `git log -p --all -- .claude/settings.json` shows the key was never committed — so the bootstrap had never run in a cloud session. Registered with matcher `startup|resume`, pointing at the script via `$CLAUDE_PROJECT_DIR`.

**2. Declaring a marketplace is not installing it.** [What runs before you trust a folder](https://code.claude.com/docs/en/permissions#what-runs-before-you-trust-a-folder) groups `extraKnownMarketplaces` entries with content that needs *this exact folder* trusted, while hooks and the `env` block are used whether or not it is. A cloud session on this repo had `hasTrustDialogAccepted` false, an empty plugin registry, and no plugin loaded — while the same settings file's `env` block *had* applied, exactly the split that table predicts. A hook is the durable fix because hooks run untrusted.

The hook registers the checkout by absolute path and installs every plugin `enabledPlugins` sets to `true`, computed from the tracked settings file with `jq` so it cannot drift from the catalog. It deliberately never calls `claude plugin marketplace remove` — that subcommand deletes the marketplace's entry from `.claude/settings.json`, so a hook using it to force a re-add would silently mutate tracked repository config. (Observed directly while diagnosing this.)

It also repairs same-version commit drift. A directory-source cache is keyed by the semver in `plugin.json` rather than the commit (`docs/MIGRATION-PLAYBOOK.md`, #2061), so a presence check alone would keep serving whichever commit installed first — defeating the reason this repo uses a directory source. The hook compares the `gitCommitSha` recorded at install time against `HEAD` and runs the documented uninstall/install/enable cycle for the plugins whose own directory changed, so an ordinary resume stays cheap.

**3. The Python install aborted the bootstrap.** `.github/requirements-ci.txt` was hash-locked against CI's Python 3.14 wheels only; the cloud VM ships 3.11.15 and resolves a different `pyyaml` wheel, so `--require-hashes` refused it and `set -e` aborted before the hygiene binaries and git-history steps ever ran. That surfaced #2654, fixed on `main` by #2657, which added the cp311 hash set.

This branch is rebased onto that fix and keeps the install **fail-closed**: SessionStart always runs the hash-locked install and a failure stays fatal. An earlier revision of this branch fell back to a ruff-only install on an interpreter-version mismatch; that was removed, because it both weakened the one control that catches a tampered wheel and — once #2657 landed — would have skipped an install that now succeeds, leaving `pyyaml`/`pytest` permanently absent.

`docs/CLOUD-SESSIONS.md` is corrected in the same change: it previously claimed the hook was registered and described the directory source as installing at session start.

## Verification

Verified live rather than by inspection — the session restarted mid-change and the newly registered hook fired on its own:

```
SessionStart:resume hook success: session-start: plugins 65 enabled, 26 newly installed, 0 failed
session-start: bootstrap complete in /home/user/claude-code-plugins
```

All 65 plugin skill sets became available in-session (`/claude-config:audit`, the command that surfaced this, among them), and `markdown-format` and `hardcoded-path-check` hooks then fired on subsequent edits — confirming plugin hooks load, not just skills.

The fail-closed install, checked on a real cloud VM at `8773eae5`:

```
$ python3 -V
Python 3.11.15
$ python3 -m pip install --user --only-binary=:all: --require-hashes -r .github/requirements-ci.txt
EXIT=0   (2.4s)
```

Full CI-parity inventory now present, all three previously absent or wrong: `ruff` 0.16.2 (CI's exact pin, against the VM image's 0.15.8), `pytest` 9.1.1, `pyyaml` 6.0.3.

Other post-run state:

- `claude plugin list --json | jq length` → 103 (65 enabled + 38 auto-installed dependencies)
- `claude plugin marketplace list --json` → `{"name":"melodic-software","source":"directory","path":"<repo-root>"}` — resolved from the checkout, so a session exercises branch code rather than published `main`
- Refresh predicate selects `repo-fleet-hygiene` (10 files changed since the recorded SHA) and skips `session-flow`, `adhd`, `claude-config` (0 changed); an uninstalled id falls through to the install path

Gates, all clean: `shellcheck` (with the repo's `check-set-e-suppressed`), `shfmt -d`, `bash -n`, `markdownlint-cli2`, `typos`, `editorconfig-checker`, `check-jsonschema` against the settings schema, and both repo-local hook tests (17/17). Empty-array handling under `set -u` checked against the VM's bash 5.2.21.

Not verified: whether a `github`-source marketplace auto-installs at session start without a hook. That is the path consumer repos should use, and it resolves fine here (`claude plugin marketplace add melodic-software/claude-code-plugins` clones through the proxy), but confirming the no-hook auto-install needs a fresh cloud session on a consumer repo.

Follow-up, not blocking: the strict path is load-bearing on `requirements-ci.txt` covering whatever `python3` the cloud image ships. If that image moves to a minor with no wheel hashes, session start aborts rather than degrades — worth generating hashes per supported interpreter instead of reactively, as #2654 → #2657 just did.

## Related

Refs #2061 (same-version commit drift), #2654 / #2657 (cp311 wheel hashes), and the plugin-enablement setup in `docs/CLOUD-SESSIONS.md` and `docs/CLOUD-FLEET-SETUP.md`.