### PR TITLE
docs(knowledge): drop the unfollowable Brief attribution from the 0.12.1 entry

### DIFF
--- a/plugins/knowledge/CHANGELOG.md
+++ b/plugins/knowledge/CHANGELOG.md
@@ -26,9 +26,9 @@ only after that version increases.
 - **Owner doc for the tracked citation shape** (`reference/citation-shape.md`): URL + retrieval
   date (ISO 8601, UTC) + `sha256:<hex64>` over raw snapshot bytes, with inline and structured
   forms, an optional node-id sub-resource anchor, and a drift rule (new fetch = new citation;
-  never edit a hash in place). Pays down the Brief-captured debt `map-corpus` recorded ("that
-  citation shape still needs an owner doc before a second skill emits it") — the skill's
-  cite-never-copy gotcha now points at the owner doc instead of naming the debt.
+  never edit a hash in place). Pays down the debt `map-corpus` recorded ("that citation shape still
+  needs an owner doc before a second skill emits it") — the skill's cite-never-copy gotcha now
+  points at the owner doc instead of naming the debt.
 
 ## [0.12.0]
 


### PR DESCRIPTION
## What

Drops two words from the shipped `knowledge` 0.12.1 changelog entry: "Pays down the ~~Brief-captured~~ debt `map-corpus` recorded".

## Why

`Brief-captured` attributes the debt to an authoring-time planning document that **exists in no git ref** — `git log --all -- docs/topics/docsite-digest` is empty, and the mapper's own working slice is untracked and self-ignoring by design. A consumer reading the changelog cannot follow it, and never could.

This is the same unresolvable-reference shape #2719 removed from the `map-corpus` skill body one version later. #2719 scoped it out deliberately, because editing a *shipped* entry is a different judgment call than fixing an unreleased one. This PR makes that call explicitly rather than leaving the residue in place.

## Why this does not rewrite history

The debt itself is quoted inline in the same sentence — "that citation shape still needs an owner doc before a second skill emits it" — so the entry still records what was owed and what paid it down. Only the unfollowable attribution goes. No version heading is touched, no entry is added or removed, and no ordering changes.

## Verification

Ran locally before pushing, all exit 0:

- `check-changelog-parity.sh --check` — every versioned plugin has a CHANGELOG, none documents a version above its manifest.
- `check-changelog-parity.sh --check-preserved origin/main` — all 1 changed changelog preserves every version heading it carried at `a326a877`, 58 headings compared.
- `check-changelog-parity.sh --check-bump origin/main` — every plugin whose version changed has a matching entry (none changed here; prose only).

No version bump: nothing a consumer receives changes behavior, and the changelog header's own rule ties the version to delivered change.

## Related

Completes the reference-debt cleanup begun in #2719, which established that `docs/topics/docsite-digest/` exists in no ref and that self-containment was therefore the only conforming outcome.

No related issue: routine hygiene on a shipped surface, found by the verifier on #2719 and deferred out of that PR's scope.
