### PR TITLE
fix(autonomy): parameterize the deferred join-row marker with its trigger

### DIFF
--- a/docs/adr/0011-resolve-routine-prerequisites-per-identity-declared-over-detected.md
+++ b/docs/adr/0011-resolve-routine-prerequisites-per-identity-declared-over-detected.md
@@ -160,3 +160,23 @@ would be the precise agent-writable bypass the classification obligation forbids
   per-identity prerequisite sections in the ten `v1` leaves; the generated emission with its
   drift gate; the deterministic resolver; the setup slice), each carrying its own version bump,
   CHANGELOG entry, and inlined incumbent evidence.
+
+## Amendment (2026-08-16) — the naming ruling, and its reconciliation with the shipped state
+
+The human naming ruling this ADR deferred to landed on #2717 — after the contract document and
+its downstream phases had already merged with a working vocabulary. The ruling's premise ("the
+contract document may be authored against these") was stale when written; this amendment is the
+reconciliation of record.
+
+- **Verdict tokens: the shipped set is ratified.** `supported` / `conditional` / `unsupported` /
+  `unknown` stays. The ruling's `met` family was a precision preference, not a defect cure: the
+  shipped set clears every constraint that binds — no security-binding reading, no barred health
+  word, no collision with the five named incumbents. Migrating ~60 sites across four merged PRs,
+  including machine-emitted resolver tokens, buys no correctness.
+- **The deferred marker gains its mandatory trigger: `deferred(<trigger>)`.** This half of the
+  ruling names a genuine defect: a bare marker records that resolution is postponed while
+  discarding the condition under which the deferral is revisited — the half that makes it
+  auditable rather than an indefinite hold. The trigger is the `join:` row's own catalog Status
+  trigger; the parameterized shape reuses the deferral-with-explicit-trigger idiom already in
+  `work-classes.md`.
+- The contract noun and filename were confirmed unchanged.

--- a/plugins/autonomy/.claude-plugin/plugin.json
+++ b/plugins/autonomy/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "autonomy",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "description": "Governed autonomous agent operation: role-topology, binding-seam, wiring-vs-advisor, telemetry, return-accounting, trigger-dispatch, per-work-class guardrail-matrix, standing-routine-catalog, and design-only runner-charter contracts for climbing the AI-adoption ladder, plus a guided-setup skill that discovers an adopting org's state, writes its schema-versioned binding, wires standards-pinned OTLP emission with a zero-cost file-artifact default, wires human-attested return capture at the task boundary, wires signal adapters with one governed dispatch entrypoint, binds the five-class guardrail matrix to an org's isolation substrates with an in-boundary live-validation probe before recording each fail-closed binding, and stands up standing-routine-catalog classes as scheduled temporal signal adapters behind the one governed queue with free scheduling defaults wired as reviewable changes and each routine's work-class mapping homed on the security surface.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/autonomy/CHANGELOG.md
+++ b/plugins/autonomy/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to the `autonomy` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.22.1]
+
+### Changed
+
+- **Join-row marker parameterized: `deferred-class` → `deferred(<trigger>)`** (#2717). The
+  naming ruling on #2717 landed after the contract document shipped; it ratified the verdict
+  tokens as shipped and required the deferred marker to carry the row's own join trigger — a
+  bare marker discards the condition under which a deferral is revisited, the half that makes
+  it auditable. Updated in `reference/prerequisite-resolution.md` and the README bullet;
+  ADR 0011 carries the reconciliation amendment.
+
 ## [0.22.0]
 
 ### Added

--- a/plugins/autonomy/CHANGELOG.md
+++ b/plugins/autonomy/CHANGELOG.md
@@ -8,10 +8,10 @@ All notable changes to the `autonomy` plugin are documented here. Format follows
 ### Changed
 
 - **Join-row marker parameterized: `deferred-class` → `deferred(<trigger>)`** (#2717). The
-  naming ruling on #2717 landed after the contract document shipped; it ratified the verdict
-  tokens as shipped and required the deferred marker to carry the row's own join trigger — a
-  bare marker discards the condition under which a deferral is revisited, the half that makes
-  it auditable. Updated in `reference/prerequisite-resolution.md` and the README bullet;
+  naming ruling on #2717 landed after the contract document shipped; the subsequent
+  reconciliation ratified the verdict tokens as shipped and adopted the ruling's requirement
+  that the deferred marker carry the row's own join trigger — a bare marker discards the
+  condition under which a deferral is revisited, the half that makes it auditable. Updated in `reference/prerequisite-resolution.md` and the README bullet;
   ADR 0011 carries the reconciliation amendment.
 
 ## [0.22.0]

--- a/plugins/autonomy/README.md
+++ b/plugins/autonomy/README.md
@@ -48,7 +48,8 @@ state and records that binding.
 - **Routine prerequisite resolution** (`reference/prerequisite-resolution.md`): fail-closed,
   per-identity-per-surface verdicts (`supported` / `conditional` / `unsupported` / `unknown`) for
   which catalog identities can run against a repository, composing owning seams rather than a new
-  prober — with `deferred-class` marking `join:` rows that have no identities yet. Per-identity
+  prober — with `deferred(<trigger>)` (the row's own join trigger) marking `join:` rows that
+  have no identities yet. Per-identity
   facts live in each `v1` leaf; `generated/identity-prerequisites.json` is the drift-gated
   emission derived from those leaves (generator under `skills/setup/scripts/`);
   `skills/setup/scripts/resolve-prerequisites.mjs` is the deterministic per-surface resolver;

--- a/plugins/autonomy/reference/prerequisite-resolution.md
+++ b/plugins/autonomy/reference/prerequisite-resolution.md
@@ -29,9 +29,12 @@ substrates binds here. Isolation bindings key on execution-surface ids; the sche
 ## Candidate set
 
 - **`v1` rows only.** They alone have definition leaves, and posture tokens are leaf-owned.
-- **`join:` and `join (external):` rows** report under the join-row marker `deferred-class`.
-  Both deferred status forms have no leaf and therefore no identities to resolve;
-  `deferred-class` is a catalog-row marker, not a verdict.
+- **`join:` and `join (external):` rows** report under the join-row marker
+  `deferred(<trigger>)`, where `<trigger>` is the row's own join trigger from its catalog Status
+  cell. The trigger is never omitted: a bare marker would record that resolution is postponed
+  while discarding the condition under which the row gains a leaf — the half that makes a
+  deferral auditable rather than an indefinite hold. Both deferred status forms have no leaf and
+  therefore no identities to resolve; the marker is a catalog-row marker, not a verdict.
 - **`not-a-routine` rows** are outside the domain. No agent session exists to bind, so any
   verdict for them is a category error.
 


### PR DESCRIPTION
## Summary

Reconciles the #2717 naming ruling with the already-shipped prerequisite-resolution chain. The ruling was posted 2026-08-16T01:54Z — about three hours **after** PR #2772 merged the contract document (2026-08-15T22:47Z) and after the downstream phases (#2783, #2809, #2813) had shipped a working vocabulary. Its premise ("the contract document may be authored against these") was stale when written, so the reconciliation decision re-derived the outcome:

- **Verdict tokens ratified as shipped.** `supported` / `conditional` / `unsupported` / `unknown` clears every constraint that binds — no security-binding reading, no barred health word, no collision with the five named incumbents. The ruling's `met` family was a precision preference, not a defect cure; migrating ~60 sites across four merged PRs, including machine-emitted resolver tokens, buys no correctness. **No token changes.**
- **The deferred marker gains its mandatory trigger: `deferred-class` → `deferred(<trigger>)`.** This half of the ruling names a genuine defect — a bare marker records that resolution is postponed while discarding the condition under which the deferral is revisited, the half that makes it auditable. The trigger is the `join:` row's own catalog Status trigger. 6 sites, 4 files: the contract document, the README bullet, ADR 0011 (a dated appended amendment — the original decision text is byte-identical, and the released CHANGELOG entries stay untouched as historical record), and a new 0.22.1 changelog entry with the version bump.

A reader who finds the ruling comment and the shipped vocabulary disagreeing now finds the reconciliation on the record in ADR 0011's amendment.

## Test plan

- `scripts/check-changelog-parity.sh --check-bump origin/main` exits 0; `plugin.json` bumped 0.22.0 → 0.22.1 with a matching `## [0.22.1]` entry
- `markdownlint-cli2` and `typos` clean over all five changed files
- `scripts/validate-plugins.sh` passes; `generate-catalog.mjs` / `generate-cheatsheet.mjs` report no drift
- Repo-wide `git grep deferred-class` at the head commit hits only historical released changelog text and ADR 0011's original pre-amendment lines
- Independently verified by a fresh-context auditor reading blobs at the pushed SHA with authoring rationale withheld: all nine checks PASS (its one finding — a changelog sentence misattributing the ratification to the ruling — is fixed in the head commit)

## Related

Closes #2717

🤖 Generated with [Claude Code](https://claude.com/claude-code)
