### PR TITLE
test(ci): gate audit skill grammar against the fleet parser

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -625,6 +625,26 @@ jobs:
       - name: "Check every emitted fleet finding kind has a Finding: assertion"
         run: scripts/check-fleet-finding-test-coverage.sh --check
 
+  # The audit skill's documented argument grammar must match what audit-fleet.sh
+  # actually accepts. Lives outside both SKILL.md and the collector so a
+  # docs-only silent revert (#2646) cannot delete its own defender (#2713).
+  # Probes the script (never pattern-matches the parser) under a sealed env.
+  fleet-audit-doc-grammar-gate:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - name: Check out
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          # Full history so the self-test can prove the gate goes red on the
+          # historical commit that shipped the docs-only grammar revert (#2713).
+          fetch-depth: 0
+      - name: Test the fleet audit doc-grammar detector
+        run: bash scripts/check-fleet-audit-doc-grammar.test.sh
+      - name: Check audit skill grammar matches the parser
+        run: scripts/check-fleet-audit-doc-grammar.sh --check
+
   # CHANGELOG parity: a versioned plugin must keep a CHANGELOG.md whose newest
   # version heading does not outrun the manifest (static --check), a PR that
   # changes a plugin's manifest version must update that plugin's CHANGELOG.md in
@@ -1191,6 +1211,7 @@ jobs:
       - plugin-manifest-presence-gate
       - orphaned-fixture-gate
       - fleet-finding-test-coverage-gate
+      - fleet-audit-doc-grammar-gate
       - changelog-parity-gate
       - contract-slice-prune-gate
       - contract-clause-coverage-gate

--- a/scripts/check-fleet-audit-doc-grammar.sh
+++ b/scripts/check-fleet-audit-doc-grammar.sh
@@ -1,0 +1,229 @@
+#!/usr/bin/env bash
+# Gate: the audit skill's documented argument grammar must match what
+# audit-fleet.sh actually accepts.
+#
+#   scripts/check-fleet-audit-doc-grammar.sh --check
+#
+# Why this lives outside SKILL.md and audit-fleet.sh: #2646 rebased cleanly and
+# reverted only the skill prose, leaving the parser untouched. Every script-side
+# test stayed green while the skill instructed agents to refuse a valid
+# invocation (claude-code-plugins#2713). A check that only lives inside either
+# protected file cannot defend the agreement between them.
+#
+# Agreement is established by probing the script and reading its answers — never
+# by pattern-matching the parser source:
+#   1. Bare positional is in both or neither (probe --apply-plan <missing> <dir>).
+#   2. Every scope form the no-scope remedy names has a grammar bullet in SKILL.md.
+#   3. No-scope stops non-zero with the remedy block (no report).
+#
+# The environment is sealed (HOME / USERPROFILE / CLAUDE_PROJECT_DIR /
+# XDG_CONFIG_HOME → scratch) so a maintainer config cannot change the verdict.
+# An unrecognized probe outcome is a hard exit 2 ("probe inconclusive"), never
+# a pass. FLEET_DOC_GRAMMAR_SCRIPT / FLEET_DOC_GRAMMAR_SKILL override paths
+# (self-test injection and historical proofs).
+set -uo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.." || exit 2
+
+SCRIPT="${FLEET_DOC_GRAMMAR_SCRIPT:-plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.sh}"
+SKILL="${FLEET_DOC_GRAMMAR_SKILL:-plugins/repo-fleet-hygiene/skills/audit/SKILL.md}"
+
+mode="${1:-}"
+case "$mode" in
+--check) ;;
+*)
+  echo "usage: $(basename "$0") --check" >&2
+  exit 2
+  ;;
+esac
+
+if [[ ! -f "$SCRIPT" ]]; then
+  echo "check-fleet-audit-doc-grammar: collector not found: $SCRIPT" >&2
+  exit 2
+fi
+if [[ ! -f "$SKILL" ]]; then
+  echo "check-fleet-audit-doc-grammar: skill not found: $SKILL" >&2
+  exit 2
+fi
+
+seal_dir="$(mktemp -d)"
+probe_out="$(mktemp)"
+trap 'rm -rf "$seal_dir" "$probe_out"' EXIT
+mkdir -p "$seal_dir/home" "$seal_dir/xdg" "$seal_dir/project" "$seal_dir/probe"
+
+# Seal config/project env so probes never reach a maintainer fleet config or an
+# incidental project-scoped rung. No network, no gh, no discovery.
+run_sealed() {
+  env -i \
+    PATH="$PATH" \
+    HOME="$seal_dir/home" \
+    USERPROFILE="$seal_dir/home" \
+    XDG_CONFIG_HOME="$seal_dir/xdg" \
+    CLAUDE_PROJECT_DIR="$seal_dir/project" \
+    TMPDIR="$seal_dir/probe" \
+    bash "$SCRIPT" "$@" >"$probe_out" 2>&1
+}
+
+# Classify --apply-plan <missing> <dir>: three distinguishable outcomes after the
+# argument loop and before config resolution / discovery.
+#   rejected     → "unknown argument"
+#   accepted     → "cannot be combined with audit discovery flags"
+#   ignored      → "apply-plan file not found"
+# anything else  → inconclusive (exit 2)
+classify_bare_positional() {
+  local missing="$seal_dir/probe/missing-plan-$$.json"
+  local bare="$seal_dir/probe/bare-dir-$$"
+  mkdir -p "$bare"
+  rm -f "$missing"
+  run_sealed --apply-plan "$missing" "$bare" || true
+  if grep -Fq "unknown argument" "$probe_out"; then
+    printf 'rejected'
+    return 0
+  fi
+  if grep -Fq "cannot be combined with audit discovery flags" "$probe_out"; then
+    printf 'accepted'
+    return 0
+  fi
+  if grep -Fq "apply-plan file not found" "$probe_out"; then
+    printf 'ignored'
+    return 0
+  fi
+  echo "check-fleet-audit-doc-grammar: probe inconclusive (bare positional): $(tr '\n' ' ' <"$probe_out")" >&2
+  exit 2
+}
+
+# argument-hint carries a bare positional form when it documents [<dir>], not
+# merely --root <dir> / --repo <dir> as flag values.
+argument_hint_has_bare() {
+  local hint
+  hint="$(grep -E '^argument-hint:' "$SKILL" | head -n1 || true)"
+  [[ -n "$hint" ]] || return 1
+  [[ "$hint" == *'[<dir>]'* ]]
+}
+
+# Leading code span of each Input-resolution grammar bullet (structured surface).
+grammar_spans() {
+  awk '
+    /^## Input resolution/ { p = 1; next }
+    p && /^## / { exit }
+    p && /^- `/ {
+      line = $0
+      sub(/^- `/, "", line)
+      sub(/`.*/, "", line)
+      if (length(line) > 0) print line
+    }
+  ' "$SKILL"
+}
+
+grammar_covers_token() {
+  local token="$1" span
+  while IFS= read -r span; do
+    [[ -n "$span" ]] || continue
+    if [[ "$span" == "$token" || "$span" == "$token "* ]]; then
+      return 0
+    fi
+  done < <(grammar_spans)
+  return 1
+}
+
+# No-scope probe: must stop non-zero with the remedy block, never a report.
+# Parse scope tokens from the script's own remedy (first field of each indented
+# form line), so the expected set tracks the script without a hand list.
+probe_no_scope_and_collect_tokens() {
+  local tokens_file="$1" rc=0
+  run_sealed || rc=$?
+  if [[ "$rc" -eq 0 ]]; then
+    echo "check-fleet-audit-doc-grammar: no-scope probe exited 0 (expected non-zero stop)" >&2
+    exit 2
+  fi
+  if ! grep -Fq "no scope resolved" "$probe_out"; then
+    echo "check-fleet-audit-doc-grammar: probe inconclusive (no-scope): $(tr '\n' ' ' <"$probe_out")" >&2
+    exit 2
+  fi
+  # Remedy block: either the no-config form ("Give it a scope instead") or the
+  # consumed-empty-config form ("Add scope to that config"). Sealed env should
+  # hit the former; either way we require the indented scope-form lines.
+  if ! grep -Eq 'Give it a scope instead|Add scope to that config' "$probe_out"; then
+    echo "check-fleet-audit-doc-grammar: no-scope stop missing remedy block" >&2
+    exit 1
+  fi
+  if grep -Eq 'Fleet verdict|Repo Fleet Hygiene —|repositories_audited' "$probe_out"; then
+    echo "check-fleet-audit-doc-grammar: no-scope probe produced a report instead of stopping" >&2
+    exit 1
+  fi
+
+  : >"$tokens_file"
+  # Indented remedy forms: "  <dir> ..." or "  --root <dir> ..." (not git config lines).
+  while IFS= read -r line; do
+    case "$line" in
+    '  <dir>'* | '  --'[a-z]*)
+      # First field; for "--root <dir>" keep only --root.
+      # shellcheck disable=SC2086 # intentional word-split of the indented form line
+      set -- $line
+      token="$1"
+      [[ -n "$token" ]] || continue
+      printf '%s\n' "$token" >>"$tokens_file"
+      ;;
+    *) ;;
+    esac
+  done <"$probe_out"
+  if [[ ! -s "$tokens_file" ]]; then
+    echo "check-fleet-audit-doc-grammar: probe inconclusive (no scope tokens in remedy)" >&2
+    exit 2
+  fi
+  sort -u -o "$tokens_file" "$tokens_file"
+}
+
+errors=0
+
+bare_status="$(classify_bare_positional)"
+case "$bare_status" in
+accepted)
+  if argument_hint_has_bare; then
+    :
+  else
+    echo "MISSING BARE POSITIONAL: parser accepts a bare <dir> but argument-hint does not document [<dir>]" >&2
+    errors=$((errors + 1))
+  fi
+  if ! grammar_covers_token '<dir>'; then
+    echo "MISSING GRAMMAR BULLET: parser accepts a bare <dir> but Input resolution has no \`<dir>\` bullet" >&2
+    errors=$((errors + 1))
+  fi
+  ;;
+rejected | ignored)
+  if argument_hint_has_bare; then
+    echo "STALE BARE POSITIONAL: argument-hint documents [<dir>] but parser does not accept a bare path ($bare_status)" >&2
+    errors=$((errors + 1))
+  fi
+  if grammar_covers_token '<dir>'; then
+    echo "STALE GRAMMAR BULLET: Input resolution documents \`<dir>\` but parser does not accept a bare path ($bare_status)" >&2
+    errors=$((errors + 1))
+  fi
+  ;;
+*)
+  echo "check-fleet-audit-doc-grammar: probe inconclusive (bare status '$bare_status')" >&2
+  exit 2
+  ;;
+esac
+
+tokens_tmp="$(mktemp)"
+trap 'rm -rf "$seal_dir" "$probe_out" "$tokens_tmp"' EXIT
+probe_no_scope_and_collect_tokens "$tokens_tmp"
+
+while IFS= read -r token; do
+  [[ -n "$token" ]] || continue
+  # Bare <dir> is already asserted against the bare-positional probe above.
+  [[ "$token" == '<dir>' ]] && continue
+  if ! grammar_covers_token "$token"; then
+    echo "MISSING GRAMMAR BULLET: remedy names $token but Input resolution has no matching bullet" >&2
+    errors=$((errors + 1))
+  fi
+done <"$tokens_tmp"
+
+if [[ "$errors" -gt 0 ]]; then
+  echo "check-fleet-audit-doc-grammar: FAILED — $errors gap(s)" >&2
+  exit 1
+fi
+
+echo "check-fleet-audit-doc-grammar: passed — documented grammar matches parser probes"
+exit 0

--- a/scripts/check-fleet-audit-doc-grammar.test.sh
+++ b/scripts/check-fleet-audit-doc-grammar.test.sh
@@ -1,0 +1,286 @@
+#!/usr/bin/env bash
+# Self-test for check-fleet-audit-doc-grammar.sh. Synthetic trees prove each
+# assertion and the inconclusive-probe guard; a historical extract of a6be07f9
+# proves the gate goes red on the docs-only silent revert (#2713).
+set -uo pipefail
+
+SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$SELF_DIR/check-fleet-audit-doc-grammar.sh"
+
+PASS=0
+FAIL=0
+fail() {
+  echo "FAIL: $*" >&2
+  FAIL=$((FAIL + 1))
+}
+ok() {
+  echo "ok: $*"
+  PASS=$((PASS + 1))
+}
+
+# Minimal stub collector: classifies the bare-positional probe and the no-scope
+# probe from argv / emptiness without touching git or the network.
+write_stub_script() {
+  local path="$1"
+  local bare_mode="$2" # accept | reject | ignore | noise
+  local noscope_mode="$3" # remedy | report | noise | zero
+  cat >"$path" <<EOF
+#!/usr/bin/env bash
+set -uo pipefail
+# synthetic audit-fleet stub for doc-grammar self-test
+if [[ "\${1:-}" == "--apply-plan" ]]; then
+  case "$bare_mode" in
+  accept)
+    if [[ \$# -ge 3 ]]; then
+      echo "Error: --apply-plan cannot be combined with audit discovery flags" >&2
+      exit 2
+    fi
+    echo "Error: apply-plan file not found: \$2" >&2
+    exit 2
+    ;;
+  reject)
+    if [[ \$# -ge 3 ]]; then
+      echo "Error: unknown argument: \$3" >&2
+      exit 2
+    fi
+    echo "Error: apply-plan file not found: \$2" >&2
+    exit 2
+    ;;
+  ignore)
+    echo "Error: apply-plan file not found: \$2" >&2
+    exit 2
+    ;;
+  noise)
+    echo "Error: something unexpected happened" >&2
+    exit 2
+    ;;
+  esac
+fi
+if [[ \$# -eq 0 ]]; then
+  case "$noscope_mode" in
+  remedy)
+    echo "Error: no scope resolved: no bare path, --root, or --repo, and no config-supplied fleet.root/fleet.repo" >&2
+    cat >&2 <<'REMEDY'
+
+No bare path, --root, --repo, or --config was given, so no repository scope resolved. Give it a scope instead:
+
+  <dir>            bare path — same as --root (drive roots like D: are allowed)
+  --root <dir>     bounded recursive repository discovery
+  --repo <dir>     one exact repository or worktree
+  --config <file>  a Git-format fleet config listing fleet.root / fleet.repo entries
+
+Or run /repo-fleet-hygiene:setup apply to write a config the audit picks up on its own.
+REMEDY
+    exit 2
+    ;;
+  report)
+    echo "Error: no scope resolved: no bare path, --root, or --repo, and no config-supplied fleet.root/fleet.repo" >&2
+    echo "Give it a scope instead:" >&2
+    echo "  --root <dir>     bounded recursive repository discovery" >&2
+    echo "Fleet verdict: CLEAN" >&2
+    exit 2
+    ;;
+  noise)
+    echo "Error: unexpected no-scope failure mode" >&2
+    exit 2
+    ;;
+  zero)
+    echo "Fleet verdict: CLEAN"
+    exit 0
+    ;;
+  esac
+fi
+echo "Error: unexpected stub invocation: \$*" >&2
+exit 2
+EOF
+  chmod +x "$path"
+}
+
+write_skill() {
+  local path="$1"
+  local hint="$2"
+  shift 2
+  {
+    printf '%s\n' '---'
+    printf 'argument-hint: "%s"\n' "$hint"
+    printf '%s\n' '---'
+    printf '%s\n' ''
+    printf '%s\n' '## Input resolution'
+    printf '%s\n' ''
+    local bullet
+    for bullet in "$@"; do
+      # shellcheck disable=SC2016 # markdown code spans use literal backticks
+      printf -- '- `%s`: synthetic grammar bullet\n' "$bullet"
+    done
+    printf '%s\n' ''
+    printf '%s\n' '## Evidence rules'
+    printf '%s\n' ''
+    printf '%s\n' 'Synthetic skill body.'
+  } >"$path"
+}
+
+mk_tree() {
+  local dir
+  dir="$(mktemp -d)"
+  mkdir -p "$dir/plugins/repo-fleet-hygiene/skills/audit/scripts" "$dir/scripts"
+  cp "$SCRIPT" "$dir/scripts/check-fleet-audit-doc-grammar.sh"
+  printf '%s' "$dir"
+}
+
+run_check() {
+  local repo="$1"
+  (cd "$repo" && bash scripts/check-fleet-audit-doc-grammar.sh --check)
+}
+
+# Aligned tree: bare accepted + hint + grammar bullets covering remedy tokens.
+repo="$(mk_tree)"
+write_stub_script "$repo/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.sh" accept remedy
+write_skill "$repo/plugins/repo-fleet-hygiene/skills/audit/SKILL.md" \
+  '[<dir>]... [--root <dir>]... [--repo <dir>]... [--config <file>] | --apply-plan <path>' \
+  '<dir>' '--root <dir>' '--repo <dir>' '--config <file>' '--apply-plan <path>'
+if run_check "$repo" >/dev/null; then ok "aligned skill+parser passes --check"; else fail "aligned tree wrongly flagged"; fi
+rm -rf "$repo"
+
+# Bare accepted but argument-hint omits [<dir>] (the #2646 shape).
+repo="$(mk_tree)"
+write_stub_script "$repo/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.sh" accept remedy
+write_skill "$repo/plugins/repo-fleet-hygiene/skills/audit/SKILL.md" \
+  '[--root <dir>]... [--repo <dir>]... [--config <file>] | --apply-plan <path>' \
+  '<dir>' '--root <dir>' '--repo <dir>' '--config <file>'
+out="$(run_check "$repo" 2>&1)"
+rc=$?
+if [[ $rc -ne 0 && "$out" == *"MISSING BARE POSITIONAL"* ]]; then
+  ok "missing bare positional in argument-hint red-lines"
+else
+  fail "missing bare positional not caught: rc=$rc out='$out'"
+fi
+rm -rf "$repo"
+
+# Bare accepted but Input-resolution grammar omits the <dir> bullet.
+repo="$(mk_tree)"
+write_stub_script "$repo/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.sh" accept remedy
+write_skill "$repo/plugins/repo-fleet-hygiene/skills/audit/SKILL.md" \
+  '[<dir>]... [--root <dir>]... [--repo <dir>]... [--config <file>] | --apply-plan <path>' \
+  '--root <dir>' '--repo <dir>' '--config <file>'
+out="$(run_check "$repo" 2>&1)"
+rc=$?
+if [[ $rc -ne 0 && "$out" == *"MISSING GRAMMAR BULLET"* && "$out" == *'<dir>'* ]]; then
+  ok "missing <dir> grammar bullet red-lines"
+else
+  fail "missing <dir> bullet not caught: rc=$rc out='$out'"
+fi
+rm -rf "$repo"
+
+# Remedy names --repo but skill omits that bullet.
+repo="$(mk_tree)"
+write_stub_script "$repo/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.sh" accept remedy
+write_skill "$repo/plugins/repo-fleet-hygiene/skills/audit/SKILL.md" \
+  '[<dir>]... [--root <dir>]... [--config <file>] | --apply-plan <path>' \
+  '<dir>' '--root <dir>' '--config <file>'
+out="$(run_check "$repo" 2>&1)"
+rc=$?
+if [[ $rc -ne 0 && "$out" == *"MISSING GRAMMAR BULLET"* && "$out" == *'--repo'* ]]; then
+  ok "missing --repo grammar bullet red-lines"
+else
+  fail "missing --repo bullet not caught: rc=$rc out='$out'"
+fi
+rm -rf "$repo"
+
+# Hint documents bare positional but parser rejects it.
+repo="$(mk_tree)"
+write_stub_script "$repo/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.sh" reject remedy
+write_skill "$repo/plugins/repo-fleet-hygiene/skills/audit/SKILL.md" \
+  '[<dir>]... [--root <dir>]... [--repo <dir>]... [--config <file>] | --apply-plan <path>' \
+  '<dir>' '--root <dir>' '--repo <dir>' '--config <file>'
+out="$(run_check "$repo" 2>&1)"
+rc=$?
+if [[ $rc -ne 0 && "$out" == *"STALE BARE POSITIONAL"* ]]; then
+  ok "stale bare positional in argument-hint red-lines"
+else
+  fail "stale bare positional not caught: rc=$rc out='$out'"
+fi
+rm -rf "$repo"
+
+# No-scope produces a report instead of a clean stop.
+repo="$(mk_tree)"
+write_stub_script "$repo/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.sh" accept report
+write_skill "$repo/plugins/repo-fleet-hygiene/skills/audit/SKILL.md" \
+  '[<dir>]... [--root <dir>]... [--repo <dir>]... [--config <file>] | --apply-plan <path>' \
+  '<dir>' '--root <dir>' '--repo <dir>' '--config <file>'
+out="$(run_check "$repo" 2>&1)"
+rc=$?
+if [[ $rc -ne 0 && "$out" == *"produced a report"* ]]; then
+  ok "no-scope report-instead-of-stop red-lines"
+else
+  fail "no-scope report not caught: rc=$rc out='$out'"
+fi
+rm -rf "$repo"
+
+# Inconclusive bare-positional probe → exit 2 (never a pass).
+repo="$(mk_tree)"
+write_stub_script "$repo/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.sh" noise remedy
+write_skill "$repo/plugins/repo-fleet-hygiene/skills/audit/SKILL.md" \
+  '[<dir>]... [--root <dir>]... [--repo <dir>]... [--config <file>] | --apply-plan <path>' \
+  '<dir>' '--root <dir>' '--repo <dir>' '--config <file>'
+out="$(run_check "$repo" 2>&1)"
+rc=$?
+if [[ $rc -eq 2 && "$out" == *"probe inconclusive"* ]]; then
+  ok "inconclusive bare probe exits 2"
+else
+  fail "inconclusive bare probe not guarded: rc=$rc out='$out'"
+fi
+rm -rf "$repo"
+
+# Inconclusive no-scope probe → exit 2.
+repo="$(mk_tree)"
+write_stub_script "$repo/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.sh" accept noise
+write_skill "$repo/plugins/repo-fleet-hygiene/skills/audit/SKILL.md" \
+  '[<dir>]... [--root <dir>]... [--repo <dir>]... [--config <file>] | --apply-plan <path>' \
+  '<dir>' '--root <dir>' '--repo <dir>' '--config <file>'
+out="$(run_check "$repo" 2>&1)"
+rc=$?
+if [[ $rc -eq 2 && "$out" == *"probe inconclusive"* ]]; then
+  ok "inconclusive no-scope probe exits 2"
+else
+  fail "inconclusive no-scope probe not guarded: rc=$rc out='$out'"
+fi
+rm -rf "$repo"
+
+# Historical proof (#2713): a6be07f9's SKILL.md + audit-fleet.sh must go red,
+# naming the missing bare positional form.
+if git rev-parse --verify --quiet "a6be07f9^{commit}" >/dev/null 2>&1; then
+  hist="$(mktemp -d)"
+  mkdir -p "$hist/scripts" \
+    "$hist/a6be07f9/plugins/repo-fleet-hygiene/skills/audit/scripts"
+  cp "$SCRIPT" "$hist/scripts/check-fleet-audit-doc-grammar.sh"
+  git show a6be07f9:plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.sh \
+    >"$hist/a6be07f9/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.sh"
+  git show a6be07f9:plugins/repo-fleet-hygiene/skills/audit/SKILL.md \
+    >"$hist/a6be07f9/plugins/repo-fleet-hygiene/skills/audit/SKILL.md"
+  chmod +x "$hist/a6be07f9/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.sh"
+  out="$(
+    cd "$hist" &&
+      FLEET_DOC_GRAMMAR_SCRIPT="$hist/a6be07f9/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.sh" \
+        FLEET_DOC_GRAMMAR_SKILL="$hist/a6be07f9/plugins/repo-fleet-hygiene/skills/audit/SKILL.md" \
+        bash scripts/check-fleet-audit-doc-grammar.sh --check 2>&1
+  )"
+  rc=$?
+  if [[ $rc -ne 0 && "$out" == *"MISSING BARE POSITIONAL"* ]]; then
+    ok "historical a6be07f9 goes red naming missing bare positional"
+  else
+    fail "historical a6be07f9 did not go red as expected: rc=$rc out='$out'"
+  fi
+  rm -rf "$hist"
+else
+  ok "skip historical proof (a6be07f9 not in this clone)"
+fi
+
+# Live tree must pass.
+if (cd "$SELF_DIR/.." && bash scripts/check-fleet-audit-doc-grammar.sh --check) >/dev/null; then
+  ok "repository skill+parser passes --check"
+else
+  fail "repository skill+parser fails --check"
+fi
+
+echo "PASS=$PASS FAIL=$FAIL"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
Closes #2713

## Summary

CI could not catch a docs-only silent revert of the audit skill's argument grammar (#2646): every test lives on the script side, so a rebased `SKILL.md` that disagrees with `audit-fleet.sh` stayed green. This adds a repo-level gate outside both protected files that probes the parser and asserts the skill's structured surfaces agree.

## Fix

- Add `scripts/check-fleet-audit-doc-grammar.sh --check` (sealed `HOME` / `USERPROFILE` / `CLAUDE_PROJECT_DIR` / `XDG_CONFIG_HOME`):
  - bare positional accepted iff `argument-hint` documents `[<dir>]` and Input resolution has a `` `<dir>` `` bullet
  - every scope form named in the no-scope remedy has a matching grammar bullet
  - no-scope stops non-zero with the remedy block (never a report)
  - unrecognized probe output → exit 2 (`probe inconclusive`), never a pass
- Add `scripts/check-fleet-audit-doc-grammar.test.sh` with synthetic cases plus historical proof against `a6be07f9`
- Wire `fleet-audit-doc-grammar-gate` into `ci.yml` / `ci-status` (unconditional; full history for the historical proof)

No plugin version bump: CI scripts and `ci.yml` carry no plugin version (same as the orphaned-fixture gate).

## Verification

```
bash scripts/check-fleet-audit-doc-grammar.test.sh
# PASS=10 FAIL=0 (includes historical a6be07f9 → MISSING BARE POSITIONAL)

bash scripts/check-fleet-audit-doc-grammar.sh --check
# passed against current main

# a6be07f9 skill+script via FLEET_DOC_GRAMMAR_* → FAILED naming missing bare positional
```

## Related

- Predecessor silent-revert case: #2646 (docs-only grammar drift that this gate now catches).
- Pattern sibling: orphaned-fixture-gate (CI-script gate outside the protected surfaces).