### PR TITLE
chore(claude): disable auto-memory via project settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "autoMemoryEnabled": false,
   "env": {
     "CLAUDE_CODE_DISABLE_AUTO_MEMORY": "1",
     "HOOK_TELEMETRY_SINK": ".claude/hooks/hook-telemetry-sink.sh"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "env": {
+    "CLAUDE_CODE_DISABLE_AUTO_MEMORY": "1",
     "HOOK_TELEMETRY_SINK": ".claude/hooks/hook-telemetry-sink.sh"
   },
   "hooks": {


### PR DESCRIPTION
Closes #

No linked issue

## Summary

Disables Claude Code auto-memory for this repo via project settings, using both levers from the `claude-memory` disable workflow.

## Fix

In `.claude/settings.json`:
- `"autoMemoryEnabled": false` (persistent fallback / `/memory` toggle)
- `"CLAUDE_CODE_DISABLE_AUTO_MEMORY": "1"` in `env` (authoritative override)

## Verification

Matches `plugins/claude-memory/skills/stateless/context/disable.md` both-levers pattern. Takes effect on the next Claude Code session.

## Related

No linked issue — project-settings chore to keep auto-memory off for all clones (local and cloud).

https://claude.ai/code/session_01Vv9chg7WBeXL7otV1SMJE6