### PR TITLE
fix(disk-hygiene): flag the parent-folder send-to-Recycle-Bin spelling

### DIFF
--- a/plugins/disk-hygiene/.claude-plugin/plugin.json
+++ b/plugins/disk-hygiene/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "disk-hygiene",
-  "version": "0.20.10",
+  "version": "0.20.11",
   "description": "Context-aware disk hygiene for arbitrary directory trees: inventories orphaned and temporary artifacts, classifies evidence into review tiers, and offers exact-path cleanup only after a fresh safety preview and explicit per-tier approval. The target is read-only by default; OS-managed paths, links and mount points, VCS-tracked content without the complete checkout evidence bundle, changed entries, and live-handle uncertainty fail closed.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/disk-hygiene/CHANGELOG.md
+++ b/plugins/disk-hygiene/CHANGELOG.md
@@ -16,9 +16,9 @@ All notable changes to the `disk-hygiene` plugin are documented here. Format fol
   `InvokeVerbEx` spelling is covered by the same token, which a word boundary closed after
   `InvokeVerb` had excluded.
 - **What the rule deliberately still does not catch (#2850).** `MoveHere` into an ordinary
-  (non-bin) folder is a MOVE, not a deletion, and keeps deferring; so do `CopyHere`, non-delete
-  verbs such as `InvokeVerb('open')`, the omitted default verb, and an opaque verb argument
-  (`InvokeVerb($verb)`). The delete-verb set is enumerated, not identity-checked — a COM shell verb
+  (non-bin) folder is a MOVE, not a deletion, and keeps deferring; so do `CopyHere` into an
+  ordinary folder, non-delete verbs such as `InvokeVerb('open')`, the omitted default verb, and an
+  opaque verb argument (`InvokeVerb($verb)`). The delete-verb set is enumerated, not identity-checked — a COM shell verb
   is named by the item's own verb collection, so completeness is not implied — and the pattern set
   now says so. The test note claiming `Move-Item` is the catch-all for these COM spellings is
   corrected: `_POWERSHELL_MUTATION_WORDS` matches neither `MoveHere` nor `InvokeVerb`.

--- a/plugins/disk-hygiene/CHANGELOG.md
+++ b/plugins/disk-hygiene/CHANGELOG.md
@@ -3,6 +3,26 @@
 All notable changes to the `disk-hygiene` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.20.11]
+
+### Fixed
+
+- **Flag the ordinary send-an-item-to-the-Recycle-Bin spelling (#2850).** The `Shell.Application`
+  rule shipped for #2595 required the literal bin folder id — `NameSpace(10)` / `NameSpace(0xa)` —
+  so `$sh.NameSpace('<parent folder>').ParseName('victim').InvokeVerb('delete')`, which addresses
+  the item through its parent folder and never names the bin, returned no verdict and raised no
+  prompt. That shape is now keyed on the delete VERB rather than on the folder id, and returns
+  `ask` (or `deny` in audit-only mode) like every other recognized deletion spelling. The suffixed
+  `InvokeVerbEx` spelling is covered by the same token, which a word boundary closed after
+  `InvokeVerb` had excluded.
+- **What the rule deliberately still does not catch (#2850).** `MoveHere` into an ordinary
+  (non-bin) folder is a MOVE, not a deletion, and keeps deferring; so do `CopyHere`, non-delete
+  verbs such as `InvokeVerb('open')`, the omitted default verb, and an opaque verb argument
+  (`InvokeVerb($verb)`). The delete-verb set is enumerated, not identity-checked — a COM shell verb
+  is named by the item's own verb collection, so completeness is not implied — and the pattern set
+  now says so. The test note claiming `Move-Item` is the catch-all for these COM spellings is
+  corrected: `_POWERSHELL_MUTATION_WORDS` matches neither `MoveHere` nor `InvokeVerb`.
+
 ## [0.20.10]
 
 ### Fixed

--- a/plugins/disk-hygiene/skills/clean/scripts/destructive_guard.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/destructive_guard.py
@@ -1429,11 +1429,19 @@ def _shell_verb_name_deletes(verb: str) -> bool:
 
 
 def _shell_application_recycle_bin_delete_reason(command: str) -> str | None:
-    """Reason for a Shell.Application Recycle Bin deletion spelling, or None.
+    """Reason for a COM shell deletion spelling, or None.
 
     The bin-id branch is tested first so a command satisfying both (a bin-id
     `NameSpace` whose item is deleted with `InvokeVerb`) keeps naming the folder
     id in its verdict.
+
+    Only that first branch requires a `Shell.Application` context. The verb-arg
+    branch below is deliberately context-free: it matches a literal delete verb
+    passed to `InvokeVerb` on ANY COM object, with no `Shell.Application` or
+    `NameSpace` call required anywhere in the command. A caller reading only the
+    function name should not infer otherwise — the name is historical, and the
+    reason string the second branch returns says "COM shell delete verb" rather
+    than naming `Shell.Application` for exactly this reason.
     """
     if (
         _POWERSHELL_SHELL_APP_NAMESPACE_BIN.search(command) is not None

--- a/plugins/disk-hygiene/skills/clean/scripts/destructive_guard.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/destructive_guard.py
@@ -1371,17 +1371,79 @@ _POWERSHELL_VB_FILESYSTEM_DELETE = re.compile(
 _POWERSHELL_SHELL_APP_NAMESPACE_BIN = re.compile(
     r"(?i)NameSpace\s*\(\s*(?:10|0x0*a)\s*\)"
 )
+# `InvokeVerbEx` is the same call with arguments, so the stem carries the `Ex`
+# suffix here rather than being closed off by `\b` after `InvokeVerb` (which
+# does NOT match `InvokeVerbEx`): "This method is similar to InvokeVerb, but it
+# allows you to specify arguments to the command as well as the command itself"
+# (https://learn.microsoft.com/en-us/windows/win32/shell/invokeverbex, fetched
+# 2026-08-16).
 _POWERSHELL_SHELL_APP_BIN_ACTION = re.compile(
-    r"(?i)(?<![\w])(?:MoveHere|InvokeVerb)\b"
+    r"(?i)(?<![\w])(?:MoveHere|InvokeVerb(?:Ex)?)\b"
 )
+# The rule above is keyed on the bin's folder id, which the ordinary
+# send-an-item-to-the-bin spelling never mentions: there `NameSpace()` takes the
+# item's PARENT FOLDER path and the delete verb is invoked on the item —
+# `$sh.NameSpace('<folder>').ParseName('victim').InvokeVerb('delete')` (#2850).
+# That shape is keyed on the delete VERB instead of on the folder id.
+#
+# ENUMERATED, NOT IDENTITY-CHECKED — completeness is not implied. No identity
+# test exists for a COM shell verb: the argument is a name out of the item's own
+# verb collection, not a stable canonical token. Of `vVerb`, Microsoft's
+# `FolderItem.InvokeVerb` reference
+# (https://learn.microsoft.com/en-us/windows/win32/shell/folderitem-invokeverb,
+# fetched 2026-08-16) says: "A string that specifies the verb to be executed. It
+# must be one of the values returned by the item's FolderItemVerb.Name property.
+# If no verb is specified, the default verb will be invoked." `FolderItemVerb
+# .Name` in turn only "Contains the verb's name"
+# (https://learn.microsoft.com/en-us/windows/win32/shell/folderitemverb-name,
+# fetched 2026-08-16) — so a verb named anything other than the enumerated
+# spellings below (a localized name, for instance) is NOT covered.
+#
+# Deliberately outside this rule, each still deferring:
+#   - `MoveHere` into an ordinary (non-bin) folder — that is a MOVE, not a
+#     deletion;
+#   - a non-literal verb argument (`InvokeVerb($verb)`) — the verb is opaque;
+#   - the omitted verb (`InvokeVerb()`) — the default verb, "typically 'open'"
+#     per the `FolderItem.InvokeVerb` reference above.
+_POWERSHELL_SHELL_APP_INVOKE_VERB_ARG = re.compile(
+    r"(?i)(?<![\w])InvokeVerb(?:Ex)?\s*\(\s*(?P<quote>[\"'])(?P<verb>[^\"']*)(?P=quote)"
+)
+_SHELL_APP_DELETE_VERB_NAMES = frozenset({"delete"})
 
 
-def _is_shell_application_recycle_bin_delete(command: str) -> bool:
-    """True for Shell.Application Recycle Bin MoveHere / InvokeVerb shapes."""
-    return (
+def _shell_verb_name_deletes(verb: str) -> bool:
+    """True when a shell verb NAME is one of the enumerated delete verbs.
+
+    A menu accelerator marks the same verb (`&Delete`, `De&lete`), so `&` is
+    dropped before the comparison.
+    """
+    return verb.replace("&", "").strip().casefold() in _SHELL_APP_DELETE_VERB_NAMES
+
+
+def _shell_application_recycle_bin_delete_reason(command: str) -> str | None:
+    """Reason for a Shell.Application Recycle Bin deletion spelling, or None.
+
+    The bin-id branch is tested first so a command satisfying both (a bin-id
+    `NameSpace` whose item is deleted with `InvokeVerb`) keeps naming the folder
+    id in its verdict.
+    """
+    if (
         _POWERSHELL_SHELL_APP_NAMESPACE_BIN.search(command) is not None
         and _POWERSHELL_SHELL_APP_BIN_ACTION.search(command) is not None
-    )
+    ):
+        return (
+            "disk-hygiene flagged a Shell.Application NameSpace(10) Recycle Bin "
+            "MoveHere/InvokeVerb deletion."
+        )
+    if any(
+        _shell_verb_name_deletes(match.group("verb"))
+        for match in _POWERSHELL_SHELL_APP_INVOKE_VERB_ARG.finditer(command)
+    ):
+        return (
+            "disk-hygiene flagged a Shell.Application delete verb "
+            "(InvokeVerb sends the item to the Recycle Bin)."
+        )
+    return None
 
 
 def powershell_decision(command: str, enabled: bool) -> tuple[str, str] | None:
@@ -1418,12 +1480,9 @@ def powershell_decision(command: str, enabled: bool) -> tuple[str, str] | None:
             "disk-hygiene flagged Microsoft.VisualBasic.FileIO.FileSystem "
             "DeleteFile/DeleteDirectory (Recycle Bin / FileIO deletion).",
         )
-    if _is_shell_application_recycle_bin_delete(command):
-        return _powershell_mutation_verdict(
-            enabled,
-            "disk-hygiene flagged a Shell.Application NameSpace(10) Recycle Bin "
-            "MoveHere/InvokeVerb deletion.",
-        )
+    shell_app_recycle_bin = _shell_application_recycle_bin_delete_reason(command)
+    if shell_app_recycle_bin is not None:
+        return _powershell_mutation_verdict(enabled, shell_app_recycle_bin)
     match = _POWERSHELL_MUTATION_WORDS.search(command)
     if match:
         return _powershell_mutation_verdict(

--- a/plugins/disk-hygiene/skills/clean/scripts/destructive_guard.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/destructive_guard.py
@@ -1405,6 +1405,12 @@ _POWERSHELL_SHELL_APP_BIN_ACTION = re.compile(
 #   - a non-literal verb argument (`InvokeVerb($verb)`) — the verb is opaque;
 #   - the omitted verb (`InvokeVerb()`) — the default verb, "typically 'open'"
 #     per the `FolderItem.InvokeVerb` reference above.
+#
+# The lookbehind is `(?<![\w])`, not the cmdlet list's `(?<![\w./\\-])`: a
+# hyphen-prefixed relative (`My-InvokeVerb('delete')`, a wrapper function) still
+# matches, deliberately. Tightening it would buy precision by making a wrapper
+# that deletes go SILENT, which is the failure this rule exists to close;
+# prompting once on a wrapper is the cheaper error.
 _POWERSHELL_SHELL_APP_INVOKE_VERB_ARG = re.compile(
     r"(?i)(?<![\w])InvokeVerb(?:Ex)?\s*\(\s*(?P<quote>[\"'])(?P<verb>[^\"']*)(?P=quote)"
 )
@@ -1415,7 +1421,9 @@ def _shell_verb_name_deletes(verb: str) -> bool:
     """True when a shell verb NAME is one of the enumerated delete verbs.
 
     A menu accelerator marks the same verb (`&Delete`, `De&lete`), so `&` is
-    dropped before the comparison.
+    dropped before the comparison, and surrounding whitespace is stripped so a
+    padded literal (`' delete '`) resolves to the same verb rather than slipping
+    past the enumeration.
     """
     return verb.replace("&", "").strip().casefold() in _SHELL_APP_DELETE_VERB_NAMES
 
@@ -1440,7 +1448,7 @@ def _shell_application_recycle_bin_delete_reason(command: str) -> str | None:
         for match in _POWERSHELL_SHELL_APP_INVOKE_VERB_ARG.finditer(command)
     ):
         return (
-            "disk-hygiene flagged a Shell.Application delete verb "
+            "disk-hygiene flagged a COM shell delete verb "
             "(InvokeVerb sends the item to the Recycle Bin)."
         )
     return None

--- a/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
@@ -6173,6 +6173,9 @@ class GuardTests(unittest.TestCase):
             "(New-Object -ComObject Shell.Application).NameSpace(10).MoveHere($path)",
             "$shell = New-Object -ComObject Shell.Application; $shell.NameSpace(10).MoveHere($path)",
             "$shell.NameSpace(0xa).ParseName($path).InvokeVerb('delete')",
+            # #2850: the send-to-the-bin spelling names the item's PARENT folder,
+            # so no bin id appears anywhere in the command.
+            "$sh.NameSpace('C:\\some\\parent').ParseName('victim').InvokeVerb('delete')",
             "Move-Item C:/tmp/old C:/tmp/new",
             "Rename-Item C:/tmp/old C:/tmp/new",
             "Set-Content C:/tmp/file.txt 'overwrite'",
@@ -6321,6 +6324,7 @@ class GuardTests(unittest.TestCase):
             "[Microsoft.VisualBasic.FileIO.FileSystem]::DeleteDirectory($path,'OnlyErrorDialogs','SendToRecycleBin')",
             "(New-Object -ComObject Shell.Application).NameSpace(10).MoveHere($path)",
             "$shell.NameSpace(0xa).ParseName($path).InvokeVerb('delete')",
+            "$sh.NameSpace('C:\\some\\parent').ParseName('victim').InvokeVerb('delete')",
         ):
             result = self.run_guard_powershell_disabled(command)
             assert result is not None, command
@@ -6363,14 +6367,59 @@ class GuardTests(unittest.TestCase):
                 command,
             )
 
+    def test_powershell_shell_app_send_to_bin_via_parent_folder_prompts(self) -> None:
+        """#2850: the send-to-the-bin spelling names the PARENT folder, not the bin.
+
+        `NameSpace()` takes the containing folder's path and the delete verb is
+        invoked on the item, so no Recycle Bin folder id (10 / 0xa) appears
+        anywhere in the command. The verdict must key on the delete verb.
+        """
+        for command in (
+            "$sh = New-Object -ComObject Shell.Application; "
+            "$item = $sh.NameSpace('C:\\some\\parent').ParseName('victim'); "
+            "$item.InvokeVerb('delete')",
+            "$sh.NameSpace('C:\\some\\parent').ParseName('victim').InvokeVerb('delete')",
+            '$sh.NameSpace("C:\\some\\parent").ParseName("victim").InvokeVerb("Delete")',
+            # A menu accelerator names the same verb.
+            "$sh.NameSpace('C:\\some\\parent').ParseName('victim').InvokeVerb('&Delete')",
+            # `InvokeVerbEx` is the same call with arguments; a word boundary
+            # closed immediately after `InvokeVerb` would not cover the suffixed
+            # spelling.
+            "$sh.NameSpace('C:\\some\\parent').ParseName('victim').InvokeVerbEx('delete')",
+        ):
+            result = self.run_guard_powershell(command)
+            assert result is not None, command
+            self.assertEqual(
+                "ask",
+                result["hookSpecificOutput"]["permissionDecision"],
+                command,
+            )
+            self.assertRegex(
+                result["hookSpecificOutput"]["permissionDecisionReason"],
+                r"Recycle Bin",
+                command,
+            )
+
     def test_powershell_shell_app_without_bin_action_defers(self) -> None:
         """Listing the bin is not a deletion spelling; MoveHere/InvokeVerb is required."""
         for command in (
             "(New-Object -ComObject Shell.Application).NameSpace(10).Items()",
             "$shell = New-Object -ComObject Shell.Application; $shell.NameSpace(10)",
-            # MoveHere against a non-bin namespace is outside this Recycle Bin rule;
-            # Move-Item remains the catch-all for rename/move cmdlets.
+            # MoveHere into an ordinary (non-bin) folder is a MOVE, not a
+            # deletion, so it stays outside the Recycle Bin rule — including the
+            # verb-keyed half added for #2850. Nothing else on this lane covers
+            # it either: `_POWERSHELL_MUTATION_WORDS` matches neither `MoveHere`
+            # (the `move` entry's trailing `(?![\w-])` rejects the `here`) nor
+            # `InvokeVerb`, so `Move-Item` is not the catch-all for these COM
+            # spellings. Widening the mutation-word set is its own change.
             "(New-Object -ComObject Shell.Application).NameSpace('C:\\tmp').MoveHere($path)",
+            # CopyHere copies; the original is untouched.
+            "(New-Object -ComObject Shell.Application).NameSpace('C:\\tmp').CopyHere($path)",
+            # Non-delete verbs, and the omitted verb (the default, typically
+            # "open"), are not deletions.
+            "$sh.NameSpace('C:\\some\\parent').ParseName('victim').InvokeVerb('open')",
+            "$sh.NameSpace('C:\\some\\parent').ParseName('victim').InvokeVerb()",
+            "$sh.NameSpace('C:\\some\\parent').ParseName('victim').Verbs()",
         ):
             self.assertIsNone(self.run_guard_powershell(command), command)
 


### PR DESCRIPTION
## Summary

The `Shell.Application` Recycle Bin rule shipped for issue 2595 required the literal bin folder id
(`NameSpace(10)` / `NameSpace(0xa)`) **and** a `MoveHere`/`InvokeVerb` action. The ordinary way to
send a named item to the bin addresses the item through its **parent folder** and never mentions
the bin at all:

```powershell
$sh.NameSpace('C:\some\parent').ParseName('victim').InvokeVerb('delete')
```

That spelling returned no verdict, so the belt raised no prompt — and because the gate keyed on the
presence of a literal token rather than on the deletion, the same command could be made to prompt by
adding an inert `NameSpace(10).Items().Count` call.

This keys that shape on the delete **verb** instead of on the folder id. The bin-id branch is still
evaluated first and keeps its verdict text, so commands satisfying both are unaffected; its action
pattern gains only the `InvokeVerbEx` suffix described below.

## What it now catches

- `InvokeVerb` / `InvokeVerbEx` whose **literal** verb argument names the delete verb, in single or
  double quotes, with or without a menu accelerator (`'&Delete'`, `'De&lete'`), from any namespace —
  the match is context-free, like every other spelling in this pattern set. Requiring a
  `Shell.Application` context would be a second, trivially-defeated way of doing the same test.
- `InvokeVerbEx` specifically: a word boundary closed immediately after `InvokeVerb` never matched
  the suffixed spelling, which is the stem-vs-suffixed-relative gap this repo has been bitten by
  before. `InvokeVerbEx` is "similar to InvokeVerb, but it allows you to specify arguments to the
  command as well as the command itself"
  ([ShellFolderItem.InvokeVerbEx](https://learn.microsoft.com/en-us/windows/win32/shell/invokeverbex),
  fetched 2026-08-16).

## What it deliberately still does NOT catch

Each of these still defers, and each is now locked by a fixture:

- **`MoveHere` into an ordinary (non-bin) folder** — a MOVE, not a deletion. The existing
  `assertIsNone` fixture is untouched.
- `CopyHere` **into an ordinary folder** — copies; the original is untouched. `CopyHere` into the
  bin namespace also defers, exactly as it did before this PR; it is left alone rather than widened
  because no primary source establishes what it does there.
- Non-delete verbs (`InvokeVerb('open')`) and the omitted verb (the default, "typically open").
- An **opaque verb argument** (`InvokeVerb($verb)`) — unknowable from the command text. Widening to
  it is its own change, as is widening `_POWERSHELL_MUTATION_WORDS`.

The delete-verb set is **enumerated, not identity-checked**, and the pattern set now says so with
its source: the verb argument "must be one of the values returned by the item's
**FolderItemVerb.Name** property. If no verb is specified, the default verb will be invoked"
([FolderItem.InvokeVerb](https://learn.microsoft.com/en-us/windows/win32/shell/folderitem-invokeverb),
fetched 2026-08-16), and `FolderItemVerb.Name` merely "Contains the verb's name"
([reference](https://learn.microsoft.com/en-us/windows/win32/shell/folderitemverb-name), fetched
2026-08-16). There is no canonical-token identity test available for a COM shell verb, so a verb
named anything else (a localized name) is not covered and completeness is not implied.

The test note claiming `Move-Item` is the catch-all for these COM spellings is corrected:
`_POWERSHELL_MUTATION_WORDS` matches neither `MoveHere` (the `move` entry's trailing `(?![\w-])`
rejects the `here`) nor `InvokeVerb` — verified by execution, printed below, not by reading.

## Verified by execution

`powershell_decision(command, enabled=True)` driven directly against the pre-fix module (the
`origin/main` blob `042b7051`, copied out and hash-verified) and against the patched module:

| probe | before | after |
| --- | --- | --- |
| `$sh.NameSpace('C:\some\parent').ParseName('victim').InvokeVerb('delete')` (send form) | DEFER | `ask` |
| `(New-Object -ComObject Shell.Application).NameSpace(10).MoveHere($path)` | `ask` | `ask` |
| `$shell = New-Object -ComObject Shell.Application; $shell.NameSpace(10).MoveHere($path)` | `ask` | `ask` |
| `$shell.NameSpace(0xa).ParseName($path).InvokeVerb('delete')` | `ask` | `ask` |
| `(New-Object -ComObject Shell.Application).NameSpace('C:\tmp').MoveHere($path)` (move) | DEFER | **DEFER** |
| `...ParseName('victim').InvokeVerbEx('delete')` | DEFER | `ask` |
| `...ParseName('victim').InvokeVerb('&Delete')` | DEFER | `ask` |
| `...ParseName('victim').InvokeVerb('open')` | DEFER | **DEFER** |
| `...ParseName('victim').InvokeVerb()` | DEFER | **DEFER** |
| `NameSpace('C:\tmp').CopyHere($path)` | DEFER | **DEFER** |
| `NameSpace(10).Items()` | DEFER | **DEFER** |
| `...ParseName('victim').Verbs()` | DEFER | **DEFER** |

`_POWERSHELL_MUTATION_WORDS.search(...)` returns `None` for both the folder-path `MoveHere` and the
`InvokeVerb('delete')` command, before and after.

The three new fixture sets were run against the pre-fix guard module and **fail** there
(`test_powershell_deletion_spellings_force_final_prompt`,
`test_powershell_deletion_spellings_denied_in_audit_only_mode`, and the new
`test_powershell_shell_app_send_to_bin_via_parent_folder_prompts`); the deferral test passes both
before and after, so its added cases lock existing behavior rather than change it.

## Deliberate over-coverage

A fresh-context reviewer flagged that the leading `(?<![\w])` lets a hyphen-prefixed relative
through: `My-InvokeVerb('delete')` (a wrapper function) returns `ask`. That is kept on purpose and
the reason is now recorded in the pattern comment — tightening it to the cmdlet list's
`(?<![\w./\\-])` would buy precision by making a *deleting wrapper* go silent, which is the exact
failure this rule exists to close. Prompting once on a wrapper is the cheaper error. Text that
merely mentions the spelling (`Select-String "InvokeVerb('delete')"`) likewise prompts, which is the
same behavior every other spelling in this file already has for a mention of `Remove-Item`.

## Gates run locally

`check-changelog-parity.sh --check`, `--check-order`, `--check-bump origin/main`,
`--check-preserved origin/main`, `validate-plugins.sh`, `markdownlint-cli2` on the CHANGELOG,
`run-ruff.sh check`/`format --diff` on both touched Python files (no new findings; the only
pre-existing ones are untouched regions), and the plugin's Python suites. Six failures in the local
Windows run (`test_stash_must_exist_in_an_independent_checkout`,
`test_preview_allows_root_children_os_managed_snapshot`, two in `test_guard_launch_monitor`, two in
`test_hook_telemetry`) reproduce identically on a pristine `origin/main` worktree and are unrelated
to this change.

## Related

- Closes #2850
- Issue 2595 — the original Recycle Bin coverage, closed by PR 2639, allowlist re-landed by PR 2706.
  This PR widens the rule that shipped there; it does not revert any of it.
- Issue 2691 — stale-base squash merges silently reverting merged fixes. This branch was rebased
  onto `origin/main` at `2d20a277` and every cited line was re-derived from that content.
