### PR TITLE
docs(claude-config,claude-memory): ratify C6/I15 boundary after C6 widening

### DIFF
--- a/docs/adr/0004-rightsize-instruction-surfaces-by-incumbent-first-arbitration.md
+++ b/docs/adr/0004-rightsize-instruction-surfaces-by-incumbent-first-arbitration.md
@@ -443,3 +443,23 @@ output styles).
 so this ADR does not depend on another to be actionable; the full option analysis and the cost that
 placement carries — Phase A must first gain a plugin-source surface, since it enumerates only the
 user and project `.claude/**` roots today — are recorded in ADR 0005 on the sweep boundary.
+
+## Addendum (2026-08-15): C6 population widened — user↔project now operationally covered
+
+**Status: superseding note only.** The ratified decision text above is preserved. What changed is
+C6's *operational* population, not the reuse predicate.
+
+`claude-memory:audit` 0.8.0 replaced the bare `find . -maxdepth 1` discovery with
+`scripts/discover-instruction-surfaces.sh`, which emits **project and user** scope and whose Step 3
+compares user surfaces against project ones as live C6 conflicts. Operator ratification for #2705
+(2026-08-15) confirms the boundary that follows:
+
+- **C6 owns** instruction-content conflicts across scopes — **including user↔project** — when both
+  anchors are in the discover-instruction-surfaces population.
+- **I15 owns** memory-layer precedence adjudication, settings, and every conflict pair with an
+  anchor outside that population (nested `CLAUDE.md`, auto-memory, hooks, skills, agents, output
+  styles).
+
+The coverage-predicate rule in this ADR and ADR 0005 still binds: route on what C6 enumerates, never
+on the layer name. The table in `audit-instructions`' `conflict-criteria.md` was updated to match the
+widened population so the two plugins no longer double-cover user↔project pairs.

--- a/docs/adr/0005-bound-instruction-surface-work-by-question-not-population.md
+++ b/docs/adr/0005-bound-instruction-surface-work-by-question-not-population.md
@@ -403,3 +403,24 @@ search filtered the open-issue list by title for audit/sweep/scan/all-plugin/con
 criteria/conflict shapes; that list moves week to week and is deliberately not stated as a figure.
 Counts and `path:line` citations were re-verified against the post-#1276 tree, since `main` landed a
 plugin rename during the effort.
+
+## Addendum (2026-08-15): C6 operational coverage now includes user↔project
+
+**Status: superseding note only.** Decisions 1–3 and the coverage-predicate consequence above remain
+as ratified. This note records that C6's operational population moved after ADR acceptance.
+
+When this ADR was written, C6's discovery was CWD-relative `find` and **"the only pair C6
+operationally covers for contradiction is root project `CLAUDE.md` versus project `.claude/rules/`"**
+— so user-global versus project was correctly listed as L2/I15 novel scope. That discovery was later
+replaced by `discover-instruction-surfaces.sh` (project **and** user). Operator ratification for
+[#2705](https://github.com/melodic-software/claude-code-plugins/issues/2705) (2026-08-15) locks the
+routing that follows from the new population:
+
+| Predicate | Owner |
+|---|---|
+| Both anchors in discover-instruction-surfaces (including user↔project) | C6 |
+| Any anchor outside that population; memory-layer precedence / settings adjudication | I15 |
+
+The load-bearing consequence is unchanged: **route on operational coverage, not on layer name.**
+What changed is which pairs satisfy the coverage predicate. Nested `CLAUDE.md` and auto-memory
+remain outside C6's population and stay with I15.

--- a/plugins/claude-config/.claude-plugin/plugin.json
+++ b/plugins/claude-config/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "claude-config",
-  "version": "0.38.3",
+  "version": "0.38.4",
   "description": "Nine configuration-health skills (plus setup) for a repo's Claude Code configuration: audit (settings.json / .mcp.json / hooks / plugins / permissions drift), audit-automation-gaps (evidence-gated verdicts on automation gaps), audit-permission-grants (allow-rule / allowed-tools grants for auto-mode durability and portability), audit-permission-state (the permission rules actually in effect — every settings scope merged with per-rule provenance, what auto mode drops on entry, config written where nothing reads it, and which managed intents are enforced versus loosenable), draft-auto-mode-rules (interview and draft a paste-ready autoMode classifier block; prints only, never writes), audit-instructions (locally-owned instruction surfaces vs current model capability — proposes removals/rewrites of instructions the model no longer needs, and detects cross-surface instruction conflicts), audit-prompting-postures (the additive lane — posture guidance the prompting guide says a component's purpose needs but the component does not carry), audit-pass (one coordinated, ordered, resumable pass over a named target — three-scope inventory, run-time-derived exclusion set, stable finding identity, suppression memory, resume, one human gate — delegating every check to the plugin that owns it), and unhobble (the empirical bare-baseline experiment: reversibly strip a repo's standing instructions, log real stumbles against the current model, re-add only what evidence earns).",
   "author": {
     "name": "Melodic Software",

--- a/plugins/claude-config/CHANGELOG.md
+++ b/plugins/claude-config/CHANGELOG.md
@@ -3,6 +3,19 @@
 All notable changes to the `claude-config` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.38.4]
+
+### Changed
+
+- **`audit-instructions`: ratify the C6/I15 boundary against C6's widened population (#2705).**
+  `conflict-criteria.md` 1.5.0 no longer routes every `~/.claude/` half to I15. C6 owns
+  instruction-content conflicts whose both anchors are in `discover-instruction-surfaces`
+  (project **and** user root-level CLAUDE.md / rules) — **including user↔project**. I15 keeps
+  nested `CLAUDE.md`, auto-memory, settings, and every surface outside that population, plus
+  memory-layer precedence adjudication for the pairs it retains. SKILL.md "What this skill does
+  NOT do", eval 7, and new eval 18 pin the routing; ADR 0004/0005 carry superseding notes so the
+  immutable records stay accurate beside the live table.
+
 ## [0.38.3]
 
 ### Fixed

--- a/plugins/claude-config/skills/audit-instructions/SKILL.md
+++ b/plugins/claude-config/skills/audit-instructions/SKILL.md
@@ -74,7 +74,8 @@ own surface declaration**, which is narrower than the partition for some checks.
 their own surface sets and are not run outside them; this partition never widens a row.
 
 I15 (cross-surface conflict) carries its own narrower routing on the same convention, drawn from the
-population `claude-memory:audit`'s C6 actually enumerates rather than from the name of the layer.
+population `claude-memory:audit`'s C6 actually enumerates via `discover-instruction-surfaces`
+(project **and** user root-level CLAUDE.md / rules) rather than from the name of the layer.
 [reference/conflict-criteria.md](reference/conflict-criteria.md) states that boundary and owns it.
 
 **Upstream-owned surfaces are excluded from the editable set.** Installed plugin-cache content is
@@ -486,8 +487,10 @@ catalog).
 - Not memory-layer hygiene — checks I1–I5 on CLAUDE.md/rules route to `claude-memory`'s `audit`
   skill when installed, and upstream-owned plugin-cache or managed materializations route to the
   owning repository rather than being edited here.
-- Does not grade a contradiction whose two halves both sit in **root-level** project `CLAUDE.md` /
-  `CLAUDE.local.md` / `.claude/rules/**` — that is `claude-memory:audit`'s C6. A **nested**
-  `CLAUDE.md` / `CLAUDE.local.md` side keeps the pair here, because C6 never discovers that file;
+- Does not grade a contradiction whose two halves both sit in the
+  **discover-instruction-surfaces** population — root-level project **or user** `CLAUDE.md` /
+  `CLAUDE.local.md` / rules, including **user↔project** pairs — that is `claude-memory:audit`'s C6.
+  A **nested** `CLAUDE.md` / `CLAUDE.local.md` side, an auto-memory side, or any surface outside that
+  population keeps the pair here;
   [reference/conflict-criteria.md](reference/conflict-criteria.md) owns the routing table and its
   evidence.

--- a/plugins/claude-config/skills/audit-instructions/evals/evals.json
+++ b/plugins/claude-config/skills/audit-instructions/evals/evals.json
@@ -79,10 +79,10 @@
       "id": 7,
       "name": "memory-layer-conflict-routes-to-c6",
       "prompt": "/claude-config:audit-instructions my CLAUDE.md says \"always run the full test suite before committing\" and .claude/rules/testing.md says \"never run the full suite locally, let CI do it\". Which one is wrong?",
-      "expected_output": "Recognizes that both sides of the contradiction sit inside the memory layer (CLAUDE.md and a rules file), which is check C6 Consistency in the claude-memory plugin's audit skill, not check I15 here. Routes the finding there when claude-memory is installed — reporting the pair as an observation and pointing at /claude-memory:audit rather than grading it — so one finding is emitted rather than two. When claude-memory is NOT installed it keeps the pair as an I15 finding instead, per the fallback contract in conflict-criteria.md, so a real contradiction is never silently dropped just because the incumbent is absent.",
+      "expected_output": "Recognizes that both sides of the contradiction sit inside the discover-instruction-surfaces population C6 enumerates (root-level project CLAUDE.md and a rules file), which is check C6 Consistency in the claude-memory plugin's audit skill, not check I15 here. Routes the finding there when claude-memory is installed — reporting the pair as an observation and pointing at /claude-memory:audit rather than grading it — so one finding is emitted rather than two. When claude-memory is NOT installed it keeps the pair as an I15 finding instead, per the fallback contract in conflict-criteria.md, so a real contradiction is never silently dropped just because the incumbent is absent.",
       "files": [],
       "expectations": [
-        "Identifies both sides as root-level project memory surfaces and, when claude-memory is installed, does NOT emit an I15 conflict finding for them",
+        "Identifies both sides as discover-instruction-surfaces population members and, when claude-memory is installed, does NOT emit an I15 conflict finding for them",
         "Routes the contradiction to the claude-memory plugin's audit skill check C6 when that plugin is installed",
         "When claude-memory is NOT installed, emits the I15 fallback finding for the pair rather than reporting it unchecked — the routing exists to avoid duplicate findings, not to drop the only one"
       ]
@@ -206,6 +206,19 @@
         "Derives the state key by running the resolver rather than by evaluating whether ${CLAUDE_PROJECT_DIR} is set",
         "Omits the per-surface token delta and says why, instead of computing one against another project's prior report",
         "Reuses audit-pass's <repo-identity>/<worktree-discriminator> scheme rather than inventing a second one"
+      ]
+    },
+    {
+      "id": 18,
+      "name": "user-project-conflict-routes-to-c6",
+      "prompt": "/claude-config:audit-instructions my ~/.claude/CLAUDE.md says \"always ask before running any shell command\" and this project's CLAUDE.md says \"never ask — run the full test suite without confirmation\". Which audit owns that?",
+      "expected_output": "Routes the pair to claude-memory:audit's C6. Both anchors are in the discover-instruction-surfaces population — user-scope CLAUDE.md and project-scope CLAUDE.md — and C6's Step 3 explicitly compares user surfaces against project ones as live conflicts. I15 does not grade the pair when claude-memory is installed; it reports an observation pointing at /claude-memory:audit. When claude-memory is NOT installed it keeps the pair as an I15 finding per the fallback contract, so the contradiction is never silently dropped. Nested CLAUDE.md, auto-memory, and skill-body halves stay with I15 because they are outside that population.",
+      "files": [],
+      "expectations": [
+        "Identifies the user↔project CLAUDE.md pair as inside C6's discover-instruction-surfaces population, not as an I15-only concern",
+        "When claude-memory is installed, routes to C6 / does NOT emit a graded I15 conflict finding for the pair",
+        "When claude-memory is NOT installed, emits the I15 fallback finding rather than dropping the only coverage",
+        "Does not treat nested CLAUDE.md or auto-memory pairs as if they followed the same route — those stay with I15"
       ]
     }
   ]

--- a/plugins/claude-config/skills/audit-instructions/reference/conflict-criteria.md
+++ b/plugins/claude-config/skills/audit-instructions/reference/conflict-criteria.md
@@ -1,7 +1,7 @@
 # Cross-Surface Conflict Criteria
 
-Version: 1.4.0
-Last updated: 2026-08-08
+Version: 1.5.0
+Last updated: 2026-08-15
 
 **The adjudication procedure for check I15.** [criteria.md](criteria.md)'s I15 entry owns the
 definition — what a cross-surface conflict *is*, its comparison set, its import and symlink
@@ -43,45 +43,51 @@ pages do not make is recorded as unresolved and given no winner.
 
 ## Boundary: what C6's population actually is
 
-I15 routes a contradiction "wholly inside the memory layer" to `claude-memory:audit`'s **C6
-Consistency** check, and counts `~/.claude/rules/` among the memory-layer surfaces. Those two
-statements do not compose, and the gap is silent.
+I15 routes a contradiction whose **both** anchors sit in `claude-memory:audit`'s C6 discovery
+population to that check, and keeps every other pair here — including memory-layer pairs C6 still
+does not enumerate, and every cross-layer pair. The predicate is the population, never the layer
+name.
 
 The `claude-memory:audit` skill's check **C6** asks its question "across CLAUDE.md, CLAUDE.local.md,
-and rules files", and its population is **project-relative**: the audit workflow discovers files
-with `find . -maxdepth 1 -name "CLAUDE.md"` and `find .claude/rules`, and the orphan-rule script
-scans `.claude/rules/*.md`. The plugin resolves a user-level directory only for auto-memory under
-`~/.claude/projects/<slug>/`, never for rules. Its official-guidance reference notes `~/.claude/rules/`
-exists as background and never audits it.
+and rules files". Its live discovery is
+`skills/audit/scripts/discover-instruction-surfaces.sh`, which emits **project and user** scope —
+root-level project `CLAUDE.md` / `CLAUDE.local.md` / `.claude/rules/**`, plus
+`${CLAUDE_CONFIG_DIR:-~/.claude}/CLAUDE.md` and `…/rules/**` — each tagged so project-scoped criteria
+can skip personal files. Step 3 of the audit workflow then compares user-scope surfaces against
+project ones as live C6 conflicts. That widening closed the silent gap the previous edition of this
+section documented: a user-global instruction contradicting a project one is no longer deferred by
+I15 into a check that could not see it.
 
-So a user-global instruction contradicting a project one — `~/.claude/CLAUDE.md` against project
-`CLAUDE.md`, or `~/.claude/rules/` against `.claude/rules/` — is deferred by I15 as "memory-layer" and
-never picked up by C6. **Neither check reports it.** Route on C6's actual population instead:
+Route on that population:
 
 | Pair | Owner |
 |---|---|
-| Both halves inside **root-level project** `CLAUDE.md` / `CLAUDE.local.md` / `.claude/rules/**` | `claude-memory`'s C6 |
-| Anything else — any `~/.claude/` side, any auto-memory side, **any nested `CLAUDE.md` / `CLAUDE.local.md` side** | I15 |
+| Both anchors in the **discover-instruction-surfaces** population (any mix of project / user / `both` scope among root-level `CLAUDE.md` / `CLAUDE.local.md` / rules) — **including user↔project** | `claude-memory`'s C6 |
+| Anything else — **any nested `CLAUDE.md` / `CLAUDE.local.md` side**, any auto-memory side, settings, hooks, skills, agents, output styles, or any other surface outside that population | I15 |
 
-**Nested memory files are not routed out either**, for the same reason and by the same evidence.
-Phase A inventories every nested `CLAUDE.md` / `CLAUDE.local.md` in the project tree, while C6
-discovers with `find . -maxdepth 1` — so routing a nested pair to C6 hands it to a check that never
-reads the file. "Project-scope" is the wrong predicate; **root-level project** is the right one.
+**Nested memory files stay with I15**, for the same reason as before. Phase A inventories every nested
+`CLAUDE.md` / `CLAUDE.local.md` in the project tree, while discover-instruction-surfaces is depth-1 by
+design — so routing a nested pair to C6 hands it to a check that never reads the file.
 
-**Auto-memory is deliberately not routed out** for the same reason. `claude-memory` audits `MEMORY.md`
-for size and index integrity, but C6's question names only "CLAUDE.md, CLAUDE.local.md, and rules
-files" — auto-memory is absent from the check text. Routing a `MEMORY.md`-versus-`CLAUDE.md`
-contradiction to C6 would leave it audited by neither skill, so it stays with I15 until C6 widens.
+**Auto-memory stays with I15** on the same evidence. `claude-memory` audits `MEMORY.md` for size and
+index integrity via a separate resolver, but that path is not in the discover-instruction-surfaces
+population C6 pairs over. Routing a `MEMORY.md`-versus-`CLAUDE.md` contradiction to C6 would leave it
+audited by neither skill's conflict check.
 
-When a pair is wholly project-scope memory-layer, report it as an observation and point the operator
-at `/claude-memory:audit` rather than grading it here; when that plugin is not installed, keep it as a
+**I15 still owns memory-layer precedence adjudication** — what the docs settle, what they leave
+unresolved, and the co-residency / liveness gates in this file — for every pair it keeps. C6 owns
+instruction-*content* consistency inside its discovery population; it does not absorb this file's
+precedence tables or the surfaces outside that population.
+
+When both anchors are in C6's population, report the pair as an observation and point the operator at
+`/claude-memory:audit` rather than grading it here; when that plugin is not installed, keep it as a
 finding so nothing is silently dropped. This mirrors the reciprocal routing `claude-memory` already
 performs for content-fit findings.
 
-The durable fix is upstream: C6's population should widen to cover the user scope, at which point this
-table narrows again. Until then, the rule is **route on the population a check actually enumerates,
-never on the name of the layer** — a boundary drawn from a label rather than from the incumbent's
-discovery globs is how a gap this size stays invisible.
+The rule remains **route on the population a check actually enumerates, never on the name of the
+layer** — a boundary drawn from a label rather than from the incumbent's discovery script is how a
+gap the size of the pre-widening user↔project hole stays invisible. When that script's population
+moves again, this table moves with it.
 
 ## Prerequisite: co-residency
 

--- a/plugins/claude-memory/.claude-plugin/plugin.json
+++ b/plugins/claude-memory/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "claude-memory",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "Keeps a repo's Claude Code memory layer healthy and under your control, against criteria derived from official Claude Code documentation. The audit skill checks the instruction/memory layer (CLAUDE.md, CLAUDE.local.md, .claude/rules/, auto-memory) with a deterministic script-backed spine plus judgment-tier checks. The stateless skill inspects, disables, and (confirm-gated) purges Claude-written auto memory across all settings scopes.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/claude-memory/CHANGELOG.md
+++ b/plugins/claude-memory/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to the `claude-memory` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.9.2]
+
+### Changed
+
+- **C6/I15 boundary ratified against the widened discover-instruction-surfaces population (#2705).**
+  C6 criteria 1.5.4 and the audit SKILL.md / workflow now state explicitly that C6 owns
+  instruction-content conflicts across scopes — **including user↔project** — when both anchors are
+  in `discover-instruction-surfaces`. Nested `CLAUDE.md`, auto-memory, and non-memory surfaces stay
+  with `claude-config:audit-instructions` I15 (precedence / settings / out-of-population pairs).
+  New eval 11 pins the ownership claim; sibling `conflict-criteria.md` on the config side was the
+  stale half this closes.
+
 ## [0.9.1]
 
 ### Changed

--- a/plugins/claude-memory/CHANGELOG.md
+++ b/plugins/claude-memory/CHANGELOG.md
@@ -12,6 +12,8 @@ All notable changes to the `claude-memory` plugin are documented here. Format fo
   instruction-content conflicts across scopes — **including user↔project** — when both anchors are
   in `discover-instruction-surfaces`. Nested `CLAUDE.md`, auto-memory, and non-memory surfaces stay
   with `claude-config:audit-instructions` I15 (precedence / settings / out-of-population pairs).
+  Step 3 now compares every distinct population pair for contradictions (including
+  CLAUDE.md↔CLAUDE.local.md and rule↔rule), not only the prior cross-scope redundancy pass.
   New eval 11 pins the ownership claim; sibling `conflict-criteria.md` on the config side was the
   stale half this closes.
 

--- a/plugins/claude-memory/skills/audit/SKILL.md
+++ b/plugins/claude-memory/skills/audit/SKILL.md
@@ -38,10 +38,13 @@ the `audit` and `automation-gaps` skills in the `claude-config` plugin).
 | Auto-memory | `~/.claude/projects/<project>/memory/` | First 200 lines / 25KB of MEMORY.md | Yes |
 | Settings, hooks, MCP, agents, skills | Various | Various | No — use `claude-config`'s `audit` / `automation-gaps` |
 
-The two user-scope rows are in scope because they load in every session regardless of where it starts,
-and because `claude-config`'s `audit-instructions` partitions memory-layer surfaces here **by name**,
-`~/.claude/rules/` included. Discovery tags every file with its scope so project-scoped criteria (C9)
-skip personal files rather than reporting a repo-scoped finding against one.
+The two user-scope rows are in scope because they load in every session regardless of where it starts.
+Discovery tags every file with its scope so project-scoped criteria (C9) skip personal files rather
+than reporting a repo-scoped finding against one. **C6 Consistency** owns instruction-content
+conflicts across that discover-instruction-surfaces population — including **user↔project** pairs.
+`claude-config:audit-instructions` I15 owns memory-layer precedence adjudication and every conflict
+pair with an anchor outside that population (nested `CLAUDE.md`, auto-memory, settings, hooks,
+skills, agents, output styles).
 
 ## Scope boundary (route out)
 

--- a/plugins/claude-memory/skills/audit/context/audit.md
+++ b/plugins/claude-memory/skills/audit/context/audit.md
@@ -86,16 +86,20 @@ skipping the judgment.
 
 ## Step 3: Cross-file consistency check (C6)
 
-After per-file checks, cross-reference:
+After per-file checks, cross-reference every pair of distinct surfaces in the
+discover-instruction-surfaces population for **contradictions** (C6 owns all such pairs). Also
+report **redundancy** where both sides load together in the same session. Concrete passes:
 
-1. Compare CLAUDE.md sections against `.claude/rules/` for contradictions
-2. Compare CLAUDE.md against CLAUDE.local.md for redundancy
-3. Check if any CLAUDE.md instruction is already enforced by rule, hook, or analyzer
-4. Compare the **user**-scope surfaces against the project ones. Both load together in every session
-   here, so a user instruction that contradicts a project one is a live conflict rather than a
-   layering choice, and a user instruction the project already states is redundant context on every
-   run. Report the contradiction against the pair, and say which scope each side came from — the
-   resolution differs, since only one of the two is yours to edit on behalf of the repo.
+1. Compare each CLAUDE.md (any scope) against every co-resident rule for contradictions
+2. Compare CLAUDE.md against CLAUDE.local.md (same or cross-scope) for contradictions and redundancy
+3. Compare rules against other co-resident rules for contradictions (same-scope and cross-scope)
+4. Check if any CLAUDE.md instruction is already enforced by rule, hook, or analyzer
+5. Compare the **user**-scope surfaces against the project ones for any remaining pair not covered
+   above. Both load together in every session here, so a user instruction that contradicts a project
+   one is a live conflict rather than a layering choice, and a user instruction the project already
+   states is redundant context on every run. Report the finding against the pair, and say which scope
+   each side came from — the resolution differs, since only one of the two is yours to edit on behalf
+   of the repo.
    **Two exclusions.** A `both`-scoped file is one file, not a pair: never compare it with itself. And
    a path-scoped user rule only co-resides where its `paths:` can match here, so establish that before
    calling it a contradiction or a redundancy

--- a/plugins/claude-memory/skills/audit/context/audit.md
+++ b/plugins/claude-memory/skills/audit/context/audit.md
@@ -12,7 +12,8 @@ Find files in scope:
 # The bundled script resolves ${CLAUDE_CONFIG_DIR:-$HOME/.claude} the same way the
 # memory-dir resolver does. A bare `find .` sees project scope only, which left
 # ~/.claude/CLAUDE.md and ~/.claude/rules/*.md audited by nothing — they load in
-# every session, and audit-instructions' surface partition hands them here by name.
+# every session. C6 owns instruction-content conflicts across this population
+# (including user↔project); I15 owns pairs with an anchor outside it.
 bash "${CLAUDE_PLUGIN_ROOT}/skills/audit/scripts/discover-instruction-surfaces.sh"
 # Output: <scope>\t<kind>\t<path>  — scope is `project` or `user`
 

--- a/plugins/claude-memory/skills/audit/evals/evals.json
+++ b/plugins/claude-memory/skills/audit/evals/evals.json
@@ -124,6 +124,18 @@
         "Names the leftover path to the user and explains it cannot be attributed to a project",
         "Offers to run a fresh audit for this project"
       ]
+    },
+    {
+      "id": 11,
+      "name": "c6-owns-user-project-instruction-conflicts",
+      "prompt": "My ~/.claude/CLAUDE.md says never use AskUserQuestion, and this project's CLAUDE.md says always use AskUserQuestion before any destructive action. Is that your C6 check or audit-instructions' I15?",
+      "expected_output": "C6 owns it. Both anchors are in the discover-instruction-surfaces population (user CLAUDE.md and project CLAUDE.md), and Step 3 compares user-scope surfaces against project ones as live conflicts. I15 does not grade that pair when this skill is installed — it routes here. Nested CLAUDE.md, auto-memory, and skill-body halves stay with I15 because they are outside this population; I15 also keeps memory-layer precedence adjudication for pairs it retains.",
+      "files": [],
+      "expectations": [
+        "Attributes the user↔project CLAUDE.md contradiction to C6 Consistency, not to I15",
+        "Names discover-instruction-surfaces (or Step 3 cross-scope comparison) as why both sides are in population",
+        "States that nested CLAUDE.md / auto-memory / non-memory surfaces remain outside C6 and belong to I15"
+      ]
     }
   ]
 }

--- a/plugins/claude-memory/skills/audit/reference/criteria.md
+++ b/plugins/claude-memory/skills/audit/reference/criteria.md
@@ -1,7 +1,7 @@
 # Memory Health Criteria
 
-Version: 1.5.3
-Last updated: 2026-08-08
+Version: 1.5.4
+Last updated: 2026-08-15
 Source: Official Claude Code docs (code.claude.com/docs/en/memory, code.claude.com/docs/en/best-practices, code.claude.com/docs/en/sub-agents, code.claude.com/docs/en/skills)
 
 This file defines every check the audit runs. Each check has a severity, description, and instructions
@@ -165,15 +165,25 @@ instead)."
 
 ### C6: Consistency [FAIL]
 
-**What**: Do any instructions contradict each other across CLAUDE.md, CLAUDE.local.md, and rules files?
+**What**: Do any instructions contradict each other across CLAUDE.md, CLAUDE.local.md, and rules
+files — including across **user and project** scope when both sides are in the
+`discover-instruction-surfaces` population?
 
 **How to check**:
 
-1. Identify instructions touching the same topic across files
+1. Identify instructions touching the same topic across files discovered by
+   `scripts/discover-instruction-surfaces.sh` (project and user scope)
 2. Check for contradictions (e.g., "always use X" in one file, "never use X" in another)
 3. Check for redundancy (same instruction in multiple files)
-4. FAIL for contradictions (Claude picks one arbitrarily)
-5. WARN for redundancy (wastes context budget)
+4. Compare **user**-scope surfaces against project ones — both load together, so a
+   user↔project contradiction is a live conflict (see Step 3 in `context/audit.md`)
+5. FAIL for contradictions (Claude picks one arbitrarily)
+6. WARN for redundancy (wastes context budget)
+
+**Boundary**: This check owns instruction-content conflicts whose **both** anchors are in the
+discover-instruction-surfaces population. Nested `CLAUDE.md` files, auto-memory, settings, hooks,
+skills, agents, and output styles are outside that population — those pairs belong to
+`claude-config:audit-instructions` I15 (and its precedence / co-residency adjudication), not here.
 
 **Why**: Official docs: "If two rules contradict each other, Claude may pick one arbitrarily."
 

--- a/plugins/claude-memory/skills/audit/scripts/discover-instruction-surfaces.sh
+++ b/plugins/claude-memory/skills/audit/scripts/discover-instruction-surfaces.sh
@@ -6,9 +6,10 @@
 # current directory (`find . -maxdepth 1 -name CLAUDE.md`, `find .claude/rules ...`), so it
 # could only ever see PROJECT-scope files. The user-global surfaces — `~/.claude/CLAUDE.md`
 # and `~/.claude/rules/*.md` — load in every session and were reachable by neither this
-# skill nor `claude-config:audit-instructions` I15 once C6 owns conflicts inside this
-# population (including user↔project). One skill's conflict pass deferred a user-global
-# surface; the receiving skill's discovery could not reach it, so nothing audited it.
+# skill nor `claude-config:audit-instructions` (I15 now defers to C6 once both anchors are
+# in this population, including user↔project; at the time this comment was written, neither
+# check reached them). One skill's conflict pass deferred a user-global surface; the
+# receiving skill's discovery could not reach it, so nothing audited it.
 #
 # Scope tagging is not cosmetic. Several criteria are project-scoped (C9 is the live case),
 # and widening discovery WITHOUT a scope field would make them fire on personal files that

--- a/plugins/claude-memory/skills/audit/scripts/discover-instruction-surfaces.sh
+++ b/plugins/claude-memory/skills/audit/scripts/discover-instruction-surfaces.sh
@@ -6,9 +6,9 @@
 # current directory (`find . -maxdepth 1 -name CLAUDE.md`, `find .claude/rules ...`), so it
 # could only ever see PROJECT-scope files. The user-global surfaces — `~/.claude/CLAUDE.md`
 # and `~/.claude/rules/*.md` — load in every session and were reachable by neither this
-# skill nor `claude-config:audit-instructions`, whose surface partition explicitly hands
-# `~/.claude/rules/` here by name. One skill delegated a user-global surface; the receiving
-# skill's discovery could not reach it, so nothing audited it.
+# skill nor `claude-config:audit-instructions` I15 once C6 owns conflicts inside this
+# population (including user↔project). One skill's conflict pass deferred a user-global
+# surface; the receiving skill's discovery could not reach it, so nothing audited it.
 #
 # Scope tagging is not cosmetic. Several criteria are project-scoped (C9 is the live case),
 # and widening discovery WITHOUT a scope field would make them fire on personal files that


### PR DESCRIPTION
Closes #2705

## Summary

Ratifies the C6/I15 audit-scope boundary against C6's live `discover-instruction-surfaces` population so the two plugins stop double-covering user↔project instruction conflicts.

## Binding

- **C6** owns instruction-content conflicts across scopes (**including user↔project**) when both anchors are in the discover-instruction-surfaces population.
- **I15** owns memory-layer precedence adjudication, settings, and every conflict pair with an anchor outside that population (nested `CLAUDE.md`, auto-memory, hooks, skills, agents, output styles).

## Changes

- `conflict-criteria.md` 1.5.0 — rewrite the Boundary section and routing table
- `audit-instructions` SKILL.md + evals (update eval 7; add eval 18)
- `claude-memory` C6 criteria 1.5.4, SKILL.md, audit workflow, eval 11
- ADR 0004 / 0005 superseding notes (ratified text preserved)
- Versions: `claude-config` 0.38.4, `claude-memory` 0.9.2 + CHANGELOGs

## Verification

- `discover-instruction-surfaces.test.sh` — 43 checks pass
- `check-changelog-parity.sh --check` for both plugins — pass

## Related

ADR 0004 / 0005 (superseding notes). Boundary ratification after C6 discover-instruction-surfaces widening.