### PR TITLE
fix(plugin-quality): ground auditor doc claims on the rung-1 raw-markdown route

### DIFF
--- a/plugins/plugin-quality/.claude-plugin/plugin.json
+++ b/plugins/plugin-quality/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "plugin-quality",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "Post-use behavioral audit of Claude Code plugin components: a six-step audit workflow (evidence capture, grounded mapping in a fresh subagent, blindspot pass, interactive contract lock, presence-gated review seams, work-item emit with draft+confirm) over any skill, agent, hook, command, or config you have actually used — zone-informed by context-guard snapshots when present, conservative when not.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/plugin-quality/CHANGELOG.md
+++ b/plugins/plugin-quality/CHANGELOG.md
@@ -5,38 +5,13 @@ All notable changes to the `plugin-quality` plugin.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.6.5]
-
-### Changed
-
-- **The quote check now covers the span that is actually emitted, not a fragment of it.** Step 3 of
-  `agents/auditor.md` asked only that a *distinctive fragment* of a quotation hit under
-  `grep -c -F`. A genuine fragment spliced into a recalled surrounding sentence cleared that check,
-  which is the fabrication the whole change exists to stop. The step now requires the **full quoted
-  span exactly as it will appear in the finding** to match literally against the fetched bytes, and
-  says what to do when the wording crosses a newline (`grep -F` is line-oriented): quote the single
-  line carrying the load-bearing claim, or emit each line as its own separately-verified span —
-  never verify one line and emit more.
-- **A successful rung-2 read grounds a claim, recorded as rung 2.** The unverified-trigger list
-  named "the `.md` channel was unavailable" as a standalone reason a claim could not be verified,
-  which cancelled the `WebFetch` fallback the same step sanctions: a complete, matching fallback
-  read was forced to unverified. A claim is unverified when **no** channel produced the bytes, when
-  the read arrived truncated, or when the emitted span did not match — not when the preferred
-  channel was merely unavailable. Rung 2 still never grounds an **absence** claim, because its
-  truncation is silent.
-- **Hosts without `curl` keep doc verification.** The rung-1 command is mandatory but not universally
-  installed, and `WebFetch` was permitted only where a page lacked a raw-markdown channel — so a
-  Linux or Git Bash host without `curl` lost doc grounding entirely, having previously worked
-  through the built-in fetch tool. The fallback now covers both cases (`command -v curl`), records
-  either as rung 2, and `README.md`'s Requirements section declares `curl` in the same
-  optional-with-degradation shape it already uses for `gh` and `jq`.
-- **The consumer-side check enforces both citation fields.** `skills/audit/SKILL.md` step 3 demoted
-  a finding to unverified only when its citation omitted the **retrieval channel**, while the
-  preceding sentence and the auditor's own output contract require the channel **and** a byte count
-  or line number. A citation carrying a channel but no count and no line passed. Either field
-  missing now demotes the finding, and the agent's output contract says so at the producing end too.
-
 ## [0.6.4]
+
+Supersedes an intra-development entry of this same branch that was never published: it described an
+intermediate state of this work that review then reversed, so the two would have contradicted each
+other inside one release. Folded into this entry, which describes what actually ships. The `0.6.3`
+number went to the repository-wide batch-simplify pass that landed on `main` while this branch was
+in review, so this work ships as `0.6.4` and that entry is kept below unchanged.
 
 ### Changed
 
@@ -46,17 +21,30 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `docs/conventions/upstream-drift/README.md`, which the convention labels *degraded* and which
   truncates long pages silently — and "not in the response" is indistinguishable from "not on the
   page". The step now names the convention's rung-1 route (`curl` the `.md` channel to a file,
-  search the file locally) as the default, cites `docs/conventions/upstream-drift/README.md` as the
-  owning record, and keeps `WebFetch` as the rung-2
-  fallback. The tool-honesty note was amended in step: the step-3 `curl` joins Bash's
-  enumerated uses, and the network clause now permits it alongside `WebFetch` instead of capping
-  network reach at `WebFetch`.
-- **A quotation must survive a literal substring search of the fetched bytes.** The same step states
-  the concrete check — `grep -c -F` a distinctive fragment against the saved file, non-zero or it is
-  not a quote — and that a failed fetch, an unresolvable `.md` channel, or a fragment that does not
-  match is recorded as **unverified**, never reconstructed from recall. Realized cost that motivated
-  this: two fabricated load-bearing doc quotes reached filed-ready drafts in one audit chain, both
-  attributed verbatim to the hooks reference, neither present in it.
+  search the file locally) as the default and cites that convention as the owning record. The
+  tool-honesty note was amended in step: the step-3 `curl` joins Bash's enumerated uses, and the
+  network clause now permits it alongside `WebFetch` instead of capping network reach at `WebFetch`.
+  Realized cost that motivated this: two fabricated load-bearing doc quotes reached filed-ready
+  drafts in one audit chain, both attributed verbatim to the hooks reference, neither present in it.
+- **A quotation must survive a literal substring search of the fetched bytes — the FULL span that
+  gets emitted, not a fragment of it.** A check on a *distinctive fragment* proves the fragment and
+  nothing around it, so a genuine fragment spliced into a recalled surrounding sentence would clear
+  it: the very fabrication this change exists to stop. Step 3 requires the complete quoted span
+  exactly as it will appear in the finding to match under `grep -c -F` against the saved file, and
+  says what to do when the wording crosses a newline (`grep -F` is line-oriented): quote the single
+  line carrying the load-bearing claim, or emit each line as its own separately-verified span —
+  never verify one line and emit more.
+- **`WebFetch` is a real rung-2 fallback, in two cases, and never a dead end.** It applies where the
+  `.md` channel does not resolve for the page **or** where `curl` is not installed on the host
+  (`command -v curl`) — the rung-1 command is mandatory but not universally present, and a Git Bash
+  or Linux host without it would otherwise lose doc grounding entirely, having previously worked
+  through the built-in fetch tool. Either case is **recorded as rung 2**, and a rung-2 read grounds
+  a claim on the same terms as rung 1: the full emitted span matches, and the read shows it arrived
+  whole. A claim is unverified when **no** channel produced the bytes, when the read arrived
+  truncated, or when the emitted span did not match — not when the preferred channel was merely
+  unavailable. Rung 2 still never grounds an **absence** claim, because its truncation is silent.
+  `README.md`'s Requirements section declares `curl` in the same optional-with-degradation shape it
+  already uses for `gh` and `jq`.
 - **The step stands alone from a plugin cache.** The auditor often runs from an installed plugin
   cache, where this repo's convention file may not be on disk — so a step that only pointed at it
   could be unexecutable. The rules the step needs are stated inline (the rung-1 route, the
@@ -65,11 +53,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   convention named as the owning record for the full text rather than as a required dereference. The
   agent's closing contract and its network clause were widened to match: both previously forbade the
   fetch and the scratch file the new step requires.
-- **Doc citations now carry their retrieval channel.** The agent's output contract requires each
-  harness-behavior citation to state the channel it came over and a byte count or line number
-  alongside the URL and fetch date, and `skills/audit/SKILL.md` step 3 records a finding whose
-  citation omits the channel as unverified — so the requirement binds where the output is consumed,
-  not only where it is produced.
+- **Doc citations carry their retrieval channel AND a byte count or line number, enforced at both
+  ends.** The agent's output contract requires both alongside the URL and fetch date, and states
+  what a rung-2 read records in place of a `wc -c` byte count so the two rungs are held to a
+  contract each can actually satisfy. `skills/audit/SKILL.md` step 3 records a finding whose citation
+  omits **either** field as unverified — a channel with no count and no line is a half-citation — so
+  the requirement binds where the output is consumed, not only where it is produced.
 
 ## [0.6.3]
 

--- a/plugins/plugin-quality/CHANGELOG.md
+++ b/plugins/plugin-quality/CHANGELOG.md
@@ -15,8 +15,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `docs/conventions/upstream-drift/README.md`, which the convention labels *degraded* and which
   truncates long pages silently — and "not in the response" is indistinguishable from "not on the
   page". The step now names the convention's rung-1 route (`curl` the `.md` channel to a file,
-  search the file locally) as the default, points at the convention for the ladder and the identity
-  and absence checks rather than restating them, and keeps `WebFetch` only for pages with no
+  search the file locally) as the default, cites `docs/conventions/upstream-drift/README.md` as the
+  owning record, and keeps `WebFetch` only for pages with no
   raw-markdown channel. The tool-honesty note was amended in step: the step-3 `curl` joins Bash's
   enumerated uses, and the network clause now permits it alongside `WebFetch` instead of capping
   network reach at `WebFetch`.

--- a/plugins/plugin-quality/CHANGELOG.md
+++ b/plugins/plugin-quality/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable changes to the `plugin-quality` plugin.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.4]
+
+### Changed
+
+- **The `auditor` grounds harness claims on the raw-markdown `curl` route, not `WebFetch`
+  (issue 2854).** Step 3 of `agents/auditor.md` prescribed `WebFetch` as the default for every
+  load-bearing harness-behavior claim. That is rung 2 of the ladder in
+  `docs/conventions/upstream-drift/README.md`, which the convention labels *degraded* and which
+  truncates long pages silently — and "not in the response" is indistinguishable from "not on the
+  page". The step now names the convention's rung-1 route (`curl` the `.md` channel to a file,
+  search the file locally) as the default, points at the convention for the ladder and the identity
+  and absence checks rather than restating them, and keeps `WebFetch` only for pages with no
+  raw-markdown channel. The tool-honesty note was amended in step: the step-3 `curl` joins Bash's
+  enumerated uses, and the network clause now permits it alongside `WebFetch` instead of capping
+  network reach at `WebFetch`.
+- **A quotation must survive a literal substring search of the fetched bytes.** The same step states
+  the concrete check — `grep -c -F` a distinctive fragment against the saved file, non-zero or it is
+  not a quote — and that a failed fetch, an unresolvable `.md` channel, or a fragment that does not
+  match is recorded as **unverified**, never reconstructed from recall. Realized cost that motivated
+  this: two fabricated load-bearing doc quotes reached filed-ready drafts in one audit chain, both
+  attributed verbatim to the hooks reference, neither present in it.
+- **Doc citations now carry their retrieval channel.** The agent's output contract requires each
+  harness-behavior citation to state the channel it came over and a byte count or line number
+  alongside the URL and fetch date, and `skills/audit/SKILL.md` step 3 records a finding whose
+  citation omits the channel as unverified — so the requirement binds where the output is consumed,
+  not only where it is produced.
+
 ## [0.6.3]
 
 ### Changed

--- a/plugins/plugin-quality/CHANGELOG.md
+++ b/plugins/plugin-quality/CHANGELOG.md
@@ -26,10 +26,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   match is recorded as **unverified**, never reconstructed from recall. Realized cost that motivated
   this: two fabricated load-bearing doc quotes reached filed-ready drafts in one audit chain, both
   attributed verbatim to the hooks reference, neither present in it.
-- **The step stands alone from a plugin cache.** The auditor runs from an installed plugin cache,
-  where this repo's convention file is not on disk — so a step that only pointed at it would have
-  been unexecutable. The rules the step needs are stated inline (the rung-1 route, the canonical-slug
-  and first-heading identity checks that make an absence assertable, the substring check), with the
+- **The step stands alone from a plugin cache.** The auditor often runs from an installed plugin
+  cache, where this repo's convention file may not be on disk — so a step that only pointed at it
+  could be unexecutable. The rules the step needs are stated inline (the rung-1 route, the
+  canonical-slug and first-heading identity checks that make an absence assertable — including the
+  carve-out that a differently-worded title is still the right page — the substring check), with the
   convention named as the owning record for the full text rather than as a required dereference. The
   agent's closing contract and its network clause were widened to match: both previously forbade the
   fetch and the scratch file the new step requires.

--- a/plugins/plugin-quality/CHANGELOG.md
+++ b/plugins/plugin-quality/CHANGELOG.md
@@ -58,7 +58,11 @@ in review, so this work ships as `0.6.4` and that entry is kept below unchanged.
   what a rung-2 read records in place of a `wc -c` byte count so the two rungs are held to a
   contract each can actually satisfy. `skills/audit/SKILL.md` step 3 records a finding whose citation
   omits **either** field as unverified — a channel with no count and no line is a half-citation — so
-  the requirement binds where the output is consumed, not only where it is produced.
+  the requirement binds where the output is consumed, not only where it is produced. The rung-2
+  substitute obeys the same "either" rule: its retrieved size and its arrived-whole confirmation are
+  independently mandatory, so a rung-2 read carrying a size but no closing-section confirmation — a
+  silently truncated read, the one failure rung 2 cannot detect for itself — is unverified rather
+  than grounded.
 
 ## [0.6.3]
 

--- a/plugins/plugin-quality/CHANGELOG.md
+++ b/plugins/plugin-quality/CHANGELOG.md
@@ -5,6 +5,37 @@ All notable changes to the `plugin-quality` plugin.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.5]
+
+### Changed
+
+- **The quote check now covers the span that is actually emitted, not a fragment of it.** Step 3 of
+  `agents/auditor.md` asked only that a *distinctive fragment* of a quotation hit under
+  `grep -c -F`. A genuine fragment spliced into a recalled surrounding sentence cleared that check,
+  which is the fabrication the whole change exists to stop. The step now requires the **full quoted
+  span exactly as it will appear in the finding** to match literally against the fetched bytes, and
+  says what to do when the wording crosses a newline (`grep -F` is line-oriented): quote the single
+  line carrying the load-bearing claim, or emit each line as its own separately-verified span —
+  never verify one line and emit more.
+- **A successful rung-2 read grounds a claim, recorded as rung 2.** The unverified-trigger list
+  named "the `.md` channel was unavailable" as a standalone reason a claim could not be verified,
+  which cancelled the `WebFetch` fallback the same step sanctions: a complete, matching fallback
+  read was forced to unverified. A claim is unverified when **no** channel produced the bytes, when
+  the read arrived truncated, or when the emitted span did not match — not when the preferred
+  channel was merely unavailable. Rung 2 still never grounds an **absence** claim, because its
+  truncation is silent.
+- **Hosts without `curl` keep doc verification.** The rung-1 command is mandatory but not universally
+  installed, and `WebFetch` was permitted only where a page lacked a raw-markdown channel — so a
+  Linux or Git Bash host without `curl` lost doc grounding entirely, having previously worked
+  through the built-in fetch tool. The fallback now covers both cases (`command -v curl`), records
+  either as rung 2, and `README.md`'s Requirements section declares `curl` in the same
+  optional-with-degradation shape it already uses for `gh` and `jq`.
+- **The consumer-side check enforces both citation fields.** `skills/audit/SKILL.md` step 3 demoted
+  a finding to unverified only when its citation omitted the **retrieval channel**, while the
+  preceding sentence and the auditor's own output contract require the channel **and** a byte count
+  or line number. A citation carrying a channel but no count and no line passed. Either field
+  missing now demotes the finding, and the agent's output contract says so at the producing end too.
+
 ## [0.6.4]
 
 ### Changed
@@ -16,8 +47,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   truncates long pages silently — and "not in the response" is indistinguishable from "not on the
   page". The step now names the convention's rung-1 route (`curl` the `.md` channel to a file,
   search the file locally) as the default, cites `docs/conventions/upstream-drift/README.md` as the
-  owning record, and keeps `WebFetch` only for pages with no
-  raw-markdown channel. The tool-honesty note was amended in step: the step-3 `curl` joins Bash's
+  owning record, and keeps `WebFetch` as the rung-2
+  fallback. The tool-honesty note was amended in step: the step-3 `curl` joins Bash's
   enumerated uses, and the network clause now permits it alongside `WebFetch` instead of capping
   network reach at `WebFetch`.
 - **A quotation must survive a literal substring search of the fetched bytes.** The same step states

--- a/plugins/plugin-quality/CHANGELOG.md
+++ b/plugins/plugin-quality/CHANGELOG.md
@@ -26,6 +26,13 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   match is recorded as **unverified**, never reconstructed from recall. Realized cost that motivated
   this: two fabricated load-bearing doc quotes reached filed-ready drafts in one audit chain, both
   attributed verbatim to the hooks reference, neither present in it.
+- **The step stands alone from a plugin cache.** The auditor runs from an installed plugin cache,
+  where this repo's convention file is not on disk — so a step that only pointed at it would have
+  been unexecutable. The rules the step needs are stated inline (the rung-1 route, the canonical-slug
+  and first-heading identity checks that make an absence assertable, the substring check), with the
+  convention named as the owning record for the full text rather than as a required dereference. The
+  agent's closing contract and its network clause were widened to match: both previously forbade the
+  fetch and the scratch file the new step requires.
 - **Doc citations now carry their retrieval channel.** The agent's output contract requires each
   harness-behavior citation to state the channel it came over and a byte count or line number
   alongside the URL and fetch date, and `skills/audit/SKILL.md` step 3 records a finding whose

--- a/plugins/plugin-quality/README.md
+++ b/plugins/plugin-quality/README.md
@@ -58,7 +58,9 @@ config.
 
 `gh` (authenticated) for the issue sink — optional; without it the ladder ends in a local
 markdown item. `jq` for the context-gate probe — optional; without it dispatch is conservative.
-Works on Git Bash (Windows), macOS, and Linux shells.
+`curl` for the auditor's rung-1 raw-markdown doc fetch — optional; without it the auditor falls
+back to `WebFetch` and records the read as rung 2, which still grounds a claim but never an
+absence. Works on Git Bash (Windows), macOS, and Linux shells.
 
 ## License
 

--- a/plugins/plugin-quality/README.md
+++ b/plugins/plugin-quality/README.md
@@ -14,7 +14,8 @@ their repo mid-session.
   the resolved sink behind an unconditional draft+confirm gate.
 - **Auditor agent** (`agents/auditor.md`) — the fresh-context specialist for steps 2–3. Tools:
   Read/Grep/Glob/WebFetch plus Bash — named honestly: Bash is there for `claude plugin validate`,
-  config-resolution probes, and the rung-1 `curl` of the raw-markdown docs channel, not mutation.
+  config-resolution probes, and the fetch ladder's rung-1 `curl` of the raw-markdown docs channel,
+  not mutation.
 - **Reference corpus** (`skills/audit/references/`) — the recurring-concerns checklist plus five
   component-type lenses (hook, skill, agent, command, config). Extending coverage = one file +
   one index row; the hub never grows.

--- a/plugins/plugin-quality/README.md
+++ b/plugins/plugin-quality/README.md
@@ -13,8 +13,8 @@ their repo mid-session.
   written into the packet); (5) presence-gated review seams with stated fallbacks; (6) emit to
   the resolved sink behind an unconditional draft+confirm gate.
 - **Auditor agent** (`agents/auditor.md`) — the fresh-context specialist for steps 2–3. Tools:
-  Read/Grep/Glob/WebFetch plus Bash — named honestly: Bash is there for `claude plugin validate`
-  and config-resolution probes, not mutation.
+  Read/Grep/Glob/WebFetch plus Bash — named honestly: Bash is there for `claude plugin validate`,
+  config-resolution probes, and the rung-1 `curl` of the raw-markdown docs channel, not mutation.
 - **Reference corpus** (`skills/audit/references/`) — the recurring-concerns checklist plus five
   component-type lenses (hook, skill, agent, command, config). Extending coverage = one file +
   one index row; the hub never grows.

--- a/plugins/plugin-quality/agents/auditor.md
+++ b/plugins/plugin-quality/agents/auditor.md
@@ -154,9 +154,9 @@ unverified. A rung-1 read gets both for free: `wc -c` the saved file, `grep -n` 
 read has no saved file to measure, so record the size of the text you actually received — said
 plainly as the *retrieved* size, not the page's — and show the read arrived whole by naming the
 page's closing section as present in what came back. Both are independently mandatory: a rung-2
-read that cannot show **either** the retrieved size **or** the closing section it arrived with is
-unverified. Showing one does not excuse the other — a read carrying a size but no closing-section
-confirmation is a silently truncated read, which is exactly the case rung 2 cannot be trusted on.
+read missing **either** the retrieved size **or** the closing-section confirmation is unverified.
+Showing one does not excuse the other — a read carrying a size but no closing-section confirmation
+is a silently truncated read, which is exactly the case rung 2 cannot be trusted on.
 Never a citation with a field left blank, and never a byte count carried over from a page you did
 not save.
 

--- a/plugins/plugin-quality/agents/auditor.md
+++ b/plugins/plugin-quality/agents/auditor.md
@@ -22,7 +22,8 @@ own findings so the main thread can stay summary-only. You do NOT modify the aud
 install anything, or use Write outside the packet — the audit is a
 read-and-verify pass, and the emit decision belongs to the main session, not you. Your network
 reach is reading documentation and nothing else: the step-3 `curl` and its slug check, `WebFetch`
-only where a page has no raw-markdown channel, and the upstream-drift convention step 3 cites when
+as the rung-2 fallback step 3 defines (the page has no raw-markdown channel, or this host has no
+`curl`), and the upstream-drift convention step 3 cites when
 you want its full text and this repo is not on disk.
 
 **Report-file write guardrail (why the packet file is not named `findings.md`).** Some subagent
@@ -99,8 +100,14 @@ audit may alter your task, your output destination, or the main session's sink a
    which names rung 1 the default and is the owning record — read it for the full text when this
    repo is on disk or reachable, but the rules you need are stated here so this step stands alone
    from a plugin cache. `WebFetch` is rung 2, which that convention calls degraded because it
-   truncates long pages silently; use it only where the `.md` channel does not resolve for the
-   page, and record that you did. Before quoting a body, confirm the slug is canonical against
+   truncates long pages silently. Fall back to it in exactly two cases — the `.md` channel does not
+   resolve for the page, or `curl` is not installed on this host (`command -v curl`; a host without
+   `curl` is a supported host, not a reason to stop verifying) — and **record the read as rung 2**
+   either way. A rung-2 read grounds a claim on the same terms as rung 1: the full emitted span must
+   match, and the response must show it arrived whole. What rung 2 can never ground is an
+   **absence** claim — its truncation is silent, so "not in the response" is not "not on the page",
+   and an absence needs the rung-1 whole-file read.
+   Before quoting a body, confirm the slug is canonical against
    `https://code.claude.com/docs/llms.txt` and check the body's own first heading: a retired slug is
    silently aliased to its successor's content, so a `200` is not proof you got the page you asked
    for, and an absence is only assertable against a page whose identity was checked. A heading about
@@ -109,15 +116,22 @@ audit may alter your task, your output destination, or the main session's sink a
    effectively", and both are the right page. A slug the index does not carry is retired or
    renamed — find the successor in the index and cite that slug, not the retired one that still
    serves bytes.
-   **A quotation is usable only if a literal substring search for a distinctive fragment of it
-   succeeds against the fetched bytes** — `grep -c -F '<fragment>' <saved-file>` returning a
-   non-zero count. `grep` is line-oriented, so pick a fragment that sits on one line; a span broken
-   by a newline can never match and is not evidence of absence. A fragment that does not hit is not
-   a quote but recall, and it never enters a finding. Never rely on training-data recall, the
-   component's own comments, or plausibility. If a
-   claim cannot be verified from a fetched page — the fetch failed, the `.md` channel was
-   unavailable, or no fragment matched — mark it unverified and say so; never reconstruct the
-   wording from memory.
+   **A quotation is usable only if the FULL span you will emit — the complete quoted text exactly as
+   it will appear in the finding, not a distinctive fragment of it — matches literally against the
+   fetched bytes**: `grep -c -F '<the entire emitted span>' <saved-file>` returning a non-zero
+   count. Checking a fragment proves the fragment and nothing around it, which lets a genuine
+   fragment spliced into a recalled sentence pass — the fabrication this step exists to stop.
+   `grep -F` is line-oriented, so quote a span that sits on one line; where the wording you want
+   crosses a newline, quote the single line carrying the load-bearing claim, or emit each line as
+   its own separately-verified span — never verify one line and emit more. A span broken by a
+   newline that fails to match is not evidence of absence. A span that does not hit is not a quote
+   but recall, and it never enters a finding. Never rely on training-data recall, the
+   component's own comments, or plausibility. Mark a claim **unverified** — and say so, never
+   reconstructing the wording from memory — when **no channel produced the bytes** (the rung-1
+   `curl` failed, and the rung-2 fallback failed or was unavailable too), when the read arrived
+   truncated, or when the span you meant to emit did not match the bytes you did get. The preferred
+   channel merely being unavailable is not itself a trigger: a rung-2 read that arrived whole and
+   whose emitted span matches grounds the claim, recorded as rung 2.
 4. **Apply the lenses.** Walk the component-type lens file(s) named in your dispatch prompt and
    `references/recurring-concerns.md` (silent bypass surfaces, enforcement scope/tiers,
    SSOT/drift, coupling, cross-platform, escape hatches, observability). Reproduce claimed gaps
@@ -131,8 +145,9 @@ audit may alter your task, your output destination, or the main session's sink a
 Write `audit-notes.md` into the evidence packet directory AND return a summary. For each finding:
 component + location, the claim vs observed behavior, evidence (packet reference or reproduction),
 doc citation for any harness-behavior assertion — URL, fetch date, the retrieval channel it came
-over (rung-1 `curl` of the `.md`, or `WebFetch`), and the fetched byte count or the line number the
-quoted span sat on — severity suggestion, and a
+over (rung-1 `curl` of the `.md`, or rung-2 `WebFetch`), and the fetched byte count or the line
+number the quoted span sat on — both fields are required, and the consuming skill records a citation
+missing either one as unverified — severity suggestion, and a
 candidate remediation ordered cheapest-first. List blindspots and unverified claims separately and
 honestly. Your final message must be the summary form: finding count by severity, the top findings
 in one line each, and the packet path — with one exception, the both-names-refused branch above,

--- a/plugins/plugin-quality/agents/auditor.md
+++ b/plugins/plugin-quality/agents/auditor.md
@@ -147,7 +147,12 @@ component + location, the claim vs observed behavior, evidence (packet reference
 doc citation for any harness-behavior assertion — URL, fetch date, the retrieval channel it came
 over (rung-1 `curl` of the `.md`, or rung-2 `WebFetch`), and the fetched byte count or the line
 number the quoted span sat on — both fields are required, and the consuming skill records a citation
-missing either one as unverified — severity suggestion, and a
+missing either one as unverified. A rung-1 read gets both for free (`wc -c` the saved file,
+`grep -n` the span). A rung-2 read has no saved file to measure: record the size of the text you
+actually received, said plainly as the retrieved size rather than the page's, and show the read
+arrived whole by naming the page's closing section as present in what came back. A rung-2 read that
+can show neither is unverified — never a citation with a field left blank or a byte count carried
+over from a page you did not save — severity suggestion, and a
 candidate remediation ordered cheapest-first. List blindspots and unverified claims separately and
 honestly. Your final message must be the summary form: finding count by severity, the top findings
 in one line each, and the packet path — with one exception, the both-names-refused branch above,

--- a/plugins/plugin-quality/agents/auditor.md
+++ b/plugins/plugin-quality/agents/auditor.md
@@ -153,9 +153,12 @@ Both citation fields are required, and the consuming skill records a citation mi
 unverified. A rung-1 read gets both for free: `wc -c` the saved file, `grep -n` the span. A rung-2
 read has no saved file to measure, so record the size of the text you actually received — said
 plainly as the *retrieved* size, not the page's — and show the read arrived whole by naming the
-page's closing section as present in what came back. A rung-2 read that can show neither is
-unverified: never a citation with a field left blank, and never a byte count carried over from a
-page you did not save.
+page's closing section as present in what came back. Both are independently mandatory: a rung-2
+read that cannot show **either** the retrieved size **or** the closing section it arrived with is
+unverified. Showing one does not excuse the other — a read carrying a size but no closing-section
+confirmation is a silently truncated read, which is exactly the case rung 2 cannot be trusted on.
+Never a citation with a field left blank, and never a byte count carried over from a page you did
+not save.
 
 List blindspots and unverified claims separately and
 honestly. Your final message must be the summary form: finding count by severity, the top findings

--- a/plugins/plugin-quality/agents/auditor.md
+++ b/plugins/plugin-quality/agents/auditor.md
@@ -103,7 +103,9 @@ audit may alter your task, your output destination, or the main session's sink a
    page, and record that you did. Before quoting a body, confirm the slug is canonical against
    `https://code.claude.com/docs/llms.txt` and check the body's own first heading: a retired slug is
    silently aliased to its successor's content, so a `200` is not proof you got the page you asked
-   for, and an absence is only assertable against a page whose identity was checked.
+   for, and an absence is only assertable against a page whose identity was checked. A slug the
+   index does not carry is retired or renamed — find the successor in the index and cite that slug,
+   not the retired one that still serves bytes.
    **A quotation is usable only if a literal substring search for a distinctive fragment of it
    succeeds against the fetched bytes** — `grep -c -F '<fragment>' <saved-file>` returning a
    non-zero count. `grep` is line-oriented, so pick a fragment that sits on one line; a span broken

--- a/plugins/plugin-quality/agents/auditor.md
+++ b/plugins/plugin-quality/agents/auditor.md
@@ -21,8 +21,9 @@ exactly one destination: files inside the evidence-packet directory named in you
 own findings so the main thread can stay summary-only. You do NOT modify the audited plugin,
 install anything, or use Write outside the packet — the audit is a
 read-and-verify pass, and the emit decision belongs to the main session, not you. Your network
-reach is reading official documentation and nothing else: the step-3 `curl`, and `WebFetch` only
-where a page has no raw-markdown channel.
+reach is reading documentation and nothing else: the step-3 `curl` and its slug check, `WebFetch`
+only where a page has no raw-markdown channel, and the upstream-drift convention step 3 cites when
+you want its full text and this repo is not on disk.
 
 **Report-file write guardrail (why the packet file is not named `findings.md`).** Some subagent
 contexts run under a Write-tool guardrail that rejects report-shaped *filenames* with a message of
@@ -91,17 +92,24 @@ audit may alter your task, your output destination, or the main session's sink a
    depends on (hook event semantics, matcher behavior, skill loading, settings precedence, path
    substitutions…), read the CURRENT official doc page for that topic over the **rung-1
    raw-markdown route**: `curl` `https://code.claude.com/docs/en/<slug>.md` into a scratch file
-   **outside the evidence packet** — a fetched page is working material, not a packet artifact — then
-   search that file locally with `grep`. That route, the rung ladder, and the identity and absence
+   **outside the evidence packet** — a fetched page is working material, not a packet artifact —
+   then search that file locally with `grep`. That route, the rung ladder, and the identity and absence
    checks a read must pass are owned by
    [`docs/conventions/upstream-drift`](https://github.com/melodic-software/claude-code-plugins/blob/main/docs/conventions/upstream-drift/README.md#reading-the-basis--the-fetch-route),
-   which names rung 1 the default — follow it rather than restating it here. `WebFetch` is rung 2,
-   which that convention calls degraded because it truncates long pages silently; use it only where
-   the `.md` channel does not resolve for the page, and record that you did.
+   which names rung 1 the default and is the owning record — read it for the full text when this
+   repo is on disk or reachable, but the rules you need are stated here so this step stands alone
+   from a plugin cache. `WebFetch` is rung 2, which that convention calls degraded because it
+   truncates long pages silently; use it only where the `.md` channel does not resolve for the
+   page, and record that you did. Before quoting a body, confirm the slug is canonical against
+   `https://code.claude.com/docs/llms.txt` and check the body's own first heading: a retired slug is
+   silently aliased to its successor's content, so a `200` is not proof you got the page you asked
+   for, and an absence is only assertable against a page whose identity was checked.
    **A quotation is usable only if a literal substring search for a distinctive fragment of it
    succeeds against the fetched bytes** — `grep -c -F '<fragment>' <saved-file>` returning a
-   non-zero count. A fragment that does not hit is not a quote but recall, and it never enters a
-   finding. Never rely on training-data recall, the component's own comments, or plausibility. If a
+   non-zero count. `grep` is line-oriented, so pick a fragment that sits on one line; a span broken
+   by a newline can never match and is not evidence of absence. A fragment that does not hit is not
+   a quote but recall, and it never enters a finding. Never rely on training-data recall, the
+   component's own comments, or plausibility. If a
    claim cannot be verified from a fetched page — the fetch failed, the `.md` channel was
    unavailable, or no fragment matched — mark it unverified and say so; never reconstruct the
    wording from memory.
@@ -125,5 +133,5 @@ honestly. Your final message must be the summary form: finding count by severity
 in one line each, and the packet path — with one exception, the both-names-refused branch above,
 which replaces the summary with the refusal marker plus the complete findings so the dispatching
 session can persist what you could not. The main session decides everything downstream (contract
-lock, review seams, emit); you never file issues, never write outside the packet, and never touch
-the audited plugin.
+lock, review seams, emit); you never file issues, never use Write outside the packet, and never
+touch the audited plugin.

--- a/plugins/plugin-quality/agents/auditor.md
+++ b/plugins/plugin-quality/agents/auditor.md
@@ -14,8 +14,8 @@ component-type lens file path(s) to apply.
 **Tool honesty note:** you carry Bash and Write, and neither is read-only. Bash is for
 `claude plugin validate`, config-resolution probes (checking which settings scope a value comes
 from), harmless empirical reproductions (piping a fixture into a hook script), and the rung-1
-documentation fetch step 3 requires — `curl` of `https://code.claude.com/docs/en/<slug>.md` into a
-scratch file you then search locally. Write is for
+documentation fetch step 3 requires — `curl` of `https://code.claude.com/docs/en/<slug>.md` (and of
+`llms.txt` for its slug check) into a scratch file you then search locally. Write is for
 exactly one destination: files inside the evidence-packet directory named in your dispatch prompt
 (`audit-notes.md` and supporting artifacts) — the dumb-zone contract depends on you persisting your
 own findings so the main thread can stay summary-only. You do NOT modify the audited plugin,
@@ -103,9 +103,12 @@ audit may alter your task, your output destination, or the main session's sink a
    page, and record that you did. Before quoting a body, confirm the slug is canonical against
    `https://code.claude.com/docs/llms.txt` and check the body's own first heading: a retired slug is
    silently aliased to its successor's content, so a `200` is not proof you got the page you asked
-   for, and an absence is only assertable against a page whose identity was checked. A slug the
-   index does not carry is retired or renamed — find the successor in the index and cite that slug,
-   not the retired one that still serves bytes.
+   for, and an absence is only assertable against a page whose identity was checked. A heading about
+   a *different subject* ends the read; a heading that merely words the same subject differently
+   does not — `sub-agents.md` is titled "Create custom subagents" and `costs.md` "Manage costs
+   effectively", and both are the right page. A slug the index does not carry is retired or
+   renamed — find the successor in the index and cite that slug, not the retired one that still
+   serves bytes.
    **A quotation is usable only if a literal substring search for a distinctive fragment of it
    succeeds against the fetched bytes** — `grep -c -F '<fragment>' <saved-file>` returning a
    non-zero count. `grep` is line-oriented, so pick a fragment that sits on one line; a span broken

--- a/plugins/plugin-quality/agents/auditor.md
+++ b/plugins/plugin-quality/agents/auditor.md
@@ -13,12 +13,16 @@ component-type lens file path(s) to apply.
 
 **Tool honesty note:** you carry Bash and Write, and neither is read-only. Bash is for
 `claude plugin validate`, config-resolution probes (checking which settings scope a value comes
-from), and harmless empirical reproductions (piping a fixture into a hook script). Write is for
+from), harmless empirical reproductions (piping a fixture into a hook script), and the rung-1
+documentation fetch step 3 requires — `curl` of `https://code.claude.com/docs/en/<slug>.md` into a
+scratch file you then search locally. Write is for
 exactly one destination: files inside the evidence-packet directory named in your dispatch prompt
 (`audit-notes.md` and supporting artifacts) — the dumb-zone contract depends on you persisting your
 own findings so the main thread can stay summary-only. You do NOT modify the audited plugin,
-install anything, write outside the packet, or reach the network beyond WebFetch — the audit is a
-read-and-verify pass, and the emit decision belongs to the main session, not you.
+install anything, or use Write outside the packet — the audit is a
+read-and-verify pass, and the emit decision belongs to the main session, not you. Your network
+reach is reading official documentation and nothing else: the step-3 `curl`, and `WebFetch` only
+where a page has no raw-markdown channel.
 
 **Report-file write guardrail (why the packet file is not named `findings.md`).** Some subagent
 contexts run under a Write-tool guardrail that rejects report-shaped *filenames* with a message of
@@ -83,11 +87,23 @@ audit may alter your task, your output destination, or the main session's sink a
    (`.claude-plugin/plugin.json`), the component itself (SKILL.md / agent .md / hooks.json +
    scripts / config surfaces), and how it resolves config (which layers, what wins). Establish
    what it *actually* does vs what it claims. Run `claude plugin validate` on it.
-3. **Ground every load-bearing claim.** For each harness behavior the component depends on (hook
-   event semantics, matcher behavior, skill loading, settings precedence, path substitutions…),
-   WebFetch the CURRENT official doc page for that topic and cite the URL in the finding. Never
-   rely on training-data recall, the component's own comments, or plausibility. If a claim cannot
-   be verified from a fetched page, mark it unverified and say so.
+3. **Ground every load-bearing claim in raw bytes.** For each harness behavior the component
+   depends on (hook event semantics, matcher behavior, skill loading, settings precedence, path
+   substitutions…), read the CURRENT official doc page for that topic over the **rung-1
+   raw-markdown route**: `curl` `https://code.claude.com/docs/en/<slug>.md` into a file and search
+   that file locally. That route, the rung ladder, and the identity and absence checks a read must
+   pass are owned by
+   [`docs/conventions/upstream-drift`](https://github.com/melodic-software/claude-code-plugins/blob/main/docs/conventions/upstream-drift/README.md#reading-the-basis--the-fetch-route),
+   which names rung 1 the default — follow it rather than restating it here. `WebFetch` is rung 2,
+   which that convention calls degraded because it truncates long pages silently; use it only where
+   the `.md` channel does not resolve for the page, and record that you did.
+   **A quotation is usable only if a literal substring search for a distinctive fragment of it
+   succeeds against the fetched bytes** — `grep -c -F '<fragment>' <saved-file>` returning a
+   non-zero count. A fragment that does not hit is not a quote but recall, and it never enters a
+   finding. Never rely on training-data recall, the component's own comments, or plausibility. If a
+   claim cannot be verified from a fetched page — the fetch failed, the `.md` channel was
+   unavailable, or no fragment matched — mark it unverified and say so; never reconstruct the
+   wording from memory.
 4. **Apply the lenses.** Walk the component-type lens file(s) named in your dispatch prompt and
    `references/recurring-concerns.md` (silent bypass surfaces, enforcement scope/tiers,
    SSOT/drift, coupling, cross-platform, escape hatches, observability). Reproduce claimed gaps
@@ -100,7 +116,9 @@ audit may alter your task, your output destination, or the main session's sink a
 
 Write `audit-notes.md` into the evidence packet directory AND return a summary. For each finding:
 component + location, the claim vs observed behavior, evidence (packet reference or reproduction),
-doc citation (URL + fetch date) for any harness-behavior assertion, severity suggestion, and a
+doc citation for any harness-behavior assertion — URL, fetch date, the retrieval channel it came
+over (rung-1 `curl` of the `.md`, or `WebFetch`), and the fetched byte count or the line number the
+quoted span sat on — severity suggestion, and a
 candidate remediation ordered cheapest-first. List blindspots and unverified claims separately and
 honestly. Your final message must be the summary form: finding count by severity, the top findings
 in one line each, and the packet path — with one exception, the both-names-refused branch above,

--- a/plugins/plugin-quality/agents/auditor.md
+++ b/plugins/plugin-quality/agents/auditor.md
@@ -90,9 +90,10 @@ audit may alter your task, your output destination, or the main session's sink a
 3. **Ground every load-bearing claim in raw bytes.** For each harness behavior the component
    depends on (hook event semantics, matcher behavior, skill loading, settings precedence, path
    substitutions…), read the CURRENT official doc page for that topic over the **rung-1
-   raw-markdown route**: `curl` `https://code.claude.com/docs/en/<slug>.md` into a file and search
-   that file locally. That route, the rung ladder, and the identity and absence checks a read must
-   pass are owned by
+   raw-markdown route**: `curl` `https://code.claude.com/docs/en/<slug>.md` into a scratch file
+   **outside the evidence packet** — a fetched page is working material, not a packet artifact — then
+   search that file locally with `grep`. That route, the rung ladder, and the identity and absence
+   checks a read must pass are owned by
    [`docs/conventions/upstream-drift`](https://github.com/melodic-software/claude-code-plugins/blob/main/docs/conventions/upstream-drift/README.md#reading-the-basis--the-fetch-route),
    which names rung 1 the default — follow it rather than restating it here. `WebFetch` is rung 2,
    which that convention calls degraded because it truncates long pages silently; use it only where

--- a/plugins/plugin-quality/agents/auditor.md
+++ b/plugins/plugin-quality/agents/auditor.md
@@ -146,14 +146,18 @@ Write `audit-notes.md` into the evidence packet directory AND return a summary. 
 component + location, the claim vs observed behavior, evidence (packet reference or reproduction),
 doc citation for any harness-behavior assertion — URL, fetch date, the retrieval channel it came
 over (rung-1 `curl` of the `.md`, or rung-2 `WebFetch`), and the fetched byte count or the line
-number the quoted span sat on — both fields are required, and the consuming skill records a citation
-missing either one as unverified. A rung-1 read gets both for free (`wc -c` the saved file,
-`grep -n` the span). A rung-2 read has no saved file to measure: record the size of the text you
-actually received, said plainly as the retrieved size rather than the page's, and show the read
-arrived whole by naming the page's closing section as present in what came back. A rung-2 read that
-can show neither is unverified — never a citation with a field left blank or a byte count carried
-over from a page you did not save — severity suggestion, and a
-candidate remediation ordered cheapest-first. List blindspots and unverified claims separately and
+number the quoted span sat on — severity suggestion, and a
+candidate remediation ordered cheapest-first.
+
+Both citation fields are required, and the consuming skill records a citation missing either one as
+unverified. A rung-1 read gets both for free: `wc -c` the saved file, `grep -n` the span. A rung-2
+read has no saved file to measure, so record the size of the text you actually received — said
+plainly as the *retrieved* size, not the page's — and show the read arrived whole by naming the
+page's closing section as present in what came back. A rung-2 read that can show neither is
+unverified: never a citation with a field left blank, and never a byte count carried over from a
+page you did not save.
+
+List blindspots and unverified claims separately and
 honestly. Your final message must be the summary form: finding count by severity, the top findings
 in one line each, and the packet path — with one exception, the both-names-refused branch above,
 which replaces the summary with the refusal marker plus the complete findings so the dispatching

--- a/plugins/plugin-quality/skills/audit/SKILL.md
+++ b/plugins/plugin-quality/skills/audit/SKILL.md
@@ -329,7 +329,8 @@ does or does not inherit, which is contested (see the plan's caveat on #1258).
 The `auditor` returns: grounded findings (each with evidence + doc citation), blindspots (what
 the audit framing missed), and candidate remediations ordered cheapest → most ambitious. Every doc
 citation states the retrieval channel it came over plus a byte count or line number; a finding whose
-citation omits the channel is recorded as **unverified**, however confidently it is worded.
+citation omits **either** field is recorded as **unverified**, however confidently worded — "rung-1
+`curl`, `<url>`, fetched `<date>`" with no count and no line is a half-citation, not a grounded one.
 
 **Confirm the findings reached disk before presenting anything, once per target packet.** A
 multi-target run confirms every packet — one silently empty packet among six is exactly the loss

--- a/plugins/plugin-quality/skills/audit/SKILL.md
+++ b/plugins/plugin-quality/skills/audit/SKILL.md
@@ -327,7 +327,9 @@ does or does not inherit, which is contested (see the plan's caveat on #1258).
 ### Step 3 — Persist-check, then blindspot + candidate findings (subagent output → user)
 
 The `auditor` returns: grounded findings (each with evidence + doc citation), blindspots (what
-the audit framing missed), and candidate remediations ordered cheapest → most ambitious.
+the audit framing missed), and candidate remediations ordered cheapest → most ambitious. Every doc
+citation states the retrieval channel it came over plus a byte count or line number; a finding whose
+citation omits the channel is recorded as **unverified**, however confidently it is worded.
 
 **Confirm the findings reached disk before presenting anything, once per target packet.** A
 multi-target run confirms every packet — one silently empty packet among six is exactly the loss


### PR DESCRIPTION
## Problem

`plugins/plugin-quality/agents/auditor.md` step 3 instructed the auditor to `WebFetch` the official
doc page for every load-bearing harness-behavior claim. That is **rung 2** of the ladder in
`docs/conventions/upstream-drift/README.md` — the rung the convention labels *degraded*, prescribed
as the default for exactly the claims the convention reserves rung 1 for. `WebFetch` truncates long
pages silently, and "not in the response" is indistinguishable from "not on the page".

The agent's output contract asked only for URL plus fetch date, and the consuming skill
(`skills/audit/SKILL.md` step 3) asked only for "a doc citation" — so nothing downstream could tell
a raw read from summarizer output.

Realized cost, per the issue: **two fabricated load-bearing documentation quotes reached filed-ready
drafts in one audit chain**, both attributed verbatim to the hooks reference, neither present in it.

## The instruction set this PR ships

### The fetch route

Step 3 grounds every load-bearing harness claim on the convention's **rung-1 raw-markdown route**:
`curl` `https://code.claude.com/docs/en/<slug>.md` into a scratch file **outside the evidence
packet** (a fetched page is working material, not a packet artifact), then `grep` that file locally.
`docs/conventions/upstream-drift/README.md` is named as the owning record — cited for its full text,
not required as a dereference, because the auditor often runs from an installed plugin cache where
that file is not on disk. The rules the step actually needs are therefore stated inline.

**`WebFetch` is rung 2, and it is a real fallback, not a dead end.** It applies in exactly two
cases — the `.md` channel does not resolve for the page, **or `curl` is not installed on this host**
(`command -v curl`) — and the read is **recorded as rung 2** either way. A rung-2 read grounds a
claim on the same terms as rung 1: the full emitted span must match, and the response must show it
arrived whole.

One capability rung 2 never confers: an **absence** claim. Its truncation is silent, and the
convention binds every read with "A truncated read supports no absence claim, ever." An absence
needs the rung-1 whole-file read. `README.md`'s Requirements section now declares `curl` in the same
optional-with-degradation shape the file already uses for `gh` and `jq`.

### Page identity, before anything is quoted

The slug is confirmed canonical against `https://code.claude.com/docs/llms.txt`, and the body's own
first heading is read, because a retired slug is silently aliased to its successor's content — a
`200` is not proof you got the page you asked for. A heading about a *different subject* ends the
read; **a heading that merely words the same subject differently does not** — `sub-agents.md` is
titled "Create custom subagents" and `costs.md` "Manage costs effectively", and both are the right
page. A slug the index does not carry is retired or renamed: find the successor in the index and
cite that slug, not the retired one that still serves bytes.

### The quote check

A quotation is usable only if **the full span that will actually be emitted in the finding** —
the complete quoted text exactly as it will appear, not a distinctive fragment of it — matches
literally against the fetched bytes: `grep -c -F '<the entire emitted span>' <saved-file>` returning
a non-zero count. Checking a fragment proves the fragment and nothing around it, which lets a
genuine fragment spliced into a recalled sentence pass — the fabrication this change exists to stop.

`grep -F` is line-oriented, so quote a span that sits on one line; where the wording crosses a
newline, quote the single line carrying the load-bearing claim, or emit each line as its own
separately-verified span — **never verify one line and emit more**. A newline-broken span that fails
to match is not evidence of absence. No cross-line matcher is introduced: an adjacency heuristic
over line numbers would itself be unsound, since short lines recur.

### When a claim is unverified

A claim is unverified when **no channel produced the bytes** (the rung-1 `curl` failed *and* the
rung-2 fallback failed or was unavailable too), when the read arrived truncated, or when the span
meant for emission did not match the bytes that did arrive. **The preferred channel merely being
unavailable is not itself a trigger.** Unverified is stated, never reconstructed from memory.

### The citation contract, at both ends

The agent's output contract requires each harness-behavior doc citation to carry the retrieval
channel (rung-1 `curl` of the `.md`, or rung-2 `WebFetch`) **and** a byte count or line number,
alongside URL and fetch date. `skills/audit/SKILL.md` step 3 records a finding whose citation omits
**either** field as unverified — a citation reading "rung-1 `curl`, `<url>`, fetched `<date>`" with
no count and no line is a half-citation, not a grounded one. The requirement binds where the output
is consumed, not only where it is produced, and both ends state the same rule.

Because only rung 1 has a saved file to measure, the contract states what rung 2 records in its
place, so the two rungs are held to a contract each can actually satisfy: the size of the text
actually received, said plainly as the *retrieved* size rather than the page's, plus the page's
closing section named as present to show the read arrived whole. A rung-2 read that can show neither
is unverified — never a citation with a field left blank, and never a byte count carried over from a
page that was not saved.

### Acceptance criteria (issue 2854)

- [x] Step 3 names the raw-markdown `curl` route (rung 1) as the default, citing the convention,
      rather than prescribing `WebFetch`.
- [x] That step names the concrete substring-search check and states that a failed or unavailable
      fetch is recorded as unverified, never reconstructed from recall. (The check is now stricter
      than the criterion asked for — the full emitted span rather than a distinctive fragment.)
- [x] The output contract requires retrieval channel plus byte count or line number, alongside URL
      and fetch date.
- [x] `skills/audit/SKILL.md` step 3 records a channel-less citation as unverified. (Also a
      count-less and line-less one.)

## Review rounds

### Round 1 — a blind fresh-context verifier

Three ways the new step 3 was **self-blocking**, all regressions this branch introduced, all fixed:

- The closing output contract still read "never write outside the packet" — the unamended twin of
  the tool-honesty sentence this branch qualified to "never use **Write** outside the packet". As it
  stood, the agent's own contract forbade the scratch file step 3 requires.
- The narrowed network clause ("official documentation and nothing else") barred retrieving the
  convention step 3 tells the agent to follow.
- "Follow it rather than restating it here" pointed at a file that is not on disk from a plugin
  cache, via a blob URL that serves HTML — the rung-2 channel this change exists to demote.

Also from that pass: `grep -c -F` is line-oriented, so the step says a newline-broken span failing to
match is not evidence of absence; and `README.md` names the **fetch** ladder, since "rung" already
denotes the sink/emit ladder elsewhere in this plugin. Self-review then added the missing branch for
a slug canonicality check that *fails* (cite the successor), and dropped a CHANGELOG bullet that
contradicted another four lines below it.

### Round 2 — the first-heading carve-out

The inlined identity check said a heading that does not match the page ends the read, but dropped the
convention's carve-out that a title merely *worded* differently is still correct. Applied literally
that would have rejected `sub-agents.md` — the very page `auditor.md` cites as its own stamp.
Re-confirmed by raw fetch today, 2026-08-16: `HTTP/1.1 200`, `Content-Type: text/markdown`,
**100,271 bytes**, first heading on line 5 is `# Create custom subagents`. The carve-out is stated
inline with both of the convention's examples.

### Round 3 — ten review threads, four distinct findings

Each was raised more than once; each underlying defect was fixed once, and every thread carries its
own reply.

- **P1 — a fragment match does not verify the emitted quote.** A finding could splice a genuine short
  fragment into a fabricated surrounding sentence and still pass. The check now requires the full
  emitted span. (`auditor.md:119-128`)
- **P2 — the `WebFetch` fallback was sanctioned and then made unusable.** The unverified-trigger list
  named "the `.md` channel was unavailable" as a standalone reason, so a complete successful fallback
  read was forced to unverified. Now keyed on *no* channel producing the bytes; a successful rung-2
  read grounds the claim and is recorded as rung 2. (`auditor.md:102-109`, `:129-134`)
- **P2 — consumer-side enforcement covered half the contract.** `SKILL.md` demoted only on a missing
  channel, though the contract requires channel *and* count-or-line. Either field missing now
  demotes, and the producing end states the same rule. (`SKILL.md:331-332`, `auditor.md:147-149`)
- **P2 — hosts without `curl`.** Such a host could not run the mandatory rung-1 command while the
  fallback was keyed only on the page, so it lost doc verification entirely. The fallback is now
  keyed on page **or** host, in the step, in the tool-honesty note's network clause, and in
  `README.md`'s Requirements. (`auditor.md:24-26`, `:102-109`, `README.md:59-63`)

### Round 4 — a fresh-context verifier on the round-3 fixes

Ran blind, with the rationale withheld, over both files end to end. It returned PASS on all four
findings, on internal consistency, on the curl-less and differently-worded-title executability
paths, on the convention file being untouched, and on the four ACs. It raised two items, both taken:

- **Rung 2 was held to a citation field it had no way to produce.** The contract demanded a byte
  count or line number, but only rung 1 has a saved file to measure — so on a curl-less host, the
  case the fallback exists to support, every citation risked the consumer-side demotion. Fixed as
  described above.
- **The CHANGELOG contradicted itself inside one release.** The branch carried an intra-development
  `0.6.3` entry describing an intermediate state of this same work that round 3 then reversed — a
  fragment match, and a channel-only demotion. Since `plugin.json` moves `0.6.2` → `0.6.4` in one
  PR, no installable version ever had that behavior, and the entry contradicted `0.6.4` sixty lines
  below it. Folded into `0.6.4`, which describes what ships; the version number is left at `0.6.4`
  rather than reused, and the fold is stated in the entry. Worth fixing rather than waving through
  precisely because this PR's whole subject is not publishing claims that do not hold.

The verifier also noted that ACs 2 and 4 as *written* in issue 2854 are weaker than what shipped
(AC2 asks for a "distinctive fragment"; AC4 for demotion on a missing channel only). That divergence
is deliberate — review found the AC's own wording to be the residual defect — and is called out here
so a maintainer diffing issue against code reads it as intentional strengthening, not drift.

## Deliberately not changed

- `docs/conventions/upstream-drift/README.md` — the issue proposes no change to the convention, and
  none was needed: every fix above is the auditor adopting rules the convention already states.
- `WebFetch` or any other tool; the agent's frontmatter `tools:` line is untouched.
- Filed `plugin-quality` outputs carrying the same defect — the issue scopes that out separately.
- `plugins/plugin-quality/reference/config.md:95` — the **emitted work-item body** contract still
  asks only for "evidence + doc citations", so the channel requirement stops at the audit boundary
  and never reaches the filed issue. Outside this PR's scope fence and beyond the issue's four
  criteria, so it is **filed separately as issue 2864** rather than left in prose a squash merge
  would discard.
- The two existing upstream-drift stamps inside `auditor.md` (sub-agents 2026-07-26, hooks
  2026-08-10) carry URL and date with no channel. They are the agent file's **own** stamps; the new
  contract governs citations the auditor *emits*. No byte count was invented for them — fabricating a
  figure inside this PR would be self-refuting.

## Verification

Every cited line was re-derived against `origin/main` content rather than trusting the issue's
`2de57a3` citations or any closure state (per issue 2691). The one upstream doc fact this PR asserts
— `sub-agents.md`'s first heading and byte count — was fetched raw over rung 1 today and is quoted
from those bytes, since a fabricated quote inside this PR would refute the PR.

Gates run locally from the worktree, all green:

- `scripts/check-changelog-parity.sh` `--check`, `--check-order`, `--check-bump origin/main`,
  `--check-preserved origin/main`
- `scripts/validate-plugins.sh`
- `npx --no-install markdownlint-cli2` on all four touched markdown files — 0 errors
- `skill-quality`'s `check-skill.sh` on the `audit` skill — **PASS**, 0 errors. `SKILL.md` is
  498/500 lines (hard cap 500), and the frontmatter `description` is untouched, so the
  listing-entry budget is unchanged.

`plugin-quality` is bumped `0.6.2` → **`0.6.4`**, with one CHANGELOG entry describing what ships (see
Round 4 on the folded `0.6.3`). Files touched:
`agents/auditor.md`, `skills/audit/SKILL.md`, `README.md`, `CHANGELOG.md`,
`.claude-plugin/plugin.json`.

One sourcing note, stated plainly: the two-fabrications history in the CHANGELOG and above is taken
from issue 2854's Evidence section. I did not independently re-derive that audit chain. What was
re-derived is the `.md` channel behavior the fix depends on.

## Related

- Closes #2854
- `docs/conventions/upstream-drift/README.md` — the owning convention this PR adopts and does not
  modify.
- Issue 2691 — merged fixes silently reverted by stale-base squash merges. Every citation was
  re-read from `origin/main` content rather than from closure state.
- Not issue 2297: that backlog collects surfaces *restating* an upstream-owned specific without the
  four-part stamp. `auditor.md` restates no upstream specific — it prescribes a procedure for
  obtaining them.
