### PR TITLE
fix(disk-hygiene): inventory an empty directory at the scan depth boundary

### DIFF
--- a/plugins/disk-hygiene/.claude-plugin/plugin.json
+++ b/plugins/disk-hygiene/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "disk-hygiene",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "description": "Context-aware disk hygiene for arbitrary directory trees: inventories orphaned and temporary artifacts, classifies evidence into review tiers, and offers exact-path cleanup only after a fresh safety preview and explicit per-tier approval. The target is read-only by default; OS-managed paths, links and mount points, VCS-tracked content without the complete checkout evidence bundle, changed entries, and live-handle uncertainty fail closed.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/disk-hygiene/CHANGELOG.md
+++ b/plugins/disk-hygiene/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to the `disk-hygiene` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.20.1]
+
+### Fixed
+
+- **Empty directories at `--max-depth` are inventoried as size 0 (#2618).** A depth cut used to
+  mark every boundary directory truncated even when it had no children. One first-child probe
+  (no recursion, fail-closed on unreadable) now records empty boundaries as walked with size 0
+  and keeps them out of the truncated set; directories with children and unreadable directories keep
+  the previous not-walked marking. VCS and protection cuts are unchanged — emptiness does not
+  answer those refusals.
+
 ## [0.20.0]
 
 ### Added

--- a/plugins/disk-hygiene/skills/clean/scripts/hygiene.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/hygiene.py
@@ -949,6 +949,29 @@ def top_level_entry_count(target: Path) -> tuple[int | None, str | None]:
         return None, str(exc)
 
 
+def directory_has_child(directory: Path) -> bool:
+    """Whether a directory holds at least one entry — one read, no recursion.
+
+    FAILS CLOSED. Emptiness has to be PROVEN, so an unreadable directory
+    reports True (assume content). The caller uses this to decide whether a
+    scan boundary can be reported as fully inventoried, and a directory whose
+    contents could not be read is exactly the case that must keep its
+    "not inventoried" marking. The read is inside the ``try`` deliberately:
+    Windows surfaces an access denial on the first iteration step rather than
+    on ``os.scandir`` itself.
+
+    Deliberately not ``top_level_entry_count``: that one iterates every child
+    to produce a count, and a boundary directory with hundreds of thousands of
+    entries is precisely the cost ``--max-depth`` exists to avoid. Only the
+    first entry is ever read here — the question is "any?", not "how many?".
+    """
+    try:
+        with os.scandir(directory) as iterator:
+            return next(iter(iterator), None) is not None
+    except OSError:
+        return True
+
+
 def volume_root_os_owned_names(
     platform_key: str | None = None,
 ) -> set[str]:
@@ -1235,9 +1258,26 @@ def scan_tree(
                         walked = False
                         truncated.append(relative)
                     elif max_depth is not None and depth >= max_depth:
-                        subtotal = None
-                        walked = False
-                        truncated.append(relative)
+                        # A depth cut is the one truncation reason emptiness can
+                        # answer. One cheap first-child probe (no recursion, no
+                        # count) decides it: an empty directory has no
+                        # descendants, so nothing is left uninventoried and its
+                        # size is genuinely 0 rather than unknown — record it
+                        # walked, and keep it out of truncated so the four
+                        # downstream consumers stop treating a vacuously complete
+                        # inventory as a coverage gap. Anything with a child, or
+                        # any directory the probe cannot read, keeps the old
+                        # not-walked marking. Scoped to THIS branch on purpose:
+                        # the VCS and protection branches above refuse to walk
+                        # for reasons emptiness does not answer, so an empty
+                        # protected or VCS directory must still land in
+                        # truncated.
+                        if directory_has_child(path):
+                            subtotal = None
+                            walked = False
+                            truncated.append(relative)
+                        else:
+                            subtotal = 0
                     else:
                         subtotal = visit(path, depth + 1)
                     data = metadata(path, kind, subtotal, walked=walked)

--- a/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
@@ -1777,6 +1777,145 @@ class HygieneTests(unittest.TestCase):
                 "truncated-not-inventoried", result["candidates"][0]["blockers"]
             )
 
+    def test_empty_directory_at_scan_depth_is_inventoried_not_truncated(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary) / "target"
+            root.mkdir(parents=True)
+            (root / "empty").mkdir()
+            (root / "loose.tmp").write_text("x", encoding="utf-8")
+            snapshot = hygiene.scan_tree(
+                root.resolve(), hygiene.load_policy(None), max_depth=1
+            )
+            entries = hygiene.entry_map(snapshot)
+            # An empty directory AT the boundary is vacuously fully inventoried:
+            # size 0 (not unknown), no not-walked qualifier, no coverage gap.
+            self.assertEqual(0, entries["empty"]["logical_size"])
+            self.assertEqual([], entries["empty"]["size_qualifiers"])
+            self.assertEqual([], snapshot["truncated_paths"])
+            # With nothing left unwalked, the target's own roll-up is exact.
+            self.assertNotIn(
+                "not-walked", snapshot["target_identity"]["size_qualifiers"]
+            )
+
+    def test_non_empty_directory_at_scan_depth_stays_truncated(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary) / "target"
+            (root / "full").mkdir(parents=True)
+            (root / "full" / "leaf.txt").write_text("y", encoding="utf-8")
+            (root / "empty").mkdir()
+            snapshot = hygiene.scan_tree(
+                root.resolve(), hygiene.load_policy(None), max_depth=1
+            )
+            entries = hygiene.entry_map(snapshot)
+            # The probe answers "any child?", never "how big?" — a directory
+            # with content at the boundary is as uninventoried as it ever was.
+            self.assertEqual(["full"], snapshot["truncated_paths"])
+            self.assertIsNone(entries["full"]["logical_size"])
+            self.assertIn("not-walked", entries["full"]["size_qualifiers"])
+            self.assertNotIn("full/leaf.txt", entries)
+            self.assertIn("not-walked", snapshot["target_identity"]["size_qualifiers"])
+
+    def test_empty_protected_directory_at_scan_depth_stays_truncated(self) -> None:
+        """Regression guard: the probe must not reach the protections branch.
+
+        A protected directory is refused a walk because the protection forbids
+        it, not because the walk would be deep — emptiness answers nothing
+        there, so it must keep landing in truncated whatever it contains.
+        """
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary) / "target"
+            root.mkdir(parents=True)
+            (root / "Documents").mkdir()
+            snapshot = hygiene.scan_tree(
+                root.resolve(), hygiene.load_policy(None), max_depth=1
+            )
+            entries = hygiene.entry_map(snapshot)
+            self.assertIn(
+                "baseline-protected-name", entries["Documents"]["protected_reasons"]
+            )
+            self.assertEqual(["Documents"], snapshot["truncated_paths"])
+            self.assertIsNone(entries["Documents"]["logical_size"])
+            self.assertIn("not-walked", entries["Documents"]["size_qualifiers"])
+
+    def test_empty_vcs_directory_at_scan_depth_stays_truncated(self) -> None:
+        """Regression guard: the probe must not reach the VCS branch.
+
+        ``hard_protection`` is stubbed away so the VCS branch is the ONLY thing
+        that can truncate here — otherwise ``.git``'s own ``vcs-metadata``
+        protection would keep the assertion green even if the probe had leaked
+        into the VCS branch.
+        """
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary) / "target"
+            root.mkdir(parents=True)
+            (root / ".git").mkdir()
+            with mock.patch.object(
+                hygiene, "hard_protection", side_effect=lambda *a, **k: []
+            ):
+                snapshot = hygiene.scan_tree(
+                    root.resolve(), hygiene.load_policy(None), max_depth=1
+                )
+            entries = hygiene.entry_map(snapshot)
+            self.assertEqual([".git"], snapshot["truncated_paths"])
+            self.assertIsNone(entries[".git"]["logical_size"])
+            self.assertIn("not-walked", entries[".git"]["size_qualifiers"])
+
+    def test_directory_has_child_fails_closed_when_unreadable(self) -> None:
+        # Emptiness must be proven. A directory that cannot be read reports
+        # "has content" so its boundary marking is never cleared on a guess.
+        with tempfile.TemporaryDirectory() as temporary:
+            self.assertFalse(hygiene.directory_has_child(Path(temporary)))
+            self.assertTrue(hygiene.directory_has_child(Path(temporary) / "absent"))
+
+    def test_empty_directory_at_scan_depth_is_previewable(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary) / "target"
+            root.mkdir(parents=True)
+            (root / "empty").mkdir()
+            snapshot = hygiene.scan_tree(
+                root.resolve(), hygiene.load_policy(None), max_depth=1
+            )
+            plan = {
+                "version": 1,
+                "tier": "high",
+                "candidates": [candidate("empty")],
+            }
+            with mock.patch.object(
+                hygiene, "handle_state", return_value=("clear", None)
+            ):
+                result = hygiene.preview(snapshot, plan)
+            blockers = result["candidates"][0]["blockers"]
+            self.assertNotIn("truncated-not-inventoried", blockers)
+            self.assertNotIn("changed-since-scan", blockers)
+
+    def test_cleared_boundary_directory_that_gains_a_child_is_caught(self) -> None:
+        """Clearing truncated does not weaken the drift check — it arms it.
+
+        A truncated candidate short-circuits the live descendant walk (nothing
+        can be proven about it anyway). An empty boundary directory no longer
+        short-circuits, so a child appearing between scan and preview is caught
+        as ``changed-since-scan`` instead of hiding behind the blanket block.
+        """
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary) / "target"
+            root.mkdir(parents=True)
+            (root / "empty").mkdir()
+            snapshot = hygiene.scan_tree(
+                root.resolve(), hygiene.load_policy(None), max_depth=1
+            )
+            self.assertEqual([], snapshot["truncated_paths"])
+            (root / "empty" / "arrived.txt").write_text("late", encoding="utf-8")
+            plan = {
+                "version": 1,
+                "tier": "high",
+                "candidates": [candidate("empty")],
+            }
+            with mock.patch.object(
+                hygiene, "handle_state", return_value=("clear", None)
+            ):
+                result = hygiene.preview(snapshot, plan)
+            self.assertIn("changed-since-scan", result["candidates"][0]["blockers"])
+
     def test_preview_skips_live_recursive_checks_for_truncated_candidate(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary) / "target"


### PR DESCRIPTION
No linked issue

## Summary

`scan_tree`'s depth cut was evaluated before any read of the child, so emptiness
was unobservable at the scan boundary: **every** directory at `depth == max_depth`
was marked `walked=False` regardless of what it held. That nulled its
`logical_size`, appended the `not-walked` qualifier, and put it in
`truncated_paths`, where `preview` refuses it as `truncated-not-inventoried`.

For an **empty** directory both effects are wrong in the same direction. It is
vacuously fully inventoried — there are no descendants left uncounted — and its
size is genuinely `0`, not unknown. The consequence in a real run (#2618 F2) was
that no directory at depth N could ever be planned from a `--max-depth N` scan;
clearing one cost a delete-child → rescan-at-depth+1 → delete-parent cycle, two
extra approval-gated rounds per directory.

## Fix

At the depth boundary only, probe for a first child before marking anything:

- New `directory_has_child()` — one `os.scandir`, first entry only, no recursion
  and no count. Deliberately not `top_level_entry_count()`, which iterates every
  child to produce a number; a boundary directory with hundreds of thousands of
  entries is exactly the cost `--max-depth` exists to avoid. The question is
  "any?", not "how many?".
- **Fails closed.** A directory that cannot be read reports `True` (assume
  content), so emptiness is *proven*, never assumed. The read sits inside the
  `try` because Windows surfaces an access denial on the first iteration step
  rather than on `os.scandir` itself. No new `errors` entry is recorded: the old
  code did no `scandir` there at all, so silence preserves prior behavior exactly.
- Empty at the boundary now records `walked=True`, `logical_size=0`, no
  `not-walked` qualifier, and does not enter `truncated_paths`. With nothing left
  unwalked, `target_identity` also stops carrying a `not-walked` qualifier it did
  not earn.

**Scoped to the depth branch only** (constraint (a) of the issue's fix note). The
`VCS_NAMES` and `protections` branches wear the identical
`subtotal = None; walked = False; truncated.append(...)` shape, but they refuse a
walk for reasons emptiness does not answer — an empty protected directory or an
empty VCS root must still land in `truncated`. Two regression tests assert that,
and both were confirmed to **fail** when the probe is applied to those branches.

### The four `truncated_paths` consumers, checked (constraint (b))

| Consumer | Effect of clearing an empty boundary directory |
| --- | --- |
| `preview` blocker (`overlaps_truncated` → `truncated-not-inventoried`) | The directory becomes plannable. Safe: `truncated-not-inventoried` protects an uninventoried subtree, and an empty directory has none. It also **arms** the drift check rather than weakening it — see the TOCTOU note below. |
| `preview` `unverified` short-circuit | The candidate no longer skips `current_descendants` / `tracked_blocker` / `candidate_handle_state`. Those short-circuits exist to avoid unbounded live walks on candidates that can never become approvable; an empty directory's walk is one `scandir` and it *can* be approvable, so running them is correct. |
| `handoff_verify` `contested` set | Same shape, same reasoning. Note: the audit called this "apply's contested set" — it is actually `handoff_verify`, the read-only manual-handoff revalidation lane. `apply` itself never reads `truncated_paths`; it consumes preview's verdicts. |
| `scan-complete` passthrough | Report-only. Two emit sites (normal scan and root-children mode), both pure passthrough; the reported list simply no longer names directories with nothing in them. |

**Fifth consumer, not in the audit's list:** `annotate_tracked` subtracts each
truncated path from the `git ls-files` pathspec via `:(exclude)`. A cleared empty
directory is no longer excluded, so the pathspec is marginally larger. No
behavior change: `ls-files --cached` reads the index, so a directory empty on
disk can still return index entries, but those paths were never scanned, so
`by_path.get(relative)` is `None` and no annotation changes.

**TOCTOU.** If a child appears between scan and preview, the directory is no
longer short-circuited, so `current_descendants` runs and
`current_paths != expected_paths` raises `changed-since-scan`. Asserted by
`test_cleared_boundary_directory_that_gains_a_child_is_caught`.

Rungs 2 and 3 of the issue's ladder (documenting the constraint; a separate
`empty-verified` qualifier) are deliberately not taken here.

## Verification

Covering suite, run in full on this branch and on its merge base (`b7e56070`)
for comparison:

```
$ bash plugins/disk-hygiene/skills/clean/scripts/hygiene.test.sh

branch:   Ran 282 tests in 302.530s — FAILED (failures=3, skipped=4)
baseline: Ran 275 tests in 268.288s — FAILED (failures=3, errors=1, skipped=4)
```

The 282 − 275 = 7 added tests all pass. The three failures on this branch are a
strict subset of the baseline's four and are pre-existing and environmental on
this Windows workstation — `test_stash_must_exist_in_an_independent_checkout`
(8.3 short-path `KYLESE~1` vs `KyleSexton`),
`test_preview_allows_root_children_os_managed_snapshot`, and
`test_deny_emits_blocked_telemetry_when_sink_wired`. The baseline's extra
`test_every_local_branch_head_is_confirmed` error did not recur. None are in this
diff's blast radius; CI runs the suite on a clean Linux runner.

The seven new tests, run in isolation — all `ok`:

```
$ python -m unittest -v test_hygiene.HygieneTests.test_empty_directory_at_scan_depth_is_inventoried_not_truncated ...
Ran 7 tests in 10.478s
OK
```

- `test_empty_directory_at_scan_depth_is_inventoried_not_truncated` — size `0`,
  no qualifier, `truncated_paths == []`, target roll-up exact.
- `test_non_empty_directory_at_scan_depth_stays_truncated` — unchanged behavior.
- `test_empty_protected_directory_at_scan_depth_stays_truncated` — regression guard.
- `test_empty_vcs_directory_at_scan_depth_stays_truncated` — regression guard;
  `hard_protection` is stubbed so the VCS branch is the *only* thing that can
  truncate, otherwise `.git`'s own `vcs-metadata` protection would keep the
  assertion green even if the probe had leaked into that branch.
- `test_directory_has_child_fails_closed_when_unreadable` — fail-closed contract.
- `test_empty_directory_at_scan_depth_is_previewable` — the payoff, at consumer 1.
- `test_cleared_boundary_directory_that_gains_a_child_is_caught` — TOCTOU.

**Mutation check on the regression guards.** With the probe deliberately applied
to the `VCS_NAMES` and `protections` branches, both guards fail
(`Lists differ: ['.git'] != []`); reverted before commit. The guards discriminate.

Lint:

```
$ bash scripts/run-ruff.sh check plugins/disk-hygiene/skills/clean/scripts
All checks passed!

$ bash scripts/run-ruff.sh format --check plugins/disk-hygiene/skills/clean/scripts
3 files would be reformatted, 2 files already formatted
```

Both files in this diff are among the already-formatted two; the three
reformat candidates (`destructive_guard.py`, `guard_launch_monitor.py`,
`test_guard_launch_monitor.py`) are pre-existing and untouched here.

`scripts/affected-tests.sh` selects seven suites for this diff.
`hygiene.test.sh` is the one that covers the change and is reported above;
`kill_switch_probe.test.sh` and `python3_alias_probe.test.sh` also pass. The
remaining four are transitive dependents that do not touch the traversal branch
and blow the local wall-clock budget on Windows (the README's spawn-bound
caveat) — CI runs them.

## Related

- Refs #2618 (F2) — the post-use audit umbrella. Already closed as completed
  while other findings from it were merged, so this PR carries no closing
  keyword; F2's traversal fix had not landed. F5 (belt scope) and other findings
  are covered separately.
- Touches `plugins/disk-hygiene/skills/clean/scripts/hygiene.py` and its tests
  only. The audit's markdown findings and `destructive_guard.py` are out of scope
  here and are being handled in parallel.

---

**Not for auto-merge.** This changes traversal logic that feeds a deletion
preview; it wants a human read of the four-consumer analysis above before it
lands.
