### PR TITLE
fix(typos-format): mark multi-candidate residuals as ambiguous

### DIFF
--- a/plugins/typos-format/hooks/hooks.json
+++ b/plugins/typos-format/hooks/hooks.json
@@ -8,7 +8,7 @@
             "type": "command",
             "command": "\"${CLAUDE_PLUGIN_ROOT}\"/hooks/typos-format.sh",
             "timeout": 15,
-            "statusMessage": "Fixing typos..."
+            "statusMessage": "Checking spelling..."
           }
         ]
       }

--- a/plugins/typos-format/hooks/typos-format.sh
+++ b/plugins/typos-format/hooks/typos-format.sh
@@ -438,6 +438,12 @@ CLASSIFIED=$(printf '%s\n@@typos-format-split@@\n%s\n' "$SCAN_OUTPUT" "$RESIDUAL
     def elide: if (length > 60) then (.[0:60] + "…") else . end;
     def tok: ((.typo // "") | elide);
     def corr1: ((.corrections[0] // "") | elide);
+    # Every candidate, not just the first. `corr1` is exact on the APPLIED side
+    # — typos only ever rewrites a single-candidate finding — but a RESIDUAL
+    # finding can carry several, and those are precisely the ones typos refuses
+    # to auto-correct. Rendering only `corrections[0]` there states a definite
+    # correction the tool itself declined to make (#2659).
+    def corrs: ([.corrections[] | elide] | join(" or "));
     (split("\n")) as $lines
     | (($lines | index("@@typos-format-split@@")) // ($lines | length)) as $sep
     | parse($lines[($sep + 1):]) as $r
@@ -482,7 +488,7 @@ CLASSIFIED=$(printf '%s\n@@typos-format-split@@\n%s\n' "$SCAN_OUTPUT" "$RESIDUAL
             if .corrections == null then
               "  \"\(tok)\" (line \(.line_num // 0)) is disallowed, no known correction."
             else
-              "  \"\(tok)\" (line \(.line_num // 0)) should be \"\(corr1)\"."
+              "  \"\(tok)\" (line \(.line_num // 0)) should be \(if (.corrections|length) > 1 then "\(corrs) (ambiguous — typos will not auto-correct this)" else "\"\(corrs)\"" end)."
             end) | join("\n"))
       }' 2>/dev/null) || CLASSIFIED=""
 


### PR DESCRIPTION
Closes #2659

## Summary

`typos` returns a correction **list**, and a finding carrying more than one candidate is one the tool itself refuses to auto-apply. The hook rendered only `corrections[0]` in the form `should be "X"`, presenting such a finding as a single definite correction — contradicting the plugin's own documented model, which says residual findings "surface as advisory context, never auto-applied."

## Fix

Residual findings now render every candidate and state plainly that `typos` will not auto-correct them. A new `corrs` helper joins the full list; the existing `corr1` is deliberately **kept** on the applied-correction path (lines 401/403/404), where it is exact — `typos -w` only ever rewrites single-candidate findings.

Also corrects `hooks.json`'s `statusMessage` from `"Fixing typos..."` to `"Checking spelling..."`: the default configuration is report-only and never writes.

## Verification

Ran on this host with `typos-cli 1.44.0`:

```
$ bash -n plugins/typos-format/hooks/typos-format.sh   # syntax OK
$ python -c "json.load(open('plugins/typos-format/hooks/hooks.json'))"   # valid
```

The three render cases, driven through the actual jq program:

```
  "ba" (line 3) should be by or be (ambiguous — typos will not auto-correct this).
  "recieve" (line 5) should be "receive".
  "foo" (line 7) is disallowed, no known correction.
```

Single-candidate output is byte-identical to before; the `corrections == null` arm is untouched.

**Measured basis for the change.** A control fixture of 14 ordinary English misspellings (`recieve`, `seperate`, `occured`, `foriegn`, `langauge`, `comitted`, `paramater`, `definately`, `teh`, `lenght`, `accomodate`, `responce`, `recieved`, `sucessfully`) returned **14/14 single-candidate**, all applied by `typos -w` at exit 0. The four false positives observed in real use were **4/4 multi-candidate** — `ba` → `["by","be"]` from a Python tuple unpack, `mis` → `["miss","mist"]` from the hyphenated prefixes `mis-place` / `mis-set` — and `typos -w` refused both (exit 2, files unchanged).

On that sample, marking multi-candidate findings removes **100% of observed false positives at zero cost in true positives**.

**Not run:** the full `plugins/typos-format/hooks/typos-format.test.sh` suite. The audit that produced #2659 found the suite has no residual-rendering assertion at all, which is why this shipped; adding one is worth a follow-up, and CI's `plugin-gate` will exercise the existing cases here. No version bump or CHANGELOG entry — a consolidating bump is landing separately, and parallel PRs staging the same version number collide on `check-changelog-parity.sh --check-order`.

## Related

N/A
