### PR TITLE
fix(scripts): re-pin the silent-revert clean row to the true closest sub-threshold miss

### DIFF
--- a/scripts/silent-revert-incidents.txt
+++ b/scripts/silent-revert-incidents.txt
@@ -172,12 +172,13 @@ marker cc58cbc53fbbb2cca68e071507b82d3e3ff896ff plugins/repo-fleet-hygiene/skill
 # started taxing normal development.
 clean 9a2307c431ad22b2e8f758976109bf4e59010d6b feat(songwriting) rewrote 195 lines of research text #2183 had just restored
 
-# The previously pinned closest miss, kept as a second guard one step further
-# from the edge: no fewer than 136 lines (the same #2880 floor), 109 of them
-# the persist-findings context doc that #2715 (merge commit 6370a44e7) had
-# just added, rewritten 26 minutes later by #2737's crosswalk hardening. An
-# earlier version of this row credited the content to #2679, which is a closed
-# issue in this repo, not a pull request; the commit's own body names the work
-# it builds on ("Builds on merged #2715 → #2692 → #2690; rebased onto `main`")
-# and the blamed lines trace to #2715's merge commit.
+# The previously pinned closest miss, kept as a second verified-quiet guard --
+# four other corpus commits score between it and the row above: no fewer than
+# 136 lines (the same #2880 floor), 109 of them the persist-findings context
+# doc that #2715 (squash commit 6370a44e7) had just added, rewritten 26
+# minutes later by #2737's crosswalk hardening. An earlier version of this row
+# credited the content to #2679, which is a closed issue in this repo, not a
+# pull request; the commit's own body names the work it builds on ("Builds on
+# merged #2715 → #2692 → #2690; rebased onto `main`") and the blamed lines
+# trace to the commit that landed #2715.
 clean c8470efd09d78d924a962483ff8a0b7809180e11 docs(conventions) rewrote 136 lines of a doc #2715 had just added

--- a/scripts/silent-revert-incidents.txt
+++ b/scripts/silent-revert-incidents.txt
@@ -9,9 +9,9 @@
 #
 # The `clean` rows matter as much as the `fires` rows. A detector tuned until
 # it catches the incidents but which also fires on ordinary work would be
-# switched off within a week, so a verified-legitimate commit is pinned here
-# too -- deliberately the closest sub-threshold miss found in 500 commits of
-# real history, since that is the row that breaks first if someone lowers the
+# switched off within a week, so verified-legitimate commits are pinned here
+# too -- led by the closest sub-threshold miss found in 500 commits of real
+# history, since that is the row that breaks first if someone lowers the
 # threshold to chase recall.
 #
 # Format: <expectation> <full-sha> [<attribution>] <note>. `fires` = the canary
@@ -155,9 +155,29 @@ marker cc58cbc53fbbb2cca68e071507b82d3e3ff896ff plugins/repo-fleet-hygiene/skill
 marker cc58cbc53fbbb2cca68e071507b82d3e3ff896ff plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.sh MERGED_PR_GRAPHQL_ALIAS_PAGE
 
 # --- Verified-legitimate commits that must stay quiet -------------------------
-# The closest sub-threshold miss in 500 commits: 129 lines of a doc section that
-# #2679 had just added, rewritten by a follow-up that says so ("Builds on merged
-# #2715 -> #2692 -> #2690; rebased onto main"). Ordinary iteration on very
+# Neither figure in this section is asserted by the replay. A `clean` row's
+# assertion is the ABSENCE of findings, so it carries no bracketed attribution
+# field for a count to live in (#2879) -- the numbers below are hand-measured
+# prose, and the first row's previous occupant drifting from a recorded 129 to
+# a measured 136 without anything going red is exactly that gap. Re-measure
+# before trusting either number.
+#
+# The closest sub-threshold miss in 500 commits, re-measured at the pinned git
+# invocations (#2843): no fewer than 195 lines -- a floor rather than an exact
+# count, because attribute_file drops git blame's stderr (#2880), so any line
+# blame fails on is silently not counted -- of Pat Pattison research text that
+# #2183 had just restored, rewritten by #2189's follow-up chapter-audit pass
+# five lines short of the 200-line threshold. Ordinary iteration on very
 # recent work. If a threshold change ever makes this fire, the canary has
 # started taxing normal development.
-clean c8470efd09d78d924a962483ff8a0b7809180e11 docs(conventions) rewrote 129 lines of a doc #2679 had just added
+clean 9a2307c431ad22b2e8f758976109bf4e59010d6b feat(songwriting) rewrote 195 lines of research text #2183 had just restored
+
+# The previously pinned closest miss, kept as a second guard one step further
+# from the edge: no fewer than 136 lines (the same #2880 floor), 109 of them
+# the persist-findings context doc that #2715 (merge commit 6370a44e7) had
+# just added, rewritten 26 minutes later by #2737's crosswalk hardening. An
+# earlier version of this row credited the content to #2679, which is a closed
+# issue in this repo, not a pull request; the commit's own body names the work
+# it builds on ("Builds on merged #2715 → #2692 → #2690; rebased onto `main`")
+# and the blamed lines trace to #2715's merge commit.
+clean c8470efd09d78d924a962483ff8a0b7809180e11 docs(conventions) rewrote 136 lines of a doc #2715 had just added


### PR DESCRIPTION
Closes #2865.

## What this fixes

`scripts/silent-revert-incidents.txt` pins a `clean` row that is supposed to be the closest a non-incident got to the 200-line threshold without crossing it — the row that breaks first if a threshold change starts taxing ordinary development. The pinned commit was not that, and its note named a number that is not a pull request.

**Defect 1 (the re-pin).** Measured over the file's own 500-commit corpus (`7b47d2253~500..7b47d2253`) at the pinned invocations (#2843, `GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_NOSYSTEM=1`), the pinned `c8470efd0` scores **136** blamed lines — sixth-closest of the eight commits in the 100–199 band. The true closest miss is **`9a2307c43` (#2189) at 195 lines** from `3584ae1fa` (#2183) — a margin of 5 lines, not the ~71 the old row implied. `9a2307c43` is now the lead `clean` row.

**Defect 2 (the wrong PR number).** The old note credited the deleted content to #2679, which is a closed issue in this repository, not a pull request (`gh pr view 2679` cannot resolve it). The blamed lines trace to `6370a44e7`, the squash commit that landed #2715 — `gh api .../commits/6370a44e7/pulls` returns only #2715, and the commit's own body says `Builds on merged #2715 → #2692 → #2690`. The row is kept as a second guard with its note corrected, rather than dropped: it is still a verified-legitimate quiet commit, and keeping it costs a few lines of prose.

**Defect 3 (the "once a month" rate)** was already fixed by #2847, which removed the rate claim from `scripts/check-silent-revert.sh` entirely. Nothing in this PR touches it.

## What this does NOT do

Neither clean-row figure is CI-asserted, before or after this change. `clean` rows carry no bracketed attribution field (#2879) — their assertion is the absence of findings, which has no per-culprit count to pin — so the 195 and 136 are hand-measured prose, not watched numbers. The old row's recorded 129 drifting to a measured 136 under the pinned invocations without anything going red is exactly that gap, and the section comment now states it so a reader does not mistake the re-pin for an assertion. Both counts are written as floors ("no fewer than") because `attribute_file` drops `git blame`'s stderr (#2880), so any line blame fails on is silently not counted.

## Verification

- Spot-checked both figures against PR #2843's pinned invocations before editing: `9a2307c43` reproduces **195** (75 lines `song-forms-examples.md`, 67 `box-model.md`, culprit `3584ae1fa`), `c8470efd0` reproduces **136** (109 lines `persist-findings.md`, culprit `6370a44e7`).
- `bash scripts/check-silent-revert.test.sh`: **101 passed, 0 failed** on this branch.
- `scripts/check-silent-revert.sh --verify-known-incidents`: exit 0 — all three `fires` rows reproduce their attributions exactly, and both `clean` rows stay quiet.
- `scripts/check-silent-revert.sh --verify-restoration`: exit 0 — all 5 markers present.
- A fresh-context verifier independently swept all 500 corpus commits twice (complete coverage: 487 `ok` + 2 `acknowledged` + 11 finding commits = 500) and reproduced every figure in the file. Its verdict: **195 at `9a2307c43` is the highest sub-threshold score** — the next highest is 188 (`3d69448cb`) — so the lead `clean` row pins the true closest miss. The two acknowledged commits were re-run with the ack file disabled and score 447 and 323, both above the threshold, so neither could displace it.

## Related

- #2843, #2847, #2873 — the three PRs that reshaped the canary and this file ahead of this change; the figures here are measured under #2843's pinned invocations.
- #2879 — records that `clean` rows carry no bracketed attribution field, which is why neither figure in this PR is CI-asserted.
- #2880 — records that `attribute_file` drops `git blame`'s stderr, which is why both counts are written as floors.
- #2831 / #2832 — the same wrong-PR-number defect shape, corrected earlier on the `fires` rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LwdkpWf6bptu3AqTMoeg2H
