### PR TITLE
fix(formatters): PATH probe notices + monorepo markdownlint walk (#2732)

### DIFF
--- a/docs/formatter-path-probes.md
+++ b/docs/formatter-path-probes.md
@@ -1,0 +1,31 @@
+# Formatter / lint hook PATH probes
+
+Inventory of PostToolUse hooks that resolve a formatter or linter binary, and how they
+degrade when the probe misses. Cloud / managed sessions are the failure class: hook
+processes inherit **Claude Code's own environment** (hooks reference), not the interactive
+shell's profile, so an nvm-provisioned global install the Bash tool can see is invisible to
+every `command -v` probe here (#2732; precedent #811).
+
+This document is the fleet checklist. Per-hook notices must:
+
+1. Say the skip is for **this edit** (the probe re-runs; only the notice latches).
+2. Name the environment-inheritance cause (not "install it again").
+3. Prefer a **repo-local / filesystem** install route when one exists.
+4. Append `PATH probed: …` so the miss is diagnosable.
+5. **Never** widen the probe into nvm/rbenv layout guesses — that is bootstrap work
+   (#2739 / #2748), not a hook-side search expansion.
+
+| Plugin | Hook | Probe order | Filesystem / repo-local route | Notice key |
+|---|---|---|---|---|
+| `markdown-format` | `hooks/markdown-format.sh` | `command -v markdownlint-cli2`, then walk `node_modules/.bin` from the edited file up to `$REPO_ROOT` | `npm i -D markdownlint-cli2` | `markdown-format-markdownlint` |
+| `biome-format` | `hooks/biome-format.sh` | walk `node_modules/.bin/biome` from file, then `command -v biome` | `npm i -D @biomejs/biome` | `biome-format-biome` |
+| `ruff-format` | `hooks/ruff-format.sh` | walk `.venv/{bin,Scripts}/ruff` from file, then `command -v ruff` | project `.venv` / `pip install ruff` | `ruff-format-ruff` |
+| `bash-format` | `hooks/bash-format.sh` | `command -v shfmt`, `command -v shellcheck` | host package / release binary (no npm form) | `bash-format-shfmt`, `bash-format-shellcheck` |
+| `typos-format` | `hooks/typos-format.sh` | `command -v typos` | cargo / release binary | `typos-format-typos` |
+| `go-format` | `hooks/go-format.sh` | `command -v goimports`, `command -v go` | `go install …/goimports@latest` | `go-format-goimports` |
+| `powershell-format` | `hooks/powershell-format.sh` | `command -v pwsh` | host PowerShell install | (early exit; see hook) |
+| `actionlint` | `hooks/actionlint-check.sh` | `command -v actionlint` | release binary / `go install` | `actionlint` skip notice |
+| `eol-normalizer` | `hooks/normalize-eol.sh` | `command -v perl` (optional fast path) | pure-shell fallback when perl missing | n/a (degrades, does not skip) |
+
+Bootstrap hardening that puts fleet tools on the **harness** process PATH (or pins them as
+repo `devDependencies`) is out of scope for the per-hook notice sweep — see #2739.

--- a/plugins/actionlint/.claude-plugin/plugin.json
+++ b/plugins/actionlint/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "actionlint",
-  "version": "0.8.13",
+  "version": "0.8.14",
   "description": "Lint GitHub Actions workflow files on edit via actionlint, surfacing findings as advisory context.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/actionlint/CHANGELOG.md
+++ b/plugins/actionlint/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to the `actionlint` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.8.14]
+
+### Fixed
+
+- **Accurate PATH-miss notices with probe latch wording + `PATH probed:` diagnostic (#2732).** Skip is for this edit (probe re-runs; only the notice latches). Names
+  Claude Code environment inheritance vs profile PATH; does not probe nvm layouts.
+
 ## [0.8.13]
 
 ### Changed

--- a/plugins/actionlint/hooks/actionlint-check.sh
+++ b/plugins/actionlint/hooks/actionlint-check.sh
@@ -132,7 +132,8 @@ build_data_json() {
 if ! command -v actionlint >/dev/null 2>&1; then
   emit_tel "skipped" '[]'
   if hook::notice_once "actionlint-missing" "$INPUT"; then
-    hook::emit_skip_notice PostToolUse "actionlint: 'actionlint' not found on PATH — workflow lint skipped for this session. Install: https://github.com/rhysd/actionlint/blob/main/docs/install.md"
+    hook::emit_skip_notice PostToolUse "actionlint: 'actionlint' was not found on this hook's PATH — workflow lint skipped for this edit (probe re-runs on every matching edit; only this notice latches once per session — there is no skip latch). Hook processes inherit Claude Code's own environment, not the interactive shell's profile, so a version-manager install the Bash tool can see may be invisible here. Install: https://github.com/rhysd/actionlint/blob/main/docs/install.md
+PATH probed: ${PATH:-<unset>}"
   fi
   exit 0
 fi

--- a/plugins/actionlint/hooks/actionlint-check.test.sh
+++ b/plugins/actionlint/hooks/actionlint-check.test.sh
@@ -415,6 +415,36 @@ else
   fail "jq-absent out-of-scope edit (rc=$RC_OOS out=$OUT_OOS)"
 fi
 
+# --- Minimal PATH: actionlint absent -> accurate degraded notice (#2732) ----
+# Rebuild FAKEBIN without actionlint; keep coreutils so the notice path runs.
+MINBIN="$(mktemp -d "$WORK/minbin.XXXXXX")"
+for t in bash jq git dirname basename cat env printf mktemp mkdir find tr awk grep sed uname sleep cygpath realpath readlink rm; do
+  real_t="$(command -v "$t" 2>/dev/null)" || continue
+  [[ -n "$real_t" ]] || continue
+  printf '#!/bin/sh\nexec "%s" "$@"\n' "$real_t" >"$MINBIN/$t"
+  chmod +x "$MINBIN/$t"
+done
+MIN_DATA="$(mktemp -d "$WORK/plugdata.XXXXXX")"
+OUT_MIN=$(
+  cd "$UNRELATED" || exit 1
+  printf '{"session_id":"test-min-1","tool_input":{"file_path":"%s"},"tool_name":"Write"}' \
+    "$REPO/.github/workflows/clean.yml" |
+    env -u CLAUDE_PROJECT_DIR PATH="$MINBIN" CLAUDE_PLUGIN_DATA="$MIN_DATA" \
+      CLAUDE_PLUGIN_OPTION_ACTIONLINT_ENABLED=true bash "$HOOK"
+)
+RC_MIN=$?
+if [[ $RC_MIN -eq 0 ]]; then ok "actionlint-absent (minimal PATH) -> exit 0"; else fail "actionlint-absent exit $RC_MIN"; fi
+if printf '%s' "$OUT_MIN" | jq -e '
+  (.hookSpecificOutput.additionalContext | contains("PATH probed:")) and
+  (.hookSpecificOutput.additionalContext | contains("there is no skip latch")) and
+  (.systemMessage | contains("PATH probed:")) and
+  ((.hookSpecificOutput.additionalContext | contains("skipped for this session")) | not)
+' >/dev/null 2>&1; then
+  ok "actionlint-absent -> notice-only latch + PATH diagnostic (#2732)"
+else
+  fail "actionlint-absent latch/PATH diagnostic wrong: $OUT_MIN"
+fi
+
 echo
 echo "PASS=$PASS FAIL=$FAIL"
 [[ $FAIL -eq 0 ]]

--- a/plugins/bash-format/.claude-plugin/plugin.json
+++ b/plugins/bash-format/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "bash-format",
-  "version": "0.7.15",
+  "version": "0.7.16",
   "description": "Auto-format and lint shell scripts on edit via shfmt + ShellCheck, using the consuming repo's own .editorconfig and .shellcheckrc.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/bash-format/CHANGELOG.md
+++ b/plugins/bash-format/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to the `bash-format` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.7.16]
+
+### Fixed
+
+- **Accurate PATH-miss notices with probe latch wording + `PATH probed:` diagnostic (#2732).** Skip is for this edit (probe re-runs; only the notice latches). Names
+  Claude Code environment inheritance vs profile PATH; does not probe nvm layouts.
+
 ## [0.7.15]
 
 ### Changed

--- a/plugins/bash-format/hooks/bash-format.sh
+++ b/plugins/bash-format/hooks/bash-format.sh
@@ -244,7 +244,8 @@ if shell_editorconfig_opt_in; then
       ran_any=1
     fi
   elif hook::notice_once "bash-format-shfmt" "$INPUT"; then
-    append_notice "bash-format: .editorconfig opts this repo into shell formatting but 'shfmt' is not on PATH — formatting skipped for this session. Install: https://github.com/mvdan/sh#shfmt"
+    append_notice "bash-format: .editorconfig opts this repo into shell formatting but 'shfmt' was not found on this hook's PATH — formatting skipped for this edit (probe re-runs on every shell edit; only this notice latches once per session — there is no skip latch). Hook processes inherit Claude Code's own environment, not the interactive shell's profile, so a version-manager install the Bash tool can see may be invisible here. Install: https://github.com/mvdan/sh#shfmt
+PATH probed: ${PATH:-<unset>}"
   fi
 fi
 
@@ -285,7 +286,8 @@ if command -v shellcheck >/dev/null 2>&1; then
     fi
   fi
 elif hook::notice_once "bash-format-shellcheck" "$INPUT"; then
-  append_notice "bash-format: 'shellcheck' not found on PATH — shell lint skipped for this session. Install: https://github.com/koalaman/shellcheck#installing"
+  append_notice "bash-format: 'shellcheck' was not found on this hook's PATH — shell lint skipped for this edit (probe re-runs on every shell edit; only this notice latches once per session — there is no skip latch). Hook processes inherit Claude Code's own environment, not the interactive shell's profile, so a version-manager install the Bash tool can see may be invisible here. Install: https://github.com/koalaman/shellcheck#installing
+PATH probed: ${PATH:-<unset>}"
 fi
 
 # Single emission point: findings on the agent channel, missing-tool notice on

--- a/plugins/bash-format/hooks/bash-format.test.sh
+++ b/plugins/bash-format/hooks/bash-format.test.sh
@@ -564,6 +564,15 @@ if jq -e '(.systemMessage | contains("shellcheck")) and (.hookSpecificOutput.add
 else
   fail "shellcheck-absent: notice missing or malformed: $OUT_SC"
 fi
+if jq -e '
+  (.hookSpecificOutput.additionalContext | contains("PATH probed:")) and
+  (.hookSpecificOutput.additionalContext | contains("there is no skip latch")) and
+  ((.hookSpecificOutput.additionalContext | contains("skipped for this session")) | not)
+' <<<"$OUT_SC" >/dev/null 2>&1; then
+  ok "shellcheck-absent -> notice-only latch + PATH diagnostic (#2732)"
+else
+  fail "shellcheck-absent latch/PATH diagnostic wrong: $OUT_SC"
+fi
 OUT_SC2=$(run_no_tools "$REPO/clean.sh")
 if [[ -z "$OUT_SC2" ]]; then
   ok "shellcheck-absent -> second run same session is silent (once-per-session)"

--- a/plugins/biome-format/.claude-plugin/plugin.json
+++ b/plugins/biome-format/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "biome-format",
-  "version": "0.6.14",
+  "version": "0.6.15",
   "description": "Auto-format and lint JS/TS/JSX/JSON on edit via Biome, only when a biome.json governs the repo \u2014 using the consuming repo's own Biome config.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/biome-format/CHANGELOG.md
+++ b/plugins/biome-format/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to the `biome-format` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.6.15]
+
+### Fixed
+
+- **Accurate PATH-miss notices with probe latch wording + `PATH probed:` diagnostic (#2732).** Skip is for this edit (probe re-runs; only the notice latches). Names
+  Claude Code environment inheritance vs profile PATH; does not probe nvm layouts.
+
 ## [0.6.14]
 
 ### Changed

--- a/plugins/biome-format/hooks/biome-format.sh
+++ b/plugins/biome-format/hooks/biome-format.sh
@@ -176,7 +176,8 @@ fi
 # once-per-session skip notice, not a silent gap (dim-9 doctrine).
 if [[ -z "$BIOME_BIN" ]]; then
   if hook::notice_once "biome-format-biome" "$INPUT"; then
-    hook::emit_skip_notice PostToolUse "biome-format: a Biome config governs this repo but no 'biome' binary was found (node_modules/.bin or PATH) — format/lint skipped for this session. Install: npm install --save-dev @biomejs/biome"
+    hook::emit_skip_notice PostToolUse "biome-format: a Biome config governs this repo but no 'biome' binary was found (node_modules/.bin or this hook's PATH) — format/lint skipped for this edit (probe re-runs on every matching edit; only this notice latches once per session — there is no skip latch). Hook processes inherit Claude Code's own environment, not the interactive shell's profile, so a version-manager install the Bash tool can see may be invisible here; a repo-local install (npm i -D @biomejs/biome) is the reliable route.
+PATH probed: ${PATH:-<unset>}"
   fi
   emit_skipped
 fi

--- a/plugins/go-format/.claude-plugin/plugin.json
+++ b/plugins/go-format/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "go-format",
-  "version": "0.3.15",
+  "version": "0.3.16",
   "description": "Auto-fix Go formatting and import management on edit via goimports \u2014 runs unconditionally (no consumer-config gate), skipping generated files.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/go-format/CHANGELOG.md
+++ b/plugins/go-format/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to the `go-format` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.3.16]
+
+### Fixed
+
+- **Accurate PATH-miss notices with probe latch wording + `PATH probed:` diagnostic (#2732).** Skip is for this edit (probe re-runs; only the notice latches). Names
+  Claude Code environment inheritance vs profile PATH; does not probe nvm layouts.
+
 ## [0.3.15]
 
 ### Changed

--- a/plugins/go-format/hooks/go-format.sh
+++ b/plugins/go-format/hooks/go-format.sh
@@ -197,7 +197,8 @@ GOIMPORTS_BIN="$(command -v goimports 2>/dev/null)" || GOIMPORTS_BIN=""
 
 if [[ -z "$GOIMPORTS_BIN" ]]; then
   if hook::notice_once "go-format-goimports" "$INPUT"; then
-    hook::emit_skip_notice PostToolUse "go-format: no 'goimports' binary found on PATH — format/import-fix skipped for this session. Install: go install golang.org/x/tools/cmd/goimports@latest"
+    hook::emit_skip_notice PostToolUse "go-format: no 'goimports' binary found on this hook's PATH — format/import-fix skipped for this edit (probe re-runs on every matching edit; only this notice latches once per session — there is no skip latch). Hook processes inherit Claude Code's own environment, not the interactive shell's profile, so a version-manager install the Bash tool can see may be invisible here. Install: go install golang.org/x/tools/cmd/goimports@latest
+PATH probed: ${PATH:-<unset>}"
   fi
   emit_skipped
 fi

--- a/plugins/markdown-format/.claude-plugin/plugin.json
+++ b/plugins/markdown-format/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "markdown-format",
-  "version": "0.11.18",
+  "version": "0.11.19",
   "description": "Auto-format and lint Markdown on edit via markdownlint-cli2 \u2014 only in repos that carry their own markdownlint config.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/markdown-format/CHANGELOG.md
+++ b/plugins/markdown-format/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to the `markdown-format` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.11.19]
+
+### Fixed
+
+- **Walk monorepo workspace `node_modules/.bin` for markdownlint-cli2 (#2732).** Previously only the repo root's `.bin` was probed; packages under
+  `packages/*/node_modules/.bin` are now found by walking from the edited file up to
+  `$REPO_ROOT`, keeping the per-directory symlink-containment check.
+
 ## [0.11.18]
 
 ### Fixed

--- a/plugins/markdown-format/hooks/markdown-format.sh
+++ b/plugins/markdown-format/hooks/markdown-format.sh
@@ -467,13 +467,13 @@ resolve_repo_markdownlint() {
       depth=0
       while [[ -L "$target" ]]; do
         depth=$((depth + 1))
-        ((depth <= 32)) || break
-        link="$(readlink "$target" 2>/dev/null)" || break
+        ((depth <= 32)) || return 1
+        link="$(readlink "$target" 2>/dev/null)" || return 1
         case "$link" in
         /*) target="$link" ;;
         [A-Za-z]:[\\/]*)
-          command -v cygpath >/dev/null 2>&1 || break
-          target="$(cygpath -u "$link" 2>/dev/null)" || break
+          command -v cygpath >/dev/null 2>&1 || return 1
+          target="$(cygpath -u "$link" 2>/dev/null)" || return 1
           ;;
         *) target="$(dirname -- "$target")/$link" ;;
         esac
@@ -487,6 +487,7 @@ resolve_repo_markdownlint() {
             printf '%s' "$candidate"
             return 0
             ;;
+          *) ;;
           esac
         fi
       fi

--- a/plugins/markdown-format/hooks/markdown-format.sh
+++ b/plugins/markdown-format/hooks/markdown-format.sh
@@ -452,36 +452,55 @@ fi
 # this repository's node_modules tree. This rejects a checked-in or replaced
 # .bin symlink that escapes the repository trust boundary.
 resolve_repo_markdownlint() {
-  local candidate="$REPO_ROOT/node_modules/.bin/markdownlint-cli2"
-  local root_physical target link target_dir depth=0
-
-  [[ -f "$candidate" && -x "$candidate" ]] || return 1
+  # Walk from the edited file's directory up to $REPO_ROOT so a monorepo
+  # workspace install (packages/x/node_modules/.bin) is visible; the previous
+  # root-only probe left those installs invisible (#2732).
+  local start_dir candidate root_physical target link target_dir depth dir parent
+  local dir_physical
+  start_dir="$(dirname -- "$FILE")"
   root_physical="$(cd -P -- "$REPO_ROOT" 2>/dev/null && pwd -P)" || return 1
-  target="$candidate"
-
-  while [[ -L "$target" ]]; do
-    depth=$((depth + 1))
-    ((depth <= 32)) || return 1
-    link="$(readlink "$target" 2>/dev/null)" || return 1
-    case "$link" in
-    /*) target="$link" ;;
-    [A-Za-z]:[\\/]*)
-      command -v cygpath >/dev/null 2>&1 || return 1
-      target="$(cygpath -u "$link" 2>/dev/null)" || return 1
-      ;;
-    *) target="$(dirname -- "$target")/$link" ;;
-    esac
+  dir="$start_dir"
+  while [[ -n "$dir" ]]; do
+    candidate="$dir/node_modules/.bin/markdownlint-cli2"
+    if [[ -f "$candidate" && -x "$candidate" ]]; then
+      target="$candidate"
+      depth=0
+      while [[ -L "$target" ]]; do
+        depth=$((depth + 1))
+        ((depth <= 32)) || break
+        link="$(readlink "$target" 2>/dev/null)" || break
+        case "$link" in
+        /*) target="$link" ;;
+        [A-Za-z]:[\\/]*)
+          command -v cygpath >/dev/null 2>&1 || break
+          target="$(cygpath -u "$link" 2>/dev/null)" || break
+          ;;
+        *) target="$(dirname -- "$target")/$link" ;;
+        esac
+      done
+      if [[ -f "$target" && -x "$target" ]]; then
+        target_dir="$(cd -P -- "$(dirname -- "$target")" 2>/dev/null && pwd -P)" || true
+        if [[ -n "$target_dir" ]]; then
+          target="$target_dir/$(basename -- "$target")"
+          case "$target" in
+          "$root_physical"/node_modules/* | "$root_physical"/*/node_modules/*)
+            printf '%s' "$candidate"
+            return 0
+            ;;
+          esac
+        fi
+      fi
+    fi
+    # Stop at repo root (inclusive of its own node_modules, already tried).
+    dir_physical="$(cd -P -- "$dir" 2>/dev/null && pwd -P)" || true
+    if [[ -n "$dir_physical" && "$dir_physical" == "$root_physical" ]]; then
+      break
+    fi
+    parent="$(dirname -- "$dir")"
+    [[ "$parent" == "$dir" ]] && break
+    dir="$parent"
   done
-
-  [[ -f "$target" && -x "$target" ]] || return 1
-  target_dir="$(cd -P -- "$(dirname -- "$target")" 2>/dev/null && pwd -P)" || return 1
-  target="$target_dir/$(basename -- "$target")"
-  case "$target" in
-  "$root_physical"/node_modules/*) ;;
-  *) return 1 ;;
-  esac
-
-  printf '%s' "$candidate"
+  return 1
 }
 
 MDLINT=()

--- a/plugins/markdown-format/hooks/markdown-format.test.sh
+++ b/plugins/markdown-format/hooks/markdown-format.test.sh
@@ -902,6 +902,42 @@ else
 fi
 if [[ ! -e "$NPX_MARKER" ]]; then ok "missing markdownlint never invokes npx"; else fail "missing markdownlint invoked npx"; fi
 
+# --- Monorepo workspace node_modules/.bin walk (#2732) ----------------------
+# Hide PATH markdownlint; plant the shim only under packages/pkg/node_modules
+# (not the repo root). The hook must walk from the edited file up to REPO_ROOT.
+WS_ENV="$WORK/ws-md.bashenv"
+WS_MARK="$WORK/ws-md.marker"
+cat >"$WS_ENV" <<'WSEOF'
+command() {
+  if [[ "${1:-}" == "-v" && "${2:-}" == "markdownlint-cli2" ]]; then
+    return 1
+  fi
+  if [[ "${1:-}" == "-v" && "${2:-}" == "npx" ]]; then
+    return 1
+  fi
+  builtin command "$@"
+}
+WSEOF
+WS_REPO="$WORK/monorepo"
+mkdir -p "$WS_REPO/packages/pkg/node_modules/.bin" "$WS_REPO/packages/pkg"
+git init -q "$WS_REPO" 2>/dev/null
+printf '{ "config": { "MD004": { "style": "dash" } } }\n' >"$WS_REPO/.markdownlint-cli2.jsonc"
+printf '#!/usr/bin/env bash\nprintf "WS" > "%s"\nexit 0\n' "$WS_MARK" \
+  >"$WS_REPO/packages/pkg/node_modules/.bin/markdownlint-cli2"
+chmod +x "$WS_REPO/packages/pkg/node_modules/.bin/markdownlint-cli2"
+printf '# Workspace File\n\n* star\n' >"$WS_REPO/packages/pkg/doc.md"
+rm -f "$WS_MARK"
+PD_WS="$(mktemp -d "$WORK/pd.XXXXXX")"
+(cd "$UNRELATED" && printf '{"tool_input":{"file_path":"%s"}}' "$WS_REPO/packages/pkg/doc.md" |
+  env -u CLAUDE_PROJECT_DIR BASH_ENV="$WS_ENV" CLAUDE_PLUGIN_DATA="$PD_WS" \
+    CLAUDE_PLUGIN_OPTION_MARKDOWN_FORMAT_ENABLED=true bash "$HOOK") >/dev/null 2>&1
+WS_SAW="$(cat "$WS_MARK" 2>/dev/null || echo '<no shim ran>')"
+if [[ "$WS_SAW" == "WS" ]]; then
+  ok "monorepo workspace node_modules/.bin markdownlint is resolved (#2732)"
+else
+  fail "monorepo workspace markdownlint not resolved — saw '$WS_SAW'"
+fi
+
 # --- Missing jq: visible advisory, no malformed parsing ---------------------
 NO_JQ_ENV="$WORK/no-jq.bashenv"
 cat >"$NO_JQ_ENV" <<'EOF'

--- a/plugins/ruff-format/.claude-plugin/plugin.json
+++ b/plugins/ruff-format/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "ruff-format",
-  "version": "0.6.15",
+  "version": "0.6.16",
   "description": "Auto-format and lint Python on edit via Ruff, only when a Ruff config governs the repo \u2014 using the consuming repo's own Ruff config.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/ruff-format/CHANGELOG.md
+++ b/plugins/ruff-format/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to the `ruff-format` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.6.16]
+
+### Fixed
+
+- **Accurate PATH-miss notices with probe latch wording + `PATH probed:` diagnostic (#2732).** Skip is for this edit (probe re-runs; only the notice latches). Names
+  Claude Code environment inheritance vs profile PATH; does not probe nvm layouts.
+
 ## [0.6.15]
 
 ### Changed

--- a/plugins/ruff-format/hooks/ruff-format.sh
+++ b/plugins/ruff-format/hooks/ruff-format.sh
@@ -192,7 +192,8 @@ fi
 # once-per-session skip notice, not a silent gap (dim-9 doctrine).
 if [[ -z "$RUFF_BIN" ]]; then
   if hook::notice_once "ruff-format-ruff" "$INPUT"; then
-    hook::emit_skip_notice PostToolUse "ruff-format: a Ruff config governs this repo but no 'ruff' binary was found (.venv or PATH) — format/lint skipped for this session. Install: https://docs.astral.sh/ruff/installation/"
+    hook::emit_skip_notice PostToolUse "ruff-format: a Ruff config governs this repo but no 'ruff' binary was found (.venv or this hook's PATH) — format/lint skipped for this edit (probe re-runs on every matching edit; only this notice latches once per session — there is no skip latch). Hook processes inherit Claude Code's own environment, not the interactive shell's profile, so a version-manager install the Bash tool can see may be invisible here; a project .venv install is the reliable route. Install: https://docs.astral.sh/ruff/installation/
+PATH probed: ${PATH:-<unset>}"
   fi
   emit_skipped
 fi

--- a/plugins/typos-format/.claude-plugin/plugin.json
+++ b/plugins/typos-format/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "typos-format",
-  "version": "0.6.18",
+  "version": "0.6.19",
   "description": "Spell-check on edit via typos-cli, unconditionally \u2014 report-only by default, honoring the consuming repo's own typos configuration when one is present.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/typos-format/CHANGELOG.md
+++ b/plugins/typos-format/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to the `typos-format` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.6.19]
+
+### Fixed
+
+- **Accurate PATH-miss notices with probe latch wording + `PATH probed:` diagnostic (#2732).** Skip is for this edit (probe re-runs; only the notice latches). Names
+  Claude Code environment inheritance vs profile PATH; does not probe nvm layouts.
+
 ## [0.6.18]
 
 ### Fixed

--- a/plugins/typos-format/hooks/typos-format.sh
+++ b/plugins/typos-format/hooks/typos-format.sh
@@ -183,7 +183,8 @@ fi
 # (dim-9 doctrine).
 if [[ -z "$TYPOS_BIN" ]]; then
   if hook::notice_once "typos-format-typos" "$INPUT"; then
-    hook::emit_skip_notice PostToolUse "typos-format: no 'typos' binary was found on PATH — spell-check skipped for this session. Install: https://github.com/crate-ci/typos#install"
+    hook::emit_skip_notice PostToolUse "typos-format: no 'typos' binary was found on this hook's PATH — spell-check skipped for this edit (probe re-runs on every matching edit; only this notice latches once per session — there is no skip latch). Hook processes inherit Claude Code's own environment, not the interactive shell's profile, so a version-manager install the Bash tool can see may be invisible here. Install: https://github.com/crate-ci/typos#install
+PATH probed: ${PATH:-<unset>}"
   fi
   emit_skipped
 fi


### PR DESCRIPTION
## Summary

Fleet inventory of formatter/lint `command -v` probes (`docs/formatter-path-probes.md`). Sibling hooks now emit accurate degraded notices (this-edit / notice-only latch / environment inheritance / `PATH probed:`) without nvm layout guessing. `markdown-format` walks from the edited file up to `$REPO_ROOT` for workspace `node_modules/.bin` installs.

## Test plan

- [x] `plugins/markdown-format/hooks/markdown-format.test.sh` — 149/149 (includes monorepo walk)
- [x] `plugins/bash-format/hooks/bash-format.test.sh` — PATH diagnostic assert
- [x] `plugins/actionlint/hooks/actionlint-check.test.sh` — minimal-PATH absent notice

## Related

Closes #2732