### PR TITLE
refactor(discovery): compose toolchain ecosystem signals instead of duplicating them

### DIFF
--- a/plugins/discovery/.claude-plugin/plugin.json
+++ b/plugins/discovery/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "discovery",
-  "version": "0.15.4",
+  "version": "0.15.5",
   "description": "Structured discovery before changes: explore the local codebase and run disciplined multi-source external research, both dispatching a purpose-built subagent by default so the reading stays out of the main conversation — with source tiers, falsification, recency gates, and a corpus-coverage ledger — persisting EXPLORE.md / RESEARCH.md index-plus-sidecar handoff artifacts.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/discovery/CHANGELOG.md
+++ b/plugins/discovery/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog — discovery plugin
 
+## [0.15.5]
+
+### Changed
+
+- **Explore composes the toolchain ecosystem seam instead of a silent second
+  signal table (#2726).** `skills/explore/reference/ecosystem-discovery.md` now
+  presence-gates `/toolchain:check`'s resolved surface (`globs`,
+  `project-discovery` / `anchor`, `install-hint`) for shared ecosystem vocabulary,
+  keeps explore-only keys (`dependency-grep`, `test-globs`, `test-content-grep`)
+  even when that seam is present, and retains the prior YAML table only as the
+  documented fallback when `toolchain` is absent. `explore` Dimensions 3–6, the
+  `explorer` agent, and the plugin README cite the same gate+fallback shape.
+
 ## [0.15.4]
 
 ### Fixed

--- a/plugins/discovery/CHANGELOG.md
+++ b/plugins/discovery/CHANGELOG.md
@@ -6,10 +6,13 @@
 
 - **Explore composes the toolchain ecosystem seam instead of a silent second
   signal table (#2726).** `skills/explore/reference/ecosystem-discovery.md` now
-  presence-gates `/toolchain:check`'s resolved surface (`globs`,
-  `project-discovery` / `anchor`, `install-hint`) for shared ecosystem vocabulary,
-  keeps explore-only keys (`dependency-grep`, `test-globs`, `test-content-grep`)
-  even when that seam is present, and retains the prior YAML table only as the
+  presence-gates `/toolchain:check`'s covered-ecosystem set and
+  `project-discovery` / `anchor` for shared detection and root adjacency, keeps
+  explore-only keys (`dependency-grep`, `test-globs`, `test-content-grep`,
+  `build-configs`, `runtime-version-cmd`) even when that seam is present —
+  including fallback ecosystems the seam does not cover (`rust`, `java`) and the
+  exhaustive configuration / runtime-probe inventories seam `globs` /
+  `install-hint` do not replace — and retains the prior YAML table as the
   documented fallback when `toolchain` is absent. `explore` Dimensions 3–6, the
   `explorer` agent, and the plugin README cite the same gate+fallback shape.
 

--- a/plugins/discovery/README.md
+++ b/plugins/discovery/README.md
@@ -35,9 +35,11 @@ relaxes no discipline.
 - **Self-contained.** The research discipline file (source tiers, recency gates,
   falsification recipes, failure patterns) and the per-ecosystem discovery
   reference ship inside the plugin and are referenced via `${CLAUDE_PLUGIN_ROOT}`.
-  Explore composes `/toolchain:check`'s ecosystem signal vocabulary when that
-  plugin is installed (documented fallback table when it is not) — it does not
-  bake a second inventory.
+  Explore composes `/toolchain:check`'s covered-ecosystem detection and root
+  adjacency when that plugin is installed (documented fallback table when it is
+  not; explore-owned inventories for build configs, runtime probes, and
+  ecosystems the seam does not cover stay explore-owned) — it does not bake a
+  second covered-ecosystem inventory.
 - **Reads your conventions, assumes none.** Project rules, preferred-source
   rosters, per-ecosystem source mappings, and any stated direction come from your
   own project's `CLAUDE.md` and rules; where none exist, the skills self-discover

--- a/plugins/discovery/README.md
+++ b/plugins/discovery/README.md
@@ -35,6 +35,9 @@ relaxes no discipline.
 - **Self-contained.** The research discipline file (source tiers, recency gates,
   falsification recipes, failure patterns) and the per-ecosystem discovery
   reference ship inside the plugin and are referenced via `${CLAUDE_PLUGIN_ROOT}`.
+  Explore composes `/toolchain:check`'s ecosystem signal vocabulary when that
+  plugin is installed (documented fallback table when it is not) — it does not
+  bake a second inventory.
 - **Reads your conventions, assumes none.** Project rules, preferred-source
   rosters, per-ecosystem source mappings, and any stated direction come from your
   own project's `CLAUDE.md` and rules; where none exist, the skills self-discover

--- a/plugins/discovery/agents/explorer.md
+++ b/plugins/discovery/agents/explorer.md
@@ -16,6 +16,8 @@ need arrives in your dispatch prompt.
 The `/discovery:explore` skill is preloaded into your context at startup. Its exploration
 dimensions, output format, and outcome gate are your procedure. It names a sibling
 ecosystem-discovery reference — Read that at the dimension that needs it rather than up front.
+That reference composes `/toolchain:check`'s resolved ecosystem surface when the `toolchain`
+plugin is installed (fallback table when it is not); do not invent a parallel signal inventory.
 
 ## Your dispatch prompt must carry these; refuse to guess any of them
 

--- a/plugins/discovery/agents/explorer.md
+++ b/plugins/discovery/agents/explorer.md
@@ -16,8 +16,11 @@ need arrives in your dispatch prompt.
 The `/discovery:explore` skill is preloaded into your context at startup. Its exploration
 dimensions, output format, and outcome gate are your procedure. It names a sibling
 ecosystem-discovery reference — Read that at the dimension that needs it rather than up front.
-That reference composes `/toolchain:check`'s resolved ecosystem surface when the `toolchain`
-plugin is installed (fallback table when it is not); do not invent a parallel signal inventory.
+That reference composes `/toolchain:check`'s covered-ecosystem set and root
+adjacency when the `toolchain` plugin is installed (fallback table when it is
+not; keep explore-owned `build-configs` / `runtime-version-cmd` / unsupported
+ecosystems from the fallback table); do not invent a parallel covered-ecosystem
+inventory.
 
 ## Your dispatch prompt must carry these; refuse to guess any of them
 

--- a/plugins/discovery/skills/explore/SKILL.md
+++ b/plugins/discovery/skills/explore/SKILL.md
@@ -117,7 +117,7 @@ Code has context only git reveals — who changed it, when, why, and what else c
 Understand how the pieces fit together before moving any of them.
 
 - **Directory layout** — if the project documents its repository structure, verify the doc matches reality; otherwise map the tree yourself
-- **Project references / imports** — map the dependency graph by grepping the ecosystem's import/reference token across its build-config files (per-ecosystem tokens: `${CLAUDE_PLUGIN_ROOT}/skills/explore/reference/ecosystem-discovery.md`)
+- **Project references / imports** — map the dependency graph by grepping the ecosystem's import/reference token across its build-config files (per-ecosystem tokens: `${CLAUDE_PLUGIN_ROOT}/skills/explore/reference/ecosystem-discovery.md` — compose `/toolchain:check`'s resolved ecosystem surface when the `toolchain` plugin is installed; otherwise the reference's fallback table)
 - **Solution / workspace membership** — check the repo's solution or workspace file at the root for what's included
 - **Layer boundaries** — respect any dependency-direction rules the project declares
 - **Planned direction** — cross-reference findings with any stated direction in the project's own `CLAUDE.md` or docs. Assess how changes must fit the repo's current state AND planned direction
@@ -126,7 +126,7 @@ Understand how the pieces fit together before moving any of them.
 
 Tests are executable documentation. They reveal intended behavior, edge cases, and existing coverage.
 
-- **Find test projects** — Glob the per-ecosystem test patterns in `${CLAUDE_PLUGIN_ROOT}/skills/explore/reference/ecosystem-discovery.md`
+- **Find test projects** — Glob the per-ecosystem test patterns in `${CLAUDE_PLUGIN_ROOT}/skills/explore/reference/ecosystem-discovery.md` (`test-globs` / `test-content-grep` are explore-owned even when composing the toolchain seam)
 - **Co-located tests** — check whether unit tests live next to their source (sibling test project, `__tests__/`, adjacent `_test.go`) or in a separate tree
 - **Cross-cutting tests** — a repo-root `tests/` for architecture, dependency, or naming-rule tests that span multiple libraries
 - **Test patterns** — read existing tests (start with 2-3, scale to the number of distinct patterns in play) to understand naming conventions, assertion style, and fixture patterns before writing new ones
@@ -136,7 +136,7 @@ Tests are executable documentation. They reveal intended behavior, edge cases, a
 
 Build configuration constrains what's possible. Understand it before fighting it.
 
-- **Build configs** — read the ecosystem's build / package / config files (per-ecosystem lists in `${CLAUDE_PLUGIN_ROOT}/skills/explore/reference/ecosystem-discovery.md`)
+- **Build configs** — read the ecosystem's build / package / config files per `${CLAUDE_PLUGIN_ROOT}/skills/explore/reference/ecosystem-discovery.md` (resolved `project-discovery` / `anchor` / config-bearing `globs` when the `toolchain` plugin is installed; otherwise the reference's fallback `build-configs`)
 - **Analyzer / lint config** — `.editorconfig` for shared severity levels; ecosystem-specific analyzer/linter files
 - **Package versions** — check the ecosystem's manifest (lockfile + central-version-management file if applicable)
 - **CI/CD** — `.github/workflows/` (or the project's CI equivalent) for what's validated on every PR
@@ -145,7 +145,7 @@ Build configuration constrains what's possible. Understand it before fighting it
 
 When the task involves tooling, MCP servers, or infrastructure:
 
-- **Installed versions** — run the per-ecosystem version commands in `${CLAUDE_PLUGIN_ROOT}/skills/explore/reference/ecosystem-discovery.md`
+- **Installed versions** — probe per `${CLAUDE_PLUGIN_ROOT}/skills/explore/reference/ecosystem-discovery.md` (toolchain `install-hint` / native version probe when the `toolchain` plugin is installed; otherwise the reference's fallback `runtime-version-cmd`)
 - **MCP server status** — test with a read-only call before depending on it
 - **Worktree state** — `git worktree list`, current branch, uncommitted changes
 - **Local config** — project-local settings for env vars and tokens (don't read secrets, just verify presence)

--- a/plugins/discovery/skills/explore/SKILL.md
+++ b/plugins/discovery/skills/explore/SKILL.md
@@ -117,7 +117,7 @@ Code has context only git reveals — who changed it, when, why, and what else c
 Understand how the pieces fit together before moving any of them.
 
 - **Directory layout** — if the project documents its repository structure, verify the doc matches reality; otherwise map the tree yourself
-- **Project references / imports** — map the dependency graph by grepping the ecosystem's import/reference token across its build-config files (per-ecosystem tokens: `${CLAUDE_PLUGIN_ROOT}/skills/explore/reference/ecosystem-discovery.md` — compose `/toolchain:check`'s resolved ecosystem surface when the `toolchain` plugin is installed; otherwise the reference's fallback table)
+- **Project references / imports** — map the dependency graph by grepping the ecosystem's import/reference token across its build-config files (per-ecosystem tokens: `${CLAUDE_PLUGIN_ROOT}/skills/explore/reference/ecosystem-discovery.md` — compose `/toolchain:check`'s covered-ecosystem set when the `toolchain` plugin is installed, retaining fallback ecosystems the seam does not cover; otherwise the reference's fallback table)
 - **Solution / workspace membership** — check the repo's solution or workspace file at the root for what's included
 - **Layer boundaries** — respect any dependency-direction rules the project declares
 - **Planned direction** — cross-reference findings with any stated direction in the project's own `CLAUDE.md` or docs. Assess how changes must fit the repo's current state AND planned direction
@@ -136,7 +136,7 @@ Tests are executable documentation. They reveal intended behavior, edge cases, a
 
 Build configuration constrains what's possible. Understand it before fighting it.
 
-- **Build configs** — read the ecosystem's build / package / config files per `${CLAUDE_PLUGIN_ROOT}/skills/explore/reference/ecosystem-discovery.md` (resolved `project-discovery` / `anchor` / config-bearing `globs` when the `toolchain` plugin is installed; otherwise the reference's fallback `build-configs`)
+- **Build configs** — read the ecosystem's build / package / config files per `${CLAUDE_PLUGIN_ROOT}/skills/explore/reference/ecosystem-discovery.md` (explore-owned `build-configs` even when composing the toolchain seam; resolved `project-discovery` / `anchor` locate roots)
 - **Analyzer / lint config** — `.editorconfig` for shared severity levels; ecosystem-specific analyzer/linter files
 - **Package versions** — check the ecosystem's manifest (lockfile + central-version-management file if applicable)
 - **CI/CD** — `.github/workflows/` (or the project's CI equivalent) for what's validated on every PR
@@ -145,7 +145,7 @@ Build configuration constrains what's possible. Understand it before fighting it
 
 When the task involves tooling, MCP servers, or infrastructure:
 
-- **Installed versions** — probe per `${CLAUDE_PLUGIN_ROOT}/skills/explore/reference/ecosystem-discovery.md` (toolchain `install-hint` / native version probe when the `toolchain` plugin is installed; otherwise the reference's fallback `runtime-version-cmd`)
+- **Installed versions** — probe per `${CLAUDE_PLUGIN_ROOT}/skills/explore/reference/ecosystem-discovery.md` (explore-owned `runtime-version-cmd` even when composing the toolchain seam; `install-hint` is install prose, not a version probe)
 - **MCP server status** — test with a read-only call before depending on it
 - **Worktree state** — `git worktree list`, current branch, uncommitted changes
 - **Local config** — project-local settings for env vars and tokens (don't read secrets, just verify presence)

--- a/plugins/discovery/skills/explore/reference/ecosystem-discovery.md
+++ b/plugins/discovery/skills/explore/reference/ecosystem-discovery.md
@@ -6,28 +6,29 @@ Per-ecosystem discovery primitives consumed by the explore skill's Dimensions 3�
 ## Prefer the toolchain seam
 
 When the `toolchain` plugin is installed, compose `/toolchain:check`'s ecosystem
-detection and command-resolution seam for the shared signal vocabulary — do not
-bake a second inventory of ecosystems, build/config anchors, or runtime probes.
-`/toolchain:check` is the reference skill other plugins compose for that concern
-instead of baking their own tables. Gate and fallback follow
-`docs/conventions/seam-phrasing/README.md`.
+detection and command-resolution seam for the shared signal vocabulary it owns —
+do not bake a second inventory of those signals. `/toolchain:check` is the
+reference skill other plugins compose for that concern instead of baking their
+own tables. Gate and fallback follow `docs/conventions/seam-phrasing/README.md`.
 
 Resolve each ecosystem through the ladder `/toolchain:check` documents (consumer
 `.claude/ecosystems/<ecosystem>.yaml` authoritative when present; bundled
 portable defaults only as that ladder's final rung). Read *resolved* state: an
 ecosystem present but `enabled: false` is not configured for exploration either.
 
-| Explore need | Compose from the toolchain seam |
+| Explore need | Source when `toolchain` is installed |
 |---|---|
-| Which ecosystems are in play | Resolved `globs` (and covered-ecosystem set) |
+| Which ecosystems are in play | Resolved `globs` (and covered-ecosystem set), **plus** fallback-table ecosystems the seam does not cover (`rust`, `java` today — `/toolchain:check` covers `dotnet`, `python`, `typescript`, `bash`, `powershell`, `markdown`, `go`) when their fallback `build-configs` markers are present in the repo |
 | Project / workspace roots (Dimension 3 adjacency) | Resolved `project-discovery` / `anchor` |
-| Build / package / config files to read (Dimension 5) | Resolved `project-discovery`, `anchor`, and config-bearing entries in `globs` |
-| Runtime / toolchain presence (Dimension 6) | Tools named by resolved `install-hint` and the ecosystem's native version probe — not a parallel `runtime-version-cmd` table |
+| Build / package / config files to read (Dimension 5) | Explore-owned `build-configs` from the fallback table — seam `globs` / `project-discovery` / `anchor` classify changed files and locate roots; they are not an exhaustive configuration inventory |
+| Runtime / toolchain presence (Dimension 6) | Explore-owned `runtime-version-cmd` from the fallback table — resolved `install-hint` is free-form install prose, not a version probe |
 
-**Explore-only keys the seam does not own.** `dependency-grep`, `test-globs`, and
-`test-content-grep` have no home in the ecosystem-commands surface. Use the
-fallback table below for those keys even when composing the toolchain seam for
-the shared vocabulary above.
+**Explore-only keys the seam does not own.** `dependency-grep`, `test-globs`,
+`test-content-grep`, `build-configs`, and `runtime-version-cmd` have no home in
+the ecosystem-commands surface (or the seam's fields are classifiers / install
+prose rather than these inventories). Use the fallback table below for those
+keys even when composing the toolchain seam for covered-ecosystem detection and
+project-root adjacency.
 
 Where the consuming project's own conventions differ (a custom test layout, a
 nonstandard workspace file), the project's conventions win.
@@ -37,6 +38,10 @@ nonstandard workspace file), the project's conventions win.
 When the `toolchain` plugin is not installed, use the table below for every
 sub-key. This is the documented standalone fallback, not a peer source of truth
 alongside the seam.
+
+Use only the ecosystems the consuming repo actually contains. Where the consuming
+project's own conventions differ (a custom test layout, a nonstandard workspace
+file), the project's conventions win — this table is the generic starting point.
 
 Sub-keys:
 

--- a/plugins/discovery/skills/explore/reference/ecosystem-discovery.md
+++ b/plugins/discovery/skills/explore/reference/ecosystem-discovery.md
@@ -3,6 +3,41 @@
 Per-ecosystem discovery primitives consumed by the explore skill's Dimensions 3–6
 (project structure / test discovery / configuration & build state / environment).
 
+## Prefer the toolchain seam
+
+When the `toolchain` plugin is installed, compose `/toolchain:check`'s ecosystem
+detection and command-resolution seam for the shared signal vocabulary — do not
+bake a second inventory of ecosystems, build/config anchors, or runtime probes.
+`/toolchain:check` is the reference skill other plugins compose for that concern
+instead of baking their own tables. Gate and fallback follow
+`docs/conventions/seam-phrasing/README.md`.
+
+Resolve each ecosystem through the ladder `/toolchain:check` documents (consumer
+`.claude/ecosystems/<ecosystem>.yaml` authoritative when present; bundled
+portable defaults only as that ladder's final rung). Read *resolved* state: an
+ecosystem present but `enabled: false` is not configured for exploration either.
+
+| Explore need | Compose from the toolchain seam |
+|---|---|
+| Which ecosystems are in play | Resolved `globs` (and covered-ecosystem set) |
+| Project / workspace roots (Dimension 3 adjacency) | Resolved `project-discovery` / `anchor` |
+| Build / package / config files to read (Dimension 5) | Resolved `project-discovery`, `anchor`, and config-bearing entries in `globs` |
+| Runtime / toolchain presence (Dimension 6) | Tools named by resolved `install-hint` and the ecosystem's native version probe — not a parallel `runtime-version-cmd` table |
+
+**Explore-only keys the seam does not own.** `dependency-grep`, `test-globs`, and
+`test-content-grep` have no home in the ecosystem-commands surface. Use the
+fallback table below for those keys even when composing the toolchain seam for
+the shared vocabulary above.
+
+Where the consuming project's own conventions differ (a custom test layout, a
+nonstandard workspace file), the project's conventions win.
+
+## Fallback — toolchain absent
+
+When the `toolchain` plugin is not installed, use the table below for every
+sub-key. This is the documented standalone fallback, not a peer source of truth
+alongside the seam.
+
 Sub-keys:
 
 - `test-globs` — glob patterns identifying test projects / files (Dimension 4)
@@ -13,10 +48,6 @@ Sub-keys:
 - `dependency-grep` — content regex grepped across source / project files to map
   the dependency graph (Dimension 3)
 - `runtime-version-cmd` — command to check the installed runtime version (Dimension 6)
-
-Use only the ecosystems the consuming repo actually contains. Where the consuming
-project's own conventions differ (a custom test layout, a nonstandard workspace
-file), the project's conventions win — this table is the generic starting point.
 
 ```yaml
 ecosystems:


### PR DESCRIPTION
Closes #2726

## Summary

`ecosystem-discovery.md` no longer silently duplicates the toolchain plugin's
per-ecosystem signal vocabulary. Explore composes `/toolchain:check`'s resolved
surface when that plugin is installed, and keeps the prior YAML table only as
the documented fallback.

## Fix

- Rewrote `plugins/discovery/skills/explore/reference/ecosystem-discovery.md`
  with a presence-gated toolchain seam pointer (`globs`, `project-discovery` /
  `anchor`, `install-hint`), explore-only keys (`dependency-grep`, `test-globs`,
  `test-content-grep`) retained even when the seam is present, and the previous
  table scoped as the toolchain-absent fallback.
- Updated explore Dimensions 3–6, the `explorer` agent, and the plugin README to
  cite the same gate+fallback shape (`docs/conventions/seam-phrasing`).
- Bumped discovery `0.15.4` → `0.15.5` with CHANGELOG.

## Verification

- `bash plugins/discovery/scripts/contract.test.sh` — all assertions passed
- `bash plugins/discovery/agents/tool-honesty.test.sh` — all tests passed
- Confirmed seam / fallback / explore-only phrasing in the reference, skill,
  agent, and README

## Related

- Refs #2685
- ADR 0011 (`docs/adr/0011-resolve-routine-prerequisites-per-identity-declared-over-detected.md`)