### PR TITLE
fix(disk-hygiene): re-land tidiness engine half (#2590)

### DIFF
--- a/plugins/disk-hygiene/.claude-plugin/plugin.json
+++ b/plugins/disk-hygiene/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "disk-hygiene",
-  "version": "0.20.8",
+  "version": "0.20.9",
   "description": "Context-aware disk hygiene for arbitrary directory trees: inventories orphaned and temporary artifacts, classifies evidence into review tiers, and offers exact-path cleanup only after a fresh safety preview and explicit per-tier approval. The target is read-only by default; OS-managed paths, links and mount points, VCS-tracked content without the complete checkout evidence bundle, changed entries, and live-handle uncertainty fail closed.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/disk-hygiene/CHANGELOG.md
+++ b/plugins/disk-hygiene/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to the `disk-hygiene` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.20.9]
+
+### Fixed
+
+- **Re-land the engine half of tidiness-first reporting (#2590).** #2635 shipped
+  `empty_directory_count`, plan `provenance`/`risk` validation, and preview/apply
+  tidiness fields; a later stale-base squash deleted the engine while #2714 restored
+  only the skill prose. Snapshot, `validate_plan`, `preview`, and `apply` again keep
+  zero-byte directories first-class and require provenance/risk on every candidate.
+
 ## [0.20.8]
 
 ### Fixed

--- a/plugins/disk-hygiene/skills/clean/scripts/hygiene.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/hygiene.py
@@ -780,6 +780,103 @@ def reclaimable_local_bytes(entries: list[dict[str, Any]]) -> int:
     return total
 
 
+
+def entry_is_empty_directory(
+    entry: dict[str, Any],
+    inventory: dict[str, dict[str, Any]] | list[dict[str, Any]] | set[str] | None = None,
+    *,
+    parents_with_children: set[str] | None = None,
+    unknown_paths: set[str] | None = None,
+) -> bool:
+    """True when a walked directory has no inventoried descendants.
+
+    Truncated (`not-walked`) directories are unknown, not empty — their
+    `logical_size` is null. A walked parent whose only children were cut off by
+    `--max-depth` can still show `logical_size` 0; requiring no snapshot
+    descendants keeps that case out of the empty-directory tidiness count so
+    zero-byte residue stays visible without mislabeling uninventoried trees.
+    Directories whose scandir failed (or that appear in ``unknown_paths``) are
+    likewise unknown: a coverage gap is not empty residue.
+    """
+    if entry.get("kind") != "directory":
+        return False
+    qualifiers = entry.get("size_qualifiers") or []
+    if "not-walked" in qualifiers:
+        return False
+    if entry.get("logical_size") != 0:
+        return False
+    relative = entry.get("path")
+    if not isinstance(relative, str) or not relative:
+        return False
+    if unknown_paths and relative in unknown_paths:
+        return False
+    if parents_with_children is not None:
+        return relative not in parents_with_children
+    if inventory is None:
+        paths: Iterable[str] = ()
+    elif isinstance(inventory, dict):
+        paths = inventory
+    elif isinstance(inventory, set):
+        paths = inventory
+    else:
+        paths = (
+            item["path"]
+            for item in inventory
+            if isinstance(item, dict) and isinstance(item.get("path"), str)
+        )
+    prefix = relative + "/"
+    return not any(path.startswith(prefix) for path in paths)
+
+
+def inventory_parent_paths(paths: Iterable[str]) -> set[str]:
+    """Return every inventory path that has at least one inventoried descendant.
+
+    Built in one linear pass over ``paths`` so empty-directory counting stays
+    O(entries) rather than O(directories × entries).
+    """
+    parents: set[str] = set()
+    for path in paths:
+        if not isinstance(path, str) or "/" not in path:
+            continue
+        parent = path.rsplit("/", 1)[0]
+        while parent:
+            if parent in parents:
+                break
+            parents.add(parent)
+            if "/" not in parent:
+                break
+            parent = parent.rsplit("/", 1)[0]
+    return parents
+
+
+def empty_directory_count(
+    entries: list[dict[str, Any]],
+    *,
+    error_paths: Iterable[str] | None = None,
+) -> int:
+    """Count walked empty directories in a snapshot inventory.
+
+    ``error_paths`` are scan-error relatives that must not count as empty even
+    when they were recorded with ``logical_size`` 0 and no descendants.
+    """
+    by_path = {
+        entry["path"]: entry
+        for entry in entries
+        if isinstance(entry, dict) and isinstance(entry.get("path"), str)
+    }
+    parents_with_children = inventory_parent_paths(by_path)
+    unknown = {path for path in (error_paths or ()) if isinstance(path, str) and path}
+    return sum(
+        1
+        for entry in by_path.values()
+        if entry_is_empty_directory(
+            entry,
+            parents_with_children=parents_with_children,
+            unknown_paths=unknown,
+        )
+    )
+
+
 def discover_enclosing_git(target: Path) -> tuple[list[Path], list[str]]:
     marker_root = next(
         (
@@ -1210,7 +1307,7 @@ def scan_tree(
     else:
         allowed_root_children = {name.casefold() for name in root_children}
 
-    def visit(directory: Path, depth: int = 1) -> int:
+    def visit(directory: Path, depth: int = 1) -> int | None:
         total = 0
         try:
             with os.scandir(directory) as iterator:
@@ -1219,7 +1316,8 @@ def scan_tree(
             errors.append(
                 {"path": directory.relative_to(target).as_posix(), "error": str(exc)}
             )
-            return 0
+            # Unknown coverage — not an empty directory. Caller marks not-walked.
+            return None
         for child in children:
             path = Path(child.path)
             # Root-children mode never walks the volume root as a whole: only
@@ -1280,6 +1378,9 @@ def scan_tree(
                             subtotal = 0
                     else:
                         subtotal = visit(path, depth + 1)
+                        if subtotal is None:
+                            # scandir failed inside this child: unknown, not empty.
+                            walked = False
                     data = metadata(path, kind, subtotal, walked=walked)
                     # Truncated children contribute unknown, not zero: adding
                     # null as 0 was what made a truncated subtree look empty.
@@ -1313,6 +1414,9 @@ def scan_tree(
         return total
 
     total_size = visit(target)
+    if total_size is None:
+        total_size = 0
+        truncated.append(".")
     repositories = sorted(set(repositories))
     annotate_tracked(entries, target, repositories, truncated, repo_errors)
     reclaimable = reclaimable_local_bytes(entries)
@@ -1324,6 +1428,11 @@ def scan_tree(
         target_identity["size_qualifiers"] = sorted(
             set(target_identity["size_qualifiers"] + ["not-walked"])
         )
+    error_paths = {
+        item["path"]
+        for item in errors
+        if isinstance(item, dict) and isinstance(item.get("path"), str)
+    }
     payload: dict[str, Any] = {
         "schema_version": SCHEMA_VERSION,
         "engine": "disk-hygiene-python-1",
@@ -1334,6 +1443,9 @@ def scan_tree(
         "target_identity": target_identity,
         "target_logical_bytes": total_size,
         "target_reclaimable_local_bytes": reclaimable,
+        "empty_directory_count": empty_directory_count(
+            entries, error_paths=error_paths
+        ),
         "policy": policy,
         "repositories": [str(repo) for repo in repositories],
         "repository_errors": repo_errors,
@@ -1497,9 +1609,11 @@ def validate_plan(
         required = {
             "path",
             "tier",
+            "provenance",
             "reason",
             "evidence",
             "why_not_work_product",
+            "risk",
             "owner",
         }
         if not required.issubset(candidate):
@@ -1522,6 +1636,11 @@ def validate_plan(
         ):
             raise HygieneError(f"candidate paths overlap: {relative}")
         seen.append(pure)
+        if (
+            not isinstance(candidate["provenance"], str)
+            or not candidate["provenance"].strip()
+        ):
+            raise HygieneError(f"candidate needs provenance: {relative}")
         if not isinstance(candidate["reason"], str) or not candidate["reason"].strip():
             raise HygieneError(f"candidate needs a reason: {relative}")
         if (
@@ -1529,6 +1648,8 @@ def validate_plan(
             or not candidate["why_not_work_product"].strip()
         ):
             raise HygieneError(f"candidate needs work-product analysis: {relative}")
+        if not isinstance(candidate["risk"], str) or not candidate["risk"].strip():
+            raise HygieneError(f"candidate needs a risk assessment: {relative}")
         if (
             not isinstance(candidate["evidence"], list)
             or not candidate["evidence"]
@@ -2498,6 +2619,7 @@ def preview(snapshot: dict[str, Any], plan: dict[str, Any]) -> dict[str, Any]:
                     )
                 )
         blockers = sorted(set(blockers))
+        candidate_entry = entries[relative]
         logical_bytes = sum(
             entry_logical_file_bytes(entries[name]) for name in expected_paths
         )
@@ -2510,6 +2632,11 @@ def preview(snapshot: dict[str, Any], plan: dict[str, Any]) -> dict[str, Any]:
             {
                 "path": relative,
                 "tier": plan["tier"],
+                "provenance": candidate["provenance"],
+                "reason": candidate["reason"],
+                "why_not_work_product": candidate["why_not_work_product"],
+                "risk": candidate["risk"],
+                "empty_directory": entry_is_empty_directory(candidate_entry, entries),
                 "logical_bytes": logical_bytes,
                 "reclaimable_local_bytes": reclaimable_bytes,
                 "handle_state": state,
@@ -2523,12 +2650,17 @@ def preview(snapshot: dict[str, Any], plan: dict[str, Any]) -> dict[str, Any]:
         "tier": plan["tier"],
         "target": str(target),
         "candidates": results,
+        "empty_directories": sum(1 for item in results if item["empty_directory"]),
         "logical_bytes": sum(item["logical_bytes"] for item in results),
         "reclaimable_local_bytes": sum(
             item["reclaimable_local_bytes"] for item in results
         ),
         "approval_token": None if blocked else approval_token(snapshot, plan),
-        "warning": "Approval is valid only for this tier, exact plan, and snapshot. Re-preview after any change.",
+        "warning": (
+            "Safe tidiness is the primary objective; reclaimable bytes are "
+            "secondary. Approval is valid only for this tier, exact plan, and "
+            "snapshot. Re-preview after any change."
+        ),
     }
     return payload
 
@@ -2887,6 +3019,8 @@ def apply_plan(snapshot: dict[str, Any], plan: dict[str, Any]) -> dict[str, Any]
                 }
                 for item in candidates
             ],
+            "paths_removed": 0,
+            "empty_directories_removed": 0,
             "logical_bytes_removed": 0,
             "reclaimable_local_bytes_removed": 0,
             "observed_free_space_delta_bytes": 0,
@@ -2907,6 +3041,8 @@ def apply_plan(snapshot: dict[str, Any], plan: dict[str, Any]) -> dict[str, Any]
                 }
                 for item in candidates
             ],
+            "paths_removed": 0,
+            "empty_directories_removed": 0,
             "logical_bytes_removed": 0,
             "reclaimable_local_bytes_removed": 0,
             "observed_free_space_delta_bytes": 0,
@@ -3018,6 +3154,7 @@ def apply_plan(snapshot: dict[str, Any], plan: dict[str, Any]) -> dict[str, Any]
             removed.append(
                 {
                     "path": relative,
+                    "empty_directory": entry_is_empty_directory(entry, entries),
                     "logical_bytes": logical,
                     "reclaimable_local_bytes": reclaimable,
                 }
@@ -3030,6 +3167,10 @@ def apply_plan(snapshot: dict[str, Any], plan: dict[str, Any]) -> dict[str, Any]
         "target": str(target),
         "removed": removed,
         "skipped": skipped,
+        "paths_removed": len(removed),
+        "empty_directories_removed": sum(
+            1 for item in removed if item["empty_directory"]
+        ),
         "logical_bytes_removed": logical_removed,
         "reclaimable_local_bytes_removed": reclaimable_removed,
         "observed_free_space_delta_bytes": after - before,
@@ -3288,6 +3429,7 @@ def main(argv: list[str] | None = None) -> int:
                     "snapshot": str(output_path),
                     "entries": len(snapshot["entries"]),
                     "hinted_entries": hinted,
+                    "empty_directory_count": snapshot["empty_directory_count"],
                     "target_logical_bytes": snapshot["target_logical_bytes"],
                     "target_reclaimable_local_bytes": snapshot[
                         "target_reclaimable_local_bytes"
@@ -3297,7 +3439,11 @@ def main(argv: list[str] | None = None) -> int:
                     "policy_sources": policy["policy_sources"],
                     "os_autoclean": advisory,
                     "note": (
-                        "Hints are discovery signals, never cleanup verdicts. "
+                        "Safe tidiness is the primary objective; reclaimable "
+                        "bytes are a secondary signal. empty_directory_count "
+                        "names walked empty directories (logical_size 0, not "
+                        "truncated) so zero-byte residue stays visible. Hints "
+                        "are discovery signals, never cleanup verdicts. "
                         "target_reclaimable_local_bytes excludes every entry "
                         "whose size_qualifiers is non-empty (cloud-placeholder, "
                         "hardlinked, sparse, not-walked); target_logical_bytes "

--- a/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
@@ -46,9 +46,11 @@ def candidate(path: str, tier: str = "high") -> dict[str, object]:
     return {
         "path": path,
         "tier": tier,
+        "provenance": "fixture convention documents this as abandoned atomic-write staging",
         "reason": "fixture provenance identifies an abandoned atomic-write temporary",
         "evidence": ["name matches fixture convention", "owner process is absent"],
         "why_not_work_product": "fixture content is generated and has no durable consumer",
+        "risk": "low — fixture residue with no live consumer",
         "owner": "unmanaged",
     }
 
@@ -423,10 +425,110 @@ class HygieneTests(unittest.TestCase):
             # A genuinely empty walked directory still reports 0 with no qualifier.
             self.assertEqual(0, entries["empty"]["logical_size"])
             self.assertEqual([], entries["empty"]["size_qualifiers"])
+            self.assertTrue(hygiene.entry_is_empty_directory(entries["empty"], entries))
+            self.assertFalse(
+                hygiene.entry_is_empty_directory(entries["deep/sub"], entries)
+            )
+            # Parent of a truncated child can show logical_size 0; inventory
+            # descendants keep it out of the empty-directory tidiness count.
+            self.assertFalse(hygiene.entry_is_empty_directory(entries["deep"], entries))
+            self.assertEqual(1, snapshot["empty_directory_count"])
             self.assertEqual(
                 entries["visible.tmp"]["logical_size"],
                 snapshot["target_reclaimable_local_bytes"],
             )
+
+    def test_empty_directory_count_is_linear_and_excludes_error_paths(self) -> None:
+        # Many sibling empty directories must not require a full inventory scan each.
+        entries = [
+            {
+                "path": f"d{i:04d}",
+                "kind": "directory",
+                "logical_size": 0,
+                "size_qualifiers": [],
+            }
+            for i in range(200)
+        ]
+        entries.append(
+            {
+                "path": "parent",
+                "kind": "directory",
+                "logical_size": 0,
+                "size_qualifiers": [],
+            }
+        )
+        entries.append(
+            {
+                "path": "parent/child",
+                "kind": "file",
+                "logical_size": 1,
+                "size_qualifiers": [],
+            }
+        )
+        entries.append(
+            {
+                "path": "unreadable",
+                "kind": "directory",
+                "logical_size": 0,
+                "size_qualifiers": [],
+            }
+        )
+        self.assertEqual(
+            200,
+            hygiene.empty_directory_count(
+                entries, error_paths={"unreadable"}
+            ),
+        )
+        parents = hygiene.inventory_parent_paths(
+            entry["path"] for entry in entries if isinstance(entry.get("path"), str)
+        )
+        self.assertIn("parent", parents)
+        self.assertNotIn("unreadable", parents)
+
+    def test_plan_requires_provenance_and_risk_for_tidiness_reporting(self) -> None:
+        entry = {"kind": "file", "logical_size": 1, "size_qualifiers": []}
+        base = candidate("orphan.tmp")
+        for missing in ("provenance", "risk"):
+            broken = dict(base)
+            del broken[missing]
+            plan = {"version": 1, "tier": "high", "candidates": [broken]}
+            with self.assertRaisesRegex(hygiene.HygieneError, missing):
+                hygiene.validate_plan(plan, {"orphan.tmp": entry})
+
+    def test_preview_surfaces_tidiness_fields_and_empty_directory_flag(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary) / "target"
+            root.mkdir()
+            (root / "orphan-empty").mkdir()
+            (root / "keep.txt").write_text("work", encoding="utf-8")
+            snapshot = hygiene.scan_tree(root.resolve(), hygiene.load_policy(None))
+            self.assertEqual(1, snapshot["empty_directory_count"])
+            plan = {
+                "version": 1,
+                "tier": "high",
+                "candidates": [candidate("orphan-empty")],
+            }
+            with (
+                mock.patch.object(hygiene, "execution_blockers", return_value=[]),
+                mock.patch.object(hygiene, "hard_protection", return_value=[]),
+                mock.patch.object(hygiene, "tracked_blocker", return_value=None),
+                mock.patch.object(
+                    hygiene, "linux_mount_points", return_value=(set(), None)
+                ),
+                mock.patch.object(
+                    hygiene, "handle_state", return_value=("clear", None)
+                ),
+            ):
+                preview = hygiene.preview(snapshot, plan)
+            self.assertEqual("ready-for-explicit-approval", preview["status"])
+            item = preview["candidates"][0]
+            self.assertTrue(item["empty_directory"])
+            self.assertEqual(1, preview["empty_directories"])
+            self.assertEqual(0, item["logical_bytes"])
+            self.assertEqual(0, item["reclaimable_local_bytes"])
+            self.assertEqual(candidate("orphan-empty")["provenance"], item["provenance"])
+            self.assertEqual(candidate("orphan-empty")["risk"], item["risk"])
+            self.assertIn("Safe tidiness is the primary objective", preview["warning"])
 
     def test_hard_linked_names_are_qualified_and_excluded_from_reclaimable(
         self,
@@ -1748,8 +1850,46 @@ class HygieneTests(unittest.TestCase):
                 {"candidate/nested/captured.tmp", "candidate/nested", "candidate"},
                 {item["path"] for item in report["removed"]},
             )
+            self.assertEqual(3, report["paths_removed"])
+            self.assertEqual(0, report["empty_directories_removed"])
             self.assertFalse((root / "candidate").exists())
             self.assertEqual("work product", untouched.read_text(encoding="utf-8"))
+
+    @unittest.skipUnless(
+        hygiene.os_key() == "linux", "descriptor-relative removal is Linux-only"
+    )
+    def test_apply_report_counts_empty_directory_tidiness_outcomes(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary) / "target"
+            root.mkdir()
+            (root / "orphan-empty").mkdir()
+            (root / "keep.txt").write_text("work product", encoding="utf-8")
+            snapshot = hygiene.scan_tree(root.resolve(), hygiene.load_policy(None))
+            plan = {
+                "version": 1,
+                "tier": "high",
+                "candidates": [candidate("orphan-empty")],
+            }
+            with (
+                mock.patch.object(hygiene, "execution_blockers", return_value=[]),
+                mock.patch.object(hygiene, "hard_protection", return_value=[]),
+                mock.patch.object(hygiene, "tracked_blocker", return_value=None),
+                mock.patch.object(
+                    hygiene, "linux_mount_points", return_value=(set(), None)
+                ),
+                mock.patch.object(
+                    hygiene, "handle_state", return_value=("clear", None)
+                ),
+            ):
+                report = hygiene.apply_plan(snapshot, plan)
+            self.assertEqual("completed", report["status"])
+            self.assertEqual(1, report["paths_removed"])
+            self.assertEqual(1, report["empty_directories_removed"])
+            self.assertTrue(report["removed"][0]["empty_directory"])
+            self.assertEqual(0, report["reclaimable_local_bytes_removed"])
+            self.assertFalse((root / "orphan-empty").exists())
+            self.assertEqual("work product", (root / "keep.txt").read_text(encoding="utf-8"))
+
 
     def test_scan_max_depth_truncates_and_preview_blocks_planning(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:


### PR DESCRIPTION
## Summary

#2590 stayed open: #2714 restored skill prose, but the engine half from #2635 (`empty_directory_count`, plan `provenance`/`risk`, preview/apply tidiness fields) was still absent on `main`. Re-lands that engine work and tests.

## Test plan

- [x] `python3 -m unittest test_hygiene.HygieneTests` — 94/94 pass (focused empty-dir / provenance / apply cases included)

## Related

Closes #2590