### PR TITLE
perf(disk-hygiene): read the engine once per hook launch and state the measured share

### DIFF
--- a/plugins/disk-hygiene/.claude-plugin/plugin.json
+++ b/plugins/disk-hygiene/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "disk-hygiene",
-  "version": "0.20.12",
+  "version": "0.20.13",
   "description": "Context-aware disk hygiene for arbitrary directory trees: inventories orphaned and temporary artifacts, classifies evidence into review tiers, and offers exact-path cleanup only after a fresh safety preview and explicit per-tier approval. The target is read-only by default; OS-managed paths, links and mount points, VCS-tracked content without the complete checkout evidence bundle, changed entries, and live-handle uncertainty fail closed.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/disk-hygiene/CHANGELOG.md
+++ b/plugins/disk-hygiene/CHANGELOG.md
@@ -18,9 +18,11 @@ All notable changes to the `disk-hygiene` plugin are documented here. Format fol
   scanning to EOF.
 - **README states the hook's measured always-on share (issue 2853).** The trust-surface record's
   launch-count sentence is replaced with a measured figure per the hook-budget convention's method
-  (2026-08-16, Windows 11 + Git Bash, 32 runs per variant): ≈ 190 ms per shell tool call for the
-  engine-gate hook, of which the engine read accounts for ≈ 24 ms (≈ 13%) in the single-read form,
-  down from ≈ 38 ms (≈ 19%) in the two-pass form. `hooks.json`'s `"timeout": 60` is unchanged.
+  (2026-08-16, Windows 11 + Git Bash): ≈ 190–300 ms per shell tool call for the engine-gate hook
+  across batches (92 single runs), ≈ 320–410 ms parallel wall for the two-registration set measured
+  concurrently (`&` + `wait`, 60 pairs), of which the engine read accounts for ≈ 24 ms (≈ 13%) in
+  the single-read form, down from ≈ 38 ms (≈ 19%) in the two-pass form. `hooks.json`'s
+  `"timeout": 60` is unchanged.
 
 ## [0.20.12]
 

--- a/plugins/disk-hygiene/CHANGELOG.md
+++ b/plugins/disk-hygiene/CHANGELOG.md
@@ -3,6 +3,25 @@
 All notable changes to the `disk-hygiene` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.20.13]
+
+### Changed
+
+- **Single, early-terminating read of the engine per hook launch (issue 2853).** The always-on
+  `Bash|PowerShell` launcher used to run two separate full-file `sed` passes over the ~3,500-line
+  engine — neither stopping at the match — to recover `MIN_PYTHON` from near the top of the file. It
+  now runs one `sed` whose address-block `q` terminates the read at the `MIN_PYTHON` line.
+  `hygiene.MIN_PYTHON` remains the floor's single origin (PR 1028), and `test_hygiene.py`'s
+  `VersionFloorTests` shape/count lock still passes; `hooks/run-python-hook.test.sh` now asserts
+  behaviorally (via a recording `sed` shim plus an argv replay against a two-floor fixture) that a
+  launch reads the engine exactly once and that the read stops at the first match instead of
+  scanning to EOF.
+- **README states the hook's measured always-on share (issue 2853).** The trust-surface record's
+  launch-count sentence is replaced with a measured figure per the hook-budget convention's method
+  (2026-08-16, Windows 11 + Git Bash, 32 runs per variant): ≈ 190 ms per shell tool call for the
+  engine-gate hook, of which the engine read accounts for ≈ 24 ms (≈ 13%) in the single-read form,
+  down from ≈ 38 ms (≈ 19%) in the two-pass form. `hooks.json`'s `"timeout": 60` is unchanged.
+
 ## [0.20.12]
 
 ### Changed

--- a/plugins/disk-hygiene/README.md
+++ b/plugins/disk-hygiene/README.md
@@ -227,12 +227,15 @@ hand-cleaning the zone.
   did during active cleanup. Known costs, accepted, with the always-on share measured per the
   [hook-budget convention](../../docs/conventions/hook-budget/README.md)'s method (`EPOCHREALTIME`
   wall-clock around direct hook invocation with a benign representative payload; Windows 11 +
-  Git Bash dev host, 2026-08-16, 32 runs per variant): the engine-gate hook costs **≈ 190 ms per
-  Bash/PowerShell tool call** — ≈ 19% of the convention's ≤ 1 s typical per-tool-call ceiling, and
-  doubled to ≈ 380 ms while the `clean` skill's second frontmatter registration is loaded. Of that,
-  the launcher's read of the engine to recover `MIN_PYTHON` (a single early-quit `sed` since
-  0.20.13, held to one read by `hooks/run-python-hook.test.sh`) accounts for ≈ 24 ms, **≈ 13% of
-  the hook's cost**; the prior two-full-pass form measured ≈ 38 ms (≈ 19% of a ≈ 205 ms hook).
+  Git Bash dev host, 2026-08-16): the engine-gate hook costs **≈ 190–300 ms per Bash/PowerShell
+  tool call** across batches (92 single runs) — ≈ 19–30% of the convention's ≤ 1 s typical
+  per-tool-call ceiling. While the `clean` skill is loaded, its frontmatter registration is a
+  second matching hook that the harness launches in parallel; the pair measured concurrently
+  (`&` + `wait`, 60 pairs) walls at **≈ 320–410 ms**, ≈ 1.3–1.5× the same-batch single-hook wall
+  rather than double it. Of the single-hook cost, the launcher's read of the engine to recover
+  `MIN_PYTHON` (a single early-quit `sed` since 0.20.13, held to one read by
+  `hooks/run-python-hook.test.sh`) accounts for ≈ 24 ms, **≈ 13% of the hook's cost** in the batch
+  it was measured against; the prior two-full-pass form measured ≈ 38 ms (≈ 19% of a ≈ 205 ms hook).
   On a machine where no Python 3 interpreter resolves at all the gate fails
   open on every call — the `Stop` detector emits a `systemMessage` for that case, so the blind spot is
   visible rather than silent (#1110, #1504). **0.9.0 delta:** the gate no longer carries a `${user_config.*}`

--- a/plugins/disk-hygiene/README.md
+++ b/plugins/disk-hygiene/README.md
@@ -224,8 +224,16 @@ hand-cleaning the zone.
   plugin's own `hooks.json` (see the 0.17.8 delta for exactly what that bounds now that the string
   reaches a shell), bundled standard-library scripts only, instant no-output deferral for any command
   not referencing the engine, and no new capability beyond what the skill-scoped deployment already
-  did during active cleanup. Known costs, accepted: one launcher shell plus one Python launch per
-  Bash/PowerShell call, and on a machine where no Python 3 interpreter resolves at all the gate fails
+  did during active cleanup. Known costs, accepted, with the always-on share measured per the
+  [hook-budget convention](../../docs/conventions/hook-budget/README.md)'s method (`EPOCHREALTIME`
+  wall-clock around direct hook invocation with a benign representative payload; Windows 11 +
+  Git Bash dev host, 2026-08-16, 32 runs per variant): the engine-gate hook costs **≈ 190 ms per
+  Bash/PowerShell tool call** — ≈ 19% of the convention's ≤ 1 s typical per-tool-call ceiling, and
+  doubled to ≈ 380 ms while the `clean` skill's second frontmatter registration is loaded. Of that,
+  the launcher's read of the engine to recover `MIN_PYTHON` (a single early-quit `sed` since
+  0.20.13, held to one read by `hooks/run-python-hook.test.sh`) accounts for ≈ 24 ms, **≈ 13% of
+  the hook's cost**; the prior two-full-pass form measured ≈ 38 ms (≈ 19% of a ≈ 205 ms hook).
+  On a machine where no Python 3 interpreter resolves at all the gate fails
   open on every call — the `Stop` detector emits a `systemMessage` for that case, so the blind spot is
   visible rather than silent (#1110, #1504). **0.9.0 delta:** the gate no longer carries a `${user_config.*}`
   argument (which, unset, dropped the whole hook and left the gate inert on a default install); it now

--- a/plugins/disk-hygiene/hooks/run-python-hook.sh
+++ b/plugins/disk-hygiene/hooks/run-python-hook.sh
@@ -32,8 +32,28 @@ set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ENGINE="$SCRIPT_DIR/../skills/clean/scripts/hygiene.py"
-MIN_PYTHON_MAJOR="$(sed -n 's/^MIN_PYTHON = (\([0-9]*\), \([0-9]*\)).*/\1/p' "$ENGINE")"
-MIN_PYTHON_MINOR="$(sed -n 's/^MIN_PYTHON = (\([0-9]*\), \([0-9]*\)).*/\2/p' "$ENGINE")"
+# One read of the engine, stopped at the MIN_PYTHON line (#2853). This launcher
+# sits behind an always-on `Bash|PowerShell` PreToolUse matcher, so every shell
+# tool call pays whatever happens here; the previous form ran TWO separate sed
+# passes and neither stopped at the match, scanning the whole ~3,500-line
+# engine twice to recover a constant that sits near the top of the file.
+#
+# The ADDRESS BLOCK is what makes it stop. The obvious one-liner
+# `sed -n 's/^MIN_PYTHON = (...).*/\1 \2/p;/^MIN_PYTHON/q'` does NOT quit: by
+# the time `q`'s address is evaluated, `s///` has already rewritten the pattern
+# space to `3 11`, so `/^MIN_PYTHON/` never matches and sed still reads to EOF.
+# Addressing the block on the ORIGINAL line and quitting inside it is what makes
+# the read terminate at the match.
+#
+# First-match-wins is safe because the engine has exactly one `^MIN_PYTHON` line
+# (`grep -c '^MIN_PYTHON'` = 1) and test_hygiene.py's VersionFloorTests locks
+# both that count and the line's shape. hygiene.MIN_PYTHON remains the single
+# origin of the floor (#1028); this refines how it is read, not where it lives.
+# hooks/run-python-hook.test.sh holds the one-read + stops-at-the-match contract.
+MIN_PYTHON_FLOOR="$(sed -n '/^MIN_PYTHON = (/{s/^MIN_PYTHON = (\([0-9]*\), \([0-9]*\)).*/\1 \2/p;q;}' "$ENGINE")"
+MIN_PYTHON_MAJOR=""
+MIN_PYTHON_MINOR=""
+read -r MIN_PYTHON_MAJOR MIN_PYTHON_MINOR <<<"$MIN_PYTHON_FLOOR" || true
 if [[ -z "$MIN_PYTHON_MAJOR" || -z "$MIN_PYTHON_MINOR" ]]; then
   MIN_PYTHON_MAJOR=3
   MIN_PYTHON_MINOR=11

--- a/plugins/disk-hygiene/hooks/run-python-hook.test.sh
+++ b/plugins/disk-hygiene/hooks/run-python-hook.test.sh
@@ -33,6 +33,124 @@ assert_contains() {
   fi
 }
 
+# --- the engine is read ONCE per launch, and that read stops at MIN_PYTHON ---
+#
+# #2853. This launcher sits behind an always-on `Bash|PowerShell` PreToolUse
+# matcher, so every shell tool call in every session pays whatever it does here.
+# It used to run two separate full-file `sed` passes over the ~3,500-line
+# engine, neither of which stopped at the match, to recover one constant that
+# sits near the top of the file.
+#
+# Both assertions below are BEHAVIORAL, not spelling checks. They observe the
+# reader the launcher actually runs, through a `sed` shim on PATH that records
+# each invocation's argv and delegates to the real sed:
+#
+#   1. exactly one recorded invocation names the engine;
+#   2. replaying that recorded argv against a fixture whose FIRST `MIN_PYTHON`
+#      line is `(3, 14)` and whose LAST LINE is `MIN_PYTHON = (9, 99)` prints
+#      exactly one line. A reader that scanned to EOF could not print one match
+#      when a second match sits on the final line, so one line is proof the read
+#      terminated at the first match.
+#
+# Assertion 2 is what a naive single-pass cannot fake: the tempting one-liner
+# `sed -n 's/^MIN_PYTHON = (...).*/\1 \2/p;/^MIN_PYTHON/q'` halves the passes but
+# never quits, because `q`'s address sees the already-substituted pattern space.
+# The fixture's floor values are deliberately NOT the real 3/11, so the
+# launcher's hardcoded fallback cannot be mistaken for a pass.
+SED_REAL="$(command -v sed)"
+PROBE_DIR="$(mktemp -d)"
+# NOTE: the later `trap ... EXIT` in this file REPLACES this one rather than
+# adding to it, so it removes both directories. Keep them in sync.
+trap 'rm -rf "$PROBE_DIR"' EXIT
+PROBE_BIN="$PROBE_DIR/bin"
+PROBE_CALLS="$PROBE_DIR/calls"
+mkdir -p "$PROBE_BIN" "$PROBE_CALLS"
+
+cat >"$PROBE_BIN/sed" <<'SHIM'
+#!/usr/bin/env bash
+# Record this invocation's argv when the engine is among its operands, then
+# delegate to the real sed. One newline-separated file per recorded call.
+set -uo pipefail
+for arg in "$@"; do
+  case "$arg" in
+  *"/skills/clean/scripts/hygiene.py")
+    idx=1
+    while [[ -e "$RUN_PYTHON_HOOK_CALLS/call-$idx" ]]; do
+      idx=$((idx + 1))
+    done
+    printf '%s\n' "$@" >"$RUN_PYTHON_HOOK_CALLS/call-$idx"
+    break
+    ;;
+  esac
+done
+exec "$RUN_PYTHON_HOOK_SED" "$@"
+SHIM
+chmod +x "$PROBE_BIN/sed"
+
+# No interpreter resolves under this PATH, so the launcher takes its documented
+# guard fail-open (exit 0) instead of spawning Python. The engine read happens
+# before interpreter resolution either way, which is the whole point.
+for stub in python3 python py; do
+  printf '#!/usr/bin/env bash\nexit 127\n' >"$PROBE_BIN/$stub"
+  chmod +x "$PROBE_BIN/$stub"
+done
+
+PROBE_FIXTURE="$PROBE_DIR/fixture.py"
+{
+  printf '%s\n' '"""Fixture engine for the single-read contract."""'
+  printf '%s\n' 'MIN_PYTHON = (3, 14)'
+  for ((_filler = 0; _filler < 400; _filler++)); do
+    printf '%s\n' 'FILLER = 0'
+  done
+  printf '%s\n' 'MIN_PYTHON = (9, 99)'
+} >"$PROBE_FIXTURE"
+
+RUN_PYTHON_HOOK_SED="$SED_REAL" \
+  RUN_PYTHON_HOOK_CALLS="$PROBE_CALLS" \
+  PATH="$PROBE_BIN:$PATH" \
+  bash "$LAUNCHER" \
+  "$SCRIPT_DIR/../skills/clean/scripts/destructive_guard.py" \
+  --mode engine-gate >/dev/null 2>&1 || true
+
+engine_reads=0
+for call in "$PROBE_CALLS"/call-*; do
+  [[ -e "$call" ]] || continue
+  engine_reads=$((engine_reads + 1))
+done
+assert_eq "one hook launch reads the engine exactly once" "1" "$engine_reads"
+
+if [[ "$engine_reads" -ne 1 ]]; then
+  fail "cannot check the stop-at-match contract without exactly one recorded read"
+fi
+
+recorded_argv=()
+while IFS= read -r recorded_arg; do
+  recorded_argv+=("$recorded_arg")
+done <"$PROBE_CALLS/call-1"
+
+# Replay the SAME argv, with the engine operand swapped for the fixture.
+replay_argv=()
+for recorded_arg in "${recorded_argv[@]}"; do
+  case "$recorded_arg" in
+  *"/skills/clean/scripts/hygiene.py") replay_argv+=("$PROBE_FIXTURE") ;;
+  *) replay_argv+=("$recorded_arg") ;;
+  esac
+done
+
+replay_out="$("$SED_REAL" "${replay_argv[@]}")"
+replay_lines="$(printf '%s\n' "$replay_out" | grep -c . || true)"
+assert_eq "the engine read stops at the MIN_PYTHON line instead of scanning to EOF" \
+  "1" "$replay_lines"
+assert_eq "the stopped read yields the fixture's first floor" \
+  "3 14" "${replay_out//$'\r'/}"
+
+# Same replay against the REAL engine: the refinement must still produce the
+# floor the two-pass form produced, which is what keeps MIN_PYTHON the single
+# origin (#1028) rather than a second hardcoded copy.
+real_out="$("$SED_REAL" "${recorded_argv[@]}")"
+assert_eq "the single read recovers the engine's real floor" \
+  "${FLOOR/./ }" "${real_out//$'\r'/}"
+
 # --- hooks.json wires this launcher in portable shell form ---
 #
 # These assert the PORTABILITY PROPERTY, not a literal spelling. The previous
@@ -81,7 +199,8 @@ done
 
 # --- monitor mode without python emits systemMessage JSON ---
 FAKE_BIN="$(mktemp -d)"
-trap 'rm -rf "$FAKE_BIN"' EXIT
+# Replaces (does not chain onto) the earlier EXIT trap, so it cleans up both.
+trap 'rm -rf "$FAKE_BIN" "$PROBE_DIR"' EXIT
 printf '#!/usr/bin/env bash\nexit 127\n' >"$FAKE_BIN/nopy"
 chmod +x "$FAKE_BIN/nopy"
 cat >"$FAKE_BIN/python3" <<'EOF'


### PR DESCRIPTION
Closes #2853

## What

The disk-hygiene half of the hook-budget conformance gap (sibling of the guardrails item, issue 1403 / issue 2663, under the issue 1809 budget adoption):

- **Single, early-terminating engine read per hook launch.** The always-on `Bash|PowerShell` launcher recovered `MIN_PYTHON` with two separate full-file `sed` passes over the ~3,500-line engine, neither stopping at the match. It now runs one `sed` whose address-block `q` terminates the read at the `MIN_PYTHON` line. Note the obvious one-liner (`s///p;/^MIN_PYTHON/q`) does NOT stop — `q`'s address sees the already-substituted pattern space — which is why the block form is used. `hygiene.MIN_PYTHON` stays the floor's single origin (PR 1028); `VersionFloorTests` still passes.
- **Behavioral contract test.** `run-python-hook.test.sh` now proves, via a recording `sed` shim plus an argv replay against a two-floor fixture (first floor `(3, 14)`, last line `(9, 99)`), that one launch reads the engine exactly once and that the read stops at the first match instead of scanning to EOF. Fixture floors are deliberately not 3/11 so the hardcoded fallback cannot masquerade as a pass.
- **README states the measured share.** The trust-surface record's launch-count sentence is replaced with the share measured by the method in `docs/conventions/hook-budget/README.md` — `EPOCHREALTIME` wall-clock around direct hook invocation with a benign payload, Windows 11 + Git Bash (the convention's binding host), 2026-08-16: the engine-gate hook costs ~190–300 ms per shell tool call across batches (92 single runs; ~19–30% of the <= 1 s typical per-tool-call ceiling). Per the review thread, the two-registration set (plugin hook + `clean` skill frontmatter belt) was measured as a concurrent parallel wall (`&` + `wait`, 60 pairs): ~320–410 ms, ~1.3–1.5x the same-batch single wall rather than a naive 2x. Of the single-hook cost, the engine read accounts for ~24 ms (~13%) in the single-read form, down from ~38 ms (~19% of a ~205 ms hook) in the two-pass form.
- `hooks.json` `"timeout": 60` is unchanged, per the issue's third criterion.
- Version 0.20.13 + CHANGELOG section above main's 0.20.12.

## Verification

- `run-python-hook.test.sh`: all 17 assertions pass locally (Windows 11 + Git Bash).
- `test_hygiene.VersionFloorTests`: 3/3 OK under CPython 3.14.7.
- shellcheck and markdownlint-cli2 clean; all four changelog-parity checks pass locally.
- An independent fresh-context verifier re-ran the measurement from scratch (two batches of N=15) and confirmed the README numbers are honest within host noise: full hook 209–216 ms, single read 20–30 ms, two-pass form 44–68 ms. It also confirmed by reasoning over the sed program that the `q` genuinely fires on the original pattern space.
- Verifier findings worth recording (both low, future-regression gaps, not present defects): the shim counts only `sed` readers, so a future launcher that added a second read via `cat`/`awk`/stdin-redirected `sed` would not be caught by the exactly-once assertion; and the stop-at-EOF replay is necessary-but-not-sufficient (a range-addressed `0,/floor/` program would print one line yet read to EOF). The committed program is neither shape.

## Related

- Issue 1809 — adopted the hook budget and deferred the overage to per-plugin items; this PR is the disk-hygiene item.
- Issue 1403 / issue 2663 — the guardrails sibling item and its completed analogue.
- PR 1028 — established `MIN_PYTHON` as the single origin and the `sed` parse; this PR keeps that contract intact.
- `docs/conventions/hook-budget/README.md` — the measurement method and budget this PR conforms to.
- Issue 2851 (`feat/2851-per-child-rollup`) — lands after this PR and also touches the disk-hygiene CHANGELOG and manifest; this PR does not touch `hygiene.py` or its tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RPRAvSLuRmR6rPQeCvdok6
