### PR TITLE
perf(autonomy): test the lane-stop gate's arming before buffering stdin

### DIFF
--- a/plugins/autonomy/.claude-plugin/plugin.json
+++ b/plugins/autonomy/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "autonomy",
-  "version": "0.22.1",
+  "version": "0.22.2",
   "description": "Governed autonomous agent operation: role-topology, binding-seam, wiring-vs-advisor, telemetry, return-accounting, trigger-dispatch, per-work-class guardrail-matrix, standing-routine-catalog, and design-only runner-charter contracts for climbing the AI-adoption ladder, plus a guided-setup skill that discovers an adopting org's state, writes its schema-versioned binding, wires standards-pinned OTLP emission with a zero-cost file-artifact default, wires human-attested return capture at the task boundary, wires signal adapters with one governed dispatch entrypoint, binds the five-class guardrail matrix to an org's isolation substrates with an in-boundary live-validation probe before recording each fail-closed binding, and stands up standing-routine-catalog classes as scheduled temporal signal adapters behind the one governed queue with free scheduling defaults wired as reviewable changes and each routine's work-class mapping homed on the security surface.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/autonomy/CHANGELOG.md
+++ b/plugins/autonomy/CHANGELOG.md
@@ -3,6 +3,23 @@
 All notable changes to the `autonomy` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.22.2]
+
+### Fixed
+
+- **lane-stop gate: the arm pre-filter now runs before the stdin buffer** (#2852). The `Stop`
+  hook buffered the entire payload and only then tested whether the gate was armed at all —
+  so an unarmed session (the interactive default) paid the full bounded stdin read against
+  the registration's 15s budget for a guaranteed no-op. `gate_maybe_configured` and its
+  `|| exit 0` call now sit above the `hook::buffer_stdin` assignment in
+  `hooks/lane-stop-gate.sh`. A pure reordering: the pre-filter reads two environment
+  presences and two settings-file locators whose `GATE_*` globals are already established
+  above it, and references the payload nowhere. Everything payload-derived —
+  `hook::require_jq`, `EVENT`, `SESSION_ID`, and the `SubagentStop`-versus-`Stop`
+  discrimination — stays below the buffer, unchanged. Two cases pin both halves by binding
+  stdin to a regular file and reading back what the hook left unconsumed: an unarmed session
+  leaves the whole payload unread, an armed one still drains it and still blocks.
+
 ## [0.22.1]
 
 ### Changed

--- a/plugins/autonomy/CHANGELOG.md
+++ b/plugins/autonomy/CHANGELOG.md
@@ -13,8 +13,8 @@ All notable changes to the `autonomy` plugin are documented here. Format follows
   the registration's 15s budget for a guaranteed no-op. `gate_maybe_configured` and its
   `|| exit 0` call now sit above the `hook::buffer_stdin` assignment in
   `hooks/lane-stop-gate.sh`. A pure reordering: the pre-filter reads two environment
-  presences and two settings-file locators whose `GATE_*` globals are already established
-  above it, and references the payload nowhere. Everything payload-derived —
+  presences and two settings-file locators already in scope at the new position, and
+  references the payload nowhere. Everything payload-derived —
   `hook::require_jq`, `EVENT`, `SESSION_ID`, and the `SubagentStop`-versus-`Stop`
   discrimination — stays below the buffer, unchanged. Two cases pin both halves by binding
   stdin to a regular file and reading back what the hook left unconsumed: an unarmed session

--- a/plugins/autonomy/hooks/lane-stop-gate.sh
+++ b/plugins/autonomy/hooks/lane-stop-gate.sh
@@ -112,8 +112,10 @@ emit_tel() {
 # into evaluation, where the trusted sources decide.
 #
 # Everything this reads is already in scope above: the two env presences, and
-# the two settings-file locators from lane-stop-gate-lib.sh, which derive from
-# the GATE_* globals gate_resolve_install established at the top of this file.
+# the two settings-file locators from lane-stop-gate-lib.sh — gate_user_settings_file,
+# which derives from the GATE_CONFIG_ROOT that gate_resolve_install establishes
+# at the top of this file, and gate_managed_settings_files, which depends on
+# nothing but `uname -s` and fixed absolute paths.
 # Nothing here is payload-derived, so it MUST stay above the buffer — and
 # everything payload-derived (hook::require_jq, EVENT, SESSION_ID, and the
 # SubagentStop-versus-Stop discrimination) MUST stay below it (#2852).

--- a/plugins/autonomy/hooks/lane-stop-gate.sh
+++ b/plugins/autonomy/hooks/lane-stop-gate.sh
@@ -102,17 +102,21 @@ emit_tel() {
   hook::emit_telemetry "lane-stop-gate" "Stop" "$1" "$START" "$data" "${CLAUDE_PROJECT_DIR:-}"
 }
 
-# Buffer stdin. Empty (rc 1) or timed-out (rc 2) → allow the stop (fail-open: a
-# gate that cannot read the payload must not trap the lane).
-INPUT=$(hook::buffer_stdin) || exit 0
-
-# jq-free pre-filter: is the gate plausibly configured anywhere this host could
-# honor — or at least CLAIMED, which must produce the visible notice below
-# rather than silence? Sessions with no gate footprint at all (the interactive
-# default) exit here, before the jq gate, so a jq-less machine never sees a
-# lane-stop-gate notice for a session that never opted in. The env presence
-# tests grant no authority: a hit only routes into evaluation, where the
-# trusted sources decide.
+# jq-free AND stdin-free pre-filter: is the gate plausibly configured anywhere
+# this host could honor — or at least CLAIMED, which must produce the visible
+# notice below rather than silence? Sessions with no gate footprint at all (the
+# interactive default) exit here, before the stdin buffer and the jq gate, so an
+# unarmed session never pays the buffered read for a decision it cannot make,
+# and a jq-less machine never sees a lane-stop-gate notice for a session that
+# never opted in. The env presence tests grant no authority: a hit only routes
+# into evaluation, where the trusted sources decide.
+#
+# Everything this reads is already in scope above: the two env presences, and
+# the two settings-file locators from lane-stop-gate-lib.sh, which derive from
+# the GATE_* globals gate_resolve_install established at the top of this file.
+# Nothing here is payload-derived, so it MUST stay above the buffer — and
+# everything payload-derived (hook::require_jq, EVENT, SESSION_ID, and the
+# SubagentStop-versus-Stop discrimination) MUST stay below it (#2852).
 gate_maybe_configured() {
   [[ -n "${CLAUDE_PLUGIN_OPTION_LANE_STOP_GATE_ARM_ID:-}" ]] && return 0
   [[ -n "${CLAUDE_PLUGIN_OPTION_LANE_STOP_GATE_ENABLED:-}" ]] && return 0
@@ -127,6 +131,10 @@ gate_maybe_configured() {
   return 1
 }
 gate_maybe_configured || exit 0
+
+# Buffer stdin. Empty (rc 1) or timed-out (rc 2) → allow the stop (fail-open: a
+# gate that cannot read the payload must not trap the lane).
+INPUT=$(hook::buffer_stdin) || exit 0
 
 # jq parses the payload and the trusted config. Absent → visible once-per-session
 # notice, then allow the stop (fail-open). Stop supports additionalContext, so

--- a/plugins/autonomy/hooks/lane-stop-gate.test.sh
+++ b/plugins/autonomy/hooks/lane-stop-gate.test.sh
@@ -837,6 +837,73 @@ else
 fi
 fi
 
+# ============================================================================
+# #2852 — the arm pre-filter runs BEFORE the stdin buffer.
+# ============================================================================
+# The pre-filter (`gate_maybe_configured`) needs no payload: two env presences
+# and two greps over settings files. Ordering it after the buffered read made
+# the maximum-cost path the one taken by the sessions that get zero function
+# from it — an unarmed session paying a bounded stdin read against a 15s Stop
+# budget for a guaranteed no-op.
+#
+# probe_run <payload-file> [KEY=VAL ...] — invoke the staged hook with stdin
+# bound to a REGULAR FILE on fd 3 instead of a pipe, then read what is LEFT on
+# that same open file description afterwards. The file offset is shared across
+# the fork/exec, so the leftover is exactly the bytes the hook did not consume:
+# the whole payload means stdin was never read, empty means it was drained.
+# This is the only observation that separates the two orderings — both exit 0
+# on an unarmed session, and only the read itself differs.
+PROBE_OUT=""
+PROBE_RC=0
+PROBE_LEFT=""
+probe_run() {
+  local payload="$1"
+  shift
+  PROBE_OUT=""
+  PROBE_RC=0
+  PROBE_LEFT=""
+  {
+    PROBE_OUT=$(cd "$UNRELATED" &&
+      env -u CLAUDE_PLUGIN_OPTION_LANE_STOP_GATE_ENABLED \
+        -u CLAUDE_PLUGIN_OPTION_LANE_STOP_GATE_SENTINEL \
+        -u CLAUDE_PLUGIN_OPTION_LANE_STOP_GATE_MARKER \
+        -u CLAUDE_PLUGIN_OPTION_LANE_STOP_GATE_ARM_ID \
+        -u CLAUDE_PLUGIN_DATA \
+        CLAUDE_PLUGIN_OPTION_LANE_NOTIFY_ENABLED=false \
+        ${@+"$@"} \
+        bash "$HOOK" 0<&3 2>/dev/null)
+    PROBE_RC=$?
+    PROBE_LEFT=$(cat <&3)
+  } 3<"$payload"
+}
+
+# --- Case 47: an UNARMED session exits 0 without consuming stdin ------------
+# No arm id, no env enable claim, no settings file for the helpers to find, and
+# no `lane_stop_gate` string anywhere they resolve — the interactive default.
+PROBE_PAYLOAD="$WORK/stdin-probe.json"
+build_input Stop "no token" false >"$PROBE_PAYLOAD"
+PROBE_EXPECT="$(<"$PROBE_PAYLOAD")"
+if [[ -n "$PROBE_EXPECT" ]]; then ok "stdin probe payload built (case precondition)"; else fail "stdin probe payload is empty — the leftover check would prove nothing"; fi
+rm -f "$SETTINGS"
+probe_run "$PROBE_PAYLOAD"
+if [[ $PROBE_RC -eq 0 && -z "$PROBE_OUT" ]]; then ok "unarmed session → silent exit 0 (fd-bound stdin)"; else fail "unarmed fd-bound session (rc=$PROBE_RC out=$PROBE_OUT)"; fi
+if [[ "$PROBE_LEFT" == "$PROBE_EXPECT" ]]; then
+  ok "unarmed session leaves the whole payload unread (arm pre-filter runs before the stdin buffer)"
+else
+  fail "unarmed session consumed stdin — the pre-filter is running after the buffered read (leftover=${#PROBE_LEFT} of ${#PROBE_EXPECT} bytes)"
+fi
+
+# --- Case 48: an ARMED session still reaches the payload reads --------------
+# The reorder must move only the payload-free pre-filter. A trusted-enabled
+# session must still drain stdin AND still produce the gate's block decision —
+# which it can only do by parsing hook_event_name and last_assistant_message
+# out of that payload, i.e. the payload reads all still sit below the buffer.
+write_settings true
+probe_run "$PROBE_PAYLOAD"
+if [[ $PROBE_RC -eq 0 ]]; then ok "armed fd-bound session: exit 0"; else fail "armed fd-bound session exited $PROBE_RC"; fi
+if [[ -z "$PROBE_LEFT" ]]; then ok "armed session drains stdin (the buffered read still runs when the gate is armed)"; else fail "armed session left ${#PROBE_LEFT} bytes unread — the payload never reached the gate"; fi
+if is_block "$PROBE_OUT"; then ok "armed session still blocks an unsignaled stop (payload reads intact below the buffer)"; else fail "armed session did not block — the reorder changed armed-lane behavior: $PROBE_OUT"; fi
+
 echo
 echo "PASS=$PASS FAIL=$FAIL"
 [[ $FAIL -eq 0 ]]

--- a/plugins/autonomy/hooks/lane-stop-gate.test.sh
+++ b/plugins/autonomy/hooks/lane-stop-gate.test.sh
@@ -846,7 +846,7 @@ fi
 # from it — an unarmed session paying a bounded stdin read against a 15s Stop
 # budget for a guaranteed no-op.
 #
-# probe_run <payload-file> [KEY=VAL ...] — invoke the staged hook with stdin
+# probe_run <payload-file> — invoke the staged hook with stdin
 # bound to a REGULAR FILE on fd 3 instead of a pipe, then read what is LEFT on
 # that same open file description afterwards. The file offset is shared across
 # the fork/exec, so the leftover is exactly the bytes the hook did not consume:
@@ -858,7 +858,6 @@ PROBE_RC=0
 PROBE_LEFT=""
 probe_run() {
   local payload="$1"
-  shift
   PROBE_OUT=""
   PROBE_RC=0
   PROBE_LEFT=""
@@ -870,7 +869,6 @@ probe_run() {
         -u CLAUDE_PLUGIN_OPTION_LANE_STOP_GATE_ARM_ID \
         -u CLAUDE_PLUGIN_DATA \
         CLAUDE_PLUGIN_OPTION_LANE_NOTIFY_ENABLED=false \
-        ${@+"$@"} \
         bash "$HOOK" 0<&3 2>/dev/null)
     PROBE_RC=$?
     PROBE_LEFT=$(cat <&3)


### PR DESCRIPTION
## Summary

`plugins/autonomy/hooks/lane-stop-gate.sh` buffered the entire `Stop` payload and only then
tested whether the lane gate was armed at all. An unarmed session — the interactive default,
which cannot produce a gate decision no matter what the payload contains — paid the full
bounded stdin read against the registration's 15s budget for a guaranteed no-op.

This is a pure reordering: the `gate_maybe_configured` definition and its `|| exit 0` call now
sit **above** the `hook::buffer_stdin` assignment.

## Why the reorder is safe

- `gate_maybe_configured` references `$INPUT` nowhere. Its whole body is two environment
  presence tests (`..._ARM_ID`, `..._ENABLED`) and two `grep -q lane_stop_gate` passes over the
  files `gate_user_settings_file` / `gate_managed_settings_files` resolve.
- Both helpers come from `lane-stop-gate-lib.sh`, sourced near the top of the script, and both
  derive from the `GATE_*` globals `gate_resolve_install` establishes **above** the moved block.
  Every dependency the block has is in scope at its new position; nothing it needs is
  established between the old and new positions (that span is the `START` stamp and the
  `emit_tel` definition only).
- Everything payload-derived stays exactly where it was, below the buffer: `hook::require_jq`,
  `EVENT`, `SESSION_ID`, and the `SubagentStop`-versus-`Stop` discrimination.

The comment above the pre-filter already stated the cheap-exit intent; it now says the exit is
stdin-free as well as jq-free, and records the boundary so a later edit does not undo it.

## Tests

Two cases pin both halves of the contract by binding the hook's stdin to a **regular file on
fd 3** rather than a pipe, then reading back — on that same shared open file description —
what the hook left unconsumed. The leftover byte count is the only observation that separates
the two orderings, since both exit 0 on an unarmed session.

- **Case 47** — unarmed (no `ARM_ID`, no env enable claim, no settings file, no
  `lane_stop_gate` string anywhere the helpers resolve): exits 0 with the **whole payload still
  unread**.
- **Case 48** — armed via the trusted user-settings channel: still **drains stdin** and still
  returns `decision: block`, proving the payload reads remain below the buffer.

Case 47 was confirmed to **FAIL against the pre-fix ordering** (leftover 0 of 148 bytes) and
pass after — the pre-fix hook was reproduced byte-for-byte from `origin/main` in a scratch tree
and the new suite run against it, yielding exactly one failure. Case 48 passes under both
orderings, which is what makes it the no-behavior-change control. Neither case has a skip
branch.

## Verification

Run locally on the rebased head:

- `bash plugins/autonomy/hooks/lane-stop-gate.test.sh` — PASS=89 FAIL=0
- `bash scripts/check-changelog-parity.sh --check` / `--check-order` / `--check-bump origin/main` /
  `--check-preserved origin/main`
- `bash scripts/validate-plugins.sh`
- `bash scripts/check-shell-portability.sh --paths` on both touched shell files
- `shellcheck --rcfile=.shellcheckrc` on both touched shell files
- `npx --no-install markdownlint-cli2 plugins/autonomy/CHANGELOG.md` — 0 errors
- `bash scripts/check-silent-skips.sh`, `check-discriminating-test-skips.sh`,
  `check-drive-root-litter.sh`

## Scope

Four files: the hook, its test file, `plugins/autonomy/CHANGELOG.md`, and the plugin manifest
version (`0.22.1` → `0.22.2`). No change to `hook::buffer_stdin` or `hook-utils.sh`, and no
`"shell": "bash"` pin on the `Stop` registration — the issue scopes both out.

## Related

- Closes #2852
- Issue 1809 — `docs/conventions/hook-budget/README.md` adopted the ≤ 500 ms per-turn ceiling
  for always-on `Stop`-shaped hooks that this hook's unarmed path was spending against.
- Issue 1883 (`hook-utils`: a repo env block can disable every hook by starving the stdin read
  timeout) — adjacent, about the read itself rather than its placement. Not a duplicate; this
  PR touches neither `hook::buffer_stdin` nor `hook-utils.sh`.
- Issue 2691 — merged fixes silently reverted by stale-base squash merges. Every line cited
  here was re-read from `origin/main` content today, and this branch was rebased onto the
  current tip (`2d20a2774424d88e9eb95425fab830d9a6e1f1c7`) rather than the tip it was first
  branched from.
