### PR TITLE
fix(scripts): scan skill markdown in the shell-portability gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1143,14 +1143,16 @@ jobs:
           BASE_REF: ${{ github.base_ref }}
         run: scripts/check-skill-portability.sh "origin/$BASE_REF"
 
-  # Shell-portability lint (#1491): flags GNU-only constructs in changed
-  # **/*.sh files — a class neither shellcheck (syntax/style) nor
-  # portability-lint (skill-coupling tokens, skill files only) covers, and no
-  # runner here uses BSD userland (macOS system grep/sed/date/stat/mktemp/sort
-  # — a Windows runner's Git Bash still ships GNU grep/sed, so it would not
-  # help either). Same shape as portability-lint: changed-file scoped so
-  # enabling a class never red-lines main, self-test-first so a broken
-  # detector cannot mask a regression behind a green gate, job never skips.
+  # Shell-portability lint (#1491 / #2704): flags GNU-only constructs in
+  # changed **/*.sh files and skill markdown under plugins/*/skills/ — a class
+  # neither shellcheck (syntax/style) nor portability-lint (skill-coupling
+  # tokens, skill files only) covers, and no runner here uses BSD userland
+  # (macOS system grep/sed/date/stat/mktemp/sort — a Windows runner's Git Bash
+  # still ships GNU grep/sed, so it would not help either). Same shape as
+  # portability-lint: changed-file scoped so enabling a class never red-lines
+  # main, self-test-first so a broken detector cannot mask a regression behind
+  # a green gate, job never skips. Skill-md backlog is grandfathered in
+  # scripts/shell-portability-skill-md-baseline.txt.
   shell-portability-lint:
     runs-on: ubuntu-24.04
     timeout-minutes: 15
@@ -1163,7 +1165,7 @@ jobs:
           fetch-depth: 0
       - name: Test the shell-portability gate
         run: bash scripts/check-shell-portability.test.sh
-      - name: Gate changed shell files for GNU-only constructs
+      - name: Gate changed shell and skill-md files for GNU-only constructs
         if: github.event_name == 'pull_request'
         env:
           BASE_REF: ${{ github.base_ref }}

--- a/scripts/check-shell-portability.sh
+++ b/scripts/check-shell-portability.sh
@@ -1769,18 +1769,20 @@ done
 # file that still carries at least one unexcused hit when scanned. A missing
 # file or a cleaned-up file must leave the list — same shrink-only contract as
 # scripts/orphaned-fixtures-baseline.txt / hook-userconfig-argv-allowlist.txt.
+#
+# All three stale branches share changed-file scoping: --all re-proves the
+# whole list; diff mode only re-proves entries in this run's file set. Missing
+# targets are never in that set (diff excludes deletions), so a deleted
+# baseline path is caught on the next `--all` rather than red-lining unrelated
+# PRs — same blast-radius contract as the cleaned-up / out-of-set branches.
 if ((apply_baseline)) && ((${#baseline_entries[@]} > 0)); then
   for entry in "${baseline_entries[@]}"; do
-    if [[ ! -f "$entry" ]]; then
-      echo "STALE BASELINE: $BASELINE: '$entry' names a missing file — remove it" >&2
-      violations=$((violations + 1))
-      continue
-    fi
-    # --all visits every scannable file, so absence from baseline_still_hot
-    # means the file scanned clean. Diff mode only sees changed files: an
-    # untouched baseline entry is not re-proven here (changed-file scoping),
-    # and is checked the next time it is edited or via --all.
     if [[ "$mode" == "--all" || -n "${files_in_scope[$entry]:-}" ]]; then
+      if [[ ! -f "$entry" ]]; then
+        echo "STALE BASELINE: $BASELINE: '$entry' names a missing file — remove it" >&2
+        violations=$((violations + 1))
+        continue
+      fi
       if [[ -z "${baseline_still_hot[$entry]:-}" ]]; then
         # Confirm scannable rather than trusting set membership alone: a
         # baseline entry that is_scannable rejected (vendor/evals) must still

--- a/scripts/check-shell-portability.sh
+++ b/scripts/check-shell-portability.sh
@@ -1,15 +1,19 @@
 #!/usr/bin/env bash
 # Shell-portability-lint gate (#1491): flags GNU-only shell constructs in
-# changed **/*.sh files — a class no existing gate covers. `shellcheck` lints
-# shell syntax/style; scripts/check-skill-portability.sh (#531) matches
-# skill-coupling tokens (stack/forge/branch/tracker defaults) against changed
-# *skill* files only. Neither has GNU-vs-BSD regex/flag vocabulary, and no
-# runner in this repo's CI uses BSD userland (a Windows runner's Git Bash still
-# ships GNU grep/sed, so it would not help either) — the exposure is macOS
-# system grep/sed/date/stat/mktemp/sort, unreachable from any lane here.
+# changed **/*.sh files and in skill markdown under plugins/*/skills/ (#2704)
+# — a class no existing gate covers. Skill markdown is not documentation about
+# code: for a skill, the markdown IS the executable surface an agent reads and
+# runs, so a GNU-only construct there fails on macOS exactly as it would in a
+# .sh file. `shellcheck` lints shell syntax/style; scripts/check-skill-portability.sh
+# (#531) matches skill-coupling tokens (stack/forge/branch/tracker defaults)
+# against changed *skill* files only. Neither has GNU-vs-BSD regex/flag
+# vocabulary, and no runner in this repo's CI uses BSD userland (a Windows
+# runner's Git Bash still ships GNU grep/sed, so it would not help either) —
+# the exposure is macOS system grep/sed/date/stat/mktemp/sort, unreachable
+# from any lane here.
 #
-#   scripts/check-shell-portability.sh <base-ref>   gate .sh files a PR changed
-#   scripts/check-shell-portability.sh --all         audit every tracked .sh file
+#   scripts/check-shell-portability.sh <base-ref>   gate .sh + skill .md a PR changed
+#   scripts/check-shell-portability.sh --all         audit every tracked .sh + skill .md
 #   scripts/check-shell-portability.sh --paths F...   scan exactly these files
 #
 # WHAT is detected is data, not logic: the construct list lives in
@@ -139,6 +143,15 @@ case "$TOKENS" in
 *) TOKENS="./$TOKENS" ;;
 esac
 
+# Pre-existing skill-markdown debt (#2704): widening selection onto every
+# SKILL.md / context/*.md / reference/*.md that already carries a token hit
+# would be a flag day. scripts/shell-portability-skill-md-baseline.txt
+# grandfathers today's measured hits so CI-facing modes gate NEW and CHANGED
+# skill markdown first; the baseline shrinks (a stale entry — file missing or
+# clean — fails the gate). --paths never consults it: that mode is the audit
+# tool that measured the backlog and must keep seeing every hit.
+BASELINE="${SHELL_PORTABILITY_MD_BASELINE:-scripts/shell-portability-skill-md-baseline.txt}"
+
 usage() {
   printf 'usage: check-shell-portability.sh <base-ref> | --all | --paths FILE...\n' >&2
   exit 2
@@ -146,7 +159,10 @@ usage() {
 
 # is_scannable <path> — a shell file this gate is responsible for. Vendor/
 # upstream-synced copies carry their own drift gate, not this contract.
-# Likewise the cross-plugin sync copies registered in
+# Skill markdown under plugins/*/skills/ is in scope (#2704): agents execute
+# shell snippets from those files. evals/ carries adversarial fixture prompts
+# by design (same exclusion check-skill-portability.sh uses). Likewise the
+# cross-plugin sync copies registered in
 # scripts/cross-plugin-source-registry.txt: a dedicated gate holds each copy
 # byte-identical to its in-repo SOURCE, so the source is where this contract
 # gates a change — scanning each copy would flag content no copy edit is
@@ -154,8 +170,9 @@ usage() {
 is_scannable() {
   local f="$1"
   case "$f" in
-  */vendor/*) return 1 ;;
+  */vendor/* | */evals/*) return 1 ;;
   *.sh) ;;
+  plugins/*/skills/*.md) ;;
   *) return 1 ;;
   esac
   local registry="scripts/cross-plugin-source-registry.txt" rel line
@@ -170,8 +187,25 @@ is_scannable() {
   return 0
 }
 
+# Active baseline entries: exact repo-relative paths, full-string equality.
+# SHELL_PORTABILITY_MD_BASELINE overrides the path (test injection).
+baseline_entries=()
+if [[ -f "$BASELINE" ]]; then
+  mapfile -t baseline_entries < <(sed -E 's/#.*//; s/^[[:space:]]+//; s/[[:space:]]+$//' "$BASELINE" | grep -v '^$' || true)
+fi
+
+# baselined <path> — 0 when the path is on the skill-md backlog list.
+baselined() {
+  local path="$1" entry
+  for entry in "${baseline_entries[@]}"; do
+    [[ "$path" == "$entry" ]] && return 0
+  done
+  return 1
+}
+
 # Resolve the file set for the requested mode.
 files=()
+apply_baseline=0
 if (($# == 0)); then
   usage
 fi
@@ -181,13 +215,20 @@ case "$mode" in
 --all)
   shift
   (($# == 0)) || usage
+  apply_baseline=1
   while IFS= read -r f; do
     is_scannable "$f" && files+=("$f")
-  done < <(find . -type f -name '*.sh' -not -path '*/node_modules/*' -not -path '*/.git/*' | sed 's|^\./||' | sort)
+  done < <(
+    {
+      find . -type f -name '*.sh' -not -path '*/node_modules/*' -not -path '*/.git/*'
+      find plugins -type f -path 'plugins/*/skills/*' -name '*.md' -not -path '*/node_modules/*' -not -path '*/.git/*' 2>/dev/null
+    } | sed 's|^\./||' | sort -u
+  )
   ;;
 --paths)
   shift
   (($# > 0)) || usage
+  # --paths is the audit tool: scan exactly what was asked, no baseline skip.
   files=("$@")
   ;;
 -*)
@@ -198,19 +239,24 @@ case "$mode" in
   base="$mode"
   shift
   (($# == 0)) || usage
+  apply_baseline=1
   if ! git rev-parse --verify --quiet "${base}^{commit}" >/dev/null; then
     printf 'Error: base ref %s is not a valid commit\n' "$base" >&2
     exit 2
   fi
   # NUL-delimited (-z) so a pathname Git would C-quote (non-ASCII bytes under
   # the default core.quotePath, or a literal quote/backslash) arrives verbatim
-  # — a quoted path would miss the *.sh suffix check below and be silently
-  # dropped, the exact silent exclusion the contract forbids.
+  # — a quoted path would miss the *.sh / skill-md suffix check below and be
+  # silently dropped, the exact silent exclusion the contract forbids.
+  # Diff plugins/ in addition to *.sh so skill markdown under
+  # plugins/*/skills/ reaches is_scannable (#2704); a plugins/*/skills/
+  # pathspec alone does not match under git's default (non-pathname) globbing
+  # (same rationale as check-skill-portability.sh).
   while IFS= read -r -d '' f; do
     is_scannable "$f" || continue
     [[ -f "$f" ]] || continue # a rename-away/deletion leaves nothing to scan
     files+=("$f")
-  done < <(git diff --name-only --diff-filter=d -z "$base" -- '*.sh' | sort -z -u)
+  done < <(git diff --name-only --diff-filter=d -z "$base" -- '*.sh' 'plugins/' | sort -z -u)
   ;;
 esac
 
@@ -1684,7 +1730,13 @@ violations=0
 # Printed unconditionally it followed every `grep -P` and `sed -i` failure with
 # advice about an ampersand the developer never wrote.
 amp_violation=0
+# Baselined skill-md paths that still produced at least one hit this run — used
+# by the stale-baseline guard below so a cleaned-up file cannot linger on the
+# backlog list.
+declare -A baseline_still_hot=()
+declare -A files_in_scope=()
 for file in "${files[@]}"; do
+  files_in_scope["$file"]=1
   if [[ ! -f "$file" ]]; then
     printf 'Error: no such file: %s\n' "$file" >&2
     exit 2
@@ -1697,6 +1749,11 @@ for file in "${files[@]}"; do
     exit 2
   }
   if [[ -n "$out" ]]; then
+    # shellcheck disable=SC2310 # baselined only walks a static array
+    if ((apply_baseline)) && baselined "$file"; then
+      baseline_still_hot["$file"]=1
+      continue
+    fi
     while IFS= read -r v; do
       echo "PORTABILITY: ${file}:${v}" >&2
       violations=$((violations + 1))
@@ -1707,6 +1764,37 @@ for file in "${files[@]}"; do
     done <<<"$out"
   fi
 done
+
+# Stale-baseline guard (CI-facing modes only): every entry must name a skill-md
+# file that still carries at least one unexcused hit when scanned. A missing
+# file or a cleaned-up file must leave the list — same shrink-only contract as
+# scripts/orphaned-fixtures-baseline.txt / hook-userconfig-argv-allowlist.txt.
+if ((apply_baseline)) && ((${#baseline_entries[@]} > 0)); then
+  for entry in "${baseline_entries[@]}"; do
+    if [[ ! -f "$entry" ]]; then
+      echo "STALE BASELINE: $BASELINE: '$entry' names a missing file — remove it" >&2
+      violations=$((violations + 1))
+      continue
+    fi
+    # --all visits every scannable file, so absence from baseline_still_hot
+    # means the file scanned clean. Diff mode only sees changed files: an
+    # untouched baseline entry is not re-proven here (changed-file scoping),
+    # and is checked the next time it is edited or via --all.
+    if [[ "$mode" == "--all" || -n "${files_in_scope[$entry]:-}" ]]; then
+      if [[ -z "${baseline_still_hot[$entry]:-}" ]]; then
+        # Confirm scannable rather than trusting set membership alone: a
+        # baseline entry that is_scannable rejected (vendor/evals) must still
+        # be shed.
+        if is_scannable "$entry"; then
+          echo "STALE BASELINE: $BASELINE: '$entry' no longer has unexcused hits — remove it" >&2
+        else
+          echo "STALE BASELINE: $BASELINE: '$entry' is outside the scannable skill-md set — remove it" >&2
+        fi
+        violations=$((violations + 1))
+      fi
+    fi
+  done
+fi
 
 if ((violations > 0)); then
   {

--- a/scripts/check-shell-portability.test.sh
+++ b/scripts/check-shell-portability.test.sh
@@ -1501,21 +1501,27 @@ else
 fi
 
 # =============================================================================
-# Scope resolution: --all excludes vendor/, non-.sh files stay out of scope
+# Scope resolution: --all excludes vendor/evals; skill .md is in scope (#2704)
 # =============================================================================
 
 fx="$(mktemp -d)"
-mkdir -p "$fx/scripts" "$fx/plugins/alpha/vendor"
+mkdir -p "$fx/scripts" "$fx/plugins/alpha/vendor" "$fx/plugins/alpha/skills/demo/evals" \
+  "$fx/plugins/alpha/skills/demo/context"
 cp "$SCRIPT" "$fx/scripts/"
 printf '%s\n' 'grep -Eq "\\bfoo\\b" "$file"' >"$fx/plugins/alpha/gate.sh"
 printf '%s\n' 'grep -Eq "\\bfoo\\b" "$file"' >"$fx/plugins/alpha/vendor/upstream.sh"
-printf '%s\n' 'grep -Eq "\\bfoo\\b" "$file"' >"$fx/plugins/alpha/notes.md" # non-.sh stays out of scope
+printf '%s\n' 'grep -Eq "\\bfoo\\b" "$file"' >"$fx/plugins/alpha/notes.md" # non-skill .md stays out
+printf '%s\n' 'grep -Eq "\\bfoo\\b" "$file"' >"$fx/plugins/alpha/skills/demo/SKILL.md"
+printf '%s\n' 'grep -Eq "\\bfoo\\b" "$file"' >"$fx/plugins/alpha/skills/demo/context/run.md"
+printf '%s\n' 'grep -Eq "\\bfoo\\b" "$file"' >"$fx/plugins/alpha/skills/demo/evals/adversarial.md"
 out="$(cd "$fx" && SHELL_PORTABILITY_TOKENS="$(one_token_list '\\b')" bash scripts/check-shell-portability.sh --all 2>&1)"
 rc=$?
 if [[ "$rc" -ne 0 ]] &&
   echo "$out" | grep -q 'gate.sh' &&
-  ! echo "$out" | grep -qE 'vendor/|notes\.md'; then
-  ok "--all scans gate.sh but excludes vendor/ and non-.sh files"
+  echo "$out" | grep -q 'SKILL\.md' &&
+  echo "$out" | grep -q 'context/run\.md' &&
+  ! echo "$out" | grep -qE 'vendor/|notes\.md|evals/'; then
+  ok "--all scans .sh and skill .md but excludes vendor/, evals/, and non-skill .md"
 else
   fail "--all exclusion set wrong (rc=$rc): $out"
 fi
@@ -1528,6 +1534,71 @@ if (cd "$fx" && SHELL_PORTABILITY_TOKENS="$(one_token_list '\\b')" bash scripts/
   ok "an empty tree passes"
 else
   fail "an empty tree should pass"
+fi
+rm -rf "$fx"
+
+# --- diff-mode gates a changed skill markdown file (#2704) -----------------
+fx="$(mktemp -d)"
+mkdir -p "$fx/scripts" "$fx/plugins/alpha/skills/demo/context"
+cp "$SCRIPT" "$fx/scripts/"
+out="$(
+  cd "$fx" &&
+    git init -q &&
+    git config user.email test@example.com &&
+    git config user.name test &&
+    git commit -q --allow-empty -m base &&
+    base="$(git rev-parse HEAD)" &&
+    printf '%s\n' 'stat -c %Y "$f"' >'plugins/alpha/skills/demo/context/mtime.md' &&
+    git add -A >/dev/null 2>&1 &&
+    git commit -q -m add-skill-md &&
+    SHELL_PORTABILITY_TOKENS="$(one_token_list 'stat[[:space:]]+-c')" bash scripts/check-shell-portability.sh "$base" 2>&1
+)"
+rc=$?
+if [[ "$rc" -ne 0 ]] && echo "$out" | grep -q 'mtime\.md'; then
+  ok "diff-mode gates a changed skill markdown file (#2704)"
+else
+  fail "diff-mode should flag changed skill .md (rc=$rc): $out"
+fi
+rm -rf "$fx"
+
+# --- skill-md baseline grandfathers backlog; --paths still sees it (#2704) -
+fx="$(mktemp -d)"
+mkdir -p "$fx/scripts" "$fx/plugins/alpha/skills/demo"
+cp "$SCRIPT" "$fx/scripts/"
+printf '%s\n' 'grep -Eq "\\bfoo\\b" "$file"' >"$fx/plugins/alpha/skills/demo/SKILL.md"
+printf '%s\n' 'plugins/alpha/skills/demo/SKILL.md' >"$fx/scripts/shell-portability-skill-md-baseline.txt"
+out="$(
+  cd "$fx" &&
+    SHELL_PORTABILITY_TOKENS="$(one_token_list '\\b')" bash scripts/check-shell-portability.sh --all 2>&1
+)"
+rc=$?
+if [[ "$rc" -eq 0 ]] && echo "$out" | grep -q 'No unexcused'; then
+  ok "skill-md baseline grandfathers a known hit under --all"
+else
+  fail "baselined skill .md should pass --all (rc=$rc): $out"
+fi
+out="$(
+  cd "$fx" &&
+    SHELL_PORTABILITY_TOKENS="$(one_token_list '\\b')" bash scripts/check-shell-portability.sh --paths \
+      plugins/alpha/skills/demo/SKILL.md 2>&1
+)"
+rc=$?
+if [[ "$rc" -ne 0 ]] && echo "$out" | grep -q 'PORTABILITY:.*SKILL\.md'; then
+  ok "--paths ignores the skill-md baseline (audit mode)"
+else
+  fail "--paths should still flag a baselined file (rc=$rc): $out"
+fi
+# Stale: clean up the file but leave the baseline entry.
+printf '%s\n' 'echo clean' >"$fx/plugins/alpha/skills/demo/SKILL.md"
+out="$(
+  cd "$fx" &&
+    SHELL_PORTABILITY_TOKENS="$(one_token_list '\\b')" bash scripts/check-shell-portability.sh --all 2>&1
+)"
+rc=$?
+if [[ "$rc" -ne 0 ]] && echo "$out" | grep -q 'STALE BASELINE'; then
+  ok "a cleaned-up skill-md baseline entry fails as stale"
+else
+  fail "stale baseline entry should fail (rc=$rc): $out"
 fi
 rm -rf "$fx"
 

--- a/scripts/check-shell-portability.test.sh
+++ b/scripts/check-shell-portability.test.sh
@@ -1600,6 +1600,36 @@ if [[ "$rc" -ne 0 ]] && echo "$out" | grep -q 'STALE BASELINE'; then
 else
   fail "stale baseline entry should fail (rc=$rc): $out"
 fi
+# Stale: missing file under --all.
+rm -f "$fx/plugins/alpha/skills/demo/SKILL.md"
+out="$(
+  cd "$fx" &&
+    SHELL_PORTABILITY_TOKENS="$(one_token_list '\\b')" bash scripts/check-shell-portability.sh --all 2>&1
+)"
+rc=$?
+if [[ "$rc" -ne 0 ]] && echo "$out" | grep -q "names a missing file"; then
+  ok "a missing skill-md baseline entry fails as stale under --all"
+else
+  fail "missing baseline entry should fail under --all (rc=$rc): $out"
+fi
+# Restore a hot file, then move it under vendor/ (outside scannable set).
+mkdir -p "$fx/plugins/alpha/skills/demo"
+printf '%s\n' 'word-boundary \\b token' >"$fx/plugins/alpha/skills/demo/SKILL.md"
+mkdir -p "$fx/plugins/alpha/skills/demo/vendor"
+mv "$fx/plugins/alpha/skills/demo/SKILL.md" "$fx/plugins/alpha/skills/demo/vendor/SKILL.md"
+# Baseline still names the old (now missing) path — covered above. Point the
+# baseline at the vendor path to exercise the outside-scannable branch.
+printf '%s\n' 'plugins/alpha/skills/demo/vendor/SKILL.md' >"$fx/scripts/shell-portability-skill-md-baseline.txt"
+out="$(
+  cd "$fx" &&
+    SHELL_PORTABILITY_TOKENS="$(one_token_list '\\b')" bash scripts/check-shell-portability.sh --all 2>&1
+)"
+rc=$?
+if [[ "$rc" -ne 0 ]] && echo "$out" | grep -q 'outside the scannable skill-md set'; then
+  ok "a vendor/-moved skill-md baseline entry fails as outside-scannable"
+else
+  fail "outside-scannable baseline entry should fail (rc=$rc): $out"
+fi
 rm -rf "$fx"
 
 # --- diff-mode reads a Git-quoted (non-ASCII) changed path -----------------

--- a/scripts/shell-portability-skill-md-baseline.txt
+++ b/scripts/shell-portability-skill-md-baseline.txt
@@ -1,0 +1,52 @@
+# Grandfathered skill-markdown debt for scripts/check-shell-portability.sh
+# (#2704). Widening the gate onto plugins/*/skills/**/*.md newly surfaces
+# today's measured hits — mostly Windows path prose (`C:\Users\…`,
+# `HKCU\SOFTWARE\…`) that collide with the bare `\\b`/`\\s`/`\\w` token class,
+# intentional regex documentation in docs-hygiene rename-references, and a
+# handful of markdown-structure false positives (inline backticks / fenced
+# PowerShell `-Profile` joined across records by the shell quote tracker).
+# That is backlog, not a flag day: CI-facing modes (--all and <base-ref>) skip
+# these paths so NEW and CHANGED skill markdown is gated first; --paths never
+# consults this list (it is the audit tool that measured the debt).
+#
+# Each line is one exact repo-relative path, matched by full-string EQUALITY
+# (not prefix). An entry is a standing promise the debt is tracked; the gate
+# fails on a STALE entry (file missing, outside the scannable skill-md set, or
+# no longer carrying an unexcused hit), so the list can only shrink. Do NOT add
+# a path here to dodge the gate on NEW work — fix the construct, add a
+# `portability-ok: <reason>` site annotation, or a whole-file
+# `portability-scope: <reason>` declaration.
+
+plugins/claude-config/skills/audit-permission-grants/reference/criteria.md
+plugins/claude-config/skills/audit/reference/audit-checklist.md
+plugins/claude-config/skills/audit/SKILL.md
+plugins/claude-memory/skills/stateless/reference/official-guidance.md
+plugins/claude-memory/skills/stateless/SKILL.md
+plugins/claude-ops/skills/observability/context/data-sources.md
+plugins/claude-ops/skills/observability/context/operator-setup-retention.md
+plugins/claude-ops/skills/plugins/context/scope-semantics.md
+plugins/discovery/skills/explore/reference/ecosystem-discovery.md
+plugins/disk-hygiene/skills/clean/reference/safety-model.md
+plugins/disk-hygiene/skills/setup/SKILL.md
+plugins/docs-hygiene/skills/rename-references/context/apply.md
+plugins/docs-hygiene/skills/rename-references/context/audit.md
+plugins/docs-hygiene/skills/rename-references/context/audit-modes.md
+plugins/docs-hygiene/skills/rename-references/context/patterns.md
+plugins/docs-hygiene/skills/rename-references/context/triage.md
+plugins/docs-hygiene/skills/rename-references/SKILL.md
+plugins/education/skills/quiz-me/SKILL.md
+plugins/kindle-dedrm/skills/manage/references/troubleshooting.md
+plugins/kindle-dedrm/skills/manage/references/workflow.md
+plugins/knowledge/skills/course-digest/reference/adapters/discovery-checklist.md
+plugins/knowledge/skills/course-digest/reference/adapters/dometrain.md
+plugins/machine-health/skills/audit/README.md
+plugins/machine-health/skills/audit/references/shared/discovery-guide.md
+plugins/machine-health/skills/audit/references/shared/testing.md
+plugins/machine-health/skills/audit/references/windows/check-catalog.md
+plugins/machine-health/skills/audit/references/windows/elevation-matrix.md
+plugins/machine-health/skills/audit/references/windows/remediation-policy.md
+plugins/playwright/skills/playwright/reference/snapshots-and-refs.md
+plugins/skill-quality/skills/check/reference/fresh-eyes-declarations.md
+plugins/source-control/skills/setup/SKILL.md
+plugins/toolchain/skills/check/context/powershell.md
+plugins/work-items/skills/scan-todos/SKILL.md

--- a/scripts/shell-portability-tokens.txt
+++ b/scripts/shell-portability-tokens.txt
@@ -1,14 +1,16 @@
 # Shell-portability-lint token list (issue #1491). Each ACTIVE line is one ERE
 # pattern that scripts/check-shell-portability.sh matches, line-by-line, against
-# changed **/*.sh files. Detects GNU-only constructs that a BSD userland (macOS
-# system grep/sed/date/stat/mktemp/sort — the one platform no CI runner in this
-# repo covers; a Windows runner's Git Bash still ships GNU grep/sed) either
-# rejects outright or silently reinterprets. The motivating near-miss: a
-# `grep -Eq '\brequire\b'` word-boundary escape in
-# plugins/markdown-format/hooks/markdown-format.sh would have made a security
-# predicate fail OPEN (return "nothing unpinnable found" for every input) on
-# BSD grep, with no test on a GNU runner able to catch it. The fix (now on
-# main) is the reference implementation this gate self-tests against.
+# changed **/*.sh files and skill markdown under plugins/*/skills/ (#2704).
+# Detects GNU-only constructs that a BSD userland (macOS system grep/sed/date/
+# stat/mktemp/sort — the one platform no CI runner in this repo covers; a
+# Windows runner's Git Bash still ships GNU grep/sed) either rejects outright
+# or silently reinterprets. The motivating near-miss: a `grep -Eq '\brequire\b'`
+# word-boundary escape in plugins/markdown-format/hooks/markdown-format.sh
+# would have made a security predicate fail OPEN (return "nothing unpinnable
+# found" for every input) on BSD grep, with no test on a GNU runner able to
+# catch it. The fix (now on main) is the reference implementation this gate
+# self-tests against. Skill-markdown backlog lives in
+# scripts/shell-portability-skill-md-baseline.txt, not here.
 #
 # Ownership / growth: this list is the gate's data, deliberately kept OUT of the
 # script — the same shape as scripts/skill-portability-tokens.txt for the


### PR DESCRIPTION
## Summary

- Extends `scripts/check-shell-portability.sh` so CI-facing modes (`--all` and `<base-ref>`) also select skill markdown under `plugins/*/skills/**/*.md` (excluding `vendor/` and `evals/`), matching the executable surface agents actually run.
- Stages today's measured backlog (69 hits / 33 files at measure time — mostly Windows-path prose colliding with bare `\\b`/`\\s`/`\\w`, intentional docs-hygiene regex docs, and markdown-structure false positives) in `scripts/shell-portability-skill-md-baseline.txt` so new/changed skill markdown is gated first; the list is shrink-only (stale entries fail).
- `--paths` remains the unfiltered audit tool (never consults the baseline), preserving the reproduction path from #2704.

## Test plan

- [x] `bash scripts/check-shell-portability.test.sh` (PASS=331)
- [x] `--paths` on a synthetic skill md with `stat -c` fails (detector + selection)
- [x] `--paths` on a baselined skill md still reports hits (audit mode)
- [x] `--all` does not report baselined skill-md PORTABILITY lines; no STALE BASELINE
- [x] Unit coverage for skill-md `--all` / diff-mode selection, baseline grandfathering, stale baseline, and `--paths` bypass

Closes #2704

## Related

- Baseline staging is shrink-only; residual skill-md portability hits remain grandfathered until cleaned (tracked by the baseline file itself, not a separate issue).