### PR TITLE
docs(work-items): document local-markdown branch and worktree confinement

### DIFF
--- a/plugins/work-items/.claude-plugin/plugin.json
+++ b/plugins/work-items/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "work-items",
-  "version": "0.35.24",
+  "version": "0.35.25",
   "description": "Manages development work items through a provider-neutral tracker seam that ships with the plugin (bundled dispatcher plus github and local-markdown adapters; seam plugin-dir canonical, adapters consumer-local-first): dashboard, taxonomy-labeled creation, a race-safe assignee-plus-lease claim protocol, recurring-schedule checks, TODO scanning, stale-lease auditing, plan decomposition into vertical-slice items, raw-intake triage (issues and unsolicited PRs through raw, verified, briefed, autonomous-eligible states), plus the two work-items loop lanes of the loop-lane convention: a self-paced autonomous work-loop drain (work-class admission gate, adaptive item cap, PR-only) and an attended attend-queue escalation lane. The re-runnable setup skill binds the provider (.work-item-tracker.json), seeds the recurring-schedule seam (.github/recurring-schedule.json), and remaps canonical role labels.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/work-items/CHANGELOG.md
+++ b/plugins/work-items/CHANGELOG.md
@@ -12,6 +12,9 @@ All notable changes to the `work-items` plugin are documented here. Format follo
   (`adapters/local-markdown/README.md`); setup provider-comparison and the plugin
   README now point at those (#2944). local-markdown remains never a coordination
   surface.
+- **Docs:** local-markdown isolation and Resolve-item-ID docs corrected for
+  honesty — same-worktree `git switch` carries untracked/uncommitted item files;
+  lookups key by number without re-validating owner/repo (#2944).
 
 ## [0.35.24]
 

--- a/plugins/work-items/CHANGELOG.md
+++ b/plugins/work-items/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to the `work-items` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.35.25]
+
+### Changed
+
+- **Docs:** local-markdown branch, worktree, and lease confinement documented in
+  CONTRACT.md plus a new adapter operations README
+  (`adapters/local-markdown/README.md`); setup provider-comparison and the plugin
+  README now point at those (#2944). local-markdown remains never a coordination
+  surface.
+
 ## [0.35.24]
 
 ### Changed

--- a/plugins/work-items/README.md
+++ b/plugins/work-items/README.md
@@ -52,9 +52,10 @@ provider adapter executes it (contract + resolution:
 selection, single-item fetch — uses seam verbs directly. Operations without a
 core verb (filtered listing, search, aggregation, close, label/comment edits)
 are provider-specific and route through the bound adapter's operations reference
-(GitHub: `${CLAUDE_PLUGIN_ROOT}/tools/work-item-tracker/adapters/github/README.md`). The skill core
-inlines no provider commands, so swapping the backend is swapping the bound
-adapter, not editing the skills.
+(GitHub: `${CLAUDE_PLUGIN_ROOT}/tools/work-item-tracker/adapters/github/README.md`;
+local-markdown: `${CLAUDE_PLUGIN_ROOT}/tools/work-item-tracker/adapters/local-markdown/README.md`).
+The skill core inlines no provider commands, so swapping the backend is swapping the bound
+adapter, not editing the skills. CONTRACT.md remains the SSOT for verbs.
 
 ## Multi-agent claim protocol
 

--- a/plugins/work-items/skills/setup/SKILL.md
+++ b/plugins/work-items/skills/setup/SKILL.md
@@ -77,14 +77,10 @@ when this pass must stop instead of guessing.
      issue (`gh auth status --help`), so an unrelated stale credential would condemn a good
      checkout. Run it to explain a failure, never to gate the choice.
    - **`local-markdown`** — the offline reference provider (one markdown file per item); never a
-     coordination surface. The store is working-tree files, so items, leases, and ids are branch- and
-     worktree-confined — multi-session / multi-machine work needs a tracker-published spec on a
-     coordination provider, not this adapter. Requires `config.storage_dir` (no baked default) — a
-     tracked directory the items live in (e.g. `.work-items`). Confinement and operational mechanics:
-     the seam contract's "local-markdown adapter" section
-     ([`${CLAUDE_PLUGIN_ROOT}/tools/work-item-tracker/CONTRACT.md`](${CLAUDE_PLUGIN_ROOT}/tools/work-item-tracker/CONTRACT.md))
-     and
-     [`${CLAUDE_PLUGIN_ROOT}/tools/work-item-tracker/adapters/local-markdown/README.md`](${CLAUDE_PLUGIN_ROOT}/tools/work-item-tracker/adapters/local-markdown/README.md).
+     coordination surface. The store is working-tree files, so items/leases/ids are branch- and
+     worktree-confined — multi-session work needs a tracker-published spec on a coordination
+     provider. Requires `config.storage_dir` (no baked default; e.g. `.work-items`). See CONTRACT.md
+     "local-markdown adapter" and `adapters/local-markdown/README.md`.
    - **`jira`** — read/resolve-only against a Jira Cloud project set (consume-only: no ticket
      creation/claim/mutation; write verbs exit `6`). Requires `config.jira` (`site`, non-empty
      `project_keys[]`, `auth_email`, `auth_env`) and `curl`; the API token is referenced by env-var

--- a/plugins/work-items/skills/setup/SKILL.md
+++ b/plugins/work-items/skills/setup/SKILL.md
@@ -77,8 +77,14 @@ when this pass must stop instead of guessing.
      issue (`gh auth status --help`), so an unrelated stale credential would condemn a good
      checkout. Run it to explain a failure, never to gate the choice.
    - **`local-markdown`** — the offline reference provider (one markdown file per item); never a
-     coordination surface. Requires `config.storage_dir` (no baked default) — a tracked directory the
-     items live in (e.g. `.work-items`).
+     coordination surface. The store is working-tree files, so items, leases, and ids are branch- and
+     worktree-confined — multi-session / multi-machine work needs a tracker-published spec on a
+     coordination provider, not this adapter. Requires `config.storage_dir` (no baked default) — a
+     tracked directory the items live in (e.g. `.work-items`). Confinement and operational mechanics:
+     the seam contract's "local-markdown adapter" section
+     ([`${CLAUDE_PLUGIN_ROOT}/tools/work-item-tracker/CONTRACT.md`](${CLAUDE_PLUGIN_ROOT}/tools/work-item-tracker/CONTRACT.md))
+     and
+     [`${CLAUDE_PLUGIN_ROOT}/tools/work-item-tracker/adapters/local-markdown/README.md`](${CLAUDE_PLUGIN_ROOT}/tools/work-item-tracker/adapters/local-markdown/README.md).
    - **`jira`** — read/resolve-only against a Jira Cloud project set (consume-only: no ticket
      creation/claim/mutation; write verbs exit `6`). Requires `config.jira` (`site`, non-empty
      `project_keys[]`, `auth_email`, `auth_env`) and `curl`; the API token is referenced by env-var

--- a/plugins/work-items/tools/work-item-tracker/CONTRACT.md
+++ b/plugins/work-items/tools/work-item-tracker/CONTRACT.md
@@ -342,6 +342,36 @@ network tool (`gh`, `curl`); the conformance suite runs it in CI, offline.
   provider is used when a repo's binding names it, never as an automatic fallback
   from a network failure of another provider.
 
+### Branch, worktree, and lease confinement
+
+The store is working-tree files (`<storage_dir>/<number>.md`). Visibility is
+therefore confined to the tree that holds those files: an item created on a
+feature branch is invisible on every other branch until the store directory is
+merged. `wit_next_number` is the max existing file number + 1 with no file
+lock, so two diverged branches (or two writers against one store) can both mint
+the same next number.
+
+A relative `config.storage_dir` roots against the **binding file's directory**,
+not the caller's CWD (`lib/binding.sh`). Distinct worktrees that climb to the
+same binding therefore share one store when `storage_dir` is relative. Distinct
+worktrees that each carry their own copy of the binding and store — the
+`/work-items:work` skill's worker-worktree model — each have a divergent copy:
+an uncommitted lease is invisible to a sibling worktree; a committed lease is a
+lease-churn commit on that worktree's branch. A shared **absolute**
+`storage_dir` across worktrees is one store, so concurrent create/claim races
+on numbers and the lease marker.
+
+Claim identity is `git config user.name`, then `$USER`, then `local`. The same
+git user in two worktrees looks like the same holder. The lease handle is a
+store-global `lease_comment_id` in the marker JSON (not a GitHub comment id).
+The manifest declares `reclaim: false`; invoking `reclaim` exits `6`. On
+expiry, `list-items` reports empty `assignees` (effective post-expiry
+assignment) while `get-item` still shows the stored assignee.
+
+This confinement is why multi-session / multi-machine work needs a
+tracker-published spec on a coordination provider — a `work-map` container lane
+(see "Containers and state"). local-markdown is never that surface.
+
 ## jira adapter
 
 The `jira` adapter binds a Jira Cloud project set behind the seam. It is **read/resolve-only

--- a/plugins/work-items/tools/work-item-tracker/CONTRACT.md
+++ b/plugins/work-items/tools/work-item-tracker/CONTRACT.md
@@ -345,11 +345,14 @@ network tool (`gh`, `curl`); the conformance suite runs it in CI, offline.
 ### Branch, worktree, and lease confinement
 
 The store is working-tree files (`<storage_dir>/<number>.md`). Visibility is
-therefore confined to the tree that holds those files: an item created on a
-feature branch is invisible on every other branch until the store directory is
-merged. `wit_next_number` is the max existing file number + 1 with no file
-lock, so two diverged branches (or two writers against one store) can both mint
-the same next number.
+therefore confined to the tree that holds those files. Untracked or uncommitted
+item files are **not** branch-isolated in the same worktree: `git switch`
+normally carries them onto the new branch (and a nonconflicting uncommitted
+lease edit can likewise follow). Invisibility holds for sibling worktrees that
+do not share those store files, and for committed store files on other branches
+until those commits are merged. `wit_next_number` is the max existing file
+number + 1 with no file lock, so two diverged branches (or two writers against
+one store) can both mint the same next number.
 
 A relative `config.storage_dir` roots against the **binding file's directory**,
 not the caller's CWD (`lib/binding.sh`). Distinct worktrees that climb to the

--- a/plugins/work-items/tools/work-item-tracker/adapters/local-markdown/README.md
+++ b/plugins/work-items/tools/work-item-tracker/adapters/local-markdown/README.md
@@ -13,8 +13,9 @@ take a fully-qualified ID (`local-markdown:<owner>/<repo>#<N>` — CONTRACT.md
 "ID grammar"); a bare `#N` is rejected. The default namespace is
 `local/markdown`, so a typical id is `local-markdown:local/markdown#N`.
 `create-item --repo <owner>/<repo>` overrides that namespace at create time.
-`cross_repo_edges` is `false`: one store is one logical namespace. A blocker in
-another namespace is a text pointer only — never a resolvable edge.
+Lookups key by number only; the owner/repo in the id is not re-validated
+against the store. `cross_repo_edges` is `false` means there is no second store
+to consult — not that a foreign-looking qualified id fails lookup.
 
 The **seam** verbs (`list-frontier`, `get-item`, `create-item`) already emit the
 qualified `id` — pass it straight through.

--- a/plugins/work-items/tools/work-item-tracker/adapters/local-markdown/README.md
+++ b/plugins/work-items/tools/work-item-tracker/adapters/local-markdown/README.md
@@ -1,0 +1,60 @@
+# local-markdown adapter — operations reference
+
+The `local-markdown` adapter is **offline-only**: it is **NEVER a coordination
+surface** and never invokes `gh` or `curl`. Coordination verbs still go through
+the seam (`work-item-tracker.sh <verb>`; see [`../../CONTRACT.md`](../../CONTRACT.md)).
+This file covers the local-markdown operational mechanics a skill needs and does
+not restate the full contract.
+
+## Resolve item ID
+
+Seam verbs (`get-item`, `claim`, `renew-lease`, `link-blocks`, `add-sub-item`)
+take a fully-qualified ID (`local-markdown:<owner>/<repo>#<N>` — CONTRACT.md
+"ID grammar"); a bare `#N` is rejected. The default namespace is
+`local/markdown`, so a typical id is `local-markdown:local/markdown#N`.
+`create-item --repo <owner>/<repo>` overrides that namespace at create time.
+`cross_repo_edges` is `false`: one store is one logical namespace. A blocker in
+another namespace is a text pointer only — never a resolvable edge.
+
+The **seam** verbs (`list-frontier`, `get-item`, `create-item`) already emit the
+qualified `id` — pass it straight through.
+
+## Storage
+
+`config.storage_dir` is required (no baked default). One markdown file per item
+at `<storage_dir>/<number>.md`. A relative `storage_dir` roots against the
+**binding file's directory**, not CWD (`lib/binding.sh`); an absolute path is
+used as given. The store is single-writer files: `wit_next_number` is max
+existing file number + 1 with no file lock.
+
+## Claim / lease
+
+Claim identity is `git config user.name`, then `$USER`, then `local`. The same
+git user in two worktrees looks like the same holder. The lease handle is a
+store-global `lease_comment_id` in the marker JSON (not a GitHub comment id);
+`renew-lease` addresses that handle. The manifest declares `reclaim: false`;
+invoking `reclaim` exits `6`. On expiry, `list-items` reports empty `assignees`
+while `get-item` still shows the stored assignee.
+
+## Branch, worktree, and lease confinement
+
+The store is working-tree files, so items, leases, and ids are confined to the
+tree that holds those files. Branch visibility, worktree copies vs a shared
+absolute store, number races, and why this adapter is never a coordination
+surface are the seam contract's "Branch, worktree, and lease confinement"
+subsection under "local-markdown adapter" — do not treat this README as a
+second copy of that fact set.
+
+## List / frontier
+
+There is no provider search syntax. Listing and frontier selection are seam
+verbs only: `work-item-tracker.sh list-items` (raw candidates; `--state
+open|closed|all`; `--repo` is accepted for interface parity and does not
+re-target the single-namespace store) and the core-derived
+`work-item-tracker.sh list-frontier`. Filter, search, and aggregation stay on
+those verbs; do not invent a query language against the markdown files.
+
+## Auth
+
+None. The adapter touches no network and has no credential. Claim identity is
+the git user name as under "Claim / lease" above.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #2944

## Summary

Documents the local-markdown adapter's branch, worktree, and lease confinement — working-tree files are never a coordination surface — in the seam contract, a new adapter README (matching github/jira siblings), the setup provider comparison, and the plugin README operations pointer.

## Fix

- CONTRACT.md `## local-markdown adapter` gains `### Branch, worktree, and lease confinement` (relative `storage_dir` roots at the binding file; shared vs divergent worktrees; identity; `reclaim: false`; `work-map` container cross-ref).
- New `adapters/local-markdown/README.md` operations reference (offline-only; no `gh`/`curl` recipes).
- Setup skill provider-comparison bullet names confinement (kept under the 500-line SKILL.md cap).
- Plugin README cites the local-markdown operations README alongside GitHub.
- Plugin version `0.35.24` → `0.35.25` with matching CHANGELOG.

## Verification

- `bash plugins/work-items/tools/work-item-tracker/lib/binding.test.sh` — 23 PASS (relative `storage_dir` already covered).
- `scripts/check-changed-skills.sh origin/main` — setup SKILL.md 499/500, PASS.

## Related

Refs #2933 (parent work-map). No adapter code changes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-60311e3e-bf89-4375-aded-ebb9933c68fa?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-60311e3e-bf89-4375-aded-ebb9933c68fa&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

