### PR TITLE
ci: add a post-merge silent-revert canary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,6 +166,7 @@ jobs:
             .github/workflows/link-check.yml
             .github/workflows/pr-issue-linkage.yml
             .github/workflows/pr-title.yml
+            .github/workflows/silent-revert-canary.yml
 
       - name: Verify shebang files are executable
         id: exec_bit

--- a/.github/workflows/silent-revert-canary.yml
+++ b/.github/workflows/silent-revert-canary.yml
@@ -35,9 +35,33 @@ name: silent-revert-canary
 # exactly the false-green this lane exists to remove. Pushes to main are
 # infrequent enough that letting every run finish costs nothing worth saving.
 
+# The `pull_request` trigger runs the detector's OWN tests, never the canary.
+# The scan step is gated off for PR events below, so nothing on a PR ever
+# inspects that PR for silent reverts -- detection stays post-merge, per the
+# design note above. What a PR gets is ordinary unit-test coverage of a shipped
+# script, scoped by `paths` to the canary's own files so it is inert on every
+# other PR.
+#
+# Without it the detector would ship untested until the next push to main, and
+# the specific way this script can break is a false GREEN: if the blame parser
+# stops matching (awk dialects differ between the runner's mawk and a
+# developer's gawk), attribution yields nothing and every commit reports `ok`.
+# A canary whose failure mode is silent success is the exact thing #2691 is
+# about, so it gets tested before it lands, not after.
+#
+# This does not make the lane a merge gate. It is not in ci.yml and not in that
+# workflow's `ci-status` aggregate, which is the single required check the org
+# ci-gate ruleset keys on, so nothing here can block a merge.
 on:
   push:
     branches: [main]
+  pull_request:
+    paths:
+      - 'scripts/check-silent-revert.sh'
+      - 'scripts/check-silent-revert.test.sh'
+      - 'scripts/silent-revert-incidents.txt'
+      - 'scripts/silent-revert-acknowledged.txt'
+      - '.github/workflows/silent-revert-canary.yml'
   workflow_dispatch:
 
 permissions:
@@ -78,8 +102,12 @@ jobs:
       # workflow_dispatch; in both cases fall back to the head commit and SAY
       # SO, rather than reporting a clean scan of nothing. Values arrive through
       # env, never interpolated into the script body.
+      # Detection is post-merge only. On a pull_request event the two steps
+      # above have already proven the detector works; scanning stops here so the
+      # lane never inspects a PR and never has an opinion about merging it.
       - name: Resolve the pushed range
         id: range
+        if: github.event_name != 'pull_request'
         env:
           EVENT_BEFORE: ${{ github.event.before }}
           EVENT_AFTER: ${{ github.event.after }}
@@ -106,6 +134,7 @@ jobs:
           fi
 
       - name: Scan the merged commits for silent reverts
+        if: github.event_name != 'pull_request'
         env:
           SCAN_MODE: ${{ steps.range.outputs.mode }}
           SCAN_TARGET: ${{ steps.range.outputs.target }}

--- a/.github/workflows/silent-revert-canary.yml
+++ b/.github/workflows/silent-revert-canary.yml
@@ -1,0 +1,118 @@
+name: silent-revert-canary
+
+# Post-merge canary for #2691: detect a merge that silently deleted content
+# another recently-merged commit had just added.
+#
+# On 2026-08-15 three squash merges each landed a tree that dropped work a
+# sibling PR had merged minutes earlier (#2633 dropped #2632, #2639 dropped
+# #2635, #2641 dropped #2639). Every check stayed green through all three,
+# because each reverting squash removed the code AND its tests in the same
+# commit -- no suite can fail for a behavior whose tests are gone. Two issues
+# sat CLOSED as COMPLETED with their fixes absent from main.
+#
+# DETECTION, NOT PREVENTION -- and deliberately so.
+#
+#   * It runs on `push` to main only. There is no `pull_request` trigger, so it
+#     can never gate a PR. By the time it speaks, the merge has happened; the
+#     value is that a human learns within minutes instead of during a
+#     from-scratch content audit weeks later.
+#   * It is NOT in ci.yml and is NOT wired into that workflow's `ci-status`
+#     aggregate, which is the single required check the org ci-gate ruleset
+#     keys on. Adding it there would make a detection heuristic able to block
+#     merges, which is how canaries acquire a constituency for switching them
+#     off. Same posture as link-check.yml: advisory lane, outside ci-status.
+#   * Nothing here changes any ruleset. The global
+#     `strict_required_status_checks_policy` stays off under the accepted ADR
+#     in melodic-software/github-iac
+#     (docs/adr/0001-relax-strict-required-status-checks.md), and this canary
+#     is valuable precisely because it catches the class without that churn --
+#     and, per the evidence in scripts/check-silent-revert.sh, without needing
+#     it, since all three branches were up to date with main in history and
+#     stale only in content. `strict` would have passed every one of them.
+#
+# No cancelling concurrency group on purpose. ci.yml cancels superseded runs to
+# save minutes on a PR, but a cancelled canary is a silently missed detection --
+# exactly the false-green this lane exists to remove. Pushes to main are
+# infrequent enough that letting every run finish costs nothing worth saving.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  silent-revert-canary:
+    name: Silent-revert canary
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - name: Check out
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          # Full history: the canary blames the lines a merge deleted against
+          # its parent, and replays the recorded incidents from 2026-08. A
+          # shallow clone cannot do either, and the script exits 2 rather than
+          # reporting a clean run it did not earn.
+          fetch-depth: 0
+
+      # Self-test first, unconditionally: a broken detector must not be able to
+      # mask a real regression behind a green canary. Same never-skip,
+      # self-test-first shape as the ci.yml gates.
+      - name: Test the silent-revert detector
+        run: bash scripts/check-silent-revert.test.sh
+
+      # The honesty proof. The shipped thresholds are replayed against the
+      # actual merges from #2691 and must still fire on them -- and must still
+      # stay quiet on the verified-legitimate commit pinned alongside. A
+      # detector that only looks plausible is worthless here, because every
+      # signal a reader normally checks looked healthy during the incident.
+      - name: Replay the recorded incidents
+        run: scripts/check-silent-revert.sh --verify-known-incidents
+
+      # Resolve the pushed range. `github.event.before` is all-zeros on a first
+      # push or after a history rewrite, and absent entirely on
+      # workflow_dispatch; in both cases fall back to the head commit and SAY
+      # SO, rather than reporting a clean scan of nothing. Values arrive through
+      # env, never interpolated into the script body.
+      - name: Resolve the pushed range
+        id: range
+        env:
+          EVENT_BEFORE: ${{ github.event.before }}
+          EVENT_AFTER: ${{ github.event.after }}
+        run: |
+          set -uo pipefail
+          zero='0000000000000000000000000000000000000000'
+          before="${EVENT_BEFORE:-}"
+          after="${EVENT_AFTER:-$(git rev-parse HEAD)}"
+
+          if [ -z "$before" ] || [ "$before" = "$zero" ] ||
+            ! git rev-parse --verify --quiet "${before}^{commit}" >/dev/null; then
+            echo "::warning::No usable push range (before='${before:-<unset>}');" \
+              "scanning only the head commit ${after}. Any earlier commit in" \
+              "this push was NOT scanned."
+            {
+              echo "mode=commit"
+              echo "target=$after"
+            } >>"$GITHUB_OUTPUT"
+          else
+            {
+              echo "mode=range"
+              echo "target=${before}..${after}"
+            } >>"$GITHUB_OUTPUT"
+          fi
+
+      - name: Scan the merged commits for silent reverts
+        env:
+          SCAN_MODE: ${{ steps.range.outputs.mode }}
+          SCAN_TARGET: ${{ steps.range.outputs.target }}
+        run: |
+          set -uo pipefail
+          if [ "$SCAN_MODE" = "commit" ]; then
+            scripts/check-silent-revert.sh --commit "$SCAN_TARGET"
+          else
+            scripts/check-silent-revert.sh "$SCAN_TARGET"
+          fi

--- a/scripts/check-silent-revert.sh
+++ b/scripts/check-silent-revert.sh
@@ -28,7 +28,7 @@
 # ------------------------------------------------------------------------------
 # The intuitive reading of #2691 is "stale base", whose fix is GitHub's
 # `strict_required_status_checks_policy` (require branches up to date before
-# merging). That reading does not survive the evidence. PR #2641's head commit
+# merging). That reading does not survive the evidence. pull request 2641's head commit
 # a1cc5cf6 has f603880d (#2639) IN ITS ANCESTRY -- `git merge-base --is-ancestor
 # f603880d refs/pull/2641/head` is true -- while its TREE carried zero
 # occurrences of #2639's marker strings. #2639 shows the identical shape against

--- a/scripts/check-silent-revert.sh
+++ b/scripts/check-silent-revert.sh
@@ -237,6 +237,24 @@ ack_reason() {
 #
 # One blame invocation per FILE, not per hunk: git blame accepts repeated -L
 # ranges, and a commit touching a 900-line test file produces hundreds of hunks.
+#
+# Rename detection is left ON (git's default) everywhere in this script, and
+# that is load-bearing rather than incidental. With --no-renames a `git mv`
+# decomposes into a delete plus an add, the delete side reaches the enumeration
+# below as a whole-file removal, and every line in a moved file gets attributed
+# to whoever last touched it -- so relocating a large file a recent commit had
+# added would fire. This repo restructures skills and docs constantly, so that
+# is a live false-positive class, not a hypothetical one. With detection on, a
+# rename reports as R and the --diff-filter=MD enumeration skips it.
+#
+# The measured false-positive rate in the header was taken with detection on,
+# so this is also what keeps the shipped behaviour and the calibrated number
+# describing the same detector.
+#
+# The cost is a narrow blind spot, stated rather than hidden: content gutted in
+# the same commit that renames its file is not attributed. A rename that git
+# still pairs is a mostly-similar file, which bounds how much content can vanish
+# inside one; the incident class this canary targets modifies existing paths.
 attribute_file() {
   local parent="$1" commit="$2" file="$3"
   local -a ranges=()
@@ -248,7 +266,7 @@ attribute_file() {
     [[ "$count" -gt 0 ]] || continue
     ranges+=(-L "$start,$((start + count - 1))")
   done < <(
-    git diff --unified=0 --no-color --no-renames "$parent" "$commit" -- "$file" 2>/dev/null |
+    git diff --unified=0 --no-color "$parent" "$commit" -- "$file" 2>/dev/null |
       awk '/^@@ /{
              split($2, a, ",")
              start = substr(a[1], 2) + 0
@@ -261,9 +279,19 @@ attribute_file() {
 
   # --line-porcelain repeats the header for every line, so sha and text stay
   # paired without tracking porcelain's abbreviated continuation form.
+  #
+  # The header match deliberately avoids an ERE interval ({40}): interval
+  # support is an awk-implementation variable, and the runner's default awk is
+  # mawk while most development machines run gawk. A pattern that silently
+  # fails to match would make attribute_file emit nothing and every commit
+  # report `ok` -- a false green, which is precisely the failure this canary
+  # exists to remove. The porcelain header is `<sha> <orig> <final> [<n>]`, so
+  # matching hex-then-two-numbers and checking the length explicitly is both
+  # interval-free and unambiguous against the `author`/`filename`/`summary`
+  # lines it must not match.
   git blame --line-porcelain "${ranges[@]}" "$parent" -- "$file" 2>/dev/null |
     awk '
-      /^[0-9a-f]{40} /{ sha = $1; next }
+      /^[0-9a-f]+ [0-9]+ [0-9]+/ { if (length($1) == 40) { sha = $1; next } }
       /^\t/ { if (sha != "") printf "%s\t%s\n", sha, substr($0, 2) }
     '
 }
@@ -320,7 +348,7 @@ scan_commit() {
   while IFS= read -r -d '' file; do
     attribute_file "$parent" "$sha" "$file" |
       awk -v f="$file" -F '\t' '{printf "%s\t%s\t%s\n", $1, f, $2}' >>"$attributed"
-  done < <(git diff --name-only -z --no-renames --diff-filter=MD "$parent" "$sha")
+  done < <(git diff --name-only -z --diff-filter=MD "$parent" "$sha")
 
   # Keep only lines whose culprit is inside the recency window.
   local in_window

--- a/scripts/check-silent-revert.sh
+++ b/scripts/check-silent-revert.sh
@@ -1,0 +1,501 @@
+#!/usr/bin/env bash
+# Post-merge canary: detect a merge that silently DELETED content another
+# recently-merged commit had just added, with nothing in its own message saying
+# it meant to.
+#
+#   scripts/check-silent-revert.sh <range>        scan commits in a range (A..B)
+#   scripts/check-silent-revert.sh --commit <sha> scan one commit
+#   scripts/check-silent-revert.sh --verify-known-incidents
+#                                                 replay the recorded incidents
+#
+# Exit 0 clean, 1 findings, 2 the canary could not run (never a quiet pass).
+#
+# WHY THIS EXISTS (#2691)
+# ----------------------
+# On 2026-08-15, three squash merges each landed a tree that dropped work a
+# sibling PR had merged minutes earlier. #2633 dropped #2632's rollups (853
+# lines); #2639 dropped #2635's report-ordering fix (346); #2641 dropped
+# #2639's guard work (451) -- destructive_guard.py went 1643 -> 1424 lines.
+#
+# Every check stayed green through all three, and that is the point: each
+# reverting squash removed the code AND the tests covering it in the same
+# commit, so no suite could fail for a behavior whose tests no longer existed.
+# A squash that merely omits content leaves no `Revert:` commit either, so the
+# log reads clean. Two issues sat CLOSED as COMPLETED with their fixes absent
+# from origin/main, and it took a from-scratch content audit to notice.
+#
+# WHAT THIS IS NOT A SUBSTITUTE FOR -- and why the obvious guards do not cover it
+# ------------------------------------------------------------------------------
+# The intuitive reading of #2691 is "stale base", whose fix is GitHub's
+# `strict_required_status_checks_policy` (require branches up to date before
+# merging). That reading does not survive the evidence. PR #2641's head commit
+# a1cc5cf6 has f603880d (#2639) IN ITS ANCESTRY -- `git merge-base --is-ancestor
+# f603880d refs/pull/2641/head` is true -- while its TREE carried zero
+# occurrences of #2639's marker strings. #2639 shows the identical shape against
+# #2635. The branches were up to date with main in history and stale in content:
+# a bad conflict resolution or a force-push from an older worktree, not a stale
+# base.
+#
+# So `strict` would have passed all three merges, and so would a merge queue
+# (CI was green -- the tests were deleted alongside the code). That is why this
+# canary is not defence in depth behind a real fix; for this failure class it is
+# the only control that fires at all. It is also why the global strict toggle
+# stays off, which is separately governed by an accepted ADR in
+# melodic-software/github-iac (docs/adr/0001-relax-strict-required-status-checks.md).
+#
+# WHY BLAME-OF-DELETED-LINES, AND NOT THE ALTERNATIVES
+# ---------------------------------------------------
+# Three designs were measured against the real history before this one was
+# chosen.
+#
+#   Curated marker strings (#2691's own suggestion 3). Catches only what
+#   somebody pre-registered. Nobody had registered #2632, #2635 or #2639 --
+#   registration happens after you already know a fix matters, which is exactly
+#   the knowledge the incident destroys. It also decays: the list is only as
+#   fresh as the last person who remembered to append to it.
+#
+#   Merge-base staleness (the PR's branch point vs. what landed since).
+#   Tested and REJECTED on evidence: it exonerates all three real incidents,
+#   because all three branches were up to date in history. It is a
+#   false-negative machine for the exact class it is meant to catch.
+#
+#   PR-creation-time overlap (culprit landed after the PR was opened).
+#   Tested and rejected as non-discriminating: at the 17-concurrent-PR rate the
+#   ADR records for this repo, nearly every PR has siblings landing while it is
+#   open, so it fires on almost everything.
+#
+# What is left is content: blame the lines a merge deleted and see who had just
+# added them. Measured over the last 500 first-parent commits of main, the three
+# known incidents score 853 / 451 / 346 lines against a single recent commit,
+# and the highest verified-legitimate commit scores well below the threshold
+# below. The separation is what makes the canary livable.
+#
+# FALSE-POSITIVE STRATEGY (the whole design rests on this)
+# -------------------------------------------------------
+# A canary that cries wolf gets disabled, which is worse than not having one.
+# Four constraints keep the firing rate near the true-incident rate:
+#
+#   1. VOLUME. Only a large block of removed content counts, and the lines must
+#      all trace to ONE culprit commit. Ordinary iteration deletes a handful of
+#      recent lines from several places; a wholesale revert deletes hundreds
+#      from one. Per-culprit aggregation is deliberate -- summing across
+#      culprits would re-admit the routine case.
+#
+#   2. RECENCY. The culprit must be within the last SILENT_REVERT_WINDOW
+#      first-parent commits. This class is created by PRs open CONCURRENTLY, so
+#      the culprit is always a near neighbour. Corollary limitation, stated
+#      plainly: content reverted from OUTSIDE that window is missed by design.
+#      Widening the window buys little (deletions of older code are normal
+#      maintenance) and costs a lot of noise.
+#
+#   3. INTENT, matched in CONSTRAINED FORMS ONLY -- a `Revert "` subject, a
+#      `This reverts commit <sha>` line, or an explicit `Intentional-removal:`
+#      trailer. Deliberately NOT a substring search for "revert": a body
+#      reading "this does not revert X" would silence a real finding, turning
+#      the false-positive fix into a false-negative hole.
+#
+#   4. NON-BLOCKING. It runs post-merge on main only, never as a PR gate, and
+#      is never wired into ci-status's needs. Detection, not prevention. A
+#      canary that can block a merge acquires a constituency for disabling it.
+#
+# THE RESIDUAL FALSE POSITIVE, MEASURED RATHER THAN ASSUMED
+# ---------------------------------------------------------
+# At these settings, over the last 500 first-parent commits of main, the canary
+# fires 5 times -- 1%. Three are the confirmed incidents. The other two are both
+# real, and neither is a bug in the detector:
+#
+#   6f0a31109 (#2640, 390 lines) is the manual RESTORE of #2633's revert. To
+#   put back what #2633 dropped it had to delete what #2633 had added, so a
+#   large deliberate removal of very recent content is exactly what it is.
+#
+#   91e77fc16 (#2135, 340 lines) is a deliberate merge reconciliation: main
+#   moved under the PR, the author merged origin/main in and consciously chose
+#   which side won, and the PR body argues the choice at length.
+#
+# State the uncomfortable part plainly: 340 is the largest false positive and
+# 346 is the smallest true one. NO THRESHOLD SEPARATES THEM. Picking a number
+# in that 2% gap would be overfitting to this corpus, so the threshold is set
+# at 200 instead -- which costs nothing (200 and 300 fire on the identical five
+# commits here) and leaves headroom for a smaller future revert.
+#
+# So the canary is calibrated to fire roughly once a month, on something a
+# human should genuinely glance at, and precision is deliberately traded for
+# recall because the miss is expensive and the fire is cheap. Cheap requires a
+# disposition path for BOTH directions in time, which is why there are two:
+#
+#   PROSPECTIVE -- `Intentional-removal:` in the PR body, which GitHub carries
+#   into the squash message. Costs one line and the canary never fires.
+#
+#   RETROSPECTIVE -- scripts/silent-revert-acknowledged.txt. A commit message
+#   cannot be amended after the merge, so a fire that turns out to be fine is
+#   cleared by recording the reviewed SHA and its disposition, the same shape
+#   as scripts/changelog-parity-baseline.txt and
+#   scripts/orphaned-fixtures-baseline.txt. Without this, one legitimate fire
+#   would leave main's canary permanently red, and a permanently red canary is
+#   a canary on its way to being deleted.
+#
+# The acknowledgment file is an audit trail, not a mute button: every entry
+# records a human decision about a specific commit, and a reviewer can read
+# back exactly which removals were judged intentional and why.
+#
+# The self-test (scripts/check-silent-revert.test.sh) runs BEFORE this script in
+# CI, so a broken detector cannot mask a regression behind a green canary --
+# the same never-skip, self-test-first, fail-closed shape the ci.yml gates use.
+set -uo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.." || {
+  echo "check-silent-revert: cannot reach the repository root" >&2
+  exit 2
+}
+
+# Tunables. Defaults are the measured values; the env vars exist so the
+# self-test can drive small synthetic repos without shipping a second code path.
+THRESHOLD="${SILENT_REVERT_THRESHOLD:-200}"
+WINDOW="${SILENT_REVERT_WINDOW:-40}"
+# Sample lines quoted back in a finding, and the minimum length for a line to be
+# worth quoting (a bare brace tells a reader nothing).
+SAMPLES="${SILENT_REVERT_SAMPLES:-5}"
+SAMPLE_MIN_LEN=25
+
+INCIDENTS_FILE="${SILENT_REVERT_INCIDENTS:-scripts/silent-revert-incidents.txt}"
+ACK_FILE="${SILENT_REVERT_ACK:-scripts/silent-revert-acknowledged.txt}"
+
+die() {
+  echo "check-silent-revert: $*" >&2
+  exit 2
+}
+
+usage() {
+  cat >&2 <<'EOF'
+usage:
+  scripts/check-silent-revert.sh <range>                  e.g. abc123..def456
+  scripts/check-silent-revert.sh --commit <sha>
+  scripts/check-silent-revert.sh --verify-known-incidents
+EOF
+  exit 2
+}
+
+command -v git >/dev/null 2>&1 || die "git is required"
+
+# ---------------------------------------------------------------------------
+# Intent markers. Constrained forms only -- see FALSE-POSITIVE STRATEGY above.
+# ---------------------------------------------------------------------------
+# Returns 0 when the commit declares the removal, printing the clause matched.
+declares_removal() {
+  local sha="$1" msg subject
+  msg="$(git log -1 --format=%B "$sha")" || return 1
+  subject="$(printf '%s\n' "$msg" | head -n 1)"
+
+  case "$subject" in
+    'Revert "'*)
+      printf 'the subject begins with a Revert quote, as git revert writes it\n'
+      return 0
+      ;;
+    *) ;;
+  esac
+  if printf '%s\n' "$msg" | grep -Eq '^This reverts commit [0-9a-f]{7,40}'; then
+    printf 'the body carries a "This reverts commit <sha>" line\n'
+    return 0
+  fi
+  # The explicit ack. Requires a non-empty reason so an empty trailer cannot be
+  # pasted in as a blanket mute.
+  if printf '%s\n' "$msg" | grep -Eq '^Intentional-removal:[[:space:]]*[^[:space:]]'; then
+    printf 'the body carries an Intentional-removal trailer\n'
+    return 0
+  fi
+  return 1
+}
+
+# Retrospective disposition: prints the recorded reason and returns 0 when this
+# exact commit has been reviewed and cleared by a human.
+#
+# Full 40-character shas only. An abbreviation would let one entry silence
+# whatever else happened to share its prefix, which is the difference between an
+# audit trail and a mute button.
+ack_reason() {
+  local sha="$1"
+  [[ -f "$ACK_FILE" ]] || return 1
+  local recorded reason
+  while read -r recorded reason; do
+    case "$recorded" in
+      '' | '#'*) continue ;;
+      *) ;;
+    esac
+    if [[ "$recorded" = "$sha" ]]; then
+      printf '%s\n' "${reason:-<no reason recorded>}"
+      return 0
+    fi
+  done <"$ACK_FILE"
+  return 1
+}
+
+# ---------------------------------------------------------------------------
+# Deleted-line attribution.
+# ---------------------------------------------------------------------------
+# For one file, emit "<culprit-sha> <TAB> <deleted line text>" for every line the
+# commit removed, attributed to whoever last touched it in the parent.
+#
+# One blame invocation per FILE, not per hunk: git blame accepts repeated -L
+# ranges, and a commit touching a 900-line test file produces hundreds of hunks.
+attribute_file() {
+  local parent="$1" commit="$2" file="$3"
+  local -a ranges=()
+
+  # Old-side hunk ranges (the parent's line numbers) with at least one deleted
+  # line. --unified=0 keeps each hunk tight to its own deletions.
+  while read -r start count; do
+    [[ -n "$start" ]] || continue
+    [[ "$count" -gt 0 ]] || continue
+    ranges+=(-L "$start,$((start + count - 1))")
+  done < <(
+    git diff --unified=0 --no-color --no-renames "$parent" "$commit" -- "$file" 2>/dev/null |
+      awk '/^@@ /{
+             split($2, a, ",")
+             start = substr(a[1], 2) + 0
+             count = (length(a) > 1) ? a[2] + 0 : 1
+             if (start > 0) print start, count
+           }'
+  )
+
+  [[ "${#ranges[@]}" -gt 0 ]] || return 0
+
+  # --line-porcelain repeats the header for every line, so sha and text stay
+  # paired without tracking porcelain's abbreviated continuation form.
+  git blame --line-porcelain "${ranges[@]}" "$parent" -- "$file" 2>/dev/null |
+    awk '
+      /^[0-9a-f]{40} /{ sha = $1; next }
+      /^\t/ { if (sha != "") printf "%s\t%s\n", sha, substr($0, 2) }
+    '
+}
+
+# ---------------------------------------------------------------------------
+# Scan one commit. Returns 0 clean, 1 findings.
+# ---------------------------------------------------------------------------
+scan_commit() {
+  local commit="$1"
+  local sha subject parent
+  sha="$(git rev-parse --verify "${commit}^{commit}" 2>/dev/null)" ||
+    die "not a commit: $commit"
+  subject="$(git log -1 --format=%s "$sha")"
+
+  # Root commits delete nothing. Merge commits cannot occur here (the branch
+  # ruleset requires linear history) but are handled rather than crashed on:
+  # first-parent is the mainline view this canary reasons about.
+  parent="$(git rev-parse --verify "${sha}^1" 2>/dev/null)" || {
+    printf 'skip %s (root commit, no parent to compare against)\n' "${sha:0:9}"
+    return 0
+  }
+
+  local why
+  if why="$(declares_removal "$sha")"; then
+    printf 'declared %s %s\n' "${sha:0:9}" "$subject"
+    printf '         removal is declared: %s' "$why"
+    return 0
+  fi
+
+  # Retrospective disposition. Matched on the FULL 40-char sha so an
+  # abbreviation can never widen into an unintended commit.
+  local ack_note
+  if ack_note="$(ack_reason "$sha")"; then
+    printf 'acknowledged %s %s\n' "${sha:0:9}" "$subject"
+    printf '             reviewed and cleared: %s\n' "$ack_note"
+    return 0
+  fi
+
+  # The recency window: commits reachable from the parent along first-parent.
+  local window_file
+  window_file="$(mktemp)" || die "mktemp failed"
+  git rev-list --first-parent -n "$WINDOW" "$parent" >"$window_file" 2>/dev/null
+
+  if [[ ! -s "$window_file" ]]; then
+    rm -f "$window_file"
+    printf 'skip %s (no history behind the parent to compare against)\n' "${sha:0:9}"
+    return 0
+  fi
+
+  # Attribute every deleted line across every modified/deleted file.
+  local attributed
+  attributed="$(mktemp)" || die "mktemp failed"
+  local file
+  while IFS= read -r -d '' file; do
+    attribute_file "$parent" "$sha" "$file" |
+      awk -v f="$file" -F '\t' '{printf "%s\t%s\t%s\n", $1, f, $2}' >>"$attributed"
+  done < <(git diff --name-only -z --no-renames --diff-filter=MD "$parent" "$sha")
+
+  # Keep only lines whose culprit is inside the recency window.
+  local in_window
+  in_window="$(mktemp)" || die "mktemp failed"
+  if [[ -s "$attributed" ]]; then
+    awk -F '\t' 'NR == FNR { w[$1] = 1; next } ($1 in w)' \
+      "$window_file" "$attributed" >"$in_window"
+  fi
+
+  local findings=0 culprit count
+  while read -r count culprit; do
+    [[ -n "$culprit" ]] || continue
+    [[ "$count" -ge "$THRESHOLD" ]] || continue
+    findings=$((findings + 1))
+    report_finding "$sha" "$subject" "$parent" "$culprit" "$count" "$in_window"
+  done < <(awk -F '\t' '{c[$1]++} END {for (k in c) print c[k], k}' "$in_window" |
+    sort -rn)
+
+  rm -f "$window_file" "$attributed" "$in_window"
+
+  if [[ "$findings" -eq 0 ]]; then
+    printf 'ok %s %s\n' "${sha:0:9}" "$subject"
+    return 0
+  fi
+  return 1
+}
+
+# report_finding <sha> <subject> <parent> <culprit> <count> <attributed-file>
+# Names WHAT disappeared, WHICH commit removed it, and WHICH commit had added
+# it -- a finding that says only "something changed" is not worth having.
+report_finding() {
+  local sha="$1" subject="$2" parent="$3" culprit="$4" count="$5" data="$6"
+  local distance
+  distance="$(git rev-list --first-parent --count "${culprit}..${parent}" 2>/dev/null)"
+
+  printf '\n'
+  printf 'SILENT REVERT SUSPECTED\n'
+  printf '\n'
+  printf '  removed by   %s  %s\n' "${sha:0:9}" "$subject"
+  printf '               %s\n' "$(git log -1 --format=%ci "$sha")"
+  printf '  content from %s  %s\n' "${culprit:0:9}" "$(git log -1 --format=%s "$culprit")"
+  printf '               %s  (%s commit(s) earlier on main)\n' \
+    "$(git log -1 --format=%ci "$culprit")" "$((distance + 1))"
+  printf '  lines lost   %s  (threshold %s, window %s commits)\n' \
+    "$count" "$THRESHOLD" "$WINDOW"
+  printf '\n'
+  printf '  by file:\n'
+  awk -F '\t' -v c="$culprit" '$1 == c {n[$2]++} END {for (f in n) printf "%8d  %s\n", n[f], f}' \
+    "$data" | sort -rn
+  printf '\n'
+  printf '  sample of the removed content:\n'
+  awk -F '\t' -v c="$culprit" -v min="$SAMPLE_MIN_LEN" -v max="$SAMPLES" '
+    $1 == c {
+      line = $3
+      gsub(/^[[:space:]]+|[[:space:]]+$/, "", line)
+      if (length(line) >= min) {
+        printf "      | %s\n", substr(line, 1, 100)
+        if (++shown >= max) exit
+      }
+    }' "$data"
+  printf '\n'
+  printf '  What to do:\n'
+  printf '    Compare the merged tree against what %s landed:\n' "${culprit:0:9}"
+  printf '      git diff %s %s -- <file>\n' "${culprit:0:9}" "${sha:0:9}"
+  printf '    If the content should still be on main, re-land it.\n'
+  printf '    If the removal was intended, record the review in %s:\n' "$ACK_FILE"
+  printf '      %s  <why it was intended>\n' "$sha"
+  printf '    Next time, saying it in the PR body up front avoids the fire\n'
+  printf '    entirely -- GitHub carries the body into the squash message:\n'
+  printf '      Intentional-removal: <why>\n'
+  printf '\n'
+}
+
+# ---------------------------------------------------------------------------
+# Replay of the recorded incidents. This is the proof the canary catches the
+# real thing rather than merely being plausible: the shipped thresholds are run
+# against the actual merges from #2691 and must fire, and against a verified
+# legitimate commit and must not.
+# ---------------------------------------------------------------------------
+verify_known_incidents() {
+  [[ -f "$INCIDENTS_FILE" ]] || die "incident file not found: $INCIDENTS_FILE"
+
+  local rc=0 expect sha note
+  while read -r expect sha note; do
+    case "$expect" in
+      '' | '#'*) continue ;;
+      *) ;;
+    esac
+    if ! git rev-parse --verify --quiet "${sha}^{commit}" >/dev/null; then
+      die "incident commit $sha is unreachable -- the canary self-check needs full history (fetch-depth: 0)"
+    fi
+    local out status
+    out="$(scan_commit "$sha" 2>&1)"
+    status=$?
+    case "$expect" in
+      fires)
+        if [[ "$status" -eq 1 ]]; then
+          printf 'ok   %s fires as recorded  (%s)\n' "${sha:0:9}" "$note"
+        else
+          printf 'FAIL %s should fire and did not  (%s)\n' "${sha:0:9}" "$note"
+          printf '%s\n' "$out"
+          rc=1
+        fi
+        ;;
+      clean)
+        if [[ "$status" -eq 0 ]]; then
+          printf 'ok   %s stays clean as recorded  (%s)\n' "${sha:0:9}" "$note"
+        else
+          printf 'FAIL %s should stay clean and fired  (%s)\n' "${sha:0:9}" "$note"
+          printf '%s\n' "$out"
+          rc=1
+        fi
+        ;;
+      *) die "unknown expectation '$expect' in $INCIDENTS_FILE" ;;
+    esac
+  done <"$INCIDENTS_FILE"
+
+  if [[ "$rc" -ne 0 ]]; then
+    echo
+    echo "The canary no longer reproduces the incidents it was built for."
+    echo "Do not relax the recorded expectations to make this pass."
+    return 1
+  fi
+  echo
+  echo "Canary reproduces every recorded incident at the shipped settings."
+  return 0
+}
+
+# ---------------------------------------------------------------------------
+main() {
+  [[ $# -ge 1 ]] || usage
+
+  case "$1" in
+    --verify-known-incidents)
+      verify_known_incidents
+      exit $?
+      ;;
+    --commit)
+      [[ $# -eq 2 ]] || usage
+      scan_commit "$2"
+      exit $?
+      ;;
+    -h | --help) usage ;;
+    -*) usage ;;
+    # Anything else is a range, handled below.
+    *) ;;
+  esac
+
+  local range="$1"
+  case "$range" in
+    *..*) ;;
+    *) die "expected a commit range like A..B, got '$range'" ;;
+  esac
+
+  local commits
+  commits="$(git rev-list --first-parent --reverse "$range" 2>/dev/null)" ||
+    die "cannot resolve range '$range' -- is the full history fetched (fetch-depth: 0)?"
+
+  if [[ -z "$commits" ]]; then
+    echo "check-silent-revert: no commits in range '$range'; nothing to scan."
+    exit 0
+  fi
+
+  local rc=0 c
+  for c in $commits; do
+    scan_commit "$c" || rc=1
+  done
+
+  if [[ "$rc" -ne 0 ]]; then
+    echo
+    echo "One or more merges removed a large block of content that had just"
+    echo "landed on main, without declaring the removal. See each finding above."
+    echo "This check NEVER blocks a merge -- the merge has already happened."
+  fi
+  exit "$rc"
+}
+
+main "$@"

--- a/scripts/check-silent-revert.test.sh
+++ b/scripts/check-silent-revert.test.sh
@@ -207,6 +207,26 @@ t_does_not_sum_across_culprits() {
   fi
 }
 
+# Renaming a file is not deleting its content. Without git's rename detection a
+# `git mv` decomposes into delete + add, and every line of a moved file would be
+# attributed as removed -- so relocating a large file a recent commit had added
+# would fire. This repo restructures skills and docs constantly, which makes
+# that a live false-positive class rather than a hypothetical one.
+t_rename_is_not_a_removal() {
+  local repo out
+  repo="$(mk_repo)"
+  add_block "$repo" moved.txt 60 alpha
+  git_test_config "$repo" mv moved.txt relocated.txt >/dev/null
+  git_test_config "$repo" commit -qm "refactor: relocate the guard (#99)"
+  SILENT_REVERT_THRESHOLD=20 run_canary "$repo" --commit HEAD
+  out="$OUT"
+  if [[ "$RC" -eq 0 ]]; then
+    ok "renaming a file a recent commit added is not reported as a removal"
+  else
+    fail "a pure rename must not fire, rc=$RC: $out"
+  fi
+}
+
 # --------------------------------------------------------------------------
 # 3. Declared-intent forms. Constrained matching only.
 # --------------------------------------------------------------------------
@@ -491,6 +511,7 @@ t_finding_is_actionable
 t_quiet_below_threshold
 t_quiet_outside_recency_window
 t_does_not_sum_across_culprits
+t_rename_is_not_a_removal
 t_declared_forms
 t_prose_mentioning_revert_still_fires
 t_empty_trailer_still_fires

--- a/scripts/check-silent-revert.test.sh
+++ b/scripts/check-silent-revert.test.sh
@@ -1,0 +1,510 @@
+#!/usr/bin/env bash
+# Unit tests for check-silent-revert.sh.
+#
+# Every case builds a throwaway git repository and drives the real script, so
+# the suite is hermetic: it needs no network, no GitHub API, and nothing about
+# this repository's own history. That split is deliberate. These tests pin the
+# MECHANICS -- attribution, per-culprit aggregation, the recency window, every
+# disposition path, and the fail-closed exits. The claim that the shipped
+# thresholds still catch the real #2691 merges is a different claim about
+# different data, and it is pinned separately by
+# `check-silent-revert.sh --verify-known-incidents` against
+# scripts/silent-revert-incidents.txt, which the canary workflow runs with full
+# history. Neither is allowed to substitute for the other, and neither is
+# allowed to skip.
+#
+# Most cases override SILENT_REVERT_THRESHOLD so fixtures stay small and
+# readable. `default_threshold_is_wired` deliberately does not, so a typo in the
+# shipped default cannot hide behind an override in every single test.
+set -uo pipefail
+
+SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$SELF_DIR/check-silent-revert.sh"
+# shellcheck source=test-git-helpers.sh
+. "$SELF_DIR/test-git-helpers.sh"
+
+PASS=0
+FAIL=0
+fail() {
+  echo "FAIL: $*" >&2
+  FAIL=$((FAIL + 1))
+}
+ok() {
+  echo "ok: $*"
+  PASS=$((PASS + 1))
+}
+
+TMPDIRS=()
+cleanup() {
+  local d
+  for d in ${TMPDIRS+"${TMPDIRS[@]}"}; do
+    [[ -n "$d" ]] && rm -rf "$d"
+  done
+}
+trap cleanup EXIT
+
+# A repo laid out the way the incident was: a base file, then a "culprit" commit
+# that adds a block of content, then optional filler commits, then whatever the
+# test wants to do to that block.
+mk_repo() {
+  local dir
+  dir="$(mktemp -d)"
+  TMPDIRS+=("$dir")
+  git_init_test_repo "$dir" >/dev/null || return 1
+  mkdir -p "$dir/scripts"
+  cp "$SCRIPT" "$dir/scripts/check-silent-revert.sh"
+  printf 'base line %s\n' $(seq 1 5) >"$dir/feature.txt"
+  git_test_config "$dir" add -A >/dev/null
+  git_test_config "$dir" commit -qm "base"
+  printf '%s' "$dir"
+}
+
+# add_block <repo> <file> <count> <tag> -- the content a later commit will drop.
+add_block() {
+  local repo="$1" file="$2" count="$3" tag="$4" i
+  for i in $(seq 1 "$count"); do
+    printf 'the %s guard rejects a relocation outside the session root, case %s\n' \
+      "$tag" "$i" >>"$repo/$file"
+  done
+  git_test_config "$repo" add -A >/dev/null
+  git_test_config "$repo" commit -qm "feat: add the $tag guard"
+}
+
+# drop_block <repo> <file> <tag> <commit-message> -- a squash carrying a tree
+# from before the block existed, exactly as the incident's merges did.
+drop_block() {
+  local repo="$1" file="$2" tag="$3" msg="$4"
+  grep -v "the $tag guard rejects" "$repo/$file" >"$repo/$file.tmp" || true
+  mv "$repo/$file.tmp" "$repo/$file"
+  printf 'unrelated work from the stale branch\n' >>"$repo/$file"
+  git_test_config "$repo" add -A >/dev/null
+  git_test_config "$repo" commit -qm "$msg"
+}
+
+filler() {
+  local repo="$1" n="$2" i
+  for i in $(seq 1 "$n"); do
+    printf 'filler %s\n' "$i" >>"$repo/other.txt"
+    git_test_config "$repo" add -A >/dev/null
+    git_test_config "$repo" commit -qm "chore: unrelated change $i"
+  done
+}
+
+# run_canary <repo> <args...>
+#
+# Sets RC and OUT. Deliberately NOT a function whose output the caller captures
+# with $(...): a command substitution runs in a subshell, so an exit status
+# assigned to a global inside one is silently discarded and every assertion
+# degrades to "rc=0". Callers therefore invoke it as a statement and read the
+# globals afterwards. Env overrides go on the call as a prefix
+# (`SILENT_REVERT_THRESHOLD=20 run_canary ...`), which bash applies to the
+# child process the function launches.
+RC=0
+OUT=""
+run_canary() {
+  local repo="$1"
+  shift
+  local tmp
+  tmp="$(mktemp)"
+  (cd "$repo" && bash scripts/check-silent-revert.sh "$@") >"$tmp" 2>&1
+  RC=$?
+  OUT="$(cat "$tmp")"
+  rm -f "$tmp"
+}
+
+# --------------------------------------------------------------------------
+# 1. The incident shape itself.
+# --------------------------------------------------------------------------
+t_fires_on_silent_revert() {
+  local repo out
+  repo="$(mk_repo)"
+  add_block "$repo" feature.txt 40 alpha
+  filler "$repo" 2
+  drop_block "$repo" feature.txt alpha "feat: unrelated feature (#99)"
+  SILENT_REVERT_THRESHOLD=20 run_canary "$repo" --commit HEAD
+  out="$OUT"
+  if [[ "$RC" -eq 1 ]] && printf '%s' "$out" | grep -q 'SILENT REVERT SUSPECTED'; then
+    ok "fires when a merge drops a block a recent commit had added"
+  else
+    fail "expected a finding (rc=1), got rc=$RC: $out"
+  fi
+}
+
+# Requirement 4: a finding that only says "something changed" is useless. It has
+# to name what vanished, which commit removed it, and which commit added it.
+t_finding_is_actionable() {
+  local repo out culprit remover
+  repo="$(mk_repo)"
+  add_block "$repo" feature.txt 40 alpha
+  culprit="$(git -C "$repo" rev-parse --short=9 HEAD)"
+  drop_block "$repo" feature.txt alpha "feat: unrelated feature (#99)"
+  remover="$(git -C "$repo" rev-parse --short=9 HEAD)"
+  SILENT_REVERT_THRESHOLD=20 run_canary "$repo" --commit HEAD
+  out="$OUT"
+
+  local missing=""
+  printf '%s' "$out" | grep -q "$culprit" || missing="$missing adding-commit"
+  printf '%s' "$out" | grep -q "$remover" || missing="$missing removing-commit"
+  printf '%s' "$out" | grep -q 'feature.txt' || missing="$missing file-name"
+  printf '%s' "$out" | grep -q 'the alpha guard rejects' || missing="$missing removed-content"
+  if [[ -z "$missing" ]]; then
+    ok "finding names the content, the remover, the adder, and the file"
+  else
+    fail "finding omitted:$missing -- $out"
+  fi
+}
+
+# --------------------------------------------------------------------------
+# 2. False-positive controls.
+# --------------------------------------------------------------------------
+t_quiet_below_threshold() {
+  local repo out
+  repo="$(mk_repo)"
+  add_block "$repo" feature.txt 40 alpha
+  drop_block "$repo" feature.txt alpha "chore: trim (#99)"
+  SILENT_REVERT_THRESHOLD=500 run_canary "$repo" --commit HEAD
+  out="$OUT"
+  if [[ "$RC" -eq 0 ]]; then
+    ok "stays quiet when the removal is below the volume threshold"
+  else
+    fail "expected clean below threshold, got rc=$RC: $out"
+  fi
+}
+
+t_quiet_outside_recency_window() {
+  local repo out
+  repo="$(mk_repo)"
+  add_block "$repo" feature.txt 40 alpha
+  filler "$repo" 6
+  drop_block "$repo" feature.txt alpha "chore: remove old guard (#99)"
+  SILENT_REVERT_THRESHOLD=20 SILENT_REVERT_WINDOW=3 run_canary "$repo" --commit HEAD
+  out="$OUT"
+  if [[ "$RC" -eq 0 ]]; then
+    ok "stays quiet when the removed content is older than the recency window"
+  else
+    fail "expected clean outside window, got rc=$RC: $out"
+  fi
+}
+
+# Per-culprit aggregation, not a repo-wide sum. Ordinary work deletes a few
+# recent lines from several commits at once; summing them would re-admit exactly
+# the routine case the volume threshold exists to exclude.
+t_does_not_sum_across_culprits() {
+  local repo out
+  repo="$(mk_repo)"
+  add_block "$repo" feature.txt 18 alpha
+  add_block "$repo" feature.txt 18 beta
+  grep -v 'guard rejects' "$repo/feature.txt" >"$repo/f.tmp" || true
+  mv "$repo/f.tmp" "$repo/feature.txt"
+  git_test_config "$repo" add -A >/dev/null
+  git_test_config "$repo" commit -qm "chore: tidy (#99)"
+  SILENT_REVERT_THRESHOLD=25 run_canary "$repo" --commit HEAD
+  out="$OUT"
+  if [[ "$RC" -eq 0 ]]; then
+    ok "does not sum unrelated culprits into one finding (36 lines, 18 each, threshold 25)"
+  else
+    fail "expected clean; culprits must be counted separately: $out"
+  fi
+}
+
+# --------------------------------------------------------------------------
+# 3. Declared-intent forms. Constrained matching only.
+# --------------------------------------------------------------------------
+assert_declared() {
+  local label="$1" msg="$2" expect_rc="$3"
+  local repo out
+  repo="$(mk_repo)"
+  add_block "$repo" feature.txt 40 alpha
+  drop_block "$repo" feature.txt alpha "$msg"
+  SILENT_REVERT_THRESHOLD=20 run_canary "$repo" --commit HEAD
+  out="$OUT"
+  if [[ "$RC" -eq "$expect_rc" ]]; then
+    ok "$label"
+  else
+    fail "$label: expected rc=$expect_rc, got rc=$RC: $out"
+  fi
+}
+
+t_declared_forms() {
+  assert_declared 'a Revert-quote subject silences the canary' \
+    'Revert "feat: add the alpha guard"' 0
+  assert_declared 'a "This reverts commit <sha>" line silences the canary' \
+    "$(printf 'chore: back out the guard\n\nThis reverts commit 0123456789abcdef0123456789abcdef01234567.\n')" 0
+  assert_declared 'an Intentional-removal trailer silences the canary' \
+    "$(printf 'refactor: drop the alpha guard (#99)\n\nIntentional-removal: superseded by the shared guard in #100\n')" 0
+}
+
+# The reason why matching is constrained rather than a substring search: a body
+# that merely mentions reverting must NOT silence a real finding, or the
+# false-positive fix becomes a false-negative hole.
+t_prose_mentioning_revert_still_fires() {
+  assert_declared 'prose mentioning "revert" does not silence the canary' \
+    "$(printf 'feat: unrelated feature (#99)\n\nThis does not revert anything; the guard work is untouched.\n')" 1
+}
+
+# An empty trailer would be a blanket mute with no accountability.
+t_empty_trailer_still_fires() {
+  assert_declared 'an empty Intentional-removal trailer does not silence the canary' \
+    "$(printf 'refactor: drop the guard (#99)\n\nIntentional-removal:\n')" 1
+}
+
+# --------------------------------------------------------------------------
+# 4. Retrospective acknowledgment.
+# --------------------------------------------------------------------------
+t_acknowledged_commit_is_cleared() {
+  local repo out sha
+  repo="$(mk_repo)"
+  add_block "$repo" feature.txt 40 alpha
+  drop_block "$repo" feature.txt alpha "feat: unrelated feature (#99)"
+  sha="$(git -C "$repo" rev-parse HEAD)"
+  printf '# ack\n%s  reviewed: intentional\n' "$sha" >"$repo/scripts/ack.txt"
+  SILENT_REVERT_THRESHOLD=20 SILENT_REVERT_ACK=scripts/ack.txt \
+    run_canary "$repo" --commit HEAD
+  out="$OUT"
+  if [[ "$RC" -eq 0 ]] && printf '%s' "$out" | grep -q 'reviewed and cleared'; then
+    ok "a reviewed commit recorded in the acknowledgment file is cleared"
+  else
+    fail "expected the acknowledged commit to clear, rc=$RC: $out"
+  fi
+}
+
+# Abbreviations are refused so one row can never widen to cover a commit nobody
+# reviewed -- the difference between an audit trail and a mute button.
+t_abbreviated_ack_does_not_clear() {
+  local repo out sha
+  repo="$(mk_repo)"
+  add_block "$repo" feature.txt 40 alpha
+  drop_block "$repo" feature.txt alpha "feat: unrelated feature (#99)"
+  sha="$(git -C "$repo" rev-parse --short=9 HEAD)"
+  printf '%s  reviewed: intentional\n' "$sha" >"$repo/scripts/ack.txt"
+  SILENT_REVERT_THRESHOLD=20 SILENT_REVERT_ACK=scripts/ack.txt \
+    run_canary "$repo" --commit HEAD
+  out="$OUT"
+  if [[ "$RC" -eq 1 ]]; then
+    ok "an abbreviated sha in the acknowledgment file does not clear a finding"
+  else
+    fail "expected an abbreviated ack to be refused, rc=$RC: $out"
+  fi
+}
+
+# --------------------------------------------------------------------------
+# 5. Shipped defaults, range mode, whole-file removal, fail-closed exits.
+# --------------------------------------------------------------------------
+# No env override here on purpose: this is the only case that would catch a
+# broken shipped default.
+t_default_threshold_is_wired() {
+  local repo out
+  repo="$(mk_repo)"
+  add_block "$repo" feature.txt 260 alpha
+  drop_block "$repo" feature.txt alpha "feat: unrelated feature (#99)"
+  run_canary "$repo" --commit HEAD
+  out="$OUT"
+  if [[ "$RC" -eq 1 ]]; then
+    ok "the shipped default threshold fires on a 260-line drop"
+  else
+    fail "shipped default did not fire on 260 lines, rc=$RC: $out"
+  fi
+  # And the shipped default must not fire on a drop well under it.
+  repo="$(mk_repo)"
+  add_block "$repo" feature.txt 60 beta
+  drop_block "$repo" feature.txt beta "feat: unrelated feature (#98)"
+  run_canary "$repo" --commit HEAD
+  out="$OUT"
+  if [[ "$RC" -eq 0 ]]; then
+    ok "the shipped default threshold stays quiet on a 60-line drop"
+  else
+    fail "shipped default fired on 60 lines, rc=$RC: $out"
+  fi
+}
+
+t_range_mode_scans_every_commit() {
+  local repo out base
+  repo="$(mk_repo)"
+  base="$(git -C "$repo" rev-parse HEAD)"
+  add_block "$repo" feature.txt 40 alpha
+  filler "$repo" 1
+  drop_block "$repo" feature.txt alpha "feat: unrelated feature (#99)"
+  SILENT_REVERT_THRESHOLD=20 run_canary "$repo" "$base..HEAD"
+  out="$OUT"
+  if [[ "$RC" -eq 1 ]] && printf '%s' "$out" | grep -q 'SILENT REVERT SUSPECTED'; then
+    ok "range mode scans every commit in the push"
+  else
+    fail "expected range mode to find the revert, rc=$RC: $out"
+  fi
+}
+
+t_whole_file_deletion_is_attributed() {
+  local repo out
+  repo="$(mk_repo)"
+  printf 'the alpha guard rejects relocation, case %s\n' $(seq 1 40) >"$repo/guard.txt"
+  git_test_config "$repo" add -A >/dev/null
+  git_test_config "$repo" commit -qm "feat: add the guard file"
+  rm "$repo/guard.txt"
+  git_test_config "$repo" add -A >/dev/null
+  git_test_config "$repo" commit -qm "feat: unrelated feature (#99)"
+  SILENT_REVERT_THRESHOLD=20 run_canary "$repo" --commit HEAD
+  out="$OUT"
+  if [[ "$RC" -eq 1 ]] && printf '%s' "$out" | grep -q 'guard.txt'; then
+    ok "a wholly deleted file is attributed like any other removal"
+  else
+    fail "expected the deleted file to be attributed, rc=$RC: $out"
+  fi
+}
+
+# Fail-closed: an unresolvable range must exit 2 (cannot run), never 0 (clean).
+# A canary that reports success when it could not see the history is the exact
+# false-green this whole check exists to eliminate.
+t_unresolvable_range_fails_closed() {
+  local repo out
+  repo="$(mk_repo)"
+  run_canary "$repo" "deadbeef..HEAD"
+  out="$OUT"
+  if [[ "$RC" -eq 2 ]]; then
+    ok "an unresolvable range exits 2 (cannot run), never a quiet pass"
+  else
+    fail "expected rc=2 on an unresolvable range, got rc=$RC: $out"
+  fi
+  run_canary "$repo" "not-a-range"
+  out="$OUT"
+  if [[ "$RC" -eq 2 ]]; then
+    ok "a malformed range argument exits 2"
+  else
+    fail "expected rc=2 on a malformed range, got rc=$RC: $out"
+  fi
+  run_canary "$repo"
+  out="$OUT"
+  if [[ "$RC" -eq 2 ]]; then
+    ok "no arguments exits 2 with usage"
+  else
+    fail "expected rc=2 with no arguments, got rc=$RC: $out"
+  fi
+}
+
+t_root_commit_is_handled() {
+  local repo out
+  repo="$(mk_repo)"
+  run_canary "$repo" --commit HEAD
+  out="$OUT"
+  if [[ "$RC" -eq 0 ]] && printf '%s' "$out" | grep -q 'root commit'; then
+    ok "a root commit is reported as having no parent, not crashed on"
+  else
+    fail "expected the root commit to be handled, rc=$RC: $out"
+  fi
+}
+
+# An empty range is a real state (a push that fast-forwards nothing) and must be
+# distinguishable from a failure.
+t_empty_range_is_clean() {
+  local repo out head
+  repo="$(mk_repo)"
+  add_block "$repo" feature.txt 5 alpha
+  head="$(git -C "$repo" rev-parse HEAD)"
+  run_canary "$repo" "$head..$head"
+  out="$OUT"
+  if [[ "$RC" -eq 0 ]] && printf '%s' "$out" | grep -q 'no commits in range'; then
+    ok "an empty range is clean and says so"
+  else
+    fail "expected an empty range to be clean, rc=$RC: $out"
+  fi
+}
+
+# --------------------------------------------------------------------------
+# 6. The incident-replay harness must itself fail when an expectation breaks.
+# --------------------------------------------------------------------------
+t_replay_fails_on_broken_expectation() {
+  local repo out sha
+  repo="$(mk_repo)"
+  add_block "$repo" feature.txt 40 alpha
+  drop_block "$repo" feature.txt alpha "feat: unrelated feature (#99)"
+  sha="$(git -C "$repo" rev-parse HEAD)"
+
+  printf '# fixture\nfires %s a real drop\n' "$sha" >"$repo/scripts/inc.txt"
+  SILENT_REVERT_THRESHOLD=20 SILENT_REVERT_INCIDENTS=scripts/inc.txt \
+    run_canary "$repo" --verify-known-incidents
+  out="$OUT"
+  if [[ "$RC" -eq 0 ]]; then
+    ok "replay passes when a recorded incident still fires"
+  else
+    fail "replay should have passed, rc=$RC: $out"
+  fi
+
+  # Same commit, wrong expectation: the harness must go red rather than
+  # rubber-stamp whatever the detector currently happens to do.
+  printf 'clean %s deliberately wrong\n' "$sha" >"$repo/scripts/inc.txt"
+  SILENT_REVERT_THRESHOLD=20 SILENT_REVERT_INCIDENTS=scripts/inc.txt \
+    run_canary "$repo" --verify-known-incidents
+  out="$OUT"
+  if [[ "$RC" -eq 1 ]]; then
+    ok "replay fails when a recorded expectation no longer holds"
+  else
+    fail "replay should have failed on a wrong expectation, rc=$RC: $out"
+  fi
+
+  # An unreachable commit is a shallow clone, not a pass.
+  printf 'fires 0123456789abcdef0123456789abcdef01234567 unreachable\n' \
+    >"$repo/scripts/inc.txt"
+  SILENT_REVERT_INCIDENTS=scripts/inc.txt run_canary "$repo" --verify-known-incidents
+  out="$OUT"
+  if [[ "$RC" -eq 2 ]]; then
+    ok "replay exits 2 when a recorded commit is unreachable (shallow history)"
+  else
+    fail "expected rc=2 on an unreachable incident commit, rc=$RC: $out"
+  fi
+}
+
+# The shipped data files must parse and be non-empty, so a truncated or
+# malformed file cannot quietly turn the replay into a no-op.
+t_shipped_data_files_are_wellformed() {
+  local inc="$SELF_DIR/silent-revert-incidents.txt"
+  local ack="$SELF_DIR/silent-revert-acknowledged.txt"
+  local bad=0 n
+
+  if [[ ! -f "$inc" ]]; then
+    fail "missing $inc"
+    return
+  fi
+  n="$(grep -cE '^(fires|clean)[[:space:]]+[0-9a-f]{40}[[:space:]]' "$inc")"
+  [[ "$n" -ge 2 ]] || bad=1
+  # Anything non-blank, non-comment must match the row grammar.
+  grep -vE '^[[:space:]]*(#|$)' "$inc" |
+    grep -qvE '^(fires|clean)[[:space:]]+[0-9a-f]{40}[[:space:]]' && bad=1
+  if [[ "$bad" -eq 0 ]]; then
+    ok "silent-revert-incidents.txt is well-formed with $n pinned rows"
+  else
+    fail "silent-revert-incidents.txt is malformed or has too few rows (n=$n)"
+  fi
+
+  bad=0
+  if [[ -f "$ack" ]]; then
+    grep -vE '^[[:space:]]*(#|$)' "$ack" |
+      grep -qvE '^[0-9a-f]{40}[[:space:]]+[^[:space:]]' && bad=1
+    if [[ "$bad" -eq 0 ]]; then
+      ok "silent-revert-acknowledged.txt rows are full shas with a recorded reason"
+    else
+      fail "silent-revert-acknowledged.txt has a row that is not <full-sha> <reason>"
+    fi
+  fi
+}
+
+t_fires_on_silent_revert
+t_finding_is_actionable
+t_quiet_below_threshold
+t_quiet_outside_recency_window
+t_does_not_sum_across_culprits
+t_declared_forms
+t_prose_mentioning_revert_still_fires
+t_empty_trailer_still_fires
+t_acknowledged_commit_is_cleared
+t_abbreviated_ack_does_not_clear
+t_default_threshold_is_wired
+t_range_mode_scans_every_commit
+t_whole_file_deletion_is_attributed
+t_unresolvable_range_fails_closed
+t_root_commit_is_handled
+t_empty_range_is_clean
+t_replay_fails_on_broken_expectation
+t_shipped_data_files_are_wellformed
+
+echo
+echo "check-silent-revert.test.sh: $PASS passed, $FAIL failed"
+[[ "$FAIL" -eq 0 ]]

--- a/scripts/silent-revert-acknowledged.txt
+++ b/scripts/silent-revert-acknowledged.txt
@@ -1,0 +1,39 @@
+# Reviewed-and-cleared commits for scripts/check-silent-revert.sh.
+#
+# The canary fires when a merge deletes a large block of content another commit
+# had just landed. Sometimes that is exactly what the author meant to do, and a
+# commit message cannot be amended once it is on main -- so this file is the
+# retrospective half of the disposition path. The prospective half is an
+# `Intentional-removal:` trailer in the PR body, which costs one line and means
+# the canary never fires in the first place; prefer it.
+#
+# This is an AUDIT TRAIL, not a mute list. Every row records a human decision
+# about one specific merge, and a reader should be able to reconstruct from the
+# note why the removal was judged intentional. Rows are matched on the full
+# 40-character sha, never an abbreviation, so one entry can never widen to cover
+# a commit nobody reviewed.
+#
+# Before adding a row, confirm the content is genuinely meant to be gone --
+# `git diff <culprit> <commit> -- <file>` -- rather than adding the row because
+# CI is red. The whole failure mode this canary exists for is a green signal
+# that had stopped meaning anything.
+#
+# Format: <full-40-char-sha>  <why the removal was intended>
+# Blank lines and lines beginning with `#` are ignored.
+
+# The two verified-legitimate fires found while calibrating the canary against
+# 500 commits of real history (#2691). Recorded here so main starts green and
+# the canary's first fire is a NEW event rather than known backlog.
+
+# #2640 is the manual restore of the content #2633's squash dropped. Putting
+# #2632's rollups back required deleting what #2633 had put in their place, so
+# a large removal of very recent content is precisely what this commit is.
+6f0a3110942375fb292112f5df5e2c39bbf56cb0  #2640 restores #2632's rollups; the removal undoes #2633's revert
+
+# #2135's author noticed main move under the PR, merged origin/main into the
+# branch rather than force-pushing, and argued the disposition explicitly in the
+# PR body -- a deliberate reconciliation, not a lost tree. At 340 lines this is
+# the largest measured false positive, six lines below the smallest real
+# incident (346), which is why no threshold can separate the two shapes and why
+# this file exists.
+91e77fc16f62bc0ce99b36565053636fb4a21d9e  #2135 deliberately reconciled a merge of origin/main; disposition argued in the PR body

--- a/scripts/silent-revert-incidents.txt
+++ b/scripts/silent-revert-incidents.txt
@@ -1,0 +1,45 @@
+# Recorded incidents for scripts/check-silent-revert.sh --verify-known-incidents.
+#
+# This file is the canary's honesty proof. A detector that merely looks
+# plausible is worthless against #2691, because the whole reason that incident
+# went unnoticed for hours is that every signal a reader normally checks --
+# merged PR, closed issue, green CI, no `Revert:` commit -- looked healthy. So
+# the shipped thresholds are replayed against the ACTUAL merges every time the
+# canary runs, and must still reproduce them.
+#
+# The `clean` rows matter as much as the `fires` rows. A detector tuned until
+# it catches the incidents but which also fires on ordinary work would be
+# switched off within a week, so a verified-legitimate commit is pinned here
+# too -- deliberately the closest sub-threshold miss found in 500 commits of
+# real history, since that is the row that breaks first if someone lowers the
+# threshold to chase recall.
+#
+# Format: <expectation> <full-sha> <note>. `fires` = the canary must report a
+# finding; `clean` = it must not. Blank lines and `#` lines ignored.
+#
+# Do NOT relax a row to make CI pass. A row that no longer holds means the
+# canary stopped detecting the thing it exists to detect; fix the canary.
+
+# --- The incidents from #2691 -------------------------------------------------
+# #2639's squash dropped #2635's report-ordering fix wholesale while landing its
+# own (correct) work. #2590 was left CLOSED as COMPLETED with the fix absent.
+fires f603880dad4003477ec7cac27654fce92c75eec8 #2639 dropped #2635 (346 lines), 13 minutes later
+
+# Ten minutes after that, #2641's squash dropped #2639's guard work.
+# destructive_guard.py went 1643 -> 1424 lines and every #2639 marker string
+# went to zero occurrences. #2618 was left CLOSED as COMPLETED.
+fires 9239f1541b1b15a2a183ad6b4067e577f931e3f1 #2641 dropped #2639 (451 lines), 10 minutes later
+
+# Found by this canary's own calibration run, NOT by the #2691 audit: the same
+# night, #2633's squash dropped #2632's finding rollups (853 lines). #2640 had
+# to restore them by hand. Nobody had filed it, which is the clearest argument
+# for automating the detection.
+fires cc58cbc53fbbb2cca68e071507b82d3e3ff896ff #2633 dropped #2632's rollups (853 lines) -- unfiled until now
+
+# --- Verified-legitimate commits that must stay quiet -------------------------
+# The closest sub-threshold miss in 500 commits: 129 lines of a doc section that
+# #2679 had just added, rewritten by a follow-up that says so ("Builds on merged
+# #2715 -> #2692 -> #2690; rebased onto main"). Ordinary iteration on very
+# recent work. If a threshold change ever makes this fire, the canary has
+# started taxing normal development.
+clean c8470efd09d78d924a962483ff8a0b7809180e11 docs(conventions) rewrote 129 lines of a doc #2679 had just added


### PR DESCRIPTION
No linked issue

## Summary

A post-merge canary for the failure class in #2691: a merge that silently deletes content another recently-merged commit had just added, leaving no `Revert:` marker and no failing test. Item 4 of that issue. Detection only — it runs on `push` to `main`, is not in `ci.yml`, and is not wired into `ci-status`, so it can never gate a merge.

**It also corrects the issue's premise.** This was not a stale-*base* failure, which means `strict_required_status_checks_policy` would not have prevented it. Details below.

## Fix

`scripts/check-silent-revert.sh` blames the lines each merge deleted against its own parent and reports when a large block traces to a **single** commit inside a recency window. Plus `scripts/check-silent-revert.test.sh` (26 hermetic cases), two data files, and `.github/workflows/silent-revert-canary.yml`.

### Why blame-of-deleted-lines, and not the alternatives

Three designs were measured against the real history before one was chosen.

**Merge-base staleness — tested and rejected on evidence.** It exonerates all three real incidents:

```
$ git merge-base --is-ancestor f603880d refs/pull/2641/head && echo YES
YES
$ git grep -c "read-only supporting allowlist" refs/pull/2641/head -- 'plugins/disk-hygiene/**'
(no output — zero occurrences)
$ git grep -c "read-only supporting allowlist" f603880d -- 'plugins/disk-hygiene/**'
f603880d:plugins/disk-hygiene/skills/clean/SKILL.md:1
f603880d:plugins/disk-hygiene/skills/clean/scripts/destructive_guard.py:1
```

PR #2641's head had #2639 **in its ancestry** and **zero occurrences of #2639's content in its tree**. #2639 shows the identical shape against #2635. These branches were up to date with `main` in *history* and stale only in *content* — a bad conflict resolution or a force-push from an older worktree.

So `strict` would have passed all three merges, and a merge queue would have too (CI was green — the tests were deleted alongside the code). **That reframes the canary: for this class it is not defence in depth behind a real fix, it is the only control that fires at all.** No ruleset is touched here and nothing in `github-iac` changes; ADR 0001 stands as written.

**This also matters for #2799, which merged while this was in flight.** That PR landed `scripts/check-stale-base-overlap.sh` as a *required* PR gate (it is in `ci-status`'s `needs`), and its header cites these very incidents: "claude-code-plugins#2691: #2635 then #2639 lost inside ten minutes". Its rule is `merge-base(HEAD, base) == tip(base) → fresh, exit 0`. I ran the merged script against the actual PR branches:

```
$ git worktree add --detach <tmp> refs/pull/2641/head
$ git branch -f base2641 eda5ae5ed          # main's tip when #2641 merged
$ bash ./check-stale-base-overlap.sh --check base2641
check-stale-base-overlap: HEAD is up to date with base2641
exit 0

$ git checkout --detach refs/pull/2639/head
$ git branch -f base2639 b7793d3b4          # main's tip when #2639 merged
$ bash ./check-stale-base-overlap.sh --check base2639
check-stale-base-overlap: HEAD is up to date with base2639
exit 0
```

**It exits 0 — "fresh" — on both branches that did the reverting**, because both were genuinely up to date with `main`. That is not a bug in #2799; it correctly detects the stale-*base* class it targets. But its header claims these incidents as its motivating case, and for those it is a false negative. The two guards are complementary rather than redundant: #2799 prevents a stale base pre-merge, this catches a stale *tree* post-merge, and only the second fires on what actually happened. Worth correcting #2799's header comment either way.

**Curated marker strings (the issue's own suggestion 3) — rejected.** Only catches what someone pre-registered, and nobody had registered #2632, #2635 or #2639. Registration happens *after* you know a fix matters, which is the knowledge the incident destroys.

**PR-creation-time overlap — rejected as non-discriminating.** At the 17-concurrent-PR rate ADR 0001 records, nearly every PR has siblings landing while it is open.

### False-positive strategy

A canary that cries wolf gets disabled, which is worse than none.

1. **Volume**, aggregated **per culprit commit** — summing across culprits would re-admit ordinary iteration.
2. **Recency window** (40 first-parent commits). Stated limitation: content reverted from outside the window is missed by design.
3. **Intent, in constrained forms only** — a `Revert "` subject, a `This reverts commit <sha>` line, or an explicit `Intentional-removal:` trailer. Deliberately *not* a substring search for "revert": a body reading "this does not revert X" would silence a real finding.
4. **Non-blocking** — post-merge only, outside `ci-status`.

**Measured, not assumed** — and measured by running *the shipped script itself* over the last **500** first-parent commits of `main`, not a stand-in:

```
FIRE    853 cc58cbc53 fix(repo-fleet-hygiene): report bare repos with live working trees (#2633)
FIRE    451 9239f1541 feat(disk-hygiene): verify redundant checkout evidence (#2641)
FIRE    390 6f0a31109 fix(repo-fleet-hygiene): restore GraphQL merge evidence and rollups after #2633
FIRE    346 f603880da fix(disk-hygiene): session-honest belt, read-only allowlist, ... (#2639)
FIRE    340 91e77fc16 fix(hook-utils): stop a NUL in a payload value from voiding two blocking guards
MEASUREMENT COMPLETE over 500 commits
```

**5 fires in 500 merges — 1%**, zero errors. Three are the confirmed incidents. The other two are real and are not detector bugs: #2640 (390) is the manual *restore* of #2633's revert, and #2135 (340) is a deliberate merge reconciliation the author argues at length in the PR body. Both are pre-recorded in the acknowledgment file so `main` starts green.

**Rename detection is deliberately left ON.** An earlier revision passed `--no-renames`, which silently made the shipped detector a *different* detector from the calibrated one: without detection a `git mv` decomposes into delete + add, the delete side reaches the `--diff-filter=MD` enumeration as a whole-file removal, and relocating a large file a recent commit had added would fire. In a repo that restructures skills and docs this often, that is a live false-positive class. With detection on, the shipped script reproduces the calibration corpus exactly (the five rows above), and a test pins the rename case. The narrow cost, stated rather than hidden: content gutted in the same commit that renames its file is not attributed.

**The uncomfortable part, stated plainly: 340 is the largest false positive and 346 is the smallest true one. No threshold separates them.** Picking a number inside that 2% gap would be overfitting, so the threshold is 200 — which costs nothing (200 and 300 fire on the identical five commits) and leaves headroom for a smaller future revert. Precision is traded for recall because the miss is expensive and the fire is cheap.

Cheap requires a disposition path in **both** directions in time, so there are two: the prospective `Intentional-removal:` trailer (one line in the PR body, which GitHub carries into the squash message), and `scripts/silent-revert-acknowledged.txt` for a fire that can only be judged after the fact — a commit message cannot be amended post-merge. Without the second, one legitimate fire leaves the canary permanently red, and a permanently red canary is one on its way to being deleted. It matches `changelog-parity-baseline.txt` in shape, matches full 40-char SHAs only, and requires a recorded reason, so it is an audit trail rather than a mute button.

### A third incident, previously unfiled

Calibration surfaced one #2691 never identified: **#2633's squash dropped #2632's finding rollups (853 lines)**, which #2640 restored by hand the same night. Nobody filed it. That is the clearest argument for automating the detection.

## Verification

Real output, all from this branch.

**Catches the actual incident** (requirement 1) — replayed against the real merges, and pinned in `scripts/silent-revert-incidents.txt` so CI re-proves it on every run:

```
$ scripts/check-silent-revert.sh --verify-known-incidents
ok   f603880da fires as recorded  (#2639 dropped #2635 (346 lines), 13 minutes later)
ok   9239f1541 fires as recorded  (#2641 dropped #2639 (451 lines), 10 minutes later)
ok   cc58cbc53 fires as recorded  (#2633 dropped #2632's rollups (853 lines) -- unfiled until now)
ok   c8470efd0 stays clean as recorded  (docs(conventions) rewrote 129 lines of a doc #2679 had just added)

Canary reproduces every recorded incident at the shipped settings.
```

Range mode over the incident window — both fire, the interleaved unrelated merges stay clean:

```
$ scripts/check-silent-revert.sh a95f240f~1..9239f154
ok a95f240f7 feat(disk-hygiene): prioritize tidiness over reclaimable bytes in reports (#2635)
ok b7793d3b4 fix(repo-fleet-hygiene): degrade non-repo paths under --root (#2630)
SILENT REVERT SUSPECTED
  removed by   f603880da  fix(disk-hygiene): session-honest belt, ... (#2639)
  content from a95f240f7  feat(disk-hygiene): prioritize tidiness over ... (#2635)
  lines lost   346  (threshold 200, window 40 commits)
ok eda5ae5ed feat(repo-fleet-hygiene): gather merge evidence via aliased GraphQL (#2642)
SILENT REVERT SUSPECTED
  removed by   9239f1541  feat(disk-hygiene): verify redundant checkout evidence (#2641)
  content from f603880da  fix(disk-hygiene): session-honest belt, ... (#2639)
  lines lost   451  (threshold 200, window 40 commits)
```

**Actionable when it fires** (requirement 4) — it names what disappeared, which commit removed it, which commit added it, the per-file split, and the sample quotes back the very content #2691 reported as lost:

```
  by file:
     235  plugins/disk-hygiene/skills/clean/scripts/destructive_guard.py
     156  plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
      26  plugins/disk-hygiene/skills/clean/SKILL.md
      ...
  sample of the removed content:
      | - The skill-frontmatter guard is a fail-closed allowlist. It permits canonical bundled scan/preview
      | calls made from literal shell words, a small read-only supporting set for cleanup inspection
```

**Tests** (requirement 5) — `scripts/check-silent-revert.test.sh`, hermetic synthetic repos, following the `scripts/*.test.sh` + `test-git-helpers.sh` convention. 27 cases: attribution, per-culprit aggregation, the recency window, the pure-rename negative, every intent form, the "prose mentioning revert must still fire" negative, the empty-trailer negative, abbreviated-SHA rejection, whole-file deletion, the shipped default in both directions, and fail-closed exit 2 on an unresolvable range, a malformed range, and an unreachable pinned commit.

```
$ bash scripts/check-silent-revert.test.sh
check-silent-revert.test.sh: 27 passed, 0 failed
```

**Verified in real CI on this PR, not just locally.** The lane runs on `pull_request` (scoped by `paths` to the canary's own files) so the detector is exercised before it lands — the scan step is gated off for PR events, so nothing on a PR inspects that PR. From the actual run log ([job](https://github.com/melodic-software/claude-code-plugins/actions/runs/31918399785/job/95094057983), 12s):

```
Test the silent-revert detector    check-silent-revert.test.sh: 27 passed, 0 failed
Replay the recorded incidents      ok   f603880da fires as recorded  (#2639 dropped #2635 (346 lines), 13 minutes later)
Replay the recorded incidents      ok   9239f1541 fires as recorded  (#2641 dropped #2639 (451 lines), 10 minutes later)
Replay the recorded incidents      ok   cc58cbc53 fires as recorded  (#2633 dropped #2632's rollups (853 lines) -- unfiled until now)
Replay the recorded incidents      ok   c8470efd0 stays clean as recorded  (docs(conventions) rewrote 129 lines ...)
Replay the recorded incidents      Canary reproduces every recorded incident at the shipped settings.
```

That run matters for a specific reason. The blame-header pattern originally used an ERE interval (`{40}`), and interval support is an awk-implementation variable — the runner's default awk is mawk, development machines run gawk. Had it not matched, attribution would emit nothing and **every commit would report `ok`**: a false green, the exact failure class this canary exists to remove. It is now interval-free and proven against the runner's own awk above.

**Cannot block a merge — verified, not just asserted.** The required contexts on `main` are:

```
$ gh api repos/melodic-software/claude-code-plugins/rules/branches/main \
    --jq '.[] | select(.type=="required_status_checks") | .parameters.required_status_checks[].context'
pr-title / pr-title
pr-issue-linkage / pr-issue-linkage
do-not-merge / do-not-merge
ci-status
```

`Silent-revert canary` is not among them, and its only appearance in `ci.yml` is the `workflow_schema` filename list — never `ci-status`'s `needs`. A non-required check cannot gate a merge.

**Repo gates**, all run locally on this branch: `shellcheck --rcfile=.shellcheckrc -x` (exit 0, and this repo enables `require-double-brackets` and `add-default-case`), `check-shell-portability.sh --paths` and `--all` (exit 0), `zizmor` (no findings), `actionlint` (exit 0), `typos` (exit 0), `editorconfig-checker` (exit 0), `check-jsonschema --builtin-schema vendor.github-workflows` (ok), `check-silent-skips.sh` (exit 0). The new workflow is registered in `ci.yml`'s `workflow_schema` file list; the shell scripts are committed `100755`.

### Design notes for review

- **No cancelling `concurrency` group**, unlike `ci.yml` — a cancelled canary run is a silently missed detection.
- **Fail-closed on an unusable push range.** `github.event.before` is all-zeros on a first push or history rewrite; the workflow falls back to the head commit and emits a `::warning::` saying earlier commits were not scanned, rather than reporting a clean scan of nothing. An unresolvable range exits **2**, never 0.
- **Self-test runs before every scan**, so a broken detector cannot mask a regression behind a green canary — the same never-skip, self-test-first shape the `ci.yml` gates use.
- **What runs on a PR is the detector's unit tests, never detection.** The `pull_request` trigger is `paths`-scoped to the canary's own five files, so it is inert on every other PR, and both scan steps carry `if: github.event_name != 'pull_request'`.
- **Remaining limitations, stated rather than hidden:** content reverted from outside the 40-commit recency window is missed by design; content gutted in the same commit that renames its file is not attributed; and no threshold separates a large deliberate rewrite from a silent revert, which is what the acknowledgment file exists to absorb.

## Related

Refs #2691 — this is item 4; the issue covers more and stays open.
Refs #2799 — item 2, the merge-time stale-base gate, merged while this was in flight. Complementary, not redundant: verified above to exit 0 on both reverting branches, so its header's claim to cover these incidents needs correcting.
Refs #2713 — the docs-only silent-revert blind spot, same class from the test-coverage side.
Refs melodic-software/github-iac `docs/adr/0001-relax-strict-required-status-checks.md` — unchanged; the evidence above argues it was never the relevant control for this failure mode.
