### PR TITLE
test(scripts): exercise check-skill-precompute-compose.sh argument parser

### DIFF
--- a/scripts/check-skill-precompute-compose.test.sh
+++ b/scripts/check-skill-precompute-compose.test.sh
@@ -4,6 +4,8 @@ set -uo pipefail
 
 SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SCRIPT="$SELF_DIR/check-skill-precompute-compose.sh"
+# shellcheck source=test-git-helpers.sh
+. "$SELF_DIR/test-git-helpers.sh"
 
 PASS=0
 FAIL=0
@@ -22,6 +24,16 @@ new_fixture() {
   mkdir -p "$dir/scripts" "$dir/plugins/demo/skills/sample"
   cp "$SCRIPT" "$dir/scripts/check-skill-precompute-compose.sh"
   chmod +x "$dir/scripts/check-skill-precompute-compose.sh"
+  printf '%s' "$dir"
+}
+
+# Git-backed fixture for <base-ref> / --strict <base-ref> parser paths. Those
+# invocations drain the while-loop via the *) fall-through (no --all/--paths
+# break), so they assert the $# -gt 0 termination the --paths suite never hits.
+new_git_fixture() {
+  local dir
+  dir="$(new_fixture)"
+  git_init_safe "$dir"
   printf '%s' "$dir"
 }
 
@@ -95,6 +107,93 @@ if out="$(run_check "$f" --paths "plugins/demo/skills/sample/SKILL.md" 2>&1)"; t
 else
   fail "missing section should pass: $out"
 fi
+rm -rf "$f"
+
+# =============================================================================
+# Argument parser coverage (#2708).
+#
+# Every case above enters via --paths (or --strict --paths), which break-s out
+# of the while-loop before $# reaches 0. Mutating -gt 0 to -ge 0 therefore
+# survived the suite: once $# hits 0 the loop body still ran and case "$1"
+# unbound-variable-exited under set -u — but only for invocations that drain
+# through *) or leave POSITIONAL empty after consuming --strict/--help.
+# =============================================================================
+
+# --- no args -> usage, exit 2 ------------------------------------------------
+f="$(new_fixture)"
+out="$(run_check "$f" 2>&1)" && rc=0 || rc=$?
+if [[ "$rc" -eq 2 ]] && echo "$out" | grep -q '^usage:'; then
+  ok "no args prints usage and exits 2"
+else
+  fail "no args should usage/exit 2 (rc=$rc): $out"
+fi
+rm -rf "$f"
+
+# --- --help / -h -> usage, exit 2 --------------------------------------------
+f="$(new_fixture)"
+out="$(run_check "$f" --help 2>&1)" && rc=0 || rc=$?
+if [[ "$rc" -eq 2 ]] && echo "$out" | grep -q '^usage:'; then
+  ok "--help prints usage and exits 2"
+else
+  fail "--help should usage/exit 2 (rc=$rc): $out"
+fi
+out="$(run_check "$f" -h 2>&1)" && rc=0 || rc=$?
+if [[ "$rc" -eq 2 ]] && echo "$out" | grep -q '^usage:'; then
+  ok "-h prints usage and exits 2"
+else
+  fail "-h should usage/exit 2 (rc=$rc): $out"
+fi
+rm -rf "$f"
+
+# --- --strict alone -> usage, exit 2 (drains via --strict then empty) --------
+f="$(new_fixture)"
+out="$(run_check "$f" --strict 2>&1)" && rc=0 || rc=$?
+if [[ "$rc" -eq 2 ]] && echo "$out" | grep -q '^usage:'; then
+  ok "--strict alone prints usage and exits 2"
+else
+  fail "--strict alone should usage/exit 2 (rc=$rc): $out"
+fi
+rm -rf "$f"
+
+# --- bare <base-ref> reaches scan via *) drain (no --all/--paths break) ------
+f="$(new_git_fixture)"
+skill_md "$f" $'---\ndescription: test\n---\n\n## Pre-computed context\n\nBranch: !`git branch --show-current`\n\n## Body\n'
+git_test_config "$f" add -A >/dev/null
+git_test_config "$f" commit -qm base >/dev/null
+base="$(git -C "$f" rev-parse HEAD)"
+# Empty tip commit so diff vs base is empty — parser must still complete.
+git_test_config "$f" commit --allow-empty -qm tip >/dev/null
+if out="$(run_check "$f" "$base" 2>&1)"; then
+  if echo "$out" | grep -q 'nothing to gate'; then
+    ok "bare base-ref drains parser and reaches scan"
+  else
+    fail "bare base-ref should reach scan (nothing to gate): $out"
+  fi
+else
+  fail "bare base-ref should exit 0 after parse: $out"
+fi
+rm -rf "$f"
+
+# --- --strict <base-ref> drains --strict then *) and reaches scan ------------
+f="$(new_git_fixture)"
+skill_md "$f" $'---\ndescription: test\n---\n\n## Pre-computed context\n\nA: !`git branch --show-current`\nB: !`git status --porcelain`\n\n## Body\n'
+git_test_config "$f" add -A >/dev/null
+git_test_config "$f" commit -qm base >/dev/null
+base="$(git -C "$f" rev-parse HEAD)"
+# Change the skill after base so diff-mode actually scans it.
+skill_md "$f" $'---\ndescription: test\n---\n\n## Pre-computed context\n\nA: !`git branch --show-current`\nB: !`git status --porcelain`\nC: !`pwd`\n\n## Body\n'
+git_test_config "$f" add -A >/dev/null
+git_test_config "$f" commit -qm change >/dev/null
+if out="$(run_check "$f" --strict "$base" 2>&1)"; then
+  fail "strict + base-ref should fail on violation after parse"
+else
+  if echo "$out" | grep -q 'VIOLATION:' && echo "$out" | grep -q 'Strict mode: failing'; then
+    ok "--strict base-ref drains parser, scans, and fails closed"
+  else
+    fail "expected violation + strict fail after --strict base-ref: $out"
+  fi
+fi
+rm -rf "$f"
 
 printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
 [[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
Closes #2708

## Summary

`scripts/check-skill-precompute-compose.test.sh` never exercised the argument parser's while-loop termination. Every existing case entered via `--paths` (or `--strict --paths`), which `break`s before `$#` reaches 0, so mutating `-gt 0` to `-ge 0` survived the suite while five of six real invocation shapes unbound-variable-exited under `set -u`.

## Fix

Add parser-coverage cases to `scripts/check-skill-precompute-compose.test.sh`:

- no args → usage, exit 2
- `--help` / `-h` → usage, exit 2
- `--strict` alone → usage, exit 2 (drains via `--strict` then empty)
- bare `<base-ref>` → reaches scan via the `*)` fall-through (no `--all`/`--paths` break)
- `--strict <base-ref>` → drains `--strict` then `*)`, scans, fails closed on a violation

Git-backed fixtures use `test-git-helpers.sh` so base-ref mode runs against a throwaway repo.

## Verification

```text
$ bash scripts/check-skill-precompute-compose.test.sh
11 passed, 0 failed
```

Mutation check (copy + `sed -i '30s/-gt 0/-ge 0/'`): the new suite fails four cases (`no args`, `--strict` alone, bare base-ref, `--strict` base-ref) with `$1: unbound variable` / exit 1 — the gap described in #2708 is closed. `--help`/`-h` still pass under the mutant (they exit via `usage` before the broken condition is asserted), which is expected.

## Related

Refs #2680 (detector-findings producer pilot that surfaced this gap)