### PR TITLE
docs(repo-fleet-hygiene): name the GraphQL alias constant and document .git's redundant skip entry

### DIFF
--- a/plugins/repo-fleet-hygiene/.claude-plugin/plugin.json
+++ b/plugins/repo-fleet-hygiene/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "repo-fleet-hygiene",
-  "version": "0.23.0",
+  "version": "0.23.1",
   "description": "Cross-repository Git/GitHub fleet discovery, evidence rollup, and a gated apply verb that executes a prior fleet action plan behind one confirmation. Audit stays read-only and confidence-tiered; apply mutates only with --apply plus interactive confirmation or --yes.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/repo-fleet-hygiene/CHANGELOG.md
+++ b/plugins/repo-fleet-hygiene/CHANGELOG.md
@@ -3,6 +3,24 @@
 All notable changes to `repo-fleet-hygiene` are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.23.1]
+
+### Changed
+
+- **The security review no longer restates the GraphQL alias page size as a literal (#2825).**
+  `reference/security-review.md` asserted the aliased-GraphQL rate cost as `≤100 aliases / ≤100
+  nodes per page` inside the current-state `Data egress` item, duplicating a value owned by
+  `MERGED_PR_GRAPHQL_ALIAS_PAGE`. It now names the constant, matching how the same document already
+  refers to it earlier. Documentation only; no collector behavior changes.
+- **`.git`'s role in the discovery skip list is documented as redundant (#2826).** `--skip` /
+  `fleet.skip` replace the default list, so an explicit list drops `.git` from `SKIP_NAMES` — but
+  `discover_repositories` takes the nested-repository early return on any directory holding a `.git`
+  marker, before the child loop that consults `SKIP_NAMES` runs. Dropping `.git` therefore cannot
+  expose repository internals to discovery. `usage()` and the resolution comment now say so, so an
+  operator shrinking the list does not misjudge the blast radius. The entry stays in the default
+  list as defence in depth against a future refactor of that early return. Documentation only; no
+  discovery behavior changes.
+
 ## [0.23.0]
 
 ### Added

--- a/plugins/repo-fleet-hygiene/skills/audit/reference/security-review.md
+++ b/plugins/repo-fleet-hygiene/skills/audit/reference/security-review.md
@@ -60,8 +60,8 @@ confirmation or `--yes`, re-derives OIDs before every delete, and skips fail-clo
    TERM-ignoring regression test. **Accepted** as necessary first-party metadata lookup. The
    collector pins `GH_HOST=github.com` and disables GitHub CLI prompting, update checks, extension
    update checks, spinners, color, and telemetry for every invocation. Rate cost for the aliased
-   GraphQL page is documented as bounded (measured cost 1 per call; ≤100 aliases / ≤100 nodes per
-   page).
+   GraphQL page is documented as bounded (measured cost 1 per call; at most
+   `MERGED_PR_GRAPHQL_ALIAS_PAGE` aliases and the same number of nodes per page).
 6. **Provenance/trust:** Melodic Software authors and distributes the plugin under the repository's MIT
    license. Runtime trust is limited to locally installed Git and the official GitHub CLI; there is no
    third-party SaaS delegation beyond the repository's declared GitHub host. **Accepted.**

--- a/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.sh
+++ b/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.sh
@@ -46,7 +46,9 @@ plus your names; to shrink (e.g. reach a repo under vendor/), omit the names you
 want walked. CLI and config entries compose additively with each other the same
 way other scope inputs do. Values must be bare directory names (no empty value,
 no path separator). . and .. stay skipped unconditionally even when an explicit
-list omits them.
+list omits them. .git is defence in depth only: a directory holding a .git marker
+is recorded as a repository and never descended into, so dropping .git from the
+list does not expose repository internals to discovery.
 EOF
 }
 
@@ -709,7 +711,10 @@ fi
 # appending (#2712): otherwise shrinking (e.g. reaching a repo under vendor/) is impossible. CLI and
 # config compose additively with each other like other scope inputs; with neither supplied, keep
 # today's six-name default. . and .. stay skipped unconditionally even when an explicit list omits
-# them.
+# them. .git is kept in the default list as defence in depth against a future refactor, not because
+# discovery would otherwise walk it: discover_repositories takes the nested-repository early return
+# on any directory holding a .git marker, so the child loop that consults SKIP_NAMES never runs
+# there (#2826).
 if [[ -n "$CONFIG_FILE" ]]; then
   while IFS= read -r -d '' value; do
     # Empty fleet.skip values hard-fail (same contract as --skip ''), including a bare


### PR DESCRIPTION
Closes #2825
Closes #2826

Two low-severity documentation edges surfaced by a fresh-context verifier agent during the 2026-08-15 audit-verification program, outside the filed scope of the issues that produced the surrounding code. Documentation only — no collector or discovery behavior changes.

## #2825 — the security review restated the GraphQL alias page size as a literal

`plugins/repo-fleet-hygiene/skills/audit/reference/security-review.md` item 5 (`Data egress`) asserted:

> Rate cost for the aliased GraphQL page is documented as bounded (measured cost 1 per call; ≤100 aliases / ≤100 nodes per page).

That is a **current-state** claim ending in an **Accepted** verdict, not the frozen historical record earlier in the same file (lines 5–6 legitimately narrate "raised from hardcoded 100 to 200"). The literal duplicates a value owned by `MERGED_PR_GRAPHQL_ALIAS_PAGE`, so it goes stale silently if the constant is retuned — the same drift vector #2709 fixed in `SKILL.md`. Line 16 of the same document already refers to the constant by name; this makes item 5 match.

## #2826 — `.git`'s skip-list entry, and the wording that implied it was load-bearing

`--skip` / `fleet.skip` **replace** the default skip list rather than appending (deliberate, #2712), and `.` / `..` are protected from that replacement while `.git` is not. So an explicit list does drop `.git` from `SKIP_NAMES`.

It has no effect. `discover_repositories` takes the nested-repository early return on any directory holding a `.git` marker:

```sh
if [[ -d "$dir/.git" || -f "$dir/.git" ]]; then
  add_target "$dir" discovery
  return 0
fi
[[ "$depth" -lt "$MAX_DEPTH" ]] || return 0
for child in "$dir"/* "$dir"/.[!.]* "$dir"/..?*; do
```

The child loop that consults `SKIP_NAMES` never runs on the only directory that could present a `.git` child. The residual edge — a broken symlink at `$dir/.git`, where both `-d` and `-f` are false — falls through to the loop but fails `[[ -d "$child" ]]` regardless of the skip list.

`usage()` and the skip-name resolution comment now state this, so an operator who shrinks the list to reach a repo under `vendor/` does not conclude they have exposed repository internals to discovery. The entry stays in the default list as defence in depth against a future refactor of that early return.

Note that the issue as originally filed claimed the opposite — that shrinking the list lets discovery walk `.git/modules/**`. That claim was retracted in the issue body before this PR; the behavioral half does not hold.

## Verification

- `scripts/check-changelog-parity.sh --check-bump origin/main` — passes; `repo-fleet-hygiene` bumped `0.23.0` → `0.23.1` with a matching `## [0.23.1]` entry.
- `shellcheck plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.sh` — clean.
- `shfmt -d` on the same file reports only pre-existing double-blank-line diffs at lines 969 / 1066 / 1241, untouched by this change.
- `plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.test.sh` is not runnable under Git Bash on Windows (repeatedly exceeds 500s with no buffered output); it runs in CI on Linux. No test assertions change here — both edits are comment/usage text and one prose sentence.
