### PR TITLE
fix(markdown-format): correct skip-notice latch wording; add PATH diagnostic

### DIFF
--- a/plugins/markdown-format/.claude-plugin/plugin.json
+++ b/plugins/markdown-format/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "markdown-format",
-  "version": "0.11.17",
+  "version": "0.11.18",
   "description": "Auto-format and lint Markdown on edit via markdownlint-cli2 \u2014 only in repos that carry their own markdownlint config.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/markdown-format/CHANGELOG.md
+++ b/plugins/markdown-format/CHANGELOG.md
@@ -3,6 +3,19 @@
 All notable changes to the `markdown-format` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.11.18]
+
+### Fixed
+
+- **Missing-tool notice: latch wording + probed-PATH diagnostic (#2740).** 0.11.17 already dropped
+  the "Install it explicitly" misdirection, but the notice still understated the latch: only the
+  notice itself latches (`skip-notices/` via `hook::notice_once`); the binary probe re-runs on every
+  Markdown edit and recovers mid-session when the tool becomes resolvable. The notice now says
+  "skipped for this edit", names that there is no skip latch, and appends a one-line
+  `PATH probed: …` diagnostic so a PATH-layer miss (cloud harness / nvm prefix) is diagnosable
+  without guessing. Deliberately does **not** widen the probe into nvm layout guesses — that is an
+  environment/bootstrap fix (#2739 / #2748), not a hook-side search expansion.
+
 ## [0.11.17]
 
 ### Changed

--- a/plugins/markdown-format/README.md
+++ b/plugins/markdown-format/README.md
@@ -85,8 +85,12 @@ The hook requires the following tools:
 Missing prerequisites do not block an edit. Following Claude Code's
 [PostToolUse contract](https://code.claude.com/docs/en/hooks#posttooluse-decision-control),
 the hook exits `0` and reports a once-per-session notice to both Claude
-(`additionalContext`) and you (`systemMessage`). It never falls back to `npx`,
-installs a package, or performs a network request during a hook run.
+(`additionalContext`) and you (`systemMessage`). Only the notice latches —
+the binary probe re-runs on every Markdown edit and recovers mid-session when
+the tool becomes resolvable. A missing-`markdownlint-cli2` notice includes a
+`PATH probed:` line naming the PATH the hook process actually searched. The
+hook never falls back to `npx`, installs a package, or performs a network
+request during a hook run.
 
 Telemetry timing uses `EPOCHREALTIME` (Bash 5.0+); on older Bash the telemetry
 envelope is skipped while formatting still runs.

--- a/plugins/markdown-format/hooks/markdown-format.sh
+++ b/plugins/markdown-format/hooks/markdown-format.sh
@@ -493,9 +493,18 @@ else
   # Never invoke a package runner here: hooks must not download or execute an
   # unpinned package as a side effect of editing a file. Degrade visibly on
   # both channels, once per session.
+  #
+  # Wording is load-bearing (#2740): only the NOTICE latches (skip-notices/
+  # marker via hook::notice_once). The binary probe re-runs on every Markdown
+  # edit and recovers silently mid-session when the tool becomes resolvable —
+  # there is no skip latch. Saying "skipped for this session" made operators
+  # and agents stop retrying. The trailing PATH line is the probe diagnostic
+  # (what this hook process actually searched); do not widen the probe to
+  # nvm/rbenv layout guesses — that is a separate environment/bootstrap fix.
   if hook::notice_once "markdown-format-markdownlint" "$INPUT"; then
     hook::emit_skip_notice PostToolUse \
-      "markdown-format: markdownlint-cli2 was not found on this hook's PATH or as a contained repository-local node_modules/.bin executable — Markdown lint skipped until it is resolvable (re-checked on every Markdown edit; this notice shows once per session). Hook processes inherit Claude Code's own environment, not the interactive shell's profile, so a version-manager install (nvm/rbenv) the Bash tool can see may be invisible here; a repo-local install (npm i -D markdownlint-cli2) is the reliable route. This hook does not invoke npx or download tools."
+      "markdown-format: markdownlint-cli2 was not found on this hook's PATH or as a contained repository-local node_modules/.bin executable — Markdown lint skipped for this edit (probe re-runs on every Markdown edit; only this notice latches once per session — there is no skip latch). Hook processes inherit Claude Code's own environment, not the interactive shell's profile, so a version-manager install (nvm/rbenv) the Bash tool can see may be invisible here; a repo-local install (npm i -D markdownlint-cli2) is the reliable route. This hook does not invoke npx or download tools.
+PATH probed: ${PATH:-<unset>}"
   fi
   emit_tel "skipped" '[]'
   exit 0

--- a/plugins/markdown-format/hooks/markdown-format.test.sh
+++ b/plugins/markdown-format/hooks/markdown-format.test.sh
@@ -888,6 +888,18 @@ if printf '%s' "$OUT_NO_MDLINT" | jq -e '.hookSpecificOutput.additionalContext |
 else
   fail "missing markdownlint warning absent: $OUT_NO_MDLINT"
 fi
+# #2740: notice must not claim a session-long skip latch, and must carry the
+# probed PATH so a PATH-layer miss (nvm prefix, cloud harness env) is diagnosable.
+if printf '%s' "$OUT_NO_MDLINT" | jq -e '
+  (.hookSpecificOutput.additionalContext | contains("there is no skip latch")) and
+  (.hookSpecificOutput.additionalContext | contains("PATH probed:")) and
+  (.systemMessage | contains("PATH probed:")) and
+  ((.hookSpecificOutput.additionalContext | contains("skipped for this session")) | not)
+' >/dev/null 2>&1; then
+  ok "missing markdownlint notice: notice-only latch + PATH diagnostic"
+else
+  fail "missing markdownlint latch/PATH diagnostic wrong: $OUT_NO_MDLINT"
+fi
 if [[ ! -e "$NPX_MARKER" ]]; then ok "missing markdownlint never invokes npx"; else fail "missing markdownlint invoked npx"; fi
 
 # --- Missing jq: visible advisory, no malformed parsing ---------------------


### PR DESCRIPTION
## Summary

- Rewords the missing-`markdownlint-cli2` notice so it no longer implies a session-long skip latch: only the notice latches (`skip-notices/`); the binary probe re-runs on every Markdown edit.
- Appends a one-line `PATH probed:` diagnostic so PATH-layer misses (cloud harness / nvm prefix) are diagnosable without widening the probe into nvm layout guesses.
- Bumps `markdown-format` to 0.11.18 and updates CHANGELOG/README/tests.

Closes #2740

## Test plan

- [x] `bash plugins/markdown-format/hooks/markdown-format.test.sh` — PASS=148 FAIL=0
- [x] Asserts notice contains `there is no skip latch`, `PATH probed:`, and does not contain `skipped for this session`

## Related

Refs #2740 (closed by keyword above).