### PR TITLE
feat(autonomy): per-identity prerequisite sections in the ten v1 routine leaves (#2718)

### DIFF
--- a/plugins/autonomy/.claude-plugin/plugin.json
+++ b/plugins/autonomy/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "autonomy",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "description": "Governed autonomous agent operation: role-topology, binding-seam, wiring-vs-advisor, telemetry, return-accounting, trigger-dispatch, per-work-class guardrail-matrix, standing-routine-catalog, and design-only runner-charter contracts for climbing the AI-adoption ladder, plus a guided-setup skill that discovers an adopting org's state, writes its schema-versioned binding, wires standards-pinned OTLP emission with a zero-cost file-artifact default, wires human-attested return capture at the task boundary, wires signal adapters with one governed dispatch entrypoint, binds the five-class guardrail matrix to an org's isolation substrates with an in-boundary live-validation probe before recording each fail-closed binding, and stands up standing-routine-catalog classes as scheduled temporal signal adapters behind the one governed queue with free scheduling defaults wired as reviewable changes and each routine's work-class mapping homed on the security surface.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/autonomy/CHANGELOG.md
+++ b/plugins/autonomy/CHANGELOG.md
@@ -3,6 +3,19 @@
 All notable changes to the `autonomy` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.19.0]
+
+### Added
+
+- **Per-identity prerequisite sections on every `v1` routine leaf** (#2718). Each of the ten
+  leaves under `reference/routines/` gains a `## Prerequisites` section owning Access class,
+  isolation floor, connector entitlements (and which rung owns each), `executor_class` merge
+  cap, and repo needs — derived through the Phase 1 vocabulary in
+  `prerequisite-resolution.md`, with floors and the merge cap cited from the guardrail slice
+  rather than re-derived. Posture-divergent classes (`dependency-update-wave`,
+  `doc-freshness-sweep`, `ci-health-review`) show distinct prerequisite sets per identity.
+  Verdict tokens are `supported` | `conditional` | `unsupported` | `unknown`.
+
 ## [0.18.0]
 
 ### Added

--- a/plugins/autonomy/reference/routines/advisory-cve-triage.md
+++ b/plugins/autonomy/reference/routines/advisory-cve-triage.md
@@ -52,6 +52,28 @@ The row is derived through the catalog's mapping rules, never hand-assigned:
 
 Derived row: `C1`.
 
+## Prerequisites
+
+Per-identity needs under
+[routine prerequisite resolution](../prerequisite-resolution.md). Axes derive through the
+catalog mapping rules; the isolation floor and `executor_class` merge cap are cited from the
+guardrail slice, never re-derived. Resolution verdicts use `supported` | `conditional` |
+`unsupported` | `unknown`.
+
+Single-posture identity: `advisory-cve-triage` (bare class token). Valid only inside the
+curated-advisory-database boundary stated in the derived row — widening to arbitrary
+attacker-writable web content is out of this identity's prerequisite set (it would re-derive
+`C5`, a different identity).
+
+| Axis | Value |
+|---|---|
+| Access class | `repo` |
+| Isolation floor | `L2` — cited from the [matrix](../guardrails.md#the-matrix) `C1` row and the [unattended floor](../guardrails/isolation-ladder.md#unattended-floor) |
+| Connector entitlements | none — `repo` access; the connector branch of [Access to prerequisites](../routines.md#access-to-prerequisites) does not apply |
+| Connector entitlement rung | n/a (no connector). For `prod` / `product` / `org` / `ext`, entitlement binds at the [Org binding layer](../binding-seam.md#resolution-ladder) |
+| `executor_class` merge cap | cited from [executor surface classes](../trigger-dispatch.md#executor-surface-classes) — security-binding `executor_class`; `vendor-hosted` caps every class at human-gated merge; never repo-derivable. Merge policy for this identity is n/a (`C1`) |
+| Repo needs | dependency / build manifests (repo-file probe); a curated advisory-database source reachable on the bound scheduling surface (declared or probed). Unreachable curated source → `unsupported` or `unknown`, never a silent widen to attacker-writable web content |
+
 ## Admission and escalation
 
 Admission disposition and fan-out caps for the derived class come from the

--- a/plugins/autonomy/reference/routines/backlog-readiness-check.md
+++ b/plugins/autonomy/reference/routines/backlog-readiness-check.md
@@ -75,7 +75,7 @@ Single-posture identity: `backlog-readiness-check` (bare class token).
 | Connector entitlements | none — `repo` access; the connector branch of [Access to prerequisites](../routines.md#access-to-prerequisites) does not apply |
 | Connector entitlement rung | n/a (no connector). For `prod` / `product` / `org` / `ext`, entitlement binds at the [Org binding layer](../binding-seam.md#resolution-ladder) |
 | `executor_class` merge cap | cited from [executor surface classes](../trigger-dispatch.md#executor-surface-classes) — security-binding `executor_class`; `vendor-hosted` caps every class at human-gated merge; never repo-derivable. Merge policy for this identity is n/a (`C1`) |
-| Repo needs | tracker binding via the work-item tracker seam (`.work-item-tracker.json` + adapter `capabilities.json`); absence is `unknown` per the composition fallback |
+| Repo needs | tracker binding via the work-item tracker seam (`.work-item-tracker.json` + adapter `capabilities.json`); a deterministic repo-file probe that finds those files absent is `unsupported`; `unknown` only when the work-item seam cannot establish the fact (composition fallback) |
 
 ## Admission and escalation
 

--- a/plugins/autonomy/reference/routines/backlog-readiness-check.md
+++ b/plugins/autonomy/reference/routines/backlog-readiness-check.md
@@ -58,6 +58,25 @@ The row is derived through the catalog-to-matrix mapping rules in the
 
 Derived row: `C1` in the [guardrail matrix](../guardrails.md).
 
+## Prerequisites
+
+Per-identity needs under
+[routine prerequisite resolution](../prerequisite-resolution.md). Axes derive through the
+catalog mapping rules; the isolation floor and `executor_class` merge cap are cited from the
+guardrail slice, never re-derived. Resolution verdicts use `supported` | `conditional` |
+`unsupported` | `unknown`.
+
+Single-posture identity: `backlog-readiness-check` (bare class token).
+
+| Axis | Value |
+|---|---|
+| Access class | `repo` |
+| Isolation floor | `L2` — cited from the [matrix](../guardrails.md#the-matrix) `C1` row and the [unattended floor](../guardrails/isolation-ladder.md#unattended-floor) |
+| Connector entitlements | none — `repo` access; the connector branch of [Access to prerequisites](../routines.md#access-to-prerequisites) does not apply |
+| Connector entitlement rung | n/a (no connector). For `prod` / `product` / `org` / `ext`, entitlement binds at the [Org binding layer](../binding-seam.md#resolution-ladder) |
+| `executor_class` merge cap | cited from [executor surface classes](../trigger-dispatch.md#executor-surface-classes) — security-binding `executor_class`; `vendor-hosted` caps every class at human-gated merge; never repo-derivable. Merge policy for this identity is n/a (`C1`) |
+| Repo needs | tracker binding via the work-item tracker seam (`.work-item-tracker.json` + adapter `capabilities.json`); absence is `unknown` per the composition fallback |
+
 ## Admission and escalation
 
 Admission disposition, caps, and fail-closed behavior are imported by citation from the

--- a/plugins/autonomy/reference/routines/ci-health-review.md
+++ b/plugins/autonomy/reference/routines/ci-health-review.md
@@ -55,6 +55,37 @@ posture-qualified identities per the [catalog](../routines.md)'s binding rules �
 class token is not bindable for a multi-posture class; the posture the org enables picks
 the identity it binds.
 
+## Prerequisites
+
+Per-identity needs under
+[routine prerequisite resolution](../prerequisite-resolution.md). Axes derive through the
+catalog mapping rules; the isolation floor and `executor_class` merge cap are cited from the
+guardrail slice, never re-derived. Resolution verdicts use `supported` | `conditional` |
+`unsupported` | `unknown`. The two postures diverge on merge-path needs — different
+prerequisite sets for the same class.
+
+### `ci-health-review/advisory`
+
+| Axis | Value |
+|---|---|
+| Access class | `repo` |
+| Isolation floor | `L2` — cited from the [matrix](../guardrails.md#the-matrix) `C1` row and the [unattended floor](../guardrails/isolation-ladder.md#unattended-floor) |
+| Connector entitlements | none — `repo` access; the connector branch of [Access to prerequisites](../routines.md#access-to-prerequisites) does not apply |
+| Connector entitlement rung | n/a (no connector). For `prod` / `product` / `org` / `ext`, entitlement binds at the [Org binding layer](../binding-seam.md#resolution-ladder) |
+| `executor_class` merge cap | cited from [executor surface classes](../trigger-dispatch.md#executor-surface-classes) — security-binding `executor_class`; `vendor-hosted` caps every class at human-gated merge; never repo-derivable. Merge policy for this identity is n/a (`C1`) |
+| Repo needs | CI-config presence (ownerless repo-file probe owned by the resolution contract); tracker binding when filing work items through the work-item tracker seam |
+
+### `ci-health-review/ci-config-change`
+
+| Axis | Value |
+|---|---|
+| Access class | `repo` |
+| Isolation floor | `L2` — cited from the [matrix](../guardrails.md#the-matrix) `C4` row and the [unattended floor](../guardrails/isolation-ladder.md#unattended-floor) |
+| Connector entitlements | none — `repo` access; the connector branch of [Access to prerequisites](../routines.md#access-to-prerequisites) does not apply |
+| Connector entitlement rung | n/a (no connector). For `prod` / `product` / `org` / `ext`, entitlement binds at the [Org binding layer](../binding-seam.md#resolution-ladder) |
+| `executor_class` merge cap | cited from [executor surface classes](../trigger-dispatch.md#executor-surface-classes) — security-binding `executor_class`; `vendor-hosted` caps every class at human-gated merge; never repo-derivable. `C4` is human merge always; the cap still binds |
+| Repo needs | everything `advisory` requires, plus a merge-bearing path through the matrix for the gated CI-config change — the identity is not eligible where the bound surface cannot carry a merge-policy disposition |
+
 ## Admission and escalation
 
 Admission disposition and fan-out caps for the derived class come from the

--- a/plugins/autonomy/reference/routines/dependency-update-wave.md
+++ b/plugins/autonomy/reference/routines/dependency-update-wave.md
@@ -63,6 +63,37 @@ keys admission classification by these posture-qualified identities per the
 [catalog](../routines.md)'s binding rules — the bare class token is not bindable for a
 multi-posture class; the posture the org enables picks the identity it binds.
 
+## Prerequisites
+
+Per-identity needs under
+[routine prerequisite resolution](../prerequisite-resolution.md). Axes derive through the
+catalog mapping rules; the isolation floor and `executor_class` merge cap are cited from the
+guardrail slice, never re-derived. Resolution verdicts use `supported` | `conditional` |
+`unsupported` | `unknown`. The two postures diverge — different floors and different
+repo-need sets — which is the grain argument made concrete.
+
+### `dependency-update-wave/mechanical`
+
+| Axis | Value |
+|---|---|
+| Access class | `repo` |
+| Isolation floor | `L2` — cited from the [matrix](../guardrails.md#the-matrix) `C2` row and the [unattended floor](../guardrails/isolation-ladder.md#unattended-floor) |
+| Connector entitlements | none — `repo` access; the connector branch of [Access to prerequisites](../routines.md#access-to-prerequisites) does not apply |
+| Connector entitlement rung | n/a (no connector). For `prod` / `product` / `org` / `ext`, entitlement binds at the [Org binding layer](../binding-seam.md#resolution-ladder) |
+| `executor_class` merge cap | cited from [executor surface classes](../trigger-dispatch.md#executor-surface-classes) — security-binding `executor_class`; `vendor-hosted` caps every class at human-gated merge; never repo-derivable. Binds the `C2` merge-policy column |
+| Repo needs | dependency / build manifests (repo-file probe); CI-config presence (ownerless repo-file probe) so the mechanical CI verdict exists; ecosystems via the toolchain seam when installed (fallback: inference from the repo's own build files) |
+
+### `dependency-update-wave/changelog-informed`
+
+| Axis | Value |
+|---|---|
+| Access class | `repo` |
+| Isolation floor | `L3` — cited from the [matrix](../guardrails.md#the-matrix) `C5` row (untrusted-provenance / kernel-separated floor), not re-derived here |
+| Connector entitlements | none — Access class remains `repo`; the untrusted-provenance axis raises the floor without changing Access |
+| Connector entitlement rung | n/a (no connector). For `prod` / `product` / `org` / `ext`, entitlement binds at the [Org binding layer](../binding-seam.md#resolution-ladder) |
+| `executor_class` merge cap | cited from [executor surface classes](../trigger-dispatch.md#executor-surface-classes) — security-binding `executor_class`; `vendor-hosted` caps every class at human-gated merge; never repo-derivable. `C5` is human merge always; the cap still binds |
+| Repo needs | everything `mechanical` requires, plus reachable upstream release-note / changelog content in the reasoning loop (attacker-writable external prose). On a scheduled run that cannot establish that read path, the identity resolves `unsupported` or `unknown` — never a silent fall-back to the mechanical posture |
+
 ## Admission and escalation
 
 Admission disposition and fan-out caps for the derived class come from the

--- a/plugins/autonomy/reference/routines/doc-freshness-sweep.md
+++ b/plugins/autonomy/reference/routines/doc-freshness-sweep.md
@@ -78,6 +78,37 @@ path, `C3`). An org's security binding keys admission classification by these
 posture-qualified identities — the bare class token is not bindable for a multi-posture
 class.
 
+## Prerequisites
+
+Per-identity needs under
+[routine prerequisite resolution](../prerequisite-resolution.md). Axes derive through the
+catalog mapping rules; the isolation floor and `executor_class` merge cap are cited from the
+guardrail slice, never re-derived. Resolution verdicts use `supported` | `conditional` |
+`unsupported` | `unknown`. The two postures share Access and floor but diverge on merge-path
+needs — different prerequisite sets for the same class.
+
+### `doc-freshness-sweep/advisory`
+
+| Axis | Value |
+|---|---|
+| Access class | `repo` |
+| Isolation floor | `L2` — cited from the [matrix](../guardrails.md#the-matrix) `C1` row and the [unattended floor](../guardrails/isolation-ladder.md#unattended-floor) |
+| Connector entitlements | none — `repo` access; the connector branch of [Access to prerequisites](../routines.md#access-to-prerequisites) does not apply |
+| Connector entitlement rung | n/a (no connector). For `prod` / `product` / `org` / `ext`, entitlement binds at the [Org binding layer](../binding-seam.md#resolution-ladder) |
+| `executor_class` merge cap | cited from [executor surface classes](../trigger-dispatch.md#executor-surface-classes) — security-binding `executor_class`; `vendor-hosted` caps every class at human-gated merge; never repo-derivable. Merge policy for this identity is n/a (`C1`) |
+| Repo needs | documentation corpus and the subject code it describes (repo-file presence); tracker binding when filing work items through the work-item tracker seam |
+
+### `doc-freshness-sweep/docs-change`
+
+| Axis | Value |
+|---|---|
+| Access class | `repo` |
+| Isolation floor | `L2` — cited from the [matrix](../guardrails.md#the-matrix) `C3` row and the [unattended floor](../guardrails/isolation-ladder.md#unattended-floor) |
+| Connector entitlements | none — `repo` access; the connector branch of [Access to prerequisites](../routines.md#access-to-prerequisites) does not apply |
+| Connector entitlement rung | n/a (no connector). For `prod` / `product` / `org` / `ext`, entitlement binds at the [Org binding layer](../binding-seam.md#resolution-ladder) |
+| `executor_class` merge cap | cited from [executor surface classes](../trigger-dispatch.md#executor-surface-classes) — security-binding `executor_class`; `vendor-hosted` caps every class at human-gated merge; never repo-derivable. Binds the `C3` merge-policy column (auto-merge eligible only after promotion, and only when `executor_class` is not `vendor-hosted`) |
+| Repo needs | everything `advisory` requires, plus a merge-bearing path through the matrix for the gated docs change — the identity is not eligible where the bound surface cannot carry a merge-policy disposition |
+
 ## Admission and escalation
 
 Admission disposition, caps, and fail-closed behavior are imported by citation from the

--- a/plugins/autonomy/reference/routines/duplicate-detection-sweep.md
+++ b/plugins/autonomy/reference/routines/duplicate-detection-sweep.md
@@ -59,6 +59,25 @@ The row is derived through the catalog-to-matrix mapping rules in the
 
 Derived row: `C1` in the [guardrail matrix](../guardrails.md).
 
+## Prerequisites
+
+Per-identity needs under
+[routine prerequisite resolution](../prerequisite-resolution.md). Axes derive through the
+catalog mapping rules; the isolation floor and `executor_class` merge cap are cited from the
+guardrail slice, never re-derived. Resolution verdicts use `supported` | `conditional` |
+`unsupported` | `unknown`.
+
+Single-posture identity: `duplicate-detection-sweep` (bare class token).
+
+| Axis | Value |
+|---|---|
+| Access class | `repo` |
+| Isolation floor | `L2` — cited from the [matrix](../guardrails.md#the-matrix) `C1` row and the [unattended floor](../guardrails/isolation-ladder.md#unattended-floor) |
+| Connector entitlements | none — `repo` access; the connector branch of [Access to prerequisites](../routines.md#access-to-prerequisites) does not apply |
+| Connector entitlement rung | n/a (no connector). For `prod` / `product` / `org` / `ext`, entitlement binds at the [Org binding layer](../binding-seam.md#resolution-ladder) |
+| `executor_class` merge cap | cited from [executor surface classes](../trigger-dispatch.md#executor-surface-classes) — security-binding `executor_class`; `vendor-hosted` caps every class at human-gated merge; never repo-derivable. Merge policy for this identity is n/a (`C1`) |
+| Repo needs | tracker binding via the work-item tracker seam (`.work-item-tracker.json` + adapter `capabilities.json`); absence is `unknown` per the composition fallback |
+
 ## Admission and escalation
 
 Admission disposition, caps, and fail-closed behavior are imported by citation from the

--- a/plugins/autonomy/reference/routines/duplicate-detection-sweep.md
+++ b/plugins/autonomy/reference/routines/duplicate-detection-sweep.md
@@ -76,7 +76,7 @@ Single-posture identity: `duplicate-detection-sweep` (bare class token).
 | Connector entitlements | none — `repo` access; the connector branch of [Access to prerequisites](../routines.md#access-to-prerequisites) does not apply |
 | Connector entitlement rung | n/a (no connector). For `prod` / `product` / `org` / `ext`, entitlement binds at the [Org binding layer](../binding-seam.md#resolution-ladder) |
 | `executor_class` merge cap | cited from [executor surface classes](../trigger-dispatch.md#executor-surface-classes) — security-binding `executor_class`; `vendor-hosted` caps every class at human-gated merge; never repo-derivable. Merge policy for this identity is n/a (`C1`) |
-| Repo needs | tracker binding via the work-item tracker seam (`.work-item-tracker.json` + adapter `capabilities.json`); absence is `unknown` per the composition fallback |
+| Repo needs | tracker binding via the work-item tracker seam (`.work-item-tracker.json` + adapter `capabilities.json`); a deterministic repo-file probe that finds those files absent is `unsupported`; `unknown` only when the work-item seam cannot establish the fact (composition fallback) |
 
 ## Admission and escalation
 

--- a/plugins/autonomy/reference/routines/eng-metrics-digest.md
+++ b/plugins/autonomy/reference/routines/eng-metrics-digest.md
@@ -42,6 +42,25 @@ The row is derived through the catalog's mapping rules, never hand-assigned:
 
 Derived row: `C1`.
 
+## Prerequisites
+
+Per-identity needs under
+[routine prerequisite resolution](../prerequisite-resolution.md). Axes derive through the
+catalog mapping rules; the isolation floor and `executor_class` merge cap are cited from the
+guardrail slice, never re-derived. Resolution verdicts use `supported` | `conditional` |
+`unsupported` | `unknown`.
+
+Single-posture identity: `eng-metrics-digest` (bare class token).
+
+| Axis | Value |
+|---|---|
+| Access class | `repo` |
+| Isolation floor | `L2` — cited from the [matrix](../guardrails.md#the-matrix) `C1` row and the [unattended floor](../guardrails/isolation-ladder.md#unattended-floor) |
+| Connector entitlements | none — `repo` access; the connector branch of [Access to prerequisites](../routines.md#access-to-prerequisites) does not apply |
+| Connector entitlement rung | n/a (no connector). For `prod` / `product` / `org` / `ext`, entitlement binds at the [Org binding layer](../binding-seam.md#resolution-ladder) |
+| `executor_class` merge cap | cited from [executor surface classes](../trigger-dispatch.md#executor-surface-classes) — security-binding `executor_class`; `vendor-hosted` caps every class at human-gated merge; never repo-derivable. Merge policy for this identity is n/a (`C1`) |
+| Repo needs | repository activity signals; CI-config presence (ownerless repo-file probe); tracker binding via the work-item tracker seam — the digest collates all three; absence of any one is `unknown` or `unsupported` per probe outcome |
+
 ## Admission and escalation
 
 Admission disposition and fan-out caps for the derived class come from the

--- a/plugins/autonomy/reference/routines/issue-triage-sweep.md
+++ b/plugins/autonomy/reference/routines/issue-triage-sweep.md
@@ -74,7 +74,7 @@ Single-posture identity: `issue-triage-sweep` (bare class token).
 | Connector entitlements | none — `repo` access; the connector branch of [Access to prerequisites](../routines.md#access-to-prerequisites) does not apply |
 | Connector entitlement rung | n/a (no connector). For `prod` / `product` / `org` / `ext`, entitlement binds at the [Org binding layer](../binding-seam.md#resolution-ladder) |
 | `executor_class` merge cap | cited from [executor surface classes](../trigger-dispatch.md#executor-surface-classes) — security-binding `executor_class`; `vendor-hosted` caps every class at human-gated merge; never repo-derivable. Merge policy for this identity is n/a (`C1`) |
-| Repo needs | tracker binding via the work-item tracker seam (`.work-item-tracker.json` + adapter `capabilities.json`); absence is `unknown` per the composition fallback |
+| Repo needs | tracker binding via the work-item tracker seam (`.work-item-tracker.json` + adapter `capabilities.json`); a deterministic repo-file probe that finds those files absent is `unsupported`; `unknown` only when the work-item seam cannot establish the fact (composition fallback) |
 
 ## Admission and escalation
 

--- a/plugins/autonomy/reference/routines/issue-triage-sweep.md
+++ b/plugins/autonomy/reference/routines/issue-triage-sweep.md
@@ -57,6 +57,25 @@ The row is derived through the catalog-to-matrix mapping rules in the
 
 Derived row: `C1` in the [guardrail matrix](../guardrails.md).
 
+## Prerequisites
+
+Per-identity needs under
+[routine prerequisite resolution](../prerequisite-resolution.md). Axes derive through the
+catalog mapping rules; the isolation floor and `executor_class` merge cap are cited from the
+guardrail slice, never re-derived. Resolution verdicts use `supported` | `conditional` |
+`unsupported` | `unknown`.
+
+Single-posture identity: `issue-triage-sweep` (bare class token).
+
+| Axis | Value |
+|---|---|
+| Access class | `repo` |
+| Isolation floor | `L2` — cited from the [matrix](../guardrails.md#the-matrix) `C1` row and the [unattended floor](../guardrails/isolation-ladder.md#unattended-floor) |
+| Connector entitlements | none — `repo` access; the connector branch of [Access to prerequisites](../routines.md#access-to-prerequisites) does not apply |
+| Connector entitlement rung | n/a (no connector). For `prod` / `product` / `org` / `ext`, entitlement binds at the [Org binding layer](../binding-seam.md#resolution-ladder) |
+| `executor_class` merge cap | cited from [executor surface classes](../trigger-dispatch.md#executor-surface-classes) — security-binding `executor_class`; `vendor-hosted` caps every class at human-gated merge; never repo-derivable. Merge policy for this identity is n/a (`C1`) |
+| Repo needs | tracker binding via the work-item tracker seam (`.work-item-tracker.json` + adapter `capabilities.json`); absence is `unknown` per the composition fallback |
+
 ## Admission and escalation
 
 Admission disposition, caps, and fail-closed behavior are imported by citation from the

--- a/plugins/autonomy/reference/routines/pr-queue-tending.md
+++ b/plugins/autonomy/reference/routines/pr-queue-tending.md
@@ -58,6 +58,25 @@ The row is derived through the catalog-to-matrix mapping rules in the
 
 Derived row: `C1` in the [guardrail matrix](../guardrails.md).
 
+## Prerequisites
+
+Per-identity needs under
+[routine prerequisite resolution](../prerequisite-resolution.md). Axes derive through the
+catalog mapping rules; the isolation floor and `executor_class` merge cap are cited from the
+guardrail slice, never re-derived. Resolution verdicts use `supported` | `conditional` |
+`unsupported` | `unknown`.
+
+Single-posture identity: `pr-queue-tending` (bare class token).
+
+| Axis | Value |
+|---|---|
+| Access class | `repo` |
+| Isolation floor | `L2` — cited from the [matrix](../guardrails.md#the-matrix) `C1` row and the [unattended floor](../guardrails/isolation-ladder.md#unattended-floor) |
+| Connector entitlements | none — `repo` access; the connector branch of [Access to prerequisites](../routines.md#access-to-prerequisites) does not apply |
+| Connector entitlement rung | n/a (no connector). For `prod` / `product` / `org` / `ext`, entitlement binds at the [Org binding layer](../binding-seam.md#resolution-ladder) |
+| `executor_class` merge cap | cited from [executor surface classes](../trigger-dispatch.md#executor-surface-classes) — security-binding `executor_class`; `vendor-hosted` caps every class at human-gated merge; never repo-derivable. Merge policy for this identity is n/a (`C1`) |
+| Repo needs | tracker binding via the work-item tracker seam (`.work-item-tracker.json` + adapter `capabilities.json`); CI-config presence (ownerless repo-file probe owned by the resolution contract) so CI outcomes are readable; either absence is `unknown` or `unsupported` per probe outcome |
+
 ## Admission and escalation
 
 Admission disposition, caps, and fail-closed behavior are imported by citation from the

--- a/plugins/autonomy/reference/routines/tech-debt-sweep.md
+++ b/plugins/autonomy/reference/routines/tech-debt-sweep.md
@@ -47,6 +47,27 @@ The row is derived through the catalog's mapping rules, never hand-assigned:
 
 Derived row: `C1` for the sweep; human-gated disposition for the prioritization decision.
 
+## Prerequisites
+
+Per-identity needs under
+[routine prerequisite resolution](../prerequisite-resolution.md). Axes derive through the
+catalog mapping rules; the isolation floor and `executor_class` merge cap are cited from the
+guardrail slice, never re-derived. Resolution verdicts use `supported` | `conditional` |
+`unsupported` | `unknown`.
+
+Single-posture identity: `tech-debt-sweep` (bare class token). The human-gated prioritization
+disposition is not a second identity — it is admission disposition on the same identity's
+output.
+
+| Axis | Value |
+|---|---|
+| Access class | `repo` |
+| Isolation floor | `L2` — cited from the [matrix](../guardrails.md#the-matrix) `C1` row and the [unattended floor](../guardrails/isolation-ladder.md#unattended-floor) |
+| Connector entitlements | none — `repo` access; the connector branch of [Access to prerequisites](../routines.md#access-to-prerequisites) does not apply |
+| Connector entitlement rung | n/a (no connector). For `prod` / `product` / `org` / `ext`, entitlement binds at the [Org binding layer](../binding-seam.md#resolution-ladder) |
+| `executor_class` merge cap | cited from [executor surface classes](../trigger-dispatch.md#executor-surface-classes) — security-binding `executor_class`; `vendor-hosted` caps every class at human-gated merge; never repo-derivable. Merge policy for this identity is n/a (`C1`) |
+| Repo needs | repository source tree; ecosystems via the toolchain seam when installed (fallback: inference from the repo's own build files); tracker binding when filing work items through the work-item tracker seam |
+
 ## Admission and escalation
 
 Admission disposition and fan-out caps for the derived class come from the


### PR DESCRIPTION
Closes #2718

## Summary

Phase 2 of the routine-capability-detection plan (ADR 0011): each of the ten `v1` definition leaves under `plugins/autonomy/reference/routines/` gains a `## Prerequisites` section owning per-identity needs through the Phase 1 vocabulary.

## Fix

- **Ten leaf `## Prerequisites` sections** — Access class, isolation floor, connector entitlements + rung, `executor_class` merge cap, and repo needs. Floors and the merge cap are cited from the guardrail slice, never re-derived.
- **Posture divergence** — `dependency-update-wave` (`/mechanical` L2 vs `/changelog-informed` L3), `doc-freshness-sweep`, and `ci-health-review` each show distinct prerequisite sets per identity.
- **Verdict vocabulary** — sections use `supported` | `conditional` | `unsupported` | `unknown` from `prerequisite-resolution.md`.
- **Version bump** to `0.19.0` with matching CHANGELOG entry.

## Verification

```text
$ ls plugins/autonomy/reference/routines/*.md | wc -l   # 10
$ grep -L '^## Prerequisites' plugins/autonomy/reference/routines/*.md   # empty
$ # at least one leaf shows per-posture divergence (dependency-update-wave L2 vs L3)
$ # manifest version differs from origin/main AND:
$ bash scripts/check-changelog-parity.sh --check-bump origin/main   # exit 0
```

## Related

- ADR 0011; Refs #2685; depends on #2717 (merged)