### PR TITLE
feat(scripts): assert a recorded silent-revert incident's content came back

### DIFF
--- a/.github/workflows/silent-revert-canary.yml
+++ b/.github/workflows/silent-revert-canary.yml
@@ -97,6 +97,30 @@ jobs:
       - name: Replay the recorded incidents
         run: scripts/check-silent-revert.sh --verify-known-incidents
 
+      # The other half of the proof (#2855). The step above asserts every
+      # recorded incident is still DETECTED; this one asserts the content those
+      # incidents deleted is on the tree TODAY. Both are needed, and the gap
+      # between them has already cost 31h28m: #2828's two files were missing
+      # from main while the replay above printed `ok` and exited 0, two re-lands
+      # each missed them, and a hand audit found it rather than this lane.
+      #
+      # UNGATED, exactly like the two steps above it, for the same reason. The
+      # failure that produced #2828 is "nobody thought to check", so an
+      # on-demand mode or a `push`-only gate would reproduce it. Running on
+      # pull_request events too is not a merge gate: this workflow is not in
+      # ci.yml and not in that workflow's `ci-status` aggregate, which is the
+      # single required check the org ci-gate ruleset keys on -- and it is
+      # `paths`-scoped to the canary's own files, so it is inert on every other
+      # PR. What it buys is that a PR editing this corpus proves its markers
+      # resolve before the merge rather than after.
+      #
+      # No rev argument: the assertion resolves against the checked-out tree,
+      # which is the question worth asking here -- is the content on main RIGHT
+      # NOW. The explicit-rev form exists so a reviewer can replay the
+      # assertion against the historical tree an incident was measured on.
+      - name: Assert the recorded incidents' content is restored
+        run: scripts/check-silent-revert.sh --verify-restoration
+
       # Resolve the pushed range. `github.event.before` is all-zeros on a first
       # push or after a history rewrite, and absent entirely on
       # workflow_dispatch; in both cases fall back to the head commit and SAY

--- a/.github/workflows/silent-revert-canary.yml
+++ b/.github/workflows/silent-revert-canary.yml
@@ -97,30 +97,6 @@ jobs:
       - name: Replay the recorded incidents
         run: scripts/check-silent-revert.sh --verify-known-incidents
 
-      # The other half of the proof (#2855). The step above asserts every
-      # recorded incident is still DETECTED; this one asserts the content those
-      # incidents deleted is on the tree TODAY. Both are needed, and the gap
-      # between them has already cost 31h28m: #2828's two files were missing
-      # from main while the replay above printed `ok` and exited 0, two re-lands
-      # each missed them, and a hand audit found it rather than this lane.
-      #
-      # UNGATED, exactly like the two steps above it, for the same reason. The
-      # failure that produced #2828 is "nobody thought to check", so an
-      # on-demand mode or a `push`-only gate would reproduce it. Running on
-      # pull_request events too is not a merge gate: this workflow is not in
-      # ci.yml and not in that workflow's `ci-status` aggregate, which is the
-      # single required check the org ci-gate ruleset keys on -- and it is
-      # `paths`-scoped to the canary's own files, so it is inert on every other
-      # PR. What it buys is that a PR editing this corpus proves its markers
-      # resolve before the merge rather than after.
-      #
-      # No rev argument: the assertion resolves against the checked-out tree,
-      # which is the question worth asking here -- is the content on main RIGHT
-      # NOW. The explicit-rev form exists so a reviewer can replay the
-      # assertion against the historical tree an incident was measured on.
-      - name: Assert the recorded incidents' content is restored
-        run: scripts/check-silent-revert.sh --verify-restoration
-
       # Resolve the pushed range. `github.event.before` is all-zeros on a first
       # push or after a history rewrite, and absent entirely on
       # workflow_dispatch; in both cases fall back to the head commit and SAY
@@ -169,3 +145,45 @@ jobs:
           else
             scripts/check-silent-revert.sh "$SCAN_TARGET"
           fi
+
+      # The other half of the proof (#2855). The replay above asserts every
+      # recorded incident is still DETECTED; this asserts the content those
+      # incidents deleted is on the tree TODAY. Both are needed, and the gap
+      # between them has already cost 31h28m: the content #2828 is about was
+      # missing from main while the replay printed `ok` and exited 0, two
+      # re-lands each missed it, and a hand audit found it, not this lane.
+      #
+      # ORDER IS LOAD-BEARING, and this step is deliberately LAST.
+      #
+      # A step with no status function carries an implicit `success() &&`, so a
+      # step that fails SKIPS every later step in the job. Placed before the
+      # scan, a red restoration assertion would therefore skip the scan itself
+      # -- and those commits are never re-examined, because the next push's
+      # range starts at this push's head. That trade is unacceptable in this
+      # direction: restoration is bound to LIVE content in living files and the
+      # corpus header says a marker going red on a rename is intended
+      # loudness, while the scan is the primary detector. A churn-sensitive
+      # tripwire must never be able to silence it. Running last, this step can
+      # fail as loudly as it likes and the scan has already spoken.
+      #
+      # `success() || failure()` rather than the default, so the reverse
+      # suppression cannot happen either: a scan that fires (exit 1) must not
+      # skip the restoration answer. It excludes cancellation, so a cancelled
+      # run still reports nothing rather than a result it did not earn.
+      #
+      # UNGATED on the event, exactly like the self-test and the replay. The
+      # failure that produced #2828 is "nobody thought to check", so an
+      # on-demand mode would reproduce it. Running on pull_request events too is
+      # not a merge gate: this workflow is not in ci.yml and not in that
+      # workflow's `ci-status` aggregate, which is the single required check the
+      # org ci-gate ruleset keys on -- and it is `paths`-scoped to the canary's
+      # own files, so it is inert on every other PR. What it buys is that a PR
+      # editing this corpus proves its markers resolve before the merge.
+      #
+      # No rev argument: it resolves against the checked-out tree, which is the
+      # question worth asking here -- is the content on main RIGHT NOW. The
+      # explicit-rev form exists so a reviewer can replay the assertion against
+      # the historical tree an incident was measured on.
+      - name: Assert the recorded incidents' content is restored
+        if: success() || failure()
+        run: scripts/check-silent-revert.sh --verify-restoration

--- a/scripts/check-silent-revert.sh
+++ b/scripts/check-silent-revert.sh
@@ -615,13 +615,20 @@ parse_incidents_file() {
 
   local line kind sha path rest reason marker
   while IFS= read -r line || [[ -n "$line" ]]; do
-    case "$line" in
-      '' | '#'*) continue ;;
-      *) ;;
-    esac
+    # Split FIRST, then decide what the row is, so blank/comment recognition is
+    # done on the trimmed leading field rather than on the raw line.
+    #
+    # Testing the raw line instead would make an INDENTED comment ("  # note")
+    # or a whitespace-only line an "unknown row kind" and exit 2 -- while
+    # verify_known_incidents (which reads the same file through `read`) skips
+    # both, and t_shipped_data_files_are_wellformed explicitly accepts
+    # `^[[:space:]]*(#|$)`. Three readers of one file must not disagree about
+    # what a comment is: a formatting-only edit to this corpus would otherwise
+    # turn the canary red for a reason having nothing to do with the canary.
     read -r kind sha path rest <<<"$line"
 
     case "$kind" in
+      '' | '#'*) continue ;;
       fires | clean)
         [[ "$sha" =~ ^[0-9a-f]{40}$ ]] ||
           die "incident sha '$sha' in $INCIDENTS_FILE is not a full 40-character sha"
@@ -681,6 +688,19 @@ parse_incidents_file() {
           reason="${reason#"${reason%%[![:space:]]*}"}"
           marker="${rest#*\]}"
           marker="${marker#"${marker%%[![:space:]]*}"}"
+          # The split above takes the FIRST `]`, so a reason that itself
+          # contains one would silently truncate the reason AND corrupt the
+          # marker text with a stray leading `]`. That combination is quietly
+          # WRONG rather than merely odd: the corrupted marker stops matching,
+          # while the still-non-empty reason makes the row report
+          # "deliberately not restored" -- announcing a recorded decision about
+          # content that may be sitting right there. Undecidable from the row
+          # alone, so it is refused. Only a DISPOSITIONED row pays this cost;
+          # an ordinary marker's text may contain `]` freely.
+          case "$marker" in
+            *\]*) die "ambiguous disposition on the marker row for $sha in $INCIDENTS_FILE: a '[not-restored: ...]' reason may not contain ']'" ;;
+            *) ;;
+          esac
         fi
         [[ -n "$marker" ]] ||
           die "marker row for $sha in $INCIDENTS_FILE records no marker text"
@@ -743,6 +763,14 @@ marker_present() {
     # form of "is this a tracked path", and it makes the default mode assert
     # the same universe the explicit-rev mode does.
     git ls-files --error-unmatch -- "$path" >/dev/null 2>&1 || return 1
+    # A tracked SYMLINK is tracked as the link, but `-f` and the read below
+    # follow it -- so a link committed into the repo could still be answered
+    # with content from outside it. At a rev the same row reads the link's
+    # blob (its target string) instead. Refuse rather than let the two modes
+    # answer a different question.
+    if [[ -L "$path" ]]; then
+      die "marker path '$path' is a symlink -- bind a marker to the file that holds the content"
+    fi
     [[ -f "$path" ]] ||
       die "marker path '$path' is not a regular file -- bind a marker to exactly one file"
     content="$(<"$path")" || die "could not read '$path'"

--- a/scripts/check-silent-revert.sh
+++ b/scripts/check-silent-revert.sh
@@ -203,9 +203,13 @@
 # repo-wide `git grep` would have reported both files restored while both were
 # missing.
 #
-# Cost: one path-scoped `git grep` per marker over a four-row corpus, which is
-# why it runs in the same `push: main` job as the replay instead of behind an
-# on-demand flag. "Nobody thought to check" is the failure that produced #2828,
+# Cost: one exact-path read per marker over a four-row corpus -- `git cat-file`
+# at a rev, a tracked-path read in the working tree -- with the match done by
+# `grep -qF` on the file's contents. Not `git grep`: its pathspec semantics are
+# the very thing marker_present() below refuses, because a pathspec can widen a
+# bound path back into the repo-wide search this design exists to avoid. That
+# cost is why the assertion runs in the same `push: main` job as the replay
+# instead of behind an on-demand flag. "Nobody thought to check" is the failure that produced #2828,
 # so an on-demand-only mode would reproduce it.
 #
 # The self-test (scripts/check-silent-revert.test.sh) runs BEFORE this script in

--- a/scripts/check-silent-revert.sh
+++ b/scripts/check-silent-revert.sh
@@ -631,7 +631,8 @@ parse_incidents_file() {
         ;;
       marker)
         # The parsed view below is SEP-delimited, so a row already carrying
-        # that byte is refused up front rather than silently mis-split. It is a
+        # that byte is refused up front rather than split at the wrong field
+        # boundary without anyone noticing. It is a
         # control character no editor writes by accident; the check exists so
         # the invariant is stated rather than assumed.
         case "$line" in
@@ -642,8 +643,27 @@ parse_incidents_file() {
           die "marker row sha '$sha' in $INCIDENTS_FILE is not a full 40-character sha"
         [[ -n "$path" ]] ||
           die "marker row for $sha in $INCIDENTS_FILE records no path"
+        # The path names a file INSIDE this repository, relative to its root.
+        # An absolute path or a `..` component would reach outside the tree the
+        # assertion is about, so a marker could be satisfied by content that is
+        # not on main at all. Refused here rather than at resolution time, so
+        # both modes are held to it identically.
         case "$path" in
           \[*) die "marker row for $sha in $INCIDENTS_FILE has a disposition where its path should be" ;;
+          /* | [A-Za-z]:[/\\]* | \\*)
+            die "marker path '$path' for $sha in $INCIDENTS_FILE is absolute -- use a path relative to the repository root" ;;
+          .. | ../* | */../* | */..)
+            die "marker path '$path' for $sha in $INCIDENTS_FILE escapes the repository with '..'" ;;
+          # Glob and pathspec metacharacters are refused rather than resolved.
+          # They are the widening vectors, and refusing them at parse time is
+          # what keeps BOTH modes answering identically: `git cat-file` would
+          # simply not find such a path (absent, exit 1) while `git ls-files`
+          # would expand it (present, exit 0). A marker path is a literal file
+          # path or it is a corpus error.
+          :*)
+            die "marker path '$path' for $sha in $INCIDENTS_FILE uses pathspec magic -- a marker binds to one literal file path" ;;
+          *[*?[]*)
+            die "marker path '$path' for $sha in $INCIDENTS_FILE contains a glob character -- a marker binds to one literal file path" ;;
           *) ;;
         esac
 
@@ -715,7 +735,14 @@ marker_present() {
     content="$(git cat-file blob "${rev}:${path}" 2>/dev/null)" ||
       die "could not read '$path' at $rev"
   else
-    [[ -e "$path" ]] || return 1
+    # Working-tree mode must stay REPO-SCOPED, or the two modes disagree about
+    # what they are asserting. Reading the filesystem directly would let a
+    # marker be satisfied by an untracked file, a .gitignore'd file, or a
+    # symlink pointing outside the repository entirely -- content that is not
+    # on main and never will be. `git ls-files --error-unmatch` is the cheap
+    # form of "is this a tracked path", and it makes the default mode assert
+    # the same universe the explicit-rev mode does.
+    git ls-files --error-unmatch -- "$path" >/dev/null 2>&1 || return 1
     [[ -f "$path" ]] ||
       die "marker path '$path' is not a regular file -- bind a marker to exactly one file"
     content="$(<"$path")" || die "could not read '$path'"
@@ -743,7 +770,27 @@ verify_restoration() {
   local fires markers
   fires="$(mktemp)" || die "mktemp failed"
   markers="$(mktemp)" || die "mktemp failed"
+  # Every refusal below leaves through `die`, and there are a dozen of them, so
+  # cleanup is a trap rather than a straight-line rm at the end -- the same
+  # pairing scripts/affected-tests.sh and scripts/check-fleet-audit-doc-grammar.sh
+  # use. Without it the self-test alone leaks two files per refusal path.
+  #
+  # EXIT, not RETURN: `die` exits the shell rather than returning, so a RETURN
+  # trap would never fire on exactly the paths that leak. verify_restoration is
+  # called once and the script exits straight after, so the global trap is not
+  # shared with anything.
+  # shellcheck disable=SC2064  # expand the paths now, while they are in scope.
+  trap "rm -f '$fires' '$markers'" EXIT
   parse_incidents_file "$fires" "$markers"
+
+  # A corpus with no `fires` row at all must not report a serene pass. The
+  # marker-per-fires-row rule below only bites while a `fires` row exists, so
+  # deleting a row together with its markers would otherwise leave
+  # "Every recorded incident has its content (0 marker(s))" and exit 0 -- the
+  # mute button this corpus exists in order not to have, reached by removal
+  # instead of by editing.
+  [[ -s "$fires" ]] ||
+    die "$INCIDENTS_FILE records no 'fires' row -- the restoration assertion would pass while covering nothing"
 
   # The whole file is validated, and both directions of the sha binding are
   # checked, BEFORE any marker is resolved -- so a corpus problem can never
@@ -751,6 +798,12 @@ verify_restoration() {
   local sha
   while read -r sha; do
     [[ -n "$sha" ]] || continue
+    # The incident has to be a real commit. A well-formed sha nobody can
+    # resolve is either a shallow clone (in which case this mode cannot run) or
+    # a typo, and a matched typo on a row and its marker would otherwise assert
+    # content for an incident that never happened.
+    git rev-parse --verify --quiet "${sha}^{commit}" >/dev/null ||
+      die "incident commit $sha is unreachable -- the restoration assertion needs full history (fetch-depth: 0)"
     # A `fires` row with no marker is refused rather than skipped. Skipping it
     # would let this whole assertion be satisfied by recording markers for one
     # historical incident while silently covering no future one -- a green
@@ -797,8 +850,6 @@ verify_restoration() {
       printf '        NOT RESTORED: %s\n' "$mtext"
     fi
   done <"$markers"
-
-  rm -f "$fires" "$markers"
 
   if [[ "$rc" -ne 0 ]]; then
     printf '\n'

--- a/scripts/check-silent-revert.sh
+++ b/scripts/check-silent-revert.sh
@@ -7,6 +7,10 @@
 #   scripts/check-silent-revert.sh --commit <sha> scan one commit
 #   scripts/check-silent-revert.sh --verify-known-incidents
 #                                                 replay the recorded incidents
+#   scripts/check-silent-revert.sh --verify-restoration [<rev>]
+#                                                 assert the recorded incidents'
+#                                                 content is back (default: the
+#                                                 working tree)
 #
 # Exit 0 clean, 1 findings, 2 the canary could not run (never a quiet pass).
 #
@@ -152,6 +156,58 @@
 # records a human decision about a specific commit, and a reviewer can read
 # back exactly which removals were judged intentional and why.
 #
+# DETECTION IS NOT RESTORATION (#2855)
+# ------------------------------------
+# Everything above answers one question about a recorded incident -- does this
+# commit still produce a finding -- and never the other one: is the content it
+# deleted on main TODAY. #2828 is the proof that the gap is real rather than
+# theoretical. The f603880da row printed `ok  f603880da fires as recorded` and
+# the replay exited 0 for 31h28m while the content #2635 had added to
+# plugins/disk-hygiene/README.md and
+# plugins/disk-hygiene/skills/clean/evals/evals.json was absent from main. Two
+# separate re-lands (#2714, #2803) each missed it, and a hand audit found it,
+# not this canary.
+#
+# Say CONTENT rather than "files", precisely. Both files existed at every rev in
+# that window -- #2829 shows as `README.md | 14 ++---` and `evals.json | 15 ++-`,
+# modifications, not additions. That is exactly why the gap survived: a
+# file-level or path-level check sees two present, recently-touched files and
+# has nothing to report.
+#
+# So a `fires` row also carries one or more CONTENT MARKERS, each bound to the
+# path it must be found in, and --verify-restoration asserts every one of them
+# still resolves path-scoped against a rev (the working tree by default).
+#
+# This is NOT the curated-marker design rejected above, and the distinction is
+# the whole reason it works. That rejection is about DISCOVERY: a marker list
+# cannot find an incident nobody registered, because registration happens after
+# you already know a fix matters. These markers hang off a row that is ALREADY
+# in scripts/silent-revert-incidents.txt -- the knowledge exists and recording
+# it costs one line. #2691's own suggestion 3 asked for exactly this; only
+# suggestion 2's shape was ever built.
+#
+# Two cheaper designs were measured against the real instance and both fail:
+#
+#   PATH-LEVEL ("was this path revisited since?") is a false NEGATIVE here.
+#   9239f1541 touched BOTH files ten minutes after the incident, so the answer
+#   is yes for both on a tree where the content is gone.
+#
+#   VERBATIM HUNK ("is the deleted diff back byte-for-byte?") is permanently
+#   RED on the README half. #2828 records that #2635's README hunk was
+#   malformed and must NOT be restored byte-for-byte, and #2829 restored the
+#   intent instead. A marker survives that rewrite; the hunk cannot.
+#
+# Markers resolve PATH-SCOPED, which is load-bearing rather than tidy. Both
+# markers on the f603880da row also occur elsewhere in the same plugin on
+# current main -- the engine script, its test file, CHANGELOG.md -- so a
+# repo-wide `git grep` would have reported both files restored while both were
+# missing.
+#
+# Cost: one path-scoped `git grep` per marker over a four-row corpus, which is
+# why it runs in the same `push: main` job as the replay instead of behind an
+# on-demand flag. "Nobody thought to check" is the failure that produced #2828,
+# so an on-demand-only mode would reproduce it.
+#
 # The self-test (scripts/check-silent-revert.test.sh) runs BEFORE this script in
 # CI, so a broken detector cannot mask a regression behind a green canary --
 # the same never-skip, self-test-first, fail-closed shape the ci.yml gates use.
@@ -174,6 +230,19 @@ SAMPLE_MIN_LEN=25
 INCIDENTS_FILE="${SILENT_REVERT_INCIDENTS:-scripts/silent-revert-incidents.txt}"
 ACK_FILE="${SILENT_REVERT_ACK:-scripts/silent-revert-acknowledged.txt}"
 
+# Field separator of the parsed marker view (ASCII Unit Separator).
+#
+# Deliberately NOT a tab. A tab is an IFS *whitespace* character, so `IFS=$'\t'
+# read -r a b c d` collapses runs of tabs into one delimiter and drops empty
+# fields -- which silently shifts every field left whenever the optional
+# disposition reason is empty, i.e. on the ordinary row. Measured here: the
+# marker text landed in the reason variable and the marker came back as the
+# empty string, which `grep -F` matches against everything, so every marker
+# reported present. That is precisely the false green this file exists to
+# remove, so the separator is a non-whitespace character whose empty fields
+# survive.
+SEP=$'\037'
+
 die() {
   echo "check-silent-revert: $*" >&2
   exit 2
@@ -185,6 +254,7 @@ usage:
   scripts/check-silent-revert.sh <range>                  e.g. abc123..def456
   scripts/check-silent-revert.sh --commit <sha>
   scripts/check-silent-revert.sh --verify-known-incidents
+  scripts/check-silent-revert.sh --verify-restoration [<rev>]
 EOF
   exit 2
 }
@@ -449,6 +519,11 @@ verify_known_incidents() {
   while read -r expect sha note; do
     case "$expect" in
       '' | '#'*) continue ;;
+      # Restoration markers (#2855) are a different assertion about the same
+      # incident and belong to --verify-restoration. Skipped HERE, above the
+      # reachability check, because a marker row's second field is a path
+      # rather than a sha -- reading it as one would die on every marker row.
+      marker) continue ;;
       *) ;;
     esac
     if ! git rev-parse --verify --quiet "${sha}^{commit}" >/dev/null; then
@@ -492,12 +567,274 @@ verify_known_incidents() {
 }
 
 # ---------------------------------------------------------------------------
+# The restoration assertion (#2855). See DETECTION IS NOT RESTORATION above for
+# why a `fires` row alone is only half a proof.
+# ---------------------------------------------------------------------------
+# A `marker` row records one line of the content an incident removed, and the
+# path it must live in:
+#
+#   marker <incident-full-sha> <path> <marker text to end of line>
+#   marker <incident-full-sha> <path> [not-restored: <reason>] <marker text>
+#
+# The marker text is the whole tail of the line, unparsed and matched with
+# `grep -F`, so it may contain any character -- no separator is reserved inside
+# it. Interior whitespace is preserved exactly; only leading and trailing
+# whitespace is trimmed, by the field read itself. That is why a marker must be
+# chosen as a line of content rather than as indentation-sensitive text: a
+# marker whose distinguishing feature is its leading spaces would be recorded
+# without them and match more loosely than the reader intended.
+# The ONE reserved position is a LEADING `[`, which commits the row to
+# carrying a disposition, in the same positional slot-after-the-key the
+# attribution field uses on a `fires` row. An unterminated `[` is exit 2 rather
+# than being re-read as ordinary marker text: a row that quietly degrades into
+# "no disposition, strange marker" is the false green this file exists to
+# remove, reached by the one route nobody would look at.
+#
+# The disposition requires a NON-EMPTY reason, exactly as declares_removal()
+# requires of `Intentional-removal:`. `[not-restored:]` is rejected, not read as
+# a mute -- a marker nobody has to justify is a mute button, and this corpus is
+# an audit trail.
+
+# parse_incidents_file <fires-shas-out> <markers-out>
+#
+# Validates every row and writes the two views the assertion needs: one sha per
+# line for `fires` rows, and `<sha><SEP><path><SEP><reason><SEP><marker>` for
+# `marker` rows, where an empty reason field means "no disposition recorded".
+#
+# Call it with plain arguments, never through `$(...)` or a pipe: those run it
+# in a subshell where `die`'s exit 2 is swallowed, and a malformed corpus would
+# degrade into a confusing empty-result pass instead of a hard stop.
+#
+# Fields after the sha on a `fires` / `clean` row are free text to this parser,
+# which is what keeps it forward-compatible with the bracketed attribution
+# field #2833 adds in that position.
+parse_incidents_file() {
+  local fires_out="$1" markers_out="$2"
+  : >"$fires_out"
+  : >"$markers_out"
+
+  local line kind sha path rest reason marker
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    case "$line" in
+      '' | '#'*) continue ;;
+      *) ;;
+    esac
+    read -r kind sha path rest <<<"$line"
+
+    case "$kind" in
+      fires | clean)
+        [[ "$sha" =~ ^[0-9a-f]{40}$ ]] ||
+          die "incident sha '$sha' in $INCIDENTS_FILE is not a full 40-character sha"
+        if [[ "$kind" = "fires" ]]; then
+          printf '%s\n' "$sha" >>"$fires_out"
+        fi
+        ;;
+      marker)
+        # The parsed view below is SEP-delimited, so a row already carrying
+        # that byte is refused up front rather than silently mis-split. It is a
+        # control character no editor writes by accident; the check exists so
+        # the invariant is stated rather than assumed.
+        case "$line" in
+          *"$SEP"*) die "marker row for $sha in $INCIDENTS_FILE contains a control character" ;;
+          *) ;;
+        esac
+        [[ "$sha" =~ ^[0-9a-f]{40}$ ]] ||
+          die "marker row sha '$sha' in $INCIDENTS_FILE is not a full 40-character sha"
+        [[ -n "$path" ]] ||
+          die "marker row for $sha in $INCIDENTS_FILE records no path"
+        case "$path" in
+          \[*) die "marker row for $sha in $INCIDENTS_FILE has a disposition where its path should be" ;;
+          *) ;;
+        esac
+
+        reason=""
+        marker="$rest"
+        if [[ "$rest" == \[* ]]; then
+          [[ "$rest" == \[*\]* ]] ||
+            die "unterminated disposition on the marker row for $sha in $INCIDENTS_FILE (no closing ']'): $rest"
+          local disposition="${rest%%\]*}"
+          disposition="${disposition#\[}"
+          printf '%s\n' "$disposition" |
+            grep -Eq '^not-restored:[[:space:]]*[^[:space:]]' ||
+            die "disposition '[$disposition]' on the marker row for $sha in $INCIDENTS_FILE must be [not-restored: <non-empty reason>]"
+          reason="${disposition#not-restored:}"
+          reason="${reason#"${reason%%[![:space:]]*}"}"
+          marker="${rest#*\]}"
+          marker="${marker#"${marker%%[![:space:]]*}"}"
+        fi
+        [[ -n "$marker" ]] ||
+          die "marker row for $sha in $INCIDENTS_FILE records no marker text"
+
+        printf '%s%s%s%s%s%s%s\n' \
+          "$sha" "$SEP" "$path" "$SEP" "$reason" "$SEP" "$marker" >>"$markers_out"
+        ;;
+      *) die "unknown row kind '$kind' in $INCIDENTS_FILE" ;;
+    esac
+  done <"$INCIDENTS_FILE"
+}
+
+# marker_present <rev> <path> <marker>
+# 0 present, 1 absent. An empty rev means the working tree.
+#
+# The path is resolved to EXACTLY ONE FILE, never handed to a pathspec.
+#
+# That is the difference between this assertion meaning something and meaning
+# nothing, and it is not theoretical. `git grep -- <path>` reads its argument as
+# a PATHSPEC, so a path that is a directory (`plugins/disk-hygiene`), a glob
+# (`plugins/*`), a bare `.`, or pathspec magic (`:/`, `:(glob)**`) silently
+# widens the search to a SUPERSET of the file the marker is bound to. Nothing
+# about such a row looks wrong to a reviewer.
+#
+# The amplifier that makes it fatal: every marker string is, by construction,
+# also present in scripts/silent-revert-incidents.txt itself, because that is
+# where the marker is written down. So a widened path does not merely risk a
+# stray match -- it makes the assertion TAUTOLOGICALLY satisfiable by its own
+# corpus. Measured: with every shipped path replaced by `.`, all five markers
+# report restored on a tree with plugins/disk-hygiene and
+# plugins/repo-fleet-hygiene deleted outright.
+#
+# `git cat-file <rev>:<path>` has no pathspec semantics at all -- it is an exact
+# object lookup -- so the widening class cannot be expressed. A path that names
+# no object at the rev returns 1 (absent), which is a legitimate finding: content
+# cannot be restored to a file that is not there. A path that resolves to a tree
+# rather than a blob is a corpus error, not a finding, and exits 2.
+#
+# grep's exit status is then read explicitly rather than through `if`, because 1
+# (no match) and >1 (could not run) must not collapse. A broken invocation
+# reported as "marker absent" would be the false-RED twin of the false green the
+# rest of this script exists to remove. grep reads a here-string rather than a
+# pipe from cat-file: under `set -o pipefail`, `grep -q` exiting early on a match
+# SIGPIPEs the upstream and the pipeline status becomes 141, which would take
+# that very cannot-run branch on a marker that is present.
+marker_present() {
+  local rev="$1" path="$2" marker="$3" status kind content
+  if [[ -n "$rev" ]]; then
+    kind="$(git cat-file -t "${rev}:${path}" 2>/dev/null)" || return 1
+    [[ "$kind" = "blob" ]] ||
+      die "marker path '$path' resolves to a $kind at $rev, not a file -- bind a marker to exactly one file"
+    content="$(git cat-file blob "${rev}:${path}" 2>/dev/null)" ||
+      die "could not read '$path' at $rev"
+  else
+    [[ -e "$path" ]] || return 1
+    [[ -f "$path" ]] ||
+      die "marker path '$path' is not a regular file -- bind a marker to exactly one file"
+    content="$(<"$path")" || die "could not read '$path'"
+  fi
+  grep -qF -e "$marker" <<<"$content"
+  status=$?
+  case "$status" in
+    0) return 0 ;;
+    1) return 1 ;;
+    *) die "grep failed (status $status) resolving a marker in $path at ${rev:-the working tree}" ;;
+  esac
+}
+
+verify_restoration() {
+  local rev="${1:-}"
+  [[ -f "$INCIDENTS_FILE" ]] || die "incident file not found: $INCIDENTS_FILE"
+
+  local where="the working tree"
+  if [[ -n "$rev" ]]; then
+    git rev-parse --verify --quiet "${rev}^{commit}" >/dev/null ||
+      die "cannot resolve rev '$rev' -- the restoration assertion needs full history (fetch-depth: 0)"
+    where="$rev"
+  fi
+
+  local fires markers
+  fires="$(mktemp)" || die "mktemp failed"
+  markers="$(mktemp)" || die "mktemp failed"
+  parse_incidents_file "$fires" "$markers"
+
+  # The whole file is validated, and both directions of the sha binding are
+  # checked, BEFORE any marker is resolved -- so a corpus problem can never
+  # pre-empt the walk and leave a partially reported failure looking complete.
+  local sha
+  while read -r sha; do
+    [[ -n "$sha" ]] || continue
+    # A `fires` row with no marker is refused rather than skipped. Skipping it
+    # would let this whole assertion be satisfied by recording markers for one
+    # historical incident while silently covering no future one -- a green
+    # signal that has stopped meaning what a reader takes it to mean, which is
+    # #2691 wearing a new hat.
+    # cut's delimiter is SEP, never its TAB default: the parsed view is
+    # SEP-delimited, so `cut -f1` would hand back the WHOLE line and the
+    # `grep -qxF` below could never match -- turning "does this fires row have
+    # a marker" into "no fires row has a marker" and dying on every corpus.
+    cut -d"$SEP" -f1 "$markers" | grep -qxF "$sha" ||
+      die "the 'fires' row for ${sha:0:9} in $INCIDENTS_FILE carries no marker. Record at least one: marker $sha <path> <a line of the content it removed>"
+  done <"$fires"
+
+  local mpath mreason mtext
+  while IFS="$SEP" read -r sha mpath mreason mtext; do
+    [[ -n "$sha" ]] || continue
+    # And the reverse: a marker on a `clean` row, or on a sha with no row at
+    # all, is a typo rather than coverage. Only a removal has content to
+    # restore.
+    grep -qxF "$sha" "$fires" ||
+      die "marker row for $sha in $INCIDENTS_FILE names no recorded 'fires' incident"
+  done <"$markers"
+
+  local rc=0 checked=0 absent=0 excused=0
+  printf 'Restoration of recorded incident content, resolved at %s:\n\n' "$where"
+  while IFS="$SEP" read -r sha mpath mreason mtext; do
+    [[ -n "$sha" ]] || continue
+    checked=$((checked + 1))
+    if marker_present "$rev" "$mpath" "$mtext"; then
+      printf 'ok    %s  %s\n' "${sha:0:9}" "$mpath"
+      printf '        present: %s\n' "$mtext"
+    elif [[ -n "$mreason" ]]; then
+      excused=$((excused + 1))
+      printf 'noted %s  %s\n' "${sha:0:9}" "$mpath"
+      printf '        deliberately not restored: %s\n' "$mreason"
+      printf '        marker: %s\n' "$mtext"
+    else
+      # Never break out of the walk on the first failure: the point of the
+      # report is WHICH content is still missing, and a run that stops at the
+      # first one answers a question nobody asked.
+      absent=$((absent + 1))
+      rc=1
+      printf 'FAIL  %s  %s\n' "${sha:0:9}" "$mpath"
+      printf '        NOT RESTORED: %s\n' "$mtext"
+    fi
+  done <"$markers"
+
+  rm -f "$fires" "$markers"
+
+  if [[ "$rc" -ne 0 ]]; then
+    printf '\n'
+    printf '%s of %s recorded marker(s) are absent from %s.\n' "$absent" "$checked" "$where"
+    echo "Those incidents still FIRE as recorded, which is only half the proof:"
+    echo "the removal was detected and never fully undone. Re-land the content."
+    echo "If it is deliberately staying out, say so on its marker row -- with a"
+    echo "reason, the same shape an Intentional-removal: trailer needs:"
+    echo "  marker <incident-sha> <path> [not-restored: <why>] <marker text>"
+    echo "Do NOT delete the marker row. That is the mute button this corpus"
+    echo "exists in order not to have."
+    return 1
+  fi
+
+  printf '\n'
+  printf 'Every recorded incident has its content at %s (%s marker(s), %s dispositioned).\n' \
+    "$where" "$checked" "$excused"
+  return 0
+}
+
+# ---------------------------------------------------------------------------
 main() {
   [[ $# -ge 1 ]] || usage
 
   case "$1" in
     --verify-known-incidents)
       verify_known_incidents
+      exit $?
+      ;;
+    --verify-restoration)
+      # The rev is optional and defaults to the working tree, which is what the
+      # canary workflow wants (is the content on main RIGHT NOW) while the
+      # explicit form is what lets a reviewer replay the assertion against the
+      # historical tree an incident was measured on.
+      [[ $# -le 2 ]] || usage
+      verify_restoration "${2:-}"
       exit $?
       ;;
     --commit)

--- a/scripts/check-silent-revert.sh
+++ b/scripts/check-silent-revert.sh
@@ -594,6 +594,14 @@ verify_known_incidents() {
 # requires of `Intentional-removal:`. `[not-restored:]` is rejected, not read as
 # a mute -- a marker nobody has to justify is a mute button, and this corpus is
 # an audit trail.
+#
+# The disposition ends at the FIRST `]`, so a REASON may not contain `]`. That
+# is the only qualification on "any character", it applies to the reason alone,
+# and the marker text after the disposition is still unrestricted. It cannot be
+# enforced after the fact: a truncated reason and a legitimate row whose marker
+# happens to contain `]` are byte-indistinguishable, so any check that rejects
+# the first rejects the second too. A reason truncated at a stray `]` shows up
+# in the `noted` line, which prints it verbatim to the human reading the trail.
 
 # parse_incidents_file <fires-shas-out> <markers-out>
 #
@@ -686,21 +694,24 @@ parse_incidents_file() {
             die "disposition '[$disposition]' on the marker row for $sha in $INCIDENTS_FILE must be [not-restored: <non-empty reason>]"
           reason="${disposition#not-restored:}"
           reason="${reason#"${reason%%[![:space:]]*}"}"
+          # The disposition ends at the FIRST `]`. That is the grammar, stated
+          # up front, and it is why a reason may not itself contain `]`.
+          #
+          # It cannot be an after-the-fact check, and trying was a mistake worth
+          # recording. `[not-restored: see note (ref] for detail)] TEXT` (a
+          # truncated reason) and `[not-restored: reason] some ] text` (a
+          # perfectly good row whose MARKER happens to contain a bracket) are
+          # byte-indistinguishable in shape. Any rule that rejects the first
+          # also rejects the second, and the second is legitimate -- the header
+          # above promises marker text may contain any character.
+          #
+          # So the grammar is documented rather than policed, and the safety net
+          # is the report: a `noted` line prints the recorded reason verbatim,
+          # so a reason truncated at a stray `]` is visible to the human reading
+          # the audit trail. Dispositioned rows are the rare, hand-reviewed
+          # case; that is the right place for a documented restriction.
           marker="${rest#*\]}"
           marker="${marker#"${marker%%[![:space:]]*}"}"
-          # The split above takes the FIRST `]`, so a reason that itself
-          # contains one would silently truncate the reason AND corrupt the
-          # marker text with a stray leading `]`. That combination is quietly
-          # WRONG rather than merely odd: the corrupted marker stops matching,
-          # while the still-non-empty reason makes the row report
-          # "deliberately not restored" -- announcing a recorded decision about
-          # content that may be sitting right there. Undecidable from the row
-          # alone, so it is refused. Only a DISPOSITIONED row pays this cost;
-          # an ordinary marker's text may contain `]` freely.
-          case "$marker" in
-            *\]*) die "ambiguous disposition on the marker row for $sha in $INCIDENTS_FILE: a '[not-restored: ...]' reason may not contain ']'" ;;
-            *) ;;
-          esac
         fi
         [[ -n "$marker" ]] ||
           die "marker row for $sha in $INCIDENTS_FILE records no marker text"
@@ -747,11 +758,37 @@ parse_incidents_file() {
 # SIGPIPEs the upstream and the pipeline status becomes 141, which would take
 # that very cannot-run branch on a marker that is present.
 marker_present() {
-  local rev="$1" path="$2" marker="$3" status kind content
+  local rev="$1" path="$2" marker="$3" status kind mode content
   if [[ -n "$rev" ]]; then
     kind="$(git cat-file -t "${rev}:${path}" 2>/dev/null)" || return 1
     [[ "$kind" = "blob" ]] ||
       die "marker path '$path' resolves to a $kind at $rev, not a file -- bind a marker to exactly one file"
+    # A symlink is a blob too, holding its TARGET PATH as content -- so the
+    # `blob` check above passes it, and `git cat-file blob` would answer this
+    # marker with a filename instead of file content. Refused, for the same
+    # reason the working-tree branch refuses one: a marker binds to the file
+    # that HOLDS the content.
+    #
+    # Two deliberate choices here, both about not building a guard that fails
+    # OPEN. The mode is read from `ls-tree`'s DEFAULT output rather than
+    # `--format=%(objectmode)`, which needs git >= 2.36 -- on an older git the
+    # format string is an error, the capture is empty, and a "not 120000" test
+    # would wave the symlink straight through. And the accepted set is the
+    # REGULAR-FILE modes rather than "anything but a symlink", so an empty or
+    # unparsed reading lands on `die` instead of falling through to the read.
+    # A guard that goes quiet when it cannot tell is the false green this file
+    # exists to remove.
+    mode="$(git ls-tree "$rev" -- "$path" 2>/dev/null)"
+    mode="${mode%% *}"
+    case "$mode" in
+      100644 | 100755) ;;
+      120000)
+        die "marker path '$path' is a symlink at $rev -- bind a marker to the file that holds the content"
+        ;;
+      *)
+        die "marker path '$path' is not a regular file at $rev (mode '${mode:-unreadable}') -- bind a marker to exactly one file"
+        ;;
+    esac
     content="$(git cat-file blob "${rev}:${path}" 2>/dev/null)" ||
       die "could not read '$path' at $rev"
   else

--- a/scripts/check-silent-revert.test.sh
+++ b/scripts/check-silent-revert.test.sh
@@ -696,7 +696,7 @@ BAD_ROWS
   SILENT_REVERT_INCIDENTS=scripts/inc.txt run_canary "$repo" --verify-restoration
   out="$OUT"
   if [[ "$RC" -eq 2 ]] && printf '%s' "$out" | grep -q 'ambiguous disposition'; then
-    ok "a disposition reason containing ']' is refused instead of silently mis-split"
+    ok "a disposition reason containing ']' is refused instead of splitting wrongly"
   else
     fail "an ambiguous disposition must exit 2, rc=$RC: $out"
   fi

--- a/scripts/check-silent-revert.test.sh
+++ b/scripts/check-silent-revert.test.sh
@@ -685,6 +685,72 @@ BAD_ROWS
     fail "an unreachable incident commit must exit 2, rc=$RC: $out"
   fi
 
+  # A disposition reason containing `]` splits at the WRONG bracket, truncating
+  # the reason and corrupting the marker text -- and because the reason stays
+  # non-empty, the row would report "deliberately not restored" about content
+  # that may be present. Undecidable from the row, so it is refused.
+  {
+    printf 'fires %s a real drop\n' "$sha"
+    printf 'marker %s guarded.txt [not-restored: see note (ref] for detail)] RESTORED_MARKER_SENTINEL\n' "$sha"
+  } >"$repo/scripts/inc.txt"
+  SILENT_REVERT_INCIDENTS=scripts/inc.txt run_canary "$repo" --verify-restoration
+  out="$OUT"
+  if [[ "$RC" -eq 2 ]] && printf '%s' "$out" | grep -q 'ambiguous disposition'; then
+    ok "a disposition reason containing ']' is refused instead of silently mis-split"
+  else
+    fail "an ambiguous disposition must exit 2, rc=$RC: $out"
+  fi
+
+  # But an ORDINARY marker's text may contain `]` freely -- only a
+  # dispositioned row pays for the ambiguity.
+  printf 'expectations: ["a", "b"]\n' >>"$repo/guarded.txt"
+  git_test_config "$repo" add -A >/dev/null
+  git_test_config "$repo" commit -qm "feat: content with a bracket"
+  {
+    printf 'fires %s a real drop\n' "$sha"
+    printf 'marker %s guarded.txt expectations: ["a", "b"]\n' "$sha"
+  } >"$repo/scripts/inc.txt"
+  SILENT_REVERT_INCIDENTS=scripts/inc.txt run_canary "$repo" --verify-restoration
+  out="$OUT"
+  if [[ "$RC" -eq 0 ]]; then
+    ok "an undispositioned marker's text may contain ']'"
+  else
+    fail "a bracket in ordinary marker text must be fine, rc=$RC: $out"
+  fi
+
+  # Three readers parse this one file -- the replay, the restoration assertion,
+  # and the shipped-data grammar check -- and they must agree about what a
+  # comment is. An indented comment or a whitespace-only line is a
+  # formatting-only edit and must not turn the canary red.
+  {
+    printf '# leading comment\n'
+    printf '   # an INDENTED comment\n'
+    printf '   \n'
+    printf '\n'
+    printf 'fires %s a real drop\n' "$sha"
+    printf '  # indented comment between rows\n'
+    printf 'marker %s guarded.txt RESTORED_MARKER_SENTINEL\n' "$sha"
+  } >"$repo/scripts/inc.txt"
+  SILENT_REVERT_INCIDENTS=scripts/inc.txt run_canary "$repo" --verify-restoration
+  out="$OUT"
+  if [[ "$RC" -eq 0 ]]; then
+    ok "indented comments and whitespace-only lines are skipped, not called unknown rows"
+  else
+    fail "a formatting-only corpus edit must not fail the assertion, rc=$RC: $out"
+  fi
+  # The replay reads the same corpus. It may legitimately report FAIL here (the
+  # fixture's `fires` row names a commit that adds rather than removes), but it
+  # must never exit 2 -- that is the "cannot parse" status, and reaching it
+  # would mean the two readers disagree about what a comment is.
+  SILENT_REVERT_THRESHOLD=20 SILENT_REVERT_INCIDENTS=scripts/inc.txt \
+    run_canary "$repo" --verify-known-incidents
+  out="$OUT"
+  if [[ "$RC" -ne 2 ]]; then
+    ok "the replay parses the same indented comments the restoration assertion does"
+  else
+    fail "the two readers disagree about comments, rc=$RC: $out"
+  fi
+
   # An abbreviated sha would let a marker widen to a commit nobody recorded --
   # the same discipline the acknowledgment file holds.
   {
@@ -791,6 +857,32 @@ t_restoration_binds_a_marker_to_exactly_one_file() {
     fail "an untracked path must not satisfy a marker, rc=$RC: $out"
   fi
   rm -f "$repo/untracked.txt"
+
+  # A TRACKED symlink is tracked as the link, but a filesystem read follows it,
+  # so a link committed into the repo could be answered with content from
+  # outside it -- while at a rev the same row reads the link's blob (its target
+  # string). Refused, so the two modes cannot answer different questions.
+  # Symlink creation needs privileges on Windows, so this case skips rather than
+  # fails when the fixture cannot be built.
+  if ln -s "$PWD/../outside-target.txt" "$repo/linked.txt" 2>/dev/null &&
+    [[ -L "$repo/linked.txt" ]]; then
+    git_test_config "$repo" add -A >/dev/null 2>&1
+    git_test_config "$repo" commit -qm "chore: a symlink" >/dev/null 2>&1
+    {
+      printf 'fires %s a real drop\n' "$sha"
+      printf 'marker %s linked.txt RESTORED_MARKER_SENTINEL\n' "$sha"
+    } >"$repo/scripts/inc.txt"
+    SILENT_REVERT_INCIDENTS=scripts/inc.txt run_canary "$repo" --verify-restoration
+    out="$OUT"
+    if [[ "$RC" -ne 0 ]]; then
+      ok "a tracked symlink cannot satisfy a marker in working-tree mode"
+    else
+      fail "a symlinked marker path must not report present, rc=$RC: $out"
+    fi
+    rm -f "$repo/linked.txt"
+    git_test_config "$repo" add -A >/dev/null 2>&1
+    git_test_config "$repo" commit -qm "chore: drop the symlink" >/dev/null 2>&1
+  fi
 
   # A path that leaves the repository is refused outright, in both modes,
   # because a marker resolved outside the tree asserts nothing about main.

--- a/scripts/check-silent-revert.test.sh
+++ b/scripts/check-silent-revert.test.sh
@@ -685,24 +685,33 @@ BAD_ROWS
     fail "an unreachable incident commit must exit 2, rc=$RC: $out"
   fi
 
-  # A disposition reason containing `]` splits at the WRONG bracket, truncating
-  # the reason and corrupting the marker text -- and because the reason stays
-  # non-empty, the row would report "deliberately not restored" about content
-  # that may be present. Undecidable from the row, so it is refused.
+  # The disposition ends at the FIRST `]`, and a marker's text is unrestricted
+  # on BOTH sides of that rule. A dispositioned row whose marker text contains
+  # `]` is well-formed -- the split is unambiguous, the reason has no bracket,
+  # and only the marker does.
+  #
+  # This is the case a content-shaped ambiguity check gets wrong. A truncated
+  # reason and this legitimate row are byte-indistinguishable in shape, so a
+  # rule that rejects one rejects the other; the grammar is documented instead,
+  # and the recorded reason is printed verbatim so a truncation is visible to
+  # the human reading the trail.
+  printf 'expectations: ["x"] and ] alone\n' >>"$repo/guarded.txt"
+  git_test_config "$repo" add -A >/dev/null
+  git_test_config "$repo" commit -qm "feat: bracketed content"
   {
     printf 'fires %s a real drop\n' "$sha"
-    printf 'marker %s guarded.txt [not-restored: see note (ref] for detail)] RESTORED_MARKER_SENTINEL\n' "$sha"
+    printf 'marker %s guarded.txt [not-restored: reason with no bracket] expectations: ["x"] and ] alone\n' "$sha"
   } >"$repo/scripts/inc.txt"
   SILENT_REVERT_INCIDENTS=scripts/inc.txt run_canary "$repo" --verify-restoration
   out="$OUT"
-  if [[ "$RC" -eq 2 ]] && printf '%s' "$out" | grep -q 'ambiguous disposition'; then
-    ok "a disposition reason containing ']' is refused instead of splitting wrongly"
+  if [[ "$RC" -eq 0 ]] &&
+    printf '%s' "$out" | grep -q 'present: expectations: \["x"\] and \] alone'; then
+    ok "a dispositioned row whose MARKER text contains ']' is well-formed"
   else
-    fail "an ambiguous disposition must exit 2, rc=$RC: $out"
+    fail "a bracketed marker on a dispositioned row must resolve, rc=$RC: $out"
   fi
 
-  # But an ORDINARY marker's text may contain `]` freely -- only a
-  # dispositioned row pays for the ambiguity.
+  # And an ORDINARY marker's text may contain `]` freely too.
   printf 'expectations: ["a", "b"]\n' >>"$repo/guarded.txt"
   git_test_config "$repo" add -A >/dev/null
   git_test_config "$repo" commit -qm "feat: content with a bracket"
@@ -883,6 +892,39 @@ t_restoration_binds_a_marker_to_exactly_one_file() {
     git_test_config "$repo" add -A >/dev/null 2>&1
     git_test_config "$repo" commit -qm "chore: drop the symlink" >/dev/null 2>&1
   fi
+
+  # The same refusal in EXPLICIT-REV mode, which resolves a marker a different
+  # way and so needs its own proof. `git cat-file -t` answers `blob` for a
+  # symlink, so the kind check lets it through, and `git cat-file blob` then
+  # hands back the link's TARGET PATH as though it were file content.
+  #
+  # Two things about this fixture are deliberate. It is built straight into the
+  # index with `update-index --cacheinfo` rather than with `ln -s`, so it runs
+  # on every platform -- the working-tree case above silently SKIPS wherever
+  # creating a symlink needs privileges, and a guard proven on no platform is
+  # not proven. And the path is NESTED, because a top-level fixture would still
+  # pass if the mode lookup could not descend into a subdirectory, while every
+  # marker path in the shipped corpus is nested.
+  local link_blob link_rev
+  link_blob="$(printf '../../guarded.txt' | git_test_config "$repo" hash-object -w --stdin)"
+  git_test_config "$repo" update-index --add \
+    --cacheinfo "120000,$link_blob,nested/dir/linked.txt"
+  git_test_config "$repo" commit -qm "chore: a nested symlink" >/dev/null
+  link_rev="$(git_test_config "$repo" rev-parse HEAD)"
+  {
+    printf 'fires %s a real drop\n' "$sha"
+    printf 'marker %s nested/dir/linked.txt RESTORED_MARKER_SENTINEL\n' "$sha"
+  } >"$repo/scripts/inc.txt"
+  SILENT_REVERT_INCIDENTS=scripts/inc.txt \
+    run_canary "$repo" --verify-restoration "$link_rev"
+  out="$OUT"
+  if [[ "$RC" -eq 2 ]] && printf '%s' "$out" | grep -q 'is a symlink at'; then
+    ok "a tracked symlink cannot satisfy a marker in explicit-rev mode"
+  else
+    fail "a symlinked marker path at a rev must exit 2, rc=$RC: $out"
+  fi
+  git_test_config "$repo" rm -q --cached nested/dir/linked.txt >/dev/null
+  git_test_config "$repo" commit -qm "chore: drop the nested symlink" >/dev/null
 
   # A path that leaves the repository is refused outright, in both modes,
   # because a marker resolved outside the tree asserts nothing about main.

--- a/scripts/check-silent-revert.test.sh
+++ b/scripts/check-silent-revert.test.sh
@@ -533,6 +533,27 @@ t_restoration_reports_present_and_absent_markers() {
     fail "an absent marker must fail the assertion, rc=$RC: $out"
   fi
 
+  # A PARTIAL re-land -- the literal #2855 completion criterion. One fires row,
+  # two markers, one of them restored: the incident looks half-healthy, and an
+  # implementation that treats any matched marker as satisfying its row would
+  # report the row green. That shape passed every earlier case in this function
+  # (each row carried exactly one marker), so it gets its own pin: the mix must
+  # still exit 1 and name exactly the marker that is missing.
+  {
+    printf 'fires %s a real drop\n' "$sha"
+    printf 'marker %s guarded.txt RESTORED_MARKER_SENTINEL\n' "$sha"
+    printf 'marker %s guarded.txt NEVER_PRESENT_ANYWHERE\n' "$sha"
+  } >"$repo/scripts/inc.txt"
+  SILENT_REVERT_INCIDENTS=scripts/inc.txt run_canary "$repo" --verify-restoration
+  out="$OUT"
+  if [[ "$RC" -eq 1 ]] &&
+    printf '%s' "$out" | grep -q 'present: RESTORED_MARKER_SENTINEL' &&
+    printf '%s' "$out" | grep -q 'NOT RESTORED: NEVER_PRESENT_ANYWHERE'; then
+    ok "a partial re-land (one marker back, one still absent) fails the assertion"
+  else
+    fail "a partially re-landed incident must still fail, rc=$RC: $out"
+  fi
+
   # A dispositioned absent marker is a recorded decision, not a failure -- and
   # the reason has to be printed, or the disposition is a mute button.
   {

--- a/scripts/check-silent-revert.test.sh
+++ b/scripts/check-silent-revert.test.sh
@@ -472,6 +472,332 @@ t_replay_fails_on_broken_expectation() {
   fi
 }
 
+# --------------------------------------------------------------------------
+# 7. The restoration assertion (#2855). A `fires` row proves the removal is
+#    still DETECTED; these cases pin the other half -- that the content came
+#    back -- and every way that assertion could go quietly green.
+# --------------------------------------------------------------------------
+
+# mk_restoration_repo <repo>
+#
+# Lays out the three shapes the assertion has to tell apart:
+#   guarded.txt   holds the marker that IS restored
+#   elsewhere.txt holds a string that exists ONLY outside its bound path
+# and nothing anywhere holds the absent marker. Echoes the head sha.
+mk_restoration_repo() {
+  local repo="$1"
+  printf 'the restored guard rejects a relocation\nRESTORED_MARKER_SENTINEL\n' \
+    >"$repo/guarded.txt"
+  printf 'SCOPED_ONLY_ELSEWHERE lives here and nowhere else\n' >"$repo/elsewhere.txt"
+  git_test_config "$repo" add -A >/dev/null
+  git_test_config "$repo" commit -qm "feat: the content an incident removed"
+  git -C "$repo" rev-parse HEAD
+}
+
+t_restoration_reports_present_and_absent_markers() {
+  local repo out sha
+  repo="$(mk_repo)"
+  sha="$(mk_restoration_repo "$repo")"
+
+  # A restored marker passes.
+  #
+  # This case is also the regression pin for a defect that made the whole mode
+  # inert in the other direction: the parsed marker view is delimited with an
+  # ASCII Unit Separator, and reading its first field back with a bare `cut -f1`
+  # (whose default delimiter is TAB) returned the WHOLE line, so the
+  # "does this fires row have a marker" lookup could never match and every
+  # corpus died with `carries no marker`. A green here proves the two views
+  # still agree on their separator.
+  {
+    printf 'fires %s a real drop\n' "$sha"
+    printf 'marker %s guarded.txt RESTORED_MARKER_SENTINEL\n' "$sha"
+  } >"$repo/scripts/inc.txt"
+  SILENT_REVERT_INCIDENTS=scripts/inc.txt run_canary "$repo" --verify-restoration
+  out="$OUT"
+  if [[ "$RC" -eq 0 ]] && printf '%s' "$out" | grep -q 'present: RESTORED_MARKER_SENTINEL'; then
+    ok "a restored marker resolves and the assertion exits 0"
+  else
+    fail "a restored marker should have passed, rc=$RC: $out"
+  fi
+
+  # An absent marker is the finding this mode exists for.
+  {
+    printf 'fires %s a real drop\n' "$sha"
+    printf 'marker %s guarded.txt NEVER_PRESENT_ANYWHERE\n' "$sha"
+  } >"$repo/scripts/inc.txt"
+  SILENT_REVERT_INCIDENTS=scripts/inc.txt run_canary "$repo" --verify-restoration
+  out="$OUT"
+  if [[ "$RC" -eq 1 ]] && printf '%s' "$out" | grep -q 'NOT RESTORED: NEVER_PRESENT_ANYWHERE'; then
+    ok "an absent marker fails the restoration assertion and names the content"
+  else
+    fail "an absent marker must fail the assertion, rc=$RC: $out"
+  fi
+
+  # A dispositioned absent marker is a recorded decision, not a failure -- and
+  # the reason has to be printed, or the disposition is a mute button.
+  {
+    printf 'fires %s a real drop\n' "$sha"
+    printf 'marker %s guarded.txt [not-restored: superseded by the shared guard] NEVER_PRESENT_ANYWHERE\n' "$sha"
+  } >"$repo/scripts/inc.txt"
+  SILENT_REVERT_INCIDENTS=scripts/inc.txt run_canary "$repo" --verify-restoration
+  out="$OUT"
+  if [[ "$RC" -eq 0 ]] &&
+    printf '%s' "$out" | grep -q 'deliberately not restored: superseded by the shared guard'; then
+    ok "a dispositioned absent marker passes and prints its recorded reason"
+  else
+    fail "a dispositioned absent marker should have passed, rc=$RC: $out"
+  fi
+
+  # THE path-scoping case. The string exists in the repo, just not in the file
+  # it is bound to. A repo-wide grep reports this restored; that false green is
+  # exactly what happened on the real corpus, where both #2828 markers also
+  # occur in the engine script, its tests and CHANGELOG.md.
+  {
+    printf 'fires %s a real drop\n' "$sha"
+    printf 'marker %s guarded.txt SCOPED_ONLY_ELSEWHERE\n' "$sha"
+  } >"$repo/scripts/inc.txt"
+  SILENT_REVERT_INCIDENTS=scripts/inc.txt run_canary "$repo" --verify-restoration
+  out="$OUT"
+  if [[ "$RC" -eq 1 ]] && printf '%s' "$out" | grep -q 'NOT RESTORED: SCOPED_ONLY_ELSEWHERE'; then
+    ok "a marker present only OUTSIDE its bound path still fails (path-scoped)"
+  else
+    fail "a marker matched outside its bound path is a false green, rc=$RC: $out"
+  fi
+
+  # Same corpus, resolved at an explicit rev rather than the working tree --
+  # the form a reviewer replays an incident with.
+  {
+    printf 'fires %s a real drop\n' "$sha"
+    printf 'marker %s guarded.txt RESTORED_MARKER_SENTINEL\n' "$sha"
+  } >"$repo/scripts/inc.txt"
+  SILENT_REVERT_INCIDENTS=scripts/inc.txt run_canary "$repo" --verify-restoration "$sha"
+  out="$OUT"
+  if [[ "$RC" -eq 0 ]] && printf '%s' "$out" | grep -qF "resolved at $sha"; then
+    ok "the assertion resolves markers at an explicitly supplied rev"
+  else
+    fail "an explicit rev should have resolved, rc=$RC: $out"
+  fi
+
+  # A rev that does not exist is a shallow clone, not a pass.
+  SILENT_REVERT_INCIDENTS=scripts/inc.txt \
+    run_canary "$repo" --verify-restoration 0123456789abcdef0123456789abcdef01234567
+  out="$OUT"
+  if [[ "$RC" -eq 2 ]]; then
+    ok "an unresolvable rev exits 2 rather than reporting content it never read"
+  else
+    fail "expected rc=2 on an unresolvable rev, got rc=$RC: $out"
+  fi
+}
+
+# Every way the corpus itself can be wrong must be exit 2 (cannot run), never a
+# pass. A marker list that quietly covers nothing is the same false green as a
+# detector that has stopped detecting.
+t_restoration_refuses_a_malformed_corpus() {
+  local repo out sha
+  repo="$(mk_repo)"
+  sha="$(mk_restoration_repo "$repo")"
+
+  # THE central refusal: a `fires` row with no marker. Skipping it would let
+  # this whole assertion be satisfied by pinning one historical incident while
+  # covering no future one.
+  printf 'fires %s a real drop with nothing recorded\n' "$sha" >"$repo/scripts/inc.txt"
+  SILENT_REVERT_INCIDENTS=scripts/inc.txt run_canary "$repo" --verify-restoration
+  out="$OUT"
+  if [[ "$RC" -eq 2 ]] && printf '%s' "$out" | grep -q 'carries no marker'; then
+    ok "a fires row carrying no marker exits 2 rather than passing vacuously"
+  else
+    fail "a marker-less fires row must exit 2, rc=$RC: $out"
+  fi
+
+  # A marker naming no `fires` row covers nothing; it is a typo, not coverage.
+  {
+    printf 'fires %s a real drop\n' "$sha"
+    printf 'marker %s guarded.txt RESTORED_MARKER_SENTINEL\n' "$sha"
+    printf 'marker 0123456789abcdef0123456789abcdef01234567 guarded.txt RESTORED_MARKER_SENTINEL\n'
+  } >"$repo/scripts/inc.txt"
+  SILENT_REVERT_INCIDENTS=scripts/inc.txt run_canary "$repo" --verify-restoration
+  out="$OUT"
+  if [[ "$RC" -eq 2 ]] && printf '%s' "$out" | grep -q "names no recorded 'fires' incident"; then
+    ok "a marker naming no fires row exits 2"
+  else
+    fail "an orphan marker row must exit 2, rc=$RC: $out"
+  fi
+
+  # Malformed marker rows. The last two are the ones that matter most: an
+  # EMPTY disposition reason must be rejected rather than read as a mute, and
+  # an unterminated `[` must not degrade back into ordinary marker text -- the
+  # false green reached by the one route nobody would look at.
+  local bad desc
+  while read -r desc bad; do
+    {
+      printf 'fires %s a real drop\n' "$sha"
+      printf 'marker %s %s\n' "$sha" "$bad"
+    } >"$repo/scripts/inc.txt"
+    SILENT_REVERT_INCIDENTS=scripts/inc.txt run_canary "$repo" --verify-restoration
+    out="$OUT"
+    if [[ "$RC" -eq 2 ]]; then
+      ok "a marker row with $desc exits 2"
+    else
+      fail "expected rc=2 for a marker row with $desc, got rc=$RC: $out"
+    fi
+  done <<'BAD_ROWS'
+no-marker-text guarded.txt
+a-disposition-where-the-path-should-be [not-restored: why] RESTORED_MARKER_SENTINEL
+an-empty-disposition-reason guarded.txt [not-restored:] RESTORED_MARKER_SENTINEL
+a-whitespace-only-disposition-reason guarded.txt [not-restored:   ] RESTORED_MARKER_SENTINEL
+an-unknown-disposition-keyword guarded.txt [ignored: why] RESTORED_MARKER_SENTINEL
+an-unterminated-disposition guarded.txt [not-restored: why RESTORED_MARKER_SENTINEL
+BAD_ROWS
+
+  # An abbreviated sha would let a marker widen to a commit nobody recorded --
+  # the same discipline the acknowledgment file holds.
+  {
+    printf 'fires %s a real drop\n' "$sha"
+    printf 'marker %s guarded.txt RESTORED_MARKER_SENTINEL\n' "${sha:0:9}"
+  } >"$repo/scripts/inc.txt"
+  SILENT_REVERT_INCIDENTS=scripts/inc.txt run_canary "$repo" --verify-restoration
+  out="$OUT"
+  if [[ "$RC" -eq 2 ]]; then
+    ok "an abbreviated sha on a marker row exits 2"
+  else
+    fail "expected rc=2 on an abbreviated marker sha, got rc=$RC: $out"
+  fi
+
+  # An unknown row kind is a corpus nobody can read, not a row to skip.
+  {
+    printf 'fires %s a real drop\n' "$sha"
+    printf 'marker %s guarded.txt RESTORED_MARKER_SENTINEL\n' "$sha"
+    printf 'markers %s guarded.txt typo in the row kind\n' "$sha"
+  } >"$repo/scripts/inc.txt"
+  SILENT_REVERT_INCIDENTS=scripts/inc.txt run_canary "$repo" --verify-restoration
+  out="$OUT"
+  if [[ "$RC" -eq 2 ]] && printf '%s' "$out" | grep -q 'unknown row kind'; then
+    ok "an unknown row kind exits 2"
+  else
+    fail "expected rc=2 on an unknown row kind, got rc=$RC: $out"
+  fi
+}
+
+# A marker's path must resolve to exactly ONE FILE. Handing it to a pathspec
+# instead lets a directory, a glob, a bare `.` or pathspec magic widen the
+# search to a SUPERSET of the bound file -- and because every marker string is
+# by construction also written in the corpus file itself, a widened path makes
+# this whole assertion tautologically satisfiable by its own corpus. That is a
+# false green reachable by a row that looks entirely reasonable, so each shape
+# is pinned here rather than left to reviewer vigilance.
+t_restoration_binds_a_marker_to_exactly_one_file() {
+  local repo out sha widened
+  repo="$(mk_repo)"
+  sha="$(mk_restoration_repo "$repo")"
+
+  # THE amplifier case, in its strongest form: the target content is nowhere in
+  # the repo, but the marker text is sitting in the corpus file itself. A
+  # pathspec of `.` used to report it restored.
+  {
+    printf 'fires %s a real drop\n' "$sha"
+    printf 'marker %s . NEVER_PRESENT_ANYWHERE\n' "$sha"
+  } >"$repo/scripts/inc.txt"
+  SILENT_REVERT_INCIDENTS=scripts/inc.txt run_canary "$repo" --verify-restoration
+  out="$OUT"
+  if [[ "$RC" -ne 0 ]]; then
+    ok "a marker bound to '.' cannot be satisfied by the corpus file itself"
+  else
+    fail "a '.' path let the corpus satisfy its own marker, rc=$RC: $out"
+  fi
+
+  # Every widening shape, at the working tree and at a rev. None may report the
+  # marker present, because the content lives only in guarded.txt while the
+  # marker is bound to something broader.
+  for widened in "." ".." "*" "plugins" "" "scripts" ":/" ":(glob)**/*"; do
+    [[ -n "$widened" ]] || continue
+    {
+      printf 'fires %s a real drop\n' "$sha"
+      printf 'marker %s %s RESTORED_MARKER_SENTINEL\n' "$sha" "$widened"
+    } >"$repo/scripts/inc.txt"
+    SILENT_REVERT_INCIDENTS=scripts/inc.txt run_canary "$repo" --verify-restoration
+    out="$OUT"
+    local wt_rc="$RC"
+    SILENT_REVERT_INCIDENTS=scripts/inc.txt run_canary "$repo" --verify-restoration "$sha"
+    if [[ "$wt_rc" -ne 0 ]] && [[ "$RC" -ne 0 ]]; then
+      ok "a widened marker path '$widened' never reports the marker present"
+    else
+      fail "widened path '$widened' gave a false green (worktree rc=$wt_rc, rev rc=$RC): $out"
+    fi
+  done
+
+  # A directory is a corpus error rather than a finding, and says so.
+  {
+    printf 'fires %s a real drop\n' "$sha"
+    printf 'marker %s scripts RESTORED_MARKER_SENTINEL\n' "$sha"
+  } >"$repo/scripts/inc.txt"
+  SILENT_REVERT_INCIDENTS=scripts/inc.txt run_canary "$repo" --verify-restoration
+  out="$OUT"
+  if [[ "$RC" -eq 2 ]] && printf '%s' "$out" | grep -q 'bind a marker to exactly one file'; then
+    ok "a marker path naming a directory exits 2 and names the fix"
+  else
+    fail "a directory marker path must exit 2, rc=$RC: $out"
+  fi
+
+  # A glob that would match the bound file under a pathspec must not match it
+  # under an exact lookup -- it simply does not name a file, so: absent.
+  {
+    printf 'fires %s a real drop\n' "$sha"
+    printf 'marker %s guarded*.txt RESTORED_MARKER_SENTINEL\n' "$sha"
+  } >"$repo/scripts/inc.txt"
+  SILENT_REVERT_INCIDENTS=scripts/inc.txt run_canary "$repo" --verify-restoration
+  out="$OUT"
+  if [[ "$RC" -eq 1 ]]; then
+    ok "a glob marker path resolves to no file and reports the marker absent"
+  else
+    fail "a glob marker path must not resolve, rc=$RC: $out"
+  fi
+}
+
+# The two modes read the SAME file and must not disturb each other. The replay
+# has to step over marker rows (their second field is a path, not a sha), and
+# the restoration assertion has to step over the bracketed attribution field
+# #2833 puts after a fires row's sha.
+t_restoration_and_replay_share_the_corpus() {
+  local repo out sha culprit
+  repo="$(mk_repo)"
+  add_block "$repo" feature.txt 40 alpha
+  culprit="$(git -C "$repo" rev-parse HEAD)"
+  drop_block "$repo" feature.txt alpha "feat: unrelated feature (#99)"
+  sha="$(git -C "$repo" rev-parse HEAD)"
+  printf 'RESTORED_MARKER_SENTINEL\n' >"$repo/guarded.txt"
+  git_test_config "$repo" add -A >/dev/null
+  git_test_config "$repo" commit -qm "fix: re-land the content"
+
+  {
+    printf 'fires %s a real drop\n' "$sha"
+    printf 'marker %s guarded.txt RESTORED_MARKER_SENTINEL\n' "$sha"
+  } >"$repo/scripts/inc.txt"
+  SILENT_REVERT_THRESHOLD=20 SILENT_REVERT_INCIDENTS=scripts/inc.txt \
+    run_canary "$repo" --verify-known-incidents
+  out="$OUT"
+  if [[ "$RC" -eq 0 ]] && printf '%s' "$out" | grep -q 'fires as recorded'; then
+    ok "the replay steps over marker rows instead of reading a path as a sha"
+  else
+    fail "marker rows must not disturb --verify-known-incidents, rc=$RC: $out"
+  fi
+
+  # Forward-compatibility with #2833/#2843: a bracketed attribution field after
+  # the sha is free text to the restoration parser, which validates the sha and
+  # nothing else on a fires row. This case is what keeps the two row-format
+  # extensions composable rather than colliding.
+  {
+    printf 'fires %s [%s=40] a real drop\n' "$sha" "$culprit"
+    printf 'marker %s guarded.txt RESTORED_MARKER_SENTINEL\n' "$sha"
+  } >"$repo/scripts/inc.txt"
+  SILENT_REVERT_INCIDENTS=scripts/inc.txt run_canary "$repo" --verify-restoration
+  out="$OUT"
+  if [[ "$RC" -eq 0 ]] && printf '%s' "$out" | grep -q 'present: RESTORED_MARKER_SENTINEL'; then
+    ok "a fires row carrying a bracketed attribution field still resolves its markers"
+  else
+    fail "the restoration parser must ignore a fires row's extra fields, rc=$RC: $out"
+  fi
+}
+
 # The shipped data files must parse and be non-empty, so a truncated or
 # malformed file cannot quietly turn the replay into a no-op.
 t_shipped_data_files_are_wellformed() {
@@ -485,13 +811,48 @@ t_shipped_data_files_are_wellformed() {
   fi
   n="$(grep -cE '^(fires|clean)[[:space:]]+[0-9a-f]{40}[[:space:]]' "$inc")"
   [[ "$n" -ge 2 ]] || bad=1
-  # Anything non-blank, non-comment must match the row grammar.
+  # Anything non-blank, non-comment must match the row grammar. `marker` rows
+  # (#2855) are part of that grammar: they carry the incident sha in the same
+  # second field, then a path, then free-text marker content.
   grep -vE '^[[:space:]]*(#|$)' "$inc" |
-    grep -qvE '^(fires|clean)[[:space:]]+[0-9a-f]{40}[[:space:]]' && bad=1
+    grep -qvE '^(fires|clean|marker)[[:space:]]+[0-9a-f]{40}[[:space:]]' && bad=1
   if [[ "$bad" -eq 0 ]]; then
     ok "silent-revert-incidents.txt is well-formed with $n pinned rows"
   else
     fail "silent-revert-incidents.txt is malformed or has too few rows (n=$n)"
+  fi
+
+  # Every shipped `fires` row must carry at least one marker (#2855).
+  #
+  # --verify-restoration enforces this at run time too, but only in the canary
+  # job with full history. Pinning it HERE means a `fires` row landing without
+  # a marker is a red unit test on the PR that adds it, rather than a red
+  # canary after the merge -- and the whole point of this issue is that the
+  # restoration half must not depend on someone reading a post-merge log.
+  bad=0
+  local row_sha marker_shas
+  marker_shas="$(awk '$1 == "marker" { print $2 }' "$inc" | sort -u)"
+  while read -r row_sha; do
+    [[ -n "$row_sha" ]] || continue
+    printf '%s\n' "$marker_shas" | grep -qxF "$row_sha" || bad=1
+  done < <(awk '$1 == "fires" { print $2 }' "$inc")
+  if [[ "$bad" -eq 0 ]]; then
+    ok "every shipped fires row carries at least one restoration marker"
+  else
+    fail "a shipped fires row in silent-revert-incidents.txt carries no marker row"
+  fi
+
+  # And the reverse: a marker whose sha names no `fires` row is a typo that
+  # would silently cover nothing.
+  bad=0
+  while read -r row_sha; do
+    [[ -n "$row_sha" ]] || continue
+    awk '$1 == "fires" { print $2 }' "$inc" | grep -qxF "$row_sha" || bad=1
+  done < <(printf '%s\n' "$marker_shas")
+  if [[ "$bad" -eq 0 ]]; then
+    ok "every shipped marker row names a recorded fires incident"
+  else
+    fail "a marker row in silent-revert-incidents.txt names no fires row"
   fi
 
   bad=0
@@ -524,6 +885,10 @@ t_unresolvable_range_fails_closed
 t_root_commit_is_handled
 t_empty_range_is_clean
 t_replay_fails_on_broken_expectation
+t_restoration_reports_present_and_absent_markers
+t_restoration_refuses_a_malformed_corpus
+t_restoration_binds_a_marker_to_exactly_one_file
+t_restoration_and_replay_share_the_corpus
 t_shipped_data_files_are_wellformed
 
 echo

--- a/scripts/check-silent-revert.test.sh
+++ b/scripts/check-silent-revert.test.sh
@@ -649,6 +649,42 @@ an-unknown-disposition-keyword guarded.txt [ignored: why] RESTORED_MARKER_SENTIN
 an-unterminated-disposition guarded.txt [not-restored: why RESTORED_MARKER_SENTINEL
 BAD_ROWS
 
+  # A corpus with no `fires` row at all must not report a serene pass. The
+  # marker-per-fires-row rule only bites while a `fires` row exists, so removing
+  # a row together with its markers is a mute button reached by deletion rather
+  # than by editing.
+  printf '# only comments here\n' >"$repo/scripts/inc.txt"
+  SILENT_REVERT_INCIDENTS=scripts/inc.txt run_canary "$repo" --verify-restoration
+  out="$OUT"
+  if [[ "$RC" -eq 2 ]] && printf '%s' "$out" | grep -q "no 'fires' row"; then
+    ok "a corpus with no fires row exits 2 rather than passing while covering nothing"
+  else
+    fail "an empty corpus must exit 2, rc=$RC: $out"
+  fi
+  printf 'clean %s only a clean row\n' "$sha" >"$repo/scripts/inc.txt"
+  SILENT_REVERT_INCIDENTS=scripts/inc.txt run_canary "$repo" --verify-restoration
+  out="$OUT"
+  if [[ "$RC" -eq 2 ]]; then
+    ok "a corpus of only 'clean' rows exits 2"
+  else
+    fail "a clean-only corpus must exit 2, rc=$RC: $out"
+  fi
+
+  # A well-formed sha nobody can resolve is a shallow clone or a typo. A matched
+  # typo on a row AND its marker would otherwise assert content for an incident
+  # that never happened.
+  {
+    printf 'fires 0123456789abcdef0123456789abcdef01234567 not a real commit\n'
+    printf 'marker 0123456789abcdef0123456789abcdef01234567 guarded.txt RESTORED_MARKER_SENTINEL\n'
+  } >"$repo/scripts/inc.txt"
+  SILENT_REVERT_INCIDENTS=scripts/inc.txt run_canary "$repo" --verify-restoration
+  out="$OUT"
+  if [[ "$RC" -eq 2 ]] && printf '%s' "$out" | grep -q 'unreachable'; then
+    ok "a fires row naming an unreachable commit exits 2 even with a resolving marker"
+  else
+    fail "an unreachable incident commit must exit 2, rc=$RC: $out"
+  fi
+
   # An abbreviated sha would let a marker widen to a commit nobody recorded --
   # the same discipline the acknowledgment file holds.
   {
@@ -738,19 +774,62 @@ t_restoration_binds_a_marker_to_exactly_one_file() {
     fail "a directory marker path must exit 2, rc=$RC: $out"
   fi
 
-  # A glob that would match the bound file under a pathspec must not match it
-  # under an exact lookup -- it simply does not name a file, so: absent.
+  # Working-tree mode must stay REPO-SCOPED. Reading the filesystem directly
+  # would let an untracked file -- content that is not on main and never was --
+  # satisfy a marker in exactly the mode the canary job runs, while the same row
+  # reports NOT RESTORED at an explicit rev. The two modes must agree.
+  printf 'RESTORED_MARKER_SENTINEL\n' >"$repo/untracked.txt"
   {
     printf 'fires %s a real drop\n' "$sha"
-    printf 'marker %s guarded*.txt RESTORED_MARKER_SENTINEL\n' "$sha"
+    printf 'marker %s untracked.txt RESTORED_MARKER_SENTINEL\n' "$sha"
   } >"$repo/scripts/inc.txt"
   SILENT_REVERT_INCIDENTS=scripts/inc.txt run_canary "$repo" --verify-restoration
   out="$OUT"
   if [[ "$RC" -eq 1 ]]; then
-    ok "a glob marker path resolves to no file and reports the marker absent"
+    ok "an untracked file cannot satisfy a marker in working-tree mode"
   else
-    fail "a glob marker path must not resolve, rc=$RC: $out"
+    fail "an untracked path must not satisfy a marker, rc=$RC: $out"
   fi
+  rm -f "$repo/untracked.txt"
+
+  # A path that leaves the repository is refused outright, in both modes,
+  # because a marker resolved outside the tree asserts nothing about main.
+  local escaping
+  for escaping in "/etc/hostname" "../guarded.txt" "a/../../guarded.txt" ".."; do
+    {
+      printf 'fires %s a real drop\n' "$sha"
+      printf 'marker %s %s RESTORED_MARKER_SENTINEL\n' "$sha" "$escaping"
+    } >"$repo/scripts/inc.txt"
+    SILENT_REVERT_INCIDENTS=scripts/inc.txt run_canary "$repo" --verify-restoration
+    out="$OUT"
+    if [[ "$RC" -eq 2 ]]; then
+      ok "a marker path escaping the repository ('$escaping') exits 2"
+    else
+      fail "escaping path '$escaping' must exit 2, rc=$RC: $out"
+    fi
+  done
+
+  # A glob that WOULD match the bound file under a pathspec is a corpus error,
+  # refused at parse time so both modes answer identically. Left to resolution,
+  # `git cat-file` would report absent (exit 1) while `git ls-files` would
+  # expand the glob and report present (exit 0) -- the two modes disagreeing on
+  # the same row is how a false green gets in.
+  local globbed
+  for globbed in "guarded*.txt" "guarded?.txt" "guarded[0-9].txt" ":(glob)guarded.txt"; do
+    {
+      printf 'fires %s a real drop\n' "$sha"
+      printf 'marker %s %s RESTORED_MARKER_SENTINEL\n' "$sha" "$globbed"
+    } >"$repo/scripts/inc.txt"
+    SILENT_REVERT_INCIDENTS=scripts/inc.txt run_canary "$repo" --verify-restoration
+    out="$OUT"
+    local wt_rc="$RC"
+    SILENT_REVERT_INCIDENTS=scripts/inc.txt run_canary "$repo" --verify-restoration "$sha"
+    if [[ "$wt_rc" -eq 2 ]] && [[ "$RC" -eq 2 ]]; then
+      ok "a glob marker path '$globbed' is refused identically in both modes"
+    else
+      fail "glob path '$globbed' must exit 2 in both modes (worktree=$wt_rc, rev=$RC): $out"
+    fi
+  done
 }
 
 # The two modes read the SAME file and must not disturb each other. The replay

--- a/scripts/check-silent-revert.test.sh
+++ b/scripts/check-silent-revert.test.sh
@@ -883,10 +883,15 @@ t_restoration_binds_a_marker_to_exactly_one_file() {
     } >"$repo/scripts/inc.txt"
     SILENT_REVERT_INCIDENTS=scripts/inc.txt run_canary "$repo" --verify-restoration
     out="$OUT"
-    if [[ "$RC" -ne 0 ]]; then
+    # Assert the MESSAGE, not just a non-zero exit. The link's target does not
+    # exist, so with the `-L` guard deleted this row would still fail the `-f`
+    # test and die with rc=2 -- a bare `RC -ne 0` passes either way and pins
+    # nothing. Requiring the symlink wording is what makes this a regression
+    # test for the symlink guard rather than for dangling paths in general.
+    if [[ "$RC" -eq 2 ]] && printf '%s' "$out" | grep -q 'is a symlink'; then
       ok "a tracked symlink cannot satisfy a marker in working-tree mode"
     else
-      fail "a symlinked marker path must not report present, rc=$RC: $out"
+      fail "a symlinked marker path must be refused as a symlink, rc=$RC: $out"
     fi
     rm -f "$repo/linked.txt"
     git_test_config "$repo" add -A >/dev/null 2>&1

--- a/scripts/silent-revert-incidents.txt
+++ b/scripts/silent-revert-incidents.txt
@@ -17,6 +17,53 @@
 # Format: <expectation> <full-sha> <note>. `fires` = the canary must report a
 # finding; `clean` = it must not. Blank lines and `#` lines ignored.
 #
+# RESTORATION MARKERS (#2855)
+# ---------------------------
+# A `fires` row on its own proves only that the commit still produces a
+# finding. It says nothing about whether the content that commit deleted is on
+# main today, and that gap has already cost this repo 31h28m: the content
+# #2828 is about was missing from main while the f603880da row below printed
+# `ok ... fires as recorded` and the replay exited 0. Two re-lands (#2714,
+# #2803) each missed it, and a hand audit caught it, not this file.
+#
+# CONTENT, not files. Both files existed the whole time -- #2829 modifies them
+# rather than adding them. That is why nothing noticed: a file-level or
+# path-level check sees two present, recently touched files.
+#
+# So every `fires` row is followed by one or more MARKER rows -- a line of the
+# content that incident removed, bound to the path it must be found in:
+#
+#   marker <incident-full-sha> <path> <marker text to end of line>
+#   marker <incident-full-sha> <path> [not-restored: <reason>] <marker text>
+#
+# `check-silent-revert.sh --verify-restoration [<rev>]` reads EXACTLY the one
+# file each marker names, at that rev, defaulting to the working tree, and exits
+# non-zero for any marker that is absent and undispositioned. A `fires` row
+# carrying NO marker is refused outright (exit 2), so this cannot be satisfied
+# by pinning one historical incident and covering no future one.
+#
+# The path must name ONE FILE. It is resolved with `git cat-file <rev>:<path>`,
+# not as a pathspec, and a directory or a glob is refused rather than searched.
+# That is deliberate: a widened path would search a SUPERSET of the bound file,
+# and since every marker string below is also written on this very page, a
+# widened path makes the whole assertion satisfiable by this file alone.
+#
+# The marker text is the whole tail of the line and is matched literally, so it
+# may contain any character; the only reserved position is a leading `[`, which
+# introduces a disposition. A disposition needs a NON-EMPTY reason -- the same
+# shape `Intentional-removal:` requires in a commit message. `[not-restored:]`
+# with nothing after it is rejected, not read as a mute.
+#
+# PATH-SCOPED is load-bearing, not tidiness. Both markers on the f603880da row
+# also occur elsewhere in the same plugin on current main (the engine script,
+# its test file, CHANGELOG.md), so a repo-wide grep would have reported both
+# files restored on a tree where the content was missing.
+#
+# Choose a marker a reviewer can recognize as the content itself. An identifier
+# will go red on a rename, and that loudness is intended: the answer is a
+# disposition with a reason, or an updated marker recorded as a decision --
+# never deleting the row, which is the mute button this file exists not to have.
+#
 # Do NOT relax a row to make CI pass. A row that no longer holds means the
 # canary stopped detecting the thing it exists to detect; fix the canary.
 
@@ -24,11 +71,26 @@
 # #2639's squash dropped #2635's report-ordering fix wholesale while landing its
 # own (correct) work. #2590 was left CLOSED as COMPLETED with the fix absent.
 fires f603880dad4003477ec7cac27654fce92c75eec8 #2639 dropped #2635 (346 lines), 13 minutes later
+#
+# The two markers below are THE #2828 incident, recorded so it cannot recur
+# quietly. Both files EXISTED throughout -- what was absent from main from
+# f603880da to 534eac138 was the content #2635 had put in them, and nothing said
+# so. That is the whole reason a path-level check is useless here: it sees two
+# present files. Each marker is one line #2635 added that survived #2829's
+# restore: the README hunk #2635 landed was malformed and #2829 deliberately
+# restored the INTENT rather than the bytes, so a verbatim-hunk assertion would
+# be red here forever while this line is present in both trees.
+marker f603880dad4003477ec7cac27654fce92c75eec8 plugins/disk-hygiene/README.md Safe tidiness is the primary objective
+marker f603880dad4003477ec7cac27654fce92c75eec8 plugins/disk-hygiene/skills/clean/evals/evals.json empty-directories-remain-first-class-tidiness-findings
 
 # Ten minutes after that, #2641's squash dropped #2639's guard work.
 # destructive_guard.py went 1643 -> 1424 lines and every #2639 marker string
 # went to zero occurrences. #2618 was left CLOSED as COMPLETED.
 fires 9239f1541b1b15a2a183ad6b4067e577f931e3f1 #2641 dropped #2639 (451 lines), 10 minutes later
+# #2640 restored this surface by hand. The marker is one of the guard tables
+# #2639 added and #2641's squash took back out; it is present in every tree from
+# the restore onward, which is the property this row asserts.
+marker 9239f1541b1b15a2a183ad6b4067e577f931e3f1 plugins/disk-hygiene/skills/clean/scripts/destructive_guard.py _FIND_SIDE_EFFECT_PRIMARIES
 
 # The third merge from the same night, surfaced by this canary's own
 # calibration run rather than by the #2691 audit. #2633's squash dropped work
@@ -54,6 +116,11 @@ fires 9239f1541b1b15a2a183ad6b4067e577f931e3f1 #2641 dropped #2639 (451 lines), 
 # #2632 never merged (closed unmerged, no merge commit, not an ancestor of
 # main) and its diff contains no rollup work at all.
 fires cc58cbc53fbbb2cca68e071507b82d3e3ff896ff #2633 dropped #2644's rollups (853 blamed lines) and #2642's GraphQL merge evidence (301); already recorded in #2656
+# One marker per culprit, because this row's two attributions were restored by
+# the same hand fix (#2640) and either half could have been missed on its own --
+# which is the shape of the #2828 failure, a partial re-land nothing noticed.
+marker cc58cbc53fbbb2cca68e071507b82d3e3ff896ff plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.sh --apply-plan may be supplied only once
+marker cc58cbc53fbbb2cca68e071507b82d3e3ff896ff plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.sh MERGED_PR_GRAPHQL_ALIAS_PAGE
 
 # --- Verified-legitimate commits that must stay quiet -------------------------
 # The closest sub-threshold miss in 500 commits: 129 lines of a doc section that


### PR DESCRIPTION
Closes #2855

## Summary

The silent-revert canary answered one question about a recorded incident — does the deleting commit
still produce a finding — and never the other one: **is the content it deleted on `main` today**. So
an incident could be detected, recorded, partially re-landed, and left permanently incomplete while
every signal a reader normally checks stayed green.

That is the issue 2691 failure wearing a new hat, and it has already happened. The content issue 2828
is about was absent from `main` for 31h28m (`f603880da` → `534eac138`) while the `f603880da` row
printed `ok   f603880da fires as recorded` and the replay exited 0. Two separate re-lands (PR 2714,
PR 2803) each missed it. A hand audit found it, not the canary.

**Content, precisely — not files.** Both files existed at every rev in that window; PR 2829 shows as
`README.md | 14 ++---` and `evals.json | 15 ++-`, modifications rather than additions. That is
exactly why the gap survived: a file-level or path-level check sees two present, recently-touched
files and has nothing to report.

## Fix

A `fires` row now carries one or more marker rows — one line of the content that incident removed,
bound to the path it must be found in:

```
marker <incident-full-sha> <path> <marker text to end of line>
marker <incident-full-sha> <path> [not-restored: <reason>] <marker text>
```

`scripts/check-silent-revert.sh --verify-restoration [<rev>]` resolves each one with a path-scoped
`git grep -F` against that rev, defaulting to the working tree.

| condition | exit |
|---|---|
| every marker resolves (or is dispositioned) | 0 |
| a marker is absent and undispositioned | 1 |
| a `fires` row carries no marker | 2 |
| a marker names no `fires` row / malformed row / unresolvable rev | 2 |

A marker may be dispositioned `[not-restored: <reason>]`, and the reason must be **non-empty** — the
same shape `declares_removal()` requires of `Intentional-removal:`. `[not-restored:]` is rejected,
not read as a mute.

**The path resolves to exactly ONE FILE, via `git cat-file <rev>:<path>` — never a pathspec.** This
is the difference between the assertion meaning something and meaning nothing. `git grep -- <path>`
reads a *pathspec*, so a directory (`plugins/disk-hygiene`), a glob (`plugins/*`), a bare `.`, or
pathspec magic (`:/`, `:(glob)**`) silently widens the search to a **superset** of the bound file —
and nothing about such a row looks wrong to a reviewer.

The amplifier that makes it fatal: every marker string is, by construction, *also* written in
`scripts/silent-revert-incidents.txt` itself. So a widened path does not merely risk a stray match —
it makes the assertion **tautologically satisfiable by its own corpus**. Measured before the fix:
with every shipped path replaced by `.`, all five markers reported restored on a tree with
`plugins/disk-hygiene` and `plugins/repo-fleet-hygiene` deleted outright. `git cat-file` has no
pathspec semantics at all, so the class cannot be expressed. Found by an independent fresh-context
verifier and pinned by `t_restoration_binds_a_marker_to_exactly_one_file`.

Three related holes were closed in the same pass, each found by review and each with a regression
test:

- **Repo scope.** Working-tree mode read the filesystem directly, so an untracked file, a
  `.gitignore`d file, or a symlink out of the repo satisfied a marker — content that is not on `main`
  and never was — in exactly the mode the canary job runs, while the same row reported NOT RESTORED
  at an explicit rev. It now requires a tracked path, so both modes assert the same universe.
- **Path shape.** Absolute paths, `..` components, glob characters and pathspec magic are refused at
  parse time. Glob characters especially: left to resolution the two modes *disagree* —
  `git cat-file` would not find the path (absent) while `git ls-files` would expand it (present).
- **No-`fires`-row.** A corpus with no `fires` row printed `Every recorded incident has its content
  (0 marker(s))` and exited 0. The marker-per-row rule only bites while a `fires` row exists, so
  deleting a row *together with* its markers was a mute button reached by removal rather than by
  editing. Exit 2 now, as is an unreachable incident sha.

**Scoping is load-bearing for the ordinary reason too.** Both markers on the `f603880da` row *also
occur elsewhere in the same plugin* on current `main` — the engine script, its test file, and
`CHANGELOG.md`. A repo-wide `git grep` would have reported both files restored on the very tree where
the content was missing.

**Why a marker-less `fires` row is exit 2, not a skip.** Skipping it would let the whole assertion be
satisfied by pinning one historical incident while silently covering no future one. It is refused at
run time, and `t_shipped_data_files_are_wellformed` also pins it at unit-test time — so such a row is
a red test on the PR that adds it, rather than a red canary after the merge.

**Why not something cheaper.** Both alternatives were measured against the real instance and both
fail. *Path-level* ("was this path revisited since?") is a false **negative** here: `9239f1541`
touched both files ten minutes after the incident, so the answer is yes for both on a tree where the
content is gone. *Verbatim hunk* is permanently **red** on the README half: issue 2828 records that
PR 2635's README hunk was malformed and must not be restored byte-for-byte, and PR 2829 restored the
intent instead. A marker survives that rewrite; the hunk cannot.

**This is not the curated-marker design the script's header rejects.** That rejection is about
*discovery* — a marker list cannot find an incident nobody registered. These markers hang off a row
that is already in the corpus, where the knowledge exists and recording it costs one line. Issue
2691's own suggestion 3 asked for exactly this; only suggestion 2's shape was ever built.

**Where it runs, and why the position is load-bearing.** A new step in the `silent-revert-canary`
job, **ungated on the event** — like the self-test and the replay. "Nobody thought to check" is the
failure that produced issue 2828, so an on-demand mode would reproduce it.

It runs **last**, deliberately. A step with no status function carries an implicit `success() &&`, so
a failing step skips every later step in the job. Placed before the scan — where it started — a red
restoration assertion would have **skipped the scan itself**, and those commits are never
re-examined, because the next push's range begins at this push's head. That trade is unacceptable in
this direction: restoration is bound to *live* content in living files, and the corpus header calls a
marker going red on a rename intended loudness, while the scan is the primary detector. A
churn-sensitive tripwire must not be able to silence it. `if: success() || failure()` prevents the
reverse suppression too — a scan that fires must not skip the restoration answer — while still
reporting nothing on a cancelled run.

Verified on this PR's own canary run: the two scan steps are `skipped` on a `pull_request` event and
the restoration step still reports `success` (skipped steps do not poison `success()`), so the
pre-merge signal is real.

It is not a merge gate: the workflow is not in `ci.yml` and not in that workflow's `ci-status`
aggregate, and its `pull_request` trigger is `paths`-scoped to the canary's own files.

## Verification

Acceptance criteria 3 and 4 are executable. They were run, not asserted:

```
$ bash scripts/check-silent-revert.sh --verify-restoration 71ca05a39
Restoration of recorded incident content, resolved at 71ca05a39:

FAIL  f603880da  plugins/disk-hygiene/README.md
        NOT RESTORED: Safe tidiness is the primary objective
FAIL  f603880da  plugins/disk-hygiene/skills/clean/evals/evals.json
        NOT RESTORED: empty-directories-remain-first-class-tidiness-findings
ok    9239f1541  plugins/disk-hygiene/skills/clean/scripts/destructive_guard.py
ok    cc58cbc53  plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.sh
ok    cc58cbc53  plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.sh

2 of 5 recorded marker(s) are absent from 71ca05a39.
EXIT=1

$ bash scripts/check-silent-revert.sh --verify-restoration 534eac138
Every recorded incident has its content at 534eac138 (5 marker(s), 0 dispositioned).
EXIT=0
```

Exactly the two disk-hygiene files, and exit 0 at `534eac138` — so the assertion accepts PR 2829's
**non-verbatim** README restoration rather than demanding the original hunk back.

Also run locally, all green:

| check | result |
|---|---|
| `scripts/check-silent-revert.test.sh` | 68 passed, 0 failed (was 27 cases) — same count on the ubuntu-24.04 runner |
| `scripts/check-silent-revert.sh --verify-known-incidents` | exit 0, unchanged, no expectation relaxed |
| `scripts/check-silent-revert.sh --verify-restoration` (working tree) | exit 0, 5 markers |
| `shellcheck --rcfile=.shellcheckrc` on both scripts | clean |
| `actionlint .github/workflows/silent-revert-canary.yml` | clean |

Test coverage goes 27 → 68 cases across four new functions:

- `t_restoration_reports_present_and_absent_markers` — the four cases the issue names (restored,
  absent, dispositioned-absent, present-only-outside-its-bound-path), plus the explicit-rev form and
  an unresolvable rev.
- `t_restoration_refuses_a_malformed_corpus` — marker-less `fires` row, a corpus with **no** `fires`
  row at all, a `clean`-only corpus, an unreachable incident sha, orphan marker, empty and
  whitespace-only disposition reasons, unterminated `[`, unknown disposition keyword, abbreviated
  sha, unknown row kind. Every one is exit 2.
- `t_restoration_binds_a_marker_to_exactly_one_file` — every path-widening shape (`.`, `..`, `*`, a
  bare directory, `:/`, `:(glob)**/*`, glob filenames), at the working tree and at a rev; an
  **untracked** file, which must not satisfy a marker in working-tree mode; and absolute / `..`
  paths, which are refused. **These cases were confirmed falsifiable**: run against the pre-fix
  script, six of them go red.
- `t_restoration_and_replay_share_the_corpus` — the two modes read the same file and must not disturb
  each other.

Fresh-context verifier agents independently re-ran the acceptance proof and adversarially hunted for
a false green before this was pushed. That is how the pathspec-widening hole above was found and
closed — it was present in the first draft and is pinned by regression tests now.

No CHANGELOG entry applies: `changelog-parity-gate` is scoped to `plugins/*`
(`scripts/check-changelog-parity.sh:126,277,444`), and this change is entirely under `scripts/` and
`.github/workflows/`.

## Related

- Refs #2828 — the partial re-land this mechanism exists to make impossible. Note its body says
  `f603880da` "is already an acknowledged incident"; it is not. It is a `fires` row in
  `scripts/silent-revert-incidents.txt` and is absent from `scripts/silent-revert-acknowledged.txt`.
  The gap was never that the commit was muted — it is that firing was never connected to restoration.
- Refs #2691 — the originating audit. Its suggestion 3 is the marker design that was never built.
- Refs #2833, Refs #2837, PR 2843 — open against the same two files, adding a bracketed
  `[<culprit-sha>=<count>,...]` field after a `fires` row's sha. **The two row-format extensions
  compose, and that is verified rather than assumed:**
  - *This parser survives 2843's field — measured against 2843's own head, not assumed.*
    `parse_incidents_file`'s `fires | clean)` branch validates `$sha` and reads nothing else, so the
    bracketed field lands in the discarded `$path` variable. I built a corpus from PR 2843's three
    **verbatim** shipped `fires` rows (`[a95f240f7…=346]`, `[f603880da…=451]`, and the two-culprit
    `[bfb66beb8…=853,eda5ae5ed…=298]`) with this PR's marker rows interleaved, and ran all three
    acceptance revs against it:

    | corpus | working tree | `71ca05a39` | `534eac138` |
    |---|---|---|---|
    | this PR's | exit 0, 5 markers | exit 1, both files | exit 0 |
    | 2843's row format + these markers | exit 0, 5 markers | exit 1, both files | exit 0 |

    Identical. Also pinned as a unit test by `t_restoration_and_replay_share_the_corpus`, so the
    property survives future edits rather than resting on one manual run.
  - *2843 needs one line from this PR after rebasing.* This PR adds `marker) continue ;;` at the top
    of `verify_known_incidents`'s loop, **above the reachability check** — without it the replay
    reads a marker row's second field (a path) as a sha and dies on every marker row. PR 2843
    rewrites that whole function, so its rebase will drop the arm and must re-add it.
  - *`t_shipped_data_files_are_wellformed` is edited by both.* This PR widens the row-grammar regex
    to admit `marker` rows and adds two shipped-corpus checks; 2843 adds an attribution-field check
    to the same function. Textual conflict only — the assertions are independent.
  - *Deliberately NOT fixed here:* the workflow header still says "There is no `pull_request`
    trigger" while one has existed since PR 2808. It is stale independently of this change, and
    PR 2843 rewrites those exact lines — correcting them here would guarantee a conflict for no gain.
    Left to 2843 on purpose.
- Refs #2831, PR 2832 — the corpus attribution correction this builds on.
- PR 2847 (`fix/silent-revert-calibration-overlap`) — also open against these files; nothing here
  depends on its content.
