### PR TITLE
fix(cloud): make markdownlint hook-visible via repo-local install

### DIFF
--- a/.claude/cloud-bootstrap.sh
+++ b/.claude/cloud-bootstrap.sh
@@ -21,7 +21,7 @@
 # In-repo manifests stay the single source of truth where one exists:
 #   Node               — .node-version (standards-synced)
 #   ruff               — .github/requirements-ci.txt (hash-locked)
-#   claude CLI / Biome — root package-lock.json (installed via npm ci)
+#   claude CLI / Biome / markdownlint-cli2 — root package-lock.json (npm ci)
 # Tools with no in-repo manifest are pinned in the VERSION PINS block below.
 #
 # Idempotent by design: every step checks before it installs, so re-runs on
@@ -68,7 +68,8 @@ gitleaks_pin="8.28.0"
 gitleaks_sha="a65b5253807a68ac0cafa4414031fd740aeb55f54fb7e55f386acb52e6a840eb"
 shfmt_pin="v3.12.0" # bash-format plugin hook; optional in CI by design
 shfmt_sha="d9fbb2a9c33d13f47e7618cf362a914d029d02a6df124064fff04fd688a745ea"
-markdownlint_pin="0.23.1"     # matches the .markdownlint-cli2.jsonc schema pin
+# markdownlint-cli2: root package-lock.json (npm ci) — never npm -g into the
+# nvm prefix; hook processes do not inherit that PATH segment (#2739 / #2748).
 check_jsonschema_pin="0.37.4" # pip/uv installs carry registry integrity checks
 
 # --- Node (required) ---------------------------------------------------------
@@ -108,9 +109,12 @@ if [[ -n "${CLAUDE_ENV_FILE:-}" ]]; then
 fi
 
 # --- Root npm toolchain (required) --------------------------------------------
-# Provides the pinned claude CLI and Biome that scripts/validate-plugins.sh and
-# the biome-format contract tests expect. Skipped when node_modules is already
-# in sync with package-lock.json, so resume-time re-runs are free.
+# Provides the pinned claude CLI, Biome, and markdownlint-cli2 that
+# scripts/validate-plugins.sh, the biome-format contract tests, and the
+# markdown-format hook expect. markdownlint-cli2 must stay a root
+# package-lock install: npm -g lands in the nvm prefix, which hook processes
+# do not inherit (#2739 / #2748). Skipped when node_modules is already in sync
+# with package-lock.json, so resume-time re-runs are free.
 if [[ ! -f node_modules/.package-lock.json || package-lock.json -nt node_modules/.package-lock.json ]]; then
   npm ci --no-audit --no-fund
 fi
@@ -297,15 +301,23 @@ fetch_release_tool shfmt \
   "https://github.com/mvdan/sh/releases/download/${shfmt_pin}/shfmt_${shfmt_pin}_linux_amd64" \
   "$shfmt_sha" "-"
 
-# The npm and pip/uv installs below carry no committed hash: both registries
-# verify package integrity against registry metadata (npm `_integrity`
-# sha512, PyPI digests), a weaker trust anchor than the committed SHA-256s
-# above but an accepted one — npm -g has no --require-hashes equivalent.
-if ! command -v markdownlint-cli2 >/dev/null 2>&1; then
-  npm install -g --no-audit --no-fund "markdownlint-cli2@${markdownlint_pin}" ||
-    echo "cloud-bootstrap: warning: markdownlint-cli2 install failed" >&2
+# markdownlint-cli2 comes from root npm ci (devDependency in package.json),
+# not npm -g. Hook processes inherit Claude Code's environ — they see
+# ~/.local/bin (where shellcheck lands) but NOT the nvm prefix that npm -g
+# would write into, and CLAUDE_ENV_FILE PATH repairs reach subsequent Bash
+# tool calls only (#2739 / #2748). Symlink the repo-local shim into
+# ~/.local/bin so PATH-based hook resolution matches the filesystem probe
+# markdown-format already uses (`node_modules/.bin`).
+repo_mdlint="$repo_root/node_modules/.bin/markdownlint-cli2"
+if [[ -x "$repo_mdlint" ]]; then
+  ln -sfn "$repo_mdlint" "$bin_dir/markdownlint-cli2"
+elif [[ ! -e "$bin_dir/markdownlint-cli2" ]]; then
+  echo "cloud-bootstrap: warning: markdownlint-cli2 missing from node_modules/.bin after npm ci; markdown-format will skip until it is present" >&2
 fi
 
+# pip/uv installs carry no committed hash: the registry verifies package
+# integrity against metadata (PyPI digests), a weaker trust anchor than the
+# committed SHA-256s above but an accepted one.
 if ! command -v check-jsonschema >/dev/null 2>&1; then
   if command -v uv >/dev/null 2>&1; then
     uv tool install --quiet "check-jsonschema==${check_jsonschema_pin}" ||
@@ -331,17 +343,43 @@ git fetch --quiet origin "+main:refs/remotes/origin/main" ||
   echo "cloud-bootstrap: warning: could not fetch origin/main" >&2
 
 # --- Report --------------------------------------------------------------------
+# Hook processes do not inherit this script's nvm-augmented PATH or
+# CLAUDE_ENV_FILE repairs (#2739). Build a hook-equivalent PATH: keep
+# ~/.local/bin and every other entry, drop only the nvm node_bin prefix this
+# script may have activated, so the startup report cannot go false-green for a
+# tool hooks cannot resolve.
+hook_safe_path="$PATH"
+if [[ -n "${node_bin:-}" ]]; then
+  hook_safe_path="$(
+    PATH="$PATH" bash -c '
+      IFS=:
+      out=
+      for p in $PATH; do
+        [[ "$p" == "$0" ]] && continue
+        out="${out:+$out:}$p"
+      done
+      printf "%s" "$out"
+    ' "$node_bin"
+  )"
+fi
+
 report_tool() {
   # report_tool <cmd-name> <version-args...>
-  local name="$1"
+  # Resolves and versions under hook_safe_path; prints the resolved path.
+  local name="$1" resolved ver
   shift
-  if command -v "$name" >/dev/null 2>&1; then
-    echo "cloud-bootstrap: $name $("$name" "$@" 2>/dev/null | head -1)"
+  resolved="$(PATH="$hook_safe_path" command -v "$name" 2>/dev/null || true)"
+  if [[ -z "$resolved" && "$name" == "markdownlint-cli2" && -x "$repo_mdlint" ]]; then
+    resolved="$repo_mdlint"
+  fi
+  if [[ -n "$resolved" ]]; then
+    ver="$(PATH="$hook_safe_path" "$resolved" "$@" 2>/dev/null | head -1 || true)"
+    echo "cloud-bootstrap: $name ($resolved)${ver:+ $ver}"
   else
-    echo "cloud-bootstrap: $name ABSENT (its checks will SKIP)"
+    echo "cloud-bootstrap: $name ABSENT on hook-visible PATH (its checks will SKIP)"
   fi
 }
-echo "cloud-bootstrap: bootstrap complete in $repo_root"
+echo "cloud-bootstrap: bootstrap complete in $repo_root (report_tool uses hook-safe PATH; nvm prefix excluded)"
 report_tool node --version
 report_tool ruff --version
 report_tool shellcheck --version

--- a/docs/CLOUD-FLEET-SETUP.md
+++ b/docs/CLOUD-FLEET-SETUP.md
@@ -191,10 +191,19 @@ if [ -f .node-version ]; then
 fi
 
 # --- npm dependencies, skipped when already in sync --------------------------
+# Put hook-consumed npm CLIs (e.g. markdownlint-cli2) in the root package-lock
+# and, after npm ci, symlink them into ~/.local/bin — hook processes inherit
+# Claude Code's environ (which includes ~/.local/bin) but not the nvm prefix
+# npm -g would use, and CLAUDE_ENV_FILE PATH repairs reach Bash tools only.
 if [ -f package-lock.json ]; then
   if [ ! -f node_modules/.package-lock.json ] ||
     [ package-lock.json -nt node_modules/.package-lock.json ]; then
     npm ci --no-audit --no-fund || warn "npm ci failed"
+  fi
+  mkdir -p "$HOME/.local/bin"
+  if [ -x node_modules/.bin/markdownlint-cli2 ]; then
+    ln -sfn "$PWD/node_modules/.bin/markdownlint-cli2" \
+      "$HOME/.local/bin/markdownlint-cli2"
   fi
 fi
 

--- a/docs/CLOUD-SESSIONS.md
+++ b/docs/CLOUD-SESSIONS.md
@@ -154,12 +154,19 @@ The environment side stays generic (Default environment, Trusted network, no var
 | Tool | Pin source | Required? |
 |---|---|---|
 | Node | `.node-version` (via the VM's nvm) | required — CI pins a major the VM image doesn't ship |
-| claude CLI + Biome | root `package-lock.json` (`npm ci`) | required |
+| claude CLI + Biome + markdownlint-cli2 | root `package-lock.json` (`npm ci`) | required — markdownlint stays repo-local so the `markdown-format` hook's `node_modules/.bin` probe (and a `~/.local/bin` symlink the bootstrap adds for PATH-based resolution) can see it; `npm -g` into the nvm prefix is invisible to hooks (#2739 / #2748) |
 | ruff, pytest, pyyaml | `.github/requirements-ci.txt` (hash-locked) | required — `--require-hashes` fails closed |
-| shellcheck, actionlint, typos, editorconfig-checker, gitleaks | pinned in the bootstrap (GitHub release binaries) | best effort — warns and continues |
-| markdownlint-cli2, check-jsonschema | pinned in the bootstrap (npm -g / uv tool) | best effort |
+| shellcheck, actionlint, typos, editorconfig-checker, gitleaks | pinned in the bootstrap (GitHub release binaries → `~/.local/bin`) | best effort — warns and continues |
+| check-jsonschema | pinned in the bootstrap (uv tool / pip `--user`) | best effort |
 | full git history + `origin/main` | `git fetch` | best effort — the base-ref diff gates need it |
 | the enabled plugin catalog | `enabledPlugins` in `.claude/settings.json` | best effort — a plugin that fails to install costs its skills, not the session |
+
+The bootstrap's startup `report_tool` resolves each binary under a **hook-safe PATH**
+(the process PATH with the nvm prefix stripped) and prints the resolved path, so an
+`npm -g` install that only the SessionStart shell can see cannot print false-green
+again. `CLAUDE_ENV_FILE` PATH repairs still reach subsequent Bash tool calls only —
+hook processes inherit Claude Code's own environ, which includes `~/.local/bin` but
+not the nvm global prefix.
 
 Best-effort rather than required, deliberately: the plugin contract suites SKIP visibly when an
 optional tool is absent and CI remains the enforcing gate, while a required install failure would

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "license": "MIT",
-  "description": "Locked CI-only toolchain for the Claude Code plugin marketplace.",
+  "description": "Locked CI-only toolchain for the Claude Code plugin marketplace (claude CLI, Biome, and markdownlint-cli2 for the markdown-format hook's repo-local node_modules/.bin probe).",
   "engines": {
     "node": ">=24"
   },


### PR DESCRIPTION
## Summary

Cloud bootstrap installed `markdownlint-cli2` with `npm install -g` into the nvm prefix. Plugin hooks inherit Claude Code's environ (which includes `~/.local/bin`) but **not** that nvm segment, and `CLAUDE_ENV_FILE` PATH repairs reach subsequent Bash tool calls only — so the markdown-format gate silently skipped for the whole cloud session while SessionStart printed false-green.

## Fix

- Drop `npm -g` for markdownlint; rely on the existing root `package-lock.json` install from `npm ci`.
- Symlink `node_modules/.bin/markdownlint-cli2` into `~/.local/bin` (same place shellcheck already lands) so PATH-based hook resolution works alongside the hook's filesystem `node_modules/.bin` probe.
- Make `report_tool` resolve under a hook-safe PATH (nvm prefix stripped) and print the resolved path so the startup report cannot false-green again.
- Document the contract in `docs/CLOUD-SESSIONS.md` and the fleet bootstrap template.

Does **not** widen the markdown-format hook to probe NVM layout paths (binding; #2740 already fixed notice wording / PATH diagnostic).

Closes #2739
Closes #2748

## Test plan

- [x] `shellcheck -x .claude/cloud-bootstrap.sh`
- [x] `npm ci` materializes `node_modules/.bin/markdownlint-cli2`
- [x] Symlink into `~/.local/bin`; hook-safe PATH (nvm stripped) resolves and runs v0.23.2
- [x] Pre-fix PATH without `~/.local/bin` / `node_modules/.bin` / nvm → ABSENT (reproduces #2748)
- [x] `markdownlint-cli2` clean on changed docs
- [x] Local `CLAUDE_CODE_REMOTE` unset/false → no-op guard

## Related

- Refs #2740 (PATH diagnostic / notice wording; this PR does not reopen that scope).
