### PR TITLE
fix(scripts): fail closed when historical proof-of-red is unavailable

### DIFF
--- a/scripts/check-fleet-audit-doc-grammar.test.sh
+++ b/scripts/check-fleet-audit-doc-grammar.test.sh
@@ -272,7 +272,10 @@ if git rev-parse --verify --quiet "a6be07f9^{commit}" >/dev/null 2>&1; then
   fi
   rm -rf "$hist"
 else
-  ok "skip historical proof (a6be07f9 not in this clone)"
+  # Historical proof-of-red must fail closed when the anchor is unavailable —
+  # scoring the skip as ok would let a shallow clone or rewritten history
+  # report green while proving nothing (#2807).
+  fail "historical proof unavailable (a6be07f9 not in this clone)"
 fi
 
 # Live tree must pass.

--- a/scripts/check-fleet-finding-test-coverage.test.sh
+++ b/scripts/check-fleet-finding-test-coverage.test.sh
@@ -207,7 +207,10 @@ if git rev-parse --verify --quiet "cc58cbc5^{commit}" >/dev/null 2>&1 &&
   fi
   rm -rf "$hist"
 else
-  ok "skip historical proof (cc58cbc5/6f0a3110 not in this clone)"
+  # Historical proof-of-red must fail closed when the anchors are unavailable —
+  # scoring the skip as ok would let a shallow clone or rewritten history
+  # report green while proving nothing (#2807).
+  fail "historical proof unavailable (cc58cbc5/6f0a3110 not in this clone)"
 fi
 
 # Live tree with the real baseline must pass.

--- a/scripts/check-silent-skips.sh
+++ b/scripts/check-silent-skips.sh
@@ -6,16 +6,25 @@
 # documented classification, never a default.
 #
 #   scripts/check-silent-skips.sh          fail if any hook entry script
-#                                          silently skips on a missing CLI
+#                                          silently skips on a missing CLI,
+#                                          or if a scripts/*.test.sh scores
+#                                          a skip as PASS without annotation
 #
 # Two shapes are flagged in plugins/*/hooks/*.sh (entry scripts only —
 # hook-utils.sh lib copies have their own sync gate and review; *.test.sh
-# files exercise these patterns as fixtures):
+# files under hooks/ exercise these patterns as fixtures):
 #
 #   1. same-line guard:   command -v X ... || exit 0    (also `return 0`, or
 #                         a skip-named helper such as `|| emit_skipped`)
 #   2. block guard:       if ! command -v X ...; then ... fi   where the block
 #                         reaches `exit 0` / `return 0`
+#
+# A third shape is flagged in scripts/*.test.sh (self-tests that own
+# load-bearing historical proofs — #2807):
+#
+#   3. skip-scored-as-pass:  ok "skip ..." / ok 'skip ...'
+#      A test that cannot run its assertion must fail (or declare the soft
+#      path with `# silent-skip-ok: <reason>`), never report PASS for the skip.
 #
 # A flagged site passes when the skip is visible — the guard line or block
 # carries one of the sanctioned visibility calls (hook::emit_skip_notice,
@@ -40,22 +49,17 @@
 # helper-function bodies and does not flag a positive-form
 # `if command -v X; then ... else exit 0` (the current corpus uses the
 # else-branch for its visible notice). Its job is to stop the historical
-# regression — a new hook quietly no-op'ing when an optional CLI is absent.
+# regression — a new hook quietly no-op'ing when an optional CLI is absent,
+# or a self-test quietly scoring an unrun proof as PASS.
 set -euo pipefail
 
 cd "$(dirname "${BASH_SOURCE[0]}")/.."
 
 errors=0
 
-for hook in plugins/*/hooks/*.sh; do
-  base="${hook##*/}"
-  case "$base" in
-  hook-utils.sh | *.test.sh) continue ;;
-  *) ;;
-  esac
-  [[ -f "$hook" ]] || continue
-
-  out=$(awk '
+scan_hook() {
+  local hook="$1"
+  awk '
     function is_annotated(l) { return l ~ /#[[:space:]]*silent-skip-ok:/ }
     function is_comment(l) { return l ~ /^[[:space:]]*#/ }
     function is_visible(l) {
@@ -111,15 +115,63 @@ for hook in plugins/*/hooks/*.sh; do
       if (in_block && block_skips && !block_visible && !block_annotated)
         printf "%d: silent block skip: unterminated `if ! command -v` block reaches exit/return 0 with no visible notice\n", block_start
     }
-  ' "$hook")
+  ' "$hook"
+}
 
+# Shape 3: a self-test that scores a skip as PASS. Message must start with
+# "skip " / 'skip ' (space-delimited) so descriptions like
+# `ok "skip-named-helper ... fails"` are not flagged.
+scan_test_skip_pass() {
+  local test_file="$1"
+  awk '
+    function is_annotated(l) { return l ~ /#[[:space:]]*silent-skip-ok:/ }
+    function is_comment(l) { return l ~ /^[[:space:]]*#/ }
+    function is_skip_ok(l) {
+      return l ~ /^[[:space:]]*ok[[:space:]]+["'\'']skip[[:space:]]/
+    }
+    {
+      line = $0
+      annotated_above = pending_annot
+      if (is_comment(line)) {
+        if (is_annotated(line)) pending_annot = 1
+      } else {
+        pending_annot = 0
+      }
+      if (is_skip_ok(line) && !is_annotated(line) && !annotated_above)
+        printf "%d: skip scored as PASS via ok \"skip ...\" — fail closed or annotate with # silent-skip-ok:\n", NR
+    }
+  ' "$test_file"
+}
+
+report_hits() {
+  local path="$1"
+  local out="$2"
   if [[ -n "$out" ]]; then
     while IFS= read -r v; do
-      echo "SILENT SKIP: ${hook}:${v}" >&2
+      echo "SILENT SKIP: ${path}:${v}" >&2
       errors=$((errors + 1))
     done <<<"$out"
   fi
+}
+
+for hook in plugins/*/hooks/*.sh; do
+  base="${hook##*/}"
+  case "$base" in
+  hook-utils.sh | *.test.sh) continue ;;
+  *) ;;
+  esac
+  [[ -f "$hook" ]] || continue
+  report_hits "$hook" "$(scan_hook "$hook")"
 done
+
+shopt -s nullglob
+for test_file in scripts/*.test.sh; do
+  [[ -f "$test_file" ]] || continue
+  # The silent-skip unit suite embeds shape-1/2 fixtures as quoted strings;
+  # scanning it for hook guards would false-positive. Shape 3 still applies.
+  report_hits "$test_file" "$(scan_test_skip_pass "$test_file")"
+done
+shopt -u nullglob
 
 if ((errors > 0)); then
   {
@@ -130,7 +182,11 @@ if ((errors > 0)); then
     echo "'# silent-skip-ok: <reason>' at the site. A bare stderr write is"
     echo "NOT sufficient — stderr on exit 0 is never shown to the user or"
     echo "the agent (docs/conventions/hook-observability/)."
+    echo
+    echo "A scripts/*.test.sh that cannot run an assertion must fail closed"
+    echo "(or annotate with '# silent-skip-ok: <reason>'), never score the"
+    echo "skip as PASS via ok \"skip ...\"."
   } >&2
   exit 1
 fi
-echo "No silent prerequisite skips found in hook entry scripts."
+echo "No silent prerequisite skips found in hook entry scripts or scripts/*.test.sh."

--- a/scripts/check-silent-skips.sh
+++ b/scripts/check-silent-skips.sh
@@ -174,6 +174,7 @@ for test_file in scripts/*.test.sh; do
   # still exercised via the suite's throwaway fixtures under /tmp.
   case "$test_file" in
   scripts/check-silent-skips.test.sh) continue ;;
+  *) ;;
   esac
   report_hits "$test_file" "$(scan_test_skip_pass "$test_file")"
 done

--- a/scripts/check-silent-skips.sh
+++ b/scripts/check-silent-skips.sh
@@ -169,8 +169,12 @@ done
 shopt -s nullglob
 for test_file in scripts/*.test.sh; do
   [[ -f "$test_file" ]] || continue
-  # The silent-skip unit suite embeds shape-1/2 fixtures as quoted strings;
-  # scanning it for hook guards would false-positive. Shape 3 still applies.
+  # The silent-skip unit suite embeds shape-3 fixtures as quoted strings in its
+  # own body; scanning it would false-positive on those embeddings. Shape 3 is
+  # still exercised via the suite's throwaway fixtures under /tmp.
+  case "$test_file" in
+  scripts/check-silent-skips.test.sh) continue ;;
+  esac
   report_hits "$test_file" "$(scan_test_skip_pass "$test_file")"
 done
 shopt -u nullglob

--- a/scripts/check-silent-skips.sh
+++ b/scripts/check-silent-skips.sh
@@ -172,10 +172,9 @@ for test_file in scripts/*.test.sh; do
   # The silent-skip unit suite embeds shape-3 fixtures as quoted strings in its
   # own body; scanning it would false-positive on those embeddings. Shape 3 is
   # still exercised via the suite's throwaway fixtures under /tmp.
-  case "$test_file" in
-  scripts/check-silent-skips.test.sh) continue ;;
-  *) ;;
-  esac
+  if [[ "$test_file" == "scripts/check-silent-skips.test.sh" ]]; then
+    continue
+  fi
   report_hits "$test_file" "$(scan_test_skip_pass "$test_file")"
 done
 shopt -u nullglob

--- a/scripts/check-silent-skips.sh
+++ b/scripts/check-silent-skips.sh
@@ -127,7 +127,9 @@ scan_test_skip_pass() {
     function is_annotated(l) { return l ~ /#[[:space:]]*silent-skip-ok:/ }
     function is_comment(l) { return l ~ /^[[:space:]]*#/ }
     function is_skip_ok(l) {
-      return l ~ /^[[:space:]]*ok[[:space:]]+["'\'']skip[[:space:]]/
+      # Match at a shell command boundary (not only line-start), so one-line
+      # forms like `if x; then ok "skip ..."; fi` are caught too.
+      return l ~ /(^|[^[:alnum:]_])ok[[:space:]]+["'\'']skip[[:space:]]/
     }
     {
       line = $0

--- a/scripts/check-silent-skips.test.sh
+++ b/scripts/check-silent-skips.test.sh
@@ -36,6 +36,13 @@ hook_file() {
   printf '%s\n' "$content" >"$fixture/plugins/$plugin/hooks/$name"
 }
 
+# script_test_file <fixture> <basename> <content>
+script_test_file() {
+  local fixture="$1" name="$2" content="$3"
+  mkdir -p "$fixture/scripts"
+  printf '%s\n' "$content" >"$fixture/scripts/$name"
+}
+
 run_check() (
   cd "$1" && bash scripts/check-silent-skips.sh
 )
@@ -212,6 +219,56 @@ if out="$(run_check "$f" 2>&1)"; then
   ok "hook-utils.sh and *.test.sh are excluded from the scan"
 else
   fail "excluded files should not be scanned, got: $out"
+fi
+rm -rf "$f"
+
+# --- scripts/*.test.sh: ok "skip ..." scored as PASS fails (#2807) ---------
+f="$(new_fixture)"
+script_test_file "$f" demo.test.sh 'ok "skip historical proof (deadbeef not in this clone)"'
+if out="$(run_check "$f" 2>&1)"; then
+  fail "ok skip-scored-as-pass should fail, got success: $out"
+else
+  if echo "$out" | grep -q "SILENT SKIP: scripts/demo.test.sh:1" &&
+    echo "$out" | grep -q "skip scored as PASS"; then
+    ok "scripts/*.test.sh ok \"skip ...\" fails with file:line"
+  else
+    fail "expected SILENT SKIP skip-scored-as-pass, got: $out"
+  fi
+fi
+rm -rf "$f"
+
+# --- scripts/*.test.sh: annotated ok "skip ..." passes ---------------------
+f="$(new_fixture)"
+script_test_file "$f" demo.test.sh "$(printf '%s\n' \
+  '# silent-skip-ok: shallow clone lacks the historical anchor' \
+  'ok "skip historical proof (deadbeef not in this clone)"')"
+if out="$(run_check "$f" 2>&1)"; then
+  ok "annotated scripts/*.test.sh ok \"skip ...\" passes"
+else
+  fail "annotated ok skip should pass, got: $out"
+fi
+rm -rf "$f"
+
+# --- scripts/*.test.sh: same-line annotation passes ------------------------
+f="$(new_fixture)"
+script_test_file "$f" demo.test.sh 'ok "skip historical proof" # silent-skip-ok: declared soft path'
+if run_check "$f" >/dev/null 2>&1; then
+  ok "same-line silent-skip-ok on ok \"skip ...\" passes"
+else
+  fail "same-line annotation on ok skip should pass"
+fi
+rm -rf "$f"
+
+# --- ok messages that merely mention skip are not flagged ------------------
+f="$(new_fixture)"
+script_test_file "$f" demo.test.sh "$(printf '%s\n' \
+  'ok "skip-named-helper guard (|| emit_skipped) fails"' \
+  'ok "same-line silent skip fails with file:line"' \
+  'ok "repository baseline passes --check"')"
+if out="$(run_check "$f" 2>&1)"; then
+  ok "ok messages that mention skip without scoring a skip pass"
+else
+  fail "non skip-scored ok messages should pass, got: $out"
 fi
 rm -rf "$f"
 

--- a/scripts/check-silent-skips.test.sh
+++ b/scripts/check-silent-skips.test.sh
@@ -237,6 +237,21 @@ else
 fi
 rm -rf "$f"
 
+# --- scripts/*.test.sh: inline then ok "skip ..." also fails ----------------
+f="$(new_fixture)"
+script_test_file "$f" demo.test.sh 'if anchor_missing; then ok "skip historical proof"; fi'
+if out="$(run_check "$f" 2>&1)"; then
+  fail "inline then ok skip should fail, got success: $out"
+else
+  if echo "$out" | grep -q "SILENT SKIP: scripts/demo.test.sh:1" &&
+    echo "$out" | grep -q "skip scored as PASS"; then
+    ok "inline then ok \"skip ...\" fails with file:line"
+  else
+    fail "expected SILENT SKIP for inline then ok skip, got: $out"
+  fi
+fi
+rm -rf "$f"
+
 # --- scripts/*.test.sh: annotated ok "skip ..." passes ---------------------
 f="$(new_fixture)"
 script_test_file "$f" demo.test.sh "$(printf '%s\n' \


### PR DESCRIPTION
## Summary

- Fleet proof-of-red self-tests (`check-fleet-audit-doc-grammar.test.sh`, `check-fleet-finding-test-coverage.test.sh`) now **fail** when their historical anchor SHAs cannot be resolved, instead of scoring the skip as PASS.
- `check-silent-skips.sh` now also scans `scripts/*.test.sh` for unannotated `ok "skip ..."` (skip scored as PASS), with `# silent-skip-ok:` as the declared soft-path escape — including inline `then ok "skip ..."` forms.

Closes #2807.

## Test plan

- [x] `bash scripts/check-silent-skips.test.sh` → `PASS=19 FAIL=0`
- [x] `bash scripts/check-silent-skips.sh` → clean on live tree
- [x] `bash scripts/check-fleet-audit-doc-grammar.test.sh` → `PASS=10 FAIL=0`
- [x] `bash scripts/check-fleet-finding-test-coverage.test.sh` → `PASS=11 FAIL=0`
- [x] With historical SHAs made unresolvable via a `git` wrapper: both fleet suites exit non-zero with `FAIL: historical proof unavailable ...` (no `ok: skip historical ...`)
- [x] Synthetic `scripts/demo.test.sh` containing `ok "skip ..."` is flagged by `check-silent-skips.sh`

## Related

- Fleet silent-skip / proof-of-red lane follow-on from prior fleet audit gates