### PR TITLE
docs(cloud): first-turn slash Unknown-command harness residual (#2733)

### DIFF
--- a/.claude/cloud-bootstrap.sh
+++ b/.claude/cloud-bootstrap.sh
@@ -11,6 +11,10 @@
 #      and resume as drift repair — the environment cache can be ~7 days
 #      stale. Plugin installs made by a hook run go live at the next resume,
 #      not in the session that ran the hook.
+# First-turn slash of plugins installed only by the SessionStart caller can
+# still return "Unknown command" (harness residual — claude-code-plugins#2733):
+# resume so the process reloads the registry, or follow the skill's SKILL.md
+# from the working tree. Prefer the pre-launch caller so turn one is populated.
 # Local sessions exit immediately via the CLAUDE_CODE_REMOTE guard — a local
 # machine is presumed provisioned by its owner, and this script must never
 # mutate one.

--- a/docs/CLOUD-SESSIONS.md
+++ b/docs/CLOUD-SESSIONS.md
@@ -221,6 +221,18 @@ enables; the cloud bootstrap installs (see
   snapshot's `~/.claude` actually reaches sessions is undocumented — after adding the line,
   rebuild the cache (edit saves the script) and verify with a fresh session whose *first*
   message is a plugin slash command.
+- **Harness residual — first-turn slash of just-installed plugins (#2733).** The "Unknown
+  command" outcome above is **not remediable inside any plugin in this repository**: the
+  command registry is a Claude Code harness property (built at process start, not re-read).
+  Track occurrences via `/claude-ops:known-issues` and, when reproducible on a fresh cloud
+  session after a confirmed pre-launch bootstrap, report upstream (`anthropics/claude-code`)
+  with the bootstrap log plus the first-turn transcript. In-session workarounds when a
+  first-turn slash returns `Unknown command:` (a) **resume** the session so the process
+  restarts and reloads the registry, or retry the slash on a later turn after a resume; (b)
+  **direct-file fallback** — read `plugins/<plugin>/skills/<skill>/SKILL.md` from the repo
+  working tree and follow it manually (note: this bypasses skill-load string substitutions
+  such as `${CLAUDE_EFFORT}`). Prefer fixing the environment so the setup-script path
+  pre-installs before process start; do not invent plugin-side registry hacks.
 - Being a `directory` source may compound it —
   [that source is documented for development only](https://code.claude.com/docs/en/settings#extraknownmarketplaces)
   and the carry-over note qualifies install-at-session-start with "requires network access to reach

--- a/prompts/cloud-bootstrap-rollout.md
+++ b/prompts/cloud-bootstrap-rollout.md
@@ -97,7 +97,10 @@ edit **Default** (one environment per account; see the rationale at the end):
    `/var/log/melodic-env-setup.log` shows what the build did; and a populated
    `~/.claude/plugins/installed_plugins.json` alongside an unloaded catalog means the snapshot's
    `~/.claude` did not reach the session — a platform limitation to report upstream (resume is
-   the standing workaround).
+   the standing workaround). If SessionStart alone just installed plugins and the first slash
+   returns `Unknown command`, that is the harness residual documented in
+   [CLOUD-SESSIONS.md](../docs/CLOUD-SESSIONS.md) (#2733): resume, or read the skill's
+   `SKILL.md` from the working tree — do not expect a plugin-side fix.
 
 ## Part 3 — every repo (the copy-paste migration prompt)
 


### PR DESCRIPTION
## Summary

Documents the cloud first-turn slash `Unknown command` outcome as a **harness residual** (not remediable in-repo): resume so the process reloads the registry, or follow `SKILL.md` from the working tree. Wired into `docs/CLOUD-SESSIONS.md`, `.claude/cloud-bootstrap.sh`, and the rollout paste kit.

## Test plan

- [x] Docs-only review of the three touched surfaces
- [ ] Confirm issue closes as harness residual once merged

## Related

Closes #2733