### PR TITLE
test(repo-fleet-hygiene): make the .git skip defence falsifiable and name the gh timeout constants

### DIFF
--- a/plugins/repo-fleet-hygiene/.claude-plugin/plugin.json
+++ b/plugins/repo-fleet-hygiene/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "repo-fleet-hygiene",
-  "version": "0.23.1",
+  "version": "0.23.2",
   "description": "Cross-repository Git/GitHub fleet discovery, evidence rollup, and a gated apply verb that executes a prior fleet action plan behind one confirmation. Audit stays read-only and confidence-tiered; apply mutates only with --apply plus interactive confirmation or --yes.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/repo-fleet-hygiene/CHANGELOG.md
+++ b/plugins/repo-fleet-hygiene/CHANGELOG.md
@@ -3,15 +3,43 @@
 All notable changes to `repo-fleet-hygiene` are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.23.2]
+
+### Changed
+
+- **The `.git` discovery skip is documented as defence in depth, and defended by a test that can
+  actually fail (#2844).** `should_skip_dir_name`'s unconditional `.` / `..` / `.git` arm is
+  unreachable from its only caller: the child loop's globs (`*`, `.[!.]*`, `..?*`) can never
+  yield `.` or `..`, and for `.git` the nested-repository early return fires first on the
+  identical path and predicate. The arm stays as defence in depth against a future refactor of
+  that early return, and both it and its call site now say so. The discovery-level case
+  `--skip omitting .git still skips .git and reaches vendor/` was replaced by a direct
+  `should_skip_dir_name` contract assertion, because that case passed identically with the `.git`
+  change reverted — as did all nine cases in the skip block. No runtime behavior changes.
+- **`security-review.md` names the `gh` timeout constants instead of restating them as literals
+  (#2845).** The Accepted data-egress item said "a 30-second deadline plus a five-second KILL
+  grace"; it now names `GH_TIMEOUT_SECONDS` and `GH_KILL_AFTER_SECONDS`, the constants that own
+  those values — the same drift vector #2709 and #2825 closed elsewhere in that document. The
+  aliased-GraphQL rate claim is qualified to the alias count it was actually measured at.
+- **Declared in-place correction to the released `## [0.23.1]` section (#2388 sanction).** Its
+  `.git` bullet moved from `### Fixed` to `### Changed`, and its causal clause ("so reaching a
+  repo under `vendor/` cannot start walking `.git` internals") was replaced: the end state was
+  true, but the claim presented as newly established a guarantee the nested-repository early
+  return already provided, and the behavioral delta was zero. No other released entry is touched.
+
 ## [0.23.1]
+
+### Changed
+
+- **`.git` is now an unconditional discovery skip (#2826).** The nested-repository early return
+  already stopped discovery descending into any directory holding a `.git` marker, so this
+  changes no observable behavior; making `.git` unconditional is defence in depth against a
+  future refactor of that return, not a fix for a reachable exposure. Replace semantics are
+  unchanged; the replaceable default list is `node_modules`, `vendor`, `.venv`; to extend, pass
+  those three plus extra names. (Corrected in 0.23.2 — see #2844.)
 
 ### Fixed
 
-- **`.git` stays skipped when `--skip` / `fleet.skip` shrinks the discovery list (#2826).**
-  Replace semantics are unchanged, but `.git` now joins `.` and `..` as an unconditional skip
-  so reaching a repo under `vendor/` cannot start walking `.git` internals. The replaceable
-  default list is `node_modules`, `vendor`, `.venv`; to extend, pass those three plus extra
-  names.
 - **security-review.md no longer restates the aliased-GraphQL page size as a literal `100`
   in a current-state claim (#2825).** The Accepted egress sentence now names
   `MERGED_PR_GRAPHQL_ALIAS_PAGE`, matching the live collector constant (historical literals

--- a/plugins/repo-fleet-hygiene/skills/audit/reference/security-review.md
+++ b/plugins/repo-fleet-hygiene/skills/audit/reference/security-review.md
@@ -55,13 +55,15 @@ confirmation or `--yes`, re-derives OIDs before every delete, and skips fail-clo
    merged-PR queries) contacts only `github.com` and transmits repository identity plus the
    non-default local branch names under audit for that repository. No file content, report, commit
    content, diff, environment value, or absolute local path is sent. Non-GitHub hosts are not
-   contacted, and every `gh` call has a 30-second deadline plus a five-second KILL grace. Compatible
+   contacted, and every `gh` call has a `GH_TIMEOUT_SECONDS` deadline plus a `GH_KILL_AFTER_SECONDS`
+   KILL grace. Compatible
    coreutils is feature-detected; a finite Bash watchdog covers other supported platforms and has a
    TERM-ignoring regression test. **Accepted** as necessary first-party metadata lookup. The
    collector pins `GH_HOST=github.com` and disables GitHub CLI prompting, update checks, extension
    update checks, spinners, color, and telemetry for every invocation. Rate cost for the aliased
-   GraphQL page is documented as bounded (measured cost 1 per call; at most
-   `MERGED_PR_GRAPHQL_ALIAS_PAGE` aliases and the same number of nodes per page).
+   GraphQL page is documented as bounded (cost measured at 1 per call at 40 aliases, the largest
+   count measured live; at most `MERGED_PR_GRAPHQL_ALIAS_PAGE` aliases and the same number of
+   nodes per page).
 6. **Provenance/trust:** Melodic Software authors and distributes the plugin under the repository's MIT
    license. Runtime trust is limited to locally installed Git and the official GitHub CLI; there is no
    third-party SaaS delegation beyond the repository's declared GitHub host. **Accepted.**

--- a/plugins/repo-fleet-hygiene/skills/audit/reference/security-review.md
+++ b/plugins/repo-fleet-hygiene/skills/audit/reference/security-review.md
@@ -55,10 +55,9 @@ confirmation or `--yes`, re-derives OIDs before every delete, and skips fail-clo
    merged-PR queries) contacts only `github.com` and transmits repository identity plus the
    non-default local branch names under audit for that repository. No file content, report, commit
    content, diff, environment value, or absolute local path is sent. Non-GitHub hosts are not
-   contacted, and every `gh` call has a `GH_TIMEOUT_SECONDS` deadline plus a `GH_KILL_AFTER_SECONDS`
-   KILL grace. Compatible
-   coreutils is feature-detected; a finite Bash watchdog covers other supported platforms and has a
-   TERM-ignoring regression test. **Accepted** as necessary first-party metadata lookup. The
+   contacted, and every `gh` call has a `GH_TIMEOUT_SECONDS` deadline plus a
+   `GH_KILL_AFTER_SECONDS` KILL grace. Compatible coreutils is feature-detected; a finite Bash
+   watchdog covers other supported platforms and has a TERM-ignoring regression test. **Accepted** as necessary first-party metadata lookup. The
    collector pins `GH_HOST=github.com` and disables GitHub CLI prompting, update checks, extension
    update checks, spinners, color, and telemetry for every invocation. Rate cost for the aliased
    GraphQL page is documented as bounded (cost measured live at 1 per call for at least 40 aliases;

--- a/plugins/repo-fleet-hygiene/skills/audit/reference/security-review.md
+++ b/plugins/repo-fleet-hygiene/skills/audit/reference/security-review.md
@@ -61,9 +61,8 @@ confirmation or `--yes`, re-derives OIDs before every delete, and skips fail-clo
    TERM-ignoring regression test. **Accepted** as necessary first-party metadata lookup. The
    collector pins `GH_HOST=github.com` and disables GitHub CLI prompting, update checks, extension
    update checks, spinners, color, and telemetry for every invocation. Rate cost for the aliased
-   GraphQL page is documented as bounded (cost measured at 1 per call at 40 aliases, the largest
-   count measured live; at most `MERGED_PR_GRAPHQL_ALIAS_PAGE` aliases and the same number of
-   nodes per page).
+   GraphQL page is documented as bounded (cost measured live at 1 per call for at least 40 aliases;
+   at most `MERGED_PR_GRAPHQL_ALIAS_PAGE` aliases and the same number of nodes per page).
 6. **Provenance/trust:** Melodic Software authors and distributes the plugin under the repository's MIT
    license. Runtime trust is limited to locally installed Git and the official GitHub CLI; there is no
    third-party SaaS delegation beyond the repository's declared GitHub host. **Accepted.**

--- a/plugins/repo-fleet-hygiene/skills/audit/reference/security-review.md
+++ b/plugins/repo-fleet-hygiene/skills/audit/reference/security-review.md
@@ -57,11 +57,12 @@ confirmation or `--yes`, re-derives OIDs before every delete, and skips fail-clo
    content, diff, environment value, or absolute local path is sent. Non-GitHub hosts are not
    contacted, and every `gh` call has a `GH_TIMEOUT_SECONDS` deadline plus a
    `GH_KILL_AFTER_SECONDS` KILL grace. Compatible coreutils is feature-detected; a finite Bash
-   watchdog covers other supported platforms and has a TERM-ignoring regression test. **Accepted** as necessary first-party metadata lookup. The
-   collector pins `GH_HOST=github.com` and disables GitHub CLI prompting, update checks, extension
-   update checks, spinners, color, and telemetry for every invocation. Rate cost for the aliased
-   GraphQL page is documented as bounded (cost measured live at 1 per call for at least 40 aliases;
-   at most `MERGED_PR_GRAPHQL_ALIAS_PAGE` aliases and the same number of nodes per page).
+   watchdog covers other supported platforms and has a TERM-ignoring regression test. **Accepted**
+   as necessary first-party metadata lookup. The collector pins `GH_HOST=github.com` and disables
+   GitHub CLI prompting, update checks, extension update checks, spinners, color, and telemetry for
+   every invocation. Rate cost for the aliased GraphQL page is documented as bounded (cost measured
+   live at 1 per call for at least 40 aliases; at most `MERGED_PR_GRAPHQL_ALIAS_PAGE` aliases and
+   the same number of nodes per page).
 6. **Provenance/trust:** Melodic Software authors and distributes the plugin under the repository's MIT
    license. Runtime trust is limited to locally installed Git and the official GitHub CLI; there is no
    third-party SaaS delegation beyond the repository's declared GitHub host. **Accepted.**

--- a/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.sh
+++ b/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.sh
@@ -725,6 +725,14 @@ fi
 
 should_skip_dir_name() {
   local name="$1" skip
+  # This arm is defence in depth, not a live guard: no input reaching the sole caller
+  # (discover_repositories' child loop) can match it. `.` and `..` can never BE a child basename —
+  # the loop's globs are "$dir"/* (no dotfiles), "$dir"/.[!.]* and "$dir"/..?*, none of which can
+  # yield `.` or `..`. And for `.git`, the nested-repository early return fires first on the
+  # identical path and predicate, so the loop never runs for a directory holding one. The arm is
+  # kept so a future refactor of that early return cannot silently start walking `.git` internals.
+  # Its contract is asserted directly in audit-fleet.test.sh, because no discovery-level test can
+  # observe it (#2844).
   case "$name" in
   . | .. | .git) return 0 ;;
   *) ;;
@@ -1279,9 +1287,11 @@ discover_repositories() {
     # Unmatched globs leave literal patterns; skip those. Broken symlinks still match -L.
     [[ -e "$child" || -L "$child" ]] || continue
     name="$(basename "$child")"
-    # Configurable skip list (--skip / fleet.skip). . , .. , and .git are always skipped; other
-    # names come from SKIP_NAMES (defaults, or an explicit replace list). See usage() for replace
-    # semantics.
+    # Configurable skip list (--skip / fleet.skip): names come from SKIP_NAMES (defaults, or an
+    # explicit replace list). See usage() for replace semantics. should_skip_dir_name also carries
+    # an unconditional . / .. / .git arm, but no child basename reaching here can match it — see
+    # the note on that arm. It is defence in depth, not what keeps discovery out of .git internals;
+    # the nested-repository early return above does that.
     if should_skip_dir_name "$name"; then
       continue
     fi

--- a/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.test.sh
+++ b/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.test.sh
@@ -26,6 +26,11 @@ mkdir -p "$MOCK_BIN" "$TMP/config" "$TMP/discovered-a" "$TMP/canonical-a" "$TMP/
   "$TMP/prefix-fail" "$TMP/prefix-auth/.git" \
   "$TMP/bare-live/.git" "$TMP/bare-live-link" \
   "$TMP/bare-pure/objects" "$TMP/bare-pure/refs"
+# skip-root/keep/visible-repo/.git/modules/nested-decoy/.git: a repo-shaped decoy buried in a
+# discovered repository's .git tree. Two independent mechanisms keep it out of the report — the
+# nested-repository early return, and should_skip_dir_name's unconditional .git arm — so no case
+# here can isolate either one (#2844). It is not inert coverage: removing BOTH turns the skip
+# block's discovered-count assertions red, which is precisely what defence in depth buys.
 # bare-live: core.bare=true with checkout debris (and a linked worktree). Not a work tree, but an
 # administrative anomaly the collector must classify rather than reject (#2602 / #2656).
 : >"$TMP/bare-live/README"
@@ -1951,7 +1956,8 @@ else
 fi
 
 # Shrink: omit vendor from an explicit list so a repo under vendor/ is discovered.
-# .git is omitted on purpose (#2826): shrinking must not start walking .git internals.
+# The `.git` skip is NOT what this case observes — see the should_skip_dir_name contract assertion
+# below for why no discovery-level case can (#2844).
 if REPO_FLEET_TEST_FAST_TIMEOUTS=1 bash "$SCRIPT" --root "$TMP/skip-root" \
   --skip node_modules --skip .venv >"$skip_out" 2>&1; then
   if grep -Fq "Repo: $TMP/skip-root/vendor/under-vendor" "$skip_out" &&
@@ -1966,21 +1972,28 @@ else
   failures=$((failures + 1))
 fi
 
-# #2826: shrinking with --skip node_modules (omitting .git) still reaches vendor/ and
-# must not surface a decoy planted under a discovered repo's .git tree.
-if REPO_FLEET_TEST_FAST_TIMEOUTS=1 bash "$SCRIPT" --root "$TMP/skip-root" \
-  --skip node_modules >"$skip_out" 2>&1; then
-  if grep -Fq "Repo: $TMP/skip-root/vendor/under-vendor" "$skip_out" &&
-    grep -Fq "Repo: $TMP/skip-root/keep/visible-repo" "$skip_out" &&
-    ! grep -Fq "nested-decoy" "$skip_out" &&
-    grep -Fq "Repositories discovered (audit targets after deduplication): 3" "$skip_out"; then
-    printf 'PASS: --skip omitting .git still skips .git and reaches vendor/\n'
-  else
-    printf 'FAIL: --skip omitting .git still skips .git and reaches vendor/\n%s\n' "$(cat "$skip_out")" >&2
-    failures=$((failures + 1))
-  fi
+# #2826/#2844: should_skip_dir_name's unconditional .git arm, asserted as a FUNCTION CONTRACT.
+# This deliberately does NOT claim to protect discovery, and no discovery-level test can stand in
+# for it: the result is never consumed for `.git`, because the nested-repository early return fires
+# first on the identical path and predicate, so the child loop that calls this never runs for a
+# directory holding a .git marker. Driving the collector instead would be green with or without the
+# arm. Extracted the same way as the helpers above, since the function lives after the
+# source-early-return guard. SKIP_NAMES is shrunk to prove `.git` survives a replace list that
+# omits it, while node_modules/vendor prove the configurable half still decides everything else.
+skip_name_probe="$(
+  SCRIPT="$SCRIPT" bash -c '
+    eval "$(sed -n "/^should_skip_dir_name()/,/^}/p" "$SCRIPT")"
+    SKIP_NAMES=(node_modules)
+    for name in .git node_modules vendor; do
+      if should_skip_dir_name "$name"; then printf "%s-skip\n" "$name"; else printf "%s-walk\n" "$name"; fi
+    done
+  '
+)"
+if [[ "$skip_name_probe" == $'.git-skip\nnode_modules-skip\nvendor-walk' ]]; then
+  printf 'PASS: should_skip_dir_name skips .git unconditionally under a shrunk SKIP_NAMES\n'
 else
-  printf 'FAIL: --skip omitting .git unexpectedly aborted\n%s\n' "$(cat "$skip_out")" >&2
+  printf 'FAIL: should_skip_dir_name skips .git unconditionally under a shrunk SKIP_NAMES (%s)\n' \
+    "$(printf '%s' "$skip_name_probe" | tr '\n' '/')" >&2
   failures=$((failures + 1))
 fi
 

--- a/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.test.sh
+++ b/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.test.sh
@@ -30,7 +30,8 @@ mkdir -p "$MOCK_BIN" "$TMP/config" "$TMP/discovered-a" "$TMP/canonical-a" "$TMP/
 # discovered repository's .git tree. Two independent mechanisms keep it out of the report — the
 # nested-repository early return, and should_skip_dir_name's unconditional .git arm — so no case
 # here can isolate either one (#2844). It is not inert coverage: removing BOTH turns the skip
-# block's discovered-count assertions red, which is precisely what defence in depth buys.
+# block's three replace-semantics discovery cases red, which is precisely what defence in depth
+# buys.
 # bare-live: core.bare=true with checkout debris (and a linked worktree). Not a work tree, but an
 # administrative anomaly the collector must classify rather than reject (#2602 / #2656).
 : >"$TMP/bare-live/README"

--- a/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.test.sh
+++ b/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.test.sh
@@ -29,11 +29,12 @@ mkdir -p "$MOCK_BIN" "$TMP/config" "$TMP/discovered-a" "$TMP/canonical-a" "$TMP/
 # skip-root/keep/visible-repo/.git/modules/nested-decoy/.git: a repo-shaped decoy buried in a
 # discovered repository's .git tree. Two independent mechanisms keep it out of the report — the
 # nested-repository early return, and should_skip_dir_name's unconditional .git arm — so no case
-# here can isolate either one (#2844). It is not inert coverage: removing BOTH turns discovery
-# cases in the skip block red — the three replace-semantics cases when the unconditional arm and
-# the default list both drop .git, and the default-list case too when only the arm does, since the
-# shipped default (node_modules vendor .venv) carries no .git either. That is what defence in depth
-# buys.
+# here can isolate either one (#2844). It is not inert coverage — drop the early return and skip
+# cases go red, in two variants. Drop it together with .git from BOTH the unconditional arm and the
+# default list: the three replace-semantics cases go red, the default-list case still passes.
+# Drop it with .git removed from the arm ONLY: those three plus the default-list case go red, since
+# the shipped default (node_modules vendor .venv) carries no .git of its own. That is what defence
+# in depth buys.
 # bare-live: core.bare=true with checkout debris (and a linked worktree). Not a work tree, but an
 # administrative anomaly the collector must classify rather than reject (#2602 / #2656).
 : >"$TMP/bare-live/README"

--- a/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.test.sh
+++ b/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.test.sh
@@ -29,8 +29,10 @@ mkdir -p "$MOCK_BIN" "$TMP/config" "$TMP/discovered-a" "$TMP/canonical-a" "$TMP/
 # skip-root/keep/visible-repo/.git/modules/nested-decoy/.git: a repo-shaped decoy buried in a
 # discovered repository's .git tree. Two independent mechanisms keep it out of the report — the
 # nested-repository early return, and should_skip_dir_name's unconditional .git arm — so no case
-# here can isolate either one (#2844). It is not inert coverage: removing BOTH turns the skip
-# block's three replace-semantics discovery cases red, which is precisely what defence in depth
+# here can isolate either one (#2844). It is not inert coverage: removing BOTH turns discovery
+# cases in the skip block red — the three replace-semantics cases when the unconditional arm and
+# the default list both drop .git, and the default-list case too when only the arm does, since the
+# shipped default (node_modules vendor .venv) carries no .git either. That is what defence in depth
 # buys.
 # bare-live: core.bare=true with checkout debris (and a linked worktree). Not a work tree, but an
 # administrative anomaly the collector must classify rather than reject (#2602 / #2656).


### PR DESCRIPTION
## Summary

Two documentation- and test-weight defects in `repo-fleet-hygiene`. **No runtime behavior changes**; the only `audit-fleet.sh` edits are comments.

### #2844 — the `#2826` skip-block tests cannot fail

`should_skip_dir_name`'s unconditional `. | .. | .git` arm is unreachable from its only caller. The child loop's globs (`"$dir"/*`, `"$dir"/.[!.]*`, `"$dir"/..?*`) can never yield `.` or `..`; and for `.git`, the nested-repository early return (`audit-fleet.sh:1270-1276`) fires first on the identical path and predicate, so the loop never runs for a directory holding a `.git` marker. The fixture's `nested-decoy` sits under exactly such a directory, so the case added for #2826 was green by construction.

Taking the "keep the guard, give it a defence that can fail" option:

- **Replaced** the discovery-level case `--skip omitting .git still skips .git and reaches vendor/` with a direct `should_skip_dir_name` **function-contract** assertion, reusing the `eval "$(sed -n "/^fn()/,/^}/p" "$SCRIPT")"` extraction idiom the `directory_has_non_git_entries` / `record_bare_live_tree` probes already use. The new case is explicitly **not** labelled as protecting discovery, and carries a comment saying its result is never consumed for `.git` because the early return precedes it.
- **Commented** the unconditional arm and its call site: the arm is defence in depth against a future refactor of the early return, and `.` / `..` can never be a child basename given the loop's globs.
- **Documented** the `nested-decoy` fixture, which is now asserted on by no case directly. It is not inert: two independent mechanisms keep it unreported, so no case can isolate either — but removing **both** turns the block's discovered-count assertions red (proved below).

### #2845 — `security-review.md` hardcodes the `gh` timeout constants

`:58`, item 5 (Data egress), **Accepted** — five lines above the sentence #2825 fixed — said "a 30-second deadline plus a five-second KILL grace". Both values are owned by `GH_TIMEOUT_SECONDS` / `GH_KILL_AFTER_SECONDS` (`audit-fleet.sh:348-349`), named in no `.md` in the plugin. Now named. `:63`'s unqualified "measured cost 1 per call" is qualified to track `audit-fleet.sh:283` exactly — "measured live at 1 per call for **at least** 40 aliases". The `40` is a historical measurement, not a restatement of a live constant, which is the same distinction the 0.23.1 entry already draws for the "historical literals in the 2026-07-31 re-check paragraph". Took the "qualify the doc" branch, not "re-measure at 100" — re-measuring needs live GraphQL and is out of scope for a docs PR. `README.md:149` carries the same two literals and is explicitly out of scope per the issue; it remains as residual.

### Declared in-place correction to a released section (#2388 sanction)

Per `scripts/check-changelog-parity.sh`'s released-entry policy, the correcting PR must name each in-place edit to an already-released `## [<v>]` section in **both** the PR body and the new release entry. Two edits to `## [0.23.1]`, and only these:

1. Its `.git` bullet **moved from `### Fixed` to a new `### Changed` subsection** (Keep-a-Changelog order; the subsection is inserted above `### Fixed`). Nothing was broken and the behavioral delta was zero, so `### Fixed` was the wrong heading.
2. Its causal clause — "`.git` now joins `.` and `..` as an unconditional skip **so reaching a repo under `vendor/` cannot start walking `.git` internals**" — **replaced**. The asserted end state is true, but the "so" presented as newly established a guarantee the nested-repository early return already provided.

The `## [0.23.1]` heading is preserved, the #2825 bullet under it is untouched, and no other released entry is modified. `## [0.23.0]`'s six-name list is a frozen record of what 0.23.0 shipped and is deliberately left as written.

## Test plan

`audit-fleet.test.sh` does not complete under Git Bash on Windows, so the skip block was isolated: prelude = the verbatim head through the config heredoc's closing `EOF` (mocks + `skip-root` fixture + config heredocs), body = the whole skip block, all 9 cases. **Locate both by marker, not by fixed offset** — every edit to this file shifts them, and a prelude that stops one line short of the config `EOF` does not merely mis-slice, it fails to parse (`bash -n` exit 2, "unexpected end of file"). At `ec250090e` those are lines 1–680 and 1943–2096, and the slice must stay below `chmod a-rx "$unreadable_root"` (`:1906`) and `HANG_BIN` (`:1922`), the two Windows hangers. The runner must also sit beside a copy of `audit-fleet.sh`: line 5 sets `SCRIPT="$SCRIPT_DIR/audit-fleet.sh"`, so a runner placed anywhere else resolves to a missing script and every case aborts. The full suite runs in CI on Linux — that is the authoritative signal, and it logs the new assertion by name.

**Variant under test.** `origin/main` with exactly the two lines the issue documents reverted — reproduced independently at the same line numbers:

```
723c723
<   SKIP_NAMES=(node_modules vendor .venv)
---
>   SKIP_NAMES=(. .. .git node_modules vendor .venv)
729c729
<   . | .. | .git) return 0 ;;
---
>   . | ..) return 0 ;;
```

Note the probe sets `SKIP_NAMES` itself and the `sed` extraction does not pull the default assignment, so of these two lines the probe keys on the **case arm** (`:729`) alone. Both are reverted anyway, so the variant matches the issue's definition exactly.

**1. Re-established the defect on this branch's base.** Before the change, all nine cases pass byte-identically on both variants — the `--skip omitting .git` case cannot fail:

```
RUN A (shipped)                                    RUN B (reverted)
PASS: default skip list hides vendor/ ...          PASS: default skip list hides vendor/ ...
PASS: --skip replace shrink reaches ...            PASS: --skip replace shrink reaches ...
PASS: --skip omitting .git still skips .git ...    PASS: --skip omitting .git still skips .git ...
PASS: --skip replace extend skips ...              PASS: --skip replace extend skips ...
PASS: CLI --skip and fleet.skip compose ...        PASS: CLI --skip and fleet.skip compose ...
PASS: path-separator --skip hard-fails ...         PASS: path-separator --skip hard-fails ...
PASS: empty --skip hard-fails ...                  PASS: empty --skip hard-fails ...
PASS: path-separator fleet.skip hard-fails ...     PASS: path-separator fleet.skip hard-fails ...
PASS: empty fleet.skip hard-fails ...              PASS: empty fleet.skip hard-fails ...
### failures=0   MAIN_EXIT=0                       ### failures=0   REV_EXIT=0
```

**2. Discrimination proof — the same block with this PR's test applied.** Shipped stays green; reverted goes red, and the diagnostic names the input that flipped:

```
########## RUN A: shipped origin/main audit-fleet.sh ##########
PASS: should_skip_dir_name skips .git unconditionally under a shrunk SKIP_NAMES
### failures=0
MAIN_EXIT=0

########## RUN B: .git change reverted (2 lines) ##########
FAIL: should_skip_dir_name skips .git unconditionally under a shrunk SKIP_NAMES (.git-walk/node_modules-skip/vendor-walk)
### failures=1
REV_EXIT=1
```

The other eight cases are unchanged and pass in both runs. The assertion is a three-row contract, not a single-input tautology: under `SKIP_NAMES=(node_modules)`, `.git` must skip (the discriminating row), `node_modules` must skip, and `vendor` must walk — so the configurable half is still asserted to decide everything else.

**3. The `nested-decoy` fixture is not inert.** A third variant with **both** defences removed (the reverted case arm, plus the nested-repository early return no longer returning — the exact future refactor the defence-in-depth claim is about), run against **this PR's suite**, turns 4 of 9 cases red:

```
PASS: default skip list hides vendor/ and keeps third_party/ reachable
FAIL: --skip shrink unexpectedly aborted
FAIL: should_skip_dir_name skips .git unconditionally under a shrunk SKIP_NAMES (.git-walk/node_modules-skip/vendor-walk)
FAIL: --skip extend unexpectedly aborted
FAIL: CLI/config skip compose unexpectedly aborted
### failures=4
```

Neither defence alone is observable; losing both is. That is what "defence in depth" buys here, and why the fixture is kept and documented rather than deleted. Three of the four reds are the replace-semantics discovery cases — which is what the fixture's committed comment claims, and it was reworded to say exactly that after this run showed the fourth red is the unit probe rather than a count assertion.

**Other gates, run from the worktree:** `scripts/check-changelog-parity.sh --check-bump origin/main` passes (0.23.1 → 0.23.2, one bump covering both issues). `bash -n` clean on both scripts. `shellcheck -S warning` clean on the test file. `markdownlint-cli2` 0 errors on both changed `.md` files. `shfmt -d` reports only pre-existing double-blank-line hunks, none in any region this PR touches.

## Related

- #2836 — the merged PR that introduced the non-discriminating case and the `### Fixed` changelog bullet this PR corrects.
- #2825 — fixed the aliased-GraphQL literal at `security-review.md:64`; #2845 is the same defect class five lines above, in the same numbered item.
- #2826 — the issue #2836 closed, which asked for the unconditional `.git` skip.
- #2712 — introduced the configurable `--skip` / `fleet.skip` list and the nested-repository early return that makes the `.git` arm unreachable.
- #2709 — the earlier close of the same hardcoded-literal drift vector in `SKILL.md`.
- #2388 — the sanction under which this PR edits the released `## [0.23.1]` section in place.

Closes #2844
Closes #2845

