### PR TITLE
docs(repo-fleet-hygiene): replace ghost MERGED_PR_* constants in security-review

### DIFF
--- a/plugins/repo-fleet-hygiene/.claude-plugin/plugin.json
+++ b/plugins/repo-fleet-hygiene/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "repo-fleet-hygiene",
-  "version": "0.22.2",
+  "version": "0.22.3",
   "description": "Cross-repository Git/GitHub fleet discovery, evidence rollup, and a gated apply verb that executes a prior fleet action plan behind one confirmation. Audit stays read-only and confidence-tiered; apply mutates only with --apply plus interactive confirmation or --yes.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/repo-fleet-hygiene/CHANGELOG.md
+++ b/plugins/repo-fleet-hygiene/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to `repo-fleet-hygiene` are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.22.3]
+
+### Fixed
+
+- **security-review.md no longer names deleted REST-era `MERGED_PR_BATCH_LIMIT` /
+  `MERGED_PR_HEAD_LIMIT` constants (#2709).** The live GraphQL collector constants
+  (`MERGED_PR_GRAPHQL_ALIAS_PAGE`, `MERGED_PR_GRAPHQL_JQ`) are documented instead,
+  with historical wording for the retired names so an auditor is not sent looking
+  for symbols that do not exist.
+
 ## [0.22.2]
 
 ### Fixed

--- a/plugins/repo-fleet-hygiene/skills/audit/SKILL.md
+++ b/plugins/repo-fleet-hygiene/skills/audit/SKILL.md
@@ -116,11 +116,11 @@ The bundled collector is authoritative for classifications. Preserve its evidenc
    in `fleet.ackUnavailable` is demoted to `ACKNOWLEDGED` — still reported, never suppressed; acks
    never touch non-404/403 failures or successful-response evidence.
 3. **Merged branch:** one aliased `gh api graphql` query per repository page of local branches
-   (up to 100 `headRefName` aliases per call, `first:1`, `states:[MERGED]`). GraphQL's
-   `headRefName` argument is an **exact** match — never the search API's prefix-matching `head:`
-   qualifier, so `feature/auth` and `feature/auth-v2` never conflate. Measured rate cost stays 1
-   per call (nodeCount equals the alias count); that stays well under GitHub's documented
-   500,000-node ceiling and 5,000-point/hour primary limit. This retires the REST
+   (up to `MERGED_PR_GRAPHQL_ALIAS_PAGE` `headRefName` aliases per call, `first:1`,
+   `states:[MERGED]`). GraphQL's `headRefName` argument is an **exact** match — never the search
+   API's prefix-matching `head:` qualifier, so `feature/auth` and `feature/auth-v2` never conflate.
+   Measured rate cost stays 1 per call (nodeCount equals the alias count); that stays well under
+   GitHub's documented 500,000-node ceiling and 5,000-point/hour primary limit. This retires the REST
    `merged-pr-window-truncated` disclosure and the privacy-gated per-branch `--head` fallback:
    every non-default local branch the operator asked about is queried by exact name, including
    heads GitHub auto-deleted and a later fetch pruned. Fail closed when `gh`/GraphQL is

--- a/plugins/repo-fleet-hygiene/skills/audit/reference/security-review.md
+++ b/plugins/repo-fleet-hygiene/skills/audit/reference/security-review.md
@@ -1,18 +1,21 @@
 # Plugin-acceptance security review
 
 Reviewed 2026-07-16 against the repository migration playbook and current official Claude Code plugin,
-skills, Git, GitHub CLI, and GitHub REST documentation. Re-checked 2026-07-31 for #1795 (merged-PR
-batch limit raised to the shared `MERGED_PR_BATCH_LIMIT` / `MERGED_PR_HEAD_LIMIT` constants; probe
-allowlist still admits only the fixed `pr list` argv shapes, now keyed to those constants rather than
-hardcoded 200/100 literals; truncation at the cap emits `UNKNOWN` and does not widen network egress).
+skills, Git, GitHub CLI, and GitHub REST documentation. Re-checked 2026-07-31 for #1795 (historical:
+on the then-REST `gh pr list` path, the merged-PR batch limit was raised from hardcoded 100 to 200 and
+the probe allowlist was keyed to those batch/head limits rather than hardcoded 200/100 literals;
+truncation at the cap emitted `UNKNOWN` and did not widen network egress). Superseded by the
+2026-08-14 re-check below — those REST batch/head limit names no longer exist after the GraphQL
+migration.
 Re-checked 2026-08-11 for the `allowed-tools` pairing fix: the grant is now a narrow, skill-anchored
 `Bash(${CLAUDE_SKILL_DIR}/scripts/audit-fleet.sh:*)` matching the body's direct invocation. No new
 execution, network, or config surface — the previous rule never matched, so this makes an already
 user-invoked script prompt-free rather than admitting anything new.
 Re-checked 2026-08-14 for #2604: merge evidence moves from REST `gh pr list` (window + privacy-gated
-`--head` fallback) to one aliased `gh api graphql` query per page of local branches. The allowlist
-admits only `query` documents with exact `headRefName` / `first:1` / `states:[MERGED]` shape and a
-fixed `--jq` flatten; `mutation`/`subscription` and REST `pr list` are rejected. Branch names
+`--head` fallback) to one aliased `gh api graphql` query per page of local branches
+(`MERGED_PR_GRAPHQL_ALIAS_PAGE` aliases per call). The allowlist admits only `query` documents with
+exact `headRefName` / `first:1` / `states:[MERGED]` shape and a fixed `--jq` flatten
+(`MERGED_PR_GRAPHQL_JQ`); `mutation`/`subscription` and REST `pr list` are rejected. Branch names
 transmitted are exactly the non-default local branches under audit for the operator's own resolved
 repository identity — not a silent gate that leaves branches unverdicted.
 Re-checked 2026-08-15 for #2607 (`merged-remote-branch`): reuses the same aliased GraphQL


### PR DESCRIPTION
Closes #2709

## Summary

`security-review.md` still named REST-era `MERGED_PR_BATCH_LIMIT` / `MERGED_PR_HEAD_LIMIT` constants that died with the #2604 GraphQL migration, so a security auditor could not reconcile the review against the collector. `SKILL.md` also restated the alias-page size as a bare `100` instead of the owning constant.

## Fix

- Rewrite the 2026-07-31 #1795 re-check as an explicitly historical REST-path record and point readers at the superseding 2026-08-14 entry.
- Cite the live collector constants `MERGED_PR_GRAPHQL_ALIAS_PAGE` and `MERGED_PR_GRAPHQL_JQ` in the GraphQL re-check prose.
- Name `MERGED_PR_GRAPHQL_ALIAS_PAGE` in `SKILL.md` instead of restating its value. Docs only; no collector behavior change.

## Verification

- `git grep -n 'MERGED_PR_BATCH_LIMIT\|MERGED_PR_HEAD_LIMIT' -- plugins/repo-fleet-hygiene` returns no matches.
- Every `MERGED_PR_*` name cited in `security-review.md` (`MERGED_PR_GRAPHQL_ALIAS_PAGE`, `MERGED_PR_GRAPHQL_JQ`) exists in `audit-fleet.sh`.
- `SKILL.md` names `MERGED_PR_GRAPHQL_ALIAS_PAGE` rather than a bare `100` for the alias-page size; GitHub upstream ceilings remain literals.

## Related

Refs #2604