### PR TITLE
fix(claude-config): re-argue audit-pass non-git refusal without stale state-key claim

### DIFF
--- a/plugins/claude-config/.claude-plugin/plugin.json
+++ b/plugins/claude-config/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "claude-config",
-  "version": "0.38.2",
+  "version": "0.38.3",
   "description": "Nine configuration-health skills (plus setup) for a repo's Claude Code configuration: audit (settings.json / .mcp.json / hooks / plugins / permissions drift), audit-automation-gaps (evidence-gated verdicts on automation gaps), audit-permission-grants (allow-rule / allowed-tools grants for auto-mode durability and portability), audit-permission-state (the permission rules actually in effect — every settings scope merged with per-rule provenance, what auto mode drops on entry, config written where nothing reads it, and which managed intents are enforced versus loosenable), draft-auto-mode-rules (interview and draft a paste-ready autoMode classifier block; prints only, never writes), audit-instructions (locally-owned instruction surfaces vs current model capability — proposes removals/rewrites of instructions the model no longer needs, and detects cross-surface instruction conflicts), audit-prompting-postures (the additive lane — posture guidance the prompting guide says a component's purpose needs but the component does not carry), audit-pass (one coordinated, ordered, resumable pass over a named target — three-scope inventory, run-time-derived exclusion set, stable finding identity, suppression memory, resume, one human gate — delegating every check to the plugin that owns it), and unhobble (the empirical bare-baseline experiment: reversibly strip a repo's standing instructions, log real stumbles against the current model, re-add only what evidence earns).",
   "author": {
     "name": "Melodic Software",

--- a/plugins/claude-config/CHANGELOG.md
+++ b/plugins/claude-config/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to the `claude-config` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.38.3]
+
+### Fixed
+
+- **`audit-pass`: non-git refusal narrative no longer cites a missing state-key rung.** The gate
+  still refuses a non-git target (non-zero, before Phase 0, naming the path and the cost). The
+  justifying list dropped the stale claim that §3 / `lib/state-key.sh` has no no-git fallback — the
+  shared keyer already has a `nonrepo/` rung — and now argues from the four remaining losses: no
+  HEAD baseline, no Class 3 worktree derivation, unevaluable `git status --porcelain` assertion 2.1,
+  and (decisive) no tracked team layer so suppression can never persist. Eval 30's expected output
+  and "do not invent fallbacks" expectation track the same four-reason framing. (#2729)
+
 ## [0.38.2]
 
 ### Changed

--- a/plugins/claude-config/skills/audit-pass/SKILL.md
+++ b/plugins/claude-config/skills/audit-pass/SKILL.md
@@ -90,10 +90,8 @@ Parse `$ARGUMENTS`:
   cannot say which path it refused is barely better than a silent one. The fallback is for the message;
   it never becomes a target.
   Requiring only "the active project root" let a non-git directory through into a contract with no
-  branch for it, and the run then went quiet in five places rather than one:
+  branch for it, and the run then went quiet in four places rather than one:
 
-  - the state key (§3) has a no-**remote** fallback and no no-**git** one, and "canonicalized repo
-    root" is undefined without a repository;
   - the scan baseline is *the target's HEAD commit and the run's state digest*, and HEAD does not
     exist;
   - Class 3 exclusion derives worktrees from `git worktree list`, and unlike Class 1 it is given no
@@ -107,7 +105,7 @@ Parse `$ARGUMENTS`:
 
   **The refusal says that cost out loud** rather than reading as an arbitrary restriction, and it names
   the suppression consequence in particular. Refusing closes a target class deliberately; it is not a
-  side effect. The alternative — specifying all five branches — was considered and rejected, because
+  side effect. The alternative — specifying all four branches — was considered and rejected, because
   the last of them obliges the contract to promise a capability it can never deliver on that class.
   A non-git directory is audited by opening it as a repository, or by the delegated skills directly.
 - **`--fix`** — the explicit mutation override. Absent, the pass writes nothing into the target.

--- a/plugins/claude-config/skills/audit-pass/evals/evals.json
+++ b/plugins/claude-config/skills/audit-pass/evals/evals.json
@@ -362,14 +362,14 @@
       "id": 30,
       "name": "non-git-target-is-refused-not-half-specified",
       "prompt": "/claude-config:audit-pass ~/notes — it is not a git repository, just a directory of markdown, but it is where I stand and it has a CLAUDE.md.",
-      "expected_output": "Refuses, non-zero, before Phase 0 does any work. The target argument is the git repository to audit, and the gate enforces that rather than only 'resolves to the active project root' — the two used to disagree, which let a non-git directory through into a contract that cannot describe it. The refusal names the resolved path and the reason, and states what a non-git target would cost rather than leaving it implicit: the state key has a no-remote fallback but no no-git one, the scan baseline is defined as HEAD plus the state digest, Class 3 exclusion derives worktrees from git worktree list, assertion 2.1 is stated over git status --porcelain, and — the one that is a permanent capability loss rather than a missing derivation — suppression is enacted only by the team layer, which is the TRACKED layer, so no suppression would ever be enactable on such a target. It writes nothing, and it does not fall back to a degraded pass.",
+      "expected_output": "Refuses, non-zero, before Phase 0 does any work. The target argument is the git repository to audit, and the gate enforces that rather than only 'resolves to the active project root' — the two used to disagree, which let a non-git directory through into a contract that cannot describe it. The refusal names the resolved path and the reason, and states what a non-git target would cost rather than leaving it implicit: the scan baseline is defined as HEAD plus the state digest, Class 3 exclusion derives worktrees from git worktree list, assertion 2.1 is stated over git status --porcelain, and — the one that is a permanent capability loss rather than a missing derivation — suppression is enacted only by the team layer, which is the TRACKED layer, so no suppression would ever be enactable on such a target. It writes nothing, and it does not fall back to a degraded pass.",
       "files": [],
       "expectations": [
         "Refuses the non-git target and exits non-zero rather than running a partial or degraded pass",
         "Names the directory it refused and the reason, in the same shape as the existing not-the-active-project-root refusal — and names it even on a bare invocation where git rev-parse --show-toplevel produced nothing, falling back to the current directory for the message",
         "Refuses BEFORE doing any Phase 0 work, and writes nothing anywhere",
         "Names at least the suppression consequence — the team layer is the tracked layer, so no suppression is enactable without a repository — rather than refusing without a stated cost",
-        "Does NOT invent a non-git state key, scan baseline, or Class 3 fallback in order to proceed"
+        "Does NOT invent a scan baseline, Class 3 fallback, or git-status substitute in order to proceed"
       ]
     }
   ]


### PR DESCRIPTION
Closes #2729

## Summary

Keeps the `audit-pass` non-git target refusal, but drops the stale "no no-git state key" justification now that `lib/state-key.sh` keys `nonrepo/`. The gate is re-argued from the four remaining real losses.

## Fix

- In `plugins/claude-config/skills/audit-pass/SKILL.md`, remove the false state-key bullet and recount "five places / all five branches" → four (HEAD baseline, Class 3 worktree derivation, `git status --porcelain` assertion 2.1, tracked-team suppression).
- Align eval 30 expected output and the "do not invent fallbacks" expectation with that four-reason framing.
- Bump `claude-config` to `0.38.3` with a CHANGELOG entry for changelog-parity.

## Verification

- `bash scripts/check-changelog-parity.sh --check` and `--check-bump origin/main` pass.
- `bash plugins/claude-config/lib/state-key.test.sh` — 23/23, including `nonrepo/` case 5.
- Grep of live skill + eval 30 shows no remaining "five places" / "no no-git state key" claims.

## Related

Refs #2703 (state-key promotion that surfaced the drift); `docs/conventions/plugin-data-report-keying/` (`nonrepo/` rung).