### PR TITLE
docs(testing): record the audit detector's verifier-earned known limits (0.6.1)

### DIFF
--- a/plugins/testing/.claude-plugin/plugin.json
+++ b/plugins/testing/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "testing",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Test-stage discipline across all ecosystems: coverage-gap analysis and test planning (`/testing:plan`), TDD test authoring and placement (`/testing:write`), live E2E plus non-UI smoke verification (`/testing:run-e2e`), failing-test root-cause diagnosis with the reproduce → isolate → fix → retest loop (`/testing:diagnose`), and a deterministic can't-fail test audit with a fail-closed gate mode and opt-in findings persistence (`/testing:audit`).",
   "author": {
     "name": "Melodic Software",

--- a/plugins/testing/CHANGELOG.md
+++ b/plugins/testing/CHANGELOG.md
@@ -9,12 +9,14 @@ All notable changes to the `testing` plugin are documented here. Format follows
 
 - **Three verifier-earned known limits recorded in `/testing:audit`'s gotchas**, so the next reader
   meets them as documented boundaries rather than rediscovering them as bugs: the C# generic
-  `Assert.Equal<T>(a, a)` recall gap in `recomputed-expectation` v1; the JS regex-literal masker's
+  `Assert.equal<T>(a, a)` recall gap in `recomputed-expectation` v1; the JS regex-literal masker's
   deliberately narrow trigger set (never after an identifier, so a regex directly after `return` is
-  unmasked — the direction chosen because misreading division as a regex would mask real code); and
-  the platform-skip blindness boundary — a platform-skipped assertion is unverified on the platform
-  that skips it, the same defect family this detector hunts approached from the environment side and
-  out of static reach, making the dropped skip rule's uncovered axis platform as well as ecosystem.
+  unmasked — chosen because misreading division as a regex would mask real code — with the known
+  cost that an unmasked regex containing a brace can close the test block early and false-positive
+  `rule-zero-assertion`); and the platform-skip blindness boundary — a platform-skipped assertion is
+  unverified on the platform that skips it, the same defect family this detector hunts approached
+  from the environment side and out of static reach, making the dropped skip rule's uncovered axis
+  platform as well as ecosystem.
 
 ## [0.6.0]
 

--- a/plugins/testing/CHANGELOG.md
+++ b/plugins/testing/CHANGELOG.md
@@ -3,6 +3,19 @@
 All notable changes to the `testing` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.6.1]
+
+### Changed
+
+- **Three verifier-earned known limits recorded in `/testing:audit`'s gotchas**, so the next reader
+  meets them as documented boundaries rather than rediscovering them as bugs: the C# generic
+  `Assert.Equal<T>(a, a)` recall gap in `recomputed-expectation` v1; the JS regex-literal masker's
+  deliberately narrow trigger set (never after an identifier, so a regex directly after `return` is
+  unmasked — the direction chosen because misreading division as a regex would mask real code); and
+  the platform-skip blindness boundary — a platform-skipped assertion is unverified on the platform
+  that skips it, the same defect family this detector hunts approached from the environment side and
+  out of static reach, making the dropped skip rule's uncovered axis platform as well as ecosystem.
+
 ## [0.6.0]
 
 ### Added

--- a/plugins/testing/CHANGELOG.md
+++ b/plugins/testing/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to the `testing` plugin are documented here. Format follows
 
 - **Three verifier-earned known limits recorded in `/testing:audit`'s gotchas**, so the next reader
   meets them as documented boundaries rather than rediscovering them as bugs: the C# generic
-  `Assert.equal<T>(a, a)` recall gap in `recomputed-expectation` v1; the JS regex-literal masker's
+  `Assert.Equal<T>(a, a)` recall gap in `recomputed-expectation` v1; the JS regex-literal masker's
   deliberately narrow trigger set (never after an identifier, so a regex directly after `return` is
   unmasked — chosen because misreading division as a regex would mask real code — with the known
   cost that an unmasked regex containing a brace can close the test block early and false-positive

--- a/plugins/testing/skills/audit/SKILL.md
+++ b/plugins/testing/skills/audit/SKILL.md
@@ -127,9 +127,19 @@ line above it, or inside the body — the same recorded-decision shape as the re
   tighten the token list to chase recall at precision's expense.
 - **`recomputed-expectation` v1 is the decidable core** — textually identical actual/expected on one
   line (chains spanning lines are deliberately not matched, and only the first `expect` per line is
-  examined). `x = f(a); assert x == f(a)` is the same defect and is not yet detected.
+  examined). `x = f(a); assert x == f(a)` and C#'s generic `Assert.Equal<T>(a, a)` are the same
+  defect and are not yet detected.
+- **The JS regex-literal masker triggers only after an operator or opening delimiter** — never after
+  an identifier, so a regex directly after `return` is not masked. Wrongly reading division as a
+  regex would mask real code, which is the worse direction; no false positive has been observed
+  from the narrow set.
 - **Skips are honored at both levels** — test-level (`it.skip`/`x`-prefixed/`@skip`/`[Fact(Skip=…)]`)
   and suite-level (<!-- spellchecker:off -->`xdescribe`<!-- spellchecker:on -->/`describe.skip`/`context.skip`/`suite.skip`): a test that does not
   run is not judged.
 - **Fixture corpora under `evals/fixtures/` are pruned** — a detector's planted-defect fixtures are
   not the consumer's defects. Point `$CANT_FAIL_SCAN_ROOT` at one explicitly to scan it.
+- **A platform-skipped assertion is unverified on the platform that skips it** — a green local run is
+  not evidence about a case only another platform executes. That is the same defect family this
+  detector hunts, approached from the environment side, and it is out of the detector's reach: a
+  visible skip is not an assertion-free body. The uncovered axis of the dropped skip rule is
+  platform as well as ecosystem.

--- a/plugins/testing/skills/audit/SKILL.md
+++ b/plugins/testing/skills/audit/SKILL.md
@@ -131,8 +131,10 @@ line above it, or inside the body — the same recorded-decision shape as the re
   defect and are not yet detected.
 - **The JS regex-literal masker triggers only after an operator or opening delimiter** — never after
   an identifier, so a regex directly after `return` is not masked. Wrongly reading division as a
-  regex would mask real code, which is the worse direction; no false positive has been observed
-  from the narrow set.
+  regex would mask real code, which is the worse direction. The known cost of that narrow set is a
+  premature-block-closure false positive when an unmasked regex after `return` contains a brace
+  (e.g. `return /}/;` inside a test) — `brace_delta` treats the `}` as code and closes the test
+  before later assertions, so `rule-zero-assertion` can fire on a body that still has assertions.
 - **Skips are honored at both levels** — test-level (`it.skip`/`x`-prefixed/`@skip`/`[Fact(Skip=…)]`)
   and suite-level (<!-- spellchecker:off -->`xdescribe`<!-- spellchecker:on -->/`describe.skip`/`context.skip`/`suite.skip`): a test that does not
   run is not judged.


### PR DESCRIPTION
## Summary

Docs follow-up to #2684 (delivered by merged #2800): the three boundaries the fresh-context verification lanes surfaced are recorded in `/testing:audit`'s gotchas, so the next reader meets them as documented limits rather than rediscovering them as bugs:

- **C# generic `Assert.Equal<T>(a, a)` recall gap** — the same defect as the detected `recomputed-expectation` forms, not yet detected by v1's decidable core.
- **The JS regex-literal masker's deliberately narrow trigger set** — never after an identifier, so a regex directly after `return` is unmasked; the direction is chosen because misreading division as a regex would mask real code (no false positive observed from the narrow set).
- **Platform-skip blindness** — a platform-skipped assertion is unverified on the platform that skips it; a green local run is not evidence about a case only another platform executes. The environment-side face of this detector's own defect family, out of static reach, making the dropped skip rule's uncovered axis platform as well as ecosystem. (This exact blindness produced the one CI-only failure in #2684's own suite.)

`testing` bumps 0.6.1 with a new changelog entry (docs-only patch).

## Test plan

- `check-skill.sh audit` PASS (trigger keywords preserved vs base; 154/500 lines), markdownlint clean, `typos` clean, `check-changelog-parity` `--check` and `--check-bump origin/main` pass, catalog/cheatsheet regeneration confirmed no-op (no description or summary change).
- No behavior change: SKILL.md prose, CHANGELOG, and the version field only.

## Related

No linked issue — docs follow-up to #2684, which was closed by #2800; the limits were established by the three verifier lanes' PASS reports on that work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
