### PR TITLE
fix(repo-fleet-hygiene): distinguish --root and --repo in Scope header

### DIFF
--- a/plugins/repo-fleet-hygiene/.claude-plugin/plugin.json
+++ b/plugins/repo-fleet-hygiene/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "repo-fleet-hygiene",
-  "version": "0.22.3",
+  "version": "0.22.4",
   "description": "Cross-repository Git/GitHub fleet discovery, evidence rollup, and a gated apply verb that executes a prior fleet action plan behind one confirmation. Audit stays read-only and confidence-tiered; apply mutates only with --apply plus interactive confirmation or --yes.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/repo-fleet-hygiene/CHANGELOG.md
+++ b/plugins/repo-fleet-hygiene/CHANGELOG.md
@@ -21,7 +21,6 @@ All notable changes to `repo-fleet-hygiene` are documented here. Format follows
   with historical wording for the retired names so an auditor is not sent looking
   for symbols that do not exist.
 
-
 ## [0.22.2]
 
 ### Fixed

--- a/plugins/repo-fleet-hygiene/CHANGELOG.md
+++ b/plugins/repo-fleet-hygiene/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to `repo-fleet-hygiene` are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.22.4]
+
+### Fixed
+
+- **Audit `Scope:` header no longer conflates `--root` and `--repo` counts (#2710).**
+  Provenance now reports each flag's count separately (omitting zeros) so a
+  `--repo`-only invocation cannot read as mixed `--root/--repo` scope.
+
 ## [0.22.3]
 
 ### Fixed
@@ -12,6 +20,7 @@ All notable changes to `repo-fleet-hygiene` are documented here. Format follows
   (`MERGED_PR_GRAPHQL_ALIAS_PAGE`, `MERGED_PR_GRAPHQL_JQ`) are documented instead,
   with historical wording for the retired names so an auditor is not sent looking
   for symbols that do not exist.
+
 
 ## [0.22.2]
 

--- a/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.sh
+++ b/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.sh
@@ -696,12 +696,17 @@ fi
 # question from which config FILE was consumed, and the header used to answer it with a fixed
 # literal that could contradict the run's own inputs two lines later. Config-supplied scope is
 # ADDITIVE to any CLI-supplied scope, so both contributions are named rather than one masking the
-# other. Bare positional paths count as command-line --root equivalents.
-cli_scope_count=$((CLI_ROOT_COUNT + CLI_REPO_COUNT))
+# other. Bare positional paths are snapshotted into CLI_ROOT_COUNT (same as --root), so the
+# command-line segment attributes them as --root/bare-path rather than conflating with --repo.
 config_scope_count=$((${#ROOT_ARGS[@]} - CLI_ROOT_COUNT + ${#REPO_ARGS[@]} - CLI_REPO_COUNT))
+cli_scope_label=""
+[[ "$CLI_REPO_COUNT" -gt 0 ]] && cli_scope_label="${CLI_REPO_COUNT} --repo"
+if [[ "$CLI_ROOT_COUNT" -gt 0 ]]; then
+  [[ -n "$cli_scope_label" ]] && cli_scope_label="${cli_scope_label}, "
+  cli_scope_label="${cli_scope_label}${CLI_ROOT_COUNT} --root/bare-path"
+fi
 SCOPE_PROVENANCE=""
-[[ "$cli_scope_count" -gt 0 ]] &&
-  SCOPE_PROVENANCE="command line ($cli_scope_count --root/--repo argument(s))"
+[[ -n "$cli_scope_label" ]] && SCOPE_PROVENANCE="command line ($cli_scope_label)"
 if [[ "$config_scope_count" -gt 0 ]]; then
   [[ -n "$SCOPE_PROVENANCE" ]] && SCOPE_PROVENANCE="$SCOPE_PROVENANCE + "
   SCOPE_PROVENANCE="${SCOPE_PROVENANCE}config $CONFIG_SOURCE ($config_scope_count fleet.root/fleet.repo entr(ies))"

--- a/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.test.sh
+++ b/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.test.sh
@@ -1133,10 +1133,10 @@ else
   failures=$((failures + 1))
 fi
 
-# Bare path ≡ --root (#2599).
+# Bare path ≡ --root (#2599). Scope attributes bare paths to the root count (#2710).
 if REPO_FLEET_TEST_FAST_TIMEOUTS=1 bash "$SCRIPT" "$TMP/root" >"$ladder_out" 2>&1 &&
   grep -Fq "Repo: $TMP/root/acme/root-repo" "$ladder_out" &&
-  grep -Fq "Scope: command line (1 --root/--repo argument(s))" "$ladder_out"; then
+  grep -Fq "Scope: command line (1 --root/bare-path)" "$ladder_out"; then
   printf 'PASS: bare path is accepted as --root\n'
 else
   printf 'FAIL: bare path is accepted as --root\n' >&2
@@ -1225,11 +1225,30 @@ else
 fi
 # Scope provenance is computed, not asserted: this run's scope came from a CLI --root, so the header
 # must say so rather than printing the old fixed "current-project scope" literal that contradicted
-# the run's own inputs two lines later.
-if grep -Fq "Scope: command line (1 --root/--repo argument(s))" "$ladder_out"; then
+# the run's own inputs two lines later. --root and --repo counts stay distinct (#2710).
+if grep -Fq "Scope: command line (1 --root/bare-path)" "$ladder_out"; then
   printf 'PASS: header attributes scope to the command line when --root supplied it\n'
 else
   printf 'FAIL: header attributes scope to the command line when --root supplied it\n' >&2
+  failures=$((failures + 1))
+fi
+# --repo-only and mixed CLI scope must not collapse into one ambiguous --root/--repo total (#2710).
+# Use a separate capture file so later assertions against the wt-root ladder_out stay intact.
+scope_out="$TMP/scope-provenance.out"
+REPO_FLEET_TEST_FAST_TIMEOUTS=1 CLAUDE_PROJECT_DIR="$TMP/discovered-a" HOME="$TMP/nohome" \
+  bash "$SCRIPT" --repo "$TMP/discovered-a" >"$scope_out" 2>&1
+if grep -Fq "Scope: command line (1 --repo)" "$scope_out"; then
+  printf 'PASS: header attributes --repo-only scope without a root segment\n'
+else
+  printf 'FAIL: header attributes --repo-only scope without a root segment\n' >&2
+  failures=$((failures + 1))
+fi
+REPO_FLEET_TEST_FAST_TIMEOUTS=1 CLAUDE_PROJECT_DIR="$TMP/discovered-a" HOME="$TMP/nohome" \
+  bash "$SCRIPT" --repo "$TMP/discovered-a" --root "$TMP/emptyroot" >"$scope_out" 2>&1
+if grep -Fq "Scope: command line (1 --repo, 1 --root/bare-path)" "$scope_out"; then
+  printf 'PASS: header lists --repo and --root counts distinctly when both are supplied\n'
+else
+  printf 'FAIL: header lists --repo and --root counts distinctly when both are supplied\n' >&2
   failures=$((failures + 1))
 fi
 assert_not_contains_file() {


### PR DESCRIPTION
Closes #2710

## Summary

The audit report `Scope:` header no longer sums CLI `--root` and `--repo` counts into one ambiguous `--root/--repo` total. Each count is reported separately so operators can tell exact repos from discovery roots.

## Fix

In `audit-fleet.sh`, build the command-line provenance segment from `CLI_REPO_COUNT` and `CLI_ROOT_COUNT` independently, omitting zero segments:

- repos only: `command line (N --repo)`
- roots only (including bare positional paths): `command line (N --root/bare-path)`
- both: `command line (N --repo, M --root/bare-path)`
- neither: no command-line segment (unchanged)

Audited paths are unchanged; only the header wording changes. `audit-fleet.test.sh` updates the two existing Scope assertions and covers `--repo`-only and mixed CLI scope.

## Verification

```text
REPO_FLEET_TEST_FAST_TIMEOUTS=1 bash plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.test.sh
# → All repo-fleet-hygiene collector tests passed.
```

Smoke-checked Scope lines for `--repo` only, `--root` only, both, and bare positional path.

## Related

Refs #2599 (bare path ≡ `--root` provenance; wording now attributes bare paths explicitly)