### PR TITLE
test(scripts): scope portability-suite fixture git commands with -C

### DIFF
--- a/scripts/check-shell-portability.test.sh
+++ b/scripts/check-shell-portability.test.sh
@@ -1543,14 +1543,14 @@ mkdir -p "$fx/scripts" "$fx/plugins/alpha/skills/demo/context"
 cp "$SCRIPT" "$fx/scripts/"
 out="$(
   cd "$fx" &&
-    git init -q &&
-    git config user.email test@example.com &&
-    git config user.name test &&
-    git commit -q --allow-empty -m base &&
-    base="$(git rev-parse HEAD)" &&
+    git -C "$fx" init -q &&
+    git -C "$fx" config user.email test@example.com &&
+    git -C "$fx" config user.name test &&
+    git -C "$fx" commit -q --allow-empty -m base &&
+    base="$(git -C "$fx" rev-parse HEAD)" &&
     printf '%s\n' 'stat -c %Y "$f"' >'plugins/alpha/skills/demo/context/mtime.md' &&
-    git add -A >/dev/null 2>&1 &&
-    git commit -q -m add-skill-md &&
+    git -C "$fx" add -A >/dev/null 2>&1 &&
+    git -C "$fx" commit -q -m add-skill-md &&
     SHELL_PORTABILITY_TOKENS="$(one_token_list 'stat[[:space:]]+-c')" bash scripts/check-shell-portability.sh "$base" 2>&1
 )"
 rc=$?
@@ -1639,15 +1639,15 @@ cp "$SCRIPT" "$fx/scripts/"
 quoted_name="$(printf 'quoted-\303\251.sh')" # trailing U+00E9 byte -- non-ASCII, triggers Git quoting
 out="$(
   cd "$fx" &&
-    git init -q &&
-    git config user.email test@example.com &&
-    git config user.name test &&
-    git commit -q --allow-empty -m base &&
-    base="$(git rev-parse HEAD)" &&
+    git -C "$fx" init -q &&
+    git -C "$fx" config user.email test@example.com &&
+    git -C "$fx" config user.name test &&
+    git -C "$fx" commit -q --allow-empty -m base &&
+    base="$(git -C "$fx" rev-parse HEAD)" &&
     printf '%s\n' 'grep -Eq "\\bfoo\\b" "$file"' >'plain.sh' &&
     printf '%s\n' 'grep -Eq "\\bfoo\\b" "$file"' >"$quoted_name" &&
-    git add -A >/dev/null 2>&1 &&
-    git commit -q -m add-scripts &&
+    git -C "$fx" add -A >/dev/null 2>&1 &&
+    git -C "$fx" commit -q -m add-scripts &&
     SHELL_PORTABILITY_TOKENS="$(one_token_list '\\b')" bash scripts/check-shell-portability.sh "$base" 2>&1
 )"
 rc=$?

--- a/scripts/check-skill-portability.test.sh
+++ b/scripts/check-skill-portability.test.sh
@@ -669,16 +669,16 @@ cp "$SCRIPT" "$fx/scripts/"
 quoted_name="$(printf 'quoted-\303\251.md')" # trailing U+00E9 byte — non-ASCII, triggers Git quoting
 out="$(
   cd "$fx" &&
-    git init -q &&
-    git config user.email test@example.com &&
-    git config user.name test &&
-    git commit -q --allow-empty -m base &&
-    base="$(git rev-parse HEAD)" &&
+    git -C "$fx" init -q &&
+    git -C "$fx" config user.email test@example.com &&
+    git -C "$fx" config user.name test &&
+    git -C "$fx" commit -q --allow-empty -m base &&
+    base="$(git -C "$fx" rev-parse HEAD)" &&
     mkdir -p 'plugins/p/skills/s' &&
     printf 'diff against origin/main\n' >'plugins/p/skills/s/plain.md' &&
     printf 'diff against origin/main\n' >"plugins/p/skills/s/${quoted_name}" &&
-    git add -A >/dev/null 2>&1 &&
-    git commit -q -m add-skills &&
+    git -C "$fx" add -A >/dev/null 2>&1 &&
+    git -C "$fx" commit -q -m add-skills &&
     SKILL_PORTABILITY_TOKENS="$TEST_TOKENS" bash scripts/check-skill-portability.sh "$base" 2>&1
 )"
 rc=$?


### PR DESCRIPTION
## What

The two portability suites build their diff-mode fixtures like this:

```bash
out="$(
  cd "$fx" &&
    git init -q &&
    git config user.email test@example.com &&   # <- names no repository
    ...
)"
```

This PR names the fixture on every fixture-writing git command, adopting the
`git -C "$fixture" ...` idiom the sibling fixtures in the same directory already
establish (`scripts/check-stale-base-overlap.test.sh:22`,
`scripts/sync-standards-contract.test.sh:69`).

21 lines changed, all of them git invocations. No assertion or coverage change.

## Honest finding: the named sites were already cwd-scoped

The motivating report described these as unscoped commands writing into the
caller's `.git/config`. **They are not, under normal invocation.** The `cd "$fx" &&`
guard at the head of the `&&` chain scopes them, and I could not reproduce a leak:

```
$ # verbatim replay of the pre-fix block, run from a worktree of this repo
BEFORE: 0 local user.* keys
subshell rc=0 out=695e71c3ea35179a224c36992b6408d6de284d94
AFTER: 0 local user.* keys
(none in caller repo)
fixture config:
user.email=test@example.com
user.name=test
```

Whole-suite before/after, against the shared `.git/config` this worktree and the
main clone both use:

| phase | suite | caller `user.*` before | caller `user.*` after | result |
|---|---|---|---|---|
| pre-fix (`HEAD~1` copies) | check-shell-portability.test.sh | none | none | PASS=333 FAIL=0 |
| pre-fix (`HEAD~1` copies) | check-skill-portability.test.sh | none | none | PASS=89 FAIL=0 |
| post-fix | check-shell-portability.test.sh | none | none | PASS=333 FAIL=0 |
| post-fix | check-skill-portability.test.sh | none | none | PASS=89 FAIL=0 |

So this is **not** a demonstrated bug fix. It is an idiom-consistency and
copy-paste-hazard change: a line reading literally `git config user.email
test@example.com` at statement position in a test file is one paste away from
poisoning a real repository, which is the plausible route to the #2827 damage.
(The branch name says `fix/`; the change is hygiene. The landed squash commit
takes this PR's title and body, so history records it accurately.)

Note the `cd "$fx"` is retained deliberately and stays load-bearing — the
relative `printf … > 'plugins/…'` writes and the relative
`bash scripts/check-*-portability.sh` invocation all need cwd = `$fx`. So `-C`
here is a second, explicit scoping mechanism alongside the existing implicit
one, not a replacement for it. `$fx` is always `mktemp -d` output, i.e.
absolute, so `-C "$fx"` resolves correctly from any cwd.

## Follow-up finding: `-C` is not a fixture-isolation guarantee

The one way I *could* manufacture the leak is an exported `GIT_DIR` — the
environment git hands to every hook it invokes. `git config`'s default `--local`
scope follows `GIT_DIR`, not the working directory:

```
GIT_DIR=D:/repos/.../claude-code-plugins/.git
BEFORE:  (no local user.* keys)
subshell rc=0 gitdir-it-used=D:/repos/.../claude-code-plugins/.git
AFTER:   user.email=test@example.com
         user.name=test
```

**`git -C "$dir"` does not fix that** — I verified the prescribed idiom is
equally vulnerable (the fixture ends up with no `.git` at all and the caller's
config is poisoned):

```
== git -C "$fx" init/config under exported GIT_DIR ==
fixture has .git? NO
caller config user.*:  user.email=test@example.com  user.name=test

== git -C with GIT_DIR/GIT_WORK_TREE unset in the subshell ==
fixture2 has .git? yes
caller config user.*:  (clean)
```

Only `unset GIT_DIR GIT_WORK_TREE` (or `env -u`) actually isolates a fixture.
I did **not** build that here — it is a new shape across ~30 test files and is
not justified by any demonstrated need in this repo (no `core.hooksPath`, no
installed hooks, and CI invokes the suites as plain steps). Filing it as a
finding instead: *the established `git -C` fixture idiom is a readability and
copy-paste guard, not an isolation guarantee.*

## Sweep

Three passes, all for repo-writing git verbs
(`config|init|add|commit|checkout|switch|branch|remote|tag|reset|rm|mv|stash|update-ref|worktree|clone|push|fetch`)
at shell-statement position without `-C`:

1. All 254 `*.test.sh` / `tests/` / `run-tests.sh` files — 285 candidate hits.
2. All `*.ps1 *.psm1 *.py *.js *.ts` — every hit is a comment, docstring, or
   string literal; **no executable git write command** in any of them.
3. The `*.sh` files that build `mktemp -d` fixtures but are *not* named like
   tests (so pass 1 would have missed them) — 2 hits, both
   `git init -q -b main "$repo"` in `plugins/source-control/skills/worktree/fixtures/`.

**Every site is scoped**, by one of:

- `-C <dir>` — e.g. `sync-standards-contract.test.sh:69`.
- An explicit path *operand* — `git init -q "$REPO"`, `git clone -q <src> <dest>`
  (the repo-hygiene, source-control, docs-hygiene and preflight fixtures).
- A guarded `cd` into the fixture, `(cd "$d" || exit 1; …)` or `(cd "$d" && …)`,
  which also covers the `git init -q .` sites (`exec-bit-check.test.sh:25`,
  `block-noncanonical-commit.test.sh:358`) — those are cwd-scoped by the
  enclosing `cd`, not by their `.` argument.
- An explicit `git config -f <file>` (`preflight.test.sh:416,417,495`).

Everything else that matched is a quoted test payload — permission-rule strings
like `Bash(git push)`, PowerShell here-string bodies, `make_skill` heredoc
content — never executed. No remaining unscoped site.

One structural note, reported not touched (the file is owned by a concurrent
lane): `scripts/check-stale-base-overlap.test.sh` scopes its bare
`git checkout` / `git add` / `git commit` with a **top-level** `cd "$repo" || exit 1`
rather than a subshell-local one. It is guarded, so it is scoped — but it is more
fragile than the sibling pattern, since the cwd persists into everything after it.

## Verification

- `bash scripts/check-shell-portability.test.sh` -> PASS=333 FAIL=0
- `bash scripts/check-skill-portability.test.sh` -> PASS=89 FAIL=0
- No plugin manifest touched, so the changelog-parity gate does not apply
  (it is scoped to `plugins/<name>/`; there is no root CHANGELOG.md).
  `changelog-parity-gate` passes on this PR, confirming it.

Pass counts are identical pre- and post-change (333 and 89), which is the
coverage-unchanged proof: the diff touches 21 lines, all of them git
invocations, and no `ok "` / `fail "` assertion line.

## Related

No linked issue. This is fixture-isolation hygiene in two test suites; it closes
no GitHub issue.

- #2840 — the follow-up finding this PR surfaced but deliberately does not fix:
  `git -C` does not survive an exported `GIT_DIR`, so the established idiom is a
  copy-paste guard rather than an isolation guarantee.
- #2827 / #2830 — the abandoned-and-rebuilt PR pair that motivated this work; a
  commit re-authored to `test@example.com` failed `required_signatures` with
  `no_user` and could not be force-pushed over.
- `scripts/check-stale-base-overlap.test.sh` and
  `scripts/sync-standards-contract.test.sh` — the sibling fixtures whose idiom
  this PR adopts. Neither file is modified here (both are owned by concurrent
  lanes); they are read-only prior art.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018S8a1S71VxhLTRWBtMuEvp

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
