### PR TITLE
ci: gate every ci.yml lane through the ci-status aggregate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -866,6 +866,34 @@ jobs:
       - name: Check every restatement carries the canonical clause's qualifiers
         run: python3 scripts/check-contract-clause-coverage.py
 
+  # `ci-status` below is the single check the org ci-gate ruleset keys on, and
+  # its own comment calls its `needs` list "the single source of truth for the
+  # lane list" — but nothing enforced the other direction. A job defined in THIS
+  # file and absent from that list still runs and still turns red in the run
+  # list, while `ci-status` reports success and the merge proceeds:
+  # informational, not a gate. `hook-utils-windows` states exactly that in prose
+  # above, and prose is not a gate — `managed-scope-sync` and `state-key-sync`
+  # shipped outside the aggregate for their whole lifetime while
+  # scripts/cross-plugin-source-registry.txt advertised each as a dedicated
+  # check (#2856). Same false-green class as `liveness-assertion`, on the merge
+  # gate itself. This lane closes the loop mechanically: every job here is in
+  # `ci-status.needs`, or carries a `# lane-coverage-ok: <reason>` annotation
+  # recording why it stays out. Static, one file, no diff and no base ref, and
+  # unrecognized YAML shape exits 2 rather than reporting coverage it did not
+  # parse. Self-test first so a broken detector cannot mask a regression.
+  lane-coverage-gate:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - name: Check out
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Test the lane-coverage gate
+        run: bash scripts/check-lane-coverage.test.sh
+      - name: Check every ci.yml job is reachable from the ci-status aggregate
+        run: scripts/check-lane-coverage.sh --check
+
   # Deep plugin-contract lane and the heaviest suite (Node + Python installs,
   # every plugins/**/*.test.sh, manifest + catalog validation). A PR whose diff
   # is confined to the docs-only allowlist (scripts/docs-only-paths.txt) cannot
@@ -1321,6 +1349,8 @@ jobs:
       - windows-path-emit-gate
       - windows-path-emit-windows
       - parse-concern-value-sync
+      - managed-scope-sync
+      - state-key-sync
       - resolve-convention-pattern-sync
       - standards-contract-sync
       - cross-plugin-source-drift
@@ -1338,6 +1368,7 @@ jobs:
       - changelog-parity-gate
       - contract-slice-prune-gate
       - contract-clause-coverage-gate
+      - lane-coverage-gate
       - plugin-gate
       - miro-plugin
       - video-extraction

--- a/scripts/check-lane-coverage.sh
+++ b/scripts/check-lane-coverage.sh
@@ -1,0 +1,248 @@
+#!/usr/bin/env bash
+# Gate: every job defined in the CI workflow must be reachable from the required
+# aggregate's `needs` graph, or carry a written reason for staying out of it.
+#
+#   scripts/check-lane-coverage.sh --check [<workflow> [<aggregate-job-id>]]
+#
+# Defaults: .github/workflows/ci.yml and the `ci-status` aggregate.
+#
+# WHY. `ci-status` is the single check the org ci-gate ruleset keys on, and its
+# own comment calls its `needs` list "the single source of truth for the lane
+# list". Nothing enforced the other direction: a job DEFINED in ci.yml but
+# ABSENT from that list runs, reports, and turns red in the run list while
+# `ci-status` reports success — so it cannot gate a merge. `hook-utils-windows`
+# already states the doctrine in prose ("a lane missing from that list is
+# informational no matter how loudly a comment here calls it a gate"), and prose
+# is not a gate: `managed-scope-sync` and `state-key-sync` shipped outside the
+# aggregate for their whole lifetime (claude-code-plugins#2856), each advertised
+# as a dedicated check in scripts/cross-plugin-source-registry.txt. That is the
+# false-green shape docs/conventions/liveness-assertion/ names — green surface,
+# dead enforcement — with the added twist that the surface is the merge gate
+# itself.
+#
+# WHAT IS CHECKED (all four directions, so the two sets are provably equal):
+#   1. UNGATED LANE   — a job defined in the workflow, not in the aggregate's
+#                       `needs`, and not annotated. The class #2856 filed.
+#   2. DANGLING NEED  — a `needs` entry naming no defined job. GitHub rejects
+#                       this at workflow-parse time, but a parse error surfaces
+#                       as a failed run, not as a named defect.
+#   3. STALE OPT-OUT  — a job annotated as deliberately ungated that IS in
+#                       `needs`. Same stale-guard idiom as the baseline lists in
+#                       scripts/: an exemption must not outlive what it excuses.
+#   4. BARE OPT-OUT   — the annotation present with no reason after the colon.
+#                       An undocumented opt-out is exactly the silent off switch
+#                       this gate exists to deny, so it fails rather than passing
+#                       as "annotated".
+#
+# THE OPT-OUT. A job that legitimately does not belong in the required aggregate
+# — advisory by design, or driven by an event the merge gate never sees —
+# records that decision inline:
+#
+#   # lane-coverage-ok: <reason>
+#   some-job:
+#
+# or as a trailing comment on the job key itself. Same annotated-exemption shape
+# `# silent-skip-ok:` uses for scripts/check-silent-skips.sh: the reason lives
+# next to the thing it excuses, in the file a reviewer is already reading, and
+# there is no separate list to drift. The annotation must sit in the contiguous
+# 2-space comment block immediately above the job key (a blank line or any other
+# line breaks contiguity), so it can never be mistaken for an annotation
+# belonging to some earlier job. As of #2856 the repo carries ZERO opt-outs; the
+# path exists so that a future advisory lane is a decision on the record instead
+# of an omission nobody notices.
+#
+# The aggregate job itself is exempt by construction — it cannot depend on
+# itself — via AGGREGATE below, not via a silent filter.
+#
+# FAIL CLOSED ON SHAPE. This reads the workflow structurally with awk rather
+# than through a YAML library (the repo ships no root YAML dependency, and the
+# only workflow parser in the tree, .github/standards/runner-policy, is an
+# org-owned standards materialization this repo does not edit). Every YAML shape
+# it does not recognize — a flow-sequence `needs: [a, b]`, a scalar `needs: x`,
+# an aggregate with no `needs:` at all, a 2-space key under `jobs:` that is not a
+# plain job id — exits 2 (inconclusive), never 0. Returning an empty lane set on
+# an unparsed file would be this gate committing the very defect it detects.
+#
+# Exit: 0 covered; 1 a coverage defect; 2 usage, missing file, or unrecognized
+# workflow shape.
+set -uo pipefail
+
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  echo "check-lane-coverage: not inside a git work tree" >&2
+  exit 2
+fi
+cd "$(git rev-parse --show-toplevel)" || exit 2
+
+usage() {
+  echo "usage: $(basename "$0") --check [<workflow> [<aggregate-job-id>]]" >&2
+  exit 2
+}
+
+[[ "${1:-}" == "--check" ]] || usage
+WORKFLOW="${2:-.github/workflows/ci.yml}"
+AGGREGATE="${3:-ci-status}"
+[[ $# -le 3 ]] || usage
+
+if [[ ! -f "$WORKFLOW" ]]; then
+  echo "check-lane-coverage: workflow not found: $WORKFLOW" >&2
+  exit 2
+fi
+
+# One structural pass. Emits three record kinds on stdout:
+#   JOB <id> <A|N> <reason...>   A = annotated opt-out (reason may be empty)
+#   NEED <id>
+#   ERR <message>
+parsed="$(
+  awk -v agg="$AGGREGATE" '
+    function reset_ann() { ann = 0; reason = "" }
+    BEGIN { injobs = 0; seen_jobs = 0; job = ""; needs_state = 0; reset_ann() }
+
+    # The jobs: mapping opens at column 0 and closes at the next column-0 key.
+    !injobs && /^jobs:[[:blank:]]*$/ { injobs = 1; seen_jobs = 1; next }
+    !injobs { next }
+    /^[^[:blank:]#]/ { injobs = 0; needs_state = 0; next }
+
+    # --- inside the aggregate: the needs block sequence ---
+    needs_state == 1 {
+      if ($0 ~ /^[[:blank:]]*$/ || $0 ~ /^      #/) { next }
+      if ($0 ~ /^      - [A-Za-z_][A-Za-z0-9_-]*[[:blank:]]*$/) {
+        item = $0
+        sub(/^      - /, "", item)
+        sub(/[[:blank:]]+$/, "", item)
+        print "NEED " item
+        next
+      }
+      # Indent >= 6 that is not a plain list item is a shape we do not model.
+      if ($0 ~ /^      /) {
+        print "ERR unsupported needs entry under " agg ": " $0
+        next
+      }
+      needs_state = 0
+      # Fall through: this line may itself be a job key or a 4-space key.
+    }
+
+    # --- 2-space keys and comments under jobs: ---
+    /^  [^[:blank:]]/ {
+      if ($0 ~ /^  #/) {
+        line = $0
+        sub(/^  #[[:blank:]]*/, "", line)
+        if (line ~ /^lane-coverage-ok:/) {
+          ann = 1
+          reason = line
+          sub(/^lane-coverage-ok:[[:blank:]]*/, "", reason)
+          sub(/[[:blank:]]+$/, "", reason)
+        }
+        next
+      }
+      if ($0 ~ /^  [A-Za-z_][A-Za-z0-9_-]*:[[:blank:]]*(#.*)?$/) {
+        job = $0
+        sub(/:.*$/, "", job)
+        sub(/^  /, "", job)
+        trail = $0
+        if (trail ~ /#[[:blank:]]*lane-coverage-ok:/) {
+          sub(/^.*#[[:blank:]]*lane-coverage-ok:[[:blank:]]*/, "", trail)
+          sub(/[[:blank:]]+$/, "", trail)
+          ann = 1
+          reason = trail
+        }
+        print "JOB " job " " (ann ? "A" : "N") " " reason
+        reset_ann()
+        next
+      }
+      print "ERR unrecognized key under jobs: " $0
+      reset_ann()
+      next
+    }
+
+    # --- 4-space keys inside a job ---
+    /^    [^[:blank:]]/ {
+      reset_ann()
+      if (job == agg && $0 ~ /^    needs:/) {
+        if ($0 ~ /^    needs:[[:blank:]]*$/) { needs_state = 1; print "NEEDSBLOCK"; next }
+        print "ERR " agg " needs: is not a block sequence: " $0
+        next
+      }
+      next
+    }
+
+    { reset_ann() }
+
+    END { if (!seen_jobs) print "ERR no jobs: mapping found" }
+  ' "$WORKFLOW"
+)" || {
+  echo "check-lane-coverage: failed to read $WORKFLOW" >&2
+  exit 2
+}
+
+shape_errors="$(printf '%s\n' "$parsed" | grep '^ERR ' || true)"
+if [[ -n "$shape_errors" ]]; then
+  echo "check-lane-coverage: unrecognized workflow shape in $WORKFLOW" >&2
+  printf '%s\n' "$shape_errors" | sed 's/^ERR /  /' >&2
+  echo "  Refusing to report coverage from a file this gate did not fully parse." >&2
+  exit 2
+fi
+
+jobs_all="$(printf '%s\n' "$parsed" | grep '^JOB ' | cut -d' ' -f2 || true)"
+needs_all="$(printf '%s\n' "$parsed" | grep '^NEED ' | cut -d' ' -f2 || true)"
+
+if [[ -z "$jobs_all" ]]; then
+  echo "check-lane-coverage: no jobs parsed from $WORKFLOW" >&2
+  exit 2
+fi
+if ! printf '%s\n' "$jobs_all" | grep -Fxq "$AGGREGATE"; then
+  echo "check-lane-coverage: aggregate job '$AGGREGATE' is not defined in $WORKFLOW" >&2
+  exit 2
+fi
+if ! printf '%s\n' "$parsed" | grep -Fxq 'NEEDSBLOCK'; then
+  echo "check-lane-coverage: aggregate job '$AGGREGATE' declares no needs: block in $WORKFLOW" >&2
+  exit 2
+fi
+if [[ -z "$needs_all" ]]; then
+  echo "check-lane-coverage: aggregate job '$AGGREGATE' has an empty needs: block in $WORKFLOW" >&2
+  exit 2
+fi
+
+errors=0
+report() {
+  echo "$1" >&2
+  errors=$((errors + 1))
+}
+
+while IFS= read -r record; do
+  [[ -n "$record" ]] || continue
+  job="$(printf '%s' "$record" | cut -d' ' -f2)"
+  flag="$(printf '%s' "$record" | cut -d' ' -f3)"
+  reason="$(printf '%s' "$record" | cut -d' ' -f4-)"
+  [[ "$job" != "$AGGREGATE" ]] || continue
+
+  in_needs=1
+  printf '%s\n' "$needs_all" | grep -Fxq "$job" || in_needs=0
+
+  if [[ "$flag" == "A" ]]; then
+    if [[ -z "$reason" ]]; then
+      report "BARE OPT-OUT: job '$job' carries '# lane-coverage-ok:' with no reason. An opt-out without a written reason is not a documented opt-out."
+    elif [[ "$in_needs" -eq 1 ]]; then
+      report "STALE OPT-OUT: job '$job' is annotated '# lane-coverage-ok: $reason' but IS in ${AGGREGATE}.needs. Drop the annotation."
+    fi
+    continue
+  fi
+
+  if [[ "$in_needs" -eq 0 ]]; then
+    report "UNGATED LANE: job '$job' is defined in $WORKFLOW but absent from ${AGGREGATE}.needs, so it cannot gate a merge. Add it to needs, or annotate the job with '# lane-coverage-ok: <reason>'."
+  fi
+done <<<"$(printf '%s\n' "$parsed" | grep '^JOB ')"
+
+while IFS= read -r need; do
+  [[ -n "$need" ]] || continue
+  printf '%s\n' "$jobs_all" | grep -Fxq "$need" ||
+    report "DANGLING NEED: ${AGGREGATE}.needs names '$need', which is not a job defined in $WORKFLOW."
+done <<<"$needs_all"
+
+if [[ "$errors" -ne 0 ]]; then
+  echo "check-lane-coverage: $errors coverage defect(s) in $WORKFLOW" >&2
+  exit 1
+fi
+
+covered="$(printf '%s\n' "$needs_all" | grep -c . || true)"
+echo "check-lane-coverage: $WORKFLOW — all $covered lane(s) reachable from ${AGGREGATE}.needs"
+exit 0

--- a/scripts/check-lane-coverage.test.sh
+++ b/scripts/check-lane-coverage.test.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+# Self-test for scripts/check-lane-coverage.sh
+#
+# Fixtures are plain files under mktemp, addressed by ABSOLUTE path: the script
+# cds to the git toplevel, so an absolute fixture path resolves from anywhere and
+# no scratch git repo is needed. That is deliberate — a fixture repo would need
+# `git -C <dir> config user.*`, and the un-scoped form of that command writes the
+# test identity into the CALLER's repo config (claude-code-plugins#2839). No git
+# state means the class cannot recur here.
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$ROOT/scripts/check-lane-coverage.sh"
+failures=0
+
+ok() { printf 'ok - %s\n' "$1"; }
+fail() {
+  printf 'not ok - %s\n' "$1" >&2
+  failures=$((failures + 1))
+}
+
+scratch="$(mktemp -d)"
+trap 'rm -rf "$scratch"' EXIT
+
+# Runs the gate and asserts exit code plus (optionally) a substring of output.
+expect() {
+  local label="$1" want_rc="$2" want_text="$3"
+  shift 3
+  local out rc
+  out="$(bash "$SCRIPT" "$@" 2>&1)" && rc=0 || rc=$?
+  if [[ "$rc" -ne "$want_rc" ]]; then
+    fail "$label: expected rc=$want_rc got rc=$rc out='$out'"
+    return
+  fi
+  if [[ -n "$want_text" && "$out" != *"$want_text"* ]]; then
+    fail "$label: expected output to contain '$want_text', got '$out'"
+    return
+  fi
+  ok "$label"
+}
+
+# --- fixture builders -------------------------------------------------------
+
+# A minimal but structurally faithful workflow: two lanes, an aggregate, and a
+# body shaped like the real file (comments, block scalars, nested `if:` keys).
+write_workflow() {
+  local path="$1" extra_job_block="$2" needs_block="$3"
+  cat >"$path" <<YAML
+name: ci
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  # A leading comment block, the way the real file carries them.
+  alpha:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Do a thing
+        run: |
+          echo "  not-a-job: this line lives inside a block scalar"
+          echo done
+
+  beta:
+    runs-on: ubuntu-24.04
+    if: github.event_name == 'pull_request'
+    steps:
+      - name: Do another thing
+        run: echo ok
+${extra_job_block}
+  ci-status:
+${needs_block}
+    if: \${{ !cancelled() }}
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Aggregate lane results
+        run: echo aggregated
+YAML
+}
+
+needs_of() {
+  printf '    needs:\n'
+  local n
+  for n in "$@"; do printf '      - %s\n' "$n"; done
+}
+
+# --- usage / input errors ---------------------------------------------------
+
+expect "bare invocation exits 2 with usage" 2 "usage:"
+expect "unknown mode exits 2 with usage" 2 "usage:" --verify
+expect "missing workflow exits 2" 2 "workflow not found" --check "$scratch/nope.yml"
+expect "excess arguments exit 2" 2 "usage:" --check "$scratch/nope.yml" ci-status extra
+
+printf 'name: ci\non:\n  pull_request:\n' >"$scratch/nojobs.yml"
+expect "workflow with no jobs mapping exits 2" 2 "no jobs: mapping found" --check "$scratch/nojobs.yml"
+
+# --- the defect this gate exists to catch -----------------------------------
+
+write_workflow "$scratch/ungated.yml" "" "$(needs_of alpha)"
+expect "job absent from needs fails and names the job" 1 "UNGATED LANE: job 'beta'" \
+  --check "$scratch/ungated.yml"
+
+write_workflow "$scratch/covered.yml" "" "$(needs_of alpha beta)"
+expect "every job in needs passes" 0 "all 2 lane(s) reachable" --check "$scratch/covered.yml"
+
+# --- the opt-out path -------------------------------------------------------
+
+write_workflow "$scratch/optout.yml" "" "$(needs_of alpha)"
+# Annotate `beta` via the contiguous comment block immediately above its key.
+annotate_above() {
+  local file="$1" job="$2" comment="$3"
+  awk -v job="  ${job}:" -v c="$comment" '
+    $0 == job { print c } { print }
+  ' "$file" >"$file.tmp" && mv "$file.tmp" "$file"
+}
+annotate_above "$scratch/optout.yml" beta "  # lane-coverage-ok: advisory lane, findings routed to code scanning"
+expect "annotated opt-out passes" 0 "all 1 lane(s) reachable" --check "$scratch/optout.yml"
+
+write_workflow "$scratch/bare-optout.yml" "" "$(needs_of alpha)"
+annotate_above "$scratch/bare-optout.yml" beta "  # lane-coverage-ok:"
+expect "opt-out with no reason fails" 1 "BARE OPT-OUT: job 'beta'" --check "$scratch/bare-optout.yml"
+
+write_workflow "$scratch/trailing-optout.yml" "" "$(needs_of alpha)"
+awk '{ sub(/^  beta:$/, "  beta:  # lane-coverage-ok: deliberately advisory"); print }' \
+  "$scratch/trailing-optout.yml" >"$scratch/trailing-optout.yml.tmp" &&
+  mv "$scratch/trailing-optout.yml.tmp" "$scratch/trailing-optout.yml"
+expect "trailing-comment opt-out passes" 0 "all 1 lane(s) reachable" --check "$scratch/trailing-optout.yml"
+
+write_workflow "$scratch/stale-optout.yml" "" "$(needs_of alpha beta)"
+annotate_above "$scratch/stale-optout.yml" beta "  # lane-coverage-ok: no longer true"
+expect "opt-out on a job that IS in needs fails as stale" 1 "STALE OPT-OUT: job 'beta'" \
+  --check "$scratch/stale-optout.yml"
+
+# An annotation separated from its job key by a blank line must NOT carry over.
+write_workflow "$scratch/detached-optout.yml" "" "$(needs_of alpha)"
+awk '
+  $0 == "  beta:" { print "  # lane-coverage-ok: this comment is not contiguous"; print "" }
+  { print }
+' "$scratch/detached-optout.yml" >"$scratch/detached-optout.yml.tmp" &&
+  mv "$scratch/detached-optout.yml.tmp" "$scratch/detached-optout.yml"
+expect "non-contiguous annotation does not exempt the job" 1 "UNGATED LANE: job 'beta'" \
+  --check "$scratch/detached-optout.yml"
+
+# --- dangling needs ---------------------------------------------------------
+
+write_workflow "$scratch/dangling.yml" "" "$(needs_of alpha beta gamma)"
+expect "needs entry with no defined job fails" 1 "DANGLING NEED" --check "$scratch/dangling.yml"
+
+# --- unrecognized shapes must be inconclusive, never green ------------------
+
+write_workflow "$scratch/flow-needs.yml" "" "    needs: [alpha, beta]"
+expect "flow-sequence needs exits 2, not 0" 2 "not a block sequence" --check "$scratch/flow-needs.yml"
+
+write_workflow "$scratch/scalar-needs.yml" "" "    needs: alpha"
+expect "scalar needs exits 2, not 0" 2 "not a block sequence" --check "$scratch/scalar-needs.yml"
+
+write_workflow "$scratch/no-needs.yml" "" "    permissions:
+      contents: read"
+expect "aggregate with no needs block exits 2" 2 "declares no needs: block" --check "$scratch/no-needs.yml"
+
+write_workflow "$scratch/empty-needs.yml" "" "    needs:
+"
+expect "aggregate with an empty needs block exits 2" 2 "empty needs: block" --check "$scratch/empty-needs.yml"
+
+write_workflow "$scratch/odd-key.yml" "  &anchor-not-a-job:
+    runs-on: ubuntu-24.04
+" "$(needs_of alpha beta)"
+expect "unmodelled 2-space key exits 2" 2 "unrecognized key under jobs" --check "$scratch/odd-key.yml"
+
+write_workflow "$scratch/missing-agg.yml" "" "$(needs_of alpha beta)"
+expect "unknown aggregate job exits 2" 2 "is not defined" --check "$scratch/missing-agg.yml" no-such-job
+
+# --- the real workflow ------------------------------------------------------
+
+expect "the repository's own ci.yml is fully covered" 0 "reachable from ci-status.needs" --check
+
+if [[ $failures -eq 0 ]]; then
+  echo "ALL PASS"
+  exit 0
+fi
+echo "$failures failure(s)" >&2
+exit 1


### PR DESCRIPTION
## Summary

`ci-status` is the single check the org `ci-gate` ruleset keys on, and its own comment calls its
`needs` list "the single source of truth for the lane list". Nothing enforced the other direction. A
job defined in `.github/workflows/ci.yml` but absent from that list still runs, still reports, and
still turns red in the run list — while `ci-status` reports success and the merge proceeds. The
`hook-utils-windows` comment already states the doctrine in prose ("a lane missing from that list is
informational no matter how loudly a comment here calls it a gate"); prose is not a gate.

The gap was computed, not read. Against `origin/main` at `2d20a277` (i.e. after #2841 landed and
added two lanes of its own):

```console
$ bash derive-gap.sh
defined jobs (incl. ci-status): 37
ci-status.needs entries:        34
--- defined but NOT in ci-status.needs (excluding ci-status itself) ---
managed-scope-sync
state-key-sync
--- in ci-status.needs but NOT defined ---
```

(The issue's "38 defined / 34 named" was an eyeball count on a pre-#2841 tree; the derived numbers
differ, the two missing lanes do not.)

## Fix

**Both missing lanes gate — neither omission was deliberate.**

| Job | Decision | Why |
| --- | --- | --- |
| `managed-scope-sync` | **Add to `needs`** | Structurally identical to the four sync lanes already in `needs` (`hook-utils-sync`, `parse-concern-value-sync`, `resolve-convention-pattern-sync`, `standards-contract-sync`): same `--check` / lib self-test / `--check-bump` triple. Not advisory, not schedule- or event-scoped — the `if: github.event_name == 'pull_request'` sits on the bump **step**, never on the job, so the job runs and reports on every PR and every push. `scripts/cross-plugin-source-registry.txt` already advertises it as the dedicated check for `lib/managed-scope.sh`. |
| `state-key-sync` | **Add to `needs`** | Same shape, same registry claim for `lib/state-key.sh`. |

No job in this workflow is intentionally omitted, so this PR ships **zero** opt-out annotations.

`cross-plugin-source-drift` (already in `needs`) covers a *drifted copy* of either cluster, so this
was never a total hole — but it does not cover the `--check-bump` half (lib changed, carrying plugin
version not bumped), which only the dedicated lanes run.

**The guard.** `scripts/check-lane-coverage.sh --check` proves the defined-job set and
`ci-status.needs` are equal in both directions, and is itself wired into `ci-status.needs` as
`lane-coverage-gate` (self-covering: its own absence from `needs` would be caught by itself). It
reports four classes:

- `UNGATED LANE` — defined, not in `needs`, not annotated. The class #2856 filed.
- `DANGLING NEED` — a `needs` entry naming no defined job.
- `STALE OPT-OUT` — a job annotated as deliberately ungated that *is* in `needs`.
- `BARE OPT-OUT` — `# lane-coverage-ok:` with no reason after the colon.

**Required, not advisory** — deliberately. An advisory lane-coverage check would be a green-and-silent
surface whose entire purpose is detecting green-and-silent surfaces, which
`docs/conventions/liveness-assertion/` names as non-conforming. The false-positive risk that normally
argues for advisory is absent here: the gate reads one file, takes no diff, no base ref and no
network, and every YAML shape it does not model (flow-sequence `needs: [a, b]`, scalar `needs:`, an
aggregate with no `needs:`, an unmodelled 2-space key under `jobs:`) exits **2 (inconclusive)** rather
than 0 — reporting coverage from a file it did not parse would be the gate committing the very defect
it detects.

**The opt-out** is the same annotated-exemption shape `# silent-skip-ok:` uses for
`scripts/check-silent-skips.sh` — a `# lane-coverage-ok: <reason>` comment in the contiguous 2-space
block immediately above the job key, or trailing the key itself. The reason lives next to the thing it
excuses, in the file a reviewer is already reading, with no separate list to drift. It carries a stale
guard (the annotation cannot outlive what it excuses) and a bare annotation **fails** rather than
passing as "annotated", so it can never become a silent off switch.

No job's logic, `runs-on`, triggers, or `if:` conditions changed. The `ci.yml` diff is
**31 insertions, 0 deletions**: three `needs:` entries and one new job block.

## Verification

**The guard fires on the real defect and stops firing once fixed** — constructed and run, not reasoned
about. On the unfixed `ci.yml` (pre-edit, at `origin/main`):

```console
$ bash scripts/check-lane-coverage.sh --check ; echo "EXIT=$?"
UNGATED LANE: job 'managed-scope-sync' is defined in .github/workflows/ci.yml but absent from ci-status.needs, so it cannot gate a merge. ...
UNGATED LANE: job 'state-key-sync' is defined in .github/workflows/ci.yml but absent from ci-status.needs, so it cannot gate a merge. ...
check-lane-coverage: 2 coverage defect(s) in .github/workflows/ci.yml
EXIT=1
```

After the wiring, the same derivation returns an empty gap and the gate is green:

```console
$ bash derive-gap.sh
defined jobs (incl. ci-status): 38
ci-status.needs entries:        37
--- defined but NOT in ci-status.needs (excluding ci-status itself) ---
--- in ci-status.needs but NOT defined ---

$ bash scripts/check-lane-coverage.sh --check
check-lane-coverage: .github/workflows/ci.yml — all 37 lane(s) reachable from ci-status.needs
```

## Test plan

`scripts/check-lane-coverage.test.sh` — 20 cases, synthetic workflow fixtures built per case, all
`ALL PASS`:

- a job absent from `needs` fails **1** and names the job; every job present passes **0**
- annotated opt-out passes **0**; trailing-comment form passes **0**
- opt-out with no reason fails **1** (`BARE OPT-OUT`)
- opt-out on a job that *is* in `needs` fails **1** (`STALE OPT-OUT`)
- an annotation separated from its key by a blank line does **not** exempt the job
- `needs` entry naming no defined job fails **1** (`DANGLING NEED`)
- flow-sequence `needs`, scalar `needs`, absent `needs`, empty `needs`, unmodelled 2-space key,
  unknown aggregate id, missing file, bad usage, no `jobs:` mapping — all exit **2**, never 0
- the repository's own `ci.yml` exits **0**

Fixtures are plain files under `mktemp` addressed by absolute path — no scratch git repo, so the
`git config user.email` caller-config-clobber class (#2839) cannot recur here.

Also run clean locally: `shellcheck` and `actionlint` on the touched files;
`check-shell-portability.sh --paths` (both new scripts); `check-silent-skips.sh`;
`check-discriminating-test-skips.sh`; `check-orphaned-fixtures.sh`; `check-changelog-parity.sh
--check` and `--check-bump origin/main` (no plugin touched, so no version bump is owed);
`check-stale-base-overlap.sh --check origin/main`; `affected-tests.sh` (both new files map to a suite
— no unmapped-file error); `affected-tests.test.sh` (32/32) and `check-docs-only.test.sh` (21/21),
the two suites the selector picked for the `ci.yml` change.

An independent fresh-context verifier re-derived both sets with its own script, rebuilt the
fired/not-fired evidence from scratch, and diff-checked that no job's logic, triggers, or `if:`
conditions changed.

## Related

- Fixes #2856
- Refs #2834, #2841 — #2841 is where "a new job is automatically required" was tested and found
  false; it added `windows-path-emit-gate` and `windows-path-emit-windows` and wired both by hand.
  This PR makes the hand-wiring mechanical. Branched off `origin/main` after #2841 merged.
- Refs #532 — `docs/conventions/liveness-assertion/`, the false-green class this defect belongs to.
- Does not touch `scripts/check-silent-revert.sh` or `scripts/silent-revert-incidents.txt` (#2843).
