### PR TITLE
fix(scripts): re-derive the overlap calibration from the pinned detector's counts

### DIFF
--- a/scripts/check-silent-revert.sh
+++ b/scripts/check-silent-revert.sh
@@ -148,11 +148,18 @@
 #   moved under the PR, the author merged origin/main in and consciously chose
 #   which side won, and the PR body argues the choice at length.
 #
-# State the uncomfortable part plainly: 340 is the largest false positive and
-# 346 is the smallest true one. NO THRESHOLD SEPARATES THEM. Picking a number
-# in that 2% gap would be overfitting to this corpus, so the threshold is set
-# at 200 instead -- which costs nothing (200 and 300 fire on the identical five
-# commits here) and leaves headroom for a smaller future revert.
+# State the uncomfortable part plainly: the legitimate fires and the real
+# incidents OVERLAP. The smallest true finding is 301 -- #2642's share of
+# #2633's squash -- while both verified-legitimate fires score higher, at 340
+# (#2135) and 390 (#2640). NO THRESHOLD SEPARATES THEM, and not because the
+# gap is narrow: there is no gap at all, only an inversion. Any number that
+# silenced 340 would silence a real incident first.
+#
+# So the threshold is set at 200, below all of them, and it is the disposition
+# path below -- not the number -- that keeps the canary livable. 200 and 300
+# fire on the identical five commits here (at 300 the 301-line finding
+# survives by a single line, which is its own argument against tuning), and
+# 200 leaves headroom for a smaller future revert.
 #
 # So the canary is calibrated to fire roughly once a month, on something a
 # human should genuinely glance at, and precision is deliberately traded for

--- a/scripts/check-silent-revert.sh
+++ b/scripts/check-silent-revert.sh
@@ -150,7 +150,8 @@
 # producing six findings, because #2633's squash deleted content from two
 # different culprits and each attribution is reported on its own. Three of the
 # five are the confirmed incidents; the other two are cleared by the
-# acknowledgment file and never print, so the number a reader sees in CI is 3.
+# acknowledgment file and never print, so what reaches a reader in CI is 3
+# commits carrying 4 findings between them, cc58cbc53 contributing two.
 # The endpoint is named rather than written as "the last 500" so the figure
 # still describes a fixed corpus after main moves, which it does several times
 # a day.
@@ -213,10 +214,14 @@
 # same two-culprit shape. So 200 stays, with headroom for a smaller future
 # revert.
 #
-# So the canary is calibrated to fire roughly once a month, on something a
-# human should genuinely glance at, and precision is deliberately traded for
-# recall because the miss is expensive and the fire is cheap. Cheap requires a
-# disposition path for BOTH directions in time, which is why there are two:
+# So the canary is calibrated to fire on something a human should genuinely
+# glance at, and precision is deliberately traded for recall because the miss
+# is expensive and the fire is cheap. No firing RATE is quoted here, and that
+# is deliberate: the corpus spans 7.9 days, and four of its five crossings land
+# within 76 minutes of each other on the one incident night. It measures a
+# burst, so dividing five by the window would invent a frequency the evidence
+# does not support, in either direction. Cheap requires a disposition path for
+# BOTH directions in time, which is why there are two:
 #
 #   PROSPECTIVE -- `Intentional-removal:` in the PR body, which GitHub carries
 #   into the squash message. Costs one line and the canary never fires.

--- a/scripts/check-silent-revert.sh
+++ b/scripts/check-silent-revert.sh
@@ -39,6 +39,11 @@
 # caller happened to have. Do not "correct" 298 back to 301 after re-measuring
 # on a machine that sets histogram -- pin the flags and re-measure instead.
 #
+# #2642's is not the only figure that moved. 6f0a31109 reads 447 where the
+# pre-pin calibration recorded 390, and 91e77fc16 reads 323 where it recorded
+# 340, for the same reason. The pin table in attribute_file records all three
+# side by side.
+#
 # Every check stayed green through all three, and that is the point: each
 # reverting squash removed the code AND the tests covering it in the same
 # commit, so no suite could fail for a behavior whose tests no longer existed.
@@ -87,12 +92,12 @@
 #   open, so it fires on almost everything.
 #
 # What is left is content: blame the lines a merge deleted and see who had just
-# added them. Measured over the last 500 first-parent commits of main, the
-# three known incidents score 853 / 451 / 346 lines against a single recent
-# commit -- plus a fourth attribution of 298 lines on the SAME #2633 squash,
-# whose deletions trace to two different culprits and are reported separately.
-# Unlike the two designs rejected above, this one fires on all three rather
-# than exonerating them.
+# added them. Measured over the 500 first-parent commits of main ending at
+# 738791c45, the three known incidents score 853 / 451 / 346 lines against a
+# single recent commit -- plus a fourth attribution of 298 lines on the SAME
+# #2633 squash, whose deletions trace to two different culprits and are
+# reported separately. Unlike the two designs rejected above, this one fires on
+# all three rather than exonerating them.
 #
 # What it does NOT buy is a clean split between incidents and ordinary work.
 # Measured below, the two populations OVERLAP on volume -- the smallest true
@@ -140,32 +145,73 @@
 #
 # THE RESIDUAL FALSE POSITIVE, MEASURED RATHER THAN ASSUMED
 # ---------------------------------------------------------
-# At these settings, over the last 500 first-parent commits of main, the canary
-# fires on 5 commits -- 1%. (Six findings, not five: #2633's squash deleted
-# content from two different culprits and each attribution is reported on its
-# own.) Three of the five commits are the confirmed incidents. The other two
-# are both real, and neither is a bug in the detector:
+# At these settings, over the 500 first-parent commits of main ending at
+# 738791c45, the attribution crosses the threshold on 5 commits -- 1% --
+# producing six findings, because #2633's squash deleted content from two
+# different culprits and each attribution is reported on its own. Three of the
+# five are the confirmed incidents; the other two are cleared by the
+# acknowledgment file and never print, so the number a reader sees in CI is 3.
+# The endpoint is named rather than written as "the last 500" so the figure
+# still describes a fixed corpus after main moves, which it does several times
+# a day.
 #
-#   6f0a31109 (#2640, 390 lines) is the manual RESTORE of #2633's revert. To
+# Those totals are FLOORS rather than exact counts, and the reason is
+# structural. attribute_file discards git's stderr on both commands that
+# produce a count, so a file whose diff or blame FAILED is indistinguishable
+# from one that had nothing to attribute, and the failure can only ever
+# subtract lines, never invent them (#2880). A second subtraction carries the
+# same one-way sign: paths the repository's own .gitattributes marks `-diff` or
+# `binary` produce no hunks at all, so their deletions attribute to zero on
+# every machine including CI (#2883). That one is a RECALL gap rather than a
+# calibration gap -- no path of that class appears in any commit whose figure
+# is quoted here, and the largest such deletion anywhere in the sweep was 72
+# lines from a package-lock.json, well under the threshold.
+#
+# Detection and disposition are separate steps, and only the first calibrates
+# the threshold. 6f0a31109 and 91e77fc16 are both recorded in
+# scripts/silent-revert-acknowledged.txt, and scan_commit consults it before it
+# attributes anything, so each reports `acknowledged` and exits 0 without a
+# line being blamed (t_acknowledged_commit_is_cleared pins the clearing). Every
+# count below is a DETECTION count, measured with the acknowledgment file out
+# of the way, because a threshold calibrated on what survives review would be
+# calibrated on its own output.
+#
+# Both cleared commits are real, and neither is a bug in the detector:
+#
+#   6f0a31109 (#2640, 447 lines) is the manual RESTORE of #2633's revert. To
 #   put back what #2633 dropped it had to delete what #2633 had added, so a
 #   large deliberate removal of very recent content is exactly what it is.
 #
-#   91e77fc16 (#2135, 340 lines) is a deliberate merge reconciliation: main
+#   91e77fc16 (#2135, 323 lines) is a deliberate merge reconciliation: main
 #   moved under the PR, the author merged origin/main in and consciously chose
 #   which side won, and the PR body argues the choice at length.
 #
-# State the uncomfortable part plainly: the legitimate fires and the real
-# incidents OVERLAP. The smallest true finding is 301 -- #2642's share of
-# #2633's squash -- while both verified-legitimate fires score higher, at 340
-# (#2135) and 390 (#2640). NO THRESHOLD SEPARATES THEM, and not because the
-# gap is narrow: there is no gap at all, only an inversion. Any number that
-# silenced 340 would silence a real incident first.
+# The incident attributions -- 853, 451, 346 and 298 -- are re-measured on
+# every CI run, because scripts/silent-revert-incidents.txt records each one
+# and the replay asserts it exactly. The shipped replay cannot assert 447 or
+# 323: an acknowledged commit short-circuits before it is attributed, which is
+# the same step that keeps it off a reader's screen.
 #
-# So the threshold is set at 200, below all of them, and it is the disposition
-# path below -- not the number -- that keeps the canary livable. 200 and 300
-# fire on the identical five commits here (at 300 the 301-line finding
-# survives by a single line, which is its own argument against tuning), and
-# 200 leaves headroom for a smaller future revert.
+# State the uncomfortable part plainly: the cleared fires and the real
+# incidents OVERLAP. The smallest true finding is 298 -- #2642's share of
+# #2633's squash -- while both cleared fires score higher, at 323 (#2135) and
+# 447 (#2640). NO THRESHOLD SEPARATES THEM, and not because the gap is narrow:
+# there is no gap at all, only an inversion. Any number that silenced 323 would
+# silence a real incident first.
+#
+# So the threshold is set at 200, below every measured finding, and it is the
+# disposition path below -- not the number -- that keeps the canary livable.
+# Raising it to 300 looks free and is not. The same five commits still cross
+# it, so the COMMIT set does not move; but cc58cbc53's 298-line attribution
+# falls under the line while its 853-line sibling survives, so the FINDING set
+# does. That is the substitution the replay's attribution expectations were
+# added to catch: on exit status alone the row would still pass on the
+# surviving 853-line finding and announce a reproduction it never performed,
+# which is the pre-#2833 gap exactly. With the expectation recorded, running
+# --verify-known-incidents at 300 reports cc58cbc53 as `fires, but NOT as
+# recorded` and exits 1 -- t_replay_asserts_the_recorded_attribution pins that
+# same two-culprit shape. So 200 stays, with headroom for a smaller future
+# revert.
 #
 # So the canary is calibrated to fire roughly once a month, on something a
 # human should genuinely glance at, and precision is deliberately traded for
@@ -473,8 +519,10 @@ attribute_file() {
   # This is not defensive decoration. The algorithm choice changes which lines a
   # hunk calls deleted, and therefore the per-culprit counts this canary
   # thresholds on. Measured on the real corpus, pre-pin, once under each
-  # algorithm -- every calibration figure in the header above was taken on a
-  # machine carrying `diff.algorithm = histogram`, and git's default disagrees:
+  # algorithm. The header above quotes the pinned column; the left column here
+  # records what those same attributions read on a machine carrying
+  # `diff.algorithm = histogram`, which is what the calibration measured before
+  # the flags were pinned:
   #
   #        commit                          histogram   myers (git default)
   #        6f0a31109 (#2640)                     390                   447

--- a/scripts/check-silent-revert.sh
+++ b/scripts/check-silent-revert.sh
@@ -91,8 +91,14 @@
 # three known incidents score 853 / 451 / 346 lines against a single recent
 # commit -- plus a fourth attribution of 298 lines on the SAME #2633 squash,
 # whose deletions trace to two different culprits and are reported separately.
-# The highest verified-legitimate commit scores well below the threshold below.
-# The separation is what makes the canary livable.
+# Unlike the two designs rejected above, this one fires on all three rather
+# than exonerating them.
+#
+# What it does NOT buy is a clean split between incidents and ordinary work.
+# Measured below, the two populations OVERLAP on volume -- the smallest true
+# finding scores under both verified-legitimate fires. So what makes the
+# canary livable is the disposition path and the non-blocking posture, not a
+# number that separates the shapes. No number does.
 #
 # FALSE-POSITIVE STRATEGY (the whole design rests on this)
 # -------------------------------------------------------

--- a/scripts/silent-revert-acknowledged.txt
+++ b/scripts/silent-revert-acknowledged.txt
@@ -33,8 +33,9 @@
 
 # #2135's author noticed main move under the PR, merged origin/main into the
 # branch rather than force-pushing, and argued the disposition explicitly in the
-# PR body -- a deliberate reconciliation, not a lost tree. At 340 lines this is
-# the largest measured false positive, six lines below the smallest real
-# incident (346), which is why no threshold can separate the two shapes and why
-# this file exists.
+# PR body -- a deliberate reconciliation, not a lost tree. At 340 lines it
+# scores ABOVE the smallest real incident finding (301 -- #2642's share of
+# #2633's squash), and the other cleared fire above scores 390. The legitimate
+# and incident ranges overlap rather than merely abut, so no threshold can
+# separate the two shapes, which is why this file exists.
 91e77fc16f62bc0ce99b36565053636fb4a21d9e  #2135 deliberately reconciled a merge of origin/main; disposition argued in the PR body

--- a/scripts/silent-revert-acknowledged.txt
+++ b/scripts/silent-revert-acknowledged.txt
@@ -33,9 +33,9 @@
 
 # #2135's author noticed main move under the PR, merged origin/main into the
 # branch rather than force-pushing, and argued the disposition explicitly in the
-# PR body -- a deliberate reconciliation, not a lost tree. At 340 lines it
-# scores ABOVE the smallest real incident finding (301 -- #2642's share of
-# #2633's squash), and the other cleared fire above scores 390. The legitimate
+# PR body -- a deliberate reconciliation, not a lost tree. At 323 lines it
+# scores ABOVE the smallest real incident finding (298 -- #2642's share of
+# #2633's squash), and the other cleared fire above scores 447. The legitimate
 # and incident ranges overlap rather than merely abut, so no threshold can
 # separate the two shapes, which is why this file exists.
 91e77fc16f62bc0ce99b36565053636fb4a21d9e  #2135 deliberately reconciled a merge of origin/main; disposition argued in the PR body

--- a/scripts/silent-revert-incidents.txt
+++ b/scripts/silent-revert-incidents.txt
@@ -138,10 +138,11 @@ marker 9239f1541b1b15a2a183ad6b4067e577f931e3f1 plugins/disk-hygiene/skills/clea
 # #2640 restored both surfaces by hand.
 #
 # This event was NOT unfiled. Issue #2656 recorded it, pinned to the same
-# commits, roughly 23 hours before this canary merged -- from the test-coverage
-# angle (the hand restore left `bare-repo-with-working-tree` uncovered) rather
-# than as a silent revert. What the canary adds is detection speed and
-# automation, not discovery.
+# commits, roughly 23 hours before this canary merged -- and recorded it AS a
+# silent revert ("#2633 was a stale-base squash that silently reverted two
+# merged features"), though what it ASKED for was the test coverage the hand
+# restore left behind. What the canary adds is detection speed and automation,
+# not discovery.
 #
 # An earlier version of this row named #2632 as the victim. That was wrong:
 # #2632 never merged (closed unmerged, no merge commit, not an ancestor of


### PR DESCRIPTION
Closes #2846.

## Summary

The calibration comments in `scripts/check-silent-revert.sh` carry the argument that
justifies the 200-line threshold. Two of their sentences depended on which finding is
the smallest, and #2832 had already falsified both by recording a fourth true finding.
This PR repairs them — and re-derives every figure they rest on against the detector as
PR #2843 pins it, because three of those figures move under the pins.

Found by fresh-context verification of #2832, after it had merged.

## Why the numbers moved

PR #2843 pins `attribute_file`'s git invocations to git's own defaults

(`--diff-algorithm=myers`, `--no-ext-diff`, `--no-textconv`, `--no-ignore-revs-file`,
`-M`). The original calibration was taken on a machine carrying
`diff.algorithm = histogram`, and the algorithm choice changes which lines a hunk calls
deleted. Every figure below was re-measured against the pinned detector and reproduced
byte-identically with `GIT_CONFIG_GLOBAL` emptied, which is the property
`t_counts_are_immune_to_ambient_git_config` asserts.

| commit | PR | pre-pin | pinned | class |
| --- | --- | ---: | ---: | --- |
| `cc58cbc53` | #2633 | 853 | **853** | incident |
| `cc58cbc53` | #2633 (#2642's share) | 301 | **298** | incident |
| `9239f1541` | #2641 | 451 | **451** | incident |
| `f603880da` | #2639 | 346 | **346** | incident |
| `6f0a31109` | #2640 | 390 | **447** | cleared |
| `91e77fc16` | #2135 | 340 | **323** | cleared |

## Fix

**The overlap argument survives; every sentence stating it was re-derived.** The
smallest true finding is 298 and both cleared fires score above it, at 323 and 447. The
relationship is an inversion, not a narrow gap — so `NO THRESHOLD SEPARATES THEM` is
now true by a wider margin than the six-line version it replaces. THRESHOLD stays 200.

**The 200-vs-300 sentence inverted and was rewritten from measurement, not patched.**
The old text said "at 300 the 301-line finding survives by a single line". Under the
pins that finding is 298, so at 300 it VANISHES. The COMMIT set at 200 and 300 is still
identical — `cc58cbc53` keeps its 853-line finding — but the FINDING set is not, and
that is the sharper argument against tuning. Measured:

```
$ SILENT_REVERT_THRESHOLD=300 scripts/check-silent-revert.sh --verify-known-incidents
FAIL cc58cbc53 fires, but NOT as recorded
     recorded attribution:
       bfb66beb8c1a6cdb52957a9a2614c6d2593739dd 853
       eda5ae5ed5c2b54fdf2db5fd3b620a9272c46da5 298
     what the detector reported:
       bfb66beb8c1a6cdb52957a9a2614c6d2593739dd 853
EXIT=1
```

Without #2833's attribution expectations that row would have passed on the surviving
853-line finding and announced a reproduction it never performed. The passage now says
that, and cites `t_replay_asserts_the_recorded_attribution`, which pins the same
two-culprit shape.

**Detection and disposition are now distinguished.** The corpus sentence said the canary
"fires on 5 commits" and left a reader to assume that is what CI shows. It is not:
`6f0a31109` and `91e77fc16` are in `scripts/silent-revert-acknowledged.txt`, so
`scan_commit` clears each before it attributes a line. Five commits cross the threshold;
three print `SILENT REVERT SUSPECTED`. The prose now states both and says which one the
threshold is calibrated against.

**The corpus endpoint is pinned.** "the last 500 first-parent commits of main" is a
moving window that falsifies itself on the next merge — the same defect class this PR
closes. It now reads "the 500 first-parent commits of main ending at `738791c45`".

**Two recall gaps are acknowledged rather than implied.**

- `attribute_file` swallows `git` stderr on both commands that produce a count, so a
  failed diff or blame is indistinguishable from nothing-to-attribute and can only
  subtract. Every corpus enumeration is therefore a floor, and the prose is worded so
  the caveat is structural rather than an appended qualifier (#2880).
- Paths the repository's `.gitattributes` marks `-diff` or `binary` produce no hunks, so
  their deletions attribute to zero on every machine including CI (#2883). This is a
  RECALL gap, not a calibration one: no path of that class appears in any commit whose
  figure is quoted, and the largest such deletion anywhere in the sweep was 72 lines
  from a `package-lock.json` — well under the threshold.

**Also corrects a mischaracterization of #2656** that #2832 introduced, which said that
issue recorded the event "rather than as a silent revert". Its Evidence section opens
with *"#2633 was a stale-base squash that silently reverted two merged features."* It
recorded it exactly as a silent revert — what was coverage-shaped was what it **asked
for**. Now quoted rather than paraphrased.

## Not fixed here

The fresh-context verifier confirmed each of these; every one sits in prose this PR does
not own, and each needs a rewording rather than a renumber.

- **"main's 1527-commit history"** (twice). Reproduces at no named endpoint — measured
  1546 at `738791c45`, 1549 at `origin/main`. The claims it supports are unaffected and
  do reproduce: `Revert "` = 0, `revert:` = 1, that one being `1d1fca6e8` (#1839).
  Renumbering it would be falsified by the next merge, which is the same moving-window
  defect this PR removes elsewhere.
- **"the replay exited 0 for 31h28m"**. The duration reproduces exactly, but it is the
  content-absence window; the replay itself only existed for about 6h13m of it. #2873's
  prose, and the same conflation appears once in `silent-revert-incidents.txt`.
- **"a four-row corpus"**. There are 5 `marker` rows, and 3 `fires` + 1 `clean`
  expectation rows; the sentence's own unit is one read per marker, so 5. #2873's prose.
- **The repo-wide-grep counterfactual.** Its present-tense half holds, but at the tree
  where both markers were actually missing, a repo-wide grep would have falsely cleared
  only the README half — the CHANGELOG copy that makes the claim true today was added by
  the restore commit itself. #2873's prose.
- **The `clean` row's "129 lines"** reads 136 under the pins. Issue #2865 owns that row;
  correcting it here would collide.

## Related

- PR #2843 — merged ahead of this one; it added the pins that move three of the figures
  here, and its pin table records the pre-pin and pinned columns side by side. This PR
  layers prose on top of it and changes no pin.
- PR #2873 — merged ahead of both; added the restoration markers and the
  `marker) continue ;;` arm. Untouched here and verified intact after the rebase.
- Refs #2880 — `attribute_file` swallows git stderr, which is why the corpus figures are
  worded as floors rather than exact counts. Acknowledged here, not fixed.
- Refs #2883 — paths marked `-diff` or `binary` contribute zero to attribution.
  Acknowledged here as a recall gap, not fixed.
- Refs #2865 — owns the `clean` row whose "129 lines" reads 136 under the pins.
  Deliberately left to that lane.
- Refs #2832 — the corpus attribution correction that added the fourth finding and
  falsified the two sentences this PR repairs.

## Verification

- Every figure re-measured against the shipped detector on this branch, twice — once
  inheriting ambient config and once with `GIT_CONFIG_GLOBAL` emptied — with identical
  results.
- `scripts/check-silent-revert.test.sh` (101 passed, 0 failed) and both replay modes run
  green against the merged content.
- An independent fresh-context verifier re-measured every number in the calibration
  comments without access to this reasoning, running the full 500-commit corpus sweep
  rather than per-commit checks alone. Every figure this PR states reproduced. It raised
  two defects in the new prose, both fixed here: "the number a reader sees in CI is 3"
  read as findings when it means commits (three commits, four findings between them),
  and "roughly once a month" was 12-19x off — the corpus spans 7.9 days with four of its
  five crossings inside 76 minutes, so that rate claim was removed rather than
  renumbered, because the corpus measures a burst and no per-month figure is defensible
  from it. Its full verdict, including drift it confirmed in prose this PR does not own,
  is recorded in the PR comments.
