### PR TITLE
fix(typos-format): render multi-candidate residuals as ambiguous

### DIFF
--- a/plugins/typos-format/.claude-plugin/plugin.json
+++ b/plugins/typos-format/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "typos-format",
-  "version": "0.6.17",
+  "version": "0.6.18",
   "description": "Spell-check on edit via typos-cli, unconditionally \u2014 report-only by default, honoring the consuming repo's own typos configuration when one is present.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/typos-format/CHANGELOG.md
+++ b/plugins/typos-format/CHANGELOG.md
@@ -3,6 +3,19 @@
 All notable changes to the `typos-format` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.6.18]
+
+### Fixed
+
+- **Multi-candidate residual findings no longer render as a single definite
+  correction (#2659).** Upstream `typos` returns a correction list and refuses to
+  auto-apply when that list has more than one entry; the residual disclosure now
+  lists every candidate and marks the finding ambiguous instead of quoting only
+  `corrections[0]` as `should be "X"`. Single-candidate and null-correction
+  residual arms, and all applied-correction renders, are unchanged.
+- **`hooks.json` `statusMessage`** reads `Checking spelling...` rather than
+  `Fixing typos...`, matching the default report-only posture that never writes.
+
 ## [0.6.17]
 
 ### Fixed

--- a/plugins/typos-format/hooks/hooks.json
+++ b/plugins/typos-format/hooks/hooks.json
@@ -8,7 +8,7 @@
             "type": "command",
             "command": "\"${CLAUDE_PLUGIN_ROOT}\"/hooks/typos-format.sh",
             "timeout": 15,
-            "statusMessage": "Fixing typos..."
+            "statusMessage": "Checking spelling..."
           }
         ]
       }

--- a/plugins/typos-format/hooks/typos-format.sh
+++ b/plugins/typos-format/hooks/typos-format.sh
@@ -438,6 +438,10 @@ CLASSIFIED=$(printf '%s\n@@typos-format-split@@\n%s\n' "$SCAN_OUTPUT" "$RESIDUAL
     def elide: if (length > 60) then (.[0:60] + "…") else . end;
     def tok: ((.typo // "") | elide);
     def corr1: ((.corrections[0] // "") | elide);
+    # Multi-candidate residuals join every option; typos itself refuses to
+    # auto-apply when length > 1, so the disclosure must not pick corrections[0]
+    # as a definite "should be X".
+    def corrs: ((.corrections // []) | map(elide) | join(" or "));
     (split("\n")) as $lines
     | (($lines | index("@@typos-format-split@@")) // ($lines | length)) as $sep
     | parse($lines[($sep + 1):]) as $r
@@ -481,8 +485,10 @@ CLASSIFIED=$(printf '%s\n@@typos-format-split@@\n%s\n' "$SCAN_OUTPUT" "$RESIDUAL
         residualText: ([limit($max; $r[])] | map(
             if .corrections == null then
               "  \"\(tok)\" (line \(.line_num // 0)) is disallowed, no known correction."
+            elif (.corrections | length) > 1 then
+              "  \"\(tok)\" (line \(.line_num // 0)) should be \(corrs) (ambiguous — typos will not auto-correct this)."
             else
-              "  \"\(tok)\" (line \(.line_num // 0)) should be \"\(corr1)\"."
+              "  \"\(tok)\" (line \(.line_num // 0)) should be \"\(corrs)\"."
             end) | join("\n"))
       }' 2>/dev/null) || CLASSIFIED=""
 

--- a/plugins/typos-format/hooks/typos-format.test.sh
+++ b/plugins/typos-format/hooks/typos-format.test.sh
@@ -485,6 +485,48 @@ else
   fail "stub/both: channels not composed: $OUT_BOTH"
 fi
 
+# --- Residual render: multi-candidate vs single-candidate vs null (#2659) ----
+# typos returns a correction LIST. When length > 1 it refuses to auto-apply, so
+# disclosing only corrections[0] as a definite "should be X" instructs the agent
+# to make an edit the tool itself declined. Multi-candidate residuals must read
+# as ambiguous; single-candidate residuals keep the quoted definite form;
+# null-correction residuals stay on the disallowed arm.
+printf 'this has wnat and a disallowme term\n' >"$STUB_REPO/multi-residual.txt" # spellchecker:disable-line
+OUT_MR=$(run_stub "$STUB_REPO/multi-residual.txt")
+CTX_MR=$(printf '%s' "$OUT_MR" | jq -r '.hookSpecificOutput.additionalContext // empty' 2>/dev/null)
+# Exact multi-candidate shape — quoting only want (corrections[0]) is the bug.
+if printf '%s' "$CTX_MR" | grep -qF '"wnat" (line 1) should be want or what (ambiguous — typos will not auto-correct this).'; then # spellchecker:disable-line
+  ok "stub/multi-candidate-residual: ambiguous findings list every candidate"
+else
+  fail "stub/multi-candidate-residual: expected ambiguous multi-candidate render, got: $CTX_MR"
+fi
+if printf '%s' "$CTX_MR" | grep -qE '"wnat" \(line 1\) should be "want"\.'; then # spellchecker:disable-line
+  fail "stub/multi-candidate-residual: multi-candidate still rendered as a single definite correction: $CTX_MR"
+else
+  ok "stub/multi-candidate-residual: does not present corrections[0] as a definite fix"
+fi
+if printf '%s' "$CTX_MR" | grep -qF '"disallowme" (line 1) is disallowed, no known correction.'; then
+  ok "stub/multi-candidate-residual: null-correction arm unchanged"
+else
+  fail "stub/multi-candidate-residual: null-correction arm missing or altered: $CTX_MR"
+fi
+
+# Report-only leaves a single-candidate finding residual; that arm must still
+# quote the one correction as a definite suggestion (not the ambiguous form).
+printf 'this has teh typo\n' >"$STUB_REPO/single-residual.txt" # spellchecker:disable-line
+OUT_SR1=$(run_stub_default "$STUB_REPO/single-residual.txt")
+CTX_SR1=$(printf '%s' "$OUT_SR1" | jq -r '.hookSpecificOutput.additionalContext // empty' 2>/dev/null)
+if printf '%s' "$CTX_SR1" | grep -qF '"teh" (line 1) should be "the".'; then # spellchecker:disable-line
+  ok "stub/single-candidate-residual: single correction still renders as a definite suggestion"
+else
+  fail "stub/single-candidate-residual: expected quoted single-candidate render, got: $CTX_SR1"
+fi
+if printf '%s' "$CTX_SR1" | grep -qi 'ambiguous'; then
+  fail "stub/single-candidate-residual: single-candidate marked ambiguous: $CTX_SR1"
+else
+  ok "stub/single-candidate-residual: not marked ambiguous"
+fi
+
 # --- A residual that MOVED between the passes is not a rewrite ---------------
 # Claude Code runs matching PostToolUse hooks in parallel, so a sibling
 # formatter can reflow the file between this hook's scan and write passes and


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #2659

## Summary

Residual findings with more than one correction candidate now list every option and mark the finding ambiguous, matching typos' refusal to auto-apply multi-candidate fixes.

## Fix

- Multi-candidate residuals render as ambiguous (not a definite `corrections[0]` suggestion)
- Single-candidate and null-correction residual arms, plus applied-correction renders, stay unchanged
- Plugin version bumped to 0.6.18

## Verification

```
bash plugins/typos-format/hooks/typos-format.test.sh
# PASS=121 FAIL=0
```

## Related

Refs #2650 — write-mode allowlist work on the same hook.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eb3f5ee5-6c9f-48a3-8e46-071bd363f8b0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eb3f5ee5-6c9f-48a3-8e46-071bd363f8b0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

