### PR TITLE
fix(docs-hygiene): speed audit-noise detect hot path (0.14.4)

### DIFF
--- a/plugins/docs-hygiene/.claude-plugin/plugin.json
+++ b/plugins/docs-hygiene/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "docs-hygiene",
-  "version": "0.14.3",
+  "version": "0.14.4",
   "description": "Documentation-hygiene toolkit: compress (flavor-trim markdown with a semantic-diff safety net), audit-noise (classify markdown noise), extract-ssot (deduplicate repeated content into a single source of truth), audit-encapsulation (detect citations into skill-private surfaces), rename-references (sweep stale references after renames), and audit-derivability (classify whether a whole document earns its existence \u2014 could a fresh agent re-derive it from the code?).",
   "author": {
     "name": "Melodic Software",

--- a/plugins/docs-hygiene/CHANGELOG.md
+++ b/plugins/docs-hygiene/CHANGELOG.md
@@ -13,6 +13,8 @@
   timeouts). `--offset` / `--limit` chunk the sorted target list so
   orchestration can fan out one process per chunk without a per-file shell
   loop (#2741).
+  Missing values for `--offset`/`--limit`/`--paths-file` now exit 2 instead of
+  hanging; leading-zero chunk values are normalized as decimal before arithmetic.
 
 ## [0.14.3]
 

--- a/plugins/docs-hygiene/CHANGELOG.md
+++ b/plugins/docs-hygiene/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog — docs-hygiene plugin
 
+## [0.14.4]
+
+### Fixed
+
+- **audit-noise detect:** hoist + export convention-root resolution once per
+  run so `AUDIT_NOISE_CONTRACT_ROOT` survives into the ghost-ref exemption
+  check (auditor F6 — a configured contract root's bare `reviews/` /
+  `handoffs/` / `running-retros/` child no longer inherits the memory-root
+  exemption). Per-line shape detection now uses nameref helpers instead of
+  command substitutions in the hot loop (the root cause of repo-wide scan
+  timeouts). `--offset` / `--limit` chunk the sorted target list so
+  orchestration can fan out one process per chunk without a per-file shell
+  loop (#2741).
+
 ## [0.14.3]
 
 ### Fixed

--- a/plugins/docs-hygiene/skills/audit-noise/SKILL.md
+++ b/plugins/docs-hygiene/skills/audit-noise/SKILL.md
@@ -69,7 +69,9 @@ Single action v1; `relocate` and `generalize` actions are deferred until real de
 1. Empty arg AND clean tree → OFFER the repo-wide audit instead of silently no-opping; run only on
    the user's confirmation. The offer carries prescribed defaults (overridable): corpus = all
    tracked `.md` minus `**/evals/fixtures/**` and `CHANGELOG.md`; slice-scoped files (contract and
-   memory tiers) sectioned separately in the report; scan via a chunked `detect.sh` pass; on a
+   memory tiers) sectioned separately in the report; scan via a chunked `detect.sh` pass
+   (`detect.sh --paths-file <list> --offset N --limit M` — one process per chunk, no
+   per-file shell loop); on a
    large corpus, judge only scanner-flagged files, fanning out a small number of concurrent
    subagents with one fresh-context verification pass over the merged verdicts; report first —
    this skill stays read-only either way, and the author applies any treatment edits only after

--- a/plugins/docs-hygiene/skills/audit-noise/scripts/detect.sh
+++ b/plugins/docs-hygiene/skills/audit-noise/scripts/detect.sh
@@ -34,18 +34,29 @@ invoke one detect.sh process per chunk without a per-file shell loop.
 EOF
 }
 
+require_opt_value() {
+  local opt="$1"
+  if [[ $# -lt 2 || -z "${2:-}" || "$2" == -* ]]; then
+    echo "detect.sh: $opt requires a value" >&2
+    exit 2
+  fi
+}
+
 while [[ $# -gt 0 ]]; do
   case "$1" in
   --paths-file)
-    PATHS_FILE="${2:-}"
+    require_opt_value "$@"
+    PATHS_FILE="$2"
     shift 2
     ;;
   --offset)
-    OFFSET="${2:-0}"
+    require_opt_value "$@"
+    OFFSET="$2"
     shift 2
     ;;
   --limit)
-    LIMIT="${2:-0}"
+    require_opt_value "$@"
+    LIMIT="$2"
     shift 2
     ;;
   -h | --help)
@@ -75,6 +86,9 @@ if [[ ! "$OFFSET" =~ ^[0-9]+$ || ! "$LIMIT" =~ ^[0-9]+$ ]]; then
   echo "detect.sh: --offset and --limit require non-negative integers" >&2
   exit 2
 fi
+# Strip leading zeros so values like 08 are decimal, not octal, under arithmetic.
+OFFSET=$((10#$OFFSET))
+LIMIT=$((10#$LIMIT))
 
 repo_root="$(git rev-parse --show-toplevel 2>/dev/null | tr -d '\r')"
 if [[ -n "$repo_root" ]]; then

--- a/plugins/docs-hygiene/skills/audit-noise/scripts/detect.sh
+++ b/plugins/docs-hygiene/skills/audit-noise/scripts/detect.sh
@@ -12,6 +12,8 @@ source "$SCRIPT_DIR/lib/noise-shapes.sh"
 
 PATHS_FILE=""
 TARGETS=()
+OFFSET=0
+LIMIT=0
 
 usage() {
   cat <<'EOF'
@@ -20,10 +22,15 @@ detect.sh — emit markdown noise findings for /audit-noise.
 Usage:
   detect.sh <file.md>...
   detect.sh --paths-file <file>
+  detect.sh --offset N --limit N   # chunk affordance over the sorted target list
   detect.sh --help
 
 When no paths are given, audits the uncommitted .md files of the repository
 it runs in (from git status). Exit: 0 on audit, 2 on unknown arguments.
+
+--offset / --limit slice the sorted unique target list after directory
+expansion (0-based offset; limit 0 means no cap). Repo-wide orchestration can
+invoke one detect.sh process per chunk without a per-file shell loop.
 EOF
 }
 
@@ -31,6 +38,14 @@ while [[ $# -gt 0 ]]; do
   case "$1" in
   --paths-file)
     PATHS_FILE="${2:-}"
+    shift 2
+    ;;
+  --offset)
+    OFFSET="${2:-0}"
+    shift 2
+    ;;
+  --limit)
+    LIMIT="${2:-0}"
     shift 2
     ;;
   -h | --help)
@@ -54,6 +69,12 @@ while [[ $# -gt 0 ]]; do
     ;;
   esac
 done
+
+# Reject non-integer offset/limit early (unknown-arg class → exit 2).
+if [[ ! "$OFFSET" =~ ^[0-9]+$ || ! "$LIMIT" =~ ^[0-9]+$ ]]; then
+  echo "detect.sh: --offset and --limit require non-negative integers" >&2
+  exit 2
+fi
 
 repo_root="$(git rev-parse --show-toplevel 2>/dev/null | tr -d '\r')"
 if [[ -n "$repo_root" ]]; then
@@ -99,6 +120,35 @@ fi
 
 mapfile -t SORTED < <(printf '%s\n' "${TARGETS[@]}" | LC_ALL=C sort -u)
 
+# Chunk affordance: slice the sorted list so a parent can fan out without a
+# per-file shell loop (hook-bypass-safe single process per chunk).
+if [[ "$OFFSET" -gt 0 || "$LIMIT" -gt 0 ]]; then
+  CHUNKED=()
+  idx=0
+  for file in "${SORTED[@]}"; do
+    if [[ "$idx" -ge "$OFFSET" ]]; then
+      if [[ "$LIMIT" -eq 0 || ${#CHUNKED[@]} -lt "$LIMIT" ]]; then
+        CHUNKED+=("$file")
+      else
+        break
+      fi
+    fi
+    idx=$((idx + 1))
+  done
+  SORTED=(${CHUNKED[@]+"${CHUNKED[@]}"})
+fi
+
+if [[ ${#SORTED[@]} -eq 0 ]]; then
+  echo "Summary total: files=0 T1=0 T2=0 T3=0"
+  echo "Note: chunk offset/limit selected no targets"
+  exit 0
+fi
+
+# Hoist convention-root resolution once per run (also repairs F6: contract
+# root must survive into the ghost-ref exemption check).
+AUDIT_NOISE_REPO_ROOT="${AUDIT_NOISE_REPO_ROOT:-${repo_root:-.}}"
+audit_noise_resolve_convention_roots
+
 total_t1=0 total_t2=0 total_t3=0 files_audited=0
 
 audit_file() {
@@ -110,8 +160,10 @@ audit_file() {
   files_audited=$((files_audited + 1))
 
   local t1=0 t2=0 t3=0
-  local in_exempt=0 current_section="" line_num=0 shapes shape tier excerpt
+  local in_exempt=0 current_section="" line_num=0
   local in_ignored_para=0 skip_next=0
+  local -a shapes=()
+  local shape tier excerpt line
 
   while IFS= read -r line || [[ -n "$line" ]]; do
     line_num=$((line_num + 1))
@@ -146,12 +198,12 @@ audit_file() {
       skip_next=0
       continue
     fi
-    shapes="$(audit_noise_detect_shapes "$line" || true)"
-    if [[ -n "$shapes" ]]; then
-      excerpt="$(audit_noise_trim_excerpt "$line")"
-      while IFS= read -r shape; do
+    # Hot path: nameref APIs only — no per-line command substitutions.
+    if audit_noise_detect_shapes_into shapes "$line"; then
+      audit_noise_trim_excerpt "$line" excerpt
+      for shape in "${shapes[@]}"; do
         [[ -z "$shape" ]] && continue
-        tier="$(audit_noise_shape_tier "$shape")"
+        audit_noise_shape_tier_into "$shape" tier
         printf 'File: %s\n' "$file"
         printf 'Finding tier: %s\n' "$tier"
         printf 'Finding shape: %s\n' "$shape"
@@ -163,7 +215,7 @@ audit_file() {
         2) t2=$((t2 + 1)) total_t2=$((total_t2 + 1)) ;;
         *) t3=$((t3 + 1)) total_t3=$((total_t3 + 1)) ;;
         esac
-      done <<<"$shapes"
+      done
     fi
   done <"$file"
 

--- a/plugins/docs-hygiene/skills/audit-noise/scripts/detect.test.sh
+++ b/plugins/docs-hygiene/skills/audit-noise/scripts/detect.test.sh
@@ -307,6 +307,21 @@ assert_contains "configured memory root flags concrete slices" "$conf_out" ".scr
 assert_not_contains "configured bare concern root stays exempt" "$conf_out" ".scratch/reviews/"
 assert_not_contains "configured bare running-retros root stays exempt" "$conf_out" ".scratch/running-retros/"
 
+# F6 regression: a configured contract root's bare reviews/handoffs child must
+# NOT inherit the memory-root exemption. AUDIT_NOISE_CONTRACT_ROOT used to be
+# set only inside a command-substitution subshell and lost, so product/topics/
+# reviews/ was incorrectly treated like .work/reviews/.
+CONF_CONTRACT_BARE="$TEST_TMPDIR/configured-contract-bare.md"
+cat >"$CONF_CONTRACT_BARE" <<'EOF'
+# Configured-contract bare-root fixture
+
+product/topics/reviews/ must flag — contract roots have no bare-child exemption.
+product/topics/handoffs/ likewise.
+EOF
+conf_bare_out="$(AUDIT_NOISE_REPO_ROOT="$CONF_ROOT" bash "$DETECT" "$CONF_CONTRACT_BARE")"
+assert_contains "configured contract bare reviews/ flags (F6)" "$conf_bare_out" "product/topics/reviews/"
+assert_contains "configured contract bare handoffs/ flags (F6)" "$conf_bare_out" "product/topics/handoffs/"
+
 # A quoted memory_dir with an interior '#' and a trailing comment: the old
 # hand-rolled `${val%%#*}`-first strip truncated this to `.scratch` (dropping
 # everything from the interior '#' on, including the closing quote), so the
@@ -326,6 +341,24 @@ EOF
 conf_quoted_out="$(AUDIT_NOISE_REPO_ROOT="$CONF_ROOT_QUOTED" bash "$DETECT" "$CONFIGURED_QUOTED")"
 assert_contains "quoted memory_dir with interior # and trailing comment flags concrete slice" \
   "$conf_quoted_out" ".scratch#dir/foo/"
+
+# --- Chunk affordance: --offset / --limit over the sorted target list ----------------
+
+CHUNK_A="$TEST_TMPDIR/chunk-a.md"
+CHUNK_B="$TEST_TMPDIR/chunk-b.md"
+CHUNK_C="$TEST_TMPDIR/chunk-c.md"
+printf '# a\n\nEmpirically observed in chunk-a.\n' >"$CHUNK_A"
+printf '# b\n\nEmpirically observed in chunk-b.\n' >"$CHUNK_B"
+printf '# c\n\nEmpirically observed in chunk-c.\n' >"$CHUNK_C"
+chunk_out="$(bash "$DETECT" --offset 1 --limit 1 "$CHUNK_A" "$CHUNK_B" "$CHUNK_C")"
+assert_contains "chunk selects middle file only" "$chunk_out" "Summary file: $CHUNK_B"
+assert_not_contains "chunk skips earlier file" "$chunk_out" "Summary file: $CHUNK_A"
+assert_not_contains "chunk skips later file" "$chunk_out" "Summary file: $CHUNK_C"
+assert_contains "chunk still emits findings for selected file" "$chunk_out" "chunk-b"
+
+bad_chunk_exit=0
+bash "$DETECT" --offset -1 "$CLEAN" >/dev/null 2>&1 || bad_chunk_exit=$?
+assert_exit "negative --offset exits 2" 2 "$bad_chunk_exit"
 
 # --- Final report --------------------------------------------------------------------
 

--- a/plugins/docs-hygiene/skills/audit-noise/scripts/lib/noise-shapes.sh
+++ b/plugins/docs-hygiene/skills/audit-noise/scripts/lib/noise-shapes.sh
@@ -9,31 +9,50 @@ audit_noise_trim_excerpt() {
   if ((${#line} > 120)); then
     line="${line:0:117}..."
   fi
+  # Prefer nameref when the caller wants to avoid a command-substitution subshell.
+  if [[ -n "${2:-}" ]]; then
+    local -n _audit_noise_excerpt_out="$2"
+    _audit_noise_excerpt_out="$line"
+    return 0
+  fi
   printf '%s' "$line"
 }
 
-# Configured convention roots: when the consuming repo's concern file
-# (.claude/topic-docs.yaml) overrides memory_dir/contract_dir, those roots
-# are ghost-ref surfaces too. Resolved once per process; defaults always
-# scan (a doc may cite the defaults regardless of local config).
-audit_noise_convention_roots_pattern() {
-  if [[ -z "${AUDIT_NOISE_ROOTS_PATTERN:-}" ]]; then
-    local pattern='\.work|docs/topics' key val yaml lib_dir
-    yaml="${AUDIT_NOISE_REPO_ROOT:-.}/.claude/topic-docs.yaml"
-    lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-    if [[ -f "$yaml" ]]; then
-      for key in memory_dir contract_dir; do
-        val=$("$lib_dir/parse-concern-value.sh" "$yaml" "$key")
-        if [[ "$key" == 'contract_dir' && -n "$val" ]]; then
-          AUDIT_NOISE_CONTRACT_ROOT="$val"
-        fi
-        if [[ -n "$val" && "$val" != '.' && "$val" != '.work' && "$val" != 'docs/topics' ]]; then
-          pattern+="|$(printf '%s' "$val" | sed "s/[.[\\*^\$()+?{|]/\\\\&/g")"
-        fi
-      done
-    fi
-    AUDIT_NOISE_ROOTS_PATTERN="$pattern"
+# Resolve configured convention roots once per process and export them.
+# Calling this (or the legacy pattern helper) inside a command substitution used
+# to set AUDIT_NOISE_CONTRACT_ROOT only in the subshell — so a configured
+# contract root's bare reviews/handoffs/running-retros child was silently
+# exempt against the lib's stated intent (auditor F6).
+audit_noise_resolve_convention_roots() {
+  if [[ -n "${AUDIT_NOISE_ROOTS_RESOLVED:-}" ]]; then
+    return 0
   fi
+  local pattern='\.work|docs/topics' key val yaml lib_dir
+  yaml="${AUDIT_NOISE_REPO_ROOT:-.}/.claude/topic-docs.yaml"
+  lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  # Default contract root matches the built-in pattern default.
+  AUDIT_NOISE_CONTRACT_ROOT="${AUDIT_NOISE_CONTRACT_ROOT:-docs/topics}"
+  if [[ -f "$yaml" ]]; then
+    for key in memory_dir contract_dir; do
+      val=$("$lib_dir/parse-concern-value.sh" "$yaml" "$key")
+      if [[ "$key" == 'contract_dir' && -n "$val" ]]; then
+        AUDIT_NOISE_CONTRACT_ROOT="$val"
+      fi
+      if [[ -n "$val" && "$val" != '.' && "$val" != '.work' && "$val" != 'docs/topics' ]]; then
+        pattern+="|$(printf '%s' "$val" | sed "s/[.[\\*^\$()+?{|]/\\\\&/g")"
+      fi
+    done
+  fi
+  AUDIT_NOISE_ROOTS_PATTERN="$pattern"
+  AUDIT_NOISE_ROOTS_RESOLVED=1
+  export AUDIT_NOISE_ROOTS_PATTERN AUDIT_NOISE_CONTRACT_ROOT AUDIT_NOISE_ROOTS_RESOLVED
+}
+
+# Back-compat wrapper: ensure roots are resolved, then print the pattern.
+# Prefer audit_noise_resolve_convention_roots + $AUDIT_NOISE_ROOTS_PATTERN in
+# hot paths so the assignment cannot be lost to a subshell.
+audit_noise_convention_roots_pattern() {
+  audit_noise_resolve_convention_roots
   printf '%s' "$AUDIT_NOISE_ROOTS_PATTERN"
 }
 
@@ -45,14 +64,16 @@ audit_noise_convention_roots_pattern() {
 # <memory_dir>/running-retros/ — reserved first-level names under the memory
 # root per docs/conventions/topic-docs/) are exempt only in bare form — a
 # concrete child under them flags. Configured non-default roots from the
-# concern file scan alongside the defaults.
+# concern file scan alongside the defaults. The bare-root exemption is for
+# memory roots only — never for the contract root (default or configured).
 audit_noise_line_has_ghost_ref() {
   local rest="$1" path root seg after roots
+  audit_noise_resolve_convention_roots
   # Retired locations: stale even in placeholder form.
   [[ "$rest" == *'.claude/notes/'* ||
     "$rest" == *'.claude/handoffs/'* ||
     "$rest" == *'.claude/review/'* ]] && return 0
-  roots="$(audit_noise_convention_roots_pattern)"
+  roots="$AUDIT_NOISE_ROOTS_PATTERN"
   while [[ "$rest" =~ ($roots)/([a-z0-9][a-z0-9_-]*)/ ]]; do
     path="${BASH_REMATCH[0]}"
     root="${BASH_REMATCH[1]}"
@@ -62,7 +83,7 @@ audit_noise_line_has_ghost_ref() {
     # sentence-ending period (`.work/running-retros/.`) starts with `.` but is
     # punctuation, not a hidden child — only `.` followed by a path segment
     # character counts as concrete (`.gitignore`-style names still flag).
-    if [[ "$root" != 'docs/topics' && "$root" != "${AUDIT_NOISE_CONTRACT_ROOT:-docs/topics}" ]] &&
+    if [[ "$root" != 'docs/topics' && "$root" != "$AUDIT_NOISE_CONTRACT_ROOT" ]] &&
       [[ "$seg" == 'handoffs' || "$seg" == 'reviews' || "$seg" == 'running-retros' ]] &&
       { [[ ! "$after" =~ ^[A-Za-z0-9._-] ]] || [[ "$after" =~ ^\.([^A-Za-z0-9_-]|$) ]]; }; then
       rest="$after"
@@ -73,41 +94,51 @@ audit_noise_line_has_ghost_ref() {
   return 1
 }
 
-# Emit zero or more shape names (one per line on stdout).
-audit_noise_detect_shapes() {
-  local line="$1"
-  local found=0
+# Append matching shape names into the nameref array (avoids a per-line
+# command-substitution subshell in the detect hot loop).
+audit_noise_detect_shapes_into() {
+  local -n _audit_noise_shapes_out="$1"
+  local line="$2"
+  _audit_noise_shapes_out=()
   if audit_noise_line_has_ghost_ref "$line"; then
-    printf '%s\n' 'ghost-ref'
-    found=1
+    _audit_noise_shapes_out+=('ghost-ref')
   fi
   if [[ "$line" =~ ^##[[:space:]]+Why[[:space:]]+this[[:space:]]+file[[:space:]]+exists ]]; then
-    printf '%s\n' 'preamble'
-    found=1
+    _audit_noise_shapes_out+=('preamble')
   fi
   if [[ "$line" =~ [Ee]mpirically[[:space:]]+observed ]] ||
     [[ "$line" =~ [Ww]e[[:space:]]+pivoted[[:space:]]+from ]] ||
     [[ "$line" =~ [Ww]as[[:space:]]+renamed[[:space:]]+to ]] ||
     [[ "$line" =~ [Pp]re-convention ]] ||
     [[ "$line" =~ [Ll]egacy[[:space:]]+layout ]]; then
-    printf '%s\n' 'citation'
-    found=1
+    _audit_noise_shapes_out+=('citation')
   fi
   if [[ "$line" =~ [Ff]ollowing[[:space:]]+(five|four|three|six|seven|eight|nine|ten|[0-9]+)[[:space:]]+(skills|consumers|agents|modules) ]]; then
-    printf '%s\n' 'enum-list'
-    found=1
+    _audit_noise_shapes_out+=('enum-list')
   fi
   if [[ "$line" =~ ^[[:space:]]*-[[:space:]]+\`?/[a-z][a-z0-9_-]*\`?[[:space:]]— ]]; then
-    printf '%s\n' 'enum-list'
-    found=1
+    _audit_noise_shapes_out+=('enum-list')
   fi
   if [[ "$line" =~ [Pp]ath-scoped[[:space:]]+to ]] ||
     [[ "$line" =~ [Ll]oads[[:space:]]+on[[:space:]]+[Rr]ead[[:space:]]+of ]] ||
     [[ "$line" =~ [Aa]uto-loads[[:space:]]+when ]]; then
-    printf '%s\n' 'scope-meta'
-    found=1
+    _audit_noise_shapes_out+=('scope-meta')
   fi
-  return "$found"
+  ((${#_audit_noise_shapes_out[@]} > 0))
+}
+
+# Emit zero or more shape names (one per line on stdout). Prefer
+# audit_noise_detect_shapes_into in hot loops.
+audit_noise_detect_shapes() {
+  local shapes=()
+  if audit_noise_detect_shapes_into shapes "$1"; then
+    local s
+    for s in "${shapes[@]}"; do
+      printf '%s\n' "$s"
+    done
+    return 0
+  fi
+  return 1
 }
 
 audit_noise_shape_tier() {
@@ -116,6 +147,17 @@ audit_noise_shape_tier() {
   ghost-ref | preamble) printf '2' ;;
   citation | enum-list | scope-meta) printf '1' ;;
   *) printf '3' ;;
+  esac
+}
+
+# Set nameref to the tier digit without a subshell.
+audit_noise_shape_tier_into() {
+  local shape="$1"
+  local -n _audit_noise_tier_out="$2"
+  case "$shape" in
+  ghost-ref | preamble) _audit_noise_tier_out=2 ;;
+  citation | enum-list | scope-meta) _audit_noise_tier_out=1 ;;
+  *) _audit_noise_tier_out=3 ;;
   esac
 }
 


### PR DESCRIPTION
## Summary
- Hoist and export convention-root resolution once per `detect.sh` run so `AUDIT_NOISE_CONTRACT_ROOT` is not lost to command-substitution subshells (auditor F6: configured contract root bare `reviews/`/`handoffs/` no longer falsely exempt).
- Restructure the per-line hot path to use nameref helpers (`detect_shapes_into`, `shape_tier_into`, `trim_excerpt`) instead of 2+ `$()` forks per markdown line.
- Add `--offset` / `--limit` so repo-wide orchestration can chunk without a per-file shell loop; document in SKILL.md clean-tree defaults.
- Bump docs-hygiene to 0.14.4.

## Test plan
- [x] `bash plugins/docs-hygiene/skills/audit-noise/scripts/detect.test.sh` — 48/48 pass (includes F6 contract-bare regression + chunk affordance)
- [x] Perf smoke: single non-CHANGELOG scan path no longer pays per-line `parse-concern-value.sh` forks; 40×885-line corpus ~7.8s in this environment

Closes #2741

## Related

- Base of the docs-hygiene stack (#2794 → #2795 → #2798 → #2805).
