### PR TITLE
feat(disk-hygiene): roll up every immediate child in the scan payload

### DIFF
--- a/plugins/disk-hygiene/.claude-plugin/plugin.json
+++ b/plugins/disk-hygiene/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "disk-hygiene",
-  "version": "0.20.13",
+  "version": "0.20.14",
   "description": "Context-aware disk hygiene for arbitrary directory trees: inventories orphaned and temporary artifacts, classifies evidence into review tiers, and offers exact-path cleanup only after a fresh safety preview and explicit per-tier approval. The target is read-only by default; OS-managed paths, links and mount points, VCS-tracked content without the complete checkout evidence bundle, changed entries, and live-handle uncertainty fail closed.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/disk-hygiene/CHANGELOG.md
+++ b/plugins/disk-hygiene/CHANGELOG.md
@@ -3,6 +3,52 @@
 All notable changes to the `disk-hygiene` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.20.14]
+
+### Added
+
+- **A per-immediate-child roll-up in every scan payload (#2851).** The skill tells operators to open
+  a large target with `--max-depth 1` and reason over its immediate children, but the engine emitted
+  only a flat per-entry list plus target-level totals — so the view the workflow prescribes existed
+  in no engine output, and the triage that surfaced this was run off a hand-built PowerShell table.
+  `children_rollup` now carries one row per immediate child with `name`, `kind`, `walked`,
+  `logical_bytes`, `reclaimable_local_bytes`, `size_qualifiers`, `entry_count`, `newest_mtime_ns`,
+  and `unwalked_reasons`; the row is present for every child the run covered, whatever that child's
+  coverage, so a gap is visible per child rather than only in `truncated_paths`. `scan-complete`
+  echoes the block alongside the snapshot.
+- **The roll-up's bytes carry the same qualifier channel every other byte surface here has (#2851).**
+  `logical_bytes` is a LOGICAL total, so a cloud placeholder's remote size, a hard link's shared
+  object, and a sparse file's unallocated extent all inflate it above what deleting the child would
+  return — and this is the block `SKILL.md` tells the operator to lead the report with. Each row
+  therefore also carries `size_qualifiers` (the union observed in the subtree) and
+  `reclaimable_local_bytes` (unqualified files only), mirroring `target_reclaimable_local_bytes`.
+  Both follow the same walked/null discipline as the other aggregates. Found by an adversarial
+  fresh-context verifier, which measured a walked row reporting `logical_bytes: 10000000` for a
+  sparse child in a payload whose `target_reclaimable_local_bytes` was 0.
+- **`unhinted_entries`, the third coverage term (#2851).** `scan-complete` already reported `entries`
+  and `hinted_entries`; it now also reports `entries` minus `hinted_entries` — every inventoried
+  entry no hint judged — so a run with 7 hinted entries out of 40,247 reads as 0.017 % hint coverage
+  rather than as seven findings. It counts every INVENTORIED entry, not only fully walked ones, which
+  is a deliberate narrowing of the request's "walked entries carrying no hint": counted that way the
+  three terms partition the inventory exactly, so `entries` is always `hinted_entries` plus
+  `unhinted_entries` and neither number needs a caveat to add up. `SKILL.md` §3 documents both the
+  roll-up block and the rate.
+
+### Disclosed deviation from the requested behavior
+
+- **Under `--max-depth 1` a non-empty child's totals are `null`, not numbers, and this is deliberate
+  (#2851).** The request asked for a recursive byte total, entry count, and newest mtime per
+  immediate child, populated under `--max-depth 1`. Those two constraints cannot both hold: a
+  recursive total for a non-empty child is only knowable by walking that child, and walking it is
+  precisely what the depth bound exists to prevent. Measured on a 740-path fixture, the bounded pass
+  opens 8 directories, stats 41 paths, and inventories 8 entries with the roll-up — byte-identical
+  to the same pass without it — while the unbounded walk costs 20 opens, 4,427 stats, and 740
+  entries. The roll-up therefore reads only what the walk already recorded and reports the honest
+  subset: exact numbers for loose files, empty children, and anything genuinely walked; `walked:
+  false` with all three aggregates `null` and a named cause (`depth-cut`) for everything else. A
+  partial subtree sum is never presented as a total and `null` never degrades to `0`, because `0`
+  remains the genuine "this child is empty" answer that the zero-byte-residue work depends on.
+
 ## [0.20.13]
 
 ### Changed

--- a/plugins/disk-hygiene/skills/clean/SKILL.md
+++ b/plugins/disk-hygiene/skills/clean/SKILL.md
@@ -145,31 +145,27 @@ The guard validates `--data-root` against the plugin data directory it derives i
 the call outright when it cannot recognize the install layout — so a run reporting that denial is a
 coverage gap, not a clean result. (Derivation and its fail-closed rationale: `reference/safety-model.md`.)
 
-For a large root (a home directory, anything whose recursive walk could exceed the engine's entry
-cap), start with a bounded pass: add `--max-depth 1` to inventory the target's loose files and
-immediate children, then fan out deeper scans per subtree that the evidence justifies. The engine
-backs this with a deterministic gate: a scan whose target resolves to the user home directory or a
-non-OS volume root (a Windows Dev Drive — an OS-managed root still cannot be walked as a whole, and
-reaches the engine only via `--root-children`) and carries neither `--max-depth` nor
-`--confirmed-large-scan` returns
+For a large root (a home directory, anything whose recursive walk could exceed the engine's entry cap),
+start with a bounded pass: add `--max-depth 1` to inventory the target's loose files and immediate children,
+then fan out deeper scans per subtree that the evidence justifies. The engine backs this with a
+deterministic gate: a scan whose target resolves to the user home directory or a non-OS volume root (a
+Windows Dev Drive — an OS-managed root still cannot be walked as a whole, and reaches the engine only via
+`--root-children`) and carries neither `--max-depth` nor `--confirmed-large-scan` returns
 `large-target-confirmation-required` (after a cheap top-level probe, not a full walk) instead of the
-unbounded traversal, so a forgotten bound never becomes an accidental whole-volume scan. `--max-depth`
-is the preferred bounded response.
-When the target is an OS-managed volume root, first run with `--root-children` alone, present the
-`admitted_children` list through the [confirmation gate](#confirmation-gate)'s root-children row,
-then re-run with the same flag plus each chosen `--root-child <name>` — one run directory, one
-snapshot, one report covers every selected subtree. Never invent the selection.
-Reserve `--confirmed-large-scan` for a deliberate full walk the human has confirmed — pass the
-[confirmation gate](#confirmation-gate)'s scan-scope row first, the same standing before an
-expensive step that the apply lane demands before a destructive one; a general "clean my home
-directory" is not that confirmation. Every
-directory whose descendants were not walked — cut off by `--max-depth`, a protected root, or a VCS
-boundary — is recorded in `truncated_paths`; report them as coverage gaps, never as clean, and
-never plan them for removal (the preview blocks them as `truncated-not-inventoried` and skips the
-live re-verification checks a candidate with no live-I/O value left to give would otherwise still
-pay for). Each fan-out worker receives a bounded subtree and returns evidence only. The parent owns
-classification, the single report, every approval, preview, and all execution. Do not let workers
-delete or prepare approvals.
+unbounded traversal, so a forgotten bound never becomes an accidental whole-volume scan. `--max-depth` is
+the preferred bounded response. When the target is an OS-managed volume root, first run with
+`--root-children` alone, present the `admitted_children` list through the [confirmation
+gate](#confirmation-gate)'s root-children row, then re-run with the same flag plus each chosen `--root-child
+<name>` — one run directory, one snapshot, one report covers every selected subtree. Never invent the
+selection. Reserve `--confirmed-large-scan` for a deliberate full walk the human has confirmed — pass the
+[confirmation gate](#confirmation-gate)'s scan-scope row first, the same standing before an expensive step
+that the apply lane demands before a destructive one; a general "clean my home directory" is not that
+confirmation. Every directory whose descendants were not walked — cut off by `--max-depth`, a protected
+root, or a VCS boundary — is recorded in `truncated_paths`; report them as coverage gaps, never as clean,
+and never plan them for removal (the preview blocks them as `truncated-not-inventoried` and skips the live
+re-verification checks a candidate with no live-I/O value left to give would otherwise still pay for). Each
+fan-out worker receives a bounded subtree and returns evidence only. The parent owns classification, the
+single report, every approval, preview, and all execution. Do not let workers delete or prepare approvals.
 
 The bundled [baseline policy](reference/baseline-policy.json) contains cross-platform candidate hints
 and protected names. Without `--policy`, the engine also layers standing policy files when present:
@@ -231,34 +227,42 @@ Report every finding with these fields, in this order — size last:
 
 Separately list protected, locked, needs-elevation, unverified, and coverage-gap entries.
 
-**Empty directories are first-class findings.** They are not inherently junk, but zero-byte residue
-must stay visible and rankable: never drop an empty directory from investigation or from the report
-because it reclaims nothing. Prefer ranking by tier, location sensitivity (for example volume-root
-or home-root orphans), and provenance strength over byte totals. The snapshot already distinguishes
-them for you: a walked directory whose `logical_size` is `0` with an empty `size_qualifiers` is a
-genuinely empty directory, while a `logical_size` of `null` carrying the `not-walked` qualifier is
-an uninventoried coverage gap. Never fold the first into a byte-centric roll-up that drops it, and
-never read it as the second.
+**Empty directories are first-class findings.** They are not inherently junk, but zero-byte residue must
+stay visible and rankable: never drop an empty directory from investigation or from the report because it
+reclaims nothing. Prefer ranking by tier, location sensitivity (for example volume-root or home-root
+orphans), and provenance strength over byte totals. The snapshot already distinguishes them for you: a
+walked directory whose `logical_size` is `0` with an empty `size_qualifiers` is a genuinely empty directory,
+while a `logical_size` of `null` carrying the `not-walked` qualifier is an uninventoried coverage gap. Never
+fold the first into a byte-centric roll-up that drops it, and never read it as the second.
 
-**Relocation is out of scope.** This skill offers exactly two outcomes per finding — keep it, or
-approve its exact path for deletion. There is no relocation lane and no move primitive in the
-engine, by design: a move is not a containment-checkable, revalidatable, token-bound operation the
-way a delete is. So when the right answer for a misplaced entry is "this belongs somewhere else",
-say so and report it as **keep**; the operator performs and verifies the move themselves, outside
-this workflow. Never imply the report's keep-or-delete choice is the complete set of dispositions,
-and never stage a move through the manual handoff.
+**Lead the frontier with `children_rollup`.** The snapshot carries one row per immediate child the run covered, whatever
+that child's coverage, and `walked` is the single discriminator: `true` means every aggregate is exact; `false` means
+they are all `null` with `unwalked_reasons` naming the cause — never `0`, never a partial subtree sum. Rank on
+`reclaimable_local_bytes`, never on `logical_bytes`, a logical total that `size_qualifiers` flags as inflated by cloud
+placeholders, hard links, or sparse extents. The block opens no directory the walk did not, so a `--max-depth 1` pass
+returns `depth-cut`/`null` for every NON-EMPTY child: the frontier is complete, but a recursive total is bought only by
+fanning a deeper scan out over that subtree — report those rows as coverage gaps, never as small or clean.
+`scan-complete` also carries `unhinted_entries` — `entries` minus `hinted_entries`, every inventoried entry no hint
+judged — so quote hint coverage as a rate: 7 hinted of 40,247 is 0.017 %, nothing like "7 findings". Fields, reasons
+and the measurement: [the safety model](reference/safety-model.md).
 
-An entry's `logical_size` is reclaimable local bytes only when its `size_qualifiers` is empty.
-Exclude every qualified entry from any reclaimable-bytes total and state the qualified bytes
-separately with their reasons — a `cloud-placeholder` carries its REMOTE size while occupying
-roughly nothing locally; a `hardlinked` name shares one object with other names; a `sparse` file's
-logical size overstates local allocation; and `not-walked` means the subtree was never inventoried,
-so `logical_size` is `null` rather than `0` — except on the target's own record, which keeps its
-partial walked sum alongside a `not-walked` qualifier, so read that number as a floor. Prefer the
-snapshot's `target_reclaimable_local_bytes` (and preview/apply `reclaimable_local_bytes*`) over summing
-`logical_size` yourself — folding qualified or unknown sizes into a total claims space that
-deleting the path would never return. Never treat a low or zero reclaimable-byte figure as a reason
-to skip a finding that otherwise clears the evidence bar.
+**Relocation is out of scope.** This skill offers exactly two outcomes per finding — keep it, or approve its
+exact path for deletion. There is no relocation lane and no move primitive in the engine, by design: a move
+is not a containment-checkable, revalidatable, token-bound operation the way a delete is. So when the right
+answer for a misplaced entry is "this belongs somewhere else", say so and report it as **keep**; the
+operator performs and verifies the move themselves, outside this workflow. Never imply the report's
+keep-or-delete choice is the complete set of dispositions, and never stage a move through the manual
+handoff.
+
+An entry's `logical_size` is reclaimable local bytes only when its `size_qualifiers` is empty. Exclude every qualified
+entry from any reclaimable-bytes total and state the qualified bytes separately with their reasons — a
+`cloud-placeholder` carries its REMOTE size while occupying roughly nothing locally; a `hardlinked` name shares one
+object with other names; a `sparse` file's logical size overstates local allocation; and `not-walked` means the subtree
+was never inventoried, so `logical_size` is `null` rather than `0` — except on the target's own record, which keeps its
+partial walked sum alongside a `not-walked` qualifier, so read that number as a floor. Prefer the snapshot's
+`target_reclaimable_local_bytes` (and preview/apply `reclaimable_local_bytes*`) over summing `logical_size` yourself —
+folding qualified or unknown sizes into a total claims space that deleting the path would never return. Never treat a
+low or zero reclaimable-byte figure as a reason to skip a finding that otherwise clears the evidence bar.
 
 ## 4. Build one exact-tier plan
 

--- a/plugins/disk-hygiene/skills/clean/reference/safety-model.md
+++ b/plugins/disk-hygiene/skills/clean/reference/safety-model.md
@@ -377,6 +377,71 @@ A depth-limited scan records every directory it declined to enter in `truncated_
 directories have no captured descendant set, so the preview blocks them (and anything beneath them)
 as `truncated-not-inventoried`; they are coverage gaps, never candidates.
 
+`children_rollup` states that same coverage per immediate child of the target, so a gap is visible
+against the child an operator actually reasons about rather than only in a flat path list. Every
+immediate child the run covered gets exactly one row, whatever that row's coverage — omission would
+read as absence. (In `--root-children` mode the run covers the SELECTED children only: an unselected
+sibling is never opened, never inventoried, and owes no row. `root_children_selected` in the same
+payload names what was in scope.)
+
+| Field | Meaning |
+|---|---|
+| `name` | The immediate child's own name (never a path) |
+| `kind` | The entry kind the walk recorded — `directory`, `file`, `link`, `other` — or `null` when no inventory record survived |
+| `walked` | `true` only when the child's whole subtree was inventoried |
+| `logical_bytes` | Recursive LOGICAL total, qualifiers included; `null` unless `walked` |
+| `reclaimable_local_bytes` | Recursive total over unqualified files only — bytes deleting the child is expected to return locally; `null` unless `walked` |
+| `size_qualifiers` | Union of the qualifiers observed in the subtree (`cloud-placeholder`, `hardlinked`, `sparse`, …); `null` unless `walked` |
+| `entry_count` | Inventoried descendants, excluding the child's own record; `null` unless `walked` |
+| `newest_mtime_ns` | Newest `mtime_ns` across the child and its inventoried descendants; `null` unless `walked` |
+| `unwalked_reasons` | Sorted causes when `walked` is false: `depth-cut`, `protected`, `vcs-boundary`, `scan-error`, `descendant-not-walked`, or the bare `not-walked` fallback when the walk recorded no more specific cause. Empty when `walked` |
+
+`walked` is the single discriminator, and every aggregate moves with it: all exact, or all `null`.
+Two failure modes are closed by construction. A partial subtree sum is never presented as a child's
+total — a child that was itself entered but holds an unwalked descendant is `descendant-not-walked`,
+`null`. And `null` never degrades to `0`, because `0` is the genuine "this child is empty" answer
+that keeps zero-byte residue first-class.
+
+**That first case is a gap the flat entry list does not state, which is the sharpest reason to read
+the roll-up.** A directory's own record gets the `not-walked` qualifier only from ITS OWN branch —
+VCS boundary, protection, depth cut, or its own `scandir` failure. It is never propagated up from a
+descendant, and only `target_identity` is special-cased to append it whenever anything truncated. So
+an intermediate child holding an unwalked descendant keeps `walked: true`, an empty
+`size_qualifiers`, and a `logical_size` that is a PARTIAL sum indistinguishable from a complete one:
+a target holding `repo_child/.git` (a VCS boundary) plus `repo_child/src.py` records
+`repo_child` at `logical_size: 10`, `size_qualifiers: []`, with only `repo_child/.git` in
+`truncated_paths`. The roll-up is what makes that gap legible per child — it draws
+`descendant-not-walked` from the walk's coverage record rather than from the child's own qualifier —
+so never read a directory's `logical_size` as a total without checking whether anything beneath it
+is in `truncated_paths`.
+
+The third failure mode — a byte figure that overstates what deleting would return — is closed by
+pairing, not by omission. `logical_bytes` is a logical total, so a cloud placeholder's REMOTE size, a
+hard link's shared object, and a sparse file's unallocated extent all inflate it; `size_qualifiers`
+says which of those are present in the subtree and `reclaimable_local_bytes` counts only unqualified
+files, exactly as `target_reclaimable_local_bytes` does for the target. Rank a child on the
+reclaimable figure and state the qualified bytes separately with their reasons — never read
+`logical_bytes` as space a delete would give back. A `link` child is the limiting case: it reads
+`logical_bytes: 0` because the walk never traverses a link, and 0 is the honest figure for deleting
+the link itself, whatever the target holds.
+
+The roll-up is assembled from what the walk already recorded: it opens no directory and stats no
+path, so it cannot turn a bounded pass into an unbounded one. That is measured, not asserted —
+`test_bounded_rollup_opens_no_directory_the_bounded_walk_did_not` counts `os.scandir`, the engine's
+only directory-enumeration route, and on a 740-path fixture the `--max-depth 1` pass opens 8
+directories, stats 41 paths and inventories 8 entries both with the roll-up and without it, against
+20 opens, 4,427 stats and 740 entries for the unbounded walk. The cost of that guarantee is the
+honest limit an operator has to read the block with: under `--max-depth 1` a recursive total for a
+NON-EMPTY child is not knowable without walking it, so every such child reads `depth-cut` and
+`null`. The bounded pass delivers the complete frontier, per-child coverage, and exact numbers for
+loose files and empty children; a per-child total is bought by fanning a deeper scan out over that
+subtree.
+
+The `scan-complete` summary reports hint coverage in three terms — `entries`, `hinted_entries`, and
+`unhinted_entries` (`entries` minus `hinted_entries`). The third is what makes the first two
+readable: without a denominator for what no hint judged, a run that annotated 7 of 40,247 entries is
+indistinguishable from a thorough one.
+
 A scan of a known-large root — the user home directory, or a non-OS volume root (a Windows Dev
 Drive) now that reasoned classification admits it as a valid target — is gated before it walks.
 Absent an explicit `--max-depth` bound or a `--confirmed-large-scan` acknowledgement, the engine

--- a/plugins/disk-hygiene/skills/clean/scripts/hygiene.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/hygiene.py
@@ -829,6 +829,145 @@ def entry_is_empty_directory(
     return not any(path.startswith(prefix) for path in paths)
 
 
+def child_rollup_name(relative: str) -> str:
+    """The immediate-child segment a snapshot-relative path belongs to."""
+    return relative.split("/", 1)[0]
+
+
+def child_rollup_bytes(entry: dict[str, Any]) -> int:
+    """The bytes one immediate child contributes to the target's walked total.
+
+    Mirrors ``scan_tree``'s own accumulation exactly: a walked directory's
+    ``logical_size`` is already its recursive subtotal, a file contributes its
+    recorded logical size, and a link or special entry contributes nothing
+    because the walk never traverses one. Keeping the two rules identical is
+    what makes the roll-up sum to ``target_logical_bytes`` when every immediate
+    child was walked.
+    """
+    if entry.get("kind") == "directory":
+        size = entry.get("logical_size")
+        return int(size) if isinstance(size, int) else 0
+    if entry.get("kind") == "file":
+        return entry_logical_file_bytes(entry)
+    return 0
+
+
+def empty_child_rollup_bucket() -> dict[str, Any]:
+    """The per-child accumulator, in one place so its shape cannot drift."""
+    return {
+        "self": None,
+        "descendants": 0,
+        "newest": None,
+        "qualifiers": set(),
+        "reclaimable": 0,
+    }
+
+
+def children_rollup(
+    entries: list[dict[str, Any]],
+    *,
+    unknown_paths: Iterable[str] = (),
+    unwalked_reasons: dict[str, str] | None = None,
+) -> list[dict[str, Any]]:
+    """One row per immediate child of the target: bytes, count, newest mtime, coverage.
+
+    The bounded pass the skill recommends (``--max-depth 1``) leaves every
+    non-empty immediate child uninventoried, so the per-child question the
+    operator is told to reason in — how big is it, how much is in it, when was
+    it last touched — has no answer anywhere in the flat entry list. This
+    assembles that answer from what the walk ALREADY recorded: it opens no
+    directory and stats no path, so it can never turn a bounded pass into an
+    unbounded one. The cost of the roll-up is one linear pass over ``entries``.
+
+    Precisely because nothing extra is walked, a child is credited with numbers
+    only when its whole subtree was inventoried. ``walked`` is the single
+    discriminator: true means every aggregate is exact, false means they are all
+    ``null`` — never 0, which stays the genuine "this is empty" answer — with
+    the causes in ``unwalked_reasons``. A partial sum is never presented as a
+    total. Every immediate child gets a row whatever its coverage, so a gap is
+    visible per child rather than only in ``truncated_paths``. (In
+    ``--root-children`` mode "every child" means every SELECTED child: the walk
+    never looks at an unselected sibling, so the row set follows the selection
+    the payload records in ``root_children_selected``.)
+
+    ``logical_bytes`` alone would mislead exactly where this engine refuses to:
+    it is a LOGICAL total, and a cloud placeholder's remote size, a hard link's
+    shared object, and a sparse file's unallocated extent all inflate it above
+    what deleting the child would return. So each row carries the same two
+    channels every other byte-bearing surface here does — ``size_qualifiers``,
+    the union of qualifiers observed in the subtree, and
+    ``reclaimable_local_bytes``, which counts only unqualified files, mirroring
+    ``target_reclaimable_local_bytes``.
+
+    ``unknown_paths`` is every relative path the walk could not fully account
+    for (truncations, scan errors, ``not-walked`` records); a path marks its own
+    child row when it IS the child and marks the child's row as
+    ``descendant-not-walked`` when it lives below one. A path recorded as
+    unknown with no more specific cause falls back to the bare ``not-walked``,
+    the same qualifier the flat entry carries.
+    """
+    reasons = unwalked_reasons or {}
+    gaps: dict[str, set[str]] = {}
+    for path in unknown_paths:
+        if not isinstance(path, str) or not path or path == ".":
+            continue
+        name = child_rollup_name(path)
+        gaps.setdefault(name, set()).add(
+            reasons.get(path, "not-walked")
+            if path == name
+            else "descendant-not-walked"
+        )
+    totals: dict[str, dict[str, Any]] = {}
+    for entry in entries:
+        relative = entry.get("path")
+        # `.` is the target itself, never one of its children: `scan_tree` keeps
+        # the target's record out of `entries`, and the same skip in the gap loop
+        # above keeps a target-level truncation from inventing a `.` child row.
+        if not isinstance(relative, str) or not relative or relative == ".":
+            continue
+        name = child_rollup_name(relative)
+        bucket = totals.setdefault(name, empty_child_rollup_bucket())
+        if relative == name:
+            bucket["self"] = entry
+        else:
+            bucket["descendants"] = bucket["descendants"] + 1
+        mtime = entry.get("mtime_ns")
+        if isinstance(mtime, int):
+            newest = bucket["newest"]
+            bucket["newest"] = mtime if newest is None else max(newest, mtime)
+        bucket["qualifiers"].update(entry.get("size_qualifiers") or ())
+        local = entry_reclaimable_local_bytes(entry)
+        if local is not None:
+            bucket["reclaimable"] = bucket["reclaimable"] + local
+    rows: list[dict[str, Any]] = []
+    for name in sorted(set(totals) | set(gaps)):
+        bucket = totals.get(name) or empty_child_rollup_bucket()
+        child = bucket["self"]
+        causes = set(gaps.get(name, ()))
+        if child is None:
+            # An immediate child whose own record never reached the inventory
+            # (its lstat or its parent's scandir failed) is a coverage gap, not
+            # a zero-byte child.
+            causes.add("scan-error")
+        walked = not causes
+        rows.append(
+            {
+                "name": name,
+                "kind": child.get("kind") if child is not None else None,
+                "walked": walked,
+                "logical_bytes": child_rollup_bytes(child)
+                if walked and child is not None
+                else None,
+                "reclaimable_local_bytes": bucket["reclaimable"] if walked else None,
+                "size_qualifiers": sorted(bucket["qualifiers"]) if walked else None,
+                "entry_count": bucket["descendants"] if walked else None,
+                "newest_mtime_ns": bucket["newest"] if walked else None,
+                "unwalked_reasons": sorted(causes),
+            }
+        )
+    return rows
+
+
 def inventory_parent_paths(paths: Iterable[str]) -> set[str]:
     """Return every inventory path that has at least one inventoried descendant.
 
@@ -1286,6 +1425,9 @@ def scan_tree(
     entries: list[dict[str, Any]] = []
     errors: list[dict[str, str]] = []
     truncated: list[str] = []
+    # Why each uninventoried path is uninventoried, so the per-child roll-up can
+    # name the cause instead of reporting an undifferentiated gap.
+    unwalked_reasons: dict[str, str] = {}
     repositories, repo_errors = discover_enclosing_git(target)
     exact_names = set(policy["protected_exact_names"])
     known_mounts, mount_error = linux_mount_points()
@@ -1343,10 +1485,12 @@ def scan_tree(
                         subtotal: int | None = None
                         walked = False
                         truncated.append(relative)
+                        unwalked_reasons[relative] = "vcs-boundary"
                     elif protections:
                         subtotal = None
                         walked = False
                         truncated.append(relative)
+                        unwalked_reasons[relative] = "protected"
                     elif max_depth is not None and depth >= max_depth:
                         # A depth cut is the one truncation reason emptiness can
                         # answer. One cheap first-child probe (no recursion, no
@@ -1366,6 +1510,7 @@ def scan_tree(
                             subtotal = None
                             walked = False
                             truncated.append(relative)
+                            unwalked_reasons[relative] = "depth-cut"
                         else:
                             subtotal = 0
                     else:
@@ -1373,6 +1518,7 @@ def scan_tree(
                         if subtotal is None:
                             # scandir failed inside this child: unknown, not empty.
                             walked = False
+                            unwalked_reasons[relative] = "scan-error"
                     data = metadata(path, kind, subtotal, walked=walked)
                     # Truncated children contribute unknown, not zero: adding
                     # null as 0 was what made a truncated subtree look empty.
@@ -1387,6 +1533,7 @@ def scan_tree(
                     data = metadata(path, kind)
             except OSError as exc:
                 errors.append({"path": relative, "error": str(exc)})
+                unwalked_reasons[relative] = "scan-error"
                 continue
             if len(entries) >= MAX_SNAPSHOT_ENTRIES:
                 raise HygieneError(
@@ -1425,6 +1572,18 @@ def scan_tree(
         for item in errors
         if isinstance(item, dict) and isinstance(item.get("path"), str)
     }
+    # Everything the walk could not fully account for, from all three places it
+    # can be recorded: an explicit truncation, a scan error (which never adds a
+    # truncation and can leave no entry at all), and a `not-walked` record.
+    unknown_paths = (
+        set(truncated)
+        | error_paths
+        | {
+            entry["path"]
+            for entry in entries
+            if "not-walked" in (entry.get("size_qualifiers") or [])
+        }
+    )
     payload: dict[str, Any] = {
         "schema_version": SCHEMA_VERSION,
         "engine": "disk-hygiene-python-1",
@@ -1444,6 +1603,11 @@ def scan_tree(
         "errors": errors,
         "max_depth": max_depth,
         "truncated_paths": sorted(truncated),
+        "children_rollup": children_rollup(
+            entries,
+            unknown_paths=unknown_paths,
+            unwalked_reasons=unwalked_reasons,
+        ),
         "entries": sorted(entries, key=lambda entry: entry["path"]),
     }
     if root_children is not None:
@@ -3354,11 +3518,13 @@ def main(argv: list[str] | None = None) -> int:
                         "snapshot": str(output_path),
                         "entries": len(snapshot["entries"]),
                         "hinted_entries": hinted,
+                        "unhinted_entries": len(snapshot["entries"]) - hinted,
                         "target_logical_bytes": snapshot["target_logical_bytes"],
                         "target_reclaimable_local_bytes": snapshot[
                             "target_reclaimable_local_bytes"
                         ],
                         "truncated_paths": snapshot["truncated_paths"],
+                        "children_rollup": snapshot["children_rollup"],
                         "errors": snapshot["errors"],
                         "policy_sources": policy["policy_sources"],
                         "os_autoclean": advisory,
@@ -3366,8 +3532,12 @@ def main(argv: list[str] | None = None) -> int:
                             "Root-children mode inventoried only the selected "
                             "immediate directories; the volume root itself and "
                             "every skipped OS-owned/hidden/system/reparse entry "
-                            "were never walked. Hints are discovery signals, "
-                            "never cleanup verdicts."
+                            "were never walked — so children_rollup covers the "
+                            "selected children only. unhinted_entries is "
+                            "entries minus hinted_entries: every inventoried "
+                            "entry no hint judged, left to positional review. "
+                            "Hints are discovery signals, never cleanup "
+                            "verdicts."
                         ),
                     }
                 )
@@ -3416,12 +3586,14 @@ def main(argv: list[str] | None = None) -> int:
                     "snapshot": str(output_path),
                     "entries": len(snapshot["entries"]),
                     "hinted_entries": hinted,
+                    "unhinted_entries": len(snapshot["entries"]) - hinted,
                     "empty_directory_count": snapshot["empty_directory_count"],
                     "target_logical_bytes": snapshot["target_logical_bytes"],
                     "target_reclaimable_local_bytes": snapshot[
                         "target_reclaimable_local_bytes"
                     ],
                     "truncated_paths": snapshot["truncated_paths"],
+                    "children_rollup": snapshot["children_rollup"],
                     "errors": snapshot["errors"],
                     "policy_sources": policy["policy_sources"],
                     "os_autoclean": advisory,
@@ -3429,8 +3601,15 @@ def main(argv: list[str] | None = None) -> int:
                         "Safe tidiness is the primary objective; reclaimable "
                         "bytes are a secondary signal. empty_directory_count "
                         "names walked empty directories (logical_size 0, not "
-                        "truncated) so zero-byte residue stays visible. Hints "
-                        "are discovery signals, never cleanup verdicts. "
+                        "truncated) so zero-byte residue stays visible. "
+                        "unhinted_entries is entries minus hinted_entries — "
+                        "every inventoried entry no hint judged, left to "
+                        "positional review — so hint coverage reads as a rate, "
+                        "not a bare count. Hints are discovery signals, "
+                        "never cleanup verdicts. children_rollup carries one "
+                        "row per immediate child; its logical_bytes, "
+                        "entry_count and newest_mtime_ns are exact where "
+                        "walked is true and null where it is false, never 0. "
                         "target_reclaimable_local_bytes excludes every entry "
                         "whose size_qualifiers is non-empty (cloud-placeholder, "
                         "hardlinked, sparse, not-walked); target_logical_bytes "

--- a/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
@@ -25,6 +25,7 @@ from contextlib import (
     redirect_stdout,
 )
 from pathlib import Path
+from typing import cast
 from unittest import mock
 
 SCRIPT_DIR = Path(__file__).resolve().parent
@@ -2337,6 +2338,349 @@ class HygieneTests(unittest.TestCase):
             mock.patch("os.path.samefile", side_effect=FileNotFoundError),
         ):
             self.assertEqual([], hygiene.large_scan_reasons(Path("/home/target")))
+
+
+class ChildrenRollupTests(unittest.TestCase):
+    """Per-immediate-child roll-up: real numbers where walked, null where not.
+
+    The skill tells the operator to open a large target with ``--max-depth 1``.
+    These pin the view that pass has to produce, and pin the two ways it could
+    lie: presenting a partial as a total, or presenting an unknown as 0.
+    """
+
+    @staticmethod
+    def rollup_by_name(snapshot: dict[str, object]) -> dict[str, dict[str, object]]:
+        rows = cast("list[dict[str, object]]", snapshot["children_rollup"])
+        return {str(row["name"]): row for row in rows}
+
+    def build_fixture(self, root: Path) -> None:
+        """An empty child, a non-empty child, a protected child, a loose file."""
+        (root / "empty_child").mkdir(parents=True)
+        (root / "full_child" / "nested").mkdir(parents=True)
+        (root / "full_child" / "a.log").write_text("a" * 100, encoding="utf-8")
+        (root / "full_child" / "nested" / "b.log").write_text("b" * 200, encoding="utf-8")
+        (root / "Documents").mkdir()
+        (root / "Documents" / "kept.txt").write_text("k" * 50, encoding="utf-8")
+        (root / "loose.tmp").write_text("x" * 42, encoding="utf-8")
+
+    def test_bounded_scan_rolls_up_every_immediate_child(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary) / "target"
+            root.mkdir(parents=True)
+            self.build_fixture(root)
+            snapshot = hygiene.scan_tree(
+                root.resolve(), hygiene.load_policy(None), max_depth=1
+            )
+            rollup = self.rollup_by_name(snapshot)
+            # Populated under the bounded pass, and no child is omitted —
+            # including the ones whose subtrees were never opened.
+            self.assertEqual(
+                {"Documents", "empty_child", "full_child", "loose.tmp"}, set(rollup)
+            )
+            # An empty child is genuinely empty, not unknown: 0 is an answer.
+            self.assertTrue(rollup["empty_child"]["walked"])
+            self.assertEqual(0, rollup["empty_child"]["logical_bytes"])
+            self.assertEqual(0, rollup["empty_child"]["entry_count"])
+            self.assertIsNotNone(rollup["empty_child"]["newest_mtime_ns"])
+            self.assertEqual([], rollup["empty_child"]["unwalked_reasons"])
+            # A non-empty child at the cut is unknown — null and marked, never 0.
+            self.assertFalse(rollup["full_child"]["walked"])
+            self.assertIsNone(rollup["full_child"]["logical_bytes"])
+            self.assertIsNone(rollup["full_child"]["entry_count"])
+            self.assertIsNone(rollup["full_child"]["newest_mtime_ns"])
+            self.assertEqual(["depth-cut"], rollup["full_child"]["unwalked_reasons"])
+            # Protection, not depth, is why this one is unknown.
+            self.assertFalse(rollup["Documents"]["walked"])
+            self.assertIsNone(rollup["Documents"]["logical_bytes"])
+            self.assertEqual(["protected"], rollup["Documents"]["unwalked_reasons"])
+            # A loose file needs no walk to be fully known.
+            self.assertTrue(rollup["loose.tmp"]["walked"])
+            self.assertEqual("file", rollup["loose.tmp"]["kind"])
+            self.assertEqual(42, rollup["loose.tmp"]["logical_bytes"])
+            self.assertEqual(42, rollup["loose.tmp"]["reclaimable_local_bytes"])
+            self.assertEqual([], rollup["loose.tmp"]["size_qualifiers"])
+
+    def test_bounded_rollup_opens_no_directory_the_bounded_walk_did_not(self) -> None:
+        """The roll-up must not smuggle an unbounded walk into a bounded pass.
+
+        Measured, not assumed: every directory open goes through os.scandir, so
+        counting them counts the walk. The bounded pass may only open the target
+        plus the one first-child probe per depth-cut directory that the
+        empty-frontier fix already paid for.
+        """
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary) / "target"
+            root.mkdir(parents=True)
+            self.build_fixture(root)
+            real_scandir = os.scandir
+            opened: list[str] = []
+
+            def counting_scandir(path="."):
+                opened.append(str(path))
+                return real_scandir(path)
+
+            with mock.patch("os.scandir", counting_scandir):
+                snapshot = hygiene.scan_tree(
+                    root.resolve(), hygiene.load_policy(None), max_depth=1
+                )
+            names = sorted(Path(item).name for item in opened)
+            # target itself + the probe of each non-protected directory child.
+            # `full_child/nested` is never opened, so no descendant was walked.
+            self.assertEqual(["empty_child", "full_child", "target"], names)
+            self.assertNotIn(
+                "full_child/nested", {entry["path"] for entry in snapshot["entries"]}
+            )
+
+    def test_unbounded_scan_gives_children_exact_recursive_totals(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary) / "target"
+            root.mkdir(parents=True)
+            self.build_fixture(root)
+            snapshot = hygiene.scan_tree(root.resolve(), hygiene.load_policy(None))
+            rollup = self.rollup_by_name(snapshot)
+            self.assertTrue(rollup["full_child"]["walked"])
+            self.assertEqual(300, rollup["full_child"]["logical_bytes"])
+            # a.log, nested, nested/b.log — the child itself is not a descendant.
+            self.assertEqual(3, rollup["full_child"]["entry_count"])
+            self.assertEqual([], rollup["full_child"]["unwalked_reasons"])
+            # Protection outlives the depth bound; that child stays unknown.
+            self.assertFalse(rollup["Documents"]["walked"])
+            self.assertIsNone(rollup["Documents"]["logical_bytes"])
+
+    def test_walked_child_totals_sum_to_the_target_total(self) -> None:
+        """No walked child's bytes may double-count or drop the target's rule."""
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary) / "target"
+            (root / "one" / "deep").mkdir(parents=True)
+            (root / "one" / "deep" / "a.bin").write_text("a" * 7, encoding="utf-8")
+            (root / "two").mkdir()
+            (root / "two" / "b.bin").write_text("b" * 11, encoding="utf-8")
+            (root / "c.bin").write_text("c" * 13, encoding="utf-8")
+            snapshot = hygiene.scan_tree(root.resolve(), hygiene.load_policy(None))
+            self.assertEqual([], snapshot["truncated_paths"])
+            self.assertTrue(all(row["walked"] for row in snapshot["children_rollup"]))
+            self.assertEqual(
+                snapshot["target_logical_bytes"],
+                sum(row["logical_bytes"] for row in snapshot["children_rollup"]),
+            )
+
+    def test_partial_child_subtree_reports_unknown_not_a_partial_sum(self) -> None:
+        """A walked child holding an unwalked descendant is NOT a total.
+
+        And the flat entry does not say so on its own: a directory gets the
+        `not-walked` qualifier only from its OWN branch, never propagated up
+        from a descendant, so `repo_child` keeps an EMPTY `size_qualifiers`
+        beside a `logical_size` that is a partial sum. Pinned here because it
+        is the sharpest reason to read the roll-up rather than the entry list —
+        if a future change starts propagating the qualifier, this assertion is
+        where the reference doc's explanation must be revisited.
+        """
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary) / "target"
+            (root / "repo_child" / ".git").mkdir(parents=True)
+            (root / "repo_child" / ".git" / "obj").write_text("g" * 90, encoding="utf-8")
+            (root / "repo_child" / "src.py").write_text("p" * 10, encoding="utf-8")
+            snapshot = hygiene.scan_tree(root.resolve(), hygiene.load_policy(None))
+            entries = hygiene.entry_map(snapshot)
+            rollup = self.rollup_by_name(snapshot)
+            self.assertEqual(10, entries["repo_child"]["logical_size"])
+            self.assertEqual([], entries["repo_child"]["size_qualifiers"])
+            self.assertEqual(["repo_child/.git"], snapshot["truncated_paths"])
+            self.assertFalse(rollup["repo_child"]["walked"])
+            self.assertIsNone(rollup["repo_child"]["logical_bytes"])
+            self.assertEqual(
+                ["descendant-not-walked"], rollup["repo_child"]["unwalked_reasons"]
+            )
+
+    def test_vcs_child_names_its_own_boundary_as_the_reason(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary) / "target"
+            root.mkdir(parents=True)
+            (root / ".git").mkdir()
+            with mock.patch.object(
+                hygiene, "hard_protection", side_effect=lambda *a, **k: []
+            ):
+                snapshot = hygiene.scan_tree(root.resolve(), hygiene.load_policy(None))
+            rollup = self.rollup_by_name(snapshot)
+            self.assertFalse(rollup[".git"]["walked"])
+            self.assertEqual(["vcs-boundary"], rollup[".git"]["unwalked_reasons"])
+
+    def test_unreadable_child_is_marked_not_omitted(self) -> None:
+        """A child whose scandir fails keeps a row, with scan-error named."""
+        rows = hygiene.children_rollup(
+            [
+                {
+                    "path": "locked",
+                    "kind": "directory",
+                    "logical_size": None,
+                    "mtime_ns": 5,
+                    "size_qualifiers": ["not-walked"],
+                }
+            ],
+            unknown_paths={"locked"},
+            unwalked_reasons={"locked": "scan-error"},
+        )
+        self.assertEqual(1, len(rows))
+        self.assertFalse(rows[0]["walked"])
+        self.assertIsNone(rows[0]["logical_bytes"])
+        self.assertEqual(["scan-error"], rows[0]["unwalked_reasons"])
+
+    def test_child_with_no_inventory_record_is_still_a_row(self) -> None:
+        """An error that left no entry at all still owes the operator a row."""
+        rows = hygiene.children_rollup(
+            [],
+            unknown_paths={"vanished"},
+            unwalked_reasons={"vanished": "scan-error"},
+        )
+        self.assertEqual(
+            [
+                {
+                    "name": "vanished",
+                    "kind": None,
+                    "walked": False,
+                    "logical_bytes": None,
+                    "reclaimable_local_bytes": None,
+                    "size_qualifiers": None,
+                    "entry_count": None,
+                    "newest_mtime_ns": None,
+                    "unwalked_reasons": ["scan-error"],
+                }
+            ],
+            rows,
+        )
+
+    def test_an_unwalked_row_nulls_every_aggregate_including_the_byte_pair(self) -> None:
+        """`walked: false` must not leave one aggregate looking answered."""
+        rows = hygiene.children_rollup(
+            [
+                {"path": "deep", "kind": "directory", "logical_size": 5, "mtime_ns": 1},
+                {"path": "deep/f.bin", "kind": "file", "logical_size": 5, "mtime_ns": 3},
+            ],
+            unknown_paths={"deep/inner"},
+        )
+        self.assertEqual(1, len(rows))
+        for field in (
+            "logical_bytes",
+            "reclaimable_local_bytes",
+            "size_qualifiers",
+            "entry_count",
+            "newest_mtime_ns",
+        ):
+            self.assertIsNone(rows[0][field], field)
+        self.assertEqual(["descendant-not-walked"], rows[0]["unwalked_reasons"])
+
+    def test_qualified_bytes_never_pass_as_reclaimable(self) -> None:
+        """A logical total is not space a delete returns, and the row says so.
+
+        `logical_bytes` counts a cloud placeholder's REMOTE size, both names of
+        a hard link, and a sparse file's unallocated extent. Leading the report
+        with that number alone is exactly the overclaim the rest of this engine
+        refuses, so the row carries the qualifiers it saw and a reclaimable
+        figure computed the same way `target_reclaimable_local_bytes` is.
+        """
+        rows = hygiene.children_rollup(
+            [
+                {"path": "mixed", "kind": "directory", "logical_size": 3000, "mtime_ns": 1},
+                {
+                    "path": "mixed/remote.bin",
+                    "kind": "file",
+                    "logical_size": 2000,
+                    "mtime_ns": 2,
+                    "size_qualifiers": ["cloud-placeholder"],
+                },
+                {
+                    "path": "mixed/real.bin",
+                    "kind": "file",
+                    "logical_size": 1000,
+                    "mtime_ns": 3,
+                    "size_qualifiers": [],
+                },
+            ]
+        )
+        row = rows[0]
+        self.assertTrue(row["walked"])
+        self.assertEqual(3000, row["logical_bytes"])
+        self.assertEqual(1000, row["reclaimable_local_bytes"])
+        self.assertEqual(["cloud-placeholder"], row["size_qualifiers"])
+
+    def test_target_scandir_failure_claims_no_child_coverage(self) -> None:
+        rows = hygiene.children_rollup([], unknown_paths={"."})
+        self.assertEqual([], rows)
+
+    def test_the_target_itself_is_never_one_of_its_own_children(self) -> None:
+        """`.` is the target, so no roll-up row may be named for it."""
+        rows = hygiene.children_rollup(
+            [
+                {"path": ".", "kind": "directory", "logical_size": 9, "mtime_ns": 1},
+                {"path": "real", "kind": "file", "logical_size": 4, "mtime_ns": 2},
+            ]
+        )
+        self.assertEqual(["real"], [row["name"] for row in rows])
+
+    def test_root_children_mode_rolls_up_only_the_selected_children(self) -> None:
+        """Selection, not depth, bounds this walk — the roll-up must follow it.
+
+        An unselected sibling is never opened and never inventoried, so it owes
+        no row: root-children mode's "target" is the selection, and claiming a
+        row for a child the mode deliberately never looked at would report a
+        coverage gap the operator did not ask this run to cover.
+        """
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary) / "target"
+            (root / "picked" / "deep").mkdir(parents=True)
+            (root / "picked" / "deep" / "a.bin").write_text("a" * 7, encoding="utf-8")
+            (root / "picked" / "b.bin").write_text("b" * 11, encoding="utf-8")
+            (root / "skipped").mkdir()
+            (root / "skipped" / "c.bin").write_text("c" * 13, encoding="utf-8")
+            snapshot = hygiene.scan_tree(
+                root.resolve(), hygiene.load_policy(None), root_children=["picked"]
+            )
+            rollup = self.rollup_by_name(snapshot)
+            self.assertEqual({"picked"}, set(rollup))
+            self.assertTrue(rollup["picked"]["walked"])
+            self.assertEqual(18, rollup["picked"]["logical_bytes"])
+            # deep, deep/a.bin, b.bin — descendants only, correctly attributed.
+            self.assertEqual(3, rollup["picked"]["entry_count"])
+
+    def test_scan_command_emits_the_third_coverage_term(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary) / "target"
+            root.mkdir(parents=True)
+            self.build_fixture(root)
+            (root / "npm-cache").mkdir()
+            (root / "npm-cache" / "x.tmp").write_text("t", encoding="utf-8")
+            data_root = Path(temporary) / "data"
+            data_root.mkdir()
+            output = data_root / "runs" / "snapshot.json"
+            stdout_io = io.StringIO()
+            with redirect_stdout(stdout_io):
+                code = hygiene.main(
+                    [
+                        "scan",
+                        "--target",
+                        str(root),
+                        "--output",
+                        str(output),
+                        "--data-root",
+                        str(data_root),
+                        "--max-depth",
+                        "1",
+                    ]
+                )
+            self.assertEqual(0, code)
+            result = json.loads(stdout_io.getvalue())
+            self.assertEqual("scan-complete", result["status"])
+            # entries = hinted + unhinted, exactly: every inventoried entry was
+            # either judged by a hint or left to positional review.
+            self.assertEqual(
+                result["entries"],
+                result["hinted_entries"] + result["unhinted_entries"],
+            )
+            self.assertGreater(result["unhinted_entries"], 0)
+            self.assertEqual(
+                {row["name"] for row in result["children_rollup"]},
+                {"Documents", "empty_child", "full_child", "loose.tmp", "npm-cache"},
+            )
 
 
 class VersionFloorTests(unittest.TestCase):


### PR DESCRIPTION
Closes #2851

## What this adds

The clean skill tells operators to open a large target with `--max-depth 1` and reason over its
immediate children (`SKILL.md:148-150`), but the engine emitted only a flat per-entry list plus
target-level totals. The view the workflow prescribes existed in no engine output, which is why the
triage behind issue 2851 ran off a hand-built PowerShell table instead of the tool.

Every scan payload now carries `children_rollup` — one row per immediate child of the target:

| Field | Meaning |
|---|---|
| `name` | The immediate child's own name (never a path) |
| `kind` | `directory`, `file`, `link`, `special`, or `null` when no inventory record survived |
| `walked` | `true` only when the child's whole subtree was inventoried |
| `logical_bytes` | Recursive LOGICAL total, qualifiers included; `null` unless `walked` |
| `reclaimable_local_bytes` | Recursive total over unqualified files only — what deleting the child is expected to return; `null` unless `walked` |
| `size_qualifiers` | Union of qualifiers observed in the subtree (`cloud-placeholder`, `hardlinked`, `sparse`, …); `null` unless `walked` |
| `entry_count` | Inventoried descendants, excluding the child's own record; `null` unless `walked` |
| `newest_mtime_ns` | Newest `mtime_ns` across the child and its inventoried descendants; `null` unless `walked` |
| `unwalked_reasons` | Sorted causes when `walked` is false: `depth-cut`, `protected`, `vcs-boundary`, `scan-error`, `descendant-not-walked` |

Every immediate child the run covered gets a row whatever its coverage — omission would read as
absence. (In `--root-children` mode that means every SELECTED child; an unselected sibling is never
opened, and `root_children_selected` records the scope.) `scan-complete` echoes the block and gains
`unhinted_entries`, the third coverage term.

**Two byte channels, not one.** `logical_bytes` is a logical total, so a cloud placeholder's remote
size, a hard link's shared object, and a sparse file's unallocated extent all inflate it above what
deleting the child would return — and this is the block `SKILL.md` tells the operator to lead the
report with. So each row also carries `size_qualifiers` and `reclaimable_local_bytes`, computed the
same way `target_reclaimable_local_bytes` is. This came out of adversarial verification: the
single-channel version reported `logical_bytes: 10000000` for a sparse child in a payload whose
`target_reclaimable_local_bytes` was `0`.

## Disclosed deviation: a bounded pass cannot report an unbounded total

The acceptance criteria ask for a recursive byte total, entry count, and newest mtime per immediate
child, **populated under `--max-depth 1`**. Those two constraints cannot both hold under this
engine's inventory-based walk. A recursive total for a non-empty child is only knowable by walking
that child, and walking it is exactly what the depth bound exists to prevent. A number that quietly
counted only part of a subtree would be worse than no number.

To be precise about what was and was not ruled out: a separate stat-only aggregate pass (`du`-style,
recursing for sizes without inventorying entries) *could* produce per-child totals under a bounded
inventory — it trades unbounded I/O for bounded inventory rather than avoiding the walk. That is a
different engine with a different cost and failure profile, out of scope here; this change takes the
strict reading, where "without an unbounded walk" means no unbounded I/O either.

So the roll-up is assembled from what the walk **already recorded** — it opens no directory and stats
no path — and reports the honest subset. That is measured, not asserted. Both engines were loaded in
one process against an identical 740-path fixture, counting `os.scandir` (the engine's only
directory-enumeration route) and `os.lstat`:

| engine | mode | scandir | lstat | entries | truncated | rollup rows |
|---|---|---|---|---|---|---|
| `origin/main` | `--max-depth 1` | 8 | 41 | 8 | 6 | — |
| `origin/main` | unbounded | 20 | 4427 | 740 | 0 | — |
| this branch | `--max-depth 1` | 8 | 41 | 8 | 6 | 8 |
| this branch | unbounded | 20 | 4427 | 740 | 0 | 8 |

Identical cost. The roll-up cannot smuggle an unbounded walk into a bounded pass — and the price of
that guarantee is that under `--max-depth 1` every **non-empty** child reads `walked: false`,
`depth-cut`, and `null` for all three aggregates. What the bounded pass does deliver is the complete
frontier, per-child coverage, and exact numbers for loose files and empty children. A per-child total
is bought by fanning a deeper scan out over that subtree.

Two invariants close the ways this could lie, and both are pinned by tests:

- **A partial is never presented as a total.** A child that was itself entered but holds an unwalked
  descendant is `descendant-not-walked` / `null`, even though its own flat entry still carries the
  partial walked sum that `size_qualifiers: ["not-walked"]` marks as a floor.
- **`null` never degrades to `0`.** `0` stays the genuine "this child is empty" answer that keeps
  zero-byte residue first-class.

`test_bounded_rollup_opens_no_directory_the_bounded_walk_did_not` re-runs the scandir measurement
inside the suite, so the bound is a regression test rather than a one-off observation.

A second, smaller deviation: `unhinted_entries` counts every **inventoried** entry no hint judged,
not only fully walked ones. Counted that way the three terms partition the inventory exactly, so
`entries` always equals `hinted_entries` plus `unhinted_entries` and neither number needs a caveat.

Both deviations are disclosed on issue 2851, in the commit message, in the plugin CHANGELOG, and
here.

## Note for review: the `SKILL.md` reflow

`SKILL.md` was at 495 lines against the skill checker's hard cap of 500, so the new section-3
paragraph had to buy its own space. Four existing paragraphs are reflowed to a wider column and are
**word-for-word unchanged** — the reflow ran through a script that asserts word-sequence equality,
and `git diff --word-diff` shows no wording change in them. The existing report-field order in
section 3 is untouched (that reordering is issue 2618 finding F1's change and is deliberately not
duplicated here). The full field list, the causes, and the measurement live in
`reference/safety-model.md`.

## Verification

- Rebased onto `9d2a0cc8` (PR 2869, already released as `0.20.13`); this ships as `0.20.14` with
  2869's `[0.20.13]` CHANGELOG section preserved byte-unchanged below it, and
  `--check-preserved` confirming all 68 headings survive.
- Disk-hygiene Python suite: 317 tests, 2 failures — both known Windows-host environment failures
  (`test_preview_allows_root_children_os_managed_snapshot`,
  `test_stash_must_exist_in_an_independent_checkout`), green on Linux CI.
- `scripts/check-changelog-parity.sh` `--check`, `--check-bump`, `--check-preserved`: pass.
- `scripts/check-changed-skills.sh`: `SKILL.md 499/500 lines`, all trigger phrases preserved.
- `check-shell-portability`, `check-skill-precompute-compose`, `check-contract-clause-coverage`,
  `check-rename-sweep`, `check-silent-skips`, `check-skill-leaf-names`, `check-orphaned-fixtures`,
  `check-cross-plugin-source-drift`, `check-discriminating-test-skips`, `validate-plugins`: pass.
- pyright over the engine directory: 140 errors before and after — this change adds none. (The
  repository gates no type checker; that count is untouched pre-existing baseline, not a clean bill.)
- Fresh-context verifier subagents independently re-ran the depth-bound measurement and audited the
  artifact against the acceptance criteria before this was pushed.
- `hooks/run-python-hook.sh` and `hooks/run-python-hook.test.sh` are deliberately untouched, to stay
  clear of the in-flight PR 2869 against the same plugin.

## Related

- Refs #2618 — finding F1 is report **ordering** and is deliberately NOT touched here; finding F2 is
  the empty-frontier-child fix this builds on, which is why an empty child at the cut reports an
  exact `0` rather than `null`.
- Refs #2590 — closed by PR 2803's tidiness re-land. `empty_directory_count` and the plan
  `provenance`/`risk` fields it delivered are on `main` and are not re-asked for here.
- PR 2869 (`fix/2853-hook-budget-measured-share`) — open against the same plugin and expected to land
  first. It owns `hooks/run-python-hook.sh` and `hooks/run-python-hook.test.sh`; this PR touches
  neither. Its CHANGELOG section stays below this one, byte-unchanged, whichever order they land in.
- Refs #2691, Refs #2828 — the stale-base squash and partial re-land failures. Merged content here
  will be verified by reading `origin/main` after a fresh fetch, not by trusting PR state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RPRAvSLuRmR6rPQeCvdok6
