### PR TITLE
docs(knowledge): preserve map-corpus deferred-with-trigger records (0.12.4)

### DIFF
--- a/plugins/knowledge/.claude-plugin/plugin.json
+++ b/plugins/knowledge/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "knowledge",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "description": "Ingest external knowledge into durable, synthesized artifacts. Ships a book-distillation pipeline (PDF/EPUB into concept-organized, author-attributed skill reference files), a YouTube pipeline (watch, transcript, link harvest, and repo-applicability synthesis), a course-digest pipeline (extract and synthesize online video courses \u2014 Dometrain, Teachable \u2014 into repo-applicable recommendations), a docpage-digest pipeline (single online documentation page into a verified knowledge slice with dual verification \u2014 one cross-vendor verifier \u2014 and an interview handoff), and a map-corpus pipeline (multi-resource corpus into a classified link map, deterministic node manifests, gate-verified relevance inventory, and an approved queue of docpage-digest runs), plus a re-runnable setup action; a configurable library directory governs where synthesized artifacts land in the consuming repo.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/knowledge/CHANGELOG.md
+++ b/plugins/knowledge/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to the `knowledge` plugin are recorded here. The `version` i
 `.claude-plugin/plugin.json` is the delivery vehicle — a consumer receives a change
 only after that version increases.
 
+## [0.12.4]
+
+### Added
+
+- **Owner doc for ingest deferred-with-trigger decisions**
+  (`reference/ingest-deferred-decisions.md`): the five records that outlived the
+  `docsite-digest` Brief — rung-3/`firecrawl` seam (user-reserved), repo-tree enumeration,
+  `docpage-digest` rename cost, shared ingest-slice retrofit of sibling skills, and cross-type
+  routing — each with its named trigger. `map-corpus` keeps today's stop/non-goal behavior and
+  points at the owner doc for the durable records. Closes #2707. No behavior, schema, gate, exit
+  code, or argument changes.
+
 ## [0.12.3]
 
 ### Added

--- a/plugins/knowledge/CHANGELOG.md
+++ b/plugins/knowledge/CHANGELOG.md
@@ -10,7 +10,7 @@ only after that version increases.
 
 - **Owner doc for ingest deferred-with-trigger decisions**
   (`reference/ingest-deferred-decisions.md`): the five records that outlived the
-  `docsite-digest` Brief — rung-3/`firecrawl` seam (user-reserved), repo-tree enumeration,
+  `docpage-digest` Brief — rung-3/`firecrawl` seam (user-reserved), repo-tree enumeration,
   `docpage-digest` rename cost, shared ingest-slice retrofit of sibling skills, and cross-type
   routing — each with its named trigger. `map-corpus` keeps today's stop/non-goal behavior and
   points at the owner doc for the durable records. Closes #2707. No behavior, schema, gate, exit

--- a/plugins/knowledge/reference/ingest-deferred-decisions.md
+++ b/plugins/knowledge/reference/ingest-deferred-decisions.md
@@ -1,0 +1,79 @@
+# Ingest deferred-with-trigger decisions
+
+This document owns the deferred-with-trigger records that outlived the
+`docsite-digest` contract-slice Brief (the Brief governed `map-corpus` authoring;
+the slice pruned after the skill shipped). None of these is actionable until its
+named trigger fires. Re-check each trigger — and re-measure item 3's cost —
+before treating an item as actionable.
+
+Operational surfaces (`map-corpus` Phase 1 stop behavior, gate messages, non-goals)
+state what a run must do today. This document is the durable record of *why* those
+surfaces stop short, and of the three Broader ingest questions the Brief also
+deferred. Source: GitHub issue #2707 (filed so the records survive Brief prune).
+
+## 1. Discovery rung 3 (in-page link extraction) and the `firecrawl` seam
+
+**Label (authoring):** Q19. **Arbiter:** USER-RESERVED.
+
+`map-corpus` discovery is rungs 1–2 only (`llms.txt`, sitemap); an origin seed
+resolving neither stops loudly. Rung 3 has an unresolved design fork: a
+presence-gated `/firecrawl:firecrawl map` call with a documented in-skill
+fallback, versus a recorded reason the skill reimplements in-page link
+extraction. `firecrawl` already ships `map <url>` (URL-only discovery) and
+`crawl <url>`, but the design boundary bars a bare unguarded cross-plugin
+reference and `dependencies` are reserved for hard requires.
+
+**Trigger:** the first corpus whose seeds resolve neither an `llms.txt` nor a
+sitemap, so rung 3 is actually reached. The answer changes the mapper's
+constraints and prerequisite set, so the user arbitrates it.
+
+## 2. Repository-tree enumeration rung
+
+V1 ingress for repository files is human-enumerated **resource seeds** (a
+non-root seed URL is itself a corpus resource, rung `seed`, no discovery at its
+origin; GitHub files seeded in `raw.githubusercontent.com` form because a `blob`
+URL snapshots HTML chrome). The first corpus hand-enumerated its 12 spec-repo
+blobs. A `git ls-tree` / tree-API enumeration rung is deferred.
+
+**Trigger:** the first corpus whose repository half is too large to enumerate by
+hand.
+
+## 3. Renaming `docpage-digest`
+
+Deliberately out of scope for the mapper: the skill keeps its name and its
+`docpage-digest-checklist.md` filename, which is load-bearing for run identity —
+a rename makes every existing work slice present as "no URL recorded", and the
+skill's collision check then permanently refuses to resume them.
+
+**Trigger:** an orchestrator that justifies the cost. **Cost measured at the time
+of deferral** (2026-08, re-measure before acting): 48 occurrences across 14
+tracked files; a two-plugin change with two CHANGELOG entries and two version
+bumps; a regenerated `docs/CATALOG.md`; 24 CHANGELOG occurrences that must
+**not** be rewritten; an unresolved question about ADRs 0006 and 0007 citing the
+live path; and an explicit migration of 14 live work slices.
+
+## 4. Retrofitting sibling ingest skills to a shared ingest-slice contract
+
+Retrofitting `youtube-digest`, `course-digest`, and `book-distill` to a shared
+ingest-slice contract was rejected for now on evidence, not preference: their
+input contracts, human-interaction points, terminal artifacts, and git posture
+diverge — `youtube-digest`'s slice artifacts are a committed durable substrate,
+the opposite of the mapper's untracked, self-ignoring root.
+
+**Trigger:** a shared web-scoped ingest-slice contract existing first (item 5's
+prerequisite).
+
+## 5. Cross-type routing
+
+A webpage's embedded YouTube video routing into the YouTube pipeline. Today such
+a URL is classified `companion` for the interview and never dispatched to a
+sibling pipeline.
+
+**Trigger:** the ingest-slice contract is authored web-scoped first; routing
+waits for it.
+
+## Disposition
+
+No trigger has fired as of the filing of #2707. This document is preservation,
+not a work queue. Closing #2707 means the records live here; it does not mean
+any trigger has fired.

--- a/plugins/knowledge/reference/ingest-deferred-decisions.md
+++ b/plugins/knowledge/reference/ingest-deferred-decisions.md
@@ -1,7 +1,7 @@
 # Ingest deferred-with-trigger decisions
 
 This document owns the deferred-with-trigger records that outlived the
-`docsite-digest` contract-slice Brief (the Brief governed `map-corpus` authoring;
+`docpage-digest` contract-slice Brief (the Brief governed `map-corpus` authoring;
 the slice pruned after the skill shipped). None of these is actionable until its
 named trigger fires. Re-check each trigger — and re-measure item 3's cost —
 before treating an item as actionable.

--- a/plugins/knowledge/skills/map-corpus/SKILL.md
+++ b/plugins/knowledge/skills/map-corpus/SKILL.md
@@ -93,12 +93,14 @@ Seeds come in two kinds, told apart by their normalized path:
   decision — a presence-gated `/firecrawl:firecrawl map` seam with a documented in-skill fallback,
   versus a recorded reason this skill reimplements in-page extraction (a bare unguarded
   cross-plugin reference is barred, and `dependencies` are reserved for hard requires). This stop
-  IS that decision's trigger: report it and ask, never crawl unasked.
+  IS that decision's trigger: report it and ask, never crawl unasked. Full deferred-with-trigger
+  record: `${CLAUDE_PLUGIN_ROOT}/reference/ingest-deferred-decisions.md` §1.
 - **Resource seed** (non-root path, e.g. a raw repo file URL) — itself a corpus resource: a
   link-map row with rung `seed`, no discovery at its origin. Human-enumerated resource seeds are
   the V1 ingress for repository files; a repo-tree enumeration rung (`git ls-tree` / tree API) is
   deferred, and its trigger is the first corpus whose repository half is too large to enumerate by
-  hand. **V1 requires at least one origin seed** — the link-map gate needs a discovery basis;
+  hand (full record: `${CLAUDE_PLUGIN_ROOT}/reference/ingest-deferred-decisions.md` §2).
+  **V1 requires at least one origin seed** — the link-map gate needs a discovery basis;
   a resource-seeds-ONLY corpus is outside V1 mapper scope (recorded deferral in
   `discovery/link-map-format.md`): route those URLs to direct `/knowledge:docpage-digest` runs.
   **GitHub blob URLs:** seed the `raw.githubusercontent.com` form — a `blob` URL snapshots the
@@ -181,10 +183,15 @@ Emit a continuation prompt when pausing mid-pipeline (slug, first unticked phase
 ## What this skill does NOT do
 
 - **Does not digest.** Verdicts and evidence tokens, yes; digests are `docpage-digest`'s job.
-- **Does not crawl in-page links.** Discovery is rungs 1–2; rung 3 is user-reserved (see Phase 1).
+  Renaming `docpage-digest` is deliberately out of scope here — see
+  `${CLAUDE_PLUGIN_ROOT}/reference/ingest-deferred-decisions.md` §3.
+- **Does not crawl in-page links.** Discovery is rungs 1–2; rung 3 is user-reserved (see Phase 1;
+  `${CLAUDE_PLUGIN_ROOT}/reference/ingest-deferred-decisions.md` §1).
 - **Does not commit or graduate.** The slice is untracked and self-ignoring.
 - **Does not route non-web ingest types.** A YouTube/course/book URL discovered in the corpus
-  is classified `companion` for the interview, never dispatched to sibling pipelines.
+  is classified `companion` for the interview, never dispatched to sibling pipelines
+  (cross-type routing and a shared ingest-slice contract are deferred —
+  `${CLAUDE_PLUGIN_ROOT}/reference/ingest-deferred-decisions.md` §4–§5).
 
 ## Gotchas
 


### PR DESCRIPTION
## Summary

- Add `plugins/knowledge/reference/ingest-deferred-decisions.md` holding all five deferred-with-trigger records from #2707 (rung-3/`firecrawl` seam, repo-tree enumeration, `docpage-digest` rename, shared ingest-slice retrofit, cross-type routing).
- Point `map-corpus` Phase 1 and non-goals at that owner doc; keep today's stop/non-goal behavior inline.
- Bump `knowledge` to 0.12.4 and record the addition in `CHANGELOG.md`.

No new GitHub issues. No behavior, schema, gate, exit code, or argument changes.

Closes #2707.

## Test plan

- [x] `npx markdownlint-cli2` on the new reference doc, updated `SKILL.md`, and `CHANGELOG.md` — 0 issues
- [x] `scripts/check-changed-skills.sh origin/main` — `CHECK-SKILL map-corpus: PASS` (pre-existing soft-target line-count warning only)
- [x] Confirm `plugin.json` version is `0.12.4` and the five issue items appear in the reference doc

## Related

Contract-slice Brief prune for `docpage-digest` / `map-corpus` authoring. No other linked PRs.