### PR TITLE
feat(docs-hygiene): confirm scope on bare extract-ssot + orchestrated whole-repo mode

### DIFF
--- a/plugins/docs-hygiene/.claude-plugin/plugin.json
+++ b/plugins/docs-hygiene/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "docs-hygiene",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Documentation-hygiene toolkit: compress (flavor-trim markdown with a semantic-diff safety net), audit-noise (classify markdown noise), extract-ssot (deduplicate repeated content into a single source of truth), audit-encapsulation (detect citations into skill-private surfaces), rename-references (sweep stale references after renames), and audit-derivability (classify whether a whole document earns its existence \u2014 could a fresh agent re-derive it from the code?).",
   "author": {
     "name": "Melodic Software",

--- a/plugins/docs-hygiene/CHANGELOG.md
+++ b/plugins/docs-hygiene/CHANGELOG.md
@@ -16,7 +16,10 @@
   between-dispatch checks when the guard's snapshot is present, and wave-committed cadence.
   `actions/batch.md` Step 6 and the identify pre-flight now route through it.
 - **extract-ssot:** eval 7 covers the bare confirm-scope gate (no auto-dispatch; prescribed
-  defaults; orchestrated-mode reference).
+  defaults including path/glob-scoped survey; orchestrated-mode reference).
+- **extract-ssot orchestrated-mode:** rate-limit capability detection matches the reader
+  contract's per-window fail-open (one malformed window does not suppress a valid sibling trip)
+  and reactive-only mode consumes `stop-events.jsonl` as well as local error text.
 
 ## [0.13.0]
 

--- a/plugins/docs-hygiene/CHANGELOG.md
+++ b/plugins/docs-hygiene/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog — docs-hygiene plugin
 
+## [0.14.0]
+
+### Added
+
+- **extract-ssot: bare invocations confirm scope before surveying.** A bare
+  `/docs-hygiene:extract-ssot` with no working notes, no argument, and no conversation-implied
+  scope now asks the user (prescribed defaults, recommended option first) instead of
+  auto-dispatching the exhaustive survey; non-interactive sessions without an explicit scope report
+  options and stop.
+- **extract-ssot: orchestrated whole-repo mode (`context/orchestrated-mode.md`).** Defaults for
+  multi-agent batches at whole-repo scale: single-survey inventory, worker tiering, a static
+  conservative concurrency ceiling (default 2 — subscription rate-limit windows are shared and
+  usually unobservable), the verbatim-inlined rate-limit-guard operable floor with
+  between-dispatch checks when the guard's snapshot is present, and wave-committed cadence.
+  `actions/batch.md` Step 6 and the identify pre-flight now route through it.
+- **extract-ssot:** eval 7 covers the bare confirm-scope gate (no auto-dispatch; prescribed
+  defaults; orchestrated-mode reference).
+
 ## [0.13.0]
 
 ### Changed

--- a/plugins/docs-hygiene/skills/extract-ssot/SKILL.md
+++ b/plugins/docs-hygiene/skills/extract-ssot/SKILL.md
@@ -69,7 +69,7 @@ Full decision matrix: `context/decision-framework.md` (6+5 checklist with worked
 
 | Argument | Action | Purpose |
 |----------|--------|---------|
-| *(empty)* | Smart default | Auto-detect: working notes from a prior run hold an active candidate roster → resume the current phase; otherwise → `identify` |
+| *(empty)* | Smart default | Auto-detect: working notes from a prior run hold an active candidate roster → resume the current phase; the invocation or conversation already names a scope → `identify`; otherwise → confirm scope with the user first (see "Bare invocation — confirm scope first") |
 | `identify [<cluster-name>]` | Find candidates (default = exhaustive subagent survey) | Dispatches a read-only exploration subagent over 30+ duplication heuristics (full body in `actions/identify.md`); ranks by ROI; emits batch-sequencing matrix + recommended `/docs-hygiene:extract-ssot batch` invocation. Refuses premature (<3 instances). Single-cluster mode (`identify <name>`) skips the subagent for a targeted Tier 0 grep |
 | `verify <cluster-name>` | Refuse-fast pre-extraction gate | 6-gate cheap check (Tier 0 grep, citation state, primary-source URL gate, bifurcation check, off-by-one heuristic, LOW-ROI threshold). Output: `PROCEED \| REFUSE-{reason} \| WARN`. OPTIONAL — does not gate `plan`/`execute`. See `actions/verify.md` |
 | `plan <cluster-name>` | Architect | Pre-step (Tier 0 grep): does an existing rule/doc already own the concept? If yes → consolidate-into-existing branch (extend the home + de-recap consumers, no new artifact). Else choose creation output type (rule vs skill); draft or extend SSOT body; sketch migration plan |
@@ -78,6 +78,28 @@ Full decision matrix: `context/decision-framework.md` (6+5 checklist with worked
 | `unwind <ssot-name>` | Reverse | Re-introduce duplication per Sandi Metz wrong-abstraction recovery |
 
 One action per response; actions don't chain implicitly.
+
+## Bare invocation — confirm scope first
+
+A bare `/docs-hygiene:extract-ssot` with no working notes to resume, no
+argument, and no scope implied by the conversation does **not**
+auto-dispatch the exhaustive survey. Exhaustive `identify` sweeps every
+tracked markdown file and, at whole-repo scale, feeds a multi-agent
+verify/execute batch — a spend the user opts into, never a default.
+Ask one question with prescribed defaults, recommended option first:
+
+1. **Whole-repo exhaustive survey** (recommended for maintenance
+   sweeps) — runs under `context/orchestrated-mode.md` defaults; in the
+   same ask, confirm depth (roster only / verified roster / full
+   pipeline with wave commits).
+2. **Targeted cluster** — the user names it; routes to
+   `identify <cluster-name>`.
+3. **Not now.**
+
+Non-interactive sessions (no user to ask): proceed only when the
+invoking automation supplied an explicit scope or action argument;
+otherwise report the available options and stop rather than assuming
+whole-repo intent.
 
 ## Decision framework
 
@@ -169,6 +191,7 @@ Per-phase checklist: `context/execution-checklist.md`.
 - `context/anti-patterns.md` — 13-pattern taxonomy with mitigations
 - `context/execution-checklist.md` — per-phase checks for the `execute` action
 - `context/lessons.md` — append-only empirical lessons from batch executions; consumed by the `verify` action and `context/decision-framework.md`
+- `context/orchestrated-mode.md` — whole-repo batch defaults: worker tiering, static concurrency cap, rate-limit-guard consumption, wave-committed cadence
 - `actions/identify.md`, `actions/verify.md`, `actions/batch.md` — action bodies (private surface)
 - `/docs-hygiene:rename-references` — load-bearing 10-pattern sweep after any heading change (owns the syntactic-form set)
 - `/docs-hygiene:audit-encapsulation` — encapsulation detection + remediation (separate concern)

--- a/plugins/docs-hygiene/skills/extract-ssot/SKILL.md
+++ b/plugins/docs-hygiene/skills/extract-ssot/SKILL.md
@@ -92,9 +92,13 @@ Ask one question with prescribed defaults, recommended option first:
    sweeps) — runs under `context/orchestrated-mode.md` defaults; in the
    same ask, confirm depth (roster only / verified roster / full
    pipeline with wave commits).
-2. **Targeted cluster** — the user names it; routes to
-   `identify <cluster-name>`.
-3. **Not now.**
+2. **Path- or glob-scoped exhaustive survey** — the user names one or
+   more directories / globs (e.g. `plugins/docs-hygiene/`, `docs/**/*.md`);
+   routes to exhaustive `identify` restricted to tracked markdown under
+   that pathspec (still a survey, not a single-cluster grep).
+3. **Targeted cluster** — the user names a semantic cluster; routes to
+   `identify <cluster-name>` (Tier 0 grep on that cluster only).
+4. **Not now.**
 
 Non-interactive sessions (no user to ask): proceed only when the
 invoking automation supplied an explicit scope or action argument;

--- a/plugins/docs-hygiene/skills/extract-ssot/actions/batch.md
+++ b/plugins/docs-hygiene/skills/extract-ssot/actions/batch.md
@@ -122,6 +122,11 @@ waves:
 
 Default: sequential. Parallel is opt-in via the batch-action argument `--parallel-waves`. Parallel collisions are a real bug class (no file locking); the default conservatism is intentional.
 
+**Worker concurrency and rate limits.** Whatever the wave grouping allows, concurrent worker
+dispatches stay under the `context/orchestrated-mode.md` ceiling (default 2, static) and honor its
+between-dispatch rate-limit-guard check when the consuming machine exposes the guard's snapshot.
+Wave grouping decides *what may* run together; the ceiling decides *how much* actually does.
+
 ## Step 7 — Lesson injection
 
 Each subagent dispatched in this batch receives the lesson snapshot from Step 1 in its prompt:

--- a/plugins/docs-hygiene/skills/extract-ssot/actions/identify.md
+++ b/plugins/docs-hygiene/skills/extract-ssot/actions/identify.md
@@ -9,9 +9,10 @@ Private surface — external consumers invoke `/docs-hygiene:extract-ssot identi
 | Invocation | Mode | Behavior |
 |------------|------|----------|
 | `/docs-hygiene:extract-ssot identify` | Exhaustive (default) | Read-only subagent deep survey across instruction files, rules, skills, agents, ADRs, docs. Returns a ranked candidate roster + dependency chains + file-overlap matrix + batch wave plan |
+| `/docs-hygiene:extract-ssot identify` + confirmed path/glob scope | Exhaustive (path-scoped) | Same survey heuristics and roster shape as whole-repo exhaustive, but the subagent's search roots are the named directories / globs only (tracked markdown under that pathspec). Not a single-cluster grep |
 | `/docs-hygiene:extract-ssot identify <cluster-name>` | Targeted | Tier 0 grep on a named cluster only. Returns instance count + Tier 0 evidence + suggested output type. No subagent dispatch |
 
-User signals like "find ANY and ALL", "deep dive", "exhaustive", "full list", or `/docs-hygiene:extract-ssot identify` with no args = default to exhaustive mode.
+User signals like "find ANY and ALL", "deep dive", "exhaustive", "full list", or `/docs-hygiene:extract-ssot identify` with no args = default to exhaustive mode. Path/glob scope from the confirm-scope gate (SKILL.md) keeps exhaustive mode and narrows roots — it does not switch to targeted.
 
 ## When to invoke
 
@@ -32,9 +33,11 @@ User signals like "find ANY and ALL", "deep dive", "exhaustive", "full list", or
 ## Exhaustive mode steps
 
 ```text
-0. Scope gate: exhaustive mode needs an affirmative scope — an explicit argument/user signal, or
-   the SKILL.md "Bare invocation — confirm scope first" ask answered whole-repo. Large repos run
-   the batch under context/orchestrated-mode.md defaults
+0. Scope gate: exhaustive mode needs an affirmative scope — an explicit argument/user signal, the
+   SKILL.md "Bare invocation — confirm scope first" ask answered whole-repo, or that ask answered
+   with named paths/globs (path-scoped exhaustive). Whole-repo large repos run the batch under
+   `context/orchestrated-mode.md` defaults; path-scoped surveys inherit the same concurrency
+   ceiling when they fan into verify/execute
 1. Pre-flight: confirm no working notes with an active candidate roster (would imply resume, not new identify)
 2. Dispatch a read-only exploration subagent with the survey prompt (template below)
 3. Subagent searches markdown surfaces with 30+ heuristics (template lists them)

--- a/plugins/docs-hygiene/skills/extract-ssot/actions/identify.md
+++ b/plugins/docs-hygiene/skills/extract-ssot/actions/identify.md
@@ -32,6 +32,9 @@ User signals like "find ANY and ALL", "deep dive", "exhaustive", "full list", or
 ## Exhaustive mode steps
 
 ```text
+0. Scope gate: exhaustive mode needs an affirmative scope — an explicit argument/user signal, or
+   the SKILL.md "Bare invocation — confirm scope first" ask answered whole-repo. Large repos run
+   the batch under context/orchestrated-mode.md defaults
 1. Pre-flight: confirm no working notes with an active candidate roster (would imply resume, not new identify)
 2. Dispatch a read-only exploration subagent with the survey prompt (template below)
 3. Subagent searches markdown surfaces with 30+ heuristics (template lists them)

--- a/plugins/docs-hygiene/skills/extract-ssot/context/orchestrated-mode.md
+++ b/plugins/docs-hygiene/skills/extract-ssot/context/orchestrated-mode.md
@@ -1,0 +1,114 @@
+# Orchestrated whole-repo mode
+
+Defaults for running the extract-ssot pipeline at whole-repo scale —
+hundreds to thousands of tracked markdown files, dozens of candidate
+clusters — where identify/verify/execute becomes a multi-agent batch
+rather than a handful of inline actions. Loaded by the confirm-scope
+gate (SKILL.md "Bare invocation — confirm scope first") when the user
+opts into a whole-repo run, and by `actions/batch.md` Step 6 when
+sizing dispatches.
+
+Private surface — external consumers invoke
+`/docs-hygiene:extract-ssot`, never cite this file directly (contract:
+`/docs-hygiene:audit-encapsulation`).
+
+## Roles
+
+- **The orchestrating session owns the loop, not the work.** It holds
+  the roster, the wave plan, the commit cadence, and the abort
+  thresholds (`actions/batch.md` Step 2); workers hold the per-cluster
+  work. It never performs a cluster's verify or execute inline while
+  workers are available — its context is the scarcest resource in the
+  run.
+- **Inventory is ONE read-only survey subagent**, not a fan-out. The
+  survey's output is unverified synthesis whatever its size, so extra
+  survey workers multiply lead lists, not evidence; the verify phase is
+  where breadth belongs.
+- **Verify and execute run as worker agents.** Verify workers are
+  read-only; execute workers edit call sites per the wave plan.
+
+## Worker tiering
+
+Verify and execute are judgment stages (gate rulings, wrong-abstraction
+calls, prose rewrites), so workers there run a strong general-purpose
+tier — as of 2026-08 that means an Opus-class model (example, not a
+pin; resolve the current tier names from the platform's model docs at
+run time). Mechanical stages — phrase sweeps, lint passes, count
+scripts — run cheaper tiers or plain scripts. Never let the whole fleet
+silently inherit the orchestrator's tier: at fleet volume, every notch
+of over-provisioning multiplies.
+
+## Concurrency — static, conservative, capped
+
+Default worker concurrency is **2**, applied as a hard cap in the
+dispatch loop (pairs of workers, sequential between pairs). The default
+is deliberately static and low:
+
+- Most consumers run under **shared subscription rate-limit windows**
+  (5-hour and 7-day). The windows are machine- and account-wide: other
+  concurrent sessions draw on them invisibly, so an orchestrator that
+  cannot observe the windows must assume contention.
+- Enterprise and API-key auth expose no window data at all
+  (capability-detect fails open to "unknown"), which is a reason for
+  MORE conservatism, not less.
+- Remote/cloud containers cannot see machine-scope guard state (below),
+  so they always operate in unknown mode.
+
+The user may raise the cap for a run; the orchestrator never raises it
+on its own, and a rate-limit error observed mid-run drops the batch to
+fully sequential for its remainder.
+
+## Rate-limit guard integration (when present)
+
+When the consuming machine runs the `rate-limit-guard` plugin, its tee
+snapshot makes the windows observable, and this mode consumes it
+between wave dispatches: before dispatching each wave (and each pair
+within a wave), read the snapshot; on a trip, finish in-flight workers,
+dispatch nothing new, and pause until the pause end. The operable floor
+below is inlined **verbatim** per the loop-lane convention's
+inline-floor rule (byte-identical across consumers and to the reader
+contract's floor); provenance is the `rate-limit-guard` plugin's reader
+contract (`plugins/rate-limit-guard/reference/reader-contract.md` in
+the marketplace repository) — cited for provenance only, since an
+installed plugin cannot read a sibling plugin's files at runtime.
+
+- **Tee file (fixed path):** `~/.claude/rate-limit-guard/rate-limits.json`
+- **Pause threshold (fixed):** pause when **either** window reports `used_percentage >= 90`
+- **Pause end:** the **tripped** window's `resets_at`; when **both** windows trip, the **later**
+  `resets_at`
+- **Staleness rule:** a snapshot whose `captured_at` is older than **10 minutes** is stale — treat
+  the windows as **unknown** (reactive-only) for that decision; a `resets_at` already latched from a
+  fresh snapshot stays valid through the pause (no refresh happens while paused). While paused, a
+  consumer **must** arm a session Monitor on the tee file and re-evaluate on every write — the file
+  carries **no account-identifier field**, so a write is the only signal that the windows changed
+  under you (account switch, another session's refresh).
+- **Drain-then-pause:** on a trip, finish in-flight work, stop claiming new work, pause until the
+  pause end, and report; a hard stop happens only on explicit user request.
+
+Snapshot absent, stale, or implausible → the guard is **unknown**: keep
+the static cap, never fabricate a pause, and fall back to reacting to
+rate-limit errors the session itself sees. A fresh plausible snapshot
+later upgrades the run back to proactive checks. Dynamic *scaling*
+(raising the cap when windows are healthy) is deliberately out of
+scope: with no account identifier in the snapshot and other sessions'
+burn invisible between refreshes, headroom is a weaker signal than a
+trip, and the cost of over-shooting a shared window lands on every
+session on the machine.
+
+## Cadence and commits
+
+Waves land **wave-committed**: each wave's migrations are one
+conventional-format commit on the task branch, so the batch reviews
+wave-by-wave and a mid-run abort loses at most one wave. Sequencing
+within and between waves stays owned by `actions/batch.md` (overlap
+matrix, sequential-by-default); this file only adds the concurrency
+ceiling and the guard check between dispatches.
+
+## Cross-references
+
+- SKILL.md "Bare invocation — confirm scope first" — the gate that
+  routes a whole-repo opt-in here
+- `actions/identify.md` — the single-survey inventory this mode retains
+- `actions/batch.md` — wave grouping and dispatch policy (Step 6)
+- `docs/conventions/loop-lane/README.md` §6 (marketplace repository) —
+  owns the inline-floor rule the block above follows

--- a/plugins/docs-hygiene/skills/extract-ssot/context/orchestrated-mode.md
+++ b/plugins/docs-hygiene/skills/extract-ssot/context/orchestrated-mode.md
@@ -85,15 +85,29 @@ installed plugin cannot read a sibling plugin's files at runtime.
 - **Drain-then-pause:** on a trip, finish in-flight work, stop claiming new work, pause until the
   pause end, and report; a hard stop happens only on explicit user request.
 
-Snapshot absent, stale, or implausible → the guard is **unknown**: keep
-the static cap, never fabricate a pause, and fall back to reacting to
-rate-limit errors the session itself sees. A fresh plausible snapshot
-later upgrades the run back to proactive checks. Dynamic *scaling*
-(raising the cap when windows are healthy) is deliberately out of
-scope: with no account identifier in the snapshot and other sessions'
-burn invisible between refreshes, headroom is a weaker signal than a
-trip, and the cost of over-shooting a shared window lands on every
-session on the machine.
+**Capability detection (fail-open), scoped like the reader contract:**
+
+| Observation | Scope | Mode |
+| --- | --- | --- |
+| Fresh snapshot with plausible `rate_limits` | whole guard | **proactive** — apply the operable floor |
+| Tee file absent, stale, or missing `rate_limits` | whole guard | **unknown → reactive-only** |
+| Absurd `used_percentage` or `resets_at` on one window | that window | that window **unknown**; keep applying the floor to every window still plausible |
+| No window plausible | whole guard | **unknown → reactive-only** |
+
+One malformed window must not suppress a valid sibling: if the five-hour record is absurd but the
+seven-day window is plausible and already ≥ 90, pause on the seven-day trip (and vice versa). Only
+the whole-guard rows above drop the run to reactive-only.
+
+**Reactive-only mode:** keep the static concurrency cap, never fabricate a pause from untrusted
+data, and react to (a) detection records in `~/.claude/rate-limit-guard/stop-events.jsonl` (read on
+entering reactive-only and again before each new work claim; records newer than this session's
+start — later, newer than the last resume baseline — are live signal) and (b) rate-limit error text
+this session itself sees. Resume timing comes from that error text where available, otherwise
+backoff-and-retry. A later fresh snapshot with plausible windows upgrades the run back to
+proactive checks. Dynamic *scaling* (raising the cap when windows are healthy) is deliberately out
+of scope: with no account identifier in the snapshot and other sessions' burn invisible between
+refreshes, headroom is a weaker signal than a trip, and the cost of over-shooting a shared window
+lands on every session on the machine.
 
 ## Cadence and commits
 

--- a/plugins/docs-hygiene/skills/extract-ssot/evals/evals.json
+++ b/plugins/docs-hygiene/skills/extract-ssot/evals/evals.json
@@ -77,11 +77,11 @@
       "id": 7,
       "name": "bare-invocation-confirms-scope",
       "prompt": "Run /docs-hygiene:extract-ssot with no argument. There are no prior working notes and the conversation has not named a scope.",
-      "expected_output": "Does NOT auto-dispatch the exhaustive survey. Asks one confirmation question with prescribed defaults (recommended option first: whole-repo under context/orchestrated-mode.md; alternatives: named paths/globs, or stop). Non-interactive sessions without an explicit scope report the options and stop.",
+      "expected_output": "Does NOT auto-dispatch the exhaustive survey. Asks one confirmation question with prescribed defaults (recommended option first: whole-repo under context/orchestrated-mode.md; then path/glob-scoped exhaustive survey; then targeted cluster; or stop). Non-interactive sessions without an explicit scope report the options and stop.",
       "files": [],
       "expectations": [
         "Output asks the user to confirm scope before surveying (does not auto-start exhaustive identify)",
-        "Output presents prescribed defaults with a recommended option first",
+        "Output presents prescribed defaults with a recommended option first, including a path/glob-scoped exhaustive survey choice distinct from targeted cluster grep",
         "Output references whole-repo / orchestrated-mode defaults when offering the repo-wide option"
       ]
     }

--- a/plugins/docs-hygiene/skills/extract-ssot/evals/evals.json
+++ b/plugins/docs-hygiene/skills/extract-ssot/evals/evals.json
@@ -72,6 +72,18 @@
         "Output has consumers cite the single canonical SSOT directly",
         "Output notes that a heading/identifier change requires a /rename-references sweep"
       ]
+    },
+    {
+      "id": 7,
+      "name": "bare-invocation-confirms-scope",
+      "prompt": "Run /docs-hygiene:extract-ssot with no argument. There are no prior working notes and the conversation has not named a scope.",
+      "expected_output": "Does NOT auto-dispatch the exhaustive survey. Asks one confirmation question with prescribed defaults (recommended option first: whole-repo under context/orchestrated-mode.md; alternatives: named paths/globs, or stop). Non-interactive sessions without an explicit scope report the options and stop.",
+      "files": [],
+      "expectations": [
+        "Output asks the user to confirm scope before surveying (does not auto-start exhaustive identify)",
+        "Output presents prescribed defaults with a recommended option first",
+        "Output references whole-repo / orchestrated-mode defaults when offering the repo-wide option"
+      ]
     }
   ]
 }


### PR DESCRIPTION
No linked issue

## Summary

Focused replacement for the skill-only portion of #2698. A bare `/docs-hygiene:extract-ssot` no longer auto-dispatches the exhaustive survey; it confirmation-gates scope with prescribed defaults and loads whole-repo batch defaults from `context/orchestrated-mode.md`.

## Fix

- **Bare confirm-scope gate** in `extract-ssot/SKILL.md` (offer whole-repo / targeted / not-now; non-interactive stops without explicit scope).
- **`context/orchestrated-mode.md`**: static concurrency ceiling 2, rate-limit-guard operable floor when present, wave-committed cadence; wired from `actions/batch.md` and `actions/identify.md`.
- **docs-hygiene 0.14.0** + CHANGELOG; **eval 7** covers the bare confirm-scope contract.

Deliberately **not** carried from #2698: fleet-wide SSOT normalization waves, contract-slice working notes under `docs/topics/…` (must stay pruned from merge), per-plugin consumer rewrites.

## Verification

- `scripts/check-changelog-parity.sh --check` and `--check-bump origin/main` pass.
- `scripts/check-changed-skills.sh origin/main` → extract-ssot PASS (0 errors).
- `markdownlint-cli2` clean on touched docs-hygiene markdown.

## Related

Supersedes the skill slice of #2698 (closed as impractical for the fleet batch).