### PR TITLE
fix(disk-hygiene): restore Windows readonly allowlist; ask in engine-gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -311,6 +311,30 @@ jobs:
       - name: Run shared lib tests on Windows
         run: bash lib/hook-utils.test.sh
 
+  # #2774: the disk-hygiene read-only Bash allowlist is NT-specific (MSYS path
+  # mapping, .exe basename stripping, ProgramFiles trust roots). Linux CI cannot
+  # exercise those branches — Path.is_absolute() is True for /usr/bin/ls on
+  # POSIX — which is how an inert Windows allowlist shipped green. Keep this
+  # job SMALL: GuardTests only, not the full hygiene suite.
+  disk-hygiene-guard-windows:
+    runs-on: windows-2025
+    timeout-minutes: 20
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Check out
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.14'
+      - name: Run disk-hygiene GuardTests on Windows
+        working-directory: plugins/disk-hygiene/skills/clean/scripts
+        run: python -m unittest -v test_hygiene.GuardTests
+
   hook-utils-sync:
     runs-on: ubuntu-24.04
     timeout-minutes: 15
@@ -1178,6 +1202,7 @@ jobs:
       - hygiene
       - hook-utils-sync
       - hook-utils-windows
+      - disk-hygiene-guard-windows
       - parse-concern-value-sync
       - resolve-convention-pattern-sync
       - standards-contract-sync

--- a/plugins/disk-hygiene/.claude-plugin/plugin.json
+++ b/plugins/disk-hygiene/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "disk-hygiene",
-  "version": "0.20.7",
+  "version": "0.20.8",
   "description": "Context-aware disk hygiene for arbitrary directory trees: inventories orphaned and temporary artifacts, classifies evidence into review tiers, and offers exact-path cleanup only after a fresh safety preview and explicit per-tier approval. The target is read-only by default; OS-managed paths, links and mount points, VCS-tracked content without the complete checkout evidence bundle, changed entries, and live-handle uncertainty fail closed.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/disk-hygiene/CHANGELOG.md
+++ b/plugins/disk-hygiene/CHANGELOG.md
@@ -3,6 +3,29 @@
 All notable changes to the `disk-hygiene` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.20.8]
+
+### Fixed
+
+- **Windows read-only Bash allowlist was inert — 0 commands accepted (#2774).** Two
+  compounding defects: (A1) MSYS path reinterpretation ran *after* `Path.is_absolute()`,
+  which is False for POSIX-style heads on Windows-native Python, so `/usr/bin/ls` never
+  reached the Git-root mapping; (A2) `_readonly_supporting_basename` did not strip
+  `.exe`/`.EXE`, so real Git-for-Windows binaries never matched the allowlist. Move the
+  MSYS branch ahead of the absolute gate and strip Windows executable extensions.
+- **Engine-gate hard-`allow` leak for allowlisted inspection commands (#2774).** In
+  `--mode engine-gate`, an allowlisted command that also names the engine path emitted
+  `permissionDecision: "allow"`, bypassing the user's prompt in every consumer session.
+  Downgrade that path to `ask`; belt mode still hard-allows.
+- **Exclude user-writable `%LOCALAPPDATA%\\Programs\\Git` from NT trust roots (#2774)**
+  and reword the trust-root comments so they no longer claim independence from
+  environment-derived input.
+
+### Changed
+
+- **CI:** add a focused `disk-hygiene-guard-windows` lane (`windows-2025`, GuardTests
+  only) so NT trust/MSYS/basename branches cannot regress silently on Linux-only CI.
+
 ## [0.20.7]
 
 ### Fixed

--- a/plugins/disk-hygiene/skills/clean/scripts/destructive_guard.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/destructive_guard.py
@@ -1057,8 +1057,19 @@ def _is_readonly_find(tokens: list[str]) -> bool:
 
 
 def _readonly_supporting_basename(head: str) -> str:
-    """Basename of a supporting command head on either path separator."""
-    return _PATH_SEPARATOR.split(head.rstrip("/\\"))[-1]
+    """Basename of a supporting command head on either path separator.
+
+    On Windows, strip a trailing executable extension (``.exe`` / ``.EXE`` /
+    ``.com`` / ``.bat`` / ``.cmd``) so a real Git-for-Windows binary such as
+    ``ls.EXE`` matches ``_READONLY_SUPPORTING_BASH_HEADS`` (#2774).
+    """
+    name = _PATH_SEPARATOR.split(head.rstrip("/\\"))[-1]
+    if os.name == "nt":
+        lower = name.lower()
+        for ext in (".exe", ".com", ".bat", ".cmd"):
+            if lower.endswith(ext):
+                return name[: -len(ext)]
+    return name
 
 
 # Absolute prefixes where an allowlisted head may live after realpath. A
@@ -1090,19 +1101,25 @@ _NT_SYSTEM_TRUSTED_BIN_SUBDIRS = (
 
 
 def _nt_known_git_installation_roots() -> tuple[Path, ...]:
-    """Git-for-Windows roots from independently trusted install locations.
+    """Git-for-Windows roots from well-known *machine* install locations.
 
     Never derived from ``PATH`` / ``shutil.which("git")``: a project-controlled
     directory ahead on ``PATH`` can plant ``cmd/git.exe`` and poison the trusted
     root, recreating the arbitrary-executable bypass the anchored-prefix change
-    closed. Only well-known installer destinations under ``ProgramFiles``,
-    ``ProgramFiles(x86)``, and ``LocalAppData\\Programs`` contribute roots, and
-    only when that directory actually exists.
+    closed. Only the per-machine installer destinations under ``ProgramFiles``
+    and ``ProgramFiles(x86)`` contribute roots, and only when that directory
+    actually exists.
+
+    ``%LOCALAPPDATA%\\Programs\\Git`` is intentionally excluded: it is a
+    user-writable path, so treating it as a trust root would let a local
+    plant under the profile contribute allowlisted heads whenever it exists
+    (#2774). Environment-variable control of ``ProgramFiles`` remains a
+    stronger precondition than PATH planting, but these roots are still
+    environment-derived — not independently attested install locations.
     """
     candidates: list[tuple[str, tuple[str, ...]]] = [
         ("ProgramFiles", ("Git",)),
         ("ProgramFiles(x86)", ("Git",)),
-        ("LocalAppData", ("Programs", "Git")),
     ]
     roots: list[Path] = []
     for key, rel in candidates:
@@ -1122,13 +1139,15 @@ def _nt_known_git_installation_roots() -> tuple[Path, ...]:
 def _nt_trusted_readonly_bin_roots() -> tuple[Path, ...]:
     """Resolved absolute directories on Windows whose contents the belt trusts.
 
-    Built from independently located Git installation roots and
+    Built from well-known Git installation roots (ProgramFiles /
+    ProgramFiles(x86) only — not user-writable LocalAppData) and
     ``%SystemRoot%`` — because a SUBSTRING match on a path fragment such as
     ``/git/usr/bin/`` is satisfied by any repository-controlled directory that
     merely spells that fragment (``D:/anyrepo/git/usr/bin/find``), which would
     hard-``allow`` a planted binary carrying an allowlisted basename. Anchoring
     to the resolved root removes that bypass; an unresolvable root contributes
-    NO trusted directories. Git roots are never taken from ``PATH``.
+    NO trusted directories. Git roots are never taken from ``PATH``. Environment
+    variables still supply the roots — they are not independently attested.
     """
     roots: list[Path] = []
     for git_root in _nt_known_git_installation_roots():
@@ -1184,18 +1203,18 @@ def _trusted_system_readonly_head(head: str) -> bool:
     what the shell will run. Relative path-qualified forms are denied.
 
     On Windows, Git Bash spells system tools as MSYS paths (``/usr/bin/ls``).
-    Native ``Path.resolve`` would map those onto the current drive, so they are
-    reinterpreted against the known Git installation roots instead.
+    Native ``Path.is_absolute()`` requires both a drive and a root, so those
+    POSIX-style heads are NOT absolute to pathlib — the MSYS reinterpretation
+    against known Git installation roots MUST run before the ``is_absolute``
+    gate, or the allowlist accepts nothing on Windows (#2774). Native
+    ``Path.resolve`` would otherwise map ``/usr/bin/ls`` onto the current drive.
     """
     if not head:
         return False
     if "/" not in head and "\\" not in head:
         return False
-    candidate = Path(head)
-    if not candidate.is_absolute():
-        return False
+    # MSYS absolute path BEFORE is_absolute(): /usr/bin/ls → <GitRoot>/usr/bin/ls[.exe]
     if os.name == "nt" and head.startswith("/") and not head.startswith("//"):
-        # MSYS absolute path: /usr/bin/ls → <GitRoot>/usr/bin/ls[.exe]
         rel_parts = tuple(part for part in head.split("/") if part)
         if not rel_parts:
             return False
@@ -1208,6 +1227,9 @@ def _trusted_system_readonly_head(head: str) -> bool:
                     continue
                 if _path_under_trusted_readonly_bin(resolved):
                     return True
+        return False
+    candidate = Path(head)
+    if not candidate.is_absolute():
         return False
     try:
         resolved = candidate.resolve()
@@ -1661,16 +1683,23 @@ def _decide(command: str, tool_name: str, start: float) -> int:
         _emit_guard_telemetry(start, tool_name, "ok", decision_value="allow")
         return 0
     if is_exact_readonly_supporting_command(command):
+        # Engine-gate mode runs in every consumer session. A hard `allow` here
+        # would bypass the user's permission prompt for an allowlisted command
+        # that also names the engine path (#2774). `ask` keeps the ergonomic
+        # win while preserving the prompt for sessions that never invoked clean.
+        permission = (
+            "ask" if resolve_mode() == _MODE_ENGINE_GATE else "allow"
+        )
         print(
             json.dumps(
                 decision(
-                    "allow",
+                    permission,
                     "Exact literal-form read-only supporting Bash command "
                     "(disk-hygiene belt inspection allowlist).",
                 )
             )
         )
-        _emit_guard_telemetry(start, tool_name, "ok", decision_value="allow")
+        _emit_guard_telemetry(start, tool_name, "ok", decision_value=permission)
         return 0
     command_kind = classify_exact_engine_command(command, authority)
     if command_kind in {"scan", "preview", "handoff-verify"}:

--- a/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
@@ -4360,19 +4360,37 @@ class GuardTests(unittest.TestCase):
                 )
 
     def test_readonly_supporting_bare_name_is_denied_as_shadowable(self) -> None:
-        """Bare allowlisted names are denied: which() cannot prove Bash will run that binary."""
+        """Bare allowlisted names are denied: which() cannot prove Bash will run that binary.
+
+        Absolute trusted forms remain allowlisted. On Windows, ``Path.is_absolute``
+        rejects POSIX-style heads and ``which("ls")`` often returns an ``.exe``
+        path — both are why this assertion previously encoded a Linux-only
+        expectation and went red (or never ran) on NT (#2774). Build the
+        absolute head with the same trust rules the guard uses.
+        """
         located = shutil.which("ls")
         self.assertIsNotNone(located)
+        assert located is not None
         resolved = Path(located).resolve()
+        absolute_head = resolved.as_posix()
+        # Prefer a form the allowlist actually accepts on this host. On Linux
+        # that is the resolved system path; on Windows it may need an MSYS
+        # spelling once Git roots are present, or an .exe-stripped native path.
+        if not guard._trusted_system_readonly_head(absolute_head):
+            for candidate in ("/usr/bin/ls", "/bin/ls"):
+                if guard._trusted_system_readonly_head(candidate):
+                    absolute_head = candidate
+                    break
+            else:
+                self.skipTest(
+                    "no trusted absolute ls on this host "
+                    f"(which={located!r}, resolved={resolved})"
+                )
         self.assertTrue(
-            guard._path_under_trusted_readonly_bin(resolved),
-            f"test host must provide system ls; got {resolved}",
+            guard.is_exact_readonly_supporting_command(f"{absolute_head} /tmp/example"),
+            absolute_head,
         )
-        # Absolute path to the same binary is allowed; the bare name is not.
-        self.assertTrue(
-            guard.is_exact_readonly_supporting_command(f"{resolved.as_posix()} /tmp/example")
-        )
-        self.assertTrue(guard._trusted_system_readonly_head(resolved.as_posix()))
+        self.assertTrue(guard._trusted_system_readonly_head(absolute_head))
         self.assertFalse(guard.is_exact_readonly_supporting_command("ls /tmp/example"))
         self.assertFalse(guard._trusted_system_readonly_head("ls"))
 
@@ -4504,7 +4522,7 @@ class GuardTests(unittest.TestCase):
             planted_git = planted / "git.exe"
             planted_git.write_text("fake")
             # which() returning a planted binary must not matter: known roots come
-            # only from ProgramFiles / LocalAppData installer locations.
+            # only from ProgramFiles / ProgramFiles(x86) machine installers.
             # Do not mock os.name here — pathlib.Path selects WindowsPath when
             # os.name is ``nt``, which cannot be instantiated on a POSIX runner.
             guard._nt_trusted_readonly_bin_roots.cache_clear()
@@ -4518,17 +4536,152 @@ class GuardTests(unittest.TestCase):
                         {
                             "ProgramFiles": str(base / "empty-pf"),
                             "ProgramFiles(x86)": str(base / "empty-pf86"),
-                            "LocalAppData": str(base / "empty-local"),
+                            "LocalAppData": str(base / "Programs" / "Git"),
                             "SystemRoot": "",
                             "SYSTEMROOT": "",
                         },
                         clear=False,
                     ),
                 ):
+                    # Even with a user-writable LocalAppData\\Programs\\Git tree
+                    # present, known roots stay empty (#2774).
+                    (base / "Programs" / "Git").mkdir(parents=True)
                     self.assertEqual((), guard._nt_known_git_installation_roots())
                     self.assertEqual((), guard._nt_trusted_readonly_bin_roots())
             finally:
                 guard._nt_trusted_readonly_bin_roots.cache_clear()
+
+    def test_nt_git_roots_exclude_user_writable_localappdata(self) -> None:
+        """#2774: %LOCALAPPDATA%\\Programs\\Git must not contribute trusted roots."""
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp).resolve()
+            user_git = base / "Local" / "Programs" / "Git"
+            user_bin = user_git / "usr" / "bin"
+            user_bin.mkdir(parents=True)
+            (user_bin / "ls.exe").write_text("fake")
+            guard._nt_trusted_readonly_bin_roots.cache_clear()
+            try:
+                with mock.patch.dict(
+                    guard.os.environ,
+                    {
+                        "ProgramFiles": str(base / "empty-pf"),
+                        "ProgramFiles(x86)": str(base / "empty-pf86"),
+                        "LocalAppData": str(base / "Local"),
+                        "SystemRoot": "",
+                        "SYSTEMROOT": "",
+                    },
+                    clear=False,
+                ):
+                    self.assertEqual((), guard._nt_known_git_installation_roots())
+            finally:
+                guard._nt_trusted_readonly_bin_roots.cache_clear()
+
+    def test_readonly_supporting_basename_strips_windows_extensions(self) -> None:
+        """#2774 A2: ls.EXE / find.exe must match the allowlisted basenames."""
+        with mock.patch.object(guard.os, "name", "nt"):
+            self.assertEqual(
+                "ls",
+                guard._readonly_supporting_basename(r"C:/Program Files/Git/usr/bin/ls.EXE"),
+            )
+            self.assertEqual(
+                "find",
+                guard._readonly_supporting_basename("/usr/bin/find.exe"),
+            )
+            self.assertEqual("ls", guard._readonly_supporting_basename("ls"))
+        with mock.patch.object(guard.os, "name", "posix"):
+            # Off Windows, .exe is a literal basename character — leave it.
+            self.assertEqual("ls.EXE", guard._readonly_supporting_basename("ls.EXE"))
+
+    def test_msys_posix_head_is_mapped_before_is_absolute_gate(self) -> None:
+        """#2774 A1: /usr/bin/ls must reach MSYS mapping on Windows-native Python.
+
+        Path.is_absolute() is False for POSIX-style heads on nt, so the old
+        order (absolute gate first) made the allowlist inert.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp).resolve()
+            git_root = base / "Git"
+            bin_dir = git_root / "usr" / "bin"
+            bin_dir.mkdir(parents=True)
+            ls_exe = bin_dir / "ls.exe"
+            ls_exe.write_text("fake")
+            guard._nt_trusted_readonly_bin_roots.cache_clear()
+            try:
+                with (
+                    mock.patch.object(guard.os, "name", "nt"),
+                    mock.patch.object(
+                        guard,
+                        "_nt_known_git_installation_roots",
+                        return_value=(git_root,),
+                    ),
+                    mock.patch.object(
+                        guard,
+                        "_nt_trusted_readonly_bin_roots",
+                        return_value=(bin_dir,),
+                    ),
+                ):
+                    self.assertTrue(
+                        guard._trusted_system_readonly_head("/usr/bin/ls"),
+                        "MSYS /usr/bin/ls must map through the Git root",
+                    )
+                    self.assertEqual(
+                        "ls",
+                        guard._readonly_supporting_basename("/usr/bin/ls.exe"),
+                    )
+                    # Basename strip + MSYS map together accept the allowlisted form.
+                    with mock.patch.object(
+                        guard,
+                        "_readonly_supporting_basename",
+                        wraps=guard._readonly_supporting_basename,
+                    ):
+                        self.assertTrue(
+                            guard.is_exact_readonly_supporting_command(
+                                "/usr/bin/ls -la /tmp/example"
+                            )
+                        )
+            finally:
+                guard._nt_trusted_readonly_bin_roots.cache_clear()
+
+    def test_engine_gate_asks_not_allows_readonly_supporting_commands(self) -> None:
+        """#2774 C: engine-gate must not hard-allow an allowlisted inspection command.
+
+        The plugin-level gate runs in every consumer session. An allowlisted
+        command that also names the engine path used to hard-``allow`` (and
+        bypass the user's prompt). `ask` preserves the prompt; belt mode still
+        hard-allows. A command that does not name the engine is deferred with
+        no output — that is not this defect.
+        """
+        head = None
+        for candidate in ("/usr/bin/ls", "/bin/ls"):
+            if Path(candidate).is_file() and guard._trusted_system_readonly_head(candidate):
+                head = candidate
+                break
+        if head is None:
+            self.skipTest("no trusted absolute ls on this host")
+        engine = (SCRIPT_DIR / "hygiene.py").resolve().as_posix()
+        command = f"{head} -la {engine}"
+        self.assertTrue(
+            guard._engine_gate_relevant(command, "Bash"),
+            "fixture must name the engine so the gate acts",
+        )
+        self.assertTrue(
+            guard.is_exact_readonly_supporting_command(command),
+            "fixture must remain allowlisted",
+        )
+        belt = self.run_guard(command)
+        self.assertEqual(
+            "allow",
+            belt["hookSpecificOutput"]["permissionDecision"],
+            "belt mode still hard-allows trusted inspection",
+        )
+        gated = self.run_guard_engine_gate(command)
+        self.assertIsNotNone(gated)
+        assert gated is not None
+        self.assertEqual(
+            "ask",
+            gated["hookSpecificOutput"]["permissionDecision"],
+            "engine-gate must ask, not allow, for readonly supporting commands",
+        )
 
     def test_bracket_test_is_not_trusted_on_name_alone(self) -> None:
         """#2618 hardening 2 + #2706: bare ``[`` is denied; absolute ``[`` clears identity.

--- a/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
@@ -6270,16 +6270,20 @@ class GuardTests(unittest.TestCase):
 
     def test_deny_emits_blocked_telemetry_when_sink_wired(self) -> None:
         out_file = Path(self._cfg.name) / "telemetry-deny.json"
-        # Windows cannot exec a #!/bin/sh sink via CreateProcess; use a .cmd that
-        # forwards stdin through this interpreter (HOOK_TELEMETRY_SINK is argv0).
+        # Windows cannot exec a #!/bin/sh sink via CreateProcess. A .cmd that
+        # runs a sibling .py keeps quoting simple and inherits stdin.
+        sink_py = Path(self._cfg.name) / "telemetry_sink.py"
+        sink_py.write_text(
+            "import sys\n"
+            f"from pathlib import Path\n"
+            f"Path(r'{out_file}').write_text(sys.stdin.read(), encoding='utf-8')\n",
+            encoding="utf-8",
+        )
         if os.name == "nt":
             sink = Path(self._cfg.name) / "telemetry-sink.cmd"
             py = os.fspath(Path(sys.executable).resolve())
             sink.write_text(
-                "@echo off\r\n"
-                f"\"{py}\" -c "
-                f"\"import sys; open(r'{out_file}', 'w', encoding='utf-8')"
-                f".write(sys.stdin.read())\"\r\n",
+                f"@echo off\r\n\"{py}\" \"{sink_py}\"\r\n",
                 encoding="utf-8",
             )
         else:
@@ -6295,25 +6299,39 @@ class GuardTests(unittest.TestCase):
             clear=False,
         ):
             self.run_guard_tool("rm -rf /tmp/foo", "Bash", enabled=False)
-        deadline = time.perf_counter() + 2.0
-        while time.perf_counter() < deadline and not out_file.exists():
+        # Fire-and-forget sink: wait for non-empty content, not mere existence
+        # (open('w') creates an empty file before write completes).
+        deadline = time.perf_counter() + 5.0
+        body = ""
+        while time.perf_counter() < deadline:
+            if out_file.exists():
+                try:
+                    body = out_file.read_text(encoding="utf-8").strip()
+                except OSError:
+                    body = ""
+                if body:
+                    break
             time.sleep(0.05)
-        self.assertTrue(out_file.exists())
-        envelope = json.loads(out_file.read_text(encoding="utf-8").strip())
+        self.assertTrue(body, f"timed out waiting for telemetry at {out_file}")
+        envelope = json.loads(body)
         self.assertEqual("destructive-guard", envelope["hook"])
         self.assertEqual("blocked", envelope["status"])
         self.assertEqual("deny", envelope["data"]["decision"])
 
     def test_engine_gate_irrelevant_emits_no_telemetry(self) -> None:
         out_file = Path(self._cfg.name) / "telemetry-skip.json"
+        sink_py = Path(self._cfg.name) / "telemetry_skip_sink.py"
+        sink_py.write_text(
+            "import sys\n"
+            f"from pathlib import Path\n"
+            f"Path(r'{out_file}').write_text(sys.stdin.read(), encoding='utf-8')\n",
+            encoding="utf-8",
+        )
         if os.name == "nt":
             sink = Path(self._cfg.name) / "telemetry-skip-sink.cmd"
             py = os.fspath(Path(sys.executable).resolve())
             sink.write_text(
-                "@echo off\r\n"
-                f"\"{py}\" -c "
-                f"\"import sys; open(r'{out_file}', 'w', encoding='utf-8')"
-                f".write(sys.stdin.read())\"\r\n",
+                f"@echo off\r\n\"{py}\" \"{sink_py}\"\r\n",
                 encoding="utf-8",
             )
         else:

--- a/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
@@ -13,6 +13,7 @@ import shlex
 import shutil
 import stat
 import subprocess
+import sys
 import tempfile
 import time
 import types
@@ -4386,8 +4387,22 @@ class GuardTests(unittest.TestCase):
                     "no trusted absolute ls on this host "
                     f"(which={located!r}, resolved={resolved})"
                 )
+        # Prefer an MSYS spelling when the native path has spaces ("Program
+        # Files"): unquoted space-bearing heads fail `_literal_shell_words`.
+        if any(ch in absolute_head for ch in " \t"):
+            for candidate in ("/usr/bin/ls", "/bin/ls"):
+                if guard._trusted_system_readonly_head(candidate):
+                    absolute_head = candidate
+                    break
+        head_for_command = (
+            f'"{absolute_head}"'
+            if any(ch in absolute_head for ch in " \t")
+            else absolute_head
+        )
         self.assertTrue(
-            guard.is_exact_readonly_supporting_command(f"{absolute_head} /tmp/example"),
+            guard.is_exact_readonly_supporting_command(
+                f"{head_for_command} /tmp/example"
+            ),
             absolute_head,
         )
         self.assertTrue(guard._trusted_system_readonly_head(absolute_head))
@@ -6255,9 +6270,22 @@ class GuardTests(unittest.TestCase):
 
     def test_deny_emits_blocked_telemetry_when_sink_wired(self) -> None:
         out_file = Path(self._cfg.name) / "telemetry-deny.json"
-        sink = Path(self._cfg.name) / "telemetry-sink.sh"
-        sink.write_text(f'#!/bin/sh\ncat >"{out_file}"\n', encoding="utf-8")
-        sink.chmod(0o755)
+        # Windows cannot exec a #!/bin/sh sink via CreateProcess; use a .cmd that
+        # forwards stdin through this interpreter (HOOK_TELEMETRY_SINK is argv0).
+        if os.name == "nt":
+            sink = Path(self._cfg.name) / "telemetry-sink.cmd"
+            py = os.fspath(Path(sys.executable).resolve())
+            sink.write_text(
+                "@echo off\r\n"
+                f"\"{py}\" -c "
+                f"\"import sys; open(r'{out_file}', 'w', encoding='utf-8')"
+                f".write(sys.stdin.read())\"\r\n",
+                encoding="utf-8",
+            )
+        else:
+            sink = Path(self._cfg.name) / "telemetry-sink.sh"
+            sink.write_text(f'#!/bin/sh\ncat >"{out_file}"\n', encoding="utf-8")
+            sink.chmod(0o755)
         with mock.patch.dict(
             os.environ,
             {
@@ -6278,9 +6306,20 @@ class GuardTests(unittest.TestCase):
 
     def test_engine_gate_irrelevant_emits_no_telemetry(self) -> None:
         out_file = Path(self._cfg.name) / "telemetry-skip.json"
-        sink = Path(self._cfg.name) / "telemetry-skip-sink.sh"
-        sink.write_text(f'#!/bin/sh\ncat >"{out_file}"\n', encoding="utf-8")
-        sink.chmod(0o755)
+        if os.name == "nt":
+            sink = Path(self._cfg.name) / "telemetry-skip-sink.cmd"
+            py = os.fspath(Path(sys.executable).resolve())
+            sink.write_text(
+                "@echo off\r\n"
+                f"\"{py}\" -c "
+                f"\"import sys; open(r'{out_file}', 'w', encoding='utf-8')"
+                f".write(sys.stdin.read())\"\r\n",
+                encoding="utf-8",
+            )
+        else:
+            sink = Path(self._cfg.name) / "telemetry-skip-sink.sh"
+            sink.write_text(f'#!/bin/sh\ncat >"{out_file}"\n', encoding="utf-8")
+            sink.chmod(0o755)
         with mock.patch.dict(
             os.environ,
             {


### PR DESCRIPTION
## Summary
- Fix inert Windows read-only Bash allowlist (#2774 A1/A2): MSYS mapping before `is_absolute()`, strip `.exe`/`.EXE` basenames.
- Engine-gate: downgrade allowlisted inspection from hard `allow` to `ask` so consumer sessions keep the permission prompt (#2774 C).
- Exclude user-writable `%LOCALAPPDATA%\\Programs\\Git` from NT trust roots; reword trust comments (#2774 D).
- Add focused `disk-hygiene-guard-windows` CI lane (`windows-2025`, GuardTests only) (#2774 B).
- Bump disk-hygiene to 0.20.8.

## Test plan
- [x] `python -m unittest test_hygiene.GuardTests` (126 tests OK on Linux)
- [x] New cases: MSYS-before-absolute, basename strip, LocalAppData exclusion, engine-gate ask

Closes #2774

## Related

- disk-hygiene Windows allowlist / engine-gate fix for #2774.