### PR TITLE
docs(cloud): fold 2026-08-14 verification results into the fleet guide

### DIFF
--- a/docs/CLOUD-FLEET-SETUP.md
+++ b/docs/CLOUD-FLEET-SETUP.md
@@ -8,7 +8,9 @@ and self-hosted environments are Team/Enterprise features and deliberately out o
 
 Basis and freshness: every repository row below was derived from a shallow clone of that repo's
 default branch on 2026-08-13; platform claims rest on the rung-1 doc fetches recorded in
-[CLOUD-SESSIONS.md](CLOUD-SESSIONS.md). Recheck trigger, per the
+[CLOUD-SESSIONS.md](CLOUD-SESSIONS.md); the environment itself was verified live on 2026-08-14
+from a cloud session inside it — results in [#2654](https://github.com/melodic-software/claude-code-plugins/issues/2654),
+folded in below. Recheck trigger, per the
 [upstream-drift convention](conventions/upstream-drift/README.md): a repo changes its toolchain
 pins (`global.json`, `.node-version`, `.python-version`, lockfiles) or its `.claude/` config, or
 a verification session (see [checklist](#verification-checklist)) contradicts a row.
@@ -36,7 +38,7 @@ Go plus the module `toolchain` mechanism covers this); **PowerShell** (`pwsh` �
 
 | Repo | Stack / pins | `.claude/` today | Cloud needs beyond the shared env |
 |---|---|---|---|
-| claude-code-plugins | Node (`.node-version`), npm, ruff, lint pins | Full bootstrap hook exists but is **not registered** (see [findings](#findings)); marketplace declared (`directory` source); full catalog enabled | Re-register the SessionStart hook |
+| claude-code-plugins | Node (`.node-version`), npm, ruff, lint pins | Full bootstrap hook **registered** (#2655), marketplace declared, full catalog enabled (#2631) | None — re-verify per the [checklist](#verification-checklist) |
 | medley | .NET 10.0.302 (repo-local `.dotnet` supported), Node 24.18.0, Python 3.14, npm, Playwright visual CI | Rich guard/telemetry hooks, 54 plugins, 13 `.mcp.json` servers — **no dependency bootstrap hook** | Add bootstrap hook: .NET into `.dotnet`, `npm ci`, `uv sync`; Playwright browsers on demand |
 | github-iac | .NET 10.0.302, Pulumi (C#), Node 24.18.0, npm | settings + CLAUDE.md, no bootstrap hook | Add bootstrap hook (.NET, `npm ci`); `pulumi` CLI only if sessions should run previews |
 | ci-workflows | .NET 10.0.400, pwsh + Pester + PSScriptAnalyzer, Go fixtures | settings + CLAUDE.md, no bootstrap hook | Add bootstrap hook (.NET 10.0.400); pwsh comes from the shared env |
@@ -61,71 +63,45 @@ Environments are created only from the environment selector at
 Either edit **Default** in place or add a new environment named e.g. **Melodic** so Default stays
 pristine:
 
-- **Network access**: start with **Trusted**. The one at-risk install is the .NET installer
-  (`dot.net/v1/dotnet-install.sh` redirects through `aka.ms` to `builds.dotnet.microsoft.com` /
-  `download.visualstudio.microsoft.com`, none of which appear on the documented default
-  allowlist; all probed reachable from a cloud session on 2026-08-13, so the documented list may
-  be conservative). If the verification session shows the .NET step failing with `403` /
-  `x-deny-reason: host_not_allowed`, switch to **Custom**, check **Also include default list of
-  common package managers**, and add: `dot.net`, `aka.ms`, `builds.dotnet.microsoft.com`,
-  `download.visualstudio.microsoft.com` (`dot.net` is already on the default list the checkbox
-  retains; it is listed here so the recovery path stands even without the checkbox).
+- **Network access**: **Custom**, with **Also include default list of common package managers**
+  checked, plus these hosts: `dot.net`, `aka.ms`, `builds.dotnet.microsoft.com`,
+  `download.visualstudio.microsoft.com`. This is a hard requirement, not a fallback: the 2026-08-14
+  verification run ([#2654](https://github.com/melodic-software/claude-code-plugins/issues/2654),
+  Blocker 1) reproduced the .NET installer's redirect chain being `403`-blocked under Trusted
+  (session-side probes on 2026-08-13 had suggested the documented allowlist was conservative; the
+  setup-script build proved otherwise). Trusted works only if the fleet ever drops .NET from the
+  environment.
 - **Environment variables**: none. There is no secrets store — anything here is readable by every
   session in the environment. `gh`/git auth comes from the GitHub proxy automatically.
-- **Setup script**: paste the script below.
+- **Setup script**: paste only the three-line bootstrap below. The real script is the
+  [`cloud-environment` component in standards](https://github.com/melodic-software/standards/blob/main/components/cloud-environment/setup.sh)
+  (standards is the org baseline SSOT and is public, so the raw fetch needs no credentials and
+  `raw.githubusercontent.com` is on the default allowlist) — edits to what environments install
+  land there by reviewed PR, never by hand-editing this account-scoped UI field.
 
 ```bash
 #!/bin/bash
-# Melodic shared cloud environment — repo-agnostic, static installs only.
-# Hard limits: must exit 0; keep total runtime well under ~5 minutes so the
-# environment cache (the warm-boot snapshot) can build. Per-repo work lives in
-# each repo's committed SessionStart hook, not here.
-export DEBIAN_FRONTEND=noninteractive
-
-# Track A: apt tools — gh CLI + PowerShell (packages.microsoft.com is allowlisted)
-(
-  apt-get update -y || true
-  # gh comes from Ubuntu's own archives: the official cloud-environments worked
-  # example is exactly `apt update && apt install -y gh`, and cli.github.com
-  # (the newer upstream apt repo) is NOT on the default allowlist, so this is
-  # the only Trusted-compatible route. A silent miss here is caught by the
-  # verification checklist's `gh --version` step.
-  apt-get install -y gh || true
-  . /etc/os-release
-  curl -fsSL "https://packages.microsoft.com/config/ubuntu/${VERSION_ID}/packages-microsoft-prod.deb" \
-    -o /tmp/msprod.deb &&
-    dpkg -i /tmp/msprod.deb && apt-get update -y && apt-get install -y powershell || true
-) &
-
-# Track B: .NET SDKs — the fleet's exact global.json pins (rollForward: disable)
-(
-  curl -fsSL https://dot.net/v1/dotnet-install.sh -o /tmp/dotnet-install.sh || exit 0
-  for v in 10.0.302 10.0.400; do
-    bash /tmp/dotnet-install.sh --version "$v" --install-dir /opt/dotnet || true
-  done
-  ln -sf /opt/dotnet/dotnet /usr/local/bin/dotnet || true
-) &
-
-# Track C: Node 24.18.0 — fleet .node-version pin; the VM image ships 20/21/22
-(
-  export NVM_DIR="${NVM_DIR:-/opt/nvm}"
-  if [ -s "$NVM_DIR/nvm.sh" ]; then
-    . "$NVM_DIR/nvm.sh" && nvm install 24.18.0 && nvm alias default 24.18.0 || true
-  fi
-) &
-
-wait
-
-# Bake the checked-out repo's own bootstrap into the cached snapshot (no-op for
-# repos without the hook; hooks are idempotent so any repo/cache pairing is safe)
-[ -f .claude/hooks/session-start.sh ] && CLAUDE_CODE_REMOTE=true bash .claude/hooks/session-start.sh || true
+curl -fsSL https://raw.githubusercontent.com/melodic-software/standards/main/components/cloud-environment/setup.sh \
+  -o /tmp/melodic-env-setup.sh && bash /tmp/melodic-env-setup.sh
 exit 0
 ```
 
-Update the .NET version list here when a repo's `global.json` bumps — the pins duplicate the
-repos' manifests by necessity (the script cannot read repos it isn't running in), which is why
-each repo's hook *also* installs its exact SDK repo-locally: the env copy is a warm cache, the
-hook is the correctness guarantee.
+What the canonical script does (details and lifecycle in the
+[component README](https://github.com/melodic-software/standards/blob/main/components/cloud-environment/README.md)):
+parallel tracks install `gh` + PowerShell (apt), the fleet's exact .NET SDK pins into
+`/opt/dotnet`, and Node 24.18.0 via the VM's nvm; it then bakes the checked-out repo's own
+SessionStart hook into the snapshot. Every step logs with a timestamp to
+`/var/log/melodic-env-setup.log`, and `/opt/melodic-env-setup.done` (version + timestamp) is
+written strictly last — so a missing stamp is the signature of an interrupted cache build
+([#2654](https://github.com/melodic-software/claude-code-plugins/issues/2654) Blocker 2), fixed
+by forcing a rebuild.
+
+Two lifecycle caveats: the fleet's toolchain pins are duplicated into the component by necessity
+(the script cannot read repos it isn't running in) — each repo's hook *also* installs its exact
+SDK repo-locally, so the env copy is a warm cache and the hook is the correctness guarantee. And
+a merged component change does **not** reach existing environments on its own: the snapshot
+rebuilds only on an edit to the environment's script/network fields or ~7-day cache expiry, so
+after a standards bump, force a rebuild with any trivial edit to the script field.
 
 ## Step 2 — per-repo templates
 
@@ -266,8 +242,15 @@ transcript to confirm the task itself succeeded.
 ## Verification checklist
 
 Run once after creating the environment (and after any setup-script edit — each edit rebuilds
-the cache). Start a cloud session on this repo in the new environment and ask Claude to verify:
+the cache). Executed live on 2026-08-14; results and forensics in
+[#2654](https://github.com/melodic-software/claude-code-plugins/issues/2654). Start a cloud
+session on this repo in the new environment and ask Claude to verify:
 
+0. **The completion stamp first**: `cat /opt/melodic-env-setup.done` (version + timestamp). A
+   missing stamp means the cache build was interrupted before the script finished — the exact
+   #2654 Blocker 2 failure, where dpkg logs showed the build stopping ~13 s in with PowerShell
+   and the baked-in bootstrap never run. Force a rebuild (any trivial script-field edit) before
+   debugging anything else; `/var/log/melodic-env-setup.log` shows how far the build got.
 1. `gh --version`, `pwsh --version`, `dotnet --list-sdks` (expect 10.0.302 and 10.0.400),
    `node --version` (expect the `.node-version` pin), `check-tools` for the VM inventory.
 2. The repo's hook ran: `node_modules/.bin` populated, pinned lint tools present (`typos`,
@@ -275,8 +258,9 @@ the cache). Start a cloud session on this repo in the new environment and ask Cl
 3. `echo $GH_TOKEN` prints `proxy-injected` (GitHub proxy is authenticating).
 4. Marketplace plugins loaded (`/plugin` → installed list shows `@melodic-software` entries) in a
    session on a repo that declares them (songwriting or medley).
-5. If the .NET setup-script step failed (`dotnet` missing), apply the Custom-allowlist fallback
-   from [Step 1](#step-1--the-shared-environment-claudeai-ui-one-time) and re-verify.
+5. If the .NET setup-script step failed (`dotnet` missing), confirm the environment actually has
+   the Custom allowlist from [Step 1](#step-1--the-shared-environment-claudeai-ui-one-time) —
+   under Trusted this step *always* fails (#2654 Blocker 1) — then rebuild and re-verify.
 6. Python: in a claude-code-proxy or medley session, `uv python install 3.14` — if the download
    is `403`-blocked (release assets ride the GitHub proxy's repository scope), fall back to the
    VM's system Python for tooling or add the astral-sh host to a Custom allowlist. This repo's
@@ -286,16 +270,16 @@ the cache). Start a cloud session on this repo in the new environment and ask Cl
 
 ## Findings
 
-- **This repo's bootstrap is currently unwired.** `.claude/hooks/session-start.sh` exists and
-  `docs/CLOUD-SESSIONS.md` §"How this repository is set up" describes `settings.json` registering
-  it (plus a nine-plugin `enabledPlugins` set), but the committed `settings.json` on `main`
-  carries neither key — confirmed empirically in the session that produced this doc: `npm ci`
-  had not run and the hook-pinned tools were absent at session start. The `claude-ops`
-  converge/sync machinery owns committed plugin enablement (see #2539), so this doc does not
-  patch `settings.json` unilaterally: **decide whether the removal was intentional**, then either
-  re-register the hook (snippet in [Step 2](#step-2--per-repo-templates)) or update
-  CLOUD-SESSIONS.md to describe the deliberate state. Until one of those lands, cloud sessions on
-  this repo start without their toolchain.
+- **Resolved: this repo's bootstrap was unwired; it is now registered.** The doc's original
+  finding (committed `settings.json` carried neither the SessionStart hook nor `enabledPlugins`)
+  was confirmed live by the 2026-08-14 verification run (#2654 check 2/4: empty
+  `node_modules/.bin`, zero plugins). #2631 enabled the catalog; #2655 registered the SessionStart hook
+  on a `startup|resume` matcher — and #2657 closed the last hook blocker (the
+  `--require-hashes` pin list lacked cp311 wheels for the cloud VM's Python 3.11, so the hook
+  failed deterministically; verified against PyPI's published digests, a coverage gap rather
+  than tampering). Remaining #2654 actions are environment-side, not repo-side: switch the
+  environment to the Custom allowlist ([Step 1](#step-1--the-shared-environment-claudeai-ui-one-time))
+  and rebuild the interrupted cache, then re-run the [checklist](#verification-checklist).
 - **`dotfiles` cannot deliver user config to the cloud.** By platform design nothing from
   `~/.claude` reaches cloud sessions; the repo remains editable in the cloud, but any behavior it
   installs locally must be re-homed (repo `.claude/`, plugins, or the environment) to exist


### PR DESCRIPTION
No linked issue

## Summary

Folds the 2026-08-14 live verification of the Melodic cloud environment (#2654) into `docs/CLOUD-FLEET-SETUP.md`, and swaps the guide's embedded environment setup script for a three-line bootstrap that curls the canonical script from the new `cloud-environment` component in standards (melodic-software/standards#388) — so environment behavior changes land by reviewed PR instead of hand-edits to an account-scoped UI field.

## Fix

- **Step 1 network access**: the Custom allowlist (default package managers + `dot.net`, `aka.ms`, `builds.dotnet.microsoft.com`, `download.visualstudio.microsoft.com`) is now documented as the requirement, not a fallback — #2654 Blocker 1 reproduced the .NET installer's `403` under Trusted, overturning the 2026-08-13 probe-based optimism.
- **Setup script section**: embedded script replaced by the bootstrap + pointers to the standards component and its README; documents the per-step timestamped log (`/var/log/melodic-env-setup.log`), the completion stamp (`/opt/melodic-env-setup.done`, written strictly last), and the cache-rebuild lifecycle (a merged standards change reaches environments only on a forced rebuild or ~7-day expiry).
- **Verification checklist**: new item 0 checks the stamp first — a missing stamp is the #2654 Blocker 2 signature (cache build interrupted ~13 s in; PowerShell and the baked-in bootstrap never ran). The .NET item now points at confirming the allowlist rather than "applying the fallback".
- **Findings + audit table**: the "bootstrap is unwired" finding is marked resolved — #2631 registered the SessionStart hook and enabled the 65-plugin catalog, #2657 closed the cp311 pyyaml hash gap the hook died on (verified against PyPI's published digests; coverage gap, not tampering). Remaining #2654 actions are environment-side (apply the allowlist, rebuild the cache, re-run the checklist).

## Verification

- `markdownlint-cli2 docs/CLOUD-FLEET-SETUP.md` — 0 issues
- All referenced anchors (`#step-1--the-shared-environment-claudeai-ui-one-time`, `#verification-checklist`) unchanged and resolvable
- Claims cross-checked against the primary sources: #2654 (live run forensics), #2631 / #2657 diffs on `main`, and the component content in melodic-software/standards#388

## Related

- Refs #2654 — the verification report this folds in (left open: the environment-side actions — Custom allowlist + cache rebuild + checklist re-run — are still pending)
- Refs #2631, #2657 — the repo-side fixes the Findings section now records
- Refs melodic-software/standards#388 — the canonical setup script this guide now bootstraps from
- Refs #2613 — the original fleet guide PR this follows up

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AXaqhrFZeGTzbCJun12Ngx

---
_Generated by [Claude Code](https://claude.ai/code/session_01AXaqhrFZeGTzbCJun12Ngx)_