### PR TITLE
feat(repo-fleet-hygiene): configurable discovery skip list (--skip / fleet.skip)

### DIFF
--- a/plugins/repo-fleet-hygiene/.claude-plugin/plugin.json
+++ b/plugins/repo-fleet-hygiene/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "repo-fleet-hygiene",
-  "version": "0.22.5",
+  "version": "0.23.0",
   "description": "Cross-repository Git/GitHub fleet discovery, evidence rollup, and a gated apply verb that executes a prior fleet action plan behind one confirmation. Audit stays read-only and confidence-tiered; apply mutates only with --apply plus interactive confirmation or --yes.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/repo-fleet-hygiene/CHANGELOG.md
+++ b/plugins/repo-fleet-hygiene/CHANGELOG.md
@@ -12,7 +12,8 @@ All notable changes to `repo-fleet-hygiene` are documented here. Format follows
   (`.`, `..`, `.git`, `node_modules`, `vendor`, `.venv`) rather than appending — so an operator
   can shrink (reach a repo under `vendor/`) or extend (skip a differently named vendored tree).
   CLI and config compose additively with each other like other scope inputs. Values must be bare
-  directory names; empty values and path separators hard-fail. `.` and `..` stay skipped
+  directory names; empty values (including a bare `skip =` config line) and path separators
+  hard-fail. `.` and `..` stay skipped
   unconditionally. Nested-repository early return (stop descending when a directory carries a
   `.git` marker) is documented in the audit skill. Setup `apply --skip` writes `fleet.skip`.
 

--- a/plugins/repo-fleet-hygiene/CHANGELOG.md
+++ b/plugins/repo-fleet-hygiene/CHANGELOG.md
@@ -3,6 +3,19 @@
 All notable changes to `repo-fleet-hygiene` are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.23.0]
+
+### Added
+
+- **Configurable discovery skip list via `--skip` / `fleet.skip` (#2712).** Repeatable CLI
+  `--skip <name>` and config `fleet.skip` replace the default directory-name skip list
+  (`.`, `..`, `.git`, `node_modules`, `vendor`, `.venv`) rather than appending — so an operator
+  can shrink (reach a repo under `vendor/`) or extend (skip a differently named vendored tree).
+  CLI and config compose additively with each other like other scope inputs. Values must be bare
+  directory names; empty values and path separators hard-fail. `.` and `..` stay skipped
+  unconditionally. Nested-repository early return (stop descending when a directory carries a
+  `.git` marker) is documented in the audit skill. Setup `apply --skip` writes `fleet.skip`.
+
 ## [0.22.5]
 
 ### Fixed

--- a/plugins/repo-fleet-hygiene/skills/audit/SKILL.md
+++ b/plugins/repo-fleet-hygiene/skills/audit/SKILL.md
@@ -1,7 +1,7 @@
 ---
 description: "Coordinate Git/GitHub hygiene across a cross-repository fleet: discover canonical repositories, collect and roll up cross-repository evidence (including merged remote-tracking heads still on origin), and hand an action plan to repo-hygiene/source-control, which own per-repository cleanup. The current collector is read-only and emits detailed exact handoffs; it never deletes, prunes, repairs, fetches, checks out, or rewrites. Use when: 'audit repositories', 'repo fleet hygiene', 'stale branches across repos', 'orphaned worktrees across repos', 'merged remote branches', 'moved repos', 'renamed GitHub owner', 'cross-repo git cleanup report'."
 user-invocable: true
-argument-hint: "[<dir>]... [--root <dir>]... [--repo <dir>]... [--config <file>] [--canonical <github.com/owner/repo=path>]... [--max-depth <1..12>] [--detail] [--plan-file <path>] | --apply-plan <path>"
+argument-hint: "[<dir>]... [--root <dir>]... [--repo <dir>]... [--config <file>] [--canonical <github.com/owner/repo=path>]... [--skip <name>]... [--max-depth <1..12>] [--detail] [--plan-file <path>] | --apply-plan <path>"
 allowed-tools:
   - Bash(${CLAUDE_SKILL_DIR}/scripts/audit-fleet.sh:*)
 metadata:
@@ -44,6 +44,13 @@ Parse `$ARGUMENTS` as opaque arguments for the bundled script. Supported flags:
 - `--config <file>`: explicit Git-format config (at most one).
 - `--canonical <github.com/owner/repo=path>`: invocation-specific canonical checkout override
   (repeatable; explicit wins over config).
+- `--skip <name>`: discovery directory-name skip (repeatable). Explicit `--skip` / `fleet.skip`
+  entries **replace** the default skip list rather than appending — otherwise shrinking is
+  impossible. Default (neither CLI nor config): `.`, `..`, `.git`, `node_modules`, `vendor`,
+  `.venv`. To extend, pass those six defaults plus your names; to shrink (e.g. reach a repo under
+  `vendor/`), omit names you want walked. CLI and config compose additively with each other like
+  other scope inputs. Values must be bare directory names (no empty value, no path separator).
+  `.` and `..` stay skipped unconditionally even when an explicit list omits them.
 - `--max-depth <1..12>`: discovery bound; explicit wins over config/default `5`.
 - `--project-dir <dir>`: the session's project directory, used for the project-scoped config rung.
   It is **not** a scope fallback — a run with no scope fails rather than auditing it.
@@ -250,6 +257,10 @@ Related fleet contracts that remain separate:
   marker) degrades the same way: an `UNKNOWN` `discovery-skip` finding, header skip counts, and the
   rest of the fleet is still audited. An explicitly named `--repo` that is not a working tree still
   hard-fails.
+- A directory that itself carries a `.git` marker (directory or file) is treated as a nested
+  repository: discovery `add_target`s it and **returns without descending into its children**. A
+  repository buried inside another repository's working tree therefore never appears as its own
+  audit target unless named explicitly via `--repo` / `fleet.repo`.
 - A symlinked or junctioned intermediate directory under `--root` is not followed (same non-following
   bound as before) but is disclosed as an `UNKNOWN` `discovery-symlink-skip` finding and counted on
   the discovery-skips header line. Windows directory junctions test as symlinks under Git Bash, so

--- a/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.sh
+++ b/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.sh
@@ -8,7 +8,7 @@ usage() {
   cat <<'EOF'
 Usage: audit-fleet.sh [DIR]... [--root DIR]... [--repo DIR]... [--config FILE]
                       [--canonical github.com/owner/repo=PATH]...
-                      [--max-depth 1..12] [--project-dir DIR]
+                      [--skip NAME]... [--max-depth 1..12] [--project-dir DIR]
                       [--detail] [--plan-file PATH]
        audit-fleet.sh --apply-plan PATH
 
@@ -37,6 +37,16 @@ names how to set scope — it does not audit the session project directory.
 config rung only (not as an implicit audit target). It is passed in rather
 than read from the environment, which does not carry it. An empty value means
 "no project directory": the project config rung is skipped.
+
+--skip NAME (repeatable) and config fleet.skip (repeatable) REPLACE the default
+discovery skip list rather than appending to it. With neither supplied, discovery
+skips . , .. , .git , node_modules , vendor , and .venv. Supplying any --skip or
+fleet.skip entry replaces that set entirely — to extend, pass the six defaults
+plus your names; to shrink (e.g. reach a repo under vendor/), omit the names you
+want walked. CLI and config entries compose additively with each other the same
+way other scope inputs do. Values must be bare directory names (no empty value,
+no path separator). . and .. stay skipped unconditionally even when an explicit
+list omits them.
 EOF
 }
 
@@ -138,7 +148,8 @@ git_probe_allowed() {
       return
     fi
     if [[ $# -eq 6 && "$4" == "--null" && "$5" == "--get-all" ]]; then
-      [[ "$6" == "fleet.root" || "$6" == "fleet.repo" || "$6" == "fleet.ackUnavailable" ]]
+      [[ "$6" == "fleet.root" || "$6" == "fleet.repo" || "$6" == "fleet.ackUnavailable" ||
+        "$6" == "fleet.skip" ]]
       return
     fi
     if [[ $# -eq 6 && "$4" == "--get-regexp" && "$5" == "-z" ]]; then
@@ -400,6 +411,7 @@ ROOT_ARGS=()
 REPO_ARGS=()
 OVERRIDE_KEYS=()
 OVERRIDE_PATHS=()
+SKIP_NAMES=()
 CONFIG_FILE=""
 MAX_DEPTH=""
 PROJECT_DIR_ARG=""
@@ -407,6 +419,18 @@ DETAIL=false
 PLAN_FILE=""
 APPLY_PLAN=""
 PLAN_FILE_EXPLICIT=false
+
+# Bare directory-name validation for --skip / fleet.skip. Reject empty values and anything with a
+# path separator so a mistaken path cannot silently widen or narrow discovery.
+validate_skip_name() {
+  local name="$1" origin="$2"
+  [[ -n "$name" ]] || fail "invalid ${origin} value (expected a bare directory name): (empty)"
+  case "$name" in
+  */* | *\\*)
+    fail "invalid ${origin} value (expected a bare directory name, no path separator): $name"
+    ;;
+  esac
+}
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -440,6 +464,12 @@ while [[ $# -gt 0 ]]; do
       fail "invalid --canonical value: $pair"
     OVERRIDE_KEYS+=("$key")
     OVERRIDE_PATHS+=("$value")
+    shift 2
+    ;;
+  --skip)
+    [[ $# -ge 2 ]] || fail "--skip requires a bare directory name"
+    validate_skip_name "$2" "--skip"
+    SKIP_NAMES+=("$2")
     shift 2
     ;;
   --max-depth)
@@ -492,8 +522,8 @@ done
 # artifact from a prior audit plan. No discovery, no GitHub calls, no mutation.
 if [[ -n "$APPLY_PLAN" ]]; then
   if [[ ${#ROOT_ARGS[@]} -gt 0 || ${#REPO_ARGS[@]} -gt 0 || -n "$CONFIG_FILE" ||
-    ${#OVERRIDE_KEYS[@]} -gt 0 || -n "$MAX_DEPTH" || -n "$PROJECT_DIR_ARG" ||
-    "$DETAIL" == "true" || "$PLAN_FILE_EXPLICIT" == "true" ]]; then
+    ${#OVERRIDE_KEYS[@]} -gt 0 || ${#SKIP_NAMES[@]} -gt 0 || -n "$MAX_DEPTH" ||
+    -n "$PROJECT_DIR_ARG" || "$DETAIL" == "true" || "$PLAN_FILE_EXPLICIT" == "true" ]]; then
     fail "--apply-plan cannot be combined with audit discovery flags"
   fi
   [[ -f "$APPLY_PLAN" ]] || fail "apply-plan file not found: $APPLY_PLAN"
@@ -673,6 +703,33 @@ if [[ -n "$CONFIG_FILE" ]]; then
     ACK_KEYS+=("$ack_key")
   done < <(run_git_probe config --file "$CONFIG_FILE" --null --get-all fleet.ackUnavailable 2>/dev/null || true)
 fi
+
+# Discovery skip names (--skip / fleet.skip). Explicit entries REPLACE the default set rather than
+# appending (#2712): otherwise shrinking (e.g. reaching a repo under vendor/) is impossible. CLI and
+# config compose additively with each other like other scope inputs; with neither supplied, keep
+# today's six-name default. . and .. stay skipped unconditionally even when an explicit list omits
+# them.
+if [[ -n "$CONFIG_FILE" ]]; then
+  while IFS= read -r -d '' value; do
+    [[ -n "$value" ]] || continue
+    validate_skip_name "$value" "fleet.skip"
+    SKIP_NAMES+=("$value")
+  done < <(run_git_probe config --file "$CONFIG_FILE" --null --get-all fleet.skip 2>/dev/null || true)
+fi
+if [[ ${#SKIP_NAMES[@]} -eq 0 ]]; then
+  SKIP_NAMES=(. .. .git node_modules vendor .venv)
+fi
+
+should_skip_dir_name() {
+  local name="$1" skip
+  case "$name" in
+  . | ..) return 0 ;;
+  esac
+  for skip in "${SKIP_NAMES[@]}"; do
+    [[ -n "$skip" && "$name" == "$skip" ]] && return 0
+  done
+  return 1
+}
 
 is_acked() {
   local key a
@@ -1206,7 +1263,10 @@ discover_repositories() {
     return 0
   fi
   if [[ -d "$dir/.git" || -f "$dir/.git" ]]; then
-    # Discovery origin: a .git marker that is not a usable working tree degrades per-entry.
+    # Nested-repository early return: a .git marker means this directory is a repository (or a husk
+    # that degrades per-entry below). Discovery stops descending here — children under a nested
+    # checkout are never walked, so a repo buried inside another repo's tree never appears as its
+    # own audit target (#2712).
     add_target "$dir" discovery
     return 0
   fi
@@ -1215,10 +1275,11 @@ discover_repositories() {
     # Unmatched globs leave literal patterns; skip those. Broken symlinks still match -L.
     [[ -e "$child" || -L "$child" ]] || continue
     name="$(basename "$child")"
-    case "$name" in
-    . | .. | .git | node_modules | vendor | .venv) continue ;;
-    *) ;; # other names fall through to the symlink/dir probes below
-    esac
+    # Configurable skip list (--skip / fleet.skip). . and .. are always skipped; other names come
+    # from SKIP_NAMES (defaults, or an explicit replace list). See usage() for replace semantics.
+    if should_skip_dir_name "$name"; then
+      continue
+    fi
     # Symlinked/junctioned intermediate dirs: do not descend, but record for disclosure (#2711).
     # Windows directory junctions satisfy both -d and -L under Git Bash, so they take this arm.
     if [[ -L "$child" && -d "$child" ]]; then

--- a/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.sh
+++ b/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.sh
@@ -429,6 +429,7 @@ validate_skip_name() {
   */* | *\\*)
     fail "invalid ${origin} value (expected a bare directory name, no path separator): $name"
     ;;
+  *) ;;
   esac
 }
 
@@ -724,6 +725,7 @@ should_skip_dir_name() {
   local name="$1" skip
   case "$name" in
   . | ..) return 0 ;;
+  *) ;;
   esac
   for skip in "${SKIP_NAMES[@]}"; do
     [[ -n "$skip" && "$name" == "$skip" ]] && return 0

--- a/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.sh
+++ b/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.sh
@@ -712,7 +712,9 @@ fi
 # them.
 if [[ -n "$CONFIG_FILE" ]]; then
   while IFS= read -r -d '' value; do
-    [[ -n "$value" ]] || continue
+    # Empty fleet.skip values hard-fail (same contract as --skip ''), including a bare
+    # `skip =` line that git-config returns as an empty string. Do not silently drop them:
+    # an empty-only list would otherwise restore the six defaults and quietly omit vendor/.
     validate_skip_name "$value" "fleet.skip"
     SKIP_NAMES+=("$value")
   done < <(run_git_probe config --file "$CONFIG_FILE" --null --get-all fleet.skip 2>/dev/null || true)

--- a/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.test.sh
+++ b/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.test.sh
@@ -11,6 +11,9 @@ mkdir -p "$MOCK_BIN" "$TMP/config" "$TMP/discovered-a" "$TMP/canonical-a" "$TMP/
   "$TMP/bad-discovered" "$TMP/bad-canonical" "$TMP/wt-fail" \
   "$TMP/ref-fail" "$TMP/rref-fail" "$TMP/dup-a" "$TMP/new-clone" \
   "$TMP/root/acme/root-repo/.git" \
+  "$TMP/skip-root/keep/visible-repo/.git" \
+  "$TMP/skip-root/vendor/under-vendor/.git" \
+  "$TMP/skip-root/third_party/under-third/.git" \
   "$TMP/emptyroot" \
   "$TMP/wt-a" "$TMP/wt-mismatch" \
   "$TMP/wt-status-fail" \
@@ -69,7 +72,8 @@ rev-parse)
     # Gate for melodic.worktreeroot reads (#2606).
     case "$base" in
     discovered-a | canonical-a | repo-b | old-repo | wt-old | bad-discovered | bad-canonical | \
-      wt-fail | ref-fail | rref-fail | dup-a | new-clone | root-repo | discovered-c | \
+      wt-fail | ref-fail | rref-fail | dup-a | new-clone | root-repo | visible-repo | \
+      under-vendor | under-third | discovered-c | \
       canonical-c | gone-repo | lost-repo | net-repo | aaa-linked | bbb-linked | zzz-canonical | \
       sub-wt | sep-wt | nested | husk | prefix-fail | wt-a | wt-mismatch | wt-status-fail | \
       conform-canon | acme-conform-feature-ok | acme-conform-feature-old | conform-sibling | \
@@ -94,6 +98,9 @@ rev-parse)
     dup-a) printf '%s\n' "$TEST_ROOT/dup-a" ;;
     new-clone) printf '%s\n' "$TEST_ROOT/new-clone" ;;
     root-repo) printf '%s\n' "$TEST_ROOT/root/acme/root-repo" ;;
+    visible-repo) printf '%s\n' "$TEST_ROOT/skip-root/keep/visible-repo" ;;
+    under-vendor) printf '%s\n' "$TEST_ROOT/skip-root/vendor/under-vendor" ;;
+    under-third) printf '%s\n' "$TEST_ROOT/skip-root/third_party/under-third" ;;
     discovered-c | canonical-c) printf '%s\n' "$TEST_ROOT/canonical-c" ;;
     gone-repo) printf '%s\n' "$TEST_ROOT/gone-repo" ;;
     lost-repo) printf '%s\n' "$TEST_ROOT/lost-repo" ;;
@@ -166,6 +173,9 @@ rev-parse)
     dup-a) printf '%s\n' "$TEST_ROOT/dup-a/.git" ;;
     new-clone) printf '%s\n' "$TEST_ROOT/new-clone/.git" ;;
     root-repo) printf '%s\n' "$TEST_ROOT/root/acme/root-repo/.git" ;;
+    visible-repo) printf '%s\n' "$TEST_ROOT/skip-root/keep/visible-repo/.git" ;;
+    under-vendor) printf '%s\n' "$TEST_ROOT/skip-root/vendor/under-vendor/.git" ;;
+    under-third) printf '%s\n' "$TEST_ROOT/skip-root/third_party/under-third/.git" ;;
     discovered-c | canonical-c) printf '%s\n' "$TEST_ROOT/canonical-c/.git" ;;
     gone-repo) printf '%s\n' "$TEST_ROOT/gone-repo/.git" ;;
     lost-repo) printf '%s\n' "$TEST_ROOT/lost-repo/.git" ;;
@@ -204,6 +214,9 @@ remote)
     dup-a) printf '%s\n' 'https://github.com/acme/repo-b.git' ;;
     new-clone) printf '%s\n' 'https://github.com/new/repo.git' ;;
     root-repo) printf '%s\n' 'https://github.com/acme/root-repo.git' ;;
+    visible-repo) printf '%s\n' 'https://github.com/acme/visible-repo.git' ;;
+    under-vendor) printf '%s\n' 'https://github.com/acme/under-vendor.git' ;;
+    under-third) printf '%s\n' 'https://github.com/acme/under-third.git' ;;
     discovered-c | canonical-c) printf '%s\n' 'https://github.com/acme/repo-c.git' ;;
     gone-repo) printf '%s\n' 'https://github.com/gone/away.git' ;;
     lost-repo) printf '%s\n' 'https://github.com/lost/cause.git' ;;
@@ -294,6 +307,15 @@ worktree)
   root-repo)
     printf 'worktree %s\0HEAD root-main\0branch refs/heads/main\0\0' "$TEST_ROOT/root/acme/root-repo"
     ;;
+  visible-repo)
+    printf 'worktree %s\0HEAD vis-main\0branch refs/heads/main\0\0' "$TEST_ROOT/skip-root/keep/visible-repo"
+    ;;
+  under-vendor)
+    printf 'worktree %s\0HEAD vend-main\0branch refs/heads/main\0\0' "$TEST_ROOT/skip-root/vendor/under-vendor"
+    ;;
+  under-third)
+    printf 'worktree %s\0HEAD third-main\0branch refs/heads/main\0\0' "$TEST_ROOT/skip-root/third_party/under-third"
+    ;;
   canonical-c)
     printf 'worktree %s\0HEAD main-c\0branch refs/heads/main\0\0' "$TEST_ROOT/canonical-c"
     ;;
@@ -344,7 +366,7 @@ symbolic-ref)
 branch)
   case "$base" in
   canonical-a) printf '%s\n' main ;;
-  repo-b | old-repo | root-repo | wt-fail | ref-fail | rref-fail | dup-a | new-clone | canonical-c | gone-repo | lost-repo | net-repo | prefix-auth) printf '%s\n' main ;;
+  repo-b | old-repo | root-repo | visible-repo | under-vendor | under-third | wt-fail | ref-fail | rref-fail | dup-a | new-clone | canonical-c | gone-repo | lost-repo | net-repo | prefix-auth) printf '%s\n' main ;;
   conform-canon) printf '%s\n' main ;;
   no-origin-canon) printf '%s\n' main ;;
   aaa-linked | bbb-linked | zzz-canonical) printf '%s\n' main ;;
@@ -390,6 +412,9 @@ for-each-ref)
   dup-a) printf 'main\tdup-main\0\n' ;;
   new-clone) printf 'main\tnc-main\0\n' ;;
   root-repo) printf 'main\troot-main\0\n' ;;
+  visible-repo) printf 'main\tvis-main\0\n' ;;
+  under-vendor) printf 'main\tvend-main\0\n' ;;
+  under-third) printf 'main\tthird-main\0\n' ;;
   canonical-c) printf 'main\tmain-c\0\n' ;;
   gone-repo) printf 'main\tgone-main\0\n' ;;
   lost-repo) printf 'main\tlost-main\0\n' ;;
@@ -551,7 +576,8 @@ api)
         *) printf '' ;;
         esac
         ;;
-      acme/repo-b | acme/root-repo | acme/repo-c | acme/rref-fail | acme/ref-fail | acme/sub-mod | acme/sep-mod)
+      acme/repo-b | acme/root-repo | acme/visible-repo | acme/under-vendor | acme/under-third | \
+        acme/repo-c | acme/rref-fail | acme/ref-fail | acme/sub-mod | acme/sep-mod)
         printf ''
         ;;
       *) return 1 ;;
@@ -582,6 +608,9 @@ api)
   repos/other/upstream-repo) printf 'other/upstream-repo\tmain' ;;
   repos/acme/repo-b) printf 'acme/repo-b\tmain' ;;
   repos/acme/root-repo) printf 'acme/root-repo\tmain' ;;
+  repos/acme/visible-repo) printf 'acme/visible-repo\tmain' ;;
+  repos/acme/under-vendor) printf 'acme/under-vendor\tmain' ;;
+  repos/acme/under-third) printf 'acme/under-third\tmain' ;;
   repos/acme/bad) printf 'acme/bad\tmain' ;;
   repos/acme/wt-fail) printf 'acme/wt-fail\tmain' ;;
   repos/acme/ref-fail) printf 'acme/ref-fail\tmain' ;;
@@ -1900,6 +1929,121 @@ elif [[ "$SECONDS" -gt 4 ]]; then
   failures=$((failures + 1))
 else
   printf 'PASS: portable watchdog killed a TERM-ignoring gh within the finite bound\n'
+fi
+
+# Configurable discovery skip list (#2712): defaults skip vendor/; --skip replaces (shrink/extend);
+# fleet.skip composes additively with CLI; invalid values hard-fail.
+skip_out="$TMP/skip-out.txt"
+if REPO_FLEET_TEST_FAST_TIMEOUTS=1 bash "$SCRIPT" --root "$TMP/skip-root" >"$skip_out" 2>&1; then
+  if grep -Fq "Repo: $TMP/skip-root/keep/visible-repo" "$skip_out" &&
+    grep -Fq "Repo: $TMP/skip-root/third_party/under-third" "$skip_out" &&
+    ! grep -Fq "under-vendor" "$skip_out" &&
+    grep -Fq "Repositories discovered (audit targets after deduplication): 2" "$skip_out"; then
+    printf 'PASS: default skip list hides vendor/ and keeps third_party/ reachable\n'
+  else
+    printf 'FAIL: default skip list hides vendor/ and keeps third_party/ reachable\n%s\n' "$(cat "$skip_out")" >&2
+    failures=$((failures + 1))
+  fi
+else
+  printf 'FAIL: default skip discovery unexpectedly aborted\n%s\n' "$(cat "$skip_out")" >&2
+  failures=$((failures + 1))
+fi
+
+# Shrink: omit vendor from an explicit list so a repo under vendor/ is discovered.
+if REPO_FLEET_TEST_FAST_TIMEOUTS=1 bash "$SCRIPT" --root "$TMP/skip-root" \
+  --skip . --skip .. --skip .git --skip node_modules --skip .venv >"$skip_out" 2>&1; then
+  if grep -Fq "Repo: $TMP/skip-root/vendor/under-vendor" "$skip_out" &&
+    grep -Fq "Repositories discovered (audit targets after deduplication): 3" "$skip_out"; then
+    printf 'PASS: --skip replace shrink reaches a repository under vendor/\n'
+  else
+    printf 'FAIL: --skip replace shrink reaches a repository under vendor/\n%s\n' "$(cat "$skip_out")" >&2
+    failures=$((failures + 1))
+  fi
+else
+  printf 'FAIL: --skip shrink unexpectedly aborted\n%s\n' "$(cat "$skip_out")" >&2
+  failures=$((failures + 1))
+fi
+
+# Extend: pass the six defaults plus third_party so that tree is skipped.
+if REPO_FLEET_TEST_FAST_TIMEOUTS=1 bash "$SCRIPT" --root "$TMP/skip-root" \
+  --skip . --skip .. --skip .git --skip node_modules --skip vendor --skip .venv \
+  --skip third_party >"$skip_out" 2>&1; then
+  if grep -Fq "Repo: $TMP/skip-root/keep/visible-repo" "$skip_out" &&
+    ! grep -Fq "under-third" "$skip_out" &&
+    ! grep -Fq "under-vendor" "$skip_out" &&
+    grep -Fq "Repositories discovered (audit targets after deduplication): 1" "$skip_out"; then
+    printf 'PASS: --skip replace extend skips a differently named vendored tree\n'
+  else
+    printf 'FAIL: --skip replace extend skips a differently named vendored tree\n%s\n' "$(cat "$skip_out")" >&2
+    failures=$((failures + 1))
+  fi
+else
+  printf 'FAIL: --skip extend unexpectedly aborted\n%s\n' "$(cat "$skip_out")" >&2
+  failures=$((failures + 1))
+fi
+
+# Config fleet.skip composes with CLI --skip (both replace defaults together).
+cat >"$TMP/config/skip-fleet.conf" <<EOF
+[fleet]
+    root = ../skip-root
+    skip = .
+    skip = ..
+    skip = .git
+    skip = node_modules
+    skip = .venv
+EOF
+if REPO_FLEET_TEST_FAST_TIMEOUTS=1 bash "$SCRIPT" --config "$TMP/config/skip-fleet.conf" \
+  --skip third_party >"$skip_out" 2>&1; then
+  if grep -Fq "Repo: $TMP/skip-root/vendor/under-vendor" "$skip_out" &&
+    ! grep -Fq "under-third" "$skip_out" &&
+    grep -Fq "Repositories discovered (audit targets after deduplication): 2" "$skip_out"; then
+    printf 'PASS: CLI --skip and fleet.skip compose additively and replace defaults\n'
+  else
+    printf 'FAIL: CLI --skip and fleet.skip compose additively and replace defaults\n%s\n' "$(cat "$skip_out")" >&2
+    failures=$((failures + 1))
+  fi
+else
+  printf 'FAIL: CLI/config skip compose unexpectedly aborted\n%s\n' "$(cat "$skip_out")" >&2
+  failures=$((failures + 1))
+fi
+
+skip_err="$TMP/skip-err.txt"
+if REPO_FLEET_TEST_FAST_TIMEOUTS=1 bash "$SCRIPT" --root "$TMP/skip-root" --skip 'vendor/lib' \
+  >"$skip_out" 2>"$skip_err"; then
+  printf 'FAIL: path-separator --skip unexpectedly succeeded\n' >&2
+  failures=$((failures + 1))
+elif grep -Fq "invalid --skip value (expected a bare directory name, no path separator): vendor/lib" "$skip_err"; then
+  printf 'PASS: path-separator --skip hard-fails with a named error\n'
+else
+  printf 'FAIL: path-separator --skip hard-fails with a named error\n%s\n' "$(cat "$skip_err" "$skip_out")" >&2
+  failures=$((failures + 1))
+fi
+
+if REPO_FLEET_TEST_FAST_TIMEOUTS=1 bash "$SCRIPT" --root "$TMP/skip-root" --skip '' \
+  >"$skip_out" 2>"$skip_err"; then
+  printf 'FAIL: empty --skip unexpectedly succeeded\n' >&2
+  failures=$((failures + 1))
+elif grep -Fq "invalid --skip value (expected a bare directory name): (empty)" "$skip_err"; then
+  printf 'PASS: empty --skip hard-fails with a named error\n'
+else
+  printf 'FAIL: empty --skip hard-fails with a named error\n%s\n' "$(cat "$skip_err" "$skip_out")" >&2
+  failures=$((failures + 1))
+fi
+
+cat >"$TMP/config/bad-skip.conf" <<EOF
+[fleet]
+    root = ../skip-root
+    skip = nested/path
+EOF
+if REPO_FLEET_TEST_FAST_TIMEOUTS=1 bash "$SCRIPT" --config "$TMP/config/bad-skip.conf" \
+  >"$skip_out" 2>"$skip_err"; then
+  printf 'FAIL: path-separator fleet.skip unexpectedly succeeded\n' >&2
+  failures=$((failures + 1))
+elif grep -Fq "invalid fleet.skip value (expected a bare directory name, no path separator): nested/path" "$skip_err"; then
+  printf 'PASS: path-separator fleet.skip hard-fails with a named error\n'
+else
+  printf 'FAIL: path-separator fleet.skip hard-fails with a named error\n%s\n' "$(cat "$skip_err" "$skip_out")" >&2
+  failures=$((failures + 1))
 fi
 
 if [[ "$failures" -ne 0 ]]; then

--- a/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.test.sh
+++ b/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.test.sh
@@ -2046,6 +2046,22 @@ else
   failures=$((failures + 1))
 fi
 
+cat >"$TMP/config/empty-skip.conf" <<EOF
+[fleet]
+    root = ../skip-root
+    skip =
+EOF
+if REPO_FLEET_TEST_FAST_TIMEOUTS=1 bash "$SCRIPT" --config "$TMP/config/empty-skip.conf" \
+  >"$skip_out" 2>"$skip_err"; then
+  printf 'FAIL: empty fleet.skip unexpectedly succeeded\n' >&2
+  failures=$((failures + 1))
+elif grep -Fq "invalid fleet.skip value (expected a bare directory name): (empty)" "$skip_err"; then
+  printf 'PASS: empty fleet.skip hard-fails with a named error\n'
+else
+  printf 'FAIL: empty fleet.skip hard-fails with a named error\n%s\n' "$(cat "$skip_err" "$skip_out")" >&2
+  failures=$((failures + 1))
+fi
+
 if [[ "$failures" -ne 0 ]]; then
   printf '\nCollector output:\n' >&2
   cat "$output" >&2

--- a/plugins/repo-fleet-hygiene/skills/setup/SKILL.md
+++ b/plugins/repo-fleet-hygiene/skills/setup/SKILL.md
@@ -2,7 +2,7 @@
 description: "Verify and configure repo-fleet-hygiene for a consumer project. check inspects the optional .claude/repo-fleet-hygiene.conf read-only (presence, parse validity, path resolution); apply creates or updates it — adding bounded fleet roots, exact repositories, and remote-keyed canonical checkout overrides — preserving unrelated entries. Use when: 'set up repo fleet audit', 'is repo-fleet-hygiene configured', 'configure fleet roots', 'canonical repo override', 'dotfiles-manager checkout'. Re-runnable and safe."
 user-invocable: true
 disable-model-invocation: true
-argument-hint: "check | apply [--config <path>] [--root <dir>]... [--repo <dir>]... [--canonical <github.com/owner/repo=path>]... [--ack-unavailable <github.com/owner/repo>]... [--max-depth <1..12>]"
+argument-hint: "check | apply [--config <path>] [--root <dir>]... [--repo <dir>]... [--canonical <github.com/owner/repo=path>]... [--ack-unavailable <github.com/owner/repo>]... [--skip <name>]... [--max-depth <1..12>]"
 ---
 
 ## Purpose
@@ -34,10 +34,14 @@ report header names which config (if any) was consumed.
 ```text
 check | apply [--config <path>] [--root <dir>]... [--repo <dir>]...
         [--canonical <github.com/owner/repo=path>]... [--ack-unavailable <github.com/owner/repo>]...
-        [--max-depth <1..12>]
+        [--skip <name>]... [--max-depth <1..12>]
 ```
 
-`--max-depth` writes `[fleet] maxDepth`; this skill owns the config file that carries it.
+`--max-depth` writes `[fleet] maxDepth`; `--skip` writes repeatable `[fleet] skip` entries. This
+skill owns the config file that carries both. Explicit `fleet.skip` entries **replace** the audit's
+default discovery skip list (they do not append) — say that when writing them, because "extend" is
+the naive reading. To extend without shrinking, write the six defaults (`.`, `..`, `.git`,
+`node_modules`, `vendor`, `.venv`) plus the extra names.
 
 ## `check` (read-only)
 
@@ -60,6 +64,9 @@ with one remediation line per FAIL, and modify nothing. Do NOT run the collector
    normalized key. Flag as FAIL only a key that is not a normalizable `github.com/owner/repository`.
 6. **Acknowledged identities** — INFO listing each `fleet.ackUnavailable` entry (normalized). FAIL any
    value that is not a normalizable `github.com/owner/repository`.
+7. **Discovery skip names** — INFO listing each `fleet.skip` entry. FAIL any value that is empty or
+   contains a path separator (must be a bare directory name). Remind that any present `fleet.skip`
+   **replaces** the audit default skip list rather than appending.
 
 ## `apply` (idempotent)
 
@@ -75,6 +82,12 @@ Run `check`, then create or update the config from the supplied arguments.
    `[fleet] ackUnavailable` entry, deduplicating case-insensitively against entries already
    present. Like roots/repos, apply is additive — removing an acknowledgment is a manual edit of
    the consumer's own config file.
+   Validate each `--skip` value as a bare directory name (reject empty and any path separator);
+   write it as a repeatable `[fleet] skip` entry, deduplicating exact matches against entries
+   already present. State the replace semantics when writing: any `fleet.skip` present replaces the
+   audit's default skip list (`.`, `..`, `.git`, `node_modules`, `vendor`, `.venv`) rather than
+   appending — to extend, include those defaults plus the new names. Removing a skip entry is a
+   manual edit.
 2. If the config exists, read it with `git config --file <path> --list --show-origin`. Preserve every
    unrelated entry. Never source it.
 3. State the proposed additions/updates before writing. With complete arguments, proceed
@@ -110,6 +123,8 @@ Run `check`, then create or update the config from the supplied arguments.
    - **`maxDepth`** — when present, confirm it is an integer in `1..12`
    - **Canonical identity** and **acknowledged identities** — confirm each key/value normalizes to
      `github.com/owner/repository`
+   - **Discovery skip names** — when present, confirm each `fleet.skip` value is a bare directory
+     name (non-empty, no path separator)
 
    Do **not** invoke the collector to verify a write. It is the full fleet walk this skill says it
    never runs — per-repository network queries across every configured root, minutes on a real fleet
@@ -130,6 +145,7 @@ Re-running `apply` with the same arguments after everything resolves changes not
     repo = ../../special/repo      # repeatable exact target
     maxDepth = 5                   # integer 1..12
     ackUnavailable = github.com/owner/repository   # repeatable; acknowledge a known-inaccessible identity
+    skip = vendor                  # repeatable; REPLACE default discovery skip list (not append)
 
 [canonical "github.com/owner/repository"]
     path = ../../../canonical-checkout
@@ -140,6 +156,12 @@ Re-running `apply` with the same arguments after everything resolves changes not
 affecting non-404/403 failures or successful-response evidence. Use it for foreseeable 404s:
 upstream repositories made private or deleted, or repositories owned by a different GitHub account
 than the authenticated `gh` login.
+
+`skip` replaces the audit's default discovery skip list (`.`, `..`, `.git`, `node_modules`,
+`vendor`, `.venv`) whenever any entry is present. It does **not** append — a lone `skip = third_party`
+means only `third_party` is skipped (plus unconditional `.` / `..`). To extend the defaults, write
+all six plus the extra names. CLI `--skip` and config `fleet.skip` compose additively with each
+other the same way other scope inputs do.
 
 Resolution priority is explicit audit CLI override, canonical config entry, then the discovered
 checkout's own **main worktree** (the first record of `git worktree list --porcelain`). A canonical

--- a/plugins/repo-fleet-hygiene/skills/setup/evals/evals.json
+++ b/plugins/repo-fleet-hygiene/skills/setup/evals/evals.json
@@ -64,6 +64,19 @@
         "Writes maxDepth into the [fleet] section",
         "Does not instruct the user to edit the config by hand"
       ]
+    },
+    {
+      "id": 6,
+      "name": "skip-replaces-default-discovery-list",
+      "prompt": "/repo-fleet-hygiene:setup apply --root <fleet-root> --skip . --skip .. --skip .git --skip node_modules --skip vendor --skip .venv --skip third_party\n\nI need discovery to skip a differently named vendored tree without losing the defaults.",
+      "expected_output": "Setup validates each --skip as a bare directory name, writes repeatable [fleet] skip entries, and states that fleet.skip replaces the audit default skip list rather than appending — which is why the six defaults were included alongside third_party. It does not tell the user to hand-edit the config.",
+      "files": [],
+      "expectations": [
+        "Validates bare directory names and rejects path separators",
+        "Writes repeatable fleet.skip entries including the six defaults plus third_party",
+        "States replace semantics (not append) when writing skip",
+        "Does not instruct the user to edit the config by hand"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Add repeatable `--skip <name>` and config `fleet.skip` for `repo-fleet-hygiene` discovery; explicit entries **replace** the default skip list (`.`, `..`, `.git`, `node_modules`, `vendor`, `.venv`) so operators can shrink or extend it.
- CLI and config compose additively; bare directory names only (empty / path separators hard-fail); `.` / `..` stay unconditionally skipped.
- Document replace semantics in `usage()`, audit and setup skills; document nested-repository early return; setup `apply --skip` writes `fleet.skip`.
- Bump plugin to 0.23.0.

Closes #2712.

## Test plan

- [x] `bash plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.test.sh`
- [x] Default skip hides `vendor/`, keeps `third_party/`
- [x] `--skip` shrink reaches repo under `vendor/`
- [x] `--skip` extend skips `third_party/`
- [x] CLI + `fleet.skip` compose and replace defaults
- [x] Invalid `--skip` / `fleet.skip` hard-fail with named errors

## Related

Discovery skip-list replace semantics for `repo-fleet-hygiene` audit/setup. No other linked PRs or ADRs.