### PR TITLE
build(dependabot): cover the pr-convention-policy dependency root

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,10 @@
 # Dependabot keeps this repo's dependencies current with REVIEWED pull requests — GitHub-native,
 # no third-party app and no PAT. It covers full-SHA GitHub Actions, the root locked Node CI
-# toolchain, the standards-managed runner-policy dependency root, the hash-locked Python CI
-# toolchain, and the miro plugin's bundled Node MCP server. The plugin hooks still use each
-# consuming repository's tools; these manifests exist only to make this repository's validation
-# reproducible. No auto-merge is configured, so every bump is a PR that runs ci before a human merges.
+# toolchain, the standards-managed runner-policy and pr-convention-policy dependency roots, the
+# hash-locked Python CI toolchain, and the miro plugin's bundled Node MCP server. The plugin hooks
+# still use each consuming repository's tools; these manifests exist only to make this repository's
+# validation reproducible. No auto-merge is configured, so every bump is a PR that runs ci before a
+# human merges.
 version: 2
 updates:
   - package-ecosystem: github-actions
@@ -69,6 +70,25 @@ updates:
   # updates are reviewed and cannot drift behind the materialized component.
   - package-ecosystem: npm
     directory: /.github/standards/runner-policy
+    labels:
+      - dependencies
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
+    groups:
+      npm-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+  # The standards-distributed PR convention policy ships its own package manifest
+  # and lockfile too. It is an independent dependency root for the same reason:
+  # the title/body parser must stay patched without waiting on the synced component.
+  - package-ecosystem: npm
+    directory: /.github/standards/pr-convention-policy
     labels:
       - dependencies
     schedule:


### PR DESCRIPTION
## Summary

Adds the missing npm Dependabot entry for the synced standards root `/.github/standards/pr-convention-policy` (standards-sync audit, Phase 0.5 — fleet-wide Dependabot coverage for synced npm roots).

## Fix

One entry appended to `.github/dependabot.yml`, copied from the existing runner-policy entry (directory swapped); header prose updated to enumerate the new root.

## Verification

`yq` parse clean; `check-jsonschema --builtin-schema vendor.dependabot` ok (same schema CI validates with); new directory string appears exactly once; existing five entries untouched.

## Related

No linked issue — tracked upstream in melodic-software/standards#406 (Phase 0 of the standards-sync audit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013NhxMDn7vZdbs7Cq32m56M
