### PR TITLE
refactor(scripts): route hand-rolled git init through test-git-helpers

### DIFF
--- a/scripts/check-shell-portability.test.sh
+++ b/scripts/check-shell-portability.test.sh
@@ -24,6 +24,7 @@ SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SELF_DIR/.." && pwd)"
 SCRIPT="$SELF_DIR/check-shell-portability.sh"
 REAL_TOKENS="$REPO_ROOT/scripts/shell-portability-tokens.txt"
+. "$SELF_DIR/test-git-helpers.sh"
 
 PASS=0
 FAIL=0
@@ -1543,9 +1544,7 @@ mkdir -p "$fx/scripts" "$fx/plugins/alpha/skills/demo/context"
 cp "$SCRIPT" "$fx/scripts/"
 out="$(
   cd "$fx" &&
-    git -C "$fx" init -q &&
-    git -C "$fx" config user.email test@example.com &&
-    git -C "$fx" config user.name test &&
+    git_init_test_repo "$fx" &&
     git -C "$fx" commit -q --allow-empty -m base &&
     base="$(git -C "$fx" rev-parse HEAD)" &&
     printf '%s\n' 'stat -c %Y "$f"' >'plugins/alpha/skills/demo/context/mtime.md' &&
@@ -1639,9 +1638,7 @@ cp "$SCRIPT" "$fx/scripts/"
 quoted_name="$(printf 'quoted-\303\251.sh')" # trailing U+00E9 byte -- non-ASCII, triggers Git quoting
 out="$(
   cd "$fx" &&
-    git -C "$fx" init -q &&
-    git -C "$fx" config user.email test@example.com &&
-    git -C "$fx" config user.name test &&
+    git_init_test_repo "$fx" &&
     git -C "$fx" commit -q --allow-empty -m base &&
     base="$(git -C "$fx" rev-parse HEAD)" &&
     printf '%s\n' 'grep -Eq "\\bfoo\\b" "$file"' >'plain.sh' &&

--- a/scripts/check-skill-portability.test.sh
+++ b/scripts/check-skill-portability.test.sh
@@ -16,6 +16,7 @@ SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SELF_DIR/.." && pwd)"
 SCRIPT="$SELF_DIR/check-skill-portability.sh"
 REAL_TOKENS="$REPO_ROOT/scripts/skill-portability-tokens.txt"
+. "$SELF_DIR/test-git-helpers.sh"
 
 # Minimal token list: just the active branch class, so a synthetic case is not
 # coupled to the shipping list's staged entries.
@@ -669,9 +670,7 @@ cp "$SCRIPT" "$fx/scripts/"
 quoted_name="$(printf 'quoted-\303\251.md')" # trailing U+00E9 byte — non-ASCII, triggers Git quoting
 out="$(
   cd "$fx" &&
-    git -C "$fx" init -q &&
-    git -C "$fx" config user.email test@example.com &&
-    git -C "$fx" config user.name test &&
+    git_init_test_repo "$fx" &&
     git -C "$fx" commit -q --allow-empty -m base &&
     base="$(git -C "$fx" rev-parse HEAD)" &&
     mkdir -p 'plugins/p/skills/s' &&

--- a/scripts/fixture-git-isolation-baseline.txt
+++ b/scripts/fixture-git-isolation-baseline.txt
@@ -61,7 +61,4 @@ plugins/testing/skills/audit/scripts/cant-fail-scan.test.sh
 plugins/typos-format/hooks/typos-format.test.sh
 plugins/work-items/skills/work/scripts/preflight.test.sh
 scripts/check-contract-slice-prune.test.sh
-scripts/check-shell-portability.test.sh
-scripts/check-skill-portability.test.sh
 scripts/check-stale-base-overlap.test.sh
-scripts/sync-standards-contract.test.sh

--- a/scripts/sync-standards-contract.test.sh
+++ b/scripts/sync-standards-contract.test.sh
@@ -77,7 +77,9 @@ base_fixture() {
 # git_fixture <fixture> → init repo + commit everything as the base ref; prints base sha
 git_fixture() {
   local fixture="$1"
-  git_init_test_repo "$fixture"
+  # On refusal (e.g. TMPDIR inside the checkout) stop before add/commit can
+  # resolve to the enclosing real repository.
+  git_init_test_repo "$fixture" || return 1
   git -C "$fixture" add -A
   git -C "$fixture" commit -qm base
   git -C "$fixture" rev-parse HEAD

--- a/scripts/sync-standards-contract.test.sh
+++ b/scripts/sync-standards-contract.test.sh
@@ -8,6 +8,7 @@ set -uo pipefail
 
 SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SCRIPT="$SELF_DIR/sync-standards-contract.sh"
+. "$SELF_DIR/test-git-helpers.sh"
 
 PASS=0
 FAIL=0
@@ -76,10 +77,7 @@ base_fixture() {
 # git_fixture <fixture> → init repo + commit everything as the base ref; prints base sha
 git_fixture() {
   local fixture="$1"
-  git -C "$fixture" init -q
-  git -C "$fixture" config core.autocrlf false
-  git -C "$fixture" config user.email test@example.com
-  git -C "$fixture" config user.name test
+  git_init_test_repo "$fixture"
   git -C "$fixture" add -A
   git -C "$fixture" commit -qm base
   git -C "$fixture" rev-parse HEAD


### PR DESCRIPTION
No linked issue

## Summary

Structure-only apply-lane batch from the first `/coupling:reduce` dogfood pass over `scripts/`: five fixture-construction sites across three test suites hand-rolled the `git init` + identity-config block that `scripts/test-git-helpers.sh` already publishes, bypassing its inside-checkout safety guard (the class that bit as #2839) and its gpgsign/autocrlf hardening.

## Fix

Source `test-git-helpers.sh` in `check-shell-portability.test.sh`, `check-skill-portability.test.sh`, and `sync-standards-contract.test.sh`, and replace each inline init+config block with `git_init_test_repo`. Net −6 lines. `check-stale-base-overlap.test.sh` is deliberately not converted — its fixture needs `init -b`, which the helper has no seam for yet (tracked in #2914's deferred item).

## Verification

- `check-shell-portability.test.sh`: PASS=333 FAIL=0
- `check-skill-portability.test.sh`: PASS=89 FAIL=0
- `sync-standards-contract.test.sh`: PASS=12 FAIL=0
- `shellcheck` clean on all three files

## Related

Refs #2914 (route-lane findings from the same pass); companion to #2913 (the skill that produced this batch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016CWMh6HAsgWWi9tLw76hZR

---
_Generated by [Claude Code](https://claude.ai/code/session_016CWMh6HAsgWWi9tLw76hZR)_