### PR TITLE
fix(knowledge): rename youtube-digest resume arg to slice-slug

### DIFF
--- a/plugins/knowledge/.claude-plugin/plugin.json
+++ b/plugins/knowledge/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "knowledge",
-  "version": "0.12.5",
+  "version": "0.12.6",
   "description": "Ingest external knowledge into durable, synthesized artifacts. Ships a book-distillation pipeline (PDF/EPUB into concept-organized, author-attributed skill reference files), a YouTube pipeline (watch, transcript, link harvest, and repo-applicability synthesis), a course-digest pipeline (extract and synthesize online video courses \u2014 Dometrain, Teachable \u2014 into repo-applicable recommendations), a docpage-digest pipeline (single online documentation page into a verified knowledge slice with dual verification \u2014 one cross-vendor verifier \u2014 and an interview handoff), and a map-corpus pipeline (multi-resource corpus into a classified link map, deterministic node manifests, gate-verified relevance inventory, and an approved queue of docpage-digest runs), plus a re-runnable setup action; a configurable library directory governs where synthesized artifacts land in the consuming repo.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/knowledge/CHANGELOG.md
+++ b/plugins/knowledge/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to the `knowledge` plugin are recorded here. The `version` i
 `.claude-plugin/plugin.json` is the delivery vehicle — a consumer receives a change
 only after that version increases.
 
+## [0.12.6]
+
+### Changed
+
+- **BREAKING: `/knowledge:youtube-digest resume` takes `<slice-slug>` instead of `<video-slug>`
+  (#2818).** The argument names the work-slice directory under `.work/<watch-epic>/`, which may
+  identify an X status post with no video as well as a YouTube video. Same slug value and same
+  on-disk layout; only the user-facing argument name in `argument-hint`, the action router, resume
+  CLI usage, and handoff messaging changed. Stored prompts that still say `resume <video-slug>`
+  should be rewritten to `resume <slice-slug>`.
+
 ## [0.12.5]
 
 ### Added

--- a/plugins/knowledge/skills/youtube-digest/SKILL.md
+++ b/plugins/knowledge/skills/youtube-digest/SKILL.md
@@ -85,7 +85,7 @@ node "${CLAUDE_PLUGIN_ROOT}/skills/youtube-digest/extraction/run.mjs" \
 | `watch` | **Active** | Dequeue first `pending` queue row (FIFO) — claim stub → bootstrap → full skill pipeline. |
 | `watch <n>` | **Active** | Dequeue queue row `#n` only (parallel path across terminals). |
 | `watch <url>` | **Active** | Full pipeline: ≤1080p download → frame selection → vision absorption → link harvest → research agenda → repo-applicability synthesis. |
-| `resume <slice-slug>` | **Active** | Continue interrupted watch from `watch.json` phase-map state in `.work/<watch-epic>/<slice-slug>/`. |
+| `resume <slice-slug>` | **Active** | Continue interrupted watch from `watch.json` phase-map state in the named slice under `.work/<watch-epic>/` (same directory documented elsewhere in this skill as `<video-slug>`). |
 
 `--target <repo>` is an optional modifier on any `watch` form (not a dispatchable action of its own) — see "Synthesis target resolution".
 
@@ -322,7 +322,7 @@ Deterministic frame-selection stages (`orchestrate-watching.js`), the standalone
 node "${CLAUDE_PLUGIN_ROOT}/skills/youtube-digest/extraction/run.mjs" watch/run-resume.js "<slice-slug>"
 ```
 
-Reads `.work/<watch-epic>/<video-slug>/watch.json`, identifies the next incomplete phase (`acquire` → `transcript` → `watching` → `vision` → `harvest` → `research` → `synthesis`), refreshes `continuation-prompt.md`, and emits a copy/paste-ready continuation prompt. When `tempSession` paths are missing, re-run `run-watch.js` before vision.
+Reads `.work/<watch-epic>/<slice-slug>/watch.json`, identifies the next incomplete phase (`acquire` → `transcript` → `watching` → `vision` → `harvest` → `research` → `synthesis`), refreshes `continuation-prompt.md`, and emits a copy/paste-ready continuation prompt. When `tempSession` paths are missing, re-run `run-watch.js` before vision.
 
 **Handoff ritual** (context pressure or session end):
 

--- a/plugins/knowledge/skills/youtube-digest/SKILL.md
+++ b/plugins/knowledge/skills/youtube-digest/SKILL.md
@@ -1,6 +1,6 @@
 ---
-description: "Watch YouTube videos, extract transcripts, harvest links, research claims, and synthesize repo-applicability recommendations. Use when: 'youtube', '/youtube-digest', 'watch this YouTube video', 'transcript for YouTube', user shares a youtube.com or youtu.be URL for a single public video (not a course platform). Actions: watch <url> (full pipeline), watch (dequeue epic queue), watch <n> (queue row), queue <url> (batch enqueue), transcript <url> (captions only), resume <video-slug>. Not for auth-walled course platforms — use /knowledge:course-digest."
-argument-hint: "watch <url> [--target <repo>] | watch [--target <repo>] | watch <n> [--target <repo>] | queue <url> | queue list | transcript <url> | resume <video-slug>"
+description: "Watch YouTube videos, extract transcripts, harvest links, research claims, and synthesize repo-applicability recommendations. Use when: 'youtube', '/youtube-digest', 'watch this YouTube video', 'transcript for YouTube', user shares a youtube.com or youtu.be URL for a single public video (not a course platform). Actions: watch <url> (full pipeline), watch (dequeue epic queue), watch <n> (queue row), queue <url> (batch enqueue), transcript <url> (captions only), resume <slice-slug>. Not for auth-walled course platforms — use /knowledge:course-digest."
+argument-hint: "watch <url> [--target <repo>] | watch [--target <repo>] | watch <n> [--target <repo>] | queue <url> | queue list | transcript <url> | resume <slice-slug>"
 user-invocable: true
 disable-model-invocation: false
 shell: bash
@@ -85,7 +85,7 @@ node "${CLAUDE_PLUGIN_ROOT}/skills/youtube-digest/extraction/run.mjs" \
 | `watch` | **Active** | Dequeue first `pending` queue row (FIFO) — claim stub → bootstrap → full skill pipeline. |
 | `watch <n>` | **Active** | Dequeue queue row `#n` only (parallel path across terminals). |
 | `watch <url>` | **Active** | Full pipeline: ≤1080p download → frame selection → vision absorption → link harvest → research agenda → repo-applicability synthesis. |
-| `resume <video-slug>` | **Active** | Continue interrupted watch from `watch.json` phase-map state in `.work/<watch-epic>/<video-slug>/`. |
+| `resume <slice-slug>` | **Active** | Continue interrupted watch from `watch.json` phase-map state in `.work/<watch-epic>/<slice-slug>/`. |
 
 `--target <repo>` is an optional modifier on any `watch` form (not a dispatchable action of its own) — see "Synthesis target resolution".
 
@@ -319,7 +319,7 @@ Deterministic frame-selection stages (`orchestrate-watching.js`), the standalone
 ## Resume action
 
 ```bash
-node "${CLAUDE_PLUGIN_ROOT}/skills/youtube-digest/extraction/run.mjs" watch/run-resume.js "<video-slug>"
+node "${CLAUDE_PLUGIN_ROOT}/skills/youtube-digest/extraction/run.mjs" watch/run-resume.js "<slice-slug>"
 ```
 
 Reads `.work/<watch-epic>/<video-slug>/watch.json`, identifies the next incomplete phase (`acquire` → `transcript` → `watching` → `vision` → `harvest` → `research` → `synthesis`), refreshes `continuation-prompt.md`, and emits a copy/paste-ready continuation prompt. When `tempSession` paths are missing, re-run `run-watch.js` before vision.
@@ -328,7 +328,7 @@ Reads `.work/<watch-epic>/<video-slug>/watch.json`, identifies the next incomple
 
 1. Update `watch.json` phase markers with timestamps
 2. Write `continuation-prompt.md` (completed phases, next phase, frame-selection state, known issues)
-3. Tell the user: *"Session state saved. Run `/knowledge:youtube-digest resume <video-slug>` to continue."*
+3. Tell the user: *"Session state saved. Run `/knowledge:youtube-digest resume <slice-slug>` to continue."*
 
 ## Output contract
 

--- a/plugins/knowledge/skills/youtube-digest/SKILL.md
+++ b/plugins/knowledge/skills/youtube-digest/SKILL.md
@@ -322,7 +322,7 @@ Deterministic frame-selection stages (`orchestrate-watching.js`), the standalone
 node "${CLAUDE_PLUGIN_ROOT}/skills/youtube-digest/extraction/run.mjs" watch/run-resume.js "<slice-slug>"
 ```
 
-Reads `.work/<watch-epic>/<slice-slug>/watch.json`, identifies the next incomplete phase (`acquire` → `transcript` → `watching` → `vision` → `harvest` → `research` → `synthesis`), refreshes `continuation-prompt.md`, and emits a copy/paste-ready continuation prompt. When `tempSession` paths are missing, re-run `run-watch.js` before vision.
+Reads the named slice's `watch.json` under `.work/<watch-epic>/` (see the directory note above), identifies the next incomplete phase (`acquire` → `transcript` → `watching` → `vision` → `harvest` → `research` → `synthesis`), refreshes `continuation-prompt.md`, and emits a copy/paste-ready continuation prompt. When `tempSession` paths are missing, re-run `run-watch.js` before vision.
 
 **Handoff ritual** (context pressure or session end):
 

--- a/plugins/knowledge/skills/youtube-digest/evals/evals.json
+++ b/plugins/knowledge/skills/youtube-digest/evals/evals.json
@@ -36,7 +36,7 @@
       "prompt": "Run /knowledge:youtube-digest resume stop-prompting-claude-use-karpathy-s-met-7zZy1QTvokM",
       "expected_output": "Reads watch.json, identifies next incomplete phase, refreshes continuation-prompt.md, emits copy/paste resume prompt.",
       "expectations": [
-        "Invokes run.mjs watch/run-resume.js (node ${CLAUDE_PLUGIN_ROOT}/skills/youtube-digest/extraction/run.mjs) with video slug",
+        "Invokes run.mjs watch/run-resume.js (node ${CLAUDE_PLUGIN_ROOT}/skills/youtube-digest/extraction/run.mjs) with slice slug",
         "Reports nextPhase from phase map (acquire → transcript → watching → vision → harvest → research → synthesis)",
         "Does NOT restart from acquire when later phases are complete"
       ]

--- a/plugins/knowledge/skills/youtube-digest/extraction/watch/run-resume.js
+++ b/plugins/knowledge/skills/youtube-digest/extraction/watch/run-resume.js
@@ -2,7 +2,7 @@
 /**
  * CLI: resume interrupted `/youtube-digest watch` from phase-map state.
  *
- * Usage: node watch/run-resume.js <video-slug>
+ * Usage: node watch/run-resume.js <slice-slug>
  */
 
 import path from "node:path";
@@ -30,7 +30,7 @@ import {
 export async function runResumeCli(argv) {
   const videoSlug = argv[2];
   if (!videoSlug) {
-    writeStderr("Usage: node watch/run-resume.js <video-slug>");
+    writeStderr("Usage: node watch/run-resume.js <slice-slug>");
     return 1;
   }
 


### PR DESCRIPTION
## Summary

Renames the user-facing `/knowledge:youtube-digest resume` argument from
`<video-slug>` to `<slice-slug>` so the name no longer claims video-only
semantics (the slug identifies a work slice that may be an X status with no
video once source-agnostic ingest lands).

Surfaces updated: `argument-hint`, action router, resume CLI usage strings,
handoff messaging, and the resume eval expectation. On-disk layout and slug
values are unchanged.

Knowledge plugin bumped to **0.12.6**.

## Fix

Closes #2818

## Verification

- `CHECK_SKILL_SKILLS_ROOT=plugins/knowledge/skills CHECK_SKILL_BASE_REF=origin/main bash plugins/skill-quality/scripts/check-skill.sh youtube-digest` → PASS (0 errors; pre-existing warnings only)
- `scripts/check-changelog-parity.sh --check` and `--check-bump origin/main` → PASS

## Related

Closes #2818 — source-neutral resume argument name for the video-digest pipeline (skill path today: `youtube-digest`).