### PR TITLE
refactor(claude): split cloud bootstrap out of the SessionStart hook

### DIFF
--- a/.claude/cloud-bootstrap.sh
+++ b/.claude/cloud-bootstrap.sh
@@ -1,10 +1,19 @@
 #!/usr/bin/env bash
-# SessionStart bootstrap for Claude Code cloud sessions (Claude Code on the web).
+# Cloud bootstrap for Claude Code cloud sessions (Claude Code on the web).
 #
-# Registered in .claude/settings.json (matcher: startup|resume); runs before the
-# agent takes its first turn. Local sessions exit immediately via the
-# CLAUDE_CODE_REMOTE guard — a local machine is presumed provisioned by its
-# owner, and this script must never mutate one.
+# Two callers run this script, both with CLAUDE_CODE_REMOTE=true:
+#   1. The account environments' setup scripts, after clone and BEFORE the
+#      session process launches. Claude Code builds its plugin/command/skill
+#      registry at process start and never re-reads it, so this pre-launch call
+#      is the only path that gets the repo's plugins loaded at turn one.
+#   2. The SessionStart hook registered in .claude/settings.json (matcher:
+#      startup|resume), which re-runs the same script on every session start
+#      and resume as drift repair — the environment cache can be ~7 days
+#      stale. Plugin installs made by a hook run go live at the next resume,
+#      not in the session that ran the hook.
+# Local sessions exit immediately via the CLAUDE_CODE_REMOTE guard — a local
+# machine is presumed provisioned by its owner, and this script must never
+# mutate one.
 #
 # Purpose: give a fresh cloud VM the same tool inventory as
 # .github/workflows/ci.yml, so the repo's gates (scripts/run-plugin-tests.sh,
@@ -25,11 +34,11 @@
 set -euo pipefail
 
 if [[ "${CLAUDE_CODE_REMOTE:-}" != "true" ]]; then
-  echo "session-start: not a cloud session; nothing to do." >&2
+  echo "cloud-bootstrap: not a cloud session; nothing to do." >&2
   exit 0
 fi
 
-repo_root="${CLAUDE_PROJECT_DIR:-$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)}"
+repo_root="${CLAUDE_PROJECT_DIR:-$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)}"
 cd -- "$repo_root"
 
 bin_dir="$HOME/.local/bin"
@@ -70,7 +79,7 @@ current_node="$(node --version 2>/dev/null || true)"
 if [[ "$current_node" != "v$node_pin" ]]; then
   export NVM_DIR="${NVM_DIR:-/opt/nvm}"
   if [[ ! -s "$NVM_DIR/nvm.sh" ]]; then
-    echo "session-start: error: Node $node_pin required and nvm not found at $NVM_DIR" >&2
+    echo "cloud-bootstrap: error: Node $node_pin required and nvm not found at $NVM_DIR" >&2
     exit 1
   fi
   set +u # nvm.sh reads intentionally-unset variables
@@ -83,9 +92,11 @@ fi
 node_bin="$(dirname -- "$(command -v node)")"
 
 # --- Session PATH (required) -------------------------------------------------
-# Hook-process env dies with this script; $CLAUDE_ENV_FILE is the sanctioned
+# This process's env dies with the script; $CLAUDE_ENV_FILE is the sanctioned
 # channel for shaping the session's Bash environment (per the cloud-environments
-# doc). node_modules/.bin exposes the pinned claude CLI and Biome from npm ci.
+# doc). It is set only for the SessionStart-hook caller — the pre-launch caller
+# has no session yet, so this block is skipped there.
+# node_modules/.bin exposes the pinned claude CLI and Biome from npm ci.
 if [[ -n "${CLAUDE_ENV_FILE:-}" ]]; then
   # shellcheck disable=SC2016 # $PATH must stay literal for the session to expand
   path_line="$(printf 'export PATH="%s:%s/node_modules/.bin:%s:$PATH"' \
@@ -116,23 +127,25 @@ fi
 # a session exercises the plugin code on the current branch, not published main.
 #
 # Never `claude plugin marketplace remove` here. That subcommand deletes the
-# marketplace's entry from .claude/settings.json, so a hook that used it to
-# force a re-add would silently mutate tracked repository config.
+# marketplace's entry from .claude/settings.json, so using it to force a
+# re-add would silently mutate tracked repository config.
 #
 # Best effort by design: a plugin that fails to install costs that plugin's
 # skills, not the session. Idempotent — installed plugins are skipped, so a
-# resume re-run costs one `claude plugin list` call.
+# resume re-run costs one `claude plugin list` call. Only the pre-launch
+# caller's installs are live at turn one; installs made by a SessionStart-hook
+# run surface at the next resume (the registry is read once, at process start).
 claude_bin="$repo_root/node_modules/.bin/claude"
 marketplace_name="melodic-software"
 if [[ -x "$claude_bin" ]] && command -v jq >/dev/null 2>&1; then
   if ! "$claude_bin" plugin marketplace list --json 2>/dev/null |
     jq -e --arg n "$marketplace_name" 'any(.[]; .name == $n)' >/dev/null; then
     "$claude_bin" plugin marketplace add "$repo_root" --scope user >/dev/null ||
-      echo "session-start: warning: could not register the $marketplace_name marketplace" >&2
+      echo "cloud-bootstrap: warning: could not register the $marketplace_name marketplace" >&2
   fi
 
-  # Enabled-and-not-yet-installed, computed from the tracked settings file so the
-  # hook can never drift from the catalog the repo actually enables.
+  # Enabled-and-not-yet-installed, computed from the tracked settings file so
+  # this script can never drift from the catalog the repo actually enables.
   mapfile -t wanted < <(
     jq -r --arg n "$marketplace_name" \
       '.enabledPlugins // {} | to_entries[]
@@ -187,7 +200,7 @@ if [[ -x "$claude_bin" ]] && command -v jq >/dev/null 2>&1; then
         refreshed=$((refreshed + 1))
       else
         failed=$((failed + 1))
-        echo "session-start: warning: plugin refresh failed: $id" >&2
+        echo "cloud-bootstrap: warning: plugin refresh failed: $id" >&2
       fi
       continue
     fi
@@ -195,12 +208,12 @@ if [[ -x "$claude_bin" ]] && command -v jq >/dev/null 2>&1; then
       installed=$((installed + 1))
     else
       failed=$((failed + 1))
-      echo "session-start: warning: plugin install failed: $id" >&2
+      echo "cloud-bootstrap: warning: plugin install failed: $id" >&2
     fi
   done
-  echo "session-start: plugins ${#wanted[@]} enabled, $installed newly installed, $refreshed refreshed, $failed failed"
+  echo "cloud-bootstrap: plugins ${#wanted[@]} enabled, $installed newly installed, $refreshed refreshed, $failed failed"
 else
-  echo "session-start: warning: claude CLI or jq unavailable; plugins will not load" >&2
+  echo "cloud-bootstrap: warning: claude CLI or jq unavailable; plugins will not load" >&2
 fi
 
 # --- Python CI deps (required) -------------------------------------------------
@@ -231,14 +244,14 @@ fetch_release_tool() {
     return 0
   fi
   if [[ "$(uname -m)" != "x86_64" ]]; then
-    echo "session-start: warning: skipping $name (non-x86_64 VM)" >&2
+    echo "cloud-bootstrap: warning: skipping $name (non-x86_64 VM)" >&2
     return 0
   fi
   tmp="$(mktemp -d)"
   local failed=0
   curl -fsSL -o "$tmp/asset" "$url" || failed=1
   if [[ "$failed" -eq 0 ]] && ! echo "$sha  $tmp/asset" | sha256sum --check --quiet --status; then
-    echo "session-start: warning: $name checksum mismatch ($url); refusing to install" >&2
+    echo "cloud-bootstrap: warning: $name checksum mismatch ($url); refusing to install" >&2
     failed=1
   fi
   if [[ "$failed" -eq 0 ]]; then
@@ -251,7 +264,7 @@ fetch_release_tool() {
   if [[ "$failed" -eq 0 && -f "$tmp/$member" ]]; then
     install -m 0755 "$tmp/$member" "$bin_dir/$name"
   else
-    echo "session-start: warning: $name install failed ($url); its checks will SKIP" >&2
+    echo "cloud-bootstrap: warning: $name install failed ($url); its checks will SKIP" >&2
   fi
   rm -rf "$tmp"
   return 0
@@ -284,16 +297,16 @@ fetch_release_tool shfmt \
 # above but an accepted one — npm -g has no --require-hashes equivalent.
 if ! command -v markdownlint-cli2 >/dev/null 2>&1; then
   npm install -g --no-audit --no-fund "markdownlint-cli2@${markdownlint_pin}" ||
-    echo "session-start: warning: markdownlint-cli2 install failed" >&2
+    echo "cloud-bootstrap: warning: markdownlint-cli2 install failed" >&2
 fi
 
 if ! command -v check-jsonschema >/dev/null 2>&1; then
   if command -v uv >/dev/null 2>&1; then
     uv tool install --quiet "check-jsonschema==${check_jsonschema_pin}" ||
-      echo "session-start: warning: check-jsonschema install failed" >&2
+      echo "cloud-bootstrap: warning: check-jsonschema install failed" >&2
   else
     python3 -m pip install --user --quiet "check-jsonschema==${check_jsonschema_pin}" ||
-      echo "session-start: warning: check-jsonschema install failed" >&2
+      echo "cloud-bootstrap: warning: check-jsonschema install failed" >&2
   fi
 fi
 
@@ -304,12 +317,12 @@ fi
 git_dir="$(git rev-parse --git-dir)"
 if [[ -f "$git_dir/shallow" ]]; then
   git fetch --quiet --unshallow ||
-    echo "session-start: warning: could not unshallow; base-ref diffs may fail" >&2
+    echo "cloud-bootstrap: warning: could not unshallow; base-ref diffs may fail" >&2
 fi
 # Explicit destination refspec: in a single-branch clone a bare `fetch origin
 # main` only writes FETCH_HEAD and never creates refs/remotes/origin/main.
 git fetch --quiet origin "+main:refs/remotes/origin/main" ||
-  echo "session-start: warning: could not fetch origin/main" >&2
+  echo "cloud-bootstrap: warning: could not fetch origin/main" >&2
 
 # --- Report --------------------------------------------------------------------
 report_tool() {
@@ -317,12 +330,12 @@ report_tool() {
   local name="$1"
   shift
   if command -v "$name" >/dev/null 2>&1; then
-    echo "session-start: $name $("$name" "$@" 2>/dev/null | head -1)"
+    echo "cloud-bootstrap: $name $("$name" "$@" 2>/dev/null | head -1)"
   else
-    echo "session-start: $name ABSENT (its checks will SKIP)"
+    echo "cloud-bootstrap: $name ABSENT (its checks will SKIP)"
   fi
 }
-echo "session-start: bootstrap complete in $repo_root"
+echo "cloud-bootstrap: bootstrap complete in $repo_root"
 report_tool node --version
 report_tool ruff --version
 report_tool shellcheck --version

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -10,7 +10,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh\""
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/cloud-bootstrap.sh\""
           }
         ]
       }

--- a/docs/CLOUD-FLEET-SETUP.md
+++ b/docs/CLOUD-FLEET-SETUP.md
@@ -22,9 +22,11 @@ result is cached as a filesystem snapshot (the "warm boot": script runs once, la
 from the snapshot; rebuilds only on script/network edits or ~7-day expiry). So the fleet uses
 **one shared environment** whose setup script installs the *union* of static toolchains the
 repos pin — .NET SDKs, Node 24, `gh`, PowerShell — inside the ~5-minute cache-build budget, while
-**each repo owns its own bootstrap** in a committed, idempotent, `CLAUDE_CODE_REMOTE`-guarded
-SessionStart hook that installs manifest-driven dependencies (`npm ci`, repo-local .NET, `uv
-sync`). The environment stays generic; repos opt in by adopting the hook pattern.
+**each repo owns its own bootstrap**: a committed, idempotent, `CLAUDE_CODE_REMOTE`-guarded
+`.claude/cloud-bootstrap.sh` that installs manifest-driven dependencies (`npm ci`, repo-local
+.NET, `uv sync`), run by the environment's setup script pre-launch (the call that gets the repo's
+plugins loaded at turn one) and re-run per session by a registered SessionStart hook as drift
+repair. The environment stays generic; repos opt in by adopting the pattern.
 
 ## Fleet audit (2026-08-13)
 
@@ -89,16 +91,18 @@ exit 0
 What the canonical script does (details and lifecycle in the
 [component README](https://github.com/melodic-software/standards/blob/main/components/cloud-environment/README.md)):
 parallel tracks install `gh` + PowerShell (apt), the fleet's exact .NET SDK pins into
-`/opt/dotnet`, and Node 24.18.0 via the VM's nvm; it then bakes the checked-out repo's own
-SessionStart hook into the snapshot. Every step logs with a timestamp to
+`/opt/dotnet`, and Node 24.18.0 via the VM's nvm; it then runs the checked-out repo's own
+`.claude/cloud-bootstrap.sh` — baking its results into the snapshot, and, because it runs before
+the session process launches, making the repo's plugins live at turn one. Every step logs with a timestamp to
 `/var/log/melodic-env-setup.log`, and `/opt/melodic-env-setup.done` (version + timestamp) is
 written strictly last — so a missing stamp is the signature of an interrupted cache build
 ([#2654](https://github.com/melodic-software/claude-code-plugins/issues/2654) Blocker 2), fixed
 by forcing a rebuild.
 
 Two lifecycle caveats: the fleet's toolchain pins are duplicated into the component by necessity
-(the script cannot read repos it isn't running in) — each repo's hook *also* installs its exact
-SDK repo-locally, so the env copy is a warm cache and the hook is the correctness guarantee. And
+(the script cannot read repos it isn't running in) — each repo's bootstrap *also* installs its
+exact SDK repo-locally, so the env copy is a warm cache and the bootstrap is the correctness
+guarantee. And
 a merged component change does **not** reach existing environments on its own: the snapshot
 rebuilds only on an edit to the environment's script/network fields or ~7-day cache expiry, so
 after a standards bump, force a rebuild with any trivial edit to the script field.
@@ -121,7 +125,7 @@ in cloud sessions, unlike anything user-scoped):
         "hooks": [
           {
             "type": "command",
-            "command": "bash \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/session-start.sh"
+            "command": "bash \"$CLAUDE_PROJECT_DIR\"/.claude/cloud-bootstrap.sh"
           }
         ]
       }
@@ -136,19 +140,21 @@ in cloud sessions, unlike anything user-scoped):
 }
 ```
 
-**`.claude/hooks/session-start.sh`** — manifest-driven, so one template serves the fleet; delete
-the blocks a repo doesn't need. Design rules (same as this repo's production hook): cloud-only
-guard, idempotent (hooks run on every startup *and* resume), warn-and-continue for anything the
-session can limp along without, and `$CLAUDE_ENV_FILE` as the only way to shape the session's
-environment (append `export`-lines, dedup-guarded):
+**`.claude/cloud-bootstrap.sh`** — manifest-driven, so one template serves the fleet; delete
+the blocks a repo doesn't need. Design rules (same as this repo's production bootstrap):
+cloud-only guard, idempotent (the SessionStart hook re-runs it on every startup *and* resume,
+on top of the environment's pre-launch call), warn-and-continue for anything the session can
+limp along without, and `$CLAUDE_ENV_FILE` as the only way to shape the session's environment
+(append `export`-lines, dedup-guarded):
 
 ```bash
 #!/usr/bin/env bash
-# SessionStart bootstrap — cloud sessions only; idempotent; warn-and-continue.
+# Cloud bootstrap — cloud sessions only; idempotent; warn-and-continue. Run by
+# the environment setup script pre-launch and by the SessionStart hook.
 set -u
 [ "${CLAUDE_CODE_REMOTE:-}" = "true" ] || exit 0
 cd "${CLAUDE_PROJECT_DIR:-.}" || exit 0
-warn() { printf 'session-start: %s\n' "$*" >&2; }
+warn() { printf 'cloud-bootstrap: %s\n' "$*" >&2; }
 
 env_line() { # append an export line to the session env, once
   [ -n "${CLAUDE_ENV_FILE:-}" ] || return 0
@@ -253,8 +259,8 @@ session on this repo in the new environment and ask Claude to verify:
    debugging anything else; `/var/log/melodic-env-setup.log` shows how far the build got.
 1. `gh --version`, `pwsh --version`, `dotnet --list-sdks` (expect 10.0.302 and 10.0.400),
    `node --version` (expect the `.node-version` pin), `check-tools` for the VM inventory.
-2. The repo's hook ran: `node_modules/.bin` populated, pinned lint tools present (`typos`,
-   `actionlint`), and re-running the hook is a fast no-op.
+2. The repo's bootstrap ran: `node_modules/.bin` populated, pinned lint tools present (`typos`,
+   `actionlint`), and re-running the bootstrap is a fast no-op.
 3. `echo $GH_TOKEN` prints `proxy-injected` (GitHub proxy is authenticating).
 4. Marketplace plugins loaded (`/plugin` → installed list shows `@melodic-software` entries) in a
    session on a repo that declares them (songwriting or medley).
@@ -264,7 +270,7 @@ session on this repo in the new environment and ask Claude to verify:
 6. Python: in a claude-code-proxy or medley session, `uv python install 3.14` — if the download
    is `403`-blocked (release assets ride the GitHub proxy's repository scope), fall back to the
    VM's system Python for tooling or add the astral-sh host to a Custom allowlist. This repo's
-   SessionStart hook installs from `.github/requirements-ci.txt` with `--require-hashes`; that
+   cloud bootstrap installs from `.github/requirements-ci.txt` with `--require-hashes`; that
    pin list includes cp311 wheels so the cloud VM's system Python 3.11 can satisfy `pyyaml`
    (CI itself uses 3.14).
 

--- a/docs/CLOUD-SESSIONS.md
+++ b/docs/CLOUD-SESSIONS.md
@@ -106,19 +106,22 @@ plus the cost model of
   `CLAUDE_CODE_REMOTE` and make every step idempotent; the cost is paid per session.
 - **Neither is for processes**: the cache keeps files, not running services. Start databases or
   `docker compose` stacks per session (ask Claude, or start them from the hook).
-- **Performance lever — cache the hook's work**: the setup script runs after the repository is
-  cloned, so a guarded line in the environment's setup script can run this repo's bootstrap and
-  bake its results into the cached snapshot, dropping per-session hook time to the idempotent
-  re-check (~3 s here):
+- **The pre-launch call — plugins at turn one, plus cached bootstrap work**: the setup script
+  runs after the repository is cloned and before the session process launches. Claude Code
+  builds its plugin/command/skill registry at process start and never re-reads it, so plugin
+  installs made by a SessionStart hook are invisible to the session that ran the hook; a
+  guarded call to the repo's committed bootstrap from the environment's setup script is the
+  only path that gets plugins loaded at turn one. It also bakes the bootstrap's results into
+  the cached snapshot, dropping per-session hook time to the idempotent re-check (~3 s here):
 
   ```bash
-  [ -f .claude/hooks/session-start.sh ] && CLAUDE_CODE_REMOTE=true bash .claude/hooks/session-start.sh || true
+  [ -f .claude/cloud-bootstrap.sh ] && CLAUDE_CODE_REMOTE=true bash .claude/cloud-bootstrap.sh || true
   ```
 
   The guard keeps it a no-op for repositories without the script, so the environment stays
   generic, and this repo's ~40 s bootstrap fits comfortably inside the five-minute cache-build
   budget. (How the cache interacts with sessions across *different* repos isn't documented;
-  the idempotent hook makes either behavior safe.)
+  the idempotent script makes either behavior safe.)
 
 ### One environment or several?
 
@@ -134,12 +137,16 @@ allowlist.
 
 ## How this repository is set up
 
-The environment side stays generic (Default environment, Trusted network, no variables, at most
-the optional `gh` setup-script one-liner from above). The repo side:
+The environment side stays generic (Default environment, Trusted network, no variables, the
+`gh` setup-script one-liner and the guarded pre-launch bootstrap call from above). The repo side:
 
-- [`.claude/settings.json`](../.claude/settings.json) registers the `SessionStart` hook
-  (matcher `startup|resume`).
-- [`.claude/hooks/session-start.sh`](../.claude/hooks/session-start.sh) is the bootstrap. Cloud
+- [`.claude/cloud-bootstrap.sh`](../.claude/cloud-bootstrap.sh) is the bootstrap, with two
+  callers: the account environments' setup scripts run it (with `CLAUDE_CODE_REMOTE=true`)
+  after clone and before the session process launches — the only path that gets plugins loaded
+  at turn one — and the `SessionStart` hook registered in
+  [`.claude/settings.json`](../.claude/settings.json) (matcher `startup|resume`) re-runs the
+  same script per session start/resume as drift repair, since the environment cache can be
+  ~7 days stale. Cloud
   VMs only; ~40 s on a fresh VM, ~3 s on re-runs. It provisions the tool inventory
   [`ci.yml`](../.github/workflows/ci.yml) pins, reading in-repo manifests wherever one exists:
 
@@ -170,7 +177,7 @@ Playwright. `gh`, `pwsh`, and `lychee` are likewise on-demand.
 
 Being the marketplace doesn't make this repo's plugins active in a session — plugins load only
 when a marketplace is declared, enabled, **and installed**. `.claude/settings.json` declares and
-enables; the session-start hook installs (see
+enables; the cloud bootstrap installs (see
 [Discover and install plugins](https://code.claude.com/docs/en/discover-plugins) and
 [extraKnownMarketplaces / enabledPlugins](https://code.claude.com/docs/en/settings#plugin-settings)):
 
@@ -187,18 +194,25 @@ enables; the session-start hook installs (see
   That is exactly the split the table predicts, and it is why
   [what carries over](https://code.claude.com/docs/en/cloud-environments#what-carries-over-from-your-setup)
   promising plugins "installed at session start from the marketplace you declared" did not hold
-  here. A hook is the durable fix precisely because hooks run untrusted.
+  here. A committed bootstrap is the durable fix precisely because it runs untrusted — but
+  *when* it runs decides what a session sees, per the next bullet.
+- **Claude Code builds its plugin/command/skill registry at process start and never re-reads
+  it**, so plugin installs made by a SessionStart hook are invisible to the session that ran the
+  hook. That is why the bootstrap has two callers: the account environments' setup scripts run
+  it after clone and before the session process launches (the only path that gets plugins live
+  at turn one), and the SessionStart hook re-runs it per session start/resume as drift repair —
+  the environment cache can be ~7 days stale — with its installs going live at the next resume.
 - Being a `directory` source may compound it —
   [that source is documented for development only](https://code.claude.com/docs/en/settings#extraknownmarketplaces)
   and the carry-over note qualifies install-at-session-start with "requires network access to reach
   the marketplace source". The two candidates were not separated, because the trust gate alone
-  accounts for the symptom and the hook makes both moot.
-- The hook therefore registers the checkout by absolute path and installs the enabled set
+  accounts for the symptom and the bootstrap makes both moot.
+- The bootstrap therefore registers the checkout by absolute path and installs the enabled set
   explicitly. It never calls `claude plugin marketplace remove`, which deletes the marketplace's
-  entry from `.claude/settings.json` and would have the hook mutate tracked config.
+  entry from `.claude/settings.json` and would have the script mutate tracked config.
 - On resume it also repairs [same-version commit drift](MIGRATION-PLAYBOOK.md): because a
   directory-source cache is keyed by the semver in `plugin.json` rather than the commit, a
-  presence check alone would keep serving whichever commit installed first. The hook compares the
+  presence check alone would keep serving whichever commit installed first. The script compares the
   `gitCommitSha` recorded at install time against `HEAD` and forces the documented
   uninstall/install/enable cycle for the plugins whose own directory changed between the two, so
   the usual resume stays cheap. Uncommitted edits are out of scope by design — use
@@ -207,12 +221,12 @@ enables; the session-start hook installs (see
   `{"source": "github", "repo": "melodic-software/claude-code-plugins"}` — since the relative
   `directory` source is specific to this repo, whose reason to exist is validating in-flight
   plugin changes. Declaring it is necessary but, per the trust gate above, not sufficient in a
-  cloud session; verify in a fresh session and add the same install-on-start hook if the catalog
-  does not load.
+  cloud session; verify in a fresh session and add the same bootstrap-plus-hook setup if the
+  catalog does not load.
 - `enabledPlugins` turns on the whole catalog, so this repo dogfoods everything it publishes and a
   regression in any plugin surfaces here first. The trade is context: every enabled plugin adds
   per-turn cost, so a *consumer* repo should enable only the plugins it needs rather than copying
-  this set wholesale. The session-start hook provisions every tool the format/lint-on-edit hooks
+  this set wholesale. The cloud bootstrap provisions every tool the format/lint-on-edit hooks
   (`markdown-format`, `bash-format`, `biome-format`, `typos-format`, `actionlint`,
   `eol-normalizer`) shell out to.
 - Entries are sorted alphabetically, one per line, so a single plugin can be flipped to `false`
@@ -236,18 +250,18 @@ Both exist in cloud sessions and don't conflict — they serve different callers
 
 ### Maintenance caveats
 
-- Some hook pin sources are materialized from `melodic-software/standards` (see
-  [`AGENTS.md`](../AGENTS.md)) — of the files the hook reads, `.node-version` is in the synced
-  set (verified against the `chore: sync standards components` history on 2026-07-30), so its
-  Node pin updates arrive via sync. `.claude/settings.json` and the hook script itself are
-  repo-owned.
+- Some bootstrap pin sources are materialized from `melodic-software/standards` (see
+  [`AGENTS.md`](../AGENTS.md)) — of the files the bootstrap reads, `.node-version` is in the
+  synced set (verified against the `chore: sync standards components` history on 2026-07-30), so
+  its Node pin updates arrive via sync. `.claude/settings.json` and the bootstrap script itself
+  are repo-owned.
 - `.github/requirements-ci.txt` is hash-locked. The lockfile carries ABI-specific hashes for both
   the CI interpreter (cp314 / 3.14) and the cloud VM system Python (cp311 / 3.11; #2657), so the
-  SessionStart hook always installs with `--require-hashes` and a digest mismatch stays fatal —
+  bootstrap always installs with `--require-hashes` and a digest mismatch stays fatal —
   no interpreter-mismatch skip, no unpinned fallback. Installs use `pip` rather than `uv`, whose
   PyPI fetches time out against the VM's egress proxy.
-- The hook's own version pins exist only because those tools have no in-repo manifest; the cloud
-  proxy blocks the GitHub API and `releases/latest` redirects, so the hook can't self-resolve
-  "latest". Each GitHub-release asset also carries a pinned SHA-256 the hook verifies before
-  installing (mismatch refuses the install and warns). Bump pin and hash together when the
-  corresponding configs bump.
+- The bootstrap's own version pins exist only because those tools have no in-repo manifest; the
+  cloud proxy blocks the GitHub API and `releases/latest` redirects, so the script can't
+  self-resolve "latest". Each GitHub-release asset also carries a pinned SHA-256 the script
+  verifies before installing (mismatch refuses the install and warns). Bump pin and hash together
+  when the corresponding configs bump.

--- a/docs/CLOUD-SESSIONS.md
+++ b/docs/CLOUD-SESSIONS.md
@@ -155,8 +155,8 @@ The environment side stays generic (Default environment, Trusted network, no var
 | Node | `.node-version` (via the VM's nvm) | required — CI pins a major the VM image doesn't ship |
 | claude CLI + Biome | root `package-lock.json` (`npm ci`) | required |
 | ruff, pytest, pyyaml | `.github/requirements-ci.txt` (hash-locked) | required — `--require-hashes` fails closed |
-| shellcheck, actionlint, typos, editorconfig-checker, gitleaks | pinned in the hook (GitHub release binaries) | best effort — warns and continues |
-| markdownlint-cli2, check-jsonschema | pinned in the hook (npm -g / uv tool) | best effort |
+| shellcheck, actionlint, typos, editorconfig-checker, gitleaks | pinned in the bootstrap (GitHub release binaries) | best effort — warns and continues |
+| markdownlint-cli2, check-jsonschema | pinned in the bootstrap (npm -g / uv tool) | best effort |
 | full git history + `origin/main` | `git fetch` | best effort — the base-ref diff gates need it |
 | the enabled plugin catalog | `enabledPlugins` in `.claude/settings.json` | best effort — a plugin that fails to install costs its skills, not the session |
 


### PR DESCRIPTION
No linked issue

## Summary

Migrates the cloud bootstrap from the SessionStart-hook layout to the split cloud-bootstrap layout: the script moves from `.claude/hooks/session-start.sh` to `.claude/cloud-bootstrap.sh` and is reframed as the repo's cloud bootstrap with two callers — the account environments' setup scripts run it pre-launch (Claude Code builds its plugin/command/skill registry at process start and never re-reads it, so this is the only path that gets plugins live at turn one), and the SessionStart hook re-runs it per session start/resume as drift repair.

## Fix

- `git mv .claude/hooks/session-start.sh .claude/cloud-bootstrap.sh`, keeping the `CLAUDE_CODE_REMOTE` guard, idempotency, and provisioning logic intact; header comments rewritten to describe the two-caller layout, and the log prefix renamed `session-start:` → `cloud-bootstrap:`.
- Adjusted the `BASH_SOURCE`-derived repo-root fallback to the new `.claude/` depth (`/..` instead of `/../..`); `CLAUDE_PROJECT_DIR` remains the preferred root source.
- `.claude/settings.json`: the SessionStart hook (matcher `startup|resume`) now runs `bash "$CLAUDE_PROJECT_DIR/.claude/cloud-bootstrap.sh"`; all other hooks and settings untouched.
- `docs/CLOUD-SESSIONS.md`: updated all path references and the "Plugins in sessions on this repo" section to document the registry-built-at-process-start timing and the two-caller split; the setup-script snippet now calls `.claude/cloud-bootstrap.sh`.
- `docs/CLOUD-FLEET-SETUP.md`: the per-repo fleet template (settings snippet + script template) moved to the same layout, matching what the environment setup scripts now call.

## Verification

- `bash -n .claude/cloud-bootstrap.sh` — OK; `shellcheck` — clean; `shfmt -d` — no diff.
- Run 1 in this cloud session with `CLAUDE_CODE_REMOTE=true` and `CLAUDE_PROJECT_DIR` unset (exercising the new root fallback): completed in ~4.5 s, reported `bootstrap complete in /home/user/claude-code-plugins` (repo root, not its parent), 65 plugins enabled / 0 failed.
- Run 2 with `CLAUDE_CODE_REMOTE=true`: fast no-op (~3.6 s, exit 0).
- Run without `CLAUDE_CODE_REMOTE`: exits 0 in 0.003 s with "not a cloud session; nothing to do." and `git status --porcelain` confirmed the worktree unchanged.
- `markdownlint-cli2`, `typos`, `editorconfig-checker` clean on the changed files; `grep -r 'session-start\.sh'` finds no remaining references.

## Related

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SiC1awyDKZMW2u1Dks1Tqh

---
_Generated by [Claude Code](https://claude.ai/code/session_01SiC1awyDKZMW2u1Dks1Tqh)_