### PR TITLE
fix(docs-hygiene): make audit-encapsulation detect a candidate enumerator

### DIFF
--- a/plugins/docs-hygiene/.claude-plugin/plugin.json
+++ b/plugins/docs-hygiene/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "docs-hygiene",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "Documentation-hygiene toolkit: compress (flavor-trim markdown with a semantic-diff safety net), audit-noise (classify markdown noise), extract-ssot (deduplicate repeated content into a single source of truth), audit-encapsulation (detect citations into skill-private surfaces), rename-references (sweep stale references after renames), and audit-derivability (classify whether a whole document earns its existence \u2014 could a fresh agent re-derive it from the code?).",
   "author": {
     "name": "Melodic Software",

--- a/plugins/docs-hygiene/CHANGELOG.md
+++ b/plugins/docs-hygiene/CHANGELOG.md
@@ -9,7 +9,9 @@
   candidates exist (not adjudicated violations), and contract/SKILL/`--help`
   language no longer invites hard-gating CI on that exit code alone. Widen the
   ERE path class so uppercase / single-char / digit-leading / underscore-leading
-  skill and subdir names match (F3). Document `plugins/` in the scan-scope
+  skill and subdir names match (F3), while restricting segments to
+  `[A-Za-z0-9_.-]+` so multi-root prose lists cannot span whitespace/punctuation
+  into a false hit. Document `plugins/` in the scan-scope
   sentence and add a Recheck-triggers row for detect.sh scope drift (F5). Drop
   the unreachable `plugins/cache/` mechanical-filter branch and fix the docs
   that claimed it fired (F7). Disclose the relative-path blind spot as #2716

--- a/plugins/docs-hygiene/CHANGELOG.md
+++ b/plugins/docs-hygiene/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog — docs-hygiene plugin
 
+## [0.14.2]
+
+### Fixed
+
+- **audit-encapsulation detect:** treat `detect.sh` as a candidate enumerator —
+  summary keys are `raw` / `mech-filtered` / `candidates`, exit 1 means
+  candidates exist (not adjudicated violations), and contract/SKILL/`--help`
+  language no longer invites hard-gating CI on that exit code alone. Widen the
+  ERE path class so uppercase / single-char / digit-leading / underscore-leading
+  skill and subdir names match (F3). Document `plugins/` in the scan-scope
+  sentence and add a Recheck-triggers row for detect.sh scope drift (F5). Drop
+  the unreachable `plugins/cache/` mechanical-filter branch and fix the docs
+  that claimed it fired (F7). Disclose the relative-path blind spot as #2716
+  (not fixed here) (#2728).
+
 ## [0.14.1]
 
 ### Fixed

--- a/plugins/docs-hygiene/skills/audit-encapsulation/SKILL.md
+++ b/plugins/docs-hygiene/skills/audit-encapsulation/SKILL.md
@@ -29,7 +29,7 @@ The **Skill** surface — public = frontmatter + documented actions + args/flags
 
 Workflows and git hooks needing logic that ALSO lives in a skill must not reach into skill internals. Pick a sharing technique by logic size — scripts/ facade (the skill exposes a public `scripts/<name>.sh` entry delegating to a private backend; hooks/CI invoke it), intentional duplication, plugin packaging, or headless `claude -p '/skill <action>'` invocation — per `context/public-surface-contract.md` "CI / git-hook consumption — entry surface, not internals".
 
-The choice is per-cite. The bundled detect script is this plugin's detector; any hard gate (pre-commit hook, CI job, drift comparison against a vendored copy) is whatever the consuming repo wires around it.
+The choice is per-cite. The bundled `detect.sh` is a **candidate enumerator**: it lists path shapes that *may* be private-surface cites. Exit 1 means candidates exist after mechanical filters — not that those hits are adjudicated violations. Classification (filter taxonomy below) is required before treating a hit as illegal. Do not hard-gate CI or pre-commit on `detect.sh`'s exit code alone.
 
 ## Action router
 
@@ -63,7 +63,11 @@ explicit opt-in that skips the confirmation and runs the repo-wide detect immedi
 
 `bash "${CLAUDE_SKILL_DIR}/scripts/detect.sh"` (`--apply-filters` optional)
 
-- Any path into a subdirectory under a skill (`<X>/<any-subdir>/...` — regardless of subdir name) **except `scripts/`** (entry-surface carve-out, see below)
+`detect.sh` enumerates **candidates**, not adjudicated violations. With `--apply-filters`, stderr summary keys are `raw` / `mech-filtered` / `candidates`. Exit 1 = candidates remain; exit 0 = no candidates (not a clean bill of health — see limitations below).
+
+Matched shapes:
+
+- Any path into a subdirectory under a skill (`<X>/<any-subdir>/...` — regardless of subdir name, including uppercase / single-char / digit-leading / underscore-leading segments) **except `scripts/`** (entry-surface carve-out, see below)
 - Heading-anchor cites into `SKILL.md` body structure (`<X>/SKILL.md#<anchor>`)
 - Any `*.schema.json` file at any depth (`<X>/<file>.schema.json`)
 
@@ -71,7 +75,12 @@ Legal external cites: bare `<X>/SKILL.md` path (discouraged but legal — natura
 
 **scripts/ entry-surface carve-out:** a skill's `scripts/` is its declared ENTRY surface per `context/public-surface-contract.md`. Harness / CI / hooks / workflow registries MAY path-cite a skill's entry scripts directly, so this inbound audit treats `<X>/scripts/...` cites as legal (like data files and bare `SKILL.md`) and never flags them. The skill-to-skill half of the asymmetry — a sibling SKILL.md citing another skill's `scripts/` stays slash-only — is out of this inbound audit's scope; a consuming repo that wants it enforced wires its own outbound gate.
 
-The script scans the consumer repo it runs in: every `.claude/` child directory except `skills/` (self-citation domain; opt in via `--include-skills` for skill-maintenance review) and `worktrees/`, plus `.github/`, `docs/`, `.lefthook/`, root instruction/config files (`AGENTS.md`, `CLAUDE.md`, `README.md`, `CONTRIBUTING.md`, `lefthook.yml`), and `.claude/` top-level files — each filtered to what exists.
+The script scans the consumer repo it runs in: every `.claude/` child directory except `skills/` (self-citation domain; opt in via `--include-skills` for skill-maintenance review) and `worktrees/`, plus `.github/`, `docs/`, `.lefthook/`, `plugins/`, root instruction/config files (`AGENTS.md`, `CLAUDE.md`, `README.md`, `CONTRIBUTING.md`, `lefthook.yml`), and `.claude/` top-level files — each filtered to what exists.
+
+**Detector limitations** (exit 0 does not mean the tree is clean):
+
+- Relative-path cites (`../skills/...`, bare `skills/...`, relative heading-anchor forms) are invisible to the PATTERN. Tracked as #2716 — not fixed here.
+- Only absolute-looking prefixes (`.claude/skills/...` and `plugins/<plugin>/skills/...`) are matched.
 
 Or invoke the skill (the agent applies the filter taxonomy below):
 
@@ -81,7 +90,7 @@ Or invoke the skill (the agent applies the filter taxonomy below):
 
 ## Filter taxonomy — legal hits
 
-`detect.sh` output is broad without `--apply-filters`. Use the filter taxonomy below for KIND-1/2/3; `--apply-filters` drops self-citation, plugin cache, and worktree paths.
+`detect.sh` output is broad without `--apply-filters`. Use the filter taxonomy below for KIND-1/2/3; `--apply-filters` drops only the mechanically-decidable subset (self-citation and worktree paths). Remaining rows are **candidates** — apply KIND-1/2/3, mirror-automation, glob-config, and plugin-cache judgment in-session before calling anything a violation.
 
 | Filter | Hit shape | Why legal |
 |--------|-----------|-----------|
@@ -91,7 +100,7 @@ Or invoke the skill (the agent applies the filter taxonomy below):
 | **KIND-3 self-test** | This skill's / a hook's own regression fixtures embed literal violation strings | Exercise the filter; not real citations |
 | **Mirror-automation** | A scheduled-automation prompt (e.g. `.claude/routines/<name>.md`) cites `.claude/skills/<name>/<private-path>` when its basename matches the skill name | Such prompts are cron arms of slash skills; mirror cites are part of the skill contract per the Public surface matrix |
 | **Glob-config** | Skill-internal path used as a glob/filter in an exclusion list, hooks allowlist, or `.gitignore` — not a content `Read` cite | Path is structural filter syntax, not progressive-disclosure content (overlaps KIND-2; named separately for grading) |
-| **Plugin cache** | `~/.claude/plugins/cache/<plugin>/...` | Upstream territory; foreign contract |
+| **Plugin cache** | `~/.claude/plugins/cache/<plugin>/...` | Upstream territory; foreign contract. These paths never match the detector PATTERN (not under a skill root), so `--apply-filters` has no cache branch — classify as legal if they appear in a manual/agent sweep |
 | **Worktree path** | `<worktree-root>/<n>/.claude/skills/<X>/...` (per the repo's worktree convention — e.g. `.worktrees/`, `.claude/worktrees/`, `.git/worktrees/`) | Worktrees share the tracked tree; same rules apply at the root path |
 
 Hits that survive ALL filters = illegal. Report.
@@ -151,8 +160,9 @@ A surfaced violation is never silently ignored: fix it, capture it as a side not
 
 ## Summary
 - Total raw hits: M
-- Filtered legal: M-N
-- Illegal violations: N
+- Mechanically filtered: M-C
+- Candidates (need taxonomy classification): C
+- Adjudicated illegal after filters: N
 - Path A candidates: a
 - Path B candidates: b
 - Missing public action (Path B blocked): c
@@ -199,6 +209,7 @@ A surfaced violation is never silently ignored: fix it, capture it as a side not
 | Condition | Action |
 |-----------|--------|
 | `context/public-surface-contract.md` changes | Re-sync the Public surface matrix here and the pattern comments in `scripts/detect.sh` |
+| Scan scope changes in `scripts/detect.sh` (dirs, file globs, include flags) | Update the Detection scan-scope sentence here so docs and script cannot drift |
 | A new CI workflow or git hook needs skill logic | Pick a technique from `context/public-surface-contract.md` "CI / git-hook consumption — entry surface, not internals"; prefer a skill `scripts/` facade the hook invokes — no vendored copy |
 | Violations recur across audits | Promote the `detect` action to a scheduled cadence in the consumer repo (e.g. `/loop` or `/schedule`) |
 | Anthropic ships a native skill-boundary linter | Demote this skill to advisory or sunset it |

--- a/plugins/docs-hygiene/skills/audit-encapsulation/context/public-surface-contract.md
+++ b/plugins/docs-hygiene/skills/audit-encapsulation/context/public-surface-contract.md
@@ -61,7 +61,7 @@ Workflows and git hooks needing logic that ALSO lives in a skill consume the ski
 | Mature, repo-external reuse | **Plugin packaging** — graduate the skill to a plugin; the manifest declares interfaces |
 | LLM-shaped CI work (not a mechanical gate) | **Headless invocation** — CI runs `claude -p '/skill <action>'`. Reserve for non-mechanical work |
 
-The choice is per-cite. Enforcement split: the bundled `scripts/detect.sh` is the detector this plugin ships; any hard gate (pre-commit hook, CI job, drift comparison) is whatever the consuming repo wires around it.
+The choice is per-cite. Enforcement split: the bundled `scripts/detect.sh` is a candidate enumerator this plugin ships — exit 1 means candidates exist after mechanical filters, not adjudicated violations. Classify via the skill filter taxonomy before treating hits as illegal. Do not hard-gate CI or pre-commit on that exit code alone; a consuming repo that wants a gate must adjudicate (or maintain an explicit baseline) rather than wiring the raw enumerator exit.
 
 ## What this contract does NOT cover
 

--- a/plugins/docs-hygiene/skills/audit-encapsulation/scripts/detect.sh
+++ b/plugins/docs-hygiene/skills/audit-encapsulation/scripts/detect.sh
@@ -99,15 +99,16 @@ fi
 #      subdirs regardless of name; excludes bare SKILL.md by requiring `/`)
 #   2. `<skill>/SKILL.md#<anchor>`  — heading-anchor cites
 #   3. `<skill>/<file>.schema.json` — schema files at any depth
-# Skill and subdir segments are `[^/]+` so uppercase, single-char,
-# digit-leading, and underscore-leading names match. Bare `<skill>/SKILL.md`
-# path cites still pass (discouraged-but-legal) because they lack `#` and a
-# trailing subdir slash. Does NOT match plain-JSON data files at skill root
-# (`<skill>/catalog.json`) per the data-file carve-out.
+# Skill and subdir segments are `[A-Za-z0-9_.-]+` so uppercase, single-char,
+# digit-leading, and underscore-leading names match, while whitespace and prose
+# punctuation between roots cannot span a false multi-root match. Bare
+# `<skill>/SKILL.md` path cites still pass (discouraged-but-legal) because they
+# lack `#` and a trailing subdir slash. Does NOT match plain-JSON data files at
+# skill root (`<skill>/catalog.json`) per the data-file carve-out.
 # Two skill-root layouts share one detector:
 #   - consumer-installed: `.claude/skills/<skill>/...`
 #   - marketplace monorepo: `plugins/<plugin>/skills/<skill>/...`
-PATTERN='\.claude/skills/[^/]+/[^/]+/|\.claude/skills/[^/]+/SKILL\.md#|\.claude/skills/[^/]+/[^/]+\.schema\.json|plugins/[^/]+/skills/[^/]+/[^/]+/|plugins/[^/]+/skills/[^/]+/SKILL\.md#|plugins/[^/]+/skills/[^/]+/[^/]+\.schema\.json'
+PATTERN='\.claude/skills/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+/|\.claude/skills/[A-Za-z0-9_.-]+/SKILL\.md#|\.claude/skills/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+\.schema\.json|plugins/[A-Za-z0-9_.-]+/skills/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+/|plugins/[A-Za-z0-9_.-]+/skills/[A-Za-z0-9_.-]+/SKILL\.md#|plugins/[A-Za-z0-9_.-]+/skills/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+\.schema\.json'
 
 # scripts/ entry-surface carve-out: a skill's `scripts/` is its declared ENTRY
 # surface — harness / CI / hooks / workflow registries MAY path-cite it. Like
@@ -121,7 +122,7 @@ PATTERN='\.claude/skills/[^/]+/[^/]+/|\.claude/skills/[^/]+/SKILL\.md#|\.claude/
 # line. The skill-to-skill half of the asymmetry (a sibling SKILL.md citing
 # another skill's scripts/ stays slash-only) is out of this inbound audit's
 # scope — see the contract file.
-SCRIPTS_RE='(\.claude/skills/[^/]+/scripts/|plugins/[^/]+/skills/[^/]+/scripts/)'
+SCRIPTS_RE='(\.claude/skills/[A-Za-z0-9_.-]+/scripts/|plugins/[A-Za-z0-9_.-]+/skills/[A-Za-z0-9_.-]+/scripts/)'
 
 HITS_FILE="$(mktemp)"
 trap 'rm -f "$HITS_FILE"' EXIT

--- a/plugins/docs-hygiene/skills/audit-encapsulation/scripts/detect.sh
+++ b/plugins/docs-hygiene/skills/audit-encapsulation/scripts/detect.sh
@@ -6,8 +6,14 @@
 # (bundled with this skill).
 # Scan root: the git repository the script runs in (the consumer repo), or the
 # current directory when outside a git repo.
-# Output TSV: file, line, match-text. Use --apply-filters to drop known legal hits.
-# Exit: 0 clean, 1 violations, 2 environment error.
+# Output TSV: file, line, match-text. Use --apply-filters to drop known
+# mechanically-decidable legal hits (self-citation, worktree paths).
+#
+# This script is a candidate enumerator, not a violation adjudicator. Exit 1
+# means candidates exist after mechanical filters — not that those hits are
+# illegal. Classify via the skill's filter taxonomy before treating any hit as
+# a violation. Do not hard-gate CI on this exit code alone.
+# Exit: 0 no candidates, 1 candidates exist, 2 environment error.
 set -euo pipefail
 
 REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null | tr -d '\r' || pwd)"
@@ -23,12 +29,22 @@ for arg in "$@"; do
     cat <<'USAGE'
 Usage: audit-encapsulation detect [--include-skills] [--apply-filters]
 
-Find external citations into private skill internals.
+Enumerate candidate citations into private skill internals.
 Output TSV: file, line, match-text.
-Exit: 0 clean, 1 violations, 2 environment error.
+Exit: 0 no candidates, 1 candidates exist, 2 environment error.
+
+Exit 1 means candidates remain after mechanical filters — not adjudicated
+violations. Classify via the skill filter taxonomy before gating. Do not
+hard-gate CI on this exit code alone.
+
+Limitations (undetected shapes — not a clean bill of health on exit 0):
+  - Relative-path cites (../skills/..., bare skills/..., relative heading
+    anchors) are invisible; tracked separately (#2716).
+  - Only absolute-looking path prefixes (.claude/skills/... and
+    plugins/<plugin>/skills/...) are matched.
 
   --include-skills  Include .claude/skills/ in scope (intra-skill self-citation review)
-  --apply-filters   Drop self-citation, plugin cache, and worktree path hits
+  --apply-filters   Drop self-citation and worktree path hits (mechanical filters only)
 USAGE
     exit 0
     ;;
@@ -44,7 +60,7 @@ done
 #   - every .claude/ child directory EXCEPT skills/ (intra-skill self-citation
 #     is legal; opt back in via --include-skills) and worktrees/ (worktrees
 #     share the tracked tree; the same rules apply at the root path)
-#   - .github/ (workflows), docs/, .lefthook/ (git-hook scripts)
+#   - .github/ (workflows), docs/, .lefthook/ (git-hook scripts), plugins/
 #   - root instruction/config files plus .claude/ top-level files
 # CI/hook surfaces stay IN-SCOPE for hit detection; the scripts/ entry-surface
 # carve-out and the filter taxonomy decide legality downstream, not exclusion.
@@ -78,24 +94,26 @@ fi
 # Private-surface pattern per ../context/public-surface-contract.md: any
 # subdir under a skill root is private; *.schema.json at any depth is
 # private; <skill>/SKILL.md#<anchor> heading-anchor cites are private.
-# Three alternations (BRE form, escaped): # spellchecker:disable-line
-#   1. `<skill>/<subdir>/`          — any kebab-style subdir name
+# Three alternations (ERE form via grep -E):
+#   1. `<skill>/<subdir>/`          — any subdirectory name (contract: all
+#      subdirs regardless of name; excludes bare SKILL.md by requiring `/`)
 #   2. `<skill>/SKILL.md#<anchor>`  — heading-anchor cites
 #   3. `<skill>/<file>.schema.json` — schema files at any depth
-# Subdir char class `[a-z][a-z0-9_-]+` matches kebab-style names and
-# excludes `SKILL.md` (uppercase) so bare `<skill>/SKILL.md` path cites
-# pass (discouraged-but-legal). Does NOT match plain-JSON data files at
-# skill root (`<skill>/catalog.json`) per the data-file carve-out.
+# Skill and subdir segments are `[^/]+` so uppercase, single-char,
+# digit-leading, and underscore-leading names match. Bare `<skill>/SKILL.md`
+# path cites still pass (discouraged-but-legal) because they lack `#` and a
+# trailing subdir slash. Does NOT match plain-JSON data files at skill root
+# (`<skill>/catalog.json`) per the data-file carve-out.
 # Two skill-root layouts share one detector:
 #   - consumer-installed: `.claude/skills/<skill>/...`
 #   - marketplace monorepo: `plugins/<plugin>/skills/<skill>/...`
-PATTERN='\.claude/skills/[a-z][a-z0-9-]\+/[a-z][a-z0-9_-]\+/\|\.claude/skills/[a-z][a-z0-9-]\+/SKILL\.md#\|\.claude/skills/[a-z][a-z0-9-]\+/[^/]\+\.schema\.json\|plugins/[a-z][a-z0-9-]\+/skills/[a-z][a-z0-9-]\+/[a-z][a-z0-9_-]\+/\|plugins/[a-z][a-z0-9-]\+/skills/[a-z][a-z0-9-]\+/SKILL\.md#\|plugins/[a-z][a-z0-9-]\+/skills/[a-z][a-z0-9-]\+/[^/]\+\.schema\.json'
+PATTERN='\.claude/skills/[^/]+/[^/]+/|\.claude/skills/[^/]+/SKILL\.md#|\.claude/skills/[^/]+/[^/]+\.schema\.json|plugins/[^/]+/skills/[^/]+/[^/]+/|plugins/[^/]+/skills/[^/]+/SKILL\.md#|plugins/[^/]+/skills/[^/]+/[^/]+\.schema\.json'
 
 # scripts/ entry-surface carve-out: a skill's `scripts/` is its declared ENTRY
 # surface — harness / CI / hooks / workflow registries MAY path-cite it. Like
 # the data-file and bare-SKILL.md public surfaces, scripts/ cites are never
 # private, so they are dropped here rather than emitted as raw hits. PATTERN
-# still matches scripts/ (the subdir alternation; BRE has no lookahead to # spellchecker:disable-line
+# still matches scripts/ (the subdir alternation; ERE has no lookahead to
 # exclude one name), so the carve-out is a post-grep exclusion. The scan grep
 # below uses `-o` to emit ONE record per cite, so this `grep -vE` drops only
 # the scripts/ cite — a line co-citing a scripts/ entry script AND another
@@ -103,7 +121,7 @@ PATTERN='\.claude/skills/[a-z][a-z0-9-]\+/[a-z][a-z0-9_-]\+/\|\.claude/skills/[a
 # line. The skill-to-skill half of the asymmetry (a sibling SKILL.md citing
 # another skill's scripts/ stays slash-only) is out of this inbound audit's
 # scope — see the contract file.
-SCRIPTS_RE='(\.claude/skills/[a-z][a-z0-9-]+/scripts/|plugins/[a-z][a-z0-9-]+/skills/[a-z][a-z0-9-]+/scripts/)'
+SCRIPTS_RE='(\.claude/skills/[^/]+/scripts/|plugins/[^/]+/skills/[^/]+/scripts/)'
 
 HITS_FILE="$(mktemp)"
 trap 'rm -f "$HITS_FILE"' EXIT
@@ -111,32 +129,33 @@ trap 'rm -f "$HITS_FILE"' EXIT
 # Aggregate hits, then drop scripts/ entry-surface cites (carve-out above).
 {
   if [[ ${#SCOPE_DIRS[@]} -gt 0 ]]; then
-    grep -rno "$PATTERN" \
+    grep -Erno "$PATTERN" \
       --include='*.md' --include='*.sh' --include='*.json' \
       --include='*.yml' --include='*.yaml' \
       "${SCOPE_DIRS[@]}" 2>/dev/null || true
   fi
   if [[ ${#SCOPE_FILES[@]} -gt 0 ]]; then
     # -H forces the file prefix even when only one file exists.
-    grep -Hno "$PATTERN" "${SCOPE_FILES[@]}" 2>/dev/null || true
+    grep -EHno "$PATTERN" "${SCOPE_FILES[@]}" 2>/dev/null || true
   fi
 } | grep -vE "$SCRIPTS_RE" >"$HITS_FILE" || true
 
 if [[ ! -s "$HITS_FILE" ]]; then
   if [[ "$APPLY_FILTERS" -eq 1 ]]; then
-    printf 'Summary: raw=0 legal=0 illegal=0\n' >&2
+    printf 'Summary: raw=0 mech-filtered=0 candidates=0\n' >&2
   fi
   exit 0
 fi
 
 # Convert grep "file:line:match" → "file<TAB>line<TAB>match". The `-o` scan
 # emits only the matched path text, which contains no colons, so colon
-# splitting is unambiguous. Under --apply-filters, drop the known-legal hit
-# shapes: self-citation (a skill citing its own internals), plugin cache
-# (upstream territory), and worktree paths (shared tree; same rules apply at
-# the root path).
+# splitting is unambiguous. Under --apply-filters, drop the known
+# mechanically-decidable legal hit shapes: self-citation (a skill citing its
+# own internals) and worktree paths (shared tree; same rules apply at the
+# root path). Plugin-cache cites never match PATTERN (cache paths are not
+# under skills/), so there is no cache filter branch here.
 raw=0
-illegal=0
+candidates=0
 while IFS= read -r line; do
   [[ -z "$line" ]] && continue
   raw=$((raw + 1))
@@ -145,36 +164,35 @@ while IFS= read -r line; do
   line_no="${rest%%:*}"
   text="${rest#*:}"
   if [[ "$APPLY_FILTERS" -eq 1 ]]; then
-    legal=0
+    mech_filtered=0
     if [[ "$file" =~ ^\.claude/skills/([^/]+)/ ]] &&
       [[ "$text" == *".claude/skills/${BASH_REMATCH[1]}/"* ]]; then
-      legal=1
+      mech_filtered=1
     elif [[ "$file" =~ ^plugins/[^/]+/skills/([^/]+)/ ]] &&
       [[ "$text" == *"/skills/${BASH_REMATCH[1]}/"* ]]; then
-      legal=1
-    elif [[ "$text" == *"plugins/cache/"* ]]; then
-      legal=1
+      mech_filtered=1
     elif [[ "$file" == *".worktrees/"* || "$text" == *".worktrees/"* ]]; then
-      legal=1
+      mech_filtered=1
     elif [[ "$file" == *".claude/worktrees/"* || "$text" == *".claude/worktrees/"* ]]; then
-      legal=1
+      mech_filtered=1
     elif [[ "$file" == *".git/worktrees/"* || "$text" == *".git/worktrees/"* ]]; then
-      legal=1
+      mech_filtered=1
     fi
-    if [[ "$legal" -eq 1 ]]; then
+    if [[ "$mech_filtered" -eq 1 ]]; then
       continue
     fi
   fi
-  illegal=$((illegal + 1))
+  candidates=$((candidates + 1))
   printf '%s\t%s\t%s\n' "$file" "$line_no" "$text"
 done <"$HITS_FILE"
 
 if [[ "$APPLY_FILTERS" -eq 1 ]]; then
-  legal=$((raw - illegal))
-  printf 'Summary: raw=%s legal=%s illegal=%s\n' "$raw" "$legal" "$illegal" >&2
+  mech_filtered=$((raw - candidates))
+  printf 'Summary: raw=%s mech-filtered=%s candidates=%s\n' \
+    "$raw" "$mech_filtered" "$candidates" >&2
 fi
 
-if [[ "$illegal" -eq 0 ]]; then
+if [[ "$candidates" -eq 0 ]]; then
   exit 0
 fi
 exit 1

--- a/plugins/docs-hygiene/skills/audit-encapsulation/scripts/detect.test.sh
+++ b/plugins/docs-hygiene/skills/audit-encapsulation/scripts/detect.test.sh
@@ -188,7 +188,8 @@ assert_contains "self-citation raw hit emitted" "$out" "${skill_root}/foo/contex
 err="$(cd "$self_repo" && bash "$SCRIPT" --include-skills --apply-filters 2>&1 >/dev/null)"
 code=$?
 assert_exit "self-citation filtered legal → exit 0" 0 "$code"
-assert_contains "summary counts self-citation as legal" "$err" "raw=1 legal=1 illegal=0"
+assert_contains "summary counts self-citation as mech-filtered" "$err" \
+  "raw=1 mech-filtered=1 candidates=0"
 
 plugin_skill_root="plugins/my-plugin/skills"
 
@@ -205,6 +206,40 @@ plugin_scripts_repo="$(fixture_repo "docs/guide.md" \
 out="$(cd "$plugin_scripts_repo" && bash "$SCRIPT" 2>/dev/null)"
 assert_exit "plugin scripts/ entry cite → exit 0 (carve-out)" 0 "$?"
 assert_silent "plugin scripts/ cite emits nothing" "$out"
+
+# F3: subdir / skill name shapes the old kebab class missed must now match.
+for shape_desc_path in \
+  "uppercase-subdir:${skill_root}/foo/Context/notes.md" \
+  "single-char-subdir:${skill_root}/foo/c/x.md" \
+  "digit-leading-subdir:${skill_root}/foo/2dir/x.md" \
+  "underscore-leading-subdir:${skill_root}/foo/_priv/x.md" \
+  "uppercase-skill:${skill_root}/Foo/context/x.md" \
+  "digit-leading-skill:${skill_root}/2skill/context/x.md" \
+  "underscore-leading-skill:${skill_root}/_x/context/x.md"; do
+  shape="${shape_desc_path%%:*}"
+  cite_path="${shape_desc_path#*:}"
+  match_prefix="$(dirname "$cite_path")/"
+  shape_repo="$(fixture_repo ".claude/rules/shape.md" "see ${cite_path}")"
+  out="$(cd "$shape_repo" && bash "$SCRIPT" 2>/dev/null)"
+  assert_exit "F3 ${shape} cite → exit 1" 1 "$?"
+  assert_contains "F3 ${shape} emitted" "$out" "$match_prefix"
+done
+
+# --help documents candidate semantics and relative-path limitation
+help_out="$(bash "$SCRIPT" --help 2>&1)"
+assert_contains "--help says candidates exist" "$help_out" "candidates exist"
+assert_contains "--help discloses relative-path gap" "$help_out" "#2716"
+assert_contains "--help warns against hard-gate" "$help_out" "hard-gate CI"
+
+# Honest summary keys under --apply-filters on a candidate hit
+cand_repo="$(fixture_repo ".claude/rules/cand.md" \
+  "see ${skill_root}/foo/context/notes.md")"
+err="$(cd "$cand_repo" && bash "$SCRIPT" --apply-filters 2>&1 >/dev/null)"
+code=$?
+assert_exit "candidate hit → exit 1" 1 "$code"
+assert_contains "summary uses candidates key" "$err" "candidates=1"
+assert_contains "summary uses mech-filtered key" "$err" "mech-filtered=0"
+assert_not_contains "summary does not say illegal=" "$err" "illegal="
 
 if [[ "$FAILED" -ne 0 ]]; then
   exit 1

--- a/plugins/docs-hygiene/skills/audit-encapsulation/scripts/detect.test.sh
+++ b/plugins/docs-hygiene/skills/audit-encapsulation/scripts/detect.test.sh
@@ -225,6 +225,13 @@ for shape_desc_path in \
   assert_contains "F3 ${shape} emitted" "$out" "$match_prefix"
 done
 
+# Prose listing multiple skill roots must not span whitespace/punctuation into one hit.
+prose_repo="$(fixture_repo ".claude/rules/prose.md" \
+  "The roots are .claude/skills/, .claude/agents/, and .claude/rules/.")"
+out="$(cd "$prose_repo" && bash "$SCRIPT" 2>/dev/null)"
+assert_exit "multi-root prose list → exit 0 (no false span)" 0 "$?"
+assert_silent "multi-root prose list emits nothing" "$out"
+
 # --help documents candidate semantics and relative-path limitation
 help_out="$(bash "$SCRIPT" --help 2>&1)"
 assert_contains "--help says candidates exist" "$help_out" "candidates exist"


### PR DESCRIPTION
Closes #2728

## Summary

`detect.sh` is a candidate enumerator, not a violation adjudicator: honest summary keys, exit 1 means candidates exist, and contract/SKILL/`--help` no longer invite hard-gating CI on that exit alone. Fixes F3/F5/F7 from the plugin-quality audit; relative-path cites remain #2716.

## Fix

- Rename `--apply-filters` summary keys to `raw` / `mech-filtered` / `candidates`; document candidate semantics in `--help`, SKILL.md, and the public-surface contract.
- Widen the ERE path class so uppercase / single-char / digit-leading / underscore-leading skill and subdir names match (F3).
- Document `plugins/` in the Detection scan-scope sentence; add a Recheck-triggers row for `detect.sh` scope drift (F5).
- Drop the unreachable `plugins/cache/` mechanical-filter branch and fix the docs that claimed it fired (F7).
- Disclose the relative-path blind spot as #2716 (not fixed here).
- Bump `docs-hygiene` 0.14.1 → 0.14.2 with CHANGELOG entry.

## Verification

- `bash plugins/docs-hygiene/skills/audit-encapsulation/scripts/detect.test.sh` — **57/57** checks passed (includes F3 shape coverage + honest-summary assertions).
- `bash scripts/check-changelog-parity.sh --check-bump origin/main` — passed.
- `bash scripts/check-changed-skills.sh origin/main` — PASS (0 errors).
- Repo smoke: `detect.sh --apply-filters` emits `Summary: raw=… mech-filtered=… candidates=…` (no `illegal=`).

## Related

Refs #2716 (relative-path cites — deferred by design). Audit findings F1 filter-depth / F4 terminal-state / F6 layout asymmetry are out of this PR’s cheap-honesty scope per frontier consensus.