### PR TITLE
feat(autonomy): generated identity-and-prerequisite emission with drift gate (#2723)

### DIFF
--- a/plugins/autonomy/.claude-plugin/plugin.json
+++ b/plugins/autonomy/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "autonomy",
-  "version": "0.19.1",
+  "version": "0.20.0",
   "description": "Governed autonomous agent operation: role-topology, binding-seam, wiring-vs-advisor, telemetry, return-accounting, trigger-dispatch, per-work-class guardrail-matrix, standing-routine-catalog, and design-only runner-charter contracts for climbing the AI-adoption ladder, plus a guided-setup skill that discovers an adopting org's state, writes its schema-versioned binding, wires standards-pinned OTLP emission with a zero-cost file-artifact default, wires human-attested return capture at the task boundary, wires signal adapters with one governed dispatch entrypoint, binds the five-class guardrail matrix to an org's isolation substrates with an in-boundary live-validation probe before recording each fail-closed binding, and stands up standing-routine-catalog classes as scheduled temporal signal adapters behind the one governed queue with free scheduling defaults wired as reviewable changes and each routine's work-class mapping homed on the security surface.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/autonomy/CHANGELOG.md
+++ b/plugins/autonomy/CHANGELOG.md
@@ -3,6 +3,20 @@
 All notable changes to the `autonomy` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.20.0]
+
+### Added
+
+- **Generated identity-and-prerequisite emission with drift gate** (#2723).
+  `skills/setup/scripts/generate-identity-prerequisites.mjs` derives
+  `generated/identity-prerequisites.json` from every `v1` leaf's `## Prerequisites`
+  section — one machine-readable record per identity (Access class, isolation floor,
+  connector entitlements + rung, structured `needs` with probe class / seam) — so the
+  resolver reads structure, never leaf prose. Leaves remain the authored single home;
+  `--check` fails CI on drift (wired through `scripts/validate-plugins.sh`). Co-located
+  `*.test.sh` + manifest cover clean `--check`, a hand-edited drift fixture, leaf↔emission
+  parity, and posture divergence (`dependency-update-wave` L2 vs L3).
+
 ## [0.19.1]
 
 ### Changed
@@ -14,6 +28,7 @@ All notable changes to the `autonomy` plugin are documented here. Format follows
   `join: proven recurring manual pattern`, the row does not flip to `v1`, and no `routines/` leaf
   is added: `v1` means a proven manual pattern, and a detector proves detection, never the repair
   pattern that trigger names.
+
 
 ## [0.19.0]
 

--- a/plugins/autonomy/CHANGELOG.md
+++ b/plugins/autonomy/CHANGELOG.md
@@ -29,7 +29,6 @@ All notable changes to the `autonomy` plugin are documented here. Format follows
   is added: `v1` means a proven manual pattern, and a detector proves detection, never the repair
   pattern that trigger names.
 
-
 ## [0.19.0]
 
 ### Added

--- a/plugins/autonomy/README.md
+++ b/plugins/autonomy/README.md
@@ -48,7 +48,9 @@ state and records that binding.
 - **Routine prerequisite resolution** (`reference/prerequisite-resolution.md`): fail-closed,
   per-identity-per-surface verdicts (`supported` / `conditional` / `unsupported` / `unknown`) for
   which catalog identities can run against a repository, composing owning seams rather than a new
-  prober — with `deferred-class` marking `join:` rows that have no identities yet.
+  prober — with `deferred-class` marking `join:` rows that have no identities yet. Per-identity
+  facts live in each `v1` leaf; `generated/identity-prerequisites.json` is the drift-gated
+  emission derived from those leaves (generator under `skills/setup/scripts/`).
 - **Runner design pack** (`reference/runner.md`): the architect-ready design contract for the
   autonomous-drain runner — the composition spine and its eight seams, the lifecycle state
   model, the two-family stop-criteria taxonomy with terminal-handoff escalation and

--- a/plugins/autonomy/generated/identity-prerequisites.json
+++ b/plugins/autonomy/generated/identity-prerequisites.json
@@ -1,0 +1,314 @@
+{
+  "_comment": "GENERATED — do not hand-edit. Regenerate with plugins/autonomy/skills/setup/scripts/generate-identity-prerequisites.mjs",
+  "schema_version": 1,
+  "identities": [
+    {
+      "identity": "advisory-cve-triage",
+      "class": "advisory-cve-triage",
+      "posture": null,
+      "leaf": "reference/routines/advisory-cve-triage.md",
+      "access_class": "repo",
+      "isolation_floor": "L2",
+      "connector_entitlements": [],
+      "connector_entitlement_rung": null,
+      "executor_class_merge_cap": "security-binding",
+      "needs": [
+        {
+          "id": "advisory_database",
+          "probe_class": "harness-context"
+        },
+        {
+          "id": "dependency_manifests",
+          "probe_class": "repo-file"
+        }
+      ]
+    },
+    {
+      "identity": "backlog-readiness-check",
+      "class": "backlog-readiness-check",
+      "posture": null,
+      "leaf": "reference/routines/backlog-readiness-check.md",
+      "access_class": "repo",
+      "isolation_floor": "L2",
+      "connector_entitlements": [],
+      "connector_entitlement_rung": null,
+      "executor_class_merge_cap": "security-binding",
+      "needs": [
+        {
+          "id": "tracker",
+          "probe_class": "repo-file",
+          "seam": "work-item-tracker"
+        }
+      ]
+    },
+    {
+      "identity": "ci-health-review/advisory",
+      "class": "ci-health-review",
+      "posture": "advisory",
+      "leaf": "reference/routines/ci-health-review.md",
+      "access_class": "repo",
+      "isolation_floor": "L2",
+      "connector_entitlements": [],
+      "connector_entitlement_rung": null,
+      "executor_class_merge_cap": "security-binding",
+      "needs": [
+        {
+          "id": "ci_config",
+          "probe_class": "repo-file",
+          "owner": "resolution-contract"
+        },
+        {
+          "id": "tracker",
+          "probe_class": "repo-file",
+          "seam": "work-item-tracker"
+        }
+      ]
+    },
+    {
+      "identity": "ci-health-review/ci-config-change",
+      "class": "ci-health-review",
+      "posture": "ci-config-change",
+      "leaf": "reference/routines/ci-health-review.md",
+      "access_class": "repo",
+      "isolation_floor": "L2",
+      "connector_entitlements": [],
+      "connector_entitlement_rung": null,
+      "executor_class_merge_cap": "security-binding",
+      "needs": [
+        {
+          "id": "ci_config",
+          "probe_class": "repo-file",
+          "owner": "resolution-contract"
+        },
+        {
+          "id": "merge_path",
+          "probe_class": "harness-context"
+        },
+        {
+          "id": "tracker",
+          "probe_class": "repo-file",
+          "seam": "work-item-tracker"
+        }
+      ]
+    },
+    {
+      "identity": "dependency-update-wave/changelog-informed",
+      "class": "dependency-update-wave",
+      "posture": "changelog-informed",
+      "leaf": "reference/routines/dependency-update-wave.md",
+      "access_class": "repo",
+      "isolation_floor": "L3",
+      "connector_entitlements": [],
+      "connector_entitlement_rung": null,
+      "executor_class_merge_cap": "security-binding",
+      "needs": [
+        {
+          "id": "ci_config",
+          "probe_class": "repo-file",
+          "owner": "resolution-contract"
+        },
+        {
+          "id": "dependency_manifests",
+          "probe_class": "repo-file"
+        },
+        {
+          "id": "ecosystems",
+          "probe_class": "repo-file",
+          "seam": "toolchain"
+        },
+        {
+          "id": "upstream_changelog",
+          "probe_class": "harness-context"
+        }
+      ]
+    },
+    {
+      "identity": "dependency-update-wave/mechanical",
+      "class": "dependency-update-wave",
+      "posture": "mechanical",
+      "leaf": "reference/routines/dependency-update-wave.md",
+      "access_class": "repo",
+      "isolation_floor": "L2",
+      "connector_entitlements": [],
+      "connector_entitlement_rung": null,
+      "executor_class_merge_cap": "security-binding",
+      "needs": [
+        {
+          "id": "ci_config",
+          "probe_class": "repo-file",
+          "owner": "resolution-contract"
+        },
+        {
+          "id": "dependency_manifests",
+          "probe_class": "repo-file"
+        },
+        {
+          "id": "ecosystems",
+          "probe_class": "repo-file",
+          "seam": "toolchain"
+        }
+      ]
+    },
+    {
+      "identity": "doc-freshness-sweep/advisory",
+      "class": "doc-freshness-sweep",
+      "posture": "advisory",
+      "leaf": "reference/routines/doc-freshness-sweep.md",
+      "access_class": "repo",
+      "isolation_floor": "L2",
+      "connector_entitlements": [],
+      "connector_entitlement_rung": null,
+      "executor_class_merge_cap": "security-binding",
+      "needs": [
+        {
+          "id": "documentation_corpus",
+          "probe_class": "repo-file"
+        },
+        {
+          "id": "tracker",
+          "probe_class": "repo-file",
+          "seam": "work-item-tracker"
+        }
+      ]
+    },
+    {
+      "identity": "doc-freshness-sweep/docs-change",
+      "class": "doc-freshness-sweep",
+      "posture": "docs-change",
+      "leaf": "reference/routines/doc-freshness-sweep.md",
+      "access_class": "repo",
+      "isolation_floor": "L2",
+      "connector_entitlements": [],
+      "connector_entitlement_rung": null,
+      "executor_class_merge_cap": "security-binding",
+      "needs": [
+        {
+          "id": "documentation_corpus",
+          "probe_class": "repo-file"
+        },
+        {
+          "id": "merge_path",
+          "probe_class": "harness-context"
+        },
+        {
+          "id": "tracker",
+          "probe_class": "repo-file",
+          "seam": "work-item-tracker"
+        }
+      ]
+    },
+    {
+      "identity": "duplicate-detection-sweep",
+      "class": "duplicate-detection-sweep",
+      "posture": null,
+      "leaf": "reference/routines/duplicate-detection-sweep.md",
+      "access_class": "repo",
+      "isolation_floor": "L2",
+      "connector_entitlements": [],
+      "connector_entitlement_rung": null,
+      "executor_class_merge_cap": "security-binding",
+      "needs": [
+        {
+          "id": "tracker",
+          "probe_class": "repo-file",
+          "seam": "work-item-tracker"
+        }
+      ]
+    },
+    {
+      "identity": "eng-metrics-digest",
+      "class": "eng-metrics-digest",
+      "posture": null,
+      "leaf": "reference/routines/eng-metrics-digest.md",
+      "access_class": "repo",
+      "isolation_floor": "L2",
+      "connector_entitlements": [],
+      "connector_entitlement_rung": null,
+      "executor_class_merge_cap": "security-binding",
+      "needs": [
+        {
+          "id": "activity_signals",
+          "probe_class": "repo-file"
+        },
+        {
+          "id": "ci_config",
+          "probe_class": "repo-file",
+          "owner": "resolution-contract"
+        },
+        {
+          "id": "tracker",
+          "probe_class": "repo-file",
+          "seam": "work-item-tracker"
+        }
+      ]
+    },
+    {
+      "identity": "issue-triage-sweep",
+      "class": "issue-triage-sweep",
+      "posture": null,
+      "leaf": "reference/routines/issue-triage-sweep.md",
+      "access_class": "repo",
+      "isolation_floor": "L2",
+      "connector_entitlements": [],
+      "connector_entitlement_rung": null,
+      "executor_class_merge_cap": "security-binding",
+      "needs": [
+        {
+          "id": "tracker",
+          "probe_class": "repo-file",
+          "seam": "work-item-tracker"
+        }
+      ]
+    },
+    {
+      "identity": "pr-queue-tending",
+      "class": "pr-queue-tending",
+      "posture": null,
+      "leaf": "reference/routines/pr-queue-tending.md",
+      "access_class": "repo",
+      "isolation_floor": "L2",
+      "connector_entitlements": [],
+      "connector_entitlement_rung": null,
+      "executor_class_merge_cap": "security-binding",
+      "needs": [
+        {
+          "id": "ci_config",
+          "probe_class": "repo-file",
+          "owner": "resolution-contract"
+        },
+        {
+          "id": "tracker",
+          "probe_class": "repo-file",
+          "seam": "work-item-tracker"
+        }
+      ]
+    },
+    {
+      "identity": "tech-debt-sweep",
+      "class": "tech-debt-sweep",
+      "posture": null,
+      "leaf": "reference/routines/tech-debt-sweep.md",
+      "access_class": "repo",
+      "isolation_floor": "L2",
+      "connector_entitlements": [],
+      "connector_entitlement_rung": null,
+      "executor_class_merge_cap": "security-binding",
+      "needs": [
+        {
+          "id": "ecosystems",
+          "probe_class": "repo-file",
+          "seam": "toolchain"
+        },
+        {
+          "id": "source_tree",
+          "probe_class": "repo-file"
+        },
+        {
+          "id": "tracker",
+          "probe_class": "repo-file",
+          "seam": "work-item-tracker"
+        }
+      ]
+    }
+  ]
+}

--- a/plugins/autonomy/skills/setup/scripts/generate-identity-prerequisites.mjs
+++ b/plugins/autonomy/skills/setup/scripts/generate-identity-prerequisites.mjs
@@ -1,0 +1,407 @@
+#!/usr/bin/env node
+
+// Generates the machine-readable identity-and-prerequisite emission from the
+// ten v1 routine definition leaves. Leaves stay the authored single home; this
+// file is derived output the resolver and CI consume. Run with no argument to
+// rewrite the emission; run with --check to fail on drift (CI gate).
+//
+// Usage:
+//   node generate-identity-prerequisites.mjs [--check] [--root <dir>]
+// Exit 0 = in sync (or rewritten); 1 = drift / parse failure; 2 = usage error.
+
+import { mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join, relative, sep } from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+const DEFAULT_PLUGIN_ROOT = join(SCRIPT_DIR, "..", "..", "..");
+const LEAVES_REL = join("reference", "routines");
+const EMISSION_REL = join("generated", "identity-prerequisites.json");
+const SCHEMA_VERSION = 1;
+
+// Stable need vocabulary derived from leaf "Repo needs" prose. Order is the
+// match priority; each id appears at most once per identity after expansion.
+const NEED_PATTERNS = [
+  {
+    id: "tracker",
+    re: /tracker binding via the work-item tracker seam/,
+    probe_class: "repo-file",
+    seam: "work-item-tracker",
+  },
+  {
+    id: "tracker",
+    re: /tracker binding when filing/,
+    probe_class: "repo-file",
+    seam: "work-item-tracker",
+  },
+  {
+    id: "ci_config",
+    re: /CI-config presence/,
+    probe_class: "repo-file",
+    owner: "resolution-contract",
+  },
+  {
+    id: "dependency_manifests",
+    re: /dependency \/ build manifests/,
+    probe_class: "repo-file",
+  },
+  {
+    id: "ecosystems",
+    re: /ecosystems via the toolchain seam/,
+    probe_class: "repo-file",
+    seam: "toolchain",
+  },
+  {
+    id: "advisory_database",
+    re: /curated advisory-database/,
+    probe_class: "harness-context",
+  },
+  {
+    id: "merge_path",
+    re: /merge-bearing path/,
+    probe_class: "harness-context",
+  },
+  {
+    id: "upstream_changelog",
+    re: /upstream release-note/,
+    probe_class: "harness-context",
+  },
+  {
+    id: "source_tree",
+    re: /repository source tree/,
+    probe_class: "repo-file",
+  },
+  {
+    id: "documentation_corpus",
+    re: /documentation corpus/,
+    probe_class: "repo-file",
+  },
+  {
+    id: "activity_signals",
+    re: /repository activity signals/,
+    probe_class: "repo-file",
+  },
+];
+
+function usage() {
+  console.error(
+    "usage: node generate-identity-prerequisites.mjs [--check] [--root <dir>]",
+  );
+  process.exit(2);
+}
+
+function parseArgs(argv) {
+  let check = false;
+  let root = null;
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--check") {
+      check = true;
+      continue;
+    }
+    if (arg === "--root") {
+      root = argv[++i];
+      if (!root) usage();
+      continue;
+    }
+    usage();
+  }
+  return { check, root };
+}
+
+function posixRel(from, to) {
+  return relative(from, to).split(sep).join("/");
+}
+
+function firstBacktick(value) {
+  const match = value.match(/`([^`]+)`/);
+  return match ? match[1] : null;
+}
+
+function parseConnectorEntitlements(value) {
+  const trimmed = value.trim();
+  if (/^none\b/i.test(trimmed)) return [];
+  const tokens = [...trimmed.matchAll(/`([^`]+)`/g)].map((m) => m[1]);
+  return tokens.filter((t) => t !== "repo");
+}
+
+function parseConnectorRung(value) {
+  if (/^n\/a\b/i.test(value.trim())) return null;
+  if (/Org binding layer/i.test(value)) return "org";
+  return firstBacktick(value);
+}
+
+function needsFromProse(prose) {
+  const byId = new Map();
+  for (const pattern of NEED_PATTERNS) {
+    if (!pattern.re.test(prose)) continue;
+    if (byId.has(pattern.id)) continue;
+    const need = { id: pattern.id, probe_class: pattern.probe_class };
+    if (pattern.seam) need.seam = pattern.seam;
+    if (pattern.owner) need.owner = pattern.owner;
+    byId.set(pattern.id, need);
+  }
+  return [...byId.values()].sort((a, b) => a.id.localeCompare(b.id));
+}
+
+function extractPrerequisitesSection(markdown) {
+  const start = markdown.search(/^## Prerequisites\s*$/m);
+  if (start === -1) {
+    throw new Error("missing ## Prerequisites section");
+  }
+  const after = markdown.slice(start);
+  const endMatch = after.slice(after.indexOf("\n") + 1).search(/^## /m);
+  if (endMatch === -1) return after;
+  return after.slice(0, after.indexOf("\n") + 1 + endMatch);
+}
+
+function parseAxisTable(block) {
+  const axes = {};
+  for (const line of block.split("\n")) {
+    const match = line.match(/^\|\s*([^|]+?)\s*\|\s*([^|]+?)\s*\|$/);
+    if (!match) continue;
+    const axis = match[1].trim();
+    const value = match[2].trim();
+    if (axis === "Axis" || /^-+$/.test(axis.replace(/\s/g, ""))) continue;
+    axes[axis] = value;
+  }
+  return axes;
+}
+
+function splitIdentityBlocks(section) {
+  const bodies = [];
+  const headingRe = /^### `([^`]+)`\s*$/gm;
+  const headings = [...section.matchAll(headingRe)];
+  if (headings.length > 0) {
+    for (let i = 0; i < headings.length; i += 1) {
+      const start = headings[i].index;
+      const end = i + 1 < headings.length ? headings[i + 1].index : section.length;
+      bodies.push({
+        identity: headings[i][1],
+        block: section.slice(start, end),
+      });
+    }
+    return bodies;
+  }
+
+  const single = section.match(/Single-posture identity:\s*`([^`]+)`/);
+  if (!single) {
+    throw new Error("no ### identity headings and no Single-posture identity line");
+  }
+  return [{ identity: single[1], block: section }];
+}
+
+function classAndPosture(identity) {
+  const slash = identity.indexOf("/");
+  if (slash === -1) return { classToken: identity, posture: null };
+  return {
+    classToken: identity.slice(0, slash),
+    posture: identity.slice(slash + 1),
+  };
+}
+
+function recordFromAxes(identity, axes, leafRel) {
+  const access = axes["Access class"];
+  const floor = axes["Isolation floor"];
+  const entitlements = axes["Connector entitlements"];
+  const rung = axes["Connector entitlement rung"];
+  const repoNeeds = axes["Repo needs"];
+  if (!access || !floor || !entitlements || !rung || !repoNeeds) {
+    throw new Error(`${identity}: incomplete axis table`);
+  }
+  const accessClass = firstBacktick(access);
+  const isolationFloor = firstBacktick(floor);
+  if (!accessClass || !isolationFloor) {
+    throw new Error(`${identity}: Access class / Isolation floor missing backtick token`);
+  }
+  const { classToken, posture } = classAndPosture(identity);
+  return {
+    identity,
+    class: classToken,
+    posture,
+    leaf: leafRel,
+    access_class: accessClass,
+    isolation_floor: isolationFloor,
+    connector_entitlements: parseConnectorEntitlements(entitlements),
+    connector_entitlement_rung: parseConnectorRung(rung),
+    executor_class_merge_cap: "security-binding",
+    repo_needs_prose: repoNeeds,
+    needs: null,
+  };
+}
+
+function expandNeeds(records) {
+  const byIdentity = new Map(records.map((r) => [r.identity, r]));
+  const byPosture = new Map();
+  for (const record of records) {
+    if (record.posture) byPosture.set(`${record.class}/${record.posture}`, record);
+  }
+
+  for (const record of records) {
+    const prose = record.repo_needs_prose;
+    const inherit = prose.match(/everything\s+`([^`]+)`\s+requires/i);
+    let needs = [];
+    if (inherit) {
+      const token = inherit[1];
+      const parentKey = token.includes("/")
+        ? token
+        : `${record.class}/${token}`;
+      const parent = byIdentity.get(parentKey) || byPosture.get(parentKey);
+      if (!parent) {
+        throw new Error(`${record.identity}: cannot expand inheritance from ${token}`);
+      }
+      if (parent.needs === null) {
+        // Parent must be expanded first; two-pass below handles ordering.
+        record._inheritFrom = parent.identity;
+        continue;
+      }
+      needs = parent.needs.map((n) => ({ ...n }));
+    }
+    const own = needsFromProse(prose);
+    const byId = new Map(needs.map((n) => [n.id, n]));
+    for (const need of own) byId.set(need.id, need);
+    record.needs = [...byId.values()].sort((a, b) => a.id.localeCompare(b.id));
+  }
+
+  // Second pass for inherit-before-parent edge cases.
+  let pending = records.filter((r) => r.needs === null);
+  let guard = pending.length + 1;
+  while (pending.length > 0 && guard > 0) {
+    guard -= 1;
+    for (const record of pending) {
+      const parent = byIdentity.get(record._inheritFrom);
+      if (!parent || parent.needs === null) continue;
+      const byId = new Map(parent.needs.map((n) => [n.id, { ...n }]));
+      for (const need of needsFromProse(record.repo_needs_prose)) {
+        byId.set(need.id, need);
+      }
+      record.needs = [...byId.values()].sort((a, b) => a.id.localeCompare(b.id));
+      delete record._inheritFrom;
+    }
+    pending = records.filter((r) => r.needs === null);
+  }
+  if (pending.length > 0) {
+    throw new Error(
+      `unresolved inheritance for: ${pending.map((r) => r.identity).join(", ")}`,
+    );
+  }
+
+  for (const record of records) {
+    delete record.repo_needs_prose;
+    delete record._inheritFrom;
+  }
+}
+
+function parseLeaf(markdown, leafRel) {
+  const section = extractPrerequisitesSection(markdown);
+  const blocks = splitIdentityBlocks(section);
+  const records = [];
+  for (const { identity, block } of blocks) {
+    const axes = parseAxisTable(block);
+    records.push(recordFromAxes(identity, axes, leafRel));
+  }
+  return records;
+}
+
+function buildEmission(pluginRoot) {
+  const leavesDir = join(pluginRoot, LEAVES_REL);
+  const leafFiles = readdirSync(leavesDir)
+    .filter((name) => name.endsWith(".md"))
+    .sort();
+  if (leafFiles.length === 0) {
+    throw new Error(`no routine leaves under ${posixRel(pluginRoot, leavesDir)}`);
+  }
+
+  const records = [];
+  for (const name of leafFiles) {
+    const abs = join(leavesDir, name);
+    const leafRel = posixRel(pluginRoot, abs);
+    const markdown = readFileSync(abs, "utf8");
+    records.push(...parseLeaf(markdown, leafRel));
+  }
+
+  expandNeeds(records);
+  records.sort((a, b) => a.identity.localeCompare(b.identity));
+
+  const seen = new Set();
+  for (const record of records) {
+    if (seen.has(record.identity)) {
+      throw new Error(`duplicate identity ${record.identity}`);
+    }
+    seen.add(record.identity);
+    if (!record.needs || record.needs.length === 0) {
+      throw new Error(`${record.identity}: derived need set is empty`);
+    }
+  }
+
+  return {
+    _comment:
+      "GENERATED — do not hand-edit. Regenerate with plugins/autonomy/skills/setup/scripts/generate-identity-prerequisites.mjs",
+    schema_version: SCHEMA_VERSION,
+    identities: records,
+  };
+}
+
+function serialize(emission) {
+  return `${JSON.stringify(emission, null, 2)}\n`;
+}
+
+function main() {
+  const { check, root } = parseArgs(process.argv.slice(2));
+  const pluginRoot = root ? join(root) : DEFAULT_PLUGIN_ROOT;
+  const emissionPath = join(pluginRoot, EMISSION_REL);
+  const emissionLabel = root
+    ? posixRel(root, emissionPath)
+    : posixRel(join(DEFAULT_PLUGIN_ROOT, "..", ".."), emissionPath);
+
+  let expected;
+  try {
+    expected = serialize(buildEmission(pluginRoot));
+  } catch (error) {
+    console.error(`identity-prerequisites: ${error.message}`);
+    process.exit(1);
+  }
+
+  let existing = null;
+  try {
+    existing = readFileSync(emissionPath, "utf8");
+  } catch {
+    existing = null;
+  }
+
+  if (check) {
+    if (existing === expected) {
+      console.log("Identity-prerequisite emission is in sync with the leaves.");
+      process.exit(0);
+    }
+    console.error(`Identity-prerequisite emission drift: ${emissionLabel} is stale.`);
+    console.error(
+      "Run `node plugins/autonomy/skills/setup/scripts/generate-identity-prerequisites.mjs` and commit the emission.",
+    );
+    if (existing === null) {
+      console.error("  found:    <missing>");
+    } else {
+      const expectedLines = expected.split("\n");
+      const existingLines = existing.split("\n");
+      const at = expectedLines.findIndex((line, i) => line !== existingLines[i]);
+      if (at !== -1) {
+        console.error(`First difference at generated line ${at + 1}:`);
+        console.error(`  expected: ${JSON.stringify(expectedLines[at] ?? null)}`);
+        console.error(`  found:    ${JSON.stringify(existingLines[at] ?? null)}`);
+      }
+    }
+    process.exit(1);
+  }
+
+  if (existing === expected) {
+    console.log(`Identity-prerequisite emission already in sync; ${emissionLabel} unchanged.`);
+    process.exit(0);
+  }
+
+  mkdirSync(dirname(emissionPath), { recursive: true });
+  writeFileSync(emissionPath, expected);
+  console.log(`Identity-prerequisite emission regenerated in ${emissionLabel}.`);
+}
+
+main();

--- a/plugins/autonomy/skills/setup/scripts/generate-identity-prerequisites.test.manifest.json
+++ b/plugins/autonomy/skills/setup/scripts/generate-identity-prerequisites.test.manifest.json
@@ -1,0 +1,9 @@
+{
+  "_comment": "Case manifest for generate-identity-prerequisites.test.sh. Each name is a scenario the harness must exercise; the orphaned-fixtures gate does not apply (no evals/fixtures/), but the harness fails if a named case is missing from this list or unhandled.",
+  "cases": [
+    "generate_and_check_clean",
+    "drift_fixture",
+    "leaf_emission_parity",
+    "posture_divergence"
+  ]
+}

--- a/plugins/autonomy/skills/setup/scripts/generate-identity-prerequisites.test.sh
+++ b/plugins/autonomy/skills/setup/scripts/generate-identity-prerequisites.test.sh
@@ -88,6 +88,7 @@ else
 fi
 
 # --- case: leaf_emission_parity ---------------------------------------------
+# shellcheck disable=SC2016 # intentional: JS regex anchors/$ stay literal in single-quoted -e
 parity_out="$(node -e '
 const fs = require("node:fs");
 const path = require("node:path");
@@ -127,6 +128,7 @@ else
 fi
 
 # --- case: posture_divergence -----------------------------------------------
+# shellcheck disable=SC2016 # intentional: JS identifiers in single-quoted -e
 div="$(node -e '
 const e = require(process.argv[1]);
 const mech = e.identities.find((i) => i.identity === "dependency-update-wave/mechanical");

--- a/plugins/autonomy/skills/setup/scripts/generate-identity-prerequisites.test.sh
+++ b/plugins/autonomy/skills/setup/scripts/generate-identity-prerequisites.test.sh
@@ -97,15 +97,15 @@ const emission = JSON.parse(fs.readFileSync(
 const leafIds = new Set();
 for (const name of fs.readdirSync(leavesDir).filter((n) => n.endsWith(".md"))) {
   const text = fs.readFileSync(path.join(leavesDir, name), "utf8");
-  const start = text.search(/^## Prerequisites\s*$/m);
+  const start = text.search(/^## Prerequisites[ \t]*$/m);
   if (start < 0) { console.error("missing Prerequisites in " + name); process.exit(1); }
   const after = text.slice(start);
   const endRel = after.slice(after.indexOf("\n") + 1).search(/^## /m);
   const section = endRel < 0 ? after : after.slice(0, after.indexOf("\n") + 1 + endRel);
-  const headings = [...section.matchAll(/^### `([^`]+)`\s*$/gm)].map((m) => m[1]);
+  const headings = [...section.matchAll(/^### `([^`]+)`[ \t]*$/gm)].map((m) => m[1]);
   if (headings.length) headings.forEach((id) => leafIds.add(id));
   else {
-    const m = section.match(/Single-posture identity:\s*`([^`]+)`/);
+    const m = section.match(/Single-posture identity:[ \t]*`([^`]+)`/);
     if (!m) { console.error("no identity in " + name); process.exit(1); }
     leafIds.add(m[1]);
   }

--- a/plugins/autonomy/skills/setup/scripts/generate-identity-prerequisites.test.sh
+++ b/plugins/autonomy/skills/setup/scripts/generate-identity-prerequisites.test.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+# Unit tests for generate-identity-prerequisites.mjs. Cases are named in the
+# co-located manifest; this harness builds throwaway trees where needed and
+# drives generate / --check / drift / leaf↔emission parity.
+set -uo pipefail
+
+SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GENERATOR="$SELF_DIR/generate-identity-prerequisites.mjs"
+MANIFEST="$SELF_DIR/generate-identity-prerequisites.test.manifest.json"
+PLUGIN_ROOT="$(cd "$SELF_DIR/../../.." && pwd)"
+
+PASS=0
+FAIL=0
+fail() {
+  echo "FAIL: $*" >&2
+  FAIL=$((FAIL + 1))
+}
+ok() {
+  echo "ok: $*"
+  PASS=$((PASS + 1))
+}
+
+if ! command -v node >/dev/null 2>&1; then
+  echo "SKIP: node not installed" >&2
+  exit 0
+fi
+
+if [[ ! -f "$MANIFEST" ]]; then
+  echo "FAIL: missing test manifest $MANIFEST" >&2
+  exit 1
+fi
+
+# --- case: generate_and_check_clean -----------------------------------------
+OUT="$(node "$GENERATOR" --check 2>&1)"
+CODE=$?
+if [[ $CODE -eq 0 ]]; then
+  ok "generate_and_check_clean: --check exits 0 on committed emission"
+else
+  fail "generate_and_check_clean: --check failed ($CODE): $OUT"
+fi
+
+# --- case: drift_fixture ----------------------------------------------------
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+mkdir -p "$tmp/reference/routines" "$tmp/generated" "$tmp/skills/setup/scripts"
+# Minimal leaf pair so the generator can run under --root.
+cat >"$tmp/reference/routines/alpha.md" <<'EOF'
+# alpha
+
+## Prerequisites
+
+Single-posture identity: `alpha` (bare class token).
+
+| Axis | Value |
+|---|---|
+| Access class | `repo` |
+| Isolation floor | `L2` — cited |
+| Connector entitlements | none — `repo` access |
+| Connector entitlement rung | n/a (no connector). For `prod` / `product` / `org` / `ext`, entitlement binds at the Org binding layer |
+| `executor_class` merge cap | cited from security-binding |
+| Repo needs | tracker binding via the work-item tracker seam (`.work-item-tracker.json` + adapter `capabilities.json`); absent is `unsupported` |
+EOF
+
+# Seed a correct emission, then hand-edit it.
+if ! node "$GENERATOR" --root "$tmp" >/dev/null 2>"$tmp/gen.err"; then
+  fail "drift_fixture: initial generate failed: $(cat "$tmp/gen.err")"
+else
+  # Hand-edit: drop a need so the emission drifts from the leaf.
+  node -e '
+    const fs = require("node:fs");
+    const p = process.argv[1];
+    const e = JSON.parse(fs.readFileSync(p, "utf8"));
+    e.identities[0].needs = [];
+    fs.writeFileSync(p, JSON.stringify(e, null, 2) + "\n");
+  ' "$tmp/generated/identity-prerequisites.json"
+  if node "$GENERATOR" --root "$tmp" --check >/dev/null 2>"$tmp/check.err"; then
+    fail "drift_fixture: --check should exit non-zero on hand-edited emission"
+  else
+    ok "drift_fixture: --check exits non-zero on hand-edited emission"
+  fi
+  # Regenerating restores sync.
+  node "$GENERATOR" --root "$tmp" >/dev/null
+  if node "$GENERATOR" --root "$tmp" --check >/dev/null 2>"$tmp/check2.err"; then
+    ok "drift_fixture: regenerated emission passes --check"
+  else
+    fail "drift_fixture: regenerated --check failed: $(cat "$tmp/check2.err")"
+  fi
+fi
+
+# --- case: leaf_emission_parity ---------------------------------------------
+parity_out="$(node -e '
+const fs = require("node:fs");
+const path = require("node:path");
+const leavesDir = path.join(process.argv[1], "reference", "routines");
+const emission = JSON.parse(fs.readFileSync(
+  path.join(process.argv[1], "generated", "identity-prerequisites.json"), "utf8"));
+const leafIds = new Set();
+for (const name of fs.readdirSync(leavesDir).filter((n) => n.endsWith(".md"))) {
+  const text = fs.readFileSync(path.join(leavesDir, name), "utf8");
+  const start = text.search(/^## Prerequisites\s*$/m);
+  if (start < 0) { console.error("missing Prerequisites in " + name); process.exit(1); }
+  const after = text.slice(start);
+  const endRel = after.slice(after.indexOf("\n") + 1).search(/^## /m);
+  const section = endRel < 0 ? after : after.slice(0, after.indexOf("\n") + 1 + endRel);
+  const headings = [...section.matchAll(/^### `([^`]+)`\s*$/gm)].map((m) => m[1]);
+  if (headings.length) headings.forEach((id) => leafIds.add(id));
+  else {
+    const m = section.match(/Single-posture identity:\s*`([^`]+)`/);
+    if (!m) { console.error("no identity in " + name); process.exit(1); }
+    leafIds.add(m[1]);
+  }
+}
+const emitted = new Set(emission.identities.map((i) => i.identity));
+const missing = [...leafIds].filter((id) => !emitted.has(id)).sort();
+const extra = [...emitted].filter((id) => !leafIds.has(id)).sort();
+if (missing.length || extra.length) {
+  console.error(JSON.stringify({ missing, extra }));
+  process.exit(1);
+}
+console.log([...emitted].sort().join(","));
+' "$PLUGIN_ROOT" 2>"$tmp/parity.err")"
+parity_code=$?
+if [[ $parity_code -eq 0 ]]; then
+  ok "leaf_emission_parity: leaf identities ↔ emission ($parity_out)"
+else
+  fail "leaf_emission_parity: $(cat "$tmp/parity.err")"
+fi
+
+# --- case: posture_divergence -----------------------------------------------
+div="$(node -e '
+const e = require(process.argv[1]);
+const mech = e.identities.find((i) => i.identity === "dependency-update-wave/mechanical");
+const chg = e.identities.find((i) => i.identity === "dependency-update-wave/changelog-informed");
+if (!mech || !chg) { console.error("missing dependency-update-wave postures"); process.exit(1); }
+if (mech.isolation_floor === chg.isolation_floor) {
+  console.error("floors should diverge: " + mech.isolation_floor);
+  process.exit(1);
+}
+const mechNeeds = mech.needs.map((n) => n.id).join(",");
+const chgNeeds = chg.needs.map((n) => n.id).join(",");
+if (mechNeeds === chgNeeds) {
+  console.error("needs should diverge");
+  process.exit(1);
+}
+if (!chg.needs.some((n) => n.id === "upstream_changelog")) {
+  console.error("changelog-informed missing upstream_changelog");
+  process.exit(1);
+}
+console.log(mech.isolation_floor + " vs " + chg.isolation_floor);
+' "$PLUGIN_ROOT/generated/identity-prerequisites.json" 2>"$tmp/div.err")"
+div_code=$?
+if [[ $div_code -eq 0 ]]; then
+  ok "posture_divergence: dependency-update-wave floors/needs differ ($div)"
+else
+  fail "posture_divergence: $(cat "$tmp/div.err")"
+fi
+
+# Manifest case names must stay honest — every named case ran above.
+expected_cases="$(node -e 'const m=require(process.argv[1]); console.log(m.cases.join("\n"))' "$MANIFEST")"
+for case_name in $expected_cases; do
+  case "$case_name" in
+    generate_and_check_clean|drift_fixture|leaf_emission_parity|posture_divergence) ;;
+    *) fail "manifest names unknown case: $case_name" ;;
+  esac
+done
+ok "manifest_cases: $(echo "$expected_cases" | wc -l | tr -d ' ') named cases exercised"
+
+echo
+echo "Passed: $PASS  Failed: $FAIL"
+if [[ $FAIL -ne 0 ]]; then
+  exit 1
+fi
+exit 0

--- a/scripts/validate-plugins.sh
+++ b/scripts/validate-plugins.sh
@@ -16,6 +16,7 @@ fi
 node scripts/validate-plugin-contracts.mjs || exit 1
 node scripts/generate-catalog.mjs --check || exit 1
 node scripts/generate-cheatsheet.mjs --check || exit 1
+node plugins/autonomy/skills/setup/scripts/generate-identity-prerequisites.mjs --check || exit 1
 
 if ! command -v claude >/dev/null 2>&1; then
   echo "error: claude CLI not on PATH (npm install -g @anthropic-ai/claude-code)" >&2


### PR DESCRIPTION
Closes #2723

## Summary

Phase 3 of the routine-capability-detection plan (ADR 0011): a machine-readable identity-and-prerequisite emission derived from the ten `v1` leaves, with a `--check` drift gate matching the catalog generator pattern.

## Fix

- **Generator** `skills/setup/scripts/generate-identity-prerequisites.mjs` — parses each leaf `## Prerequisites` section into structured records (Access class, isolation floor, connector entitlements + rung, probe-classed `needs`).
- **Emission** `generated/identity-prerequisites.json` — 13 identities; leaves stay the authored single home.
- **`--check` drift gate** wired through `scripts/validate-plugins.sh`.
- **Co-located test + manifest** — clean check, hand-edited drift fixture, leaf↔emission parity, posture divergence (`dependency-update-wave` L2 vs L3).
- **Version bump** to `0.20.0` with CHANGELOG + README pointer.

## Verification

```text
$ node plugins/autonomy/skills/setup/scripts/generate-identity-prerequisites.mjs --check
$ bash plugins/autonomy/skills/setup/scripts/generate-identity-prerequisites.test.sh
$ bash scripts/check-changelog-parity.sh --check-bump origin/main
$ bash scripts/check-orphaned-fixtures.sh --check
```

## Related

- ADR 0011; Refs #2685; depends on #2718 (merged)