### PR TITLE
fix(skill-quality): harden Q4 against files:[] prose-only fixture dodge

### DIFF
--- a/plugins/skill-quality/.claude-plugin/plugin.json
+++ b/plugins/skill-quality/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "skill-quality",
-  "version": "0.15.10",
+  "version": "0.15.11",
   "description": "Skill-authoring QA tooling: a static contract checker that runs twenty-two deterministic checks over a Claude Code skill (frontmatter, per-skill listing-entry cap, trigger-keyword preservation, line caps, broken internal refs, markdownlint, gotchas surface, evals presence, precompute opportunity, injection shell-declaration, fresh-eyes declaration conformance), a shared skill-listing budget reporter across a set of skills, and a bundled evals.json schema plus a deterministic eval-quality lint (duplicate case identities, missing fixtures, empty or vague grading criteria, set-coverage warnings). Runs against any repo's skills directory via the convention-resolution ladder \u2014 no baked layout.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/skill-quality/CHANGELOG.md
+++ b/plugins/skill-quality/CHANGELOG.md
@@ -3,6 +3,19 @@
 All notable changes to the `skill-quality` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.15.11]
+
+### Fixed
+
+- **Eval-quality Q4 no longer silent on `files: []` + prose-only paths (#2746).**
+  `check-evals-quality.sh` still FAILs unresolvable/`..`/absolute entries in the
+  declared `files` array. It now also WARNs when `files` is empty/absent, the case
+  is not `narration: true`, and `prompt`/`expected_output` contain a path-shaped
+  token (`dir/…/file.ext`) that resolves to nothing under the skill or evals
+  directory — the dodge that let compress evals 3/8/10 clear the gate while naming
+  unreachable paths. Opt out with `narration: true` (schema field added) or declare
+  a real fixture in `files`. Branch-like tokens and bare filenames stay out of scope.
+
 ## [0.15.10]
 
 ### Fixed

--- a/plugins/skill-quality/CHANGELOG.md
+++ b/plugins/skill-quality/CHANGELOG.md
@@ -15,6 +15,9 @@ All notable changes to the `skill-quality` plugin are documented here. Format fo
   directory — the dodge that let compress evals 3/8/10 clear the gate while naming
   unreachable paths. Opt out with `narration: true` (schema field added) or declare
   a real fixture in `files`. Branch-like tokens and bare filenames stay out of scope.
+  Host-shaped skips require a DNS-like first segment ending in an alphabetic label
+  (so `v1.2/schema/config.json` stays in scope); the PROSE escape gate keeps only
+  the reachable `../` check before the existence WARN.
 
 ## [0.15.10]
 

--- a/plugins/skill-quality/README.md
+++ b/plugins/skill-quality/README.md
@@ -94,8 +94,10 @@ After the schema, `check-evals-quality.sh` (bash + jq) lints eval CONTENT determ
 `FAIL:` tier — duplicate case ids/names, empty criterion items, `files` fixture entries that
 resolve to no path under the skill or evals directory. `WARN:` tier (advisory, exit 0) — a case
 carrying both `expectations` and `assertions`, identical prompt+files pairs, vague whole-item
-phrasing ("the output is good"), a thin sole-criterion `expected_output`, and a set with no
-refusal/guardrail or anti-pattern case. It deliberately does not flag low case count. Run
+phrasing ("the output is good"), a thin sole-criterion `expected_output`, a set with no
+refusal/guardrail or anti-pattern case, and (Q4 prose) an empty `files` list with
+path-shaped tokens in `prompt`/`expected_output` that resolve nowhere (silence with
+`narration: true` or declare fixtures). It deliberately does not flag low case count. Run
 `--help` on the script for the full Q1-Q9 list; without `jq` it exits 2 and the schema verdict
 stands alone.
 

--- a/plugins/skill-quality/reference/evals.schema.json
+++ b/plugins/skill-quality/reference/evals.schema.json
@@ -55,6 +55,10 @@
           "items": { "type": "string", "minLength": 1 },
           "description": "Optional list of fixture file paths required by this case."
         },
+        "narration": {
+          "type": "boolean",
+          "description": "When true, the case intentionally names fictional or consumer-repo paths in prompt/expected_output without shipping fixtures under the skill or evals directory. Opt out of the eval-quality Q4 prose-path warning that otherwise fires when files is empty and those paths do not resolve."
+        },
         "assertions": {
           "type": "array",
           "description": "Optional list of objectively-verifiable assertions (skill-creator upstream field name). Items are skill-author-defined; schema does not constrain shape."

--- a/plugins/skill-quality/scripts/check-evals-quality.sh
+++ b/plugins/skill-quality/scripts/check-evals-quality.sh
@@ -29,11 +29,17 @@
 #       whitespace-only `expected_output` standing as a case's sole
 #       criterion. Non-empty object/array items pass — item shape is
 #       skill-author-defined
-#   Q4. A `files` fixture entry that resolves to no file or directory
-#       relative to the skill dir or the evals dir, or that escapes those
-#       roots via an absolute path or a `..` component (FAIL — a case
-#       whose fixtures cannot be found under the documented roots cannot
-#       be exercised from the tree)
+#   Q4. Fixture reachability (FAIL for declared `files` entries; WARN for
+#       prose-only paths). A `files` entry that resolves to no file or
+#       directory relative to the skill dir or the evals dir, or that
+#       escapes those roots via an absolute path or a `..` component,
+#       FAILs — a case whose declared fixtures cannot be found under the
+#       documented roots cannot be exercised from the tree. Separately,
+#       when `files` is empty/absent and the case is not marked
+#       `narration: true`, path-shaped tokens (dir/…/file.ext) in
+#       `prompt`/`expected_output` that resolve to nothing under those
+#       roots WARN — otherwise `files: []` plus a path named only in
+#       prose silently dodges the declared-fixture check
 #   Q5. A case carrying BOTH `expectations` and `assertions` (WARN — the
 #       schema treats them as equivalent alternatives; carrying both makes
 #       the grading contract ambiguous. Pick one)
@@ -65,7 +71,9 @@
 # and, as a fallback, the evals dir itself. Entries naming files the eval
 # RUNNER must synthesize (consumer-repo state like `.claude/<config>.md`)
 # should still ship a fixture copy at one of those roots so the case stays
-# exercisable from the tree.
+# exercisable from the tree. Prose-path tokens use the same roots; cases
+# that intentionally name fictional consumer-repo paths without shipping
+# fixtures must set `narration: true` so the gap is explicit.
 set -uo pipefail
 
 # The header range is derived from the comment block itself, so adding
@@ -105,6 +113,11 @@ VAGUE_RE='^(the )?(output|response|result|it) (is|looks|seems) (good|correct|rig
 # Deliberately lenient (matches inside longer words/phrases): under-warning
 # beats noise for an advisory check.
 NEGATIVE_RE='refus|declin|must not|does not|doesn.t|never|reject|block|anti-pattern|antipattern|not |guardrail|instead of|rather than|without'
+# Q4 prose-path tokens: require at least one directory component and a
+# file extension so branch names (feat/foo) and slash-separated enums
+# (ours/theirs) stay silent. Bare filenames (CLAUDE.md) are also out of
+# scope — too common as narration without being a fixture claim.
+PROSE_PATH_RE='(?:\./)?(?:[A-Za-z0-9_.@+-]+/)+[A-Za-z0-9_.@+-]+\.(?:md|json|ts|tsx|js|jsx|mjs|cjs|py|sh|bash|zsh|yml|yaml|toml|txt|html|htm|css|scss|rs|go|java|rb|php|c|h|cpp|hpp|cc|cs|sql|xml|svg|png|jpg|jpeg|gif|webp|pdf|lock|env|cfg|ini|conf)'
 
 FAILED=0
 WARNINGS=0
@@ -129,6 +142,11 @@ JQ_PROG='
   input_filename as $f |
   def items: ((.expectations // []) + (.assertions // []));
   def caseref: if .name then "case \(.name) (id=\(.id))" else "case id=\(.id)" end;
+  # Path-shaped tokens in prompt/expected_output. scan/g keeps every
+  # non-overlapping match; trailing sentence punctuation is stripped in bash.
+  def prose_paths:
+    ((.prompt // "") + "\n" + (.expected_output // "")) as $t
+    | [$t | scan($prose_path)] | unique[];
   (.evals // []) as $cases |
   # Q1: duplicate ids (int 1 and string "1" collide by design — an id pair
   # distinguishable only by JSON type is still ambiguous to a grader).
@@ -151,9 +169,15 @@ JQ_PROG='
     | select((.expected_output // "") | (length > 0) and (gsub("[[:space:]]"; "") == ""))
     | caseref as $c
     | "FAIL" + $u + "\($f): \($c): whitespace-only expected_output is the sole grading criterion — it cannot be graded (Q3)"),
-  # Q4: fixture entries, resolved by bash.
+  # Q4: declared fixture entries, resolved by bash.
   ($cases[] | caseref as $c | .files[]?
     | "FILE" + $u + "\($f)" + $u + "\($c)" + $u + "\(.)"),
+  # Q4: prose-only path claims when files is empty/absent and the case is
+  # not an explicit narration scenario. Resolved by bash against the same
+  # roots as FILE entries.
+  ($cases[] | select((.files // []) | length == 0) | select(.narration != true)
+    | caseref as $c | prose_paths as $p
+    | "PROSE" + $u + "\($f)" + $u + "\($c)" + $u + "\($p)"),
   # Q5: both field names on one case.
   ($cases[] | select(.expectations != null and .assertions != null) | caseref as $c
     | "WARN" + $u + "\($f): \($c): carries BOTH expectations and assertions — the fields are equivalent alternatives; pick one (Q5)"),
@@ -185,7 +209,8 @@ JQ_PROG='
 # JSON string content, so fields with spaces/tabs survive the bash read.
 US=$'\x1f'
 LINT_OUT="$(jq -r --arg u "$US" --arg vague "$VAGUE_RE" --arg neg "$NEGATIVE_RE" \
-  --argjson min "$EXPECTED_OUTPUT_MIN" "$JQ_PROG" "$@" 2>&1)"
+  --arg prose_path "$PROSE_PATH_RE" --argjson min "$EXPECTED_OUTPUT_MIN" \
+  "$JQ_PROG" "$@" 2>&1)"
 JQ_RC=$?
 LINT_OUT="$(printf '%s' "$LINT_OUT" | tr -d '\r')"
 
@@ -193,6 +218,21 @@ if [[ $JQ_RC -ne 0 ]]; then
   printf 'Error: jq failed (unparsable JSON or internal error) — run schema validation on the input first:\n%s\n' "$LINT_OUT" >&2
   exit 2
 fi
+
+# Strip trailing sentence punctuation often glued to a prose path token
+# ("...overview.md.") without treating an interior dot as trailing.
+# Avoid `[[ =~ [[:class:]] ]]` — bash can terminate the compound command at
+# the inner `[[`, which corrupts the rest of the script's parse.
+strip_trailing_punct() {
+  local s="$1"
+  while true; do
+    case "$s" in
+      *[[:punct:]]) s="${s%?}" ;;
+      *) break ;;
+    esac
+  done
+  printf '%s' "$s"
+}
 
 while IFS="$US" read -r kind a b c; do
   [[ -z "$kind" ]] && continue
@@ -213,6 +253,28 @@ while IFS="$US" read -r kind a b c; do
         if [[ ! -e "$skill_dir/$c" && ! -e "$evals_dir/$c" ]]; then
           err "$a: $b: files entry \"$c\" not found under $skill_dir/ or $evals_dir/ — a case whose fixtures cannot be found cannot be exercised (Q4)"
         fi
+      fi
+      ;;
+    PROSE)
+      # a=file, b=caseref, c=path-shaped token from prompt/expected_output.
+      # Same roots as FILE; WARN (not FAIL) so narration-heavy corpora stay
+      # green while the silent files:[] dodge is no longer invisible. Set
+      # narration: true to opt out, or declare the path in files.
+      c="$(strip_trailing_punct "$c")"
+      [[ -z "$c" ]] && continue
+      # Skip URL leftovers (https://example.com/docs/a.md → example.com/docs/a.md)
+      # and other host-shaped first segments. Dotfiles like .claude/... stay in
+      # scope (leading-dot first segment is not a domain).
+      first="${c%%/*}"
+      if [[ "$c" == *"://"* || ( "$first" == *.* && "$first" != .* ) ]]; then
+        continue
+      fi
+      evals_dir="$(dirname "$a")"
+      skill_dir="$(dirname "$evals_dir")"
+      if [[ "$c" == /* || "$c" =~ ^[A-Za-z]: || "/$c/" == *"/../"* ]]; then
+        warn "$a: $b: path-shaped token \"$c\" in prompt/expected_output resolves to no fixture under $skill_dir/ or $evals_dir/ while files is empty — add it to files, ship a fixture, or set narration: true (Q4)"
+      elif [[ ! -e "$skill_dir/$c" && ! -e "$evals_dir/$c" ]]; then
+        warn "$a: $b: path-shaped token \"$c\" in prompt/expected_output resolves to no fixture under $skill_dir/ or $evals_dir/ while files is empty — add it to files, ship a fixture, or set narration: true (Q4)"
       fi
       ;;
     *) err "internal: unrecognized lint line kind '$kind'" ;;

--- a/plugins/skill-quality/scripts/check-evals-quality.sh
+++ b/plugins/skill-quality/scripts/check-evals-quality.sh
@@ -263,17 +263,24 @@ while IFS="$US" read -r kind a b c; do
       c="$(strip_trailing_punct "$c")"
       [[ -z "$c" ]] && continue
       # Skip URL leftovers (https://example.com/docs/a.md → example.com/docs/a.md)
-      # and other host-shaped first segments. Dotfiles like .claude/... stay in
-      # scope (leading-dot first segment is not a domain).
+      # and host-shaped first segments. A bare "has a dot" test is too wide —
+      # versioned dirs like v1.2/schema/config.json are fixture paths, not hosts.
+      # Require a DNS-like label ending in an alphabetic TLD-ish final segment.
+      # Dotfiles like .claude/... stay in scope (leading-dot first segment fails
+      # the hostname pattern).
       first="${c%%/*}"
-      if [[ "$c" == *"://"* || ( "$first" == *.* && "$first" != .* ) ]]; then
+      if [[ "$c" == *"://"* ]] ||
+        [[ "$first" =~ ^[A-Za-z0-9-]+([.][A-Za-z0-9-]+)*[.][A-Za-z]{2,}$ ]]; then
         continue
       fi
       evals_dir="$(dirname "$a")"
       skill_dir="$(dirname "$evals_dir")"
-      if [[ "$c" == /* || "$c" =~ ^[A-Za-z]: || "/$c/" == *"/../"* ]]; then
-        warn "$a: $b: path-shaped token \"$c\" in prompt/expected_output resolves to no fixture under $skill_dir/ or $evals_dir/ while files is empty — add it to files, ship a fixture, or set narration: true (Q4)"
-      elif [[ ! -e "$skill_dir/$c" && ! -e "$evals_dir/$c" ]]; then
+      # PROSE tokens come from PROSE_PATH_RE, which has no leading-/ or drive
+      # alternative — absolute-looking prose is scanned without the leading /
+      # and falls through to the existence check. Only `../` traversal is
+      # reachable as an escape here; keep that gate before the -e test.
+      if [[ "/$c/" == *"/../"* ]] ||
+        { [[ ! -e "$skill_dir/$c" && ! -e "$evals_dir/$c" ]]; }; then
         warn "$a: $b: path-shaped token \"$c\" in prompt/expected_output resolves to no fixture under $skill_dir/ or $evals_dir/ while files is empty — add it to files, ship a fixture, or set narration: true (Q4)"
       fi
       ;;

--- a/plugins/skill-quality/scripts/check-evals-quality.test.sh
+++ b/plugins/skill-quality/scripts/check-evals-quality.test.sh
@@ -328,6 +328,26 @@ else
   fail "Q4 must not warn on branch names, bare filenames, or URLs (rc=$rc): $out"
 fi
 
+# 9g. Q4: a dotted directory that is not a hostname (v1.2/...) must still WARN
+#     when unresolved — the host skip must not treat every "first.segment"
+#     with a dot as a URL leftover.
+f="$(make_evals prose-dotted-dir '{
+  "skill_name": "prose-dotted-dir",
+  "evals": [
+    {"id": 1, "name": "versioned-path", "prompt": "Load v1.2/schema/config.json and validate it.",
+     "files": [],
+     "expected_output": "The skill does NOT invent a fixture for the named versioned path."}
+  ]
+}')"
+out="$(run "$f" 2>&1)"
+rc=$?
+if [[ $rc -eq 0 ]] && grep -q 'path-shaped token "v1.2/schema/config.json".*files is empty.*(Q4)' <<<"$out" &&
+  grep -q 'case versioned-path (id=1)' <<<"$out"; then
+  pass "Q4: unresolved dotted-directory prose paths WARN"
+else
+  fail "Q4 should warn on v1.2/... prose paths (rc=$rc): $out"
+fi
+
 # 10. Q5: a case carrying BOTH expectations and assertions WARNs (exit 0).
 f="$(make_evals both-fields '{
   "skill_name": "both-fields",

--- a/plugins/skill-quality/scripts/check-evals-quality.test.sh
+++ b/plugins/skill-quality/scripts/check-evals-quality.test.sh
@@ -44,10 +44,10 @@ CLEAN='{
     {
       "id": 1,
       "name": "happy-path",
-      "prompt": "Do the thing to src/app.js.",
-      "expected_output": "The change is applied to src/app.js only, and the resulting diff is surfaced to the user.",
+      "prompt": "Do the thing to the named target file.",
+      "expected_output": "The change is applied to the named target only, and the resulting diff is surfaced to the user.",
       "expectations": [
-        "Only src/app.js is modified",
+        "Only the named target file is modified",
         "The resulting diff is shown before the turn ends"
       ]
     },
@@ -250,6 +250,82 @@ if [[ $rc -eq 1 ]] && [[ "$(grep -c 'escapes the documented fixture roots.*(Q4)'
   pass "Q4: absolute and ..-traversal entries FAIL without an existence probe"
 else
   fail "Q4 should reject escaping entries before the -e test (rc=$rc): $out"
+fi
+
+# 9c. Q4: empty files:[] with a path-shaped token only in prose WARNs — the
+#     silent dodge that previously cleared the gate with 0 findings.
+f="$(make_evals prose-missing '{
+  "skill_name": "prose-missing",
+  "evals": [
+    {"id": 1, "name": "names-missing-doc", "prompt": "Compress docs/reference/api-lifecycle.md — it is terse.",
+     "files": [],
+     "expected_output": "The skill does NOT invent a fixture; it audits the named path as specified."}
+  ]
+}')"
+out="$(run "$f" 2>&1)"
+rc=$?
+if [[ $rc -eq 0 ]] && grep -q 'path-shaped token "docs/reference/api-lifecycle.md".*files is empty.*(Q4)' <<<"$out" &&
+  grep -q 'case names-missing-doc (id=1)' <<<"$out"; then
+  pass "Q4: empty files:[] with an unresolved prose path WARNs"
+else
+  fail "Q4 should warn on prose-only unresolved paths with empty files (rc=$rc): $out"
+fi
+
+# 9d. Q4: narration: true opts out — intentional fictional consumer-repo paths
+#     must self-declare so the gap is explicit rather than silent.
+f="$(make_evals prose-narration '{
+  "skill_name": "prose-narration",
+  "evals": [
+    {"id": 1, "prompt": "Compress docs/architecture/overview.md. It is long.",
+     "files": [], "narration": true,
+     "expected_output": "The skill does NOT require a shipped fixture for this narration-only scenario."}
+  ]
+}')"
+out="$(run "$f" 2>&1)"
+rc=$?
+if [[ $rc -eq 0 ]] && ! grep -q '(Q4)' <<<"$out"; then
+  pass "Q4: narration: true silences prose-path warnings"
+else
+  fail "Q4 should stay silent when narration: true (rc=$rc): $out"
+fi
+
+# 9e. Q4: a prose path that resolves under the skill dir stays silent even
+#     with empty files (reachable-as-specified without a files declaration).
+mkdir -p "$TMP/prose-resolves/docs/reference"
+printf 'doc\n' >"$TMP/prose-resolves/docs/reference/exists.md"
+f="$(make_evals prose-resolves '{
+  "skill_name": "prose-resolves",
+  "evals": [
+    {"id": 1, "prompt": "Read docs/reference/exists.md and summarize it.",
+     "files": [],
+     "expected_output": "The skill does NOT need files[] when the prose path already resolves under the skill dir."}
+  ]
+}')"
+out="$(run "$f" 2>&1)"
+rc=$?
+if [[ $rc -eq 0 ]] && ! grep -q '(Q4)' <<<"$out"; then
+  pass "Q4: resolving prose paths with empty files stay silent"
+else
+  fail "Q4 must not warn when a prose path resolves (rc=$rc): $out"
+fi
+
+# 9f. Q4: branch-like slash tokens and bare filenames are not path-shaped —
+#     they must not WARN (feat/foo, CLAUDE.md, ours/theirs). URLs must not
+#     WARN either (https://example.com/a/b.md is not a fixture claim).
+f="$(make_evals prose-not-path '{
+  "skill_name": "prose-not-path",
+  "evals": [
+    {"id": 1, "prompt": "Commit on feat/payment-retry; touch CLAUDE.md; keep ours/theirs distinct; see https://example.com/docs/guide.md.",
+     "files": [],
+     "expected_output": "The skill does NOT treat branch names, bare filenames, or URLs as fixture claims."}
+  ]
+}')"
+out="$(run "$f" 2>&1)"
+rc=$?
+if [[ $rc -eq 0 ]] && ! grep -q '(Q4)' <<<"$out"; then
+  pass "Q4: non-fixture slash tokens, bare filenames, and URLs stay silent"
+else
+  fail "Q4 must not warn on branch names, bare filenames, or URLs (rc=$rc): $out"
 fi
 
 # 10. Q5: a case carrying BOTH expectations and assertions WARNs (exit 0).

--- a/plugins/skill-quality/skills/check/SKILL.md
+++ b/plugins/skill-quality/skills/check/SKILL.md
@@ -214,7 +214,8 @@ silent skip or a coerced-to-zero budget.
 - `check-evals-quality.sh` resolves each case's `files` entries relative to the skill directory
   first, then the evals directory. An entry that is prose (environment description) rather than a
   real path FAILs Q4 — describe environment state in the case's `prompt` parenthetical instead,
-  or ship a fixture.
+  or ship a fixture. When `files` is empty/absent, path-shaped tokens in `prompt`/`expected_output`
+  that resolve nowhere WARN under the same Q4 roots unless the case sets `narration: true`.
 - `listing-budget` never asserts a resolved live value (context window and `skillListingBudgetFraction`
   are both consumer settings this static check cannot observe) — it reports against a documented,
   overridable default and always exits 0. A clean report is a signal to investigate against `/doctor`


### PR DESCRIPTION
Closes #2746

## Summary

`check-evals-quality.sh` Q4 only resolved paths from each eval's `files` array, so a case with `"files": []` that named a nonexistent path only in `prompt`/`expected_output` cleared the gate with zero findings (compress evals 3/8/10 in #2745 M6).

## Fix

- Extend Q4 to scan path-shaped tokens (`dir/…/file.ext`) in `prompt`/`expected_output` when `files` is empty/absent.
- WARN when those tokens do not resolve under the skill or evals fixture roots (same roots as declared `files` entries).
- Add optional schema field `narration: true` so intentional narration-only cases can opt out explicitly.
- Keep declared-`files` defects as FAIL; leave branch-like tokens, bare filenames, and URL hosts out of scope.
- Bump skill-quality to 0.15.11; document in CHANGELOG/README/`check` skill caveats.

## Verification

```text
bash plugins/skill-quality/scripts/check-evals-quality.test.sh
# → 0 failure(s) (includes new 9c–9f prose-path cases)

bash plugins/skill-quality/scripts/check-evals-quality.sh \
  plugins/docs-hygiene/skills/compress/evals/evals.json
# → PASS with Q4 WARNs on evals 3/5/6/8/10 (including docs/reference/api-lifecycle.md)

bash plugins/skill-quality/scripts/check-evals-quality.sh \
  plugins/*/skills/*/evals/evals.json
# → exit 0 (WARN-tier; no new FAILs)
```

## Related

Refs #2745 (M6 — narration-only / unreachable-as-specified compress evals that exposed the dodge)