### PR TITLE
fix(disk-hygiene): re-land the guard allowlist and harden its trust anchor

### DIFF
--- a/plugins/disk-hygiene/.claude-plugin/plugin.json
+++ b/plugins/disk-hygiene/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "disk-hygiene",
-  "version": "0.20.6",
+  "version": "0.20.7",
   "description": "Context-aware disk hygiene for arbitrary directory trees: inventories orphaned and temporary artifacts, classifies evidence into review tiers, and offers exact-path cleanup only after a fresh safety preview and explicit per-tier approval. The target is read-only by default; OS-managed paths, links and mount points, VCS-tracked content without the complete checkout evidence bundle, changed entries, and live-handle uncertainty fail closed.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/disk-hygiene/CHANGELOG.md
+++ b/plugins/disk-hygiene/CHANGELOG.md
@@ -3,6 +3,40 @@
 All notable changes to the `disk-hygiene` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.20.7]
+
+### Fixed
+
+- **Re-landed the belt's read-only allowlist and session-honest docstring, and anchored
+  its trust check (#2618, #2691).** PR #2641 merged from a tree predating PR #2639 and its
+  squash merge reverted #2639 wholesale; CI stayed green because the revert removed the
+  tests with the code. `resolve_mode()` again documents that a skill-frontmatter
+  `PreToolUse` hook stays armed for the rest of the session rather than only while cleanup
+  is the active work, and the read-only supporting Bash allowlist (`ls`, `test`, `stat`,
+  `du`, `pwd`, `basename`, `dirname`, `find`, `file`, `[`) is restored — `find` gated by
+  the full GNU/BSD side-effect primary set, everything else still deny-by-default.
+- **Recycle Bin deletion spellings are recognized on the PowerShell belt (#2595).**
+  `Microsoft.VisualBasic.FileIO.FileSystem::DeleteFile`/`DeleteDirectory` and
+  `Shell.Application` `NameSpace(10)`/`NameSpace(0xa)` with `MoveHere`/`InvokeVerb` now
+  prompt like `Remove-Item`. The skill's own manual-handoff lane recommends Recycle Bin
+  removal, so these were the one deletion route the belt never saw.
+
+### Security
+
+- **Trusted-binary matching is anchored to a resolved installation root, not a path
+  substring (#2618).** `_TRUSTED_READONLY_BIN_SUBSTRINGS_NT` matched fragments such as
+  `/git/usr/bin/` and `/windows/system32/` anywhere in a path, so a repository-controlled
+  `D:/anyrepo/git/usr/bin/find` was trusted and a planted binary carrying an allowlisted
+  basename was hard-`allow`ed, bypassing even the user's own permission prompt. Trust now
+  derives from independently located Git installation roots and from `%SystemRoot%`,
+  compared as an anchored case-insensitive path prefix; an unresolvable root contributes
+  no trusted directories.
+- **`[` must clear the same executable-identity check as every other head (#2618).** The
+  `[ ... ]` branch returned before the trusted-binary check, so `[` was trusted on name
+  alone — the shell-function-shadowing exposure the guard itself cites to deny bare
+  `python`/`python3`. It is now allowed only where a real `[` binary resolves under a
+  trusted root, and denied where that cannot be proven.
+
 ## [0.20.6]
 
 ### Fixed
@@ -18,6 +52,7 @@ All notable changes to the `disk-hygiene` plugin are documented here. Format fol
   `safety-model.md` pointers. Guard-code recovery remains in the sibling lane.
 
 ## [0.20.5]
+
 
 ### Fixed
 

--- a/plugins/disk-hygiene/CHANGELOG.md
+++ b/plugins/disk-hygiene/CHANGELOG.md
@@ -13,8 +13,9 @@ All notable changes to the `disk-hygiene` plugin are documented here. Format fol
   tests with the code. `resolve_mode()` again documents that a skill-frontmatter
   `PreToolUse` hook stays armed for the rest of the session rather than only while cleanup
   is the active work, and the read-only supporting Bash allowlist (`ls`, `test`, `stat`,
-  `du`, `pwd`, `basename`, `dirname`, `find`, `file`, `[`) is restored — `find` gated by
-  the full GNU/BSD side-effect primary set, everything else still deny-by-default.
+  `du`, `pwd`, `basename`, `dirname`, `find`, `file`, `[`) is restored as absolute paths
+  under trusted system directories — `find` gated by the full GNU/BSD side-effect primary
+  set, everything else still deny-by-default.
 - **Recycle Bin deletion spellings are recognized on the PowerShell belt (#2595).**
   `Microsoft.VisualBasic.FileIO.FileSystem::DeleteFile`/`DeleteDirectory` and
   `Shell.Application` `NameSpace(10)`/`NameSpace(0xa)` with `MoveHere`/`InvokeVerb` now
@@ -28,14 +29,18 @@ All notable changes to the `disk-hygiene` plugin are documented here. Format fol
   `/git/usr/bin/` and `/windows/system32/` anywhere in a path, so a repository-controlled
   `D:/anyrepo/git/usr/bin/find` was trusted and a planted binary carrying an allowlisted
   basename was hard-`allow`ed, bypassing even the user's own permission prompt. Trust now
-  derives from independently located Git installation roots and from `%SystemRoot%`,
-  compared as an anchored case-insensitive path prefix; an unresolvable root contributes
-  no trusted directories.
+  derives from independently located Git installation roots (`ProgramFiles`,
+  `ProgramFiles(x86)`, `LocalAppData\\Programs`) and from `%SystemRoot%`, compared as an
+  anchored case-insensitive path prefix — never from a `PATH`-selected `git.exe`.
 - **`[` must clear the same executable-identity check as every other head (#2618).** The
   `[ ... ]` branch returned before the trusted-binary check, so `[` was trusted on name
   alone — the shell-function-shadowing exposure the guard itself cites to deny bare
-  `python`/`python3`. It is now allowed only where a real `[` binary resolves under a
-  trusted root, and denied where that cannot be proven.
+  `python`/`python3`. It is now allowed only as an absolute trusted `/usr/bin/[ ... ]`
+  form.
+- **Bare allowlisted heads are denied (#2618).** `shutil.which("ls")` finds the system
+  binary while Bash still executes an exported `BASH_FUNC_ls%%` first; only absolute
+  paths under trusted system directories (MSYS `/usr/bin/...` mapped through the known
+  Git root on Windows) can hard-`allow`.
 
 ## [0.20.6]
 

--- a/plugins/disk-hygiene/CHANGELOG.md
+++ b/plugins/disk-hygiene/CHANGELOG.md
@@ -58,7 +58,6 @@ All notable changes to the `disk-hygiene` plugin are documented here. Format fol
 
 ## [0.20.5]
 
-
 ### Fixed
 
 - **PowerShell `>>` append redirection is flagged like `>` (#2675).** `_POWERSHELL_OUTPUT_REDIRECT`

--- a/plugins/disk-hygiene/skills/clean/scripts/destructive_guard.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/destructive_guard.py
@@ -1431,9 +1431,10 @@ def _bash_denial_guidance(authority: str | None) -> str:
         f'"{_display_path(_engine_script_path())}", plus the argument-free '
         f'read-only kill-switch probe "{_display_path(_probe_script_path())}", '
         f"plus literal-form read-only supporting commands ({supporting}; find "
-        "without -delete/-exec/-ok/-fprint side-effect primaries; bare names "
-        "only when they resolve to trusted system binaries, or absolute paths "
-        "under those directories) — "
+        "without -delete/-exec/-ok/-fprint side-effect primaries; [ only as a "
+        "complete [ ... ] expression with the closing ] bookend; every head, "
+        "[ included, only when it resolves to a trusted system binary — a bare "
+        "name via PATH lookup, or an absolute path under those directories) — "
         "all of them using the hook's absolute Python interpreter "
         f'"{_display_python()}" for engine/probe shapes. Bare python/python3 '
         "commands are denied because shell functions and aliases can replace them."

--- a/plugins/disk-hygiene/skills/clean/scripts/destructive_guard.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/destructive_guard.py
@@ -1089,45 +1089,49 @@ _NT_SYSTEM_TRUSTED_BIN_SUBDIRS = (
 )
 
 
-def _nt_git_installation_root() -> Path | None:
-    """Resolve the Git-for-Windows installation root from the ``git`` executable.
+def _nt_known_git_installation_roots() -> tuple[Path, ...]:
+    """Git-for-Windows roots from independently trusted install locations.
 
-    ``shutil.which`` may land on ``<root>/cmd/git.exe``, ``<root>/bin/git.exe``,
-    or ``<root>/mingw64/bin/git.exe`` depending on how PATH is composed, so the
-    launcher directory is peeled back to the installation root. Returns ``None``
-    when ``git`` cannot be located or resolved — the caller then trusts NOTHING
-    from a Git tree rather than falling back to a permissive match.
+    Never derived from ``PATH`` / ``shutil.which("git")``: a project-controlled
+    directory ahead on ``PATH`` can plant ``cmd/git.exe`` and poison the trusted
+    root, recreating the arbitrary-executable bypass the anchored-prefix change
+    closed. Only well-known installer destinations under ``ProgramFiles``,
+    ``ProgramFiles(x86)``, and ``LocalAppData\\Programs`` contribute roots, and
+    only when that directory actually exists.
     """
-    located = shutil.which("git")
-    if not located:
-        return None
-    try:
-        resolved = Path(located).resolve()
-    except OSError:
-        return None
-    parent = resolved.parent
-    if parent.name.casefold() in {"cmd", "bin"}:
-        parent = parent.parent
-    if parent.name.casefold() in {"mingw64", "mingw32", "usr"}:
-        parent = parent.parent
-    return parent
+    candidates: list[tuple[str, tuple[str, ...]]] = [
+        ("ProgramFiles", ("Git",)),
+        ("ProgramFiles(x86)", ("Git",)),
+        ("LocalAppData", ("Programs", "Git")),
+    ]
+    roots: list[Path] = []
+    for key, rel in candidates:
+        base = os.environ.get(key)
+        if not base:
+            continue
+        try:
+            candidate = Path(base).joinpath(*rel).resolve()
+        except OSError:
+            continue
+        if candidate.is_dir():
+            roots.append(candidate)
+    return tuple(roots)
 
 
 @functools.lru_cache(maxsize=1)
 def _nt_trusted_readonly_bin_roots() -> tuple[Path, ...]:
     """Resolved absolute directories on Windows whose contents the belt trusts.
 
-    Built from real installation roots — the located ``git`` executable and
+    Built from independently located Git installation roots and
     ``%SystemRoot%`` — because a SUBSTRING match on a path fragment such as
     ``/git/usr/bin/`` is satisfied by any repository-controlled directory that
     merely spells that fragment (``D:/anyrepo/git/usr/bin/find``), which would
     hard-``allow`` a planted binary carrying an allowlisted basename. Anchoring
     to the resolved root removes that bypass; an unresolvable root contributes
-    NO trusted directories.
+    NO trusted directories. Git roots are never taken from ``PATH``.
     """
     roots: list[Path] = []
-    git_root = _nt_git_installation_root()
-    if git_root is not None:
+    for git_root in _nt_known_git_installation_roots():
         roots.extend(git_root.joinpath(*parts) for parts in _NT_GIT_TRUSTED_BIN_SUBDIRS)
     system_root = os.environ.get("SystemRoot") or os.environ.get("SYSTEMROOT")
     if system_root:
@@ -1173,32 +1177,76 @@ def _path_under_trusted_readonly_bin(path: Path) -> bool:
 def _trusted_system_readonly_head(head: str) -> bool:
     """True when ``head`` is a trusted-system executable for the allowlist.
 
-    - Bare names: resolve with ``shutil.which`` (ignores shell functions), then
-      require the real path under a trusted prefix. Shadowed PATH entries and
-      failed resolution fail closed — same rationale as denying bare
-      ``python``/``python3``.
-    - Absolute paths: require the real path (symlink-resolved) under a trusted
-      prefix. Relative path-qualified forms are denied.
+    Absolute paths only: require the real path (symlink-resolved) under a
+    trusted prefix. Bare names are denied — ``shutil.which`` finds the system
+    binary while Bash still executes an exported function of the same name
+    first (``BASH_FUNC_ls%%``), so a which()-based identity check cannot prove
+    what the shell will run. Relative path-qualified forms are denied.
+
+    On Windows, Git Bash spells system tools as MSYS paths (``/usr/bin/ls``).
+    Native ``Path.resolve`` would map those onto the current drive, so they are
+    reinterpreted against the known Git installation roots instead.
     """
     if not head:
         return False
-    if "/" in head or "\\" in head:
-        candidate = Path(head)
-        if not candidate.is_absolute():
+    if "/" not in head and "\\" not in head:
+        return False
+    candidate = Path(head)
+    if not candidate.is_absolute():
+        return False
+    if os.name == "nt" and head.startswith("/") and not head.startswith("//"):
+        # MSYS absolute path: /usr/bin/ls → <GitRoot>/usr/bin/ls[.exe]
+        rel_parts = tuple(part for part in head.split("/") if part)
+        if not rel_parts:
             return False
-        try:
-            resolved = candidate.resolve()
-        except OSError:
-            return False
-        return _path_under_trusted_readonly_bin(resolved)
-    located = shutil.which(head)
-    if not located:
+        for git_root in _nt_known_git_installation_roots():
+            mapped = git_root.joinpath(*rel_parts)
+            for variant in (mapped, mapped.with_suffix(".exe"), mapped.with_suffix(".EXE")):
+                try:
+                    resolved = variant.resolve()
+                except OSError:
+                    continue
+                if _path_under_trusted_readonly_bin(resolved):
+                    return True
         return False
     try:
-        resolved = Path(located).resolve()
+        resolved = candidate.resolve()
     except OSError:
         return False
     return _path_under_trusted_readonly_bin(resolved)
+
+
+def _absolute_bracket_test_words(command: str) -> tuple[str, list[str]] | None:
+    """Parse ``/usr/bin/[ ... ]`` (absolute ``[``) into ``(head, interior_words)``.
+
+    Bare ``[ ... ]`` is intentionally not accepted: a shell function named ``[``
+    shadows the binary the same way a function shadows bare ``ls``.
+    ``_literal_shell_words`` rejects ``[``/``]`` as metacharacters, so this
+    path is parsed with the same bookend rules as the bare form, then the
+    absolute head is identity-checked separately.
+    """
+    text = command.strip()
+    space = text.find(" ")
+    if space < 0:
+        return None
+    head = text[:space]
+    if not head.endswith("["):
+        return None
+    if "/" not in head and "\\" not in head:
+        return None
+    rest = text[space + 1 :]
+    # ``/usr/bin/[`` receives ``]`` as its own final argv word.
+    if rest != "]" and not rest.endswith(" ]"):
+        return None
+    interior = "" if rest == "]" else rest[:-1].strip()
+    if any(value in _SHELL_EXPANSION_OR_OPERATOR_CHARS for value in interior):
+        return None
+    if not interior:
+        return head, []
+    words = _literal_shell_words(interior)
+    if words is None:
+        return None
+    return head, words
 
 
 def is_exact_readonly_supporting_command(command: str) -> bool:
@@ -1207,19 +1255,16 @@ def is_exact_readonly_supporting_command(command: str) -> bool:
     The belt remains deny-by-default; this opens only the small inspection set
     needed after the skill-frontmatter hook stays armed for the rest of the
     session (#2618). Engine containment is still the deletion authority.
-    Bare names and absolute trusted paths both require executable identity under
-    a trusted system directory before they are allowed.
+    Heads must be absolute paths under a trusted system directory — bare names
+    are denied because exported shell functions shadow them.
     """
-    bracket_words = _parse_bracket_test_words(command)
-    if bracket_words is not None:
-        # ``[`` requires a non-empty expression and a closing ``]`` bookend, AND
-        # the same trusted-executable identity every other head must prove. The
-        # guard denies bare ``python``/``python3`` because a shell function or
-        # alias can replace them; ``[`` is no different, so it is not trusted on
-        # name alone. Where ``[`` resolves to no trusted system binary (it is
-        # commonly only a shell builtin), the shape is unprovable and therefore
-        # denied — non-Bash read-only tools remain available for inspection.
-        return bool(bracket_words) and _trusted_system_readonly_head("[")
+    absolute_bracket = _absolute_bracket_test_words(command)
+    if absolute_bracket is not None:
+        head, bracket_words = absolute_bracket
+        return bool(bracket_words) and _trusted_system_readonly_head(head)
+    # Bare ``[ ... ]`` is never allowlisted (function-shadowable bookend).
+    if _parse_bracket_test_words(command) is not None:
+        return False
     tokens = _literal_shell_words(command)
     if tokens is None or not tokens:
         return False
@@ -1431,10 +1476,11 @@ def _bash_denial_guidance(authority: str | None) -> str:
         f'"{_display_path(_engine_script_path())}", plus the argument-free '
         f'read-only kill-switch probe "{_display_path(_probe_script_path())}", '
         f"plus literal-form read-only supporting commands ({supporting}; find "
-        "without -delete/-exec/-ok/-fprint side-effect primaries; [ only as a "
-        "complete [ ... ] expression with the closing ] bookend; every head, "
-        "[ included, only when it resolves to a trusted system binary — a bare "
-        "name via PATH lookup, or an absolute path under those directories) — "
+        "without -delete/-exec/-ok/-fprint side-effect primaries; [ only as an "
+        "absolute-path complete /usr/bin/[ ... ] expression with the closing ] "
+        "bookend; every head, [ included, only as an absolute path under a "
+        "trusted system directory — bare names are denied because exported "
+        "shell functions shadow them) — "
         "all of them using the hook's absolute Python interpreter "
         f'"{_display_python()}" for engine/probe shapes. Bare python/python3 '
         "commands are denied because shell functions and aliases can replace them."

--- a/plugins/disk-hygiene/skills/clean/scripts/destructive_guard.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/destructive_guard.py
@@ -41,6 +41,7 @@ from __future__ import annotations
 
 import contextlib
 import functools
+import shutil
 import json
 import math
 import os
@@ -265,8 +266,10 @@ def _plugin_cache_family_root() -> str | None:
     the escape exists so a consumer's own ``tools/hygiene.py`` is not mistaken
     for this engine (#1640, #1611), and a previous version of this plugin is
     not a consumer's tool. Handing it the escape leaves the kill switch
-    unenforced against it whenever the clean skill is not the active work,
-    because the plugin-level gate is the only guard in that state (#1805).
+    unenforced against it whenever only the plugin-level gate is armed
+    (before the skill-frontmatter belt registers, or in sessions that never
+    invoke ``clean``), because the plugin-level gate is the only guard in
+    that state (#1805).
 
     The prefix is derived from this module's OWN path rather than from
     ``--plugin-root``: ``__file__`` is the file actually executing, so it needs
@@ -465,8 +468,8 @@ def _engine_gate_relevant(command: str, tool_name: str = "Bash") -> bool:
     with no separator, an alias inside a command the literal parser rejects
     when the marker is absent, and a copied engine. This is a belt, not the
     authority: an invocation smuggled past it still answers to the engine's own
-    preview/approval-token containment (and to the skill-scoped belt during
-    active cleanup).
+    preview/approval-token containment (and to the skill-frontmatter belt for
+    the rest of the session once that belt has registered).
     """
 
     def _is_interpreter(word: str) -> bool:
@@ -641,13 +644,16 @@ def _engine_gate_relevant(command: str, tool_name: str = "Bash") -> bool:
 def resolve_mode() -> str:
     """Resolve which registration surface launched this guard.
 
-    ``belt`` (default) is the skill-scoped deployment: deny-by-default Bash and
-    deletion-spelling PowerShell discipline, tolerable only while the clean skill
-    is the active work. ``engine-gate`` is the plugin-level deployment: it cares
-    ONLY about engine invocations (kill switch + data-root authority must hold in
-    every session), so any command that does not reference the engine defers
-    instantly — a plugin-level hook must never tax unrelated work. An
-    unrecognized or absent value falls back to ``belt``, the stricter mode.
+    ``belt`` (default) is the skill-frontmatter deployment: deny-by-default Bash
+    (with a small read-only supporting allowlist) and deletion-spelling PowerShell
+    discipline. Claude Code registers skill-frontmatter ``PreToolUse`` hooks for
+    the rest of the session after the skill is invoked — not only while cleanup is
+    the active work — so this mode stays armed session-wide once registered
+    (#2618). ``engine-gate`` is the plugin-level deployment: it cares ONLY about
+    engine invocations (kill switch + data-root authority must hold in every
+    session), so any command that does not reference the engine defers instantly
+    — a plugin-level hook must never tax unrelated work. An unrecognized or
+    absent value falls back to ``belt``, the stricter mode.
     """
     value = _argv_flag_value(sys.argv[1:], _MODE_FLAG)
     return value if value in {_MODE_BELT, _MODE_ENGINE_GATE} else _MODE_BELT
@@ -987,6 +993,249 @@ def is_exact_kill_switch_probe(command: str) -> bool:
     return _script_path_key(tokens[1]) == _script_path_key(str(_probe_script_path()))
 
 
+# Narrow belt-mode Bash allowlist for cleanup inspection (#2591). Bare names are
+# accepted only when ``shutil.which`` lands under a trusted system directory;
+# absolute paths under those same directories are accepted when the basename is
+# allowlisted. Relative path-qualified forms (``./ls``) fail closed. Every shape
+# still has to clear ``_literal_shell_words`` (no metacharacters, operators, or
+# redirections). Deletion authority remains the engine's own containment.
+_READONLY_SUPPORTING_BASH_HEADS = frozenset(
+    {
+        "ls",
+        "test",
+        "stat",
+        "du",
+        "pwd",
+        "basename",
+        "dirname",
+        "find",
+        "file",
+    }
+)
+# GNU/BSD find primaries that write or execute; a literal allowlist cannot prove
+# an ``-exec`` payload harmless, so any of these fails closed.
+_FIND_SIDE_EFFECT_PRIMARIES = frozenset(
+    {
+        "-delete",
+        "-exec",
+        "-execdir",
+        "-ok",
+        "-okdir",
+        "-fprint",
+        "-fprint0",
+        "-fprintf",
+        "-fls",
+    }
+)
+
+
+def _parse_bracket_test_words(command: str) -> list[str] | None:
+    """Parse ``[ ... ]`` with the same literal rules as other supporting commands.
+
+    ``[`` / ``]`` are otherwise rejected as shell metacharacters; here they are
+    required bookends and every interior character still faces the expansion /
+    operator deny list.
+    """
+    text = command.strip()
+    if len(text) < 2 or text[0] != "[" or text[-1] != "]":
+        return None
+    interior = text[1:-1]
+    if any(value in _SHELL_EXPANSION_OR_OPERATOR_CHARS for value in interior):
+        return None
+    stripped = interior.strip()
+    if not stripped:
+        return []
+    return _literal_shell_words(stripped)
+
+
+def _is_readonly_find(tokens: list[str]) -> bool:
+    """True only when ``find`` carries no side-effect primary."""
+    for token in tokens[1:]:
+        if token.casefold() in {name.casefold() for name in _FIND_SIDE_EFFECT_PRIMARIES}:
+            return False
+    return True
+
+
+def _readonly_supporting_basename(head: str) -> str:
+    """Basename of a supporting command head on either path separator."""
+    return _PATH_SEPARATOR.split(head.rstrip("/\\"))[-1]
+
+
+# Absolute prefixes where an allowlisted head may live after realpath. A
+# repo-controlled ``./ls`` on PATH, or a user ``~/bin/ls``, must not inherit
+# belt approval. ``Path.resolve`` follows symlinks so a trusted-prefix symlink
+# into an untrusted tree also fails closed.
+_TRUSTED_READONLY_BIN_PREFIXES = (
+    "/bin/",
+    "/usr/bin/",
+    "/usr/local/bin/",
+    "/sbin/",
+    "/usr/sbin/",
+    # Windows Git Bash / MSYS common locations
+    "/mingw64/bin/",
+)
+# Relative binary directories inside a Git-for-Windows installation where an
+# allowlisted read-only head legitimately lives. Joined onto the RESOLVED
+# installation root, never matched as a substring (see below).
+_NT_GIT_TRUSTED_BIN_SUBDIRS = (
+    ("usr", "bin"),
+    ("mingw64", "bin"),
+    ("mingw32", "bin"),
+)
+# Relative binary directories inside the resolved Windows system root.
+_NT_SYSTEM_TRUSTED_BIN_SUBDIRS = (
+    ("System32",),
+    ("SysWOW64",),
+)
+
+
+def _nt_git_installation_root() -> Path | None:
+    """Resolve the Git-for-Windows installation root from the ``git`` executable.
+
+    ``shutil.which`` may land on ``<root>/cmd/git.exe``, ``<root>/bin/git.exe``,
+    or ``<root>/mingw64/bin/git.exe`` depending on how PATH is composed, so the
+    launcher directory is peeled back to the installation root. Returns ``None``
+    when ``git`` cannot be located or resolved — the caller then trusts NOTHING
+    from a Git tree rather than falling back to a permissive match.
+    """
+    located = shutil.which("git")
+    if not located:
+        return None
+    try:
+        resolved = Path(located).resolve()
+    except OSError:
+        return None
+    parent = resolved.parent
+    if parent.name.casefold() in {"cmd", "bin"}:
+        parent = parent.parent
+    if parent.name.casefold() in {"mingw64", "mingw32", "usr"}:
+        parent = parent.parent
+    return parent
+
+
+@functools.lru_cache(maxsize=1)
+def _nt_trusted_readonly_bin_roots() -> tuple[Path, ...]:
+    """Resolved absolute directories on Windows whose contents the belt trusts.
+
+    Built from real installation roots — the located ``git`` executable and
+    ``%SystemRoot%`` — because a SUBSTRING match on a path fragment such as
+    ``/git/usr/bin/`` is satisfied by any repository-controlled directory that
+    merely spells that fragment (``D:/anyrepo/git/usr/bin/find``), which would
+    hard-``allow`` a planted binary carrying an allowlisted basename. Anchoring
+    to the resolved root removes that bypass; an unresolvable root contributes
+    NO trusted directories.
+    """
+    roots: list[Path] = []
+    git_root = _nt_git_installation_root()
+    if git_root is not None:
+        roots.extend(git_root.joinpath(*parts) for parts in _NT_GIT_TRUSTED_BIN_SUBDIRS)
+    system_root = os.environ.get("SystemRoot") or os.environ.get("SYSTEMROOT")
+    if system_root:
+        try:
+            resolved_system = Path(system_root).resolve()
+        except OSError:
+            resolved_system = None
+        if resolved_system is not None:
+            roots.extend(
+                resolved_system.joinpath(*parts)
+                for parts in _NT_SYSTEM_TRUSTED_BIN_SUBDIRS
+            )
+    return tuple(roots)
+
+
+def _is_within_directory(path: Path, directory: Path) -> bool:
+    """True when ``path`` sits under ``directory`` as an ANCHORED path prefix.
+
+    Compared case-insensitively (Windows paths are case-insensitive) on posix
+    spellings, and via a trailing separator so a sibling directory whose name
+    merely starts with the trusted one (``.../Gitx/usr/bin``) cannot match.
+    """
+    base = directory.as_posix().casefold().rstrip("/")
+    if not base:
+        return False
+    return path.as_posix().casefold().startswith(base + "/")
+
+
+def _path_under_trusted_readonly_bin(path: Path) -> bool:
+    """True when ``path`` is a real file under a trusted system binary directory."""
+    if not path.is_file():
+        return False
+    if os.name == "nt":
+        if any(
+            _is_within_directory(path, root)
+            for root in _nt_trusted_readonly_bin_roots()
+        ):
+            return True
+    key = path.as_posix()
+    return any(key.startswith(prefix) for prefix in _TRUSTED_READONLY_BIN_PREFIXES)
+
+
+def _trusted_system_readonly_head(head: str) -> bool:
+    """True when ``head`` is a trusted-system executable for the allowlist.
+
+    - Bare names: resolve with ``shutil.which`` (ignores shell functions), then
+      require the real path under a trusted prefix. Shadowed PATH entries and
+      failed resolution fail closed — same rationale as denying bare
+      ``python``/``python3``.
+    - Absolute paths: require the real path (symlink-resolved) under a trusted
+      prefix. Relative path-qualified forms are denied.
+    """
+    if not head:
+        return False
+    if "/" in head or "\\" in head:
+        candidate = Path(head)
+        if not candidate.is_absolute():
+            return False
+        try:
+            resolved = candidate.resolve()
+        except OSError:
+            return False
+        return _path_under_trusted_readonly_bin(resolved)
+    located = shutil.which(head)
+    if not located:
+        return False
+    try:
+        resolved = Path(located).resolve()
+    except OSError:
+        return False
+    return _path_under_trusted_readonly_bin(resolved)
+
+
+def is_exact_readonly_supporting_command(command: str) -> bool:
+    """Return True for one literal-form read-only supporting Bash command (#2591).
+
+    The belt remains deny-by-default; this opens only the small inspection set
+    needed after the skill-frontmatter hook stays armed for the rest of the
+    session (#2618). Engine containment is still the deletion authority.
+    Bare names and absolute trusted paths both require executable identity under
+    a trusted system directory before they are allowed.
+    """
+    bracket_words = _parse_bracket_test_words(command)
+    if bracket_words is not None:
+        # ``[`` requires a non-empty expression and a closing ``]`` bookend, AND
+        # the same trusted-executable identity every other head must prove. The
+        # guard denies bare ``python``/``python3`` because a shell function or
+        # alias can replace them; ``[`` is no different, so it is not trusted on
+        # name alone. Where ``[`` resolves to no trusted system binary (it is
+        # commonly only a shell builtin), the shape is unprovable and therefore
+        # denied — non-Bash read-only tools remain available for inspection.
+        return bool(bracket_words) and _trusted_system_readonly_head("[")
+    tokens = _literal_shell_words(command)
+    if tokens is None or not tokens:
+        return False
+    head = tokens[0]
+    basename = _readonly_supporting_basename(head)
+    if basename not in _READONLY_SUPPORTING_BASH_HEADS:
+        return False
+    if not _trusted_system_readonly_head(head):
+        return False
+    if basename == "find":
+        return _is_readonly_find(tokens)
+    if basename == "test":
+        return len(tokens) >= 2
+    return True
+
+
 _POWERSHELL_MUTATION_WORDS = re.compile(
     r"(?i)(?<![\w./\\-])("
     r"remove-item|rm|rmdir|del|erase|rd|ri|clear-content|clear-recyclebin|rimraf|unlink"
@@ -1043,6 +1292,29 @@ _POWERSHELL_ROBOCOPY_PURGE = re.compile(
 _POWERSHELL_QUALIFIED_DELETE = re.compile(
     r"(?i)[a-z][\w.]*\\(remove-item|clear-content|clear-recyclebin)(?![\w-])"
 )
+# Manual-handoff Recycle Bin spellings the skill prefers (#2595). VisualBasic
+# FileIO is also reachable via deletefile/deletedirectory word matches; keep an
+# explicit type-qualified form so the verdict names the preferred path. Shell
+# .Application NameSpace(10) (CSIDL_BITBUCKET; also 0xa) + MoveHere/InvokeVerb
+# had no prior coverage.
+_POWERSHELL_VB_FILESYSTEM_DELETE = re.compile(
+    r"(?i)Microsoft\.VisualBasic\.FileIO\.FileSystem\s*\]?\s*::\s*"
+    r"Delete(?:File|Directory)\b"
+)
+_POWERSHELL_SHELL_APP_NAMESPACE_BIN = re.compile(
+    r"(?i)NameSpace\s*\(\s*(?:10|0x0*a)\s*\)"
+)
+_POWERSHELL_SHELL_APP_BIN_ACTION = re.compile(
+    r"(?i)(?<![\w])(?:MoveHere|InvokeVerb)\b"
+)
+
+
+def _is_shell_application_recycle_bin_delete(command: str) -> bool:
+    """True for Shell.Application Recycle Bin MoveHere / InvokeVerb shapes."""
+    return (
+        _POWERSHELL_SHELL_APP_NAMESPACE_BIN.search(command) is not None
+        and _POWERSHELL_SHELL_APP_BIN_ACTION.search(command) is not None
+    )
 
 
 def powershell_decision(command: str, enabled: bool) -> tuple[str, str] | None:
@@ -1072,6 +1344,18 @@ def powershell_decision(command: str, enabled: bool) -> tuple[str, str] | None:
             "disk-hygiene engine invocations must go through the Bash tool's "
             "exact guarded command shapes, not PowerShell. To READ the engine "
             "source, use non-shell file tools.",
+        )
+    if _POWERSHELL_VB_FILESYSTEM_DELETE.search(command):
+        return _powershell_mutation_verdict(
+            enabled,
+            "disk-hygiene flagged Microsoft.VisualBasic.FileIO.FileSystem "
+            "DeleteFile/DeleteDirectory (Recycle Bin / FileIO deletion).",
+        )
+    if _is_shell_application_recycle_bin_delete(command):
+        return _powershell_mutation_verdict(
+            enabled,
+            "disk-hygiene flagged a Shell.Application NameSpace(10) Recycle Bin "
+            "MoveHere/InvokeVerb deletion.",
         )
     match = _POWERSHELL_MUTATION_WORDS.search(command)
     if match:
@@ -1140,15 +1424,22 @@ def _bash_denial_guidance(authority: str | None) -> str:
         )
     )
     subcommands = ", ".join(_ALLOWED_ENGINE_SUBCOMMANDS[:-1])
+    supporting = ", ".join(sorted(_READONLY_SUPPORTING_BASH_HEADS | {"["}))
     return (
         "Disk-hygiene fails closed: Bash is restricted to exact bundled "
         f"{subcommands}, and {_ALLOWED_ENGINE_SUBCOMMANDS[-1]} invocations of "
         f'"{_display_path(_engine_script_path())}", plus the argument-free '
-        f'read-only kill-switch probe "{_display_path(_probe_script_path())}" — '
+        f'read-only kill-switch probe "{_display_path(_probe_script_path())}", '
+        f"plus literal-form read-only supporting commands ({supporting}; find "
+        "without -delete/-exec/-ok/-fprint side-effect primaries; bare names "
+        "only when they resolve to trusted system binaries, or absolute paths "
+        "under those directories) — "
         "all of them using the hook's absolute Python interpreter "
-        f'"{_display_python()}". Bare python/python3 commands are denied because shell functions and aliases can replace them.'
+        f'"{_display_python()}" for engine/probe shapes. Bare python/python3 '
+        "commands are denied because shell functions and aliases can replace them."
         + data_sentence
-        + " Use non-Bash read-only tools for supporting inspection."
+        + " Supporting inspection may use that small Bash allowlist or non-Bash "
+        "read-only tools; everything else stays denied."
     )
 
 
@@ -1317,6 +1608,18 @@ def _decide(command: str, tool_name: str, start: float) -> int:
                 decision(
                     "allow",
                     "Exact bundled disk-hygiene kill-switch probe (read-only report).",
+                )
+            )
+        )
+        _emit_guard_telemetry(start, tool_name, "ok", decision_value="allow")
+        return 0
+    if is_exact_readonly_supporting_command(command):
+        print(
+            json.dumps(
+                decision(
+                    "allow",
+                    "Exact literal-form read-only supporting Bash command "
+                    "(disk-hygiene belt inspection allowlist).",
                 )
             )
         )

--- a/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
@@ -4254,38 +4254,54 @@ class GuardTests(unittest.TestCase):
         for head in guard._READONLY_SUPPORTING_BASH_HEADS:
             self.assertIn(head, guidance, head)
         self.assertIn("[", guidance)
+        self.assertIn("absolute path", guidance)
+        self.assertIn("bare names are denied", guidance)
 
     def test_guard_allows_literal_readonly_supporting_bash_commands(self) -> None:
-        """Belt inspection allowlist (#2591): read-only shapes pass; mutations stay denied."""
-        allowed = [
-            "ls -la /tmp/example",
-            "ls -d /tmp/example",
-            "test -d /tmp/example",
-            "test -e /tmp/example",
-            "stat /tmp/example",
-            "du -sh /tmp/example",
-            "pwd",
-            "basename /tmp/example",
-            "dirname /tmp/example",
-            "find /tmp/example -type d -maxdepth 2",
-            "find /tmp/example -name example",
-            "file /tmp/example",
-        ]
-        if os.name != "nt":
-            # Absolute trusted-system paths are safer than bare names (no PATH
-            # shadowing) and must be allowed when the basename is allowlisted.
-            # These posix roots do not exist on Windows, where trust is anchored
-            # to the resolved Git installation and %SystemRoot% instead.
-            allowed.extend(["/bin/ls /tmp/example", "/usr/bin/ls -la /tmp/example"])
-        if shutil.which("[") is not None:
-            # `[` is a real binary in coreutils and in Git for Windows, so the
-            # hardened identity check clears it and the well-formed bookend
-            # expression is allowed. Where the host ships `[` only as a shell
-            # builtin the shape is unprovable and denied instead — that policy
-            # is asserted deterministically in
-            # `test_bracket_test_is_not_trusted_on_name_alone`, which mocks the
-            # identity gate rather than depending on the host.
-            allowed.extend(["[ -d /tmp/example ]", "[ -f /tmp/example ]"])
+        """Belt inspection allowlist (#2591): read-only shapes pass; mutations stay denied.
+
+        Bare names are denied (exported shell functions shadow them); only
+        absolute paths under trusted system directories are allowlisted.
+        """
+        # Prefer /usr/bin on every runner; fall back to /bin when a binary is
+        # absent from /usr/bin (minimal images). Skip a head entirely when
+        # neither exists so the suite stays green on stripped hosts.
+        def abs_head(name: str) -> str | None:
+            for prefix in ("/usr/bin/", "/bin/"):
+                candidate = prefix + name
+                if Path(candidate).is_file():
+                    return candidate
+            return None
+
+        allowed: list[str] = []
+        for name, suffix in (
+            ("ls", " -la /tmp/example"),
+            ("ls", " -d /tmp/example"),
+            ("test", " -d /tmp/example"),
+            ("test", " -e /tmp/example"),
+            ("stat", " /tmp/example"),
+            ("du", " -sh /tmp/example"),
+            ("pwd", ""),
+            ("basename", " /tmp/example"),
+            ("dirname", " /tmp/example"),
+            ("find", " /tmp/example -type d -maxdepth 2"),
+            ("find", " /tmp/example -name example"),
+        ):
+            head = abs_head(name)
+            if head is not None:
+                allowed.append(head + suffix)
+        file_head = abs_head("file")
+        if file_head is not None:
+            # Optional utility: absent on some minimal Linux images (#2706 review).
+            allowed.append(file_head + " /tmp/example")
+        bracket_head = abs_head("[")
+        if bracket_head is not None:
+            allowed.extend(
+                [
+                    f"{bracket_head} -d /tmp/example ]",
+                    f"{bracket_head} -f /tmp/example ]",
+                ]
+            )
         for command in allowed:
             with self.subTest(command=command):
                 result = self.run_guard(command)
@@ -4295,9 +4311,16 @@ class GuardTests(unittest.TestCase):
                     command,
                 )
         denied = (
+            # Bare names are function-shadowable and must not hard-allow.
+            "ls -la /tmp/example",
+            "pwd",
+            "file /tmp/example",
+            "[ -d /tmp/example ]",
+            "[ -f /tmp/example ]",
             # Every GNU/BSD find primary that writes or executes. A literal
             # allowlist cannot prove an -exec payload harmless.
             "find /tmp/example -delete",
+            "/usr/bin/find /tmp/example -delete",
             "find /tmp/example -exec rm {} +",
             "find /tmp/example -execdir rm -rf . ;",
             "find /tmp/example -ok rm {} ;",
@@ -4336,8 +4359,8 @@ class GuardTests(unittest.TestCase):
                     command,
                 )
 
-    def test_readonly_supporting_bare_name_resolves_to_trusted_path(self) -> None:
-        """Bare allowlisted names are allowed only when which() hits a trusted dir."""
+    def test_readonly_supporting_bare_name_is_denied_as_shadowable(self) -> None:
+        """Bare allowlisted names are denied: which() cannot prove Bash will run that binary."""
         located = shutil.which("ls")
         self.assertIsNotNone(located)
         resolved = Path(located).resolve()
@@ -4345,37 +4368,33 @@ class GuardTests(unittest.TestCase):
             guard._path_under_trusted_readonly_bin(resolved),
             f"test host must provide system ls; got {resolved}",
         )
-        self.assertTrue(guard.is_exact_readonly_supporting_command("ls /tmp/example"))
-        self.assertTrue(guard._trusted_system_readonly_head("ls"))
+        # Absolute path to the same binary is allowed; the bare name is not.
+        self.assertTrue(
+            guard.is_exact_readonly_supporting_command(f"{resolved.as_posix()} /tmp/example")
+        )
+        self.assertTrue(guard._trusted_system_readonly_head(resolved.as_posix()))
+        self.assertFalse(guard.is_exact_readonly_supporting_command("ls /tmp/example"))
+        self.assertFalse(guard._trusted_system_readonly_head("ls"))
 
     def test_guard_denies_readonly_head_shadowed_on_path(self) -> None:
-        """A PATH entry that is not a trusted system binary cannot use the allowlist.
+        """A non-absolute head cannot use the allowlist (PATH / function shadowing).
 
-        ``shutil.which`` is driven directly rather than by prepending a scratch
-        directory to ``PATH``: on Windows an extension-less scratch ``ls`` does
-        not satisfy ``PATHEXT``, so a PATH-based fixture silently resolves to the
-        real system binary and the assertion proves nothing. Mocking the lookup
-        makes the property under test — a resolution landing OUTSIDE a trusted
-        system directory fails closed — deterministic on every runner.
+        Bare names are denied outright so a ``BASH_FUNC_*`` export cannot win
+        hard-``allow`` against a which()-resolved system binary. Absolute paths
+        outside a trusted directory still fail closed.
         """
+        self.assertFalse(guard._trusted_system_readonly_head("ls"))
+        self.assertFalse(guard.is_exact_readonly_supporting_command("ls /tmp/example"))
         with tempfile.TemporaryDirectory() as tmp:
             shadow = Path(tmp).resolve() / "ls"
             shadow.write_text("#!/bin/sh\necho shadowed\n")
             shadow.chmod(0o755)
-            with mock.patch.object(
-                guard.shutil, "which", return_value=str(shadow)
-            ) as located:
-                self.assertFalse(guard._trusted_system_readonly_head("ls"))
-                self.assertFalse(
-                    guard.is_exact_readonly_supporting_command("ls /tmp/example")
+            self.assertFalse(guard._trusted_system_readonly_head(shadow.as_posix()))
+            self.assertFalse(
+                guard.is_exact_readonly_supporting_command(
+                    f"{shadow.as_posix()} /tmp/example"
                 )
-            located.assert_called_with("ls")
-            # A which() that resolves to nothing at all also fails closed.
-            with mock.patch.object(guard.shutil, "which", return_value=None):
-                self.assertFalse(guard._trusted_system_readonly_head("ls"))
-                self.assertFalse(
-                    guard.is_exact_readonly_supporting_command("ls /tmp/example")
-                )
+            )
 
     def test_readonly_supporting_absolute_untrusted_basename_denied(self) -> None:
         """Allowlisted basename under an untrusted directory must not inherit approval."""
@@ -4471,43 +4490,84 @@ class GuardTests(unittest.TestCase):
         """An unresolvable installation root contributes NO trusted directories."""
         guard._nt_trusted_readonly_bin_roots.cache_clear()
         try:
-            with (
-                mock.patch.object(guard.shutil, "which", return_value=None),
-                mock.patch.dict(guard.os.environ, {}, clear=True),
-            ):
+            with mock.patch.dict(guard.os.environ, {}, clear=True):
                 self.assertEqual((), guard._nt_trusted_readonly_bin_roots())
         finally:
             guard._nt_trusted_readonly_bin_roots.cache_clear()
 
-    def test_bracket_test_is_not_trusted_on_name_alone(self) -> None:
-        """#2618 hardening 2: ``[`` must clear the same executable-identity check.
+    def test_nt_git_roots_ignore_path_selected_git(self) -> None:
+        """#2706 review: a PATH-planted git.exe must not become the trusted root."""
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp).resolve()
+            planted = base / "repo" / "cmd"
+            planted.mkdir(parents=True)
+            planted_git = planted / "git.exe"
+            planted_git.write_text("fake")
+            # which() returning a planted binary must not matter: known roots come
+            # only from ProgramFiles / LocalAppData installer locations.
+            # Do not mock os.name here — pathlib.Path selects WindowsPath when
+            # os.name is ``nt``, which cannot be instantiated on a POSIX runner.
+            guard._nt_trusted_readonly_bin_roots.cache_clear()
+            try:
+                with (
+                    mock.patch.object(
+                        guard.shutil, "which", return_value=str(planted_git)
+                    ),
+                    mock.patch.dict(
+                        guard.os.environ,
+                        {
+                            "ProgramFiles": str(base / "empty-pf"),
+                            "ProgramFiles(x86)": str(base / "empty-pf86"),
+                            "LocalAppData": str(base / "empty-local"),
+                            "SystemRoot": "",
+                            "SYSTEMROOT": "",
+                        },
+                        clear=False,
+                    ),
+                ):
+                    self.assertEqual((), guard._nt_known_git_installation_roots())
+                    self.assertEqual((), guard._nt_trusted_readonly_bin_roots())
+            finally:
+                guard._nt_trusted_readonly_bin_roots.cache_clear()
 
-        The recovered #2639 design returned from the ``[ ... ]`` branch BEFORE
-        the trusted-binary check, so ``[`` was trusted on its name alone. That
-        is precisely the shell-function-shadowing argument the guard itself uses
-        to justify denying bare ``python``/``python3``; it is applied
-        consistently here. Where ``[`` resolves to no trusted system binary the
-        shape is unprovable and therefore denied.
+    def test_bracket_test_is_not_trusted_on_name_alone(self) -> None:
+        """#2618 hardening 2 + #2706: bare ``[`` is denied; absolute ``[`` clears identity.
+
+        Bare ``[ ... ]`` is function-shadowable. Only an absolute trusted
+        ``/usr/bin/[ ... ]`` form can hard-allow, and only when the identity
+        gate passes.
         """
-        command = "[ -d /tmp/example ]"
-        # The parse still succeeds — only the identity gate decides the verdict.
+        bare = "[ -d /tmp/example ]"
         self.assertEqual(
-            ["-d", "/tmp/example"], guard._parse_bracket_test_words(command)
+            ["-d", "/tmp/example"], guard._parse_bracket_test_words(bare)
         )
+        self.assertFalse(guard.is_exact_readonly_supporting_command(bare))
+
+        absolute = "/usr/bin/[ -d /tmp/example ]"
+        parsed = guard._absolute_bracket_test_words(absolute)
+        self.assertIsNotNone(parsed)
+        assert parsed is not None
+        self.assertEqual("/usr/bin/[", parsed[0])
+        self.assertEqual(["-d", "/tmp/example"], parsed[1])
         with mock.patch.object(
             guard, "_trusted_system_readonly_head", return_value=False
         ) as untrusted:
-            self.assertFalse(guard.is_exact_readonly_supporting_command(command))
-        untrusted.assert_called_with("[")
+            self.assertFalse(guard.is_exact_readonly_supporting_command(absolute))
+        untrusted.assert_called_with("/usr/bin/[")
         with mock.patch.object(
             guard, "_trusted_system_readonly_head", return_value=True
         ):
-            self.assertTrue(guard.is_exact_readonly_supporting_command(command))
-            # An empty or unbalanced expression stays denied regardless of trust.
-            self.assertFalse(guard.is_exact_readonly_supporting_command("[ ]"))
-            self.assertFalse(guard.is_exact_readonly_supporting_command("["))
+            self.assertTrue(guard.is_exact_readonly_supporting_command(absolute))
             self.assertFalse(
-                guard.is_exact_readonly_supporting_command("[ -d $(pwd) ]")
+                guard.is_exact_readonly_supporting_command("/usr/bin/[ ]")
+            )
+            self.assertFalse(
+                guard.is_exact_readonly_supporting_command("/usr/bin/[")
+            )
+            self.assertFalse(
+                guard.is_exact_readonly_supporting_command(
+                    "/usr/bin/[ -d $(pwd) ]"
+                )
             )
 
     def test_classifier_rejects_a_subcommand_outside_the_shared_list(self) -> None:

--- a/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
@@ -4277,6 +4277,15 @@ class GuardTests(unittest.TestCase):
             # These posix roots do not exist on Windows, where trust is anchored
             # to the resolved Git installation and %SystemRoot% instead.
             allowed.extend(["/bin/ls /tmp/example", "/usr/bin/ls -la /tmp/example"])
+        if shutil.which("[") is not None:
+            # `[` is a real binary in coreutils and in Git for Windows, so the
+            # hardened identity check clears it and the well-formed bookend
+            # expression is allowed. Where the host ships `[` only as a shell
+            # builtin the shape is unprovable and denied instead — that policy
+            # is asserted deterministically in
+            # `test_bracket_test_is_not_trusted_on_name_alone`, which mocks the
+            # identity gate rather than depending on the host.
+            allowed.extend(["[ -d /tmp/example ]", "[ -f /tmp/example ]"])
         for command in allowed:
             with self.subTest(command=command):
                 result = self.run_guard(command)

--- a/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
@@ -4251,6 +4251,255 @@ class GuardTests(unittest.TestCase):
         # arrived unexpanded leaves no disclosed route to the engine, and the
         # exact-path identity check denies every guess.
         self.assertIn(guard._display_path(guard._engine_script_path()), guidance)
+        for head in guard._READONLY_SUPPORTING_BASH_HEADS:
+            self.assertIn(head, guidance, head)
+        self.assertIn("[", guidance)
+
+    def test_guard_allows_literal_readonly_supporting_bash_commands(self) -> None:
+        """Belt inspection allowlist (#2591): read-only shapes pass; mutations stay denied."""
+        allowed = [
+            "ls -la /tmp/example",
+            "ls -d /tmp/example",
+            "test -d /tmp/example",
+            "test -e /tmp/example",
+            "stat /tmp/example",
+            "du -sh /tmp/example",
+            "pwd",
+            "basename /tmp/example",
+            "dirname /tmp/example",
+            "find /tmp/example -type d -maxdepth 2",
+            "find /tmp/example -name example",
+            "file /tmp/example",
+        ]
+        if os.name != "nt":
+            # Absolute trusted-system paths are safer than bare names (no PATH
+            # shadowing) and must be allowed when the basename is allowlisted.
+            # These posix roots do not exist on Windows, where trust is anchored
+            # to the resolved Git installation and %SystemRoot% instead.
+            allowed.extend(["/bin/ls /tmp/example", "/usr/bin/ls -la /tmp/example"])
+        for command in allowed:
+            with self.subTest(command=command):
+                result = self.run_guard(command)
+                self.assertEqual(
+                    "allow",
+                    result["hookSpecificOutput"]["permissionDecision"],
+                    command,
+                )
+        denied = (
+            # Every GNU/BSD find primary that writes or executes. A literal
+            # allowlist cannot prove an -exec payload harmless.
+            "find /tmp/example -delete",
+            "find /tmp/example -exec rm {} +",
+            "find /tmp/example -execdir rm -rf . ;",
+            "find /tmp/example -ok rm {} ;",
+            "find /tmp/example -okdir rm {} ;",
+            "find /tmp/example -fprint /tmp/out",
+            "find /tmp/example -fprint0 /tmp/out",
+            "find /tmp/example -fprintf /tmp/out %p",
+            "find /tmp/example -fls /tmp/out",
+            # Shell operators, redirections and expansions stay denied.
+            "ls /tmp/example; rm -rf /tmp/example",
+            "ls /tmp/example && rm -rf /tmp/example",
+            "ls /tmp/example || rm -rf /tmp/example",
+            "ls /tmp/example | xargs rm",
+            "ls /tmp/example > /tmp/out",
+            "ls $(pwd)",
+            "ls `pwd`",
+            "ls ${HOME}",
+            # Deny-by-default holds for everything off the allowlist.
+            "command ls /tmp/example",
+            "./ls /tmp/example",
+            "true",
+            "echo hello",
+            "cat /tmp/example",
+            "head /tmp/example",
+            "grep x /tmp/example",
+            "[",
+            "[ ]",
+            "test",
+        )
+        for command in denied:
+            with self.subTest(command=command):
+                result = self.run_guard(command)
+                self.assertEqual(
+                    "deny",
+                    result["hookSpecificOutput"]["permissionDecision"],
+                    command,
+                )
+
+    def test_readonly_supporting_bare_name_resolves_to_trusted_path(self) -> None:
+        """Bare allowlisted names are allowed only when which() hits a trusted dir."""
+        located = shutil.which("ls")
+        self.assertIsNotNone(located)
+        resolved = Path(located).resolve()
+        self.assertTrue(
+            guard._path_under_trusted_readonly_bin(resolved),
+            f"test host must provide system ls; got {resolved}",
+        )
+        self.assertTrue(guard.is_exact_readonly_supporting_command("ls /tmp/example"))
+        self.assertTrue(guard._trusted_system_readonly_head("ls"))
+
+    def test_guard_denies_readonly_head_shadowed_on_path(self) -> None:
+        """A PATH entry that is not a trusted system binary cannot use the allowlist.
+
+        ``shutil.which`` is driven directly rather than by prepending a scratch
+        directory to ``PATH``: on Windows an extension-less scratch ``ls`` does
+        not satisfy ``PATHEXT``, so a PATH-based fixture silently resolves to the
+        real system binary and the assertion proves nothing. Mocking the lookup
+        makes the property under test — a resolution landing OUTSIDE a trusted
+        system directory fails closed — deterministic on every runner.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            shadow = Path(tmp).resolve() / "ls"
+            shadow.write_text("#!/bin/sh\necho shadowed\n")
+            shadow.chmod(0o755)
+            with mock.patch.object(
+                guard.shutil, "which", return_value=str(shadow)
+            ) as located:
+                self.assertFalse(guard._trusted_system_readonly_head("ls"))
+                self.assertFalse(
+                    guard.is_exact_readonly_supporting_command("ls /tmp/example")
+                )
+            located.assert_called_with("ls")
+            # A which() that resolves to nothing at all also fails closed.
+            with mock.patch.object(guard.shutil, "which", return_value=None):
+                self.assertFalse(guard._trusted_system_readonly_head("ls"))
+                self.assertFalse(
+                    guard.is_exact_readonly_supporting_command("ls /tmp/example")
+                )
+
+    def test_readonly_supporting_absolute_untrusted_basename_denied(self) -> None:
+        """Allowlisted basename under an untrusted directory must not inherit approval."""
+        with tempfile.TemporaryDirectory() as tmp:
+            fake = Path(tmp) / "ls"
+            fake.write_text("#!/bin/sh\necho fake\n")
+            fake.chmod(0o755)
+            command = f"{fake.as_posix()} /tmp/example"
+            self.assertFalse(guard.is_exact_readonly_supporting_command(command))
+            self.assertFalse(guard._trusted_system_readonly_head(fake.as_posix()))
+            result = self.run_guard(command)
+            self.assertEqual(
+                "deny",
+                result["hookSpecificOutput"]["permissionDecision"],
+                command,
+            )
+
+    def test_nt_trusted_bin_match_is_anchored_not_a_path_substring(self) -> None:
+        """#2618 hardening 1: a repo path SPELLING a trusted fragment is not trusted.
+
+        The recovered #2639 design matched Windows trust with a SUBSTRING test
+        against fragments like ``/git/usr/bin/`` and ``/windows/system32/``. Any
+        repository-controlled directory that merely spells the fragment —
+        ``D:/anyrepo/git/usr/bin/find`` — therefore satisfied it, so a planted
+        binary carrying an allowlisted basename was hard-``allow``ed, bypassing
+        even the user's own permission prompt. Trust is now anchored to the
+        RESOLVED installation root.
+
+        Driven with ``os.name`` forced to ``nt`` and an injected root so the
+        assertion is deterministic on every runner, not silently skipped off
+        Windows (where the branch would never execute).
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp).resolve()
+            real_root = base / "Program Files" / "Git"
+            real_bin = real_root / "usr" / "bin"
+            real_bin.mkdir(parents=True)
+            genuine = real_bin / "find"
+            genuine.write_text("#!/bin/sh\ntrue\n")
+
+            # A repository that merely SPELLS the trusted fragment.
+            planted_bin = base / "anyrepo" / "git" / "usr" / "bin"
+            planted_bin.mkdir(parents=True)
+            planted = planted_bin / "find"
+            planted.write_text("#!/bin/sh\necho pwned\n")
+
+            # A sibling installation whose name only starts with the trusted one.
+            lookalike_bin = base / "Program Files" / "Gitx" / "usr" / "bin"
+            lookalike_bin.mkdir(parents=True)
+            lookalike = lookalike_bin / "find"
+            lookalike.write_text("#!/bin/sh\necho pwned\n")
+
+            # Same defect on the Windows system root half of the trusted set.
+            planted_system = base / "anyrepo" / "windows" / "system32"
+            planted_system.mkdir(parents=True)
+            planted_sys_binary = planted_system / "find"
+            planted_sys_binary.write_text("#!/bin/sh\necho pwned\n")
+
+            guard._nt_trusted_readonly_bin_roots.cache_clear()
+            try:
+                with (
+                    mock.patch.object(guard.os, "name", "nt"),
+                    mock.patch.object(
+                        guard,
+                        "_nt_trusted_readonly_bin_roots",
+                        return_value=(real_bin,),
+                    ),
+                ):
+                    self.assertTrue(
+                        guard._path_under_trusted_readonly_bin(genuine),
+                        "the genuine installation root must stay trusted",
+                    )
+                    for hostile in (planted, lookalike, planted_sys_binary):
+                        with self.subTest(path=hostile.as_posix()):
+                            self.assertFalse(
+                                guard._path_under_trusted_readonly_bin(hostile),
+                                hostile.as_posix(),
+                            )
+                            self.assertFalse(
+                                guard._trusted_system_readonly_head(hostile.as_posix()),
+                                hostile.as_posix(),
+                            )
+                            self.assertFalse(
+                                guard.is_exact_readonly_supporting_command(
+                                    f"{hostile.as_posix()} /tmp/example"
+                                ),
+                                hostile.as_posix(),
+                            )
+            finally:
+                guard._nt_trusted_readonly_bin_roots.cache_clear()
+
+    def test_nt_trusted_roots_are_empty_when_git_cannot_be_located(self) -> None:
+        """An unresolvable installation root contributes NO trusted directories."""
+        guard._nt_trusted_readonly_bin_roots.cache_clear()
+        try:
+            with (
+                mock.patch.object(guard.shutil, "which", return_value=None),
+                mock.patch.dict(guard.os.environ, {}, clear=True),
+            ):
+                self.assertEqual((), guard._nt_trusted_readonly_bin_roots())
+        finally:
+            guard._nt_trusted_readonly_bin_roots.cache_clear()
+
+    def test_bracket_test_is_not_trusted_on_name_alone(self) -> None:
+        """#2618 hardening 2: ``[`` must clear the same executable-identity check.
+
+        The recovered #2639 design returned from the ``[ ... ]`` branch BEFORE
+        the trusted-binary check, so ``[`` was trusted on its name alone. That
+        is precisely the shell-function-shadowing argument the guard itself uses
+        to justify denying bare ``python``/``python3``; it is applied
+        consistently here. Where ``[`` resolves to no trusted system binary the
+        shape is unprovable and therefore denied.
+        """
+        command = "[ -d /tmp/example ]"
+        # The parse still succeeds — only the identity gate decides the verdict.
+        self.assertEqual(
+            ["-d", "/tmp/example"], guard._parse_bracket_test_words(command)
+        )
+        with mock.patch.object(
+            guard, "_trusted_system_readonly_head", return_value=False
+        ) as untrusted:
+            self.assertFalse(guard.is_exact_readonly_supporting_command(command))
+        untrusted.assert_called_with("[")
+        with mock.patch.object(
+            guard, "_trusted_system_readonly_head", return_value=True
+        ):
+            self.assertTrue(guard.is_exact_readonly_supporting_command(command))
+            # An empty or unbalanced expression stays denied regardless of trust.
+            self.assertFalse(guard.is_exact_readonly_supporting_command("[ ]"))
+            self.assertFalse(guard.is_exact_readonly_supporting_command("["))
+            self.assertFalse(
+                guard.is_exact_readonly_supporting_command("[ -d $(pwd) ]")
+            )
 
     def test_classifier_rejects_a_subcommand_outside_the_shared_list(self) -> None:
         """The denial text and the grammar are one list, so they cannot drift."""
@@ -5543,6 +5792,10 @@ class GuardTests(unittest.TestCase):
             "C:\\Windows\\System32\\robocopy.exe C:\\src C:\\dst /MIR",
             "& 'C:/Windows/System32/robocopy.exe' C:/src C:/dst /PURGE",
             "[Microsoft.VisualBasic.FileIO.FileSystem]::DeleteFile('x', 'OnlyErrorDialogs', 'SendToRecycleBin')",
+            "[Microsoft.VisualBasic.FileIO.FileSystem]::DeleteDirectory($path,'OnlyErrorDialogs','SendToRecycleBin')",
+            "(New-Object -ComObject Shell.Application).NameSpace(10).MoveHere($path)",
+            "$shell = New-Object -ComObject Shell.Application; $shell.NameSpace(10).MoveHere($path)",
+            "$shell.NameSpace(0xa).ParseName($path).InvokeVerb('delete')",
             "Move-Item C:/tmp/old C:/tmp/new",
             "Rename-Item C:/tmp/old C:/tmp/new",
             "Set-Content C:/tmp/file.txt 'overwrite'",
@@ -5688,6 +5941,9 @@ class GuardTests(unittest.TestCase):
             "$item.Delete()",
             "robocopy C:/src C:/dst /MIR",
             "[Microsoft.VisualBasic.FileIO.FileSystem]::DeleteFile('x', 'OnlyErrorDialogs', 'SendToRecycleBin')",
+            "[Microsoft.VisualBasic.FileIO.FileSystem]::DeleteDirectory($path,'OnlyErrorDialogs','SendToRecycleBin')",
+            "(New-Object -ComObject Shell.Application).NameSpace(10).MoveHere($path)",
+            "$shell.NameSpace(0xa).ParseName($path).InvokeVerb('delete')",
         ):
             result = self.run_guard_powershell_disabled(command)
             assert result is not None, command
@@ -5696,6 +5952,50 @@ class GuardTests(unittest.TestCase):
                 result["hookSpecificOutput"]["permissionDecision"],
                 command,
             )
+
+    def test_powershell_recycle_bin_preferred_spellings_force_final_prompt(self) -> None:
+        """#2595: the skill's preferred Recycle Bin paths must prompt like Remove-Item.
+
+        The clean skill's own manual-handoff lane RECOMMENDS Recycle Bin removal,
+        so these spellings were the one deletion route the belt never saw.
+        """
+        for command in (
+            "Add-Type -AssemblyName Microsoft.VisualBasic; "
+            "[Microsoft.VisualBasic.FileIO.FileSystem]::DeleteDirectory("
+            "$path,'OnlyErrorDialogs','SendToRecycleBin')",
+            "Add-Type -AssemblyName Microsoft.VisualBasic; "
+            "[Microsoft.VisualBasic.FileIO.FileSystem]::DeleteFile("
+            "$path,'OnlyErrorDialogs','SendToRecycleBin')",
+            "(New-Object -ComObject Shell.Application).NameSpace(10).MoveHere($path)",
+            "$shell = New-Object -ComObject Shell.Application; "
+            "$shell.NameSpace(10).MoveHere($path)",
+            "$shell = New-Object -ComObject Shell.Application; "
+            "$shell.NameSpace(0xa).ParseName($path).InvokeVerb('delete')",
+        ):
+            result = self.run_guard_powershell(command)
+            assert result is not None, command
+            self.assertEqual(
+                "ask",
+                result["hookSpecificOutput"]["permissionDecision"],
+                command,
+            )
+            reason = result["hookSpecificOutput"]["permissionDecisionReason"]
+            self.assertRegex(
+                reason,
+                r"(FileSystem|Recycle Bin|NameSpace\(10\))",
+                command,
+            )
+
+    def test_powershell_shell_app_without_bin_action_defers(self) -> None:
+        """Listing the bin is not a deletion spelling; MoveHere/InvokeVerb is required."""
+        for command in (
+            "(New-Object -ComObject Shell.Application).NameSpace(10).Items()",
+            "$shell = New-Object -ComObject Shell.Application; $shell.NameSpace(10)",
+            # MoveHere against a non-bin namespace is outside this Recycle Bin rule;
+            # Move-Item remains the catch-all for rename/move cmdlets.
+            "(New-Object -ComObject Shell.Application).NameSpace('C:\\tmp').MoveHere($path)",
+        ):
+            self.assertIsNone(self.run_guard_powershell(command), command)
 
     def test_kill_switch_blocks_every_lane_when_configured_false(self) -> None:
         """A configured ``disk_hygiene_enabled=false`` in user settings must block
@@ -5860,6 +6160,7 @@ class GuardTests(unittest.TestCase):
             "resolve_disk_hygiene_enabled",
             "resolve_authorized_data_root",
             "is_exact_kill_switch_probe",
+            "is_exact_readonly_supporting_command",
             "classify_exact_engine_command",
         ]
         for target in targets:


### PR DESCRIPTION
Closes #2618

## Summary

Re-lands the #2639 guard allowlist / session-honest docstring / Recycle Bin spellings that #2641 silently reverted (#2691), and hardens the allowlist against the review findings (substring trust, bare-name/`[` shadowing, PATH-selected Git root). Sibling docs lane #2714 already landed the markdown half.

## Fix

- Restore `resolve_mode()` session-lifetime docstring, read-only Bash allowlist, and PowerShell Recycle Bin deletion spellings.
- Anchor NT trust to independently located Git installer roots + `%SystemRoot%` (never `PATH`-selected `git.exe`); deny bare allowlisted heads so `BASH_FUNC_*` cannot hard-allow; require absolute trusted `/usr/bin/[ ... ]`.
- Release `disk-hygiene` 0.20.7 (0.20.6 was the docs re-land in #2714).

## Verification

- Focused `GuardTests` for the allowlist / NT trust / bracket hardenings → OK
- `changelog-parity` locally against `origin/main` for the 0.20.7 bump
- Rebased onto post-#2714 `origin/main` with `git merge-base --is-ancestor origin/main HEAD`

## Related

- Refs #2691 — stale-base squash-merge defect that made this re-land necessary
- Refs #2639 — original guard work recovered here
- Refs #2641 — PR whose stale-base squash merge reverted #2639
- Refs #2591 — read-only supporting allowlist finding restored here (already closed)
- Refs #2595 — Recycle Bin spelling finding restored here (already closed)
- Refs #2714 — sibling docs lane that closed #2590 and the markdown half of #2618