### PR TITLE
fix(scripts): correct the silent-revert incident corpus attribution

### DIFF
--- a/.github/workflows/silent-revert-canary.yml
+++ b/.github/workflows/silent-revert-canary.yml
@@ -4,8 +4,8 @@ name: silent-revert-canary
 # another recently-merged commit had just added.
 #
 # On 2026-08-15 three squash merges each landed a tree that dropped work a
-# sibling PR had merged minutes earlier (#2633 dropped #2632, #2639 dropped
-# #2635, #2641 dropped #2639). Every check stayed green through all three,
+# sibling PR had merged minutes earlier (#2633 dropped both #2644 and #2642,
+# #2639 dropped #2635, #2641 dropped #2639). Every check stayed green,
 # because each reverting squash removed the code AND its tests in the same
 # commit -- no suite can fail for a behavior whose tests are gone. Two issues
 # sat CLOSED as COMPLETED with their fixes absent from main.

--- a/.github/workflows/silent-revert-canary.yml
+++ b/.github/workflows/silent-revert-canary.yml
@@ -5,10 +5,10 @@ name: silent-revert-canary
 #
 # On 2026-08-15 three squash merges each landed a tree that dropped work a
 # sibling PR had merged minutes earlier (#2633 dropped both #2644 and #2642,
-# #2639 dropped #2635, #2641 dropped #2639). Every check stayed green,
-# because each reverting squash removed the code AND its tests in the same
-# commit -- no suite can fail for a behavior whose tests are gone. Two issues
-# sat CLOSED as COMPLETED with their fixes absent from main.
+# #2639 dropped #2635, #2641 dropped #2639). Every check stayed green through
+# all three, because each reverting squash removed the code AND its tests in
+# the same commit -- no suite can fail for a behavior whose tests are gone.
+# Two issues sat CLOSED as COMPLETED with their fixes absent from main.
 #
 # DETECTION, NOT PREVENTION -- and deliberately so.
 #

--- a/scripts/check-silent-revert.sh
+++ b/scripts/check-silent-revert.sh
@@ -13,9 +13,17 @@
 # WHY THIS EXISTS (#2691)
 # ----------------------
 # On 2026-08-15, three squash merges each landed a tree that dropped work a
-# sibling PR had merged minutes earlier. #2633 dropped #2632's rollups (853
-# lines); #2639 dropped #2635's report-ordering fix (346); #2641 dropped
-# #2639's guard work (451) -- destructive_guard.py went 1643 -> 1424 lines.
+# sibling PR had merged minutes earlier. #2633 dropped #2644's finding rollups
+# (853 lines) AND #2642's aliased GraphQL merge evidence (301) in one squash --
+# plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.sh went 2178 ->
+# 1700 lines with every `rollup` and `graphql` marker at zero; #2639 dropped
+# #2635's report-ordering fix (346); #2641 dropped #2639's guard work (451) --
+# destructive_guard.py went 1643 -> 1424 lines.
+#
+# Every line count above is a BLAME ATTRIBUTION: the number of lines the
+# reverting squash deleted that `git blame` credits to that one culprit
+# commit. It is not the squash's diffstat (cc58cbc53 removed 1165 lines in
+# total) and not the number of lines the culprit added.
 #
 # Every check stayed green through all three, and that is the point: each
 # reverting squash removed the code AND the tests covering it in the same
@@ -49,10 +57,10 @@
 # chosen.
 #
 #   Curated marker strings (#2691's own suggestion 3). Catches only what
-#   somebody pre-registered. Nobody had registered #2632, #2635 or #2639 --
-#   registration happens after you already know a fix matters, which is exactly
-#   the knowledge the incident destroys. It also decays: the list is only as
-#   fresh as the last person who remembered to append to it.
+#   somebody pre-registered. Nobody had registered #2644, #2642, #2635 or
+#   #2639 -- registration happens after you already know a fix matters, which
+#   is exactly the knowledge the incident destroys. It also decays: the list is
+#   only as fresh as the last person who remembered to append to it.
 #
 #   Merge-base staleness (the PR's branch point vs. what landed since).
 #   Tested and REJECTED on evidence: it exonerates all three real incidents,
@@ -65,10 +73,12 @@
 #   open, so it fires on almost everything.
 #
 # What is left is content: blame the lines a merge deleted and see who had just
-# added them. Measured over the last 500 first-parent commits of main, the three
-# known incidents score 853 / 451 / 346 lines against a single recent commit,
-# and the highest verified-legitimate commit scores well below the threshold
-# below. The separation is what makes the canary livable.
+# added them. Measured over the last 500 first-parent commits of main, the
+# three known incidents score 853 / 451 / 346 lines against a single recent
+# commit -- plus a fourth attribution of 301 lines on the SAME #2633 squash,
+# whose deletions trace to two different culprits and are reported separately.
+# The highest verified-legitimate commit scores well below the threshold below.
+# The separation is what makes the canary livable.
 #
 # FALSE-POSITIVE STRATEGY (the whole design rests on this)
 # -------------------------------------------------------
@@ -101,8 +111,10 @@
 # THE RESIDUAL FALSE POSITIVE, MEASURED RATHER THAN ASSUMED
 # ---------------------------------------------------------
 # At these settings, over the last 500 first-parent commits of main, the canary
-# fires 5 times -- 1%. Three are the confirmed incidents. The other two are both
-# real, and neither is a bug in the detector:
+# fires on 5 commits -- 1%. (Six findings, not five: #2633's squash deleted
+# content from two different culprits and each attribution is reported on its
+# own.) Three of the five commits are the confirmed incidents. The other two
+# are both real, and neither is a bug in the detector:
 #
 #   6f0a31109 (#2640, 390 lines) is the manual RESTORE of #2633's revert. To
 #   put back what #2633 dropped it had to delete what #2633 had added, so a

--- a/scripts/check-silent-revert.sh
+++ b/scripts/check-silent-revert.sh
@@ -20,10 +20,12 @@
 # #2635's report-ordering fix (346); #2641 dropped #2639's guard work (451) --
 # destructive_guard.py went 1643 -> 1424 lines.
 #
-# Every line count above is a BLAME ATTRIBUTION: the number of lines the
-# reverting squash deleted that `git blame` credits to that one culprit
-# commit. It is not the squash's diffstat (cc58cbc53 removed 1165 lines in
-# total) and not the number of lines the culprit added.
+# Every PARENTHESIZED line count above is a blame attribution: the number of
+# lines the reverting squash deleted that `git blame` credits to that one
+# culprit commit. It is not the squash's diffstat (cc58cbc53 removed 1165
+# lines in total) and not the number of lines the culprit added. The bare
+# `2178 -> 1700` and `1643 -> 1424` figures are a different measurement --
+# whole-file line counts before and after.
 #
 # Every check stayed green through all three, and that is the point: each
 # reverting squash removed the code AND the tests covering it in the same

--- a/scripts/silent-revert-acknowledged.txt
+++ b/scripts/silent-revert-acknowledged.txt
@@ -26,9 +26,10 @@
 # the canary's first fire is a NEW event rather than known backlog.
 
 # #2640 is the manual restore of the content #2633's squash dropped. Putting
-# #2632's rollups back required deleting what #2633 had put in their place, so
-# a large removal of very recent content is precisely what this commit is.
-6f0a3110942375fb292112f5df5e2c39bbf56cb0  #2640 restores #2632's rollups; the removal undoes #2633's revert
+# #2644's finding rollups and #2642's aliased GraphQL merge evidence back
+# required deleting what #2633 had put in their place, so a large removal of
+# very recent content is precisely what this commit is.
+6f0a3110942375fb292112f5df5e2c39bbf56cb0  #2640 restores #2644's rollups and #2642's GraphQL merge evidence; the removal undoes #2633's revert
 
 # #2135's author noticed main move under the PR, merged origin/main into the
 # branch rather than force-pushing, and argued the disposition explicitly in the

--- a/scripts/silent-revert-incidents.txt
+++ b/scripts/silent-revert-incidents.txt
@@ -30,11 +30,30 @@ fires f603880dad4003477ec7cac27654fce92c75eec8 #2639 dropped #2635 (346 lines), 
 # went to zero occurrences. #2618 was left CLOSED as COMPLETED.
 fires 9239f1541b1b15a2a183ad6b4067e577f931e3f1 #2641 dropped #2639 (451 lines), 10 minutes later
 
-# Found by this canary's own calibration run, NOT by the #2691 audit: the same
-# night, #2633's squash dropped #2632's finding rollups (853 lines). #2640 had
-# to restore them by hand. Nobody had filed it, which is the clearest argument
-# for automating the detection.
-fires cc58cbc53fbbb2cca68e071507b82d3e3ff896ff #2633 dropped #2632's rollups (853 lines) -- unfiled until now
+# The third merge from the same night, surfaced by this canary's own
+# calibration run rather than by the #2691 audit. #2633's squash dropped work
+# from TWO siblings at once, and the canary reports each culprit separately:
+#
+#   853 lines traced to bfb66beb8 (#2644, finding rollups and handoff plans)
+#   301 lines traced to eda5ae5ed (#2642, aliased GraphQL merge evidence)
+#
+# Both numbers are blame attributions -- the count of lines cc58cbc53 deleted
+# that `git blame` credits to that one culprit. Neither is the squash's
+# diffstat (it removed 1165 lines in total) and neither is what the culprit
+# itself added. plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.sh
+# went 2178 -> 1700 lines with every `rollup` and `graphql` marker at zero;
+# #2640 restored both surfaces by hand.
+#
+# This event was NOT unfiled. Issue #2656 recorded it, pinned to the same
+# commits, roughly 23 hours before this canary merged -- from the test-coverage
+# angle (the hand restore left `bare-repo-with-working-tree` uncovered) rather
+# than as a silent revert. What the canary adds is detection speed and
+# automation, not discovery.
+#
+# An earlier version of this row named #2632 as the victim. That was wrong:
+# #2632 never merged (closed unmerged, no merge commit, not an ancestor of
+# main) and its diff contains no rollup work at all.
+fires cc58cbc53fbbb2cca68e071507b82d3e3ff896ff #2633 dropped #2644's rollups (853 blamed lines) and #2642's GraphQL merge evidence (301); already recorded in #2656
 
 # --- Verified-legitimate commits that must stay quiet -------------------------
 # The closest sub-threshold miss in 500 commits: 129 lines of a doc section that


### PR DESCRIPTION
Closes #2831.

The silent-revert canary merged in #2808 ships an incident corpus that
misattributes one of its three incidents. Since `--verify-known-incidents`
replays that corpus on every `push: main`, the corpus is the guard's own
honesty proof, and a wrong row costs it the credibility it exists to earn.

The guard already contradicts its own fixture. Running the shipped detector on
the incident commit prints:

```
$ scripts/check-silent-revert.sh --commit cc58cbc53fbbb2cca68e071507b82d3e3ff896ff
  content from bfb66beb8  feat(repo-fleet-hygiene): add finding rollups and scalable handoff plans (#2644)
  lines lost   853
  content from eda5ae5ed  feat(repo-fleet-hygiene): gather merge evidence via aliased GraphQL (#2642)
  lines lost   301
```

while the corpus recorded that commit as
`#2633 dropped #2632's rollups (853 lines) -- unfiled until now`.

## What was wrong, and what it is now

**The named victim never merged.** PR #2632 is CLOSED, not merged:
`mergeCommit` null, `mergedAt` null, closed unmerged 2026-08-14T23:19:00Z, head
`2b9391be` not an ancestor of `origin/main`, and zero occurrences of `rollup`
in its diff.

**There were two victims, and neither was #2632.** Attributing each of the 1165
lines `cc58cbc53` (#2633) deleted to the commit `git blame` credits it to:

| culprit | PR | lines |
| --- | --- | ---: |
| `bfb66beb8` | #2644 — finding rollups and handoff plans | 853 |
| `eda5ae5ed` | #2642 — aliased GraphQL merge evidence | 301 |
| 11 other commits, ≤4 lines each | — | 11 |
| **total** | | **1165** |

1165 matches the squash diffstat exactly
(`6 files changed, 549 insertions(+), 1165 deletions(-)`). #2642 was not
mentioned in the corpus at all, despite the detector reporting it as a separate
finding. Corroboration:
`plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.sh` went 2178
lines / 8 `graphql` / 9 `rollup` at `bfb66beb8` → 1700 / 0 / 0 at `cc58cbc53` →
2348 with both restored at `6f0a31109` (#2640) → 2933 on current `origin/main`.

**853 was correct but unqualified.** It is a blame attribution against one
culprit — not the deleting squash's diffstat total (1165) and not what #2644
added (942 insertions in its own squash commit, per
`git diff --shortstat d55ffbf5 bfb66beb8`). Both 853 and 301 now say what they
measure, in the fixture and in the script header.

Worth noting for anyone re-measuring: `gh pr view 2644 --json additions` says
947, not 942, because the PR-level count is three-dot against the merge base
while the commit diffstat is two-dot against the parent, and main moved under
the branch in between. #2640 diverges the same way (`+1281/−463` as a commit,
`1269/451` as a PR). The branch text avoids the trap by citing no
lines-added figure at all — it just says the blame counts are not that.

**"Unfiled until now" was false.** #2656 recorded this merge event, pinned to
the same commits, roughly 23 hours before #2808 merged — from the test-coverage
angle rather than as a silent revert. The corpus now cites it and frames the
canary's contribution as detection speed and automation rather than discovery.

## Two judgement calls worth reviewing

**The `#2632` string still appears twice**, in a new note recording that the
row previously named it and why that was wrong. That is a refutation, not an
attribution; it is there so the error is not silently reintroduced. Say the
word if you would rather it be dropped entirely.

**`check-silent-revert.sh` said the canary "fires 5 times" over 500 commits.**
Measured per commit: `f603880da` 1 finding, `9239f1541` 1, `cc58cbc53` 2,
`6f0a31109` 1 (pre-acknowledgment, 390 lines), `91e77fc16` 1
(pre-acknowledgment, 340 lines) — 5 commits, 6 findings. The number was
counting commits, so the count is unchanged; the units are now stated so the
6-vs-5 gap is not read as an error.

## Blast radius

Comments and free-text fixture notes only.

- `diff <(git show HEAD~1:scripts/check-silent-revert.sh | grep -v '^\s*#') <(grep -v '^\s*#' scripts/check-silent-revert.sh)`
  is empty — no non-comment line of the detector changed.
- No threshold, window, or expectation moved. The fixture parser reads
  `expect sha note`; only `note` text changed, and both `expect` and `sha` are
  untouched.
- `shellcheck`, `bash -n`, `actionlint`, and `typos` all pass.

`scripts/check-silent-revert.sh --verify-known-incidents` after the change:

```
ok   f603880da fires as recorded  (#2639 dropped #2635 (346 lines), 13 minutes later)
ok   9239f1541 fires as recorded  (#2641 dropped #2639 (451 lines), 10 minutes later)
ok   cc58cbc53 fires as recorded  (#2633 dropped #2644's rollups (853 blamed lines) and #2642's GraphQL merge evidence (301); already recorded in #2656)
ok   c8470efd0 stays clean as recorded  (docs(conventions) rewrote 129 lines of a doc #2679 had just added)

Canary reproduces every recorded incident at the shipped settings.
```

## Related

- Refs #2808 — the PR that merged the canary and introduced the misattributed
  corpus row.
- Refs #2691 — the original silent-revert audit the corpus is built from. Its
  two incidents (#2639/#2635 and #2641/#2639) were already recorded correctly
  and are untouched here.
- Refs #2656 — the pre-existing record of this merge event, now cited by the
  corpus in place of the "unfiled until now" claim. Stays CLOSED/COMPLETED.
- Refs #2644, #2642, #2633, #2640 — the merges measured above. Refs #2632,
  which is not one of them: it never merged, which is the whole point.
- Refs #2833 — follow-up raised in review here: the replay checks only that a
  recorded commit still fires, never which culprit or how many lines, so a row
  can keep printing a reproduction it no longer performs. Pre-existing, and out
  of scope for a change constrained to leave the detector untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018S8a1S71VxhLTRWBtMuEvp
