### PR TITLE
fix(disk-hygiene): re-land tidiness-first reporting and correct the belt's documented posture

### DIFF
--- a/plugins/disk-hygiene/.claude-plugin/plugin.json
+++ b/plugins/disk-hygiene/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "disk-hygiene",
-  "version": "0.20.5",
+  "version": "0.20.6",
   "description": "Context-aware disk hygiene for arbitrary directory trees: inventories orphaned and temporary artifacts, classifies evidence into review tiers, and offers exact-path cleanup only after a fresh safety preview and explicit per-tier approval. The target is read-only by default; OS-managed paths, links and mount points, VCS-tracked content without the complete checkout evidence bundle, changed entries, and live-handle uncertainty fail closed.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/disk-hygiene/CHANGELOG.md
+++ b/plugins/disk-hygiene/CHANGELOG.md
@@ -3,6 +3,20 @@
 All notable changes to the `disk-hygiene` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.20.6]
+
+### Fixed
+
+- **Re-landed tidiness-first reporting and corrected the belt's documented posture (#2590,
+  #2618).** PR #2639 and then #2641 squash-merged from stale bases and silently reverted the
+  prior markdown fixes (#2691). Reports are again ordered by tier and evidence strength — never
+  by byte size — with empty directories as first-class findings; `provenance` and `risk` return
+  to the plan schema; preview and apply lead with tidiness. The skill and safety-model docs now
+  state that skill-frontmatter `PreToolUse` hooks stay armed for the rest of the session, drop
+  the false exec-form claim (shell form since 0.17.9 / #2568), name the long-path Recycle Bin
+  hard-stop, declare relocation out of scope, and thin Gotchas harness duplication into
+  `safety-model.md` pointers. Guard-code recovery remains in the sibling lane.
+
 ## [0.20.5]
 
 ### Fixed

--- a/plugins/disk-hygiene/skills/clean/SKILL.md
+++ b/plugins/disk-hygiene/skills/clean/SKILL.md
@@ -31,7 +31,8 @@ metadata:
 # Disk hygiene
 
 Audit first; mutate only after a fresh deterministic preview and explicit approval of one tier. A
-filename pattern is a discovery hint, never proof that an entry is junk. Read
+filename pattern is a discovery hint, never proof that an entry is junk. **Safe tidiness is the
+primary objective; reclaimed bytes are secondary.** Read
 [the safety model](reference/safety-model.md) before the optional execution lane.
 
 ## Arguments and boundaries
@@ -82,15 +83,11 @@ target; scan those without the flag.
   running the bundled probe (the guard allows exactly this argument-free shape):
   `"<hook-python>" "${CLAUDE_PLUGIN_ROOT}/skills/setup/scripts/kill_switch_probe.py"` and honor
   the `effective` value it reports; on `degraded: true` proceed as enabled but say the configured
-  value could not be read. The guard now enforces this independently: it resolves the same
-  `disk_hygiene_enabled` toggle by reading it straight from your user `settings.json` (the read is
-  shared with this probe, and the settings file is located from the tamper-resistant
-  `${CLAUDE_PLUGIN_ROOT}` — not the environment), so in audit-only mode it denies both mutation lanes
-  it gates outright — the Bash engine `apply` and the PowerShell deletion belt alike. Running the probe still
-  matters so you can state the configured value accurately and stop before proposing work the guard
-  would deny; the guard is the backstop, not the sole enforcer. The guard reports its absolute Python
-  interpreter and the authorized `--data-root` value in denial guidance. Use that exact interpreter
-  path as `<hook-python>` for
+  value could not be read. The guard enforces the same toggle independently and denies both mutation
+  lanes in audit-only mode (`reference/safety-model.md`), so run the probe anyway — to state the
+  configured value accurately and stop before proposing work the guard would deny. The guard is the
+  backstop, not the sole enforcer. It reports its absolute Python interpreter and the authorized
+  `--data-root` value in denial guidance; use that exact interpreter path as `<hook-python>` for
   every engine call; bare `python`/`python3` is rejected because Bash aliases and functions can
   replace them. If either value is not known yet, submit the otherwise exact scan shape once with
   bare `python`: the guard must deny it and report both, after which retry the scan with the
@@ -144,12 +141,9 @@ stay there, never in the target or `${CLAUDE_PLUGIN_ROOT}`. Run:
   [--root-children [--root-child <name>]...]
 ```
 
-The guard validates `--data-root` against the plugin data directory it derives from
-`${CLAUDE_PLUGIN_ROOT}` (passed to the guard as `--plugin-root`, the only substitution a
-skill-frontmatter hook receives), confining generated state to the plugin data directory even when
-the guard's own environment lacks `CLAUDE_PLUGIN_DATA`. If the guard cannot recognize the install
-layout it derives no authority and denies `--data-root` engine calls rather than trusting a guessed
-path, so re-run reporting a denial is a coverage gap, not a clean result.
+The guard validates `--data-root` against the plugin data directory it derives itself, and denies
+the call outright when it cannot recognize the install layout — so a run reporting that denial is a
+coverage gap, not a clean result. (Derivation and its fail-closed rationale: `reference/safety-model.md`.)
 
 For a large root (a home directory, anything whose recursive walk could exceed the engine's entry
 cap), start with a bounded pass: add `--max-depth 1` to inventory the target's loose files and
@@ -215,7 +209,8 @@ For each hinted or suspicious entry, inspect enough neighboring content and meta
 
 ## 3. Classify and report
 
-Confidence is report priority, not permission:
+Safe tidiness leads; reclaimed space follows. Confidence is report priority, not permission — and
+byte size is never a ranking key:
 
 | Tier | Minimum evidence | Default outcome |
 |---|---|---|
@@ -223,9 +218,35 @@ Confidence is report priority, not permission:
 | Medium | Likely disposable, but one ownership/provenance fact is indirect | Review, then optionally offer its own approval |
 | Low | Name/age-only, conflicting signals, resumable or user-content possibility | Keep unless the human separately reviews and approves exact paths |
 
-Report every finding with path, logical bytes, tier, evidence, owner/native-GC result, why it is not
-work product, and disposition. Separately list protected, locked, needs-elevation, unverified, and
-coverage-gap entries. Empty directories are not inherently junk.
+Report every finding with these fields, in this order — size last:
+
+1. **Provenance** — where it came from, resolved from evidence (a manifest, a config's own
+   contents, an owning repository's source, a documented naming contract), never guessed from the
+   name alone.
+2. **What it is** — intent / role of the entry (`reason` in engine plans).
+3. **Why removable** — why it is not work product, plus owner / native-GC result.
+4. **Risk** — what could go wrong if it is removed (and why that risk is acceptable at this tier).
+5. Path, tier, evidence, disposition.
+6. Logical / reclaimable bytes as a **secondary** signal only.
+
+Separately list protected, locked, needs-elevation, unverified, and coverage-gap entries.
+
+**Empty directories are first-class findings.** They are not inherently junk, but zero-byte residue
+must stay visible and rankable: never drop an empty directory from investigation or from the report
+because it reclaims nothing. Prefer ranking by tier, location sensitivity (for example volume-root
+or home-root orphans), and provenance strength over byte totals. The snapshot already distinguishes
+them for you: a walked directory whose `logical_size` is `0` with an empty `size_qualifiers` is a
+genuinely empty directory, while a `logical_size` of `null` carrying the `not-walked` qualifier is
+an uninventoried coverage gap. Never fold the first into a byte-centric roll-up that drops it, and
+never read it as the second.
+
+**Relocation is out of scope.** This skill offers exactly two outcomes per finding — keep it, or
+approve its exact path for deletion. There is no relocation lane and no move primitive in the
+engine, by design: a move is not a containment-checkable, revalidatable, token-bound operation the
+way a delete is. So when the right answer for a misplaced entry is "this belongs somewhere else",
+say so and report it as **keep**; the operator performs and verifies the move themselves, outside
+this workflow. Never imply the report's keep-or-delete choice is the complete set of dispositions,
+and never stage a move through the manual handoff.
 
 An entry's `logical_size` is reclaimable local bytes only when its `size_qualifiers` is empty.
 Exclude every qualified entry from any reclaimable-bytes total and state the qualified bytes
@@ -236,7 +257,8 @@ so `logical_size` is `null` rather than `0` — except on the target's own recor
 partial walked sum alongside a `not-walked` qualifier, so read that number as a floor. Prefer the
 snapshot's `target_reclaimable_local_bytes` (and preview/apply `reclaimable_local_bytes*`) over summing
 `logical_size` yourself — folding qualified or unknown sizes into a total claims space that
-deleting the path would never return.
+deleting the path would never return. Never treat a low or zero reclaimable-byte figure as a reason
+to skip a finding that otherwise clears the evidence bar.
 
 ## 4. Build one exact-tier plan
 
@@ -250,9 +272,11 @@ Only when `--execute` was requested, write `<run-dir>/plan-<tier>.json`; never m
     {
       "path": "relative/exact.tmp",
       "tier": "high",
+      "provenance": "documented atomic-write staging name; owner process absent",
       "reason": "failed atomic-write staging file",
       "evidence": ["documented name shape", "owner process absent"],
       "why_not_work_product": "generated staging bytes with no durable consumer",
+      "risk": "low — regenerable staging residue; no live consumer",
       "owner": "unmanaged"
     }
   ]
@@ -278,10 +302,11 @@ handles from current state rather than trusting snapshot annotations. It also pr
 directory-descriptor prerequisites. Windows and macOS return `execution-platform-unsupported`. Any
 blocker means no approval prompt and no deletion. Fix nothing behind the gate; rescan.
 
-When status is `ready-for-explicit-approval`, show a table naming every path, the single tier, logical
-bytes, and the preview's approval token, then pass the [confirmation gate](#confirmation-gate) — the
-approval must name **exactly that tier and list**. Process another tier only with a new plan, preview,
-and question.
+When status is `ready-for-explicit-approval`, show a table naming every path with provenance, what
+it is, why removable, risk, whether it is an empty directory, the single tier, and only then logical
+/ reclaimable bytes, plus the preview's approval token — then pass the
+[confirmation gate](#confirmation-gate) — the approval must name **exactly that tier and list**.
+Process another tier only with a new plan, preview, and question.
 
 ## 6. Apply only the confirmed preview
 
@@ -295,7 +320,7 @@ After an affirmative answer in this interactive session, run only:
 ```
 
 Never use `rm`, `rmdir`, `Remove-Item`, `del`, `find -delete`, or an ad-hoc Python deletion call. The
-skill-scoped hook blocks those bypasses and forces one final permission prompt for the exact engine
+skill-frontmatter belt blocks those bypasses and forces one final permission prompt for the exact engine
 apply command; confirm it only when it matches the tier and paths just approved. If the plan, snapshot,
 path identity, descendant set, VCS state, or handle state changed, re-scan and re-ask; never reuse a
 token.
@@ -388,6 +413,21 @@ engine plan:
    which was used. That reversibility is conditional, not guaranteed: bin size caps, a
    policy-disabled bin, or a non-NTFS/network volume can silently make the same operation
    permanent — disclose when a target's volume or policy may turn "reversible" removal permanent.
+
+   **Path length is a different failure — not a silent downgrade but a hard stop.** Those three
+   caveats all describe a reversible operation quietly turning permanent. A path longer than the
+   classic Windows `MAX_PATH` (260 characters) cannot reach the Recycle Bin *at all*: the shell
+   APIs behind it reject the path, so the operation fails outright. Deep tool residue — nested
+   dependency or build trees — routinely exceeds it. The only remaining way to remove such a path
+   is a **permanent** delete through a `\\?\` long-path API, which no bin can undo.
+
+   That fallback is its own irreversible action and does **not** inherit the approval given for a
+   reversible removal. Stop, tell the operator this exact path cannot be recycled and why, and
+   re-ask through the [confirmation gate](#confirmation-gate) for permanent deletion of that exact
+   path, named as irreversible — an approval that said "recycle these" never authorized it. If the
+   operator declines, skip and report the path; shortening or moving the tree to get under the
+   limit is a relocation, out of scope (§3) and the operator's own action. Record such removals as
+   permanent in the §6 summary, distinct from the reversible ones.
 3. Container-wide deletion commands (`Clear-RecycleBin`, emptying the Trash, or any "delete
    everything in this container" spelling) are forbidden in the manual lane — they execute
    against the live container, so items arriving between approval (or even re-enumeration) and
@@ -400,18 +440,31 @@ engine plan:
 
 The PowerShell guard lane turns deletion spellings into a final human permission prompt (the same
 bar as the engine apply prompt); confirm that prompt only when the command matches the exact
-approved list. Engine invocations from PowerShell stay hard-denied. The plugin-level engine gate
-(`hooks/hooks.json`) now registers unconditionally and resolves the kill switch itself by reading
-`disk_hygiene_enabled` from your user `settings.json`; it no longer carries a `${user_config.*}`
-argument, so the unset-default hook-drop that once made it inert on a default install is gone.
-`Bash|PowerShell` PreToolUse hooks fire for the PowerShell tool. See `reference/safety-model.md`.
+approved list. Engine invocations from PowerShell stay hard-denied.
 
-Summarize removed paths, logical bytes removed, observed free-space delta, and every skip grouped by
-`locked`, `changed-or-link`, `protected`, `needs-elevation`, `handle-state-unverified`, or
-`delete-failed`. Do not claim the observed free-space delta is exact: concurrent disk activity,
-sparse files, hard links, compression, and delayed allocation affect it.
+**That belt outlives this cleanup.** Claude Code registers a skill's frontmatter hooks when the
+skill is invoked and keeps them registered for the **rest of the session** — there is no
+harness-level "while the skill is active" window for hooks (#2618). So once `/disk-hygiene:clean`
+has run, the deny-by-default Bash lane and the PowerShell deletion prompts keep applying to
+unrelated later work in the same session, not only to this cleanup. Say so when a later,
+unrelated command is blocked or prompted, rather than treating it as a surprise; the session's own
+end is what clears it. See `reference/safety-model.md` for both registration surfaces, the kill
+switch, and what the belt does and does not bound.
+
+Summarize tidiness outcomes first: the paths removed (the report's `removed` list), how many of them
+were empty directories, the coverage gaps that remain, and every skip grouped by `locked`,
+`changed-or-link`, `protected`, `needs-elevation`, `handle-state-unverified`, or `delete-failed`.
+Report `reclaimable_local_bytes_removed` and the observed free-space delta **after** those tidiness
+figures, never as the headline. Do not claim the observed free-space delta is exact: concurrent disk
+activity, sparse files, hard links, compression, and delayed allocation affect it.
 
 ## Gotchas
+
+Harness mechanics are not restated here — one copy only, because two is how a stale claim survived
+a fix to the reference (#2618). Load [the safety model](reference/safety-model.md) when you need
+them: how the guard registers on two surfaces, how the kill switch is delivered and scoped, and
+what the PowerShell lane flags → "Kill-switch enforcement"; how the hooks launch, what that bounds,
+and the residual fail-open → "Hook launch form".
 
 - POSIX permits unlinking an open file, so successful deletion is not a live-handle check. Linux
   execution requires an authoritative `lsof` result and fails closed on diagnostics or missing access.
@@ -429,62 +482,14 @@ sparse files, hard links, compression, and delayed allocation affect it.
   snapshot token exists.
 - `allowed-tools` would pre-approve rather than restrict tools, so this destructive skill intentionally
   grants none. Consumer permission policy remains authoritative.
-- The Bash hook denies unknown commands rather than trying to enumerate deletion spellings. Supporting
-  research uses non-Bash read-only tools; only literal-word bundled scan, preview, handoff-verify, and
-  apply shapes using the hook runtime's same absolute executable pass. Shell expansions, globs,
+- The Bash lane is deny-by-default: only the literal-word bundled scan, preview, handoff-verify, and
+  apply shapes (plus the argument-free kill-switch probe) pass, using the hook runtime's own absolute
+  interpreter. Do supporting inspection with non-Bash read-only tools. Shell expansions, globs,
   splitting/escape forms, operators, redirections, aliases, and exported functions fail closed.
-- The guard registers twice: a plugin-level engine gate (`hooks/hooks.json`, `--mode engine-gate`)
-  that receives the data root by plugin-hook substitution and defers instantly on any command not
-  referencing the engine; and this skill's frontmatter belt, which adds the deny-by-default Bash and
-  deletion-spelling PowerShell discipline while cleanup is the active work. Both resolve the kill switch
-  the same single way — reading `disk_hygiene_enabled` from user-scope `pluginConfigs` in
-  `settings.json`, located from the `${CLAUDE_PLUGIN_ROOT}` both receive — so both honor a configured
-  `false`, register unconditionally, and fail closed to enabled when the value is absent or unreadable.
-  Verdicts are idempotent where both fire.
-- The two surfaces launch differently, and only one depends on a bare `python3` on `PATH`. The
-  **plugin-level engine gate** (and its `Stop` detector) register in **shell form**: the `command`
-  string names `hooks/run-python-hook.sh` with `"shell": "bash"` and no `args`, so Claude Code routes
-  them through its own Git Bash instead of a `PATH` lookup for `bash` (#1416), and the launcher then
-  resolves a real interpreter — `python3`, then `python`, then `py -3`, rejecting the zero-length
-  `WindowsApps` alias stub (#1504). A shell parses that launch string, but it is a fixed literal whose
-  only substituted values are Claude Code's own quoted `${CLAUDE_PLUGIN_ROOT}`/`${CLAUDE_PLUGIN_DATA}`
-  placeholders. When no interpreter resolves the gate still fails open, but the `Stop` detector emits
-  a `systemMessage` naming the blind spot, so it is visible rather than silent.
-- This **skill's frontmatter belt** still launches in exec form via `python3`, resolved on `PATH` with
-  no shell (`python3`, not bare `python`, because stock macOS and many Linux distros ship only
-  `python3` and a legacy `python` 2.x would crash the guard on modern syntax). Its enforcement is
-  therefore only as strong as that single lookup: on a host where `python3` does not resolve to an
-  interpreter meeting the engine's `MIN_PYTHON` floor the PreToolUse launch fails, and Claude Code
-  treats a failed hook launch as a non-blocking error, so the belt does not intercept there
-  (converting this surface is tracked in #2568). Concretely, the exposure is the manual PowerShell
-  deletion lane: engine
-  `apply` is unsupported on Windows and macOS and elsewhere runs only behind the guard's own `ask`,
-  so no silent auto-delete path opens, but the guard's PowerShell belt that turns a deletion spelling
-  into a final human prompt is lost. The backstops that remain are the per-path human approval the
-  manual-handoff lane already requires and the consumer's baseline permission policy — defense-in-depth
-  lost, not preserved. `/disk-hygiene:setup check` reports whether the interpreter resolves on this
-  machine.
-- **The kill switch is delivered by reading user settings, not by a hook argument (since 0.9.0).** Earlier
-  versions passed a bare `${user_config.disk_hygiene_enabled}` in `hooks/hooks.json`; a declared userConfig
-  `default` is not implemented upstream (#46477 / #39455 / #39827), so an unset-but-defaulted token was
-  neither substituted nor exported to `CLAUDE_PLUGIN_OPTION_*`, and its presence **dropped the whole hook
-  entry** — making the engine gate inert for any consumer who never set the key. The gate no longer carries
-  a `${user_config.*}` token; both the gate and the belt resolve `disk_hygiene_enabled` by reading it from
-  `pluginConfigs` in `settings.json`. Claude Code honors that key only from user, managed, and `--settings`
-  scope since 2.1.207 (a project/local `settings.json` is ignored), so a hostile repo cannot forge it. The
-  reader reads the **user** file (located from `${CLAUDE_PLUGIN_ROOT}` rather than repo-redirectable
-  environment) and the **managed** enterprise file (highest precedence — a value there wins, so an org can
-  enforce audit-only, with its `managed-settings.d/` drop-in dir merged over it); a session `--settings`
-  file is the one honored source a hook cannot read. Absent or unreadable settings fail closed to enabled.
-- **PreToolUse hooks DO fire for the PowerShell tool** (2.1.218; payload `tool_name` is literally
-  `PowerShell`, confirmed by a live block through that tool). A `Bash|PowerShell` matcher is correct and
-  there is no harness firing divergence — read `tool_name` from the stdin payload, not from an env var
-  (`CLAUDE_TOOL_NAME` does not exist).
-- The PowerShell lane is the inverse tradeoff: it stays open for read-only support work (git, gh,
-  metadata probes) and instead hard-denies engine invocations and turns known deletion spellings
-  into a final human permission prompt. It is a raised bar, not a fail-closed lane — move, rename,
-  overwrite, and volume-format spellings are not flagged at all (`reference/safety-model.md`); the
-  engine's own containment and the Bash lane remain the deletion authority.
+- The PowerShell lane is the inverse tradeoff: open for read-only support work, hard-denying engine
+  invocations, and turning known deletion spellings into a final human permission prompt. It is a
+  raised bar, not a fail-closed lane — its flagged set is enumerated, so an unflagged mutation
+  spelling passes it. The engine's own containment and the Bash lane remain the deletion authority.
 - The guard rejects `~` anywhere in a Bash command as a shell-expansion character, which includes
   Windows 8.3 short names (`SOMEUS~1`). Always pass long-form paths; the guard's own disclosures
   are already long-form.

--- a/plugins/disk-hygiene/skills/clean/reference/safety-model.md
+++ b/plugins/disk-hygiene/skills/clean/reference/safety-model.md
@@ -174,7 +174,7 @@ any delay or interruption means re-running handoff-verify. Managed-state exclusi
 always was in the manual lane — model judgment plus human review of the audit report — because
 snapshot entries carry no owner claim for the engine to check.
 
-The skill-scoped Bash guard accepts only complete literal words in the four declared engine command
+The skill-frontmatter Bash belt accepts only complete literal words in the four declared engine command
 shapes. It rejects every Bash expansion family, glob/word-splitting input, redirection, operator,
 escape, and compound-command form before validating arguments. Canonical script-path comparison uses
 the host platform's path case rules; POSIX path identity is never case-folded. A `--data-root` value
@@ -218,22 +218,31 @@ switch. When the guard sees execution enabled they are downgraded to a final hum
 when it sees a configured `false` (audit-only mode) they are denied outright, so the kill switch would
 block deletions on the PowerShell lane too and not only the Bash engine apply.
 
-Because this lane enumerates spellings instead of denying unknown commands, its coverage is
-knowingly partial: the flagged set is deletion- and recycle-shaped (plus `robocopy` mirror/purge/move
-and .NET `Delete`), so destructive **non-deletion** spellings — `Move-Item`/`mv`, `Rename-Item`,
-overwriting writers (`Set-Content`, `Out-File`, `>`, `New-Item -Force`), and volume operations
-(`Format-Volume`, `Clear-Disk`) — reach the tool with no guard verdict at all, in audit-only mode
-included. The only thing standing between them and the filesystem is the consumer's own permission
-policy, never this guard: the manual handoff's per-path approval covers the paths selected for
-removal, so it does not reach what such a command collaterally destroys — a `Move-Item -Force`
-destination, a truncated `Out-File` target, or an entire volume.
+The flagged set is no longer deletion-shaped only. Since #2470 it also covers destructive
+**non-deletion** spellings: `Move-Item`/`mv`/`move`, `Rename-Item`/`ren`/`rename`, the overwriting
+writers (`Set-Content`, `Out-File`, `Add-Content`, `New-Item -Force`, and both `>` file redirection
+and `>>` append — with PowerShell's stream merges and `$null` discards excluded),
+and the volume operations (`Format-Volume`, `Clear-Disk`, `Initialize-Disk`), alongside `robocopy`
+mirror/purge/move and .NET `Delete`. Each resolves against the kill switch on the same terms as a
+deletion spelling: `ask` when execution is enabled, denied outright in audit-only. Issue #387, which
+recorded the move/rename/overwrite/format gap, is closed.
 
-TODO(#387): extend the flagged set to those spellings.
+Because the lane still **enumerates** spellings rather than denying unknown commands, its coverage
+remains knowingly partial — a raised bar, not a fail-closed lane. Concrete residuals: the
+module-qualified form (`Module\Cmdlet`) is covered only for `Remove-Item`, `Clear-Content`, and
+`Clear-RecycleBin`, so a module-qualified `Move-Item` passes; the .NET pattern matches `Delete`
+alone, so writer and mover calls such as `[System.IO.File]::WriteAllText` or `::Move` pass; and any
+spelling nobody enumerated passes. For anything that passes, the only thing standing between it and
+the filesystem is the consumer's own permission policy, never this guard — the manual handoff's
+per-path approval covers the paths selected for removal, so it does not reach what such a command
+collaterally destroys: a `Move-Item -Force` destination, a truncated `Out-File` target, or an entire
+volume. The engine's own containment, revalidation, and platform gates remain the deletion
+authority.
 
 **Kill-switch enforcement (since 0.9.0): both surfaces resolve it by reading user settings.** The guard
 registers on two surfaces — the **plugin-level engine gate** (`hooks/hooks.json`, shell form through
 `hooks/run-python-hook.sh`, `--mode engine-gate`; see "Hook launch form" below) and the
-**skill-scoped belt** (the clean skill's frontmatter hook, shell form through the same launcher
+**skill-frontmatter belt** (the clean skill's frontmatter hook, shell form through the same launcher
 since 0.17.9) — and both
 resolve `disk_hygiene_enabled` the same single way: by reading it from `pluginConfigs` in the
 `settings.json` files, through the shared `lib/killswitch_config.py` reader (the same read the setup
@@ -254,8 +263,17 @@ resolves `false` (audit-only mode), `false` is guard-enforced — denied outrigh
 the two surfaces reach different lanes. The **always-on engine gate** enforces it against every Bash
 engine invocation **whether or not the clean skill is active**; it defers (no output) on any command that
 does not reference the engine, so it does **not** see PowerShell deletion spellings. Those are enforced by
-the **skill-scoped belt** (`powershell_decision`) — denied outright in audit-only — only **while the clean
-skill is active**. An absent, unreadable, or ambiguous read fails **closed to enabled**: the guard stays
+the **skill-frontmatter belt** (`powershell_decision`) — denied outright in audit-only — for the **rest of
+the session after the skill is invoked**. Claude Code registers a skill's frontmatter `PreToolUse` hooks
+when the skill is invoked and keeps them registered session-wide; the skills reference states it plainly
+("Hooks that Claude Code registers when the skill is invoked and keeps running for the rest of the
+session"). There is no harness-level "while the skill is active" window for hooks (#2618). The asymmetry
+is easy to misread and is worth naming: a skill's `allowed-tools` and `disallowed-tools` grants DO clear
+on the user's next message, but its `hooks` do not — so "skill-scoped" is true of the tool grants and
+false of the belt. Consequences in both directions: the belt keeps enforcing over unrelated later work in
+the same session (a later `Remove-Item` is still prompted long after cleanup ended), and it cannot be
+retracted by finishing the cleanup — only the session's end clears it.
+An absent, unreadable, or ambiguous read fails **closed to enabled**: the guard stays
 active and forces a human prompt before every mutation **it sees** — every Bash engine `apply`, and on
 PowerShell only the flagged spellings above — so an unreadable toggle never silently disables the
 guard.
@@ -284,7 +302,9 @@ premises if 2.1.207's user-scope-only `pluginConfigs` behavior changes upstream.
 
 PreToolUse hooks with a `Bash|PowerShell` matcher fire for the PowerShell tool on 2.1.218 (payload
 `tool_name` is literally `PowerShell`, confirmed by a live block through that tool); there is no harness
-firing divergence. The gate defers instantly (no output) for any command that does not reference the
+firing divergence. Read `tool_name` from the stdin payload, never from an env var — `CLAUDE_TOOL_NAME`
+does not exist. Where both surfaces see the same command their verdicts are idempotent. The gate defers
+instantly (no output) for any command that does not reference the
 engine, so it never taxes unrelated work; its coverage marker is the engine script name, a belt against
 casual invocation, not an authority (renaming the script evades the gate but not the engine's own
 preview/approval-token containment). The model additionally reads the `disk_hygiene_enabled` value from
@@ -295,7 +315,7 @@ deletion authority.
 
 **Hook launch form, and what it does and does not bound (0.17.8 #1416; extended to the belt in
 0.17.9, #2568).** All three registrations — the engine gate on `PreToolUse`, its detector on `Stop`,
-and the skill-scoped belt in the clean skill's frontmatter — use **shell form**: the `command` string
+and the skill-frontmatter belt in the clean skill's frontmatter — use **shell form**: the `command` string
 names `hooks/run-python-hook.sh` with `"shell": "bash"` and no `args`. Exec form was not viable: it is
 a bare `PATH` lookup, and on Windows `"command": "bash"` resolves to the WSL relay
 `System32\bash.exe` before Git Bash while `"command": "python3"` resolves to the zero-length
@@ -341,7 +361,7 @@ independently and out of scope here; the detector's command-substring filter mat
 way it is invisible to the engine gate's own coverage marker (see above); and it never retroactively
 scans a prior session's transcript — only the transcript named by the current `Stop` event's own
 `transcript_path`. Interpreter resolution is no longer one of those gaps: since #1504 the wired hooks
-— and since #2568 the skill-scoped belt — launch through the shared `hooks/run-python-hook.sh`, which
+— and since #2568 the skill-frontmatter belt — launch through the shared `hooks/run-python-hook.sh`, which
 tries `python3`, then `python`, then `py -3`, rejects the zero-length `WindowsApps` alias stub, and —
 in monitor mode — emits the `systemMessage` itself when nothing resolves, so a host with no usable
 Python reports the blind spot instead of hiding it. What every surface still shares is that launcher


### PR DESCRIPTION
Closes #2590

## Summary

Re-lands tidiness-first reporting (#2590) and corrects the clean skill's documented belt posture for the #2618 findings that belong on the markdown surfaces (`SKILL.md`, `reference/safety-model.md`). Cut from current `origin/main` so this does not silently revert under the #2691 stale-base squash-merge defect.

## Fix

- **F1 (#2590):** reports ordered by tier and evidence strength, never by byte size; empty directories are first-class findings; `provenance`/`risk` restored to the plan schema; preview/apply lead with tidiness.
- **F5(a)/F6/F4/F3/F7 (#2618 docs lane):** session-lifetime honesty, delete the false exec-form claim, long-path Recycle Bin caveat, relocation out of scope, thin Gotchas into `safety-model.md` pointers.
- Corrects `safety-model.md`'s stale claim that `Move-Item`/`Rename-Item` reach the tool ungated (fixed since #2470).
- **Does not** touch `destructive_guard.py` / `hygiene.py` — sibling lane (#2706).

Deliberately **not** `Closes #2618`: remaining findings belong to the guard lane (#2706). Closing it from here would falsely close it a second time.

## Verification

- `npx markdownlint-cli2 --config .markdownlint-cli2.jsonc` on both files → 0 errors
- `typos --config _typos.toml` → exit 0
- `editorconfig-checker` → exit 0
- `scripts/check-changed-skills.sh origin/main` → `SKILL.md` under 500-line cap; base-ref trigger phrases preserved
- Version bump to `0.20.6` with changelog entry so cached installs receive the restored skill

## Related

- Refs #2618 — docs-lane remediation only; guard half is #2706
- Refs #2691 — stale-base squash-merge defect that made this re-land necessary
- Refs #2635 — original F1 landing that #2639 silently reverted
- Refs #2639 — session-honesty docs recovered here (guard half recovered in #2706)
- Refs #2641 — PR whose stale-base squash merge reverted the prior fixes
- Refs #2706 — sibling guard allowlist re-land