### PR TITLE
fix(docs-hygiene): detect relative-path skill-private cites

### DIFF
--- a/plugins/docs-hygiene/.claude-plugin/plugin.json
+++ b/plugins/docs-hygiene/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "docs-hygiene",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "description": "Documentation-hygiene toolkit: compress (flavor-trim markdown with a semantic-diff safety net), audit-noise (classify markdown noise), extract-ssot (deduplicate repeated content into a single source of truth), audit-encapsulation (detect citations into skill-private surfaces), rename-references (sweep stale references after renames), and audit-derivability (classify whether a whole document earns its existence \u2014 could a fresh agent re-derive it from the code?).",
   "author": {
     "name": "Melodic Software",

--- a/plugins/docs-hygiene/CHANGELOG.md
+++ b/plugins/docs-hygiene/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog — docs-hygiene plugin
 
+## [0.14.3]
+
+### Fixed
+
+- **audit-encapsulation detect:** relative-path cites into skill-private surfaces
+  are no longer invisible. The detector matches bare `skills/<x>/...` (plugin
+  README short links, including heading anchors) and `../`-prefixed cites whose
+  lexical resolution lands on a private skill surface (sibling-skill links that
+  never spell `skills/` in the cite text). Scripts/ carve-out and self-citation
+  filtering cover the relative forms; scripts/ carve-out matches citation text
+  only (not the citing file path). Regression fixtures pin both shapes so a
+  future pattern regression cannot return a silent empty again (#2716).
+
 ## [0.14.2]
 
 ### Fixed

--- a/plugins/docs-hygiene/skills/audit-encapsulation/SKILL.md
+++ b/plugins/docs-hygiene/skills/audit-encapsulation/SKILL.md
@@ -71,16 +71,13 @@ Matched shapes:
 - Heading-anchor cites into `SKILL.md` body structure (`<X>/SKILL.md#<anchor>`)
 - Any `*.schema.json` file at any depth (`<X>/<file>.schema.json`)
 
+Matched path prefixes: `.claude/skills/<X>/...`, `plugins/<plugin>/skills/<X>/...`, and relative forms (`skills/<X>/...` plugin-README short cites, plus `../`-prefixed cites whose lexical resolution lands on a private skill surface — including sibling-skill links that never spell `skills/` in the cite text).
+
 Legal external cites: bare `<X>/SKILL.md` path (discouraged but legal — natural-language + slash invocation is canonical), `<X>/<file>.json` data files at skill root (data-file carve-out), and `<X>/scripts/<entry>` entry scripts (entry-surface carve-out below).
 
 **scripts/ entry-surface carve-out:** a skill's `scripts/` is its declared ENTRY surface per `context/public-surface-contract.md`. Harness / CI / hooks / workflow registries MAY path-cite a skill's entry scripts directly, so this inbound audit treats `<X>/scripts/...` cites as legal (like data files and bare `SKILL.md`) and never flags them. The skill-to-skill half of the asymmetry — a sibling SKILL.md citing another skill's `scripts/` stays slash-only — is out of this inbound audit's scope; a consuming repo that wants it enforced wires its own outbound gate.
 
 The script scans the consumer repo it runs in: every `.claude/` child directory except `skills/` (self-citation domain; opt in via `--include-skills` for skill-maintenance review) and `worktrees/`, plus `.github/`, `docs/`, `.lefthook/`, `plugins/`, root instruction/config files (`AGENTS.md`, `CLAUDE.md`, `README.md`, `CONTRIBUTING.md`, `lefthook.yml`), and `.claude/` top-level files — each filtered to what exists.
-
-**Detector limitations** (exit 0 does not mean the tree is clean):
-
-- Relative-path cites (`../skills/...`, bare `skills/...`, relative heading-anchor forms) are invisible to the PATTERN. Tracked as #2716 — not fixed here.
-- Only absolute-looking prefixes (`.claude/skills/...` and `plugins/<plugin>/skills/...`) are matched.
 
 Or invoke the skill (the agent applies the filter taxonomy below):
 
@@ -94,7 +91,7 @@ Or invoke the skill (the agent applies the filter taxonomy below):
 
 | Filter | Hit shape | Why legal |
 |--------|-----------|-----------|
-| **Self-citation** | `.claude/skills/<X>/SKILL.md` cites `.claude/skills/<X>/<private-path>` | Intra-skill progressive disclosure (per `context/public-surface-contract.md`) |
+| **Self-citation** | A skill cites its own internals — absolute (`.claude/skills/<X>/...` / `plugins/.../skills/<X>/...`), bare `skills/<X>/...`, or a `../` cite that resolves into the same skill | Intra-skill progressive disclosure (per `context/public-surface-contract.md`) |
 | **KIND-1 meta-prose** | A rule or doc describing the encapsulation contract itself, OR documenting skill internals as a worked example / historical narrative / empirically-verified quirk | Self-referential explanatory prose, not citation |
 | **KIND-2 forced-cite** | Another tool's semantics structurally require a verbatim path (a path-scoped rule trigger, a watch-glob, a drift-gate comparing against a vendored copy) | Citation IS the structural contract |
 | **KIND-3 self-test** | This skill's / a hook's own regression fixtures embed literal violation strings | Exercise the filter; not real citations |

--- a/plugins/docs-hygiene/skills/audit-encapsulation/scripts/detect.sh
+++ b/plugins/docs-hygiene/skills/audit-encapsulation/scripts/detect.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
-# Find external citations into private skill internals (.claude/skills/<X>/... and
-# plugins/<plugin>/skills/<X>/... in marketplace monorepos).
+# Find external citations into private skill internals (.claude/skills/<X>/...,
+# plugins/<plugin>/skills/<X>/... in marketplace monorepos, and relative forms
+# `skills/<X>/...` / `../`-resolved sibling cites — #2716).
 #
 # Contract this detector encodes: ../context/public-surface-contract.md
 # (bundled with this skill).
@@ -37,11 +38,9 @@ Exit 1 means candidates remain after mechanical filters — not adjudicated
 violations. Classify via the skill filter taxonomy before gating. Do not
 hard-gate CI on this exit code alone.
 
-Limitations (undetected shapes — not a clean bill of health on exit 0):
-  - Relative-path cites (../skills/..., bare skills/..., relative heading
-    anchors) are invisible; tracked separately (#2716).
-  - Only absolute-looking path prefixes (.claude/skills/... and
-    plugins/<plugin>/skills/...) are matched.
+Matched path prefixes: .claude/skills/<X>/..., plugins/<plugin>/skills/<X>/...,
+and relative forms (skills/<X>/... plugin-README short cites, plus ../-prefixed
+cites whose lexical resolution lands on a private skill surface).
 
   --include-skills  Include .claude/skills/ in scope (intra-skill self-citation review)
   --apply-filters   Drop self-citation and worktree path hits (mechanical filters only)
@@ -94,7 +93,7 @@ fi
 # Private-surface pattern per ../context/public-surface-contract.md: any
 # subdir under a skill root is private; *.schema.json at any depth is
 # private; <skill>/SKILL.md#<anchor> heading-anchor cites are private.
-# Three alternations (ERE form via grep -E):
+# Alternations (ERE form via grep -E):
 #   1. `<skill>/<subdir>/`          — any subdirectory name (contract: all
 #      subdirs regardless of name; excludes bare SKILL.md by requiring `/`)
 #   2. `<skill>/SKILL.md#<anchor>`  — heading-anchor cites
@@ -105,10 +104,14 @@ fi
 # `<skill>/SKILL.md` path cites still pass (discouraged-but-legal) because they
 # lack `#` and a trailing subdir slash. Does NOT match plain-JSON data files at
 # skill root (`<skill>/catalog.json`) per the data-file carve-out.
-# Two skill-root layouts share one detector:
+# Skill-root layouts the detector matches (absolute + relative, #2716):
 #   - consumer-installed: `.claude/skills/<skill>/...`
 #   - marketplace monorepo: `plugins/<plugin>/skills/<skill>/...`
-PATTERN='\.claude/skills/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+/|\.claude/skills/[A-Za-z0-9_.-]+/SKILL\.md#|\.claude/skills/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+\.schema\.json|plugins/[A-Za-z0-9_.-]+/skills/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+/|plugins/[A-Za-z0-9_.-]+/skills/[A-Za-z0-9_.-]+/SKILL\.md#|plugins/[A-Za-z0-9_.-]+/skills/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+\.schema\.json'
+#   - plugin-relative / short: `skills/<skill>/...` (README links, and the
+#     `skills/` suffix of `../`-prefixed paths that still name a skills root)
+# Absolute alternations are listed first so grep -o prefers the longer
+# leftmost match over the bare `skills/` suffix of the same path.
+PATTERN='\.claude/skills/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+/|\.claude/skills/[A-Za-z0-9_.-]+/SKILL\.md#|\.claude/skills/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+\.schema\.json|plugins/[A-Za-z0-9_.-]+/skills/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+/|plugins/[A-Za-z0-9_.-]+/skills/[A-Za-z0-9_.-]+/SKILL\.md#|plugins/[A-Za-z0-9_.-]+/skills/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+\.schema\.json|skills/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+/|skills/[A-Za-z0-9_.-]+/SKILL\.md#|skills/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+\.schema\.json'
 
 # scripts/ entry-surface carve-out: a skill's `scripts/` is its declared ENTRY
 # surface — harness / CI / hooks / workflow registries MAY path-cite it. Like
@@ -116,16 +119,78 @@ PATTERN='\.claude/skills/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+/|\.claude/skills/[A-Za-
 # private, so they are dropped here rather than emitted as raw hits. PATTERN
 # still matches scripts/ (the subdir alternation; ERE has no lookahead to
 # exclude one name), so the carve-out is a post-grep exclusion. The scan grep
-# below uses `-o` to emit ONE record per cite, so this `grep -vE` drops only
+# below uses `-o` to emit ONE record per cite, so this carve-out drops only
 # the scripts/ cite — a line co-citing a scripts/ entry script AND another
 # skill's private subdir keeps the genuine cite instead of dropping the whole
-# line. The skill-to-skill half of the asymmetry (a sibling SKILL.md citing
+# line. Bare `skills/<x>/scripts/` is included so plugin-relative entry cites
+# stay carved out too (#2716). Filter on the matched *citation text* only —
+# never on the citing file's path — so a file that itself lives under
+# `skills/<x>/scripts/` does not have every citation it makes swallowed.
+# The skill-to-skill half of the asymmetry (a sibling SKILL.md citing
 # another skill's scripts/ stays slash-only) is out of this inbound audit's
 # scope — see the contract file.
-SCRIPTS_RE='(\.claude/skills/[A-Za-z0-9_.-]+/scripts/|plugins/[A-Za-z0-9_.-]+/skills/[A-Za-z0-9_.-]+/scripts/)'
+SCRIPTS_RE='^(\.claude/skills/[A-Za-z0-9_.-]+/scripts/|plugins/[A-Za-z0-9_.-]+/skills/[A-Za-z0-9_.-]+/scripts/|skills/[A-Za-z0-9_.-]+/scripts/)'
+
+# Lexically resolve a repo-relative path with `.` / `..` segments. Returns 1 if
+# the path escapes the repo root. Used by the `../` relative-cite pass (#2716).
+lex_resolve() {
+  local raw="$1" seg
+  [[ "$raw" == /* ]] && return 1
+  local -a out=()
+  while IFS= read -r seg; do
+    case "$seg" in
+    '' | '.') continue ;;
+    '..')
+      ((${#out[@]})) || return 1
+      out=("${out[@]:0:${#out[@]}-1}")
+      ;;
+    *) out+=("$seg") ;;
+    esac
+  done < <(printf '%s\n' "${raw//\//$'\n'}")
+  local joined="" part
+  for part in ${out[@]+"${out[@]}"}; do
+    joined="${joined:+$joined/}$part"
+  done
+  printf '%s' "$joined"
+}
+
+# True when a resolved path is a private skill surface (subdir / SKILL.md#
+# / *.schema.json), matching the same contract as PATTERN. Trailing slash is
+# optional — lex_resolve drops a final empty segment.
+is_private_skill_path() {
+  local p="$1"
+  [[ "$p" =~ ^(\.claude/skills/|plugins/[^/]+/skills/)[A-Za-z0-9_.-]+/scripts(/|$) ]] && return 1
+  [[ "$p" =~ ^(\.claude/skills/|plugins/[^/]+/skills/)[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+(/|$) ]] && return 0
+  [[ "$p" =~ ^(\.claude/skills/|plugins/[^/]+/skills/)[A-Za-z0-9_.-]+/SKILL\.md# ]] && return 0
+  [[ "$p" =~ ^(\.claude/skills/|plugins/[^/]+/skills/)[A-Za-z0-9_.-]+/[^/]+\.schema\.json ]] && return 0
+  return 1
+}
+
+# True when citation text is a scripts/ entry-surface carve-out (text field only).
+is_scripts_carveout() {
+  local text="$1"
+  [[ "$text" =~ $SCRIPTS_RE ]]
+}
+
+# When grep -o emitted only a bare `skills/<x>/...` suffix of a `../`-prefixed
+# cite, recover the leading `../...` span from the source line so resolution
+# can see the real target (cross-plugin same-leaf-name defense).
+recover_dotdot_prefix() {
+  local file="$1" line_no="$2" text="$3" src before
+  src="$(sed -n "${line_no}p" "$file" 2>/dev/null || true)"
+  [[ -n "$src" && "$src" == *"$text"* ]] || return 1
+  before="${src%%"$text"*}"
+  if [[ "$before" =~ ((\.\./)+([A-Za-z0-9_.-]+/)*)$ ]]; then
+    printf '%s%s' "${BASH_REMATCH[1]}" "$text"
+    return 0
+  fi
+  return 1
+}
 
 HITS_FILE="$(mktemp)"
-trap 'rm -f "$HITS_FILE"' EXIT
+DOTDOT_RAW="$(mktemp)"
+RAW_HITS="$(mktemp)"
+trap 'rm -f "$HITS_FILE" "$DOTDOT_RAW" "$RAW_HITS"' EXIT
 
 # Aggregate hits, then drop scripts/ entry-surface cites (carve-out above).
 {
@@ -139,7 +204,57 @@ trap 'rm -f "$HITS_FILE"' EXIT
     # -H forces the file prefix even when only one file exists.
     grep -EHno "$PATTERN" "${SCOPE_FILES[@]}" 2>/dev/null || true
   fi
-} | grep -vE "$SCRIPTS_RE" >"$HITS_FILE" || true
+} >"$RAW_HITS" || true
+
+: >"$HITS_FILE"
+if [[ -s "$RAW_HITS" ]]; then
+  while IFS= read -r line; do
+    [[ -z "$line" ]] && continue
+    text="${line#*:*:}"
+    # shellcheck disable=SC2310  # is_scripts_carveout is a pure predicate; both branches handled
+    if is_scripts_carveout "$text"; then
+      continue
+    fi
+    printf '%s\n' "$line" >>"$HITS_FILE"
+  done <"$RAW_HITS"
+fi
+
+# Second pass (#2716): `../`-prefixed cites whose lexical resolution lands on
+# a private skill surface. Covers sibling-skill links like
+# `../other-skill/reference/...` that never spell `skills/` in the cite text.
+# Candidates already matched by the bare `skills/` alternation (paths that
+# still contain a `skills/` segment after `../`) are skipped here to avoid
+# duplicate rows.
+DOTDOT_PATTERN='(\.\./)+([A-Za-z0-9_.-]+/)+([A-Za-z0-9_.-]+/|SKILL\.md#|[A-Za-z0-9_.-]+\.schema\.json)'
+{
+  if [[ ${#SCOPE_DIRS[@]} -gt 0 ]]; then
+    grep -Erno "$DOTDOT_PATTERN" \
+      --include='*.md' --include='*.sh' --include='*.json' \
+      --include='*.yml' --include='*.yaml' \
+      "${SCOPE_DIRS[@]}" 2>/dev/null || true
+  fi
+  if [[ ${#SCOPE_FILES[@]} -gt 0 ]]; then
+    grep -EHno "$DOTDOT_PATTERN" "${SCOPE_FILES[@]}" 2>/dev/null || true
+  fi
+} >"$DOTDOT_RAW" || true
+
+if [[ -s "$DOTDOT_RAW" ]]; then
+  while IFS= read -r line; do
+    [[ -z "$line" ]] && continue
+    file="${line%%:*}"
+    rest="${line#*:}"
+    line_no="${rest%%:*}"
+    text="${rest#*:}"
+    # Already covered by the skills/-segment alternation.
+    [[ "$text" == *"/skills/"* || "$text" == skills/* ]] && continue
+    rel="$text"
+    # shellcheck disable=SC2310  # lex_resolve returns status; continue is the handled miss
+    resolved="$(lex_resolve "$(dirname "$file")/$rel")" || continue
+    # shellcheck disable=SC2310  # is_private_skill_path is a pure predicate; both branches handled
+    is_private_skill_path "$resolved" || continue
+    printf '%s:%s:%s\n' "$file" "$line_no" "$text" >>"$HITS_FILE"
+  done <"$DOTDOT_RAW"
+fi
 
 if [[ ! -s "$HITS_FILE" ]]; then
   if [[ "$APPLY_FILTERS" -eq 1 ]]; then
@@ -152,9 +267,11 @@ fi
 # emits only the matched path text, which contains no colons, so colon
 # splitting is unambiguous. Under --apply-filters, drop the known
 # mechanically-decidable legal hit shapes: self-citation (a skill citing its
-# own internals) and worktree paths (shared tree; same rules apply at the
-# root path). Plugin-cache cites never match PATTERN (cache paths are not
-# under skills/), so there is no cache filter branch here.
+# own internals — absolute, bare skills/<self>/, or ../-resolved into the same
+# skill root) and worktree paths (shared tree; same rules apply at the root
+# path). Plugin-cache cites that only match via the bare `skills/` suffix are
+# still candidates for in-session Plugin-cache taxonomy judgment (#2776); the
+# mechanical cache branch stays absent.
 raw=0
 candidates=0
 while IFS= read -r line; do
@@ -166,12 +283,62 @@ while IFS= read -r line; do
   text="${rest#*:}"
   if [[ "$APPLY_FILTERS" -eq 1 ]]; then
     mech_filtered=0
-    if [[ "$file" =~ ^\.claude/skills/([^/]+)/ ]] &&
-      [[ "$text" == *".claude/skills/${BASH_REMATCH[1]}/"* ]]; then
-      mech_filtered=1
-    elif [[ "$file" =~ ^plugins/[^/]+/skills/([^/]+)/ ]] &&
-      [[ "$text" == *"/skills/${BASH_REMATCH[1]}/"* ]]; then
-      mech_filtered=1
+    if [[ "$file" =~ ^\.claude/skills/([^/]+)/ ]]; then
+      self="${BASH_REMATCH[1]}"
+      if [[ "$text" == *".claude/skills/${self}/"* ]]; then
+        mech_filtered=1
+      elif [[ "$text" == "skills/${self}/"* ]]; then
+        # Bare skills/<self>/ may be the suffix of a ../-prefixed cross-root
+        # cite; only treat as self-citation when there is no ../ prefix or
+        # resolution lands back in this skill.
+        full=""
+        # shellcheck disable=SC2310  # recover miss → bare plugin-relative cite
+        full="$(recover_dotdot_prefix "$file" "$line_no" "$text")" || full=""
+        if [[ -z "$full" ]]; then
+          mech_filtered=1
+        else
+          # shellcheck disable=SC2310  # lex_resolve miss → leave as candidate
+          resolved="$(lex_resolve "$(dirname "$file")/$full")" || resolved=""
+          if [[ -n "$resolved" && "$resolved" == ".claude/skills/${self}/"* ]]; then
+            mech_filtered=1
+          fi
+        fi
+      elif [[ "$text" == ../* ]]; then
+        # shellcheck disable=SC2310  # lex_resolve miss → empty; not a filter hit
+        resolved="$(lex_resolve "$(dirname "$file")/$text")" || resolved=""
+        if [[ -n "$resolved" && "$resolved" == ".claude/skills/${self}/"* ]]; then
+          mech_filtered=1
+        fi
+      fi
+    elif [[ "$file" =~ ^(plugins/[^/]+)/skills/([^/]+)/ ]]; then
+      plugin="${BASH_REMATCH[1]}"
+      self="${BASH_REMATCH[2]}"
+      # Require same plugin root for absolute self-cites so a cross-plugin
+      # `.../other/skills/<same-name>/...` match cannot vacate as self-citation
+      # merely by skill leaf name (#2716 review).
+      if [[ "$text" == "${plugin}/skills/${self}/"* ||
+        "$text" == *"/${plugin}/skills/${self}/"* ]]; then
+        mech_filtered=1
+      elif [[ "$text" == "skills/${self}/"* ]]; then
+        full=""
+        # shellcheck disable=SC2310  # recover miss → bare same-plugin short cite
+        full="$(recover_dotdot_prefix "$file" "$line_no" "$text")" || full=""
+        if [[ -z "$full" ]]; then
+          mech_filtered=1
+        else
+          # shellcheck disable=SC2310  # lex_resolve miss → leave as candidate
+          resolved="$(lex_resolve "$(dirname "$file")/$full")" || resolved=""
+          if [[ -n "$resolved" && "$resolved" == "${plugin}/skills/${self}/"* ]]; then
+            mech_filtered=1
+          fi
+        fi
+      elif [[ "$text" == ../* ]]; then
+        # shellcheck disable=SC2310  # lex_resolve miss → empty; not a filter hit
+        resolved="$(lex_resolve "$(dirname "$file")/$text")" || resolved=""
+        if [[ -n "$resolved" && "$resolved" == "${plugin}/skills/${self}/"* ]]; then
+          mech_filtered=1
+        fi
+      fi
     elif [[ "$file" == *".worktrees/"* || "$text" == *".worktrees/"* ]]; then
       mech_filtered=1
     elif [[ "$file" == *".claude/worktrees/"* || "$text" == *".claude/worktrees/"* ]]; then

--- a/plugins/docs-hygiene/skills/audit-encapsulation/scripts/detect.test.sh
+++ b/plugins/docs-hygiene/skills/audit-encapsulation/scripts/detect.test.sh
@@ -232,10 +232,10 @@ out="$(cd "$prose_repo" && bash "$SCRIPT" 2>/dev/null)"
 assert_exit "multi-root prose list → exit 0 (no false span)" 0 "$?"
 assert_silent "multi-root prose list emits nothing" "$out"
 
-# --help documents candidate semantics and relative-path limitation
+# --help documents candidate semantics and relative-path coverage (#2716 closed).
 help_out="$(bash "$SCRIPT" --help 2>&1)"
 assert_contains "--help says candidates exist" "$help_out" "candidates exist"
-assert_contains "--help discloses relative-path gap" "$help_out" "#2716"
+assert_contains "--help names relative forms" "$help_out" "relative forms"
 assert_contains "--help warns against hard-gate" "$help_out" "hard-gate CI"
 
 # Honest summary keys under --apply-filters on a candidate hit
@@ -247,6 +247,100 @@ assert_exit "candidate hit → exit 1" 1 "$code"
 assert_contains "summary uses candidates key" "$err" "candidates=1"
 assert_contains "summary uses mech-filtered key" "$err" "mech-filtered=0"
 assert_not_contains "summary does not say illegal=" "$err" "illegal="
+
+# --- Relative-path cites (#2716) ---
+
+# Bare plugin-relative `skills/<x>/<subdir>/` (disk-hygiene README shape).
+bare_skills_repo="$(fixture_repo "plugins/disk-hygiene/README.md" \
+  "see [safety](skills/clean/reference/safety-model.md#standalone-git-checkout-evidence)")"
+out="$(cd "$bare_skills_repo" && bash "$SCRIPT" 2>/dev/null)"
+assert_exit "bare skills/ private-subdir cite → exit 1" 1 "$?"
+assert_contains "bare skills/ violation emitted" "$out" "skills/clean/reference/"
+
+# Heading-anchor form of bare skills/ must flag (not only the subdir slash form).
+bare_anchor_repo="$(fixture_repo "plugins/demo/README.md" \
+  "see skills/clean/SKILL.md#standalone-git-checkout-evidence")"
+out="$(cd "$bare_anchor_repo" && bash "$SCRIPT" 2>/dev/null)"
+assert_exit "bare skills/ SKILL.md#anchor cite → exit 1" 1 "$?"
+assert_contains "bare skills/ anchor emitted" "$out" "skills/clean/SKILL.md#"
+
+# `../`-prefixed path that still contains a `skills/` segment (claude-config
+# cross-plugin shape removed in #2703).
+dotdot_skills_repo="$(fixture_repo "plugins/claude-config/skills/audit/SKILL.md" \
+  "see ../../../../claude-memory/skills/audit/reference/criteria.md")"
+# Keep an in-scope non-skills surface so the default run is not exit-2.
+mkdir -p "$dotdot_skills_repo/.claude/rules"
+printf 'clean\n' >"$dotdot_skills_repo/.claude/rules/clean.md"
+out="$(cd "$dotdot_skills_repo" && bash "$SCRIPT" 2>/dev/null)"
+assert_exit "../.../skills/ private cite → exit 1" 1 "$?"
+assert_contains "../.../skills/ cite emitted via skills/ segment" "$out" "skills/audit/reference/"
+
+# Same-name cross-plugin ../.../skills/<name>/ must stay a candidate under
+# --apply-filters (not vacated as self-citation by leaf name alone).
+err="$(cd "$dotdot_skills_repo" && bash "$SCRIPT" --apply-filters 2>&1 >/dev/null)"
+code=$?
+assert_exit "cross-plugin same-leaf skills/ cite stays candidate" 1 "$code"
+assert_contains "cross-plugin same-leaf summary keeps candidate" "$err" "candidates=1"
+
+# Sibling-skill relative cite with no `skills/` segment in the text —
+# resolution pass must catch it.
+sibling_repo="$(mktemp -d)"
+git init --quiet "$sibling_repo"
+FIXTURE_REPOS+=("$sibling_repo")
+(
+  cd "$sibling_repo" || exit 1
+  mkdir -p plugins/demo/skills/alpha plugins/demo/skills/beta/reference
+  printf 'see ../beta/reference/notes.md\n' >plugins/demo/skills/alpha/SKILL.md
+  printf 'notes\n' >plugins/demo/skills/beta/reference/notes.md
+  mkdir -p .claude/rules
+  printf 'clean\n' >.claude/rules/clean.md
+)
+out="$(cd "$sibling_repo" && bash "$SCRIPT" 2>/dev/null)"
+assert_exit "sibling ../skill/reference cite → exit 1" 1 "$?"
+assert_contains "sibling relative cite emitted" "$out" "../beta/reference/"
+
+# Same-skill `../reference/deep/` from an actions/ file is self-citation under
+# --apply-filters (resolution lands in the citing skill). Assert raw>0 so a
+# silent miss cannot vacate the filter check.
+self_rel_repo="$(mktemp -d)"
+git init --quiet "$self_rel_repo"
+FIXTURE_REPOS+=("$self_rel_repo")
+(
+  cd "$self_rel_repo" || exit 1
+  mkdir -p plugins/demo/skills/alpha/actions
+  mkdir -p plugins/demo/skills/alpha/reference/deep
+  printf 'see ../reference/deep/notes.md\n' >plugins/demo/skills/alpha/actions/step.md
+  printf 'notes\n' >plugins/demo/skills/alpha/reference/deep/notes.md
+  mkdir -p .claude/rules
+  printf 'clean\n' >.claude/rules/clean.md
+)
+raw_out="$(cd "$self_rel_repo" && bash "$SCRIPT" 2>/dev/null)"
+raw_code=$?
+assert_exit "same-skill ../reference/deep/ raw → exit 1" 1 "$raw_code"
+assert_contains "same-skill relative cite raw-emitted" "$raw_out" "../reference/deep/"
+err="$(cd "$self_rel_repo" && bash "$SCRIPT" --apply-filters 2>&1 >/dev/null)"
+code=$?
+assert_exit "same-skill ../reference/ filtered → exit 0" 0 "$code"
+assert_contains "summary counts same-skill relative as mech-filtered" "$err" \
+  "raw=1 mech-filtered=1 candidates=0"
+
+# Bare skills/ scripts/ entry cite stays carved out.
+bare_scripts_repo="$(fixture_repo "plugins/demo/README.md" \
+  "run skills/alpha/scripts/foo.sh")"
+out="$(cd "$bare_scripts_repo" && bash "$SCRIPT" 2>/dev/null)"
+assert_exit "bare skills/ scripts/ cite → exit 0 (carve-out)" 0 "$?"
+assert_silent "bare skills/ scripts/ cite emits nothing" "$out"
+
+# Plugin README bare skills/ cite is NOT self-citation (README is external).
+readme_bare_repo="$(fixture_repo "plugins/demo/README.md" \
+  "see skills/alpha/reference/notes.md")"
+# Add the skill so a mistaken self-filter could fire if it keyed only on text.
+mkdir -p "$readme_bare_repo/plugins/demo/skills/alpha/reference"
+printf 'x\n' >"$readme_bare_repo/plugins/demo/skills/alpha/reference/notes.md"
+out="$(cd "$readme_bare_repo" && bash "$SCRIPT" --apply-filters 2>/dev/null)"
+code=$?
+assert_exit "plugin README bare skills/ cite stays candidate" 1 "$code"
+assert_contains "README bare skills/ hit emitted under filters" "$out" "skills/alpha/reference/"
 
 if [[ "$FAILED" -ne 0 ]]; then
   exit 1


### PR DESCRIPTION
Closes #2716

## Summary

`audit-encapsulation`'s `detect.sh` only matched absolute `.claude/skills/` and `plugins/<plugin>/skills/` prefixes, so relative cites into private surfaces passed the sweep silently. Detection now covers those forms; classification stays with the filter taxonomy.

## Fix

- Match bare `skills/<x>/...` (subdir / `SKILL.md#` / `*.schema.json`) — plugin README short links such as `disk-hygiene`'s safety-model cite.
- Second pass: `../`-prefixed cites whose lexical resolution lands on a private skill surface — sibling-skill links that never spell `skills/` in the cite text.
- Extend `scripts/` carve-out (citation-text only, not citing-file path) and same-plugin self-citation filtering to the relative forms.
- Regression fixtures pin both shapes (positive-control lesson from 0.11.1).
- Document matched prefixes in `SKILL.md`; drop the #2716 relative-path limitation language from `--help` / SKILL.
- Bump `docs-hygiene` 0.14.2 → 0.14.3 on top of merged #2776.

## Verification

- `bash plugins/docs-hygiene/skills/audit-encapsulation/scripts/detect.test.sh` — **77/77** checks passed.
- `bash scripts/check-changelog-parity.sh --check-bump origin/main` — passed.
- `bash scripts/check-changed-skills.sh origin/main` — PASS (0 errors).

## Related

- #2776 (candidate-enumerator honesty) bumped docs-hygiene to 0.14.2 and disclosed the relative-path blind spot as deferred #2716; this PR closes that gap and renumbers to 0.14.3.