### PR TITLE
ci: never skip stale-base-overlap-gate on push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -680,8 +680,11 @@ jobs:
   # passes here, and that class belongs to the post-merge silent-revert canary
   # (scripts/check-silent-revert.sh, silent-revert-canary.yml). The two are
   # disjoint; neither subsumes the other.
+  # The job itself never skips (a skipped required lane's result is not
+  # `success`, which the ci-status aggregate rejects) — only the PR overlap
+  # steps are event-gated. The detector self-test runs on every event so a
+  # broken detector cannot mask a regression behind a push-to-main skip.
   stale-base-overlap-gate:
-    if: github.event_name == 'pull_request'
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
@@ -692,15 +695,18 @@ jobs:
           fetch-depth: 0
           # PR head, not the synthetic merge commit: overlap is computed against
           # the branch tip the author will squash, so merge-base math must match
-          # that tip rather than an already-merged-with-base tree.
-          ref: ${{ github.event.pull_request.head.sha }}
+          # that tip rather than an already-merged-with-base tree. Push falls
+          # back to github.sha so `ref` is never empty on main.
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - name: Test the stale-base overlap detector
         run: bash scripts/check-stale-base-overlap.test.sh
       - name: Fetch base ref
+        if: github.event_name == 'pull_request'
         env:
           BASE_REF: ${{ github.base_ref }}
         run: git fetch --no-tags origin "$BASE_REF":"refs/remotes/origin/$BASE_REF"
       - name: Fail when behind base on overlapping paths
+        if: github.event_name == 'pull_request'
         env:
           BASE_REF: ${{ github.base_ref }}
         run: scripts/check-stale-base-overlap.sh --check "origin/$BASE_REF"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
No linked issue

## Summary

Every push to `main` since #2799 has failed the required `ci-status` check because `stale-base-overlap-gate` skipped on non-PR events and the aggregator rejects any `needs.*.result` other than `success`.

## Fix

Remove the job-level `if: github.event_name == 'pull_request'`. The detector self-test now runs on every event (including push to `main`). Fetch-base and the overlap check stay PR-only. Checkout uses `github.event.pull_request.head.sha || github.sha` so `ref` is never empty on push. The aggregator is unchanged: skipped required lanes stay fail-closed.

## Verification

- `bash scripts/check-stale-base-overlap.test.sh`: ALL PASS (usage, fresh base, overlapping behind-base fails, disjoint behind-base, missing ref).
- This PR's `stale-base-overlap-gate` ran (not skipped) and passed; `ci-status` passed.
- After merge, a `main` push should report `stale-base-overlap-gate` as `success` (self-test only) so `ci-status` can go green.

## Related

Refs #2691 (the stale-base gate this job implements). The skip-on-push failure is the same never-skip contract documented on `plugin-gate` / `skill-quality-gate` / `hygiene`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e8b0bda9-a6d8-4815-a457-6a4adfc9d54b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e8b0bda9-a6d8-4815-a457-6a4adfc9d54b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

