### PR TITLE
fix(repo-fleet-hygiene): keep .git skipped when shrinking the skip list

### DIFF
--- a/plugins/repo-fleet-hygiene/.claude-plugin/plugin.json
+++ b/plugins/repo-fleet-hygiene/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "repo-fleet-hygiene",
-  "version": "0.23.0",
+  "version": "0.23.1",
   "description": "Cross-repository Git/GitHub fleet discovery, evidence rollup, and a gated apply verb that executes a prior fleet action plan behind one confirmation. Audit stays read-only and confidence-tiered; apply mutates only with --apply plus interactive confirmation or --yes.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/repo-fleet-hygiene/CHANGELOG.md
+++ b/plugins/repo-fleet-hygiene/CHANGELOG.md
@@ -3,6 +3,20 @@
 All notable changes to `repo-fleet-hygiene` are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.23.1]
+
+### Fixed
+
+- **`.git` stays skipped when `--skip` / `fleet.skip` shrinks the discovery list (#2826).**
+  Replace semantics are unchanged, but `.git` now joins `.` and `..` as an unconditional skip
+  so reaching a repo under `vendor/` cannot start walking `.git` internals. The replaceable
+  default list is `node_modules`, `vendor`, `.venv`; to extend, pass those three plus extra
+  names.
+- **security-review.md no longer restates the aliased-GraphQL page size as a literal `100`
+  in a current-state claim (#2825).** The Accepted egress sentence now names
+  `MERGED_PR_GRAPHQL_ALIAS_PAGE`, matching the live collector constant (historical literals
+  in the 2026-07-31 re-check paragraph are unchanged).
+
 ## [0.23.0]
 
 ### Added

--- a/plugins/repo-fleet-hygiene/skills/audit/SKILL.md
+++ b/plugins/repo-fleet-hygiene/skills/audit/SKILL.md
@@ -46,11 +46,11 @@ Parse `$ARGUMENTS` as opaque arguments for the bundled script. Supported flags:
   (repeatable; explicit wins over config).
 - `--skip <name>`: discovery directory-name skip (repeatable). Explicit `--skip` / `fleet.skip`
   entries **replace** the default skip list rather than appending — otherwise shrinking is
-  impossible. Default (neither CLI nor config): `.`, `..`, `.git`, `node_modules`, `vendor`,
-  `.venv`. To extend, pass those six defaults plus your names; to shrink (e.g. reach a repo under
-  `vendor/`), omit names you want walked. CLI and config compose additively with each other like
-  other scope inputs. Values must be bare directory names (no empty value, no path separator).
-  `.` and `..` stay skipped unconditionally even when an explicit list omits them.
+  impossible. Default (neither CLI nor config): `node_modules`, `vendor`, `.venv`. To extend, pass
+  those three defaults plus your names; to shrink (e.g. reach a repo under `vendor/`), omit names
+  you want walked. CLI and config compose additively with each other like other scope inputs.
+  Values must be bare directory names (no empty value, no path separator). `.`, `..`, and `.git`
+  stay skipped unconditionally even when an explicit list omits them.
 - `--max-depth <1..12>`: discovery bound; explicit wins over config/default `5`.
 - `--project-dir <dir>`: the session's project directory, used for the project-scoped config rung.
   It is **not** a scope fallback — a run with no scope fails rather than auditing it.

--- a/plugins/repo-fleet-hygiene/skills/audit/reference/security-review.md
+++ b/plugins/repo-fleet-hygiene/skills/audit/reference/security-review.md
@@ -60,8 +60,8 @@ confirmation or `--yes`, re-derives OIDs before every delete, and skips fail-clo
    TERM-ignoring regression test. **Accepted** as necessary first-party metadata lookup. The
    collector pins `GH_HOST=github.com` and disables GitHub CLI prompting, update checks, extension
    update checks, spinners, color, and telemetry for every invocation. Rate cost for the aliased
-   GraphQL page is documented as bounded (measured cost 1 per call; ≤100 aliases / ≤100 nodes per
-   page).
+   GraphQL page is documented as bounded (measured cost 1 per call; at most
+   `MERGED_PR_GRAPHQL_ALIAS_PAGE` aliases and the same number of nodes per page).
 6. **Provenance/trust:** Melodic Software authors and distributes the plugin under the repository's MIT
    license. Runtime trust is limited to locally installed Git and the official GitHub CLI; there is no
    third-party SaaS delegation beyond the repository's declared GitHub host. **Accepted.**

--- a/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.sh
+++ b/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.sh
@@ -40,13 +40,13 @@ than read from the environment, which does not carry it. An empty value means
 
 --skip NAME (repeatable) and config fleet.skip (repeatable) REPLACE the default
 discovery skip list rather than appending to it. With neither supplied, discovery
-skips . , .. , .git , node_modules , vendor , and .venv. Supplying any --skip or
-fleet.skip entry replaces that set entirely — to extend, pass the six defaults
-plus your names; to shrink (e.g. reach a repo under vendor/), omit the names you
-want walked. CLI and config entries compose additively with each other the same
-way other scope inputs do. Values must be bare directory names (no empty value,
-no path separator). . and .. stay skipped unconditionally even when an explicit
-list omits them.
+skips node_modules, vendor, and .venv. Supplying any --skip or fleet.skip entry
+replaces that set entirely — to extend, pass those three defaults plus your names;
+to shrink (e.g. reach a repo under vendor/), omit the names you want walked. CLI
+and config entries compose additively with each other the same way other scope
+inputs do. Values must be bare directory names (no empty value, no path separator).
+. , .. , and .git stay skipped unconditionally even when an explicit list omits
+them.
 EOF
 }
 
@@ -708,25 +708,25 @@ fi
 # Discovery skip names (--skip / fleet.skip). Explicit entries REPLACE the default set rather than
 # appending (#2712): otherwise shrinking (e.g. reaching a repo under vendor/) is impossible. CLI and
 # config compose additively with each other like other scope inputs; with neither supplied, keep
-# today's six-name default. . and .. stay skipped unconditionally even when an explicit list omits
-# them.
+# today's three-name default. . , .. , and .git stay skipped unconditionally even when an explicit
+# list omits them (#2826).
 if [[ -n "$CONFIG_FILE" ]]; then
   while IFS= read -r -d '' value; do
     # Empty fleet.skip values hard-fail (same contract as --skip ''), including a bare
     # `skip =` line that git-config returns as an empty string. Do not silently drop them:
-    # an empty-only list would otherwise restore the six defaults and quietly omit vendor/.
+    # an empty-only list would otherwise restore the three defaults and quietly omit vendor/.
     validate_skip_name "$value" "fleet.skip"
     SKIP_NAMES+=("$value")
   done < <(run_git_probe config --file "$CONFIG_FILE" --null --get-all fleet.skip 2>/dev/null || true)
 fi
 if [[ ${#SKIP_NAMES[@]} -eq 0 ]]; then
-  SKIP_NAMES=(. .. .git node_modules vendor .venv)
+  SKIP_NAMES=(node_modules vendor .venv)
 fi
 
 should_skip_dir_name() {
   local name="$1" skip
   case "$name" in
-  . | ..) return 0 ;;
+  . | .. | .git) return 0 ;;
   *) ;;
   esac
   for skip in "${SKIP_NAMES[@]}"; do
@@ -1279,8 +1279,9 @@ discover_repositories() {
     # Unmatched globs leave literal patterns; skip those. Broken symlinks still match -L.
     [[ -e "$child" || -L "$child" ]] || continue
     name="$(basename "$child")"
-    # Configurable skip list (--skip / fleet.skip). . and .. are always skipped; other names come
-    # from SKIP_NAMES (defaults, or an explicit replace list). See usage() for replace semantics.
+    # Configurable skip list (--skip / fleet.skip). . , .. , and .git are always skipped; other
+    # names come from SKIP_NAMES (defaults, or an explicit replace list). See usage() for replace
+    # semantics.
     if should_skip_dir_name "$name"; then
       continue
     fi

--- a/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.test.sh
+++ b/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.test.sh
@@ -12,6 +12,7 @@ mkdir -p "$MOCK_BIN" "$TMP/config" "$TMP/discovered-a" "$TMP/canonical-a" "$TMP/
   "$TMP/ref-fail" "$TMP/rref-fail" "$TMP/dup-a" "$TMP/new-clone" \
   "$TMP/root/acme/root-repo/.git" \
   "$TMP/skip-root/keep/visible-repo/.git" \
+  "$TMP/skip-root/keep/visible-repo/.git/modules/nested-decoy/.git" \
   "$TMP/skip-root/vendor/under-vendor/.git" \
   "$TMP/skip-root/third_party/under-third/.git" \
   "$TMP/emptyroot" \
@@ -1950,8 +1951,9 @@ else
 fi
 
 # Shrink: omit vendor from an explicit list so a repo under vendor/ is discovered.
+# .git is omitted on purpose (#2826): shrinking must not start walking .git internals.
 if REPO_FLEET_TEST_FAST_TIMEOUTS=1 bash "$SCRIPT" --root "$TMP/skip-root" \
-  --skip . --skip .. --skip .git --skip node_modules --skip .venv >"$skip_out" 2>&1; then
+  --skip node_modules --skip .venv >"$skip_out" 2>&1; then
   if grep -Fq "Repo: $TMP/skip-root/vendor/under-vendor" "$skip_out" &&
     grep -Fq "Repositories discovered (audit targets after deduplication): 3" "$skip_out"; then
     printf 'PASS: --skip replace shrink reaches a repository under vendor/\n'
@@ -1964,9 +1966,27 @@ else
   failures=$((failures + 1))
 fi
 
-# Extend: pass the six defaults plus third_party so that tree is skipped.
+# #2826: shrinking with --skip node_modules (omitting .git) still reaches vendor/ and
+# must not surface a decoy planted under a discovered repo's .git tree.
 if REPO_FLEET_TEST_FAST_TIMEOUTS=1 bash "$SCRIPT" --root "$TMP/skip-root" \
-  --skip . --skip .. --skip .git --skip node_modules --skip vendor --skip .venv \
+  --skip node_modules >"$skip_out" 2>&1; then
+  if grep -Fq "Repo: $TMP/skip-root/vendor/under-vendor" "$skip_out" &&
+    grep -Fq "Repo: $TMP/skip-root/keep/visible-repo" "$skip_out" &&
+    ! grep -Fq "nested-decoy" "$skip_out" &&
+    grep -Fq "Repositories discovered (audit targets after deduplication): 3" "$skip_out"; then
+    printf 'PASS: --skip omitting .git still skips .git and reaches vendor/\n'
+  else
+    printf 'FAIL: --skip omitting .git still skips .git and reaches vendor/\n%s\n' "$(cat "$skip_out")" >&2
+    failures=$((failures + 1))
+  fi
+else
+  printf 'FAIL: --skip omitting .git unexpectedly aborted\n%s\n' "$(cat "$skip_out")" >&2
+  failures=$((failures + 1))
+fi
+
+# Extend: pass the three replaceable defaults plus third_party so that tree is skipped.
+if REPO_FLEET_TEST_FAST_TIMEOUTS=1 bash "$SCRIPT" --root "$TMP/skip-root" \
+  --skip node_modules --skip vendor --skip .venv \
   --skip third_party >"$skip_out" 2>&1; then
   if grep -Fq "Repo: $TMP/skip-root/keep/visible-repo" "$skip_out" &&
     ! grep -Fq "under-third" "$skip_out" &&
@@ -1986,9 +2006,6 @@ fi
 cat >"$TMP/config/skip-fleet.conf" <<EOF
 [fleet]
     root = ../skip-root
-    skip = .
-    skip = ..
-    skip = .git
     skip = node_modules
     skip = .venv
 EOF

--- a/plugins/repo-fleet-hygiene/skills/setup/SKILL.md
+++ b/plugins/repo-fleet-hygiene/skills/setup/SKILL.md
@@ -40,8 +40,9 @@ check | apply [--config <path>] [--root <dir>]... [--repo <dir>]...
 `--max-depth` writes `[fleet] maxDepth`; `--skip` writes repeatable `[fleet] skip` entries. This
 skill owns the config file that carries both. Explicit `fleet.skip` entries **replace** the audit's
 default discovery skip list (they do not append) — say that when writing them, because "extend" is
-the naive reading. To extend without shrinking, write the six defaults (`.`, `..`, `.git`,
-`node_modules`, `vendor`, `.venv`) plus the extra names.
+the naive reading. To extend without shrinking, write the three replaceable defaults
+(`node_modules`, `vendor`, `.venv`) plus the extra names. `.`, `..`, and `.git` stay skipped
+unconditionally and do not need to be written.
 
 ## `check` (read-only)
 
@@ -85,9 +86,9 @@ Run `check`, then create or update the config from the supplied arguments.
    Validate each `--skip` value as a bare directory name (reject empty and any path separator);
    write it as a repeatable `[fleet] skip` entry, deduplicating exact matches against entries
    already present. State the replace semantics when writing: any `fleet.skip` present replaces the
-   audit's default skip list (`.`, `..`, `.git`, `node_modules`, `vendor`, `.venv`) rather than
-   appending — to extend, include those defaults plus the new names. Removing a skip entry is a
-   manual edit.
+   audit's default skip list (`node_modules`, `vendor`, `.venv`) rather than appending — to
+   extend, include those three defaults plus the new names. `.`, `..`, and `.git` stay skipped
+   unconditionally. Removing a skip entry is a manual edit.
 2. If the config exists, read it with `git config --file <path> --list --show-origin`. Preserve every
    unrelated entry. Never source it.
 3. State the proposed additions/updates before writing. With complete arguments, proceed
@@ -157,10 +158,10 @@ affecting non-404/403 failures or successful-response evidence. Use it for fores
 upstream repositories made private or deleted, or repositories owned by a different GitHub account
 than the authenticated `gh` login.
 
-`skip` replaces the audit's default discovery skip list (`.`, `..`, `.git`, `node_modules`,
-`vendor`, `.venv`) whenever any entry is present. It does **not** append — a lone `skip = third_party`
-means only `third_party` is skipped (plus unconditional `.` / `..`). To extend the defaults, write
-all six plus the extra names. CLI `--skip` and config `fleet.skip` compose additively with each
+`skip` replaces the audit's default discovery skip list (`node_modules`, `vendor`, `.venv`)
+whenever any entry is present. It does **not** append — a lone `skip = third_party` means only
+`third_party` is skipped (plus unconditional `.` / `..` / `.git`). To extend the defaults, write
+those three plus the extra names. CLI `--skip` and config `fleet.skip` compose additively with each
 other the same way other scope inputs do.
 
 Resolution priority is explicit audit CLI override, canonical config entry, then the discovered

--- a/plugins/repo-fleet-hygiene/skills/setup/evals/evals.json
+++ b/plugins/repo-fleet-hygiene/skills/setup/evals/evals.json
@@ -68,12 +68,12 @@
     {
       "id": 6,
       "name": "skip-replaces-default-discovery-list",
-      "prompt": "/repo-fleet-hygiene:setup apply --root <fleet-root> --skip . --skip .. --skip .git --skip node_modules --skip vendor --skip .venv --skip third_party\n\nI need discovery to skip a differently named vendored tree without losing the defaults.",
-      "expected_output": "Setup validates each --skip as a bare directory name, writes repeatable [fleet] skip entries, and states that fleet.skip replaces the audit default skip list rather than appending — which is why the six defaults were included alongside third_party. It does not tell the user to hand-edit the config.",
+      "prompt": "/repo-fleet-hygiene:setup apply --root <fleet-root> --skip node_modules --skip vendor --skip .venv --skip third_party\n\nI need discovery to skip a differently named vendored tree without losing the defaults.",
+      "expected_output": "Setup validates each --skip as a bare directory name, writes repeatable [fleet] skip entries, and states that fleet.skip replaces the audit default skip list rather than appending — which is why the three replaceable defaults were included alongside third_party. It notes that . / .. / .git stay skipped unconditionally so they do not need to be written. It does not tell the user to hand-edit the config.",
       "files": [],
       "expectations": [
         "Validates bare directory names and rejects path separators",
-        "Writes repeatable fleet.skip entries including the six defaults plus third_party",
+        "Writes repeatable fleet.skip entries including the three replaceable defaults plus third_party",
         "States replace semantics (not append) when writing skip",
         "Does not instruct the user to edit the config by hand"
       ]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #2826
Closes #2825

## Summary

Shrinking `--skip` / `fleet.skip` no longer drops `.git` as a side effect of reaching a repo under `vendor/`. The current-state security-review egress claim names `MERGED_PR_GRAPHQL_ALIAS_PAGE` instead of a hardcoded `100`.

## Fix

- `should_skip_dir_name` treats `.git` like `.` and `..` (unconditional). The replaceable default list is `node_modules`, `vendor`, `.venv`.
- Usage, audit/setup skill prose, and the setup eval that said "six defaults" match the new contract.
- `security-review.md` item 5 names the collector constant; the historical `100` on the 2026-07-31 re-check paragraph is unchanged.
- Plugin `0.23.0` → `0.23.1`.

## Verification

- `bash plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.test.sh`: all collector tests passed, including `PASS: --skip omitting .git still skips .git and reaches vendor/`.
- `scripts/check-fleet-audit-doc-grammar.sh --check`: documented grammar matches parser probes.
- `scripts/check-changelog-parity.sh --check` and `--check-bump origin/main`: 0.23.1 heading matches the manifest bump.
- PR CI: `plugin-gate`, `fleet-audit-doc-grammar-gate`, `changelog-parity-gate`, and `ci-status` passed.

## Related

Refs #2712 (replace semantics, preserved). Refs #2709 (same constant-naming drift vector in this file).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e8b0bda9-a6d8-4815-a457-6a4adfc9d54b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e8b0bda9-a6d8-4815-a457-6a4adfc9d54b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

