### PR TITLE
fix(disk-hygiene): restore root-children flags to the documented argument surface

### DIFF
--- a/plugins/disk-hygiene/.claude-plugin/plugin.json
+++ b/plugins/disk-hygiene/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "disk-hygiene",
-  "version": "0.20.1",
+  "version": "0.20.3",
   "description": "Context-aware disk hygiene for arbitrary directory trees: inventories orphaned and temporary artifacts, classifies evidence into review tiers, and offers exact-path cleanup only after a fresh safety preview and explicit per-tier approval. The target is read-only by default; OS-managed paths, links and mount points, VCS-tracked content without the complete checkout evidence bundle, changed entries, and live-handle uncertainty fail closed.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/disk-hygiene/CHANGELOG.md
+++ b/plugins/disk-hygiene/CHANGELOG.md
@@ -3,6 +3,20 @@
 All notable changes to the `disk-hygiene` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.20.3]
+
+### Fixed
+
+- **The documented argument surface names the root-children flags again (#2588).** Resolving the
+  conflict in #2641 inserted a fresh "Arguments and boundaries" opening paragraph above the existing
+  one instead of merging into it, orphaning that paragraph's continuation. The section was left with
+  two overlapping sentences, and the authoritative first one silently dropped `--root-children` and
+  `--root-child <name>` — reintroducing exactly the wrong-argument-surface defect #2589 was filed
+  for, against the feature #2636 had just shipped. The two sentences are merged back into one
+  carrying every flag, and the skill's `argument-hint` now lists the root-children flags it had
+  never carried. Documentation only: the engine has accepted both flags since #2636 and its
+  behavior is unchanged.
+
 ## [0.20.1]
 
 ### Fixed

--- a/plugins/disk-hygiene/skills/clean/SKILL.md
+++ b/plugins/disk-hygiene/skills/clean/SKILL.md
@@ -1,6 +1,6 @@
 ---
 description: "Audit an arbitrary directory tree for orphaned, temporary, stale-lock, failed-write, partial-download, and empty leftover artifacts; classify evidence into confidence tiers; and optionally remove exact validated paths after explicit per-tier approval. Read-only by default and manual-only. Use when: 'audit this directory', 'find orphaned files', 'what junk can I clean up', 'reclaim disk space', 'find temp or lock leftovers', 'clean up my home directory'. Skip when: repository cache/build cleanup belongs to repo-hygiene, a product has its own prune/GC command, or the target is an OS-managed root."
-argument-hint: "[--execute] [--policy <policy.json>] [--max-depth <N>] [--confirmed-large-scan] <target-directory>"
+argument-hint: "[--execute] [--policy <policy.json>] [--max-depth <N>] [--confirmed-large-scan] [--root-children [--root-child <name>]...] <target-directory>"
 user-invocable: true
 disable-model-invocation: true
 hooks:
@@ -37,16 +37,11 @@ filename pattern is a discovery hint, never proof that an entry is junk. Read
 ## Arguments and boundaries
 
 Parse `$ARGUMENTS` as the complete user-facing surface: optional `--execute`, optional
-`--policy <file>`, optional `--max-depth <N>`, optional `--confirmed-large-scan`, and one target
-directory. Remaining engine flags (`--output`, `--project-dir`, `--data-root` on scan;
-`--snapshot`, `--plan`, `--report`, `--confirm-tier`, `--approval-token`, `--paths`, and
-`--vcs-evidence` on the other subcommands) are supplied by this skill's command templates, not typed
-by the user.
 `--policy <file>`, optional `--max-depth <N>`, optional `--confirmed-large-scan`, optional
 `--root-children` with zero or more `--root-child <name>`, and one target directory. Remaining
 engine flags (`--output`, `--project-dir`, `--data-root` on scan; `--snapshot`, `--plan`,
-`--report`, `--confirm-tier`, `--approval-token`, `--paths` on the other subcommands) are supplied
-by this skill's command templates, not typed by the user.
+`--report`, `--confirm-tier`, `--approval-token`, `--paths`, and `--vcs-evidence` on the other
+subcommands) are supplied by this skill's command templates, not typed by the user.
 `--execute` means "deletion may be offered" on every platform — the gated engine lane where the
 platform supports it, the manual handoff elsewhere; it is not approval. (Deliberate semantic
 unification, not a restatement: the flag previously read as engine-lane-only, which left the


### PR DESCRIPTION
## Problem

Root-children mode shipped in #2636 for issue #2588. The documented argument surface on `main`
does not name it.

Resolving the conflict in #2641 inserted a fresh "Arguments and boundaries" opening paragraph
**above** the existing one instead of merging into it. That left the section with two overlapping
sentences and orphaned the original paragraph's continuation. Current `main`,
`plugins/disk-hygiene/skills/clean/SKILL.md:39-49`:

```text
Parse `$ARGUMENTS` as the complete user-facing surface: optional `--execute`, optional
`--policy <file>`, optional `--max-depth <N>`, optional `--confirmed-large-scan`, and one target
directory. Remaining engine flags (... and `--vcs-evidence` on the other subcommands) are supplied
by this skill's command templates, not typed by the user.
`--policy <file>`, optional `--max-depth <N>`, optional `--confirmed-large-scan`, optional
`--root-children` with zero or more `--root-child <name>`, and one target directory. Remaining
engine flags (...) are supplied by this skill's command templates, not typed by the user.
```

Two failures compound here:

1. The **authoritative first sentence** — the one that reads as complete and that a reader stops
   at — silently drops `--root-children` and `--root-child <name>`. This reintroduces exactly the
   wrong-argument-surface defect #2589 was filed for, against the feature #2636 had just shipped.
2. The second paragraph is an orphaned fragment beginning mid-clause with no subject, so even a
   reader who continues past the first sentence hits text that does not parse.

`argument-hint` in the frontmatter had never carried the root-children flags at all.

## Fix

Documentation only. The two sentences are merged back into one carrying **every** flag —
including `--vcs-evidence`, which arrived on `main` after this branch was first written and is
preserved here — and `argument-hint` now lists the root-children flags.

The engine has accepted `--root-children` and `--root-child <name>` since #2636; its behavior is
unchanged by this PR. This closes the gap between what the engine accepts and what the skill tells
an operator it accepts.

## Verification

- No conflict markers remain; the section is one coherent sentence with no orphaned fragment.
- `argument-hint` and the body now name the same flag set.
- Rebased onto current `main` (`6c8e05a3`), so `--vcs-evidence` from #2641 survives the merge
  rather than being reverted by it.

## Note on versioning

Bumped to `0.20.3`. `0.20.2` is claimed by #2671, which is open concurrently against the same
plugin; whichever lands second may need a trivial version/CHANGELOG rebase.

## Related

- #2636 — shipped root-children mode for #2588; this restores its flags to the documented surface.
- #2641 — the conflict resolution that orphaned the paragraph; its `--vcs-evidence` addition is
  preserved here rather than reverted.
- #2589 — the argument-surface issue whose defect this regression reintroduced.
- #2671 — concurrent PR against the same plugin; it claims version `0.20.2`, this one `0.20.3`.

## Linked issue

**No linked issue.** This PR closes nothing: #2588 and #2589 are both already CLOSED — #2588 by
#2636, which shipped the feature, and #2589 by the argument-surface work. The defect fixed here is
a regression introduced *after* those closed, by the conflict resolution in #2641, so reopening
either would misrepresent their history. Filing a fresh issue for a documentation regression whose
fix is already written and verified would add tracker noise without adding information.

Refs #2588
Refs #2589
