### PR TITLE
docs(claude): bridge AGENTS.md into Claude sessions with a one-line import

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
## Summary

A one-line `CLAUDE.md` import bridges the synced `AGENTS.md` orientation into
Claude Code sessions, per the official docs: Claude Code reads `CLAUDE.md`, not
`AGENTS.md` (code.claude.com/docs/en/memory.md, fetched 2026-08-16), and
recommends creating a `CLAUDE.md` that imports it. Symlinks need admin rights on
Windows, so the `@AGENTS.md` import line is the portable bridge.

## Fix

`CLAUDE.md` becomes exactly `@AGENTS.md` (single line, trailing newline).

This is an unhobble re-add with evidence, not a restoration of prose: the root
`CLAUDE.md` is deliberately 0 bytes from the bare-baseline resets
(melodic-software/standards#348), whose rule is that an instruction returns only
with ledger evidence. The evidence cited here is the managed-file
silent-overwrite failure mode that `AGENTS.md` exists to prevent, plus the
verified doc fact that `AGENTS.md` alone never loads into a Claude session. One
import line, no restored prose.

## Verification

- `CLAUDE.md` is one line (`@AGENTS.md`) plus a trailing newline, 11 bytes.
- `AGENTS.md` confirmed non-empty at the default-branch HEAD before the change
  (952 bytes, via `gh api` with the raw media type).
- `CLAUDE.md` is not a sync target in `melodic-software/standards`
  `distribution/sync-manifest.yml` (only `AGENTS.md` is), so this edit is
  repo-owned and will not be overwritten by the next standards sync.
- No other files changed.

## Related

- melodic-software/standards#399 (orientation content)
- melodic-software/standards#397 (cloud-bootstrap component)

No linked issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012tKxg98B3QySqEPf8UqwX3
