### PR TITLE
docs(scripts): separate the absence and replay windows in the incidents corpus

### DIFF
--- a/scripts/check-silent-revert.sh
+++ b/scripts/check-silent-revert.sh
@@ -285,15 +285,28 @@
 #   malformed and must NOT be restored byte-for-byte, and #2829 restored the
 #   intent instead. A marker survives that rewrite; the hunk cannot.
 #
-# Markers resolve PATH-SCOPED, which is load-bearing rather than tidy. Both
-# markers on the f603880da row also occur elsewhere in the same plugin on
-# current main -- the engine script, its test file, CHANGELOG.md -- so a
-# repo-wide `git grep` for either one matches today no matter what the two
-# BOUND files contain, and would report the incident restored on a tree where
-# it is not. Stated in the present tense on purpose: the sibling copies are a
-# property of main as it stands now, not of the tree during the #2828 window.
-# CHANGELOG.md got its copy from 534eac138, the restore itself, so during the
-# absence a repo-wide grep for the evals marker still matched nothing.
+# Markers resolve PATH-SCOPED, which is load-bearing rather than tidy. Each
+# marker on the f603880da row also occurs on current main in a file of the same
+# plugin that is NOT the file it binds to -- but not in the SAME files, so the
+# sites do not distribute across both. The README marker occurs in the engine
+# script and again in that script's test file, and not in CHANGELOG.md; the
+# evals marker occurs in CHANGELOG.md, and in neither the engine script nor its
+# test file. What both share is that a sibling copy exists at all, which is
+# enough: a repo-wide `git grep` for either one matches today no matter what the
+# two BOUND files contain, and would report the incident restored on a tree
+# where it is not.
+#
+# The two halves also acquired their siblings at different times, and only one
+# of them is a present-tense-only property. CHANGELOG.md got its copy of the
+# evals marker from 534eac138, the restore itself, so a repo-wide grep for that
+# marker matched nothing at any point during the absence. The README marker's
+# siblings are older than the restore: 94ae28728 (#2803) -- one of the two
+# re-lands that missed the README -- put that string into the engine script and
+# its test file, and never into README.md, and it did so BEFORE 7b47d2253 merged
+# this canary. So for the entire tail of the absence that the replay actually
+# covered, a repo-wide grep for the README marker did match, on a tree whose
+# bound file did not have it. For that half the widened path is not a
+# hypothetical failure mode; it is the answer the incident would have produced.
 #
 # Cost: one exact-path read per marker row -- `git cat-file`
 # at a rev, a tracked-path read in the working tree -- with the match done by
@@ -953,8 +966,28 @@ verify_known_incidents() {
 # marker whose distinguishing feature is its leading spaces would be recorded
 # without them and match more loosely than the reader intended.
 #
-# For the same reason a marker must occur exactly ONCE in the file it binds to.
-# `grep -qF` answers "is this string anywhere in this file", so a bare
+# The ONE reserved position is a LEADING `[`, which commits the row to
+# carrying a disposition, in the same positional slot-after-the-key the
+# attribution field uses on a `fires` row. An unterminated `[` is exit 2 rather
+# than being re-read as ordinary marker text: a row that quietly degrades into
+# "no disposition, strange marker" is the false green this file exists to
+# remove, reached by the one route nobody would look at.
+#
+# The disposition requires a NON-EMPTY reason, exactly as declares_removal()
+# requires of `Intentional-removal:`. `[not-restored:]` is rejected, not read as
+# a mute -- a marker nobody has to justify is a mute button, and this corpus is
+# an audit trail.
+#
+# The disposition ends at the FIRST `]`, so a REASON may not contain `]`. That
+# is the only qualification on "any character", it applies to the reason alone,
+# and the marker text after the disposition is still unrestricted. It cannot be
+# enforced after the fact: a truncated reason and a legitimate row whose marker
+# happens to contain `]` are byte-indistinguishable, so any check that rejects
+# the first rejects the second too. A reason truncated at a stray `]` shows up
+# in the `noted` line, which prints it verbatim to the human reading the trail.
+#
+# Literal matching is also why a marker must occur exactly ONCE in the file it
+# binds to. `grep -qF` answers "is this string anywhere in this file", so a bare
 # identifier that appears at its definition AND at a use site is satisfied by a
 # re-land that restored only the use -- a PARTIAL re-land reported as `ok`,
 # which is the exact failure this assertion exists to catch (#2828 was a
@@ -979,28 +1012,9 @@ verify_known_incidents() {
 # that a FUTURE partial re-land, in either direction, could satisfy them. Fixed
 # before it was needed rather than after.
 #
-# Nothing enforces this: it is a corpus-review obligation, because a
+# Nothing enforces the once-rule: it is a corpus-review obligation, because a
 # check that counted occurrences would turn every row into an exact-shape
 # assertion and go red on edits that restored the content perfectly well.
-# The ONE reserved position is a LEADING `[`, which commits the row to
-# carrying a disposition, in the same positional slot-after-the-key the
-# attribution field uses on a `fires` row. An unterminated `[` is exit 2 rather
-# than being re-read as ordinary marker text: a row that quietly degrades into
-# "no disposition, strange marker" is the false green this file exists to
-# remove, reached by the one route nobody would look at.
-#
-# The disposition requires a NON-EMPTY reason, exactly as declares_removal()
-# requires of `Intentional-removal:`. `[not-restored:]` is rejected, not read as
-# a mute -- a marker nobody has to justify is a mute button, and this corpus is
-# an audit trail.
-#
-# The disposition ends at the FIRST `]`, so a REASON may not contain `]`. That
-# is the only qualification on "any character", it applies to the reason alone,
-# and the marker text after the disposition is still unrestricted. It cannot be
-# enforced after the fact: a truncated reason and a legitimate row whose marker
-# happens to contain `]` are byte-indistinguishable, so any check that rejects
-# the first rejects the second too. A reason truncated at a stray `]` shows up
-# in the `noted` line, which prints it verbatim to the human reading the trail.
 
 # parse_incidents_file <fires-shas-out> <markers-out>
 #

--- a/scripts/silent-revert-incidents.txt
+++ b/scripts/silent-revert-incidents.txt
@@ -43,10 +43,17 @@
 # ---------------------------
 # A `fires` row on its own proves only that the commit still produces a
 # finding. It says nothing about whether the content that commit deleted is on
-# main today, and that gap has already cost this repo 31h28m: the content
-# #2828 is about was missing from main while the f603880da row below printed
-# `ok ... fires as recorded` and the replay exited 0. Two re-lands (#2714,
-# #2803) each missed it, and a hand audit caught it, not this file.
+# main today. The content #2828 is about was absent from main for 31h28m:
+# f603880da removed it and 534eac138 (#2829) put it back.
+#
+# 31h28m is the CONTENT-ABSENCE window, not a window this replay ran through in
+# silence -- the canary did not exist for most of it. It merged part-way in, at
+# 7b47d2253 (#2808), 6h13m before the restore, so the replay covered only the
+# tail of the absence. Over that tail the f603880da row below printed
+# `ok ... fires as recorded` and the replay exited 0 while the content was still
+# gone: the row was never wrong about what it asserted, it asserted the other
+# question. Two re-lands (#2714, #2803) each missed it, and a hand audit caught
+# it, not this file.
 #
 # CONTENT, not files. Both files existed the whole time -- #2829 modifies them
 # rather than adding them. That is why nothing noticed: a file-level or
@@ -76,10 +83,13 @@
 # shape `Intentional-removal:` requires in a commit message. `[not-restored:]`
 # with nothing after it is rejected, not read as a mute.
 #
-# PATH-SCOPED is load-bearing, not tidiness. Both markers on the f603880da row
-# also occur elsewhere in the same plugin on current main (the engine script,
-# its test file, CHANGELOG.md), so a repo-wide grep would have reported both
-# files restored on a tree where the content was missing.
+# PATH-SCOPED is load-bearing, not tidiness. Each marker on the f603880da row
+# also occurs on current main in a file of the same plugin that is NOT the file
+# it binds to -- the README marker in the engine script and in that script's
+# test file, the evals marker in CHANGELOG.md. The sites differ per marker; what
+# both share is a sibling copy, so a repo-wide grep for either one matches today
+# whatever the two BOUND files contain, and would report the incident restored
+# on a tree where it is not.
 #
 # Choose a marker a reviewer can recognize as the content itself. An identifier
 # will go red on a rename, and that loudness is intended: the answer is a


### PR DESCRIPTION
#2917 item 2 named the same unhedged `31h28m` claim in two files. #2930 corrected
`scripts/check-silent-revert.sh` and left `scripts/silent-revert-incidents.txt`
byte-identical, so since #2930 the two files have actively contradicted each other
on the one question the whole restoration assertion turns on. This finishes item 2
and clears the two smaller prose defects the same review pass found.

## 1. The surviving claim in the corpus file

`scripts/silent-revert-incidents.txt` said:

> It says nothing about whether the content that commit deleted is on main today,
> and that gap has already cost this repo 31h28m: the content #2828 is about was
> missing from main while the f603880da row below printed `ok ... fires as
> recorded` and the replay exited 0.

The defect is that "that gap has already cost this repo 31h28m" charges the whole
absence to a mechanism that existed for only part of it, and it does so in the same
breath as "the replay exited 0" — so the sentence reads as thirty-one hours of a
running, silent replay. It was not. The canary did not exist for most of that
window.

Rewritten to separate the two windows in the same terms the script now uses, and
to keep the point the passage was carrying — that the replay's silence was never a
statement about content presence:

> The content #2828 is about was absent from main for 31h28m: f603880da removed it
> and 534eac138 (#2829) put it back.
>
> 31h28m is the CONTENT-ABSENCE window, not a window this replay ran through in
> silence -- the canary did not exist for most of it. It merged part-way in, at
> 7b47d2253 (#2808), 6h13m before the restore, so the replay covered only the tail
> of the absence. Over that tail the f603880da row below printed
> `ok ... fires as recorded` and the replay exited 0 while the content was still
> gone: the row was never wrong about what it asserted, it asserted the other
> question. Two re-lands (#2714, #2803) each missed it, and a hand audit caught it,
> not this file.

Both figures are closed historical intervals between two fixed commits, so neither
can rot — that is why they are stated rather than replaced with a hedge. Neither is
a running total.

### What the two figures measure

Both are committer-date deltas, re-derived here rather than carried over:

| interval | endpoints | seconds | figure |
| --- | --- | --- | --- |
| content absence | `f603880da` (1786752447) → `534eac138` (1786865745) | 113298 | 31h28m18s → **31h28m** |
| replay presence | `7b47d2253` (1786843322) → `534eac138` (1786865745) | 22423 | 6h13m43s → **6h13m** |

`7b47d2253` (#2808, the commit that merged this canary) is an ancestor of
`534eac138` and its timestamp falls inside the absence interval, so the canary
genuinely merged part-way through. The replay therefore covered 22423 of 113298
seconds — under a fifth — and the prose says "only the tail" rather than quoting
that fraction, matching the script.

## 2. The broken antecedent in `check-silent-revert.sh`

In the `The restoration assertion (#2855)` comment block, one paragraph establishes
that marker text is matched with `grep -F` and therefore "may contain any character
-- no separator is reserved inside it". The next sentence a reader needs is "The
ONE reserved position is a LEADING `[`". #2930 inserted its ~30-line uniqueness
block ("a marker must occur exactly ONCE in the file it binds to", plus the
definition/use two-row design and the corpus-review obligation) between them, and
did so without even a blank comment line before "The ONE reserved position", so
that sentence ran straight out of a paragraph about counting occurrences and its
antecedent sat about thirty lines uphill.

Fixed by relocating the uniqueness block below the disposition paragraphs, which
restores the original adjacency: whitespace/any-character → `[` is the one reserved
position → the disposition needs a non-empty reason → the disposition ends at the
first `]`. The uniqueness block now closes the section.

Two connective repairs were needed because the block no longer follows the sentence
it used to lean on, and both preserve what is asserted:

- `For the same reason a marker must occur exactly ONCE` → `Literal matching is
  also why a marker must occur exactly ONCE`. "The same reason" was the looseness
  of literal substring matching, which the block's own next sentence
  (``grep -qF` answers "is this string anywhere in this file"`) immediately
  restates, so naming it costs nothing and removes the anaphor.
- `Nothing enforces this:` → `Nothing enforces the once-rule:`, since "this" now
  has no adjacent referent.

Nothing else in the block changed — the diff is a pure relocation apart from those
two clauses.

## 3. The distributing parenthetical

Both files claimed that both `f603880da` markers occur in the same three sibling
sites:

> Both markers on the f603880da row also occur elsewhere in the same plugin on
> current main -- the engine script, its test file, CHANGELOG.md

That reads as three sites applying to both markers. Re-measured from scratch on
`origin/main` with `git grep -F` per literal, no pathspec:

**README marker** (bound to `plugins/disk-hygiene/README.md`) — 5 hits:

- `plugins/disk-hygiene/README.md:6` (the bound file)
- `plugins/disk-hygiene/skills/clean/scripts/hygiene.py:2807`
- `plugins/disk-hygiene/skills/clean/scripts/hygiene.py:3601`
- `plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py:566`
- `scripts/silent-revert-incidents.txt:107` (the marker row itself)

No CHANGELOG hit.

**evals marker** (bound to `plugins/disk-hygiene/skills/clean/evals/evals.json`) —
3 hits:

- `plugins/disk-hygiene/skills/clean/evals/evals.json:138` (the bound file)
- `plugins/disk-hygiene/CHANGELOG.md:139`
- `scripts/silent-revert-incidents.txt:108` (the marker row itself)

No engine-script or test hit.

So the sites do not distribute: the engine script and its test belong to the README
marker only, CHANGELOG.md to the evals marker only. The load-bearing claim survives
untouched — each literal does occur outside the file it binds to, which is why a
repo-wide grep would report the incident restored on a tree where it is not — and
the prose now says that in the per-marker form.

Neither rewrite quotes either literal. Doing so would have added an occurrence of
the very string whose occurrence set the sentence enumerates; the prose refers to
them by role ("the README marker", "the evals marker"), which is what the script
already did. Nor does either rewrite assert exhaustiveness, since both literals also
appear on the corpus page itself — a fact that file already states separately.

### The provenance sentence had to move with it

The script's old follow-on read:

> Stated in the present tense on purpose: the sibling copies are a property of main
> as it stands now, not of the tree during the #2828 window.

Measurement contradicts that for the README half, so it could not be left standing
next to a corrected parenthetical:

- The evals half holds. At `f603880da` the evals literal occurred nowhere in the
  tree, and a `git log -S` walk over the whole `f603880da..534eac138` range returns
  exactly one commit — `534eac138` itself. So `plugins/disk-hygiene/CHANGELOG.md`
  acquired its copy at the restore, and the interval is measured rather than
  interpolated between endpoints: a repo-wide grep for that literal matched nothing
  at any point during the absence.
- The README half does not. `git log -S` over `f603880da..534eac138` returns
  `94ae28728` (#2803, one of the two re-lands the passage already names as having
  missed the README) and then the restore. `94ae28728` put the string into
  `hygiene.py` and `test_hygiene.py` and never into `README.md`, and it landed
  2026-08-15T20:37:17-04:00, which is 44m45s before `7b47d2253` merged this canary.
  Grepping at `7b47d2253` confirms it: three hits, all in the engine script and its
  test, none in `README.md`.

So for the entire tail of the absence that the replay actually covered, a repo-wide
grep for the README marker matched on a tree whose bound file did not have the
content. The passage now says that, which turns the path-scoping argument from a
hypothetical into the answer this very incident would have produced.

## Scope note

The parenthetical defect is called out in #2981 against `check-silent-revert.sh`,
but `silent-revert-incidents.txt` carried its own shorter copy of the same claim.
Fixing only one would have re-created exactly the two-files-disagree condition this
issue exists to close, so both were corrected — the corpus version kept shorter, to
that file's register.

### A third site carries the same defect, and is deliberately NOT touched here

Verification swept `31h28m` across the whole tree rather than only the two files in
scope, and turned up a site neither #2917 nor #2981 names —
`.github/workflows/silent-revert-canary.yml:154–157`, the workflow that actually
runs the replay:

> Both are needed, and the gap between them has already cost 31h28m: the content
> #2828 is about was missing from main while the replay printed `ok` and exited 0

Same unhedged construction, charging all 31h28m to a period in which "the replay
printed `ok`". It is pre-existing — `git diff origin/main` on that path is empty —
and it is outside the file scope agreed for this change, so it is left alone here
rather than folded in unannounced.

It should be filed and fixed, and the correction is already derived above: the
content was absent for 31h28m, of which this replay was present only for the final
6h13m, and over that tail it printed `ok` and exited 0 while the content was still
gone. Recording it here so the remaining inconsistency is a known, measured
follow-up rather than something a later reader rediscovers as evidence that this
fix was incomplete.

## Verification

CI is the verification of record; the shell suites were deliberately not run
locally (they behave badly on Windows). Everything asserted above was measured with
`git log`, `git rev-parse`, `git merge-base`, `git log -S`, and `git grep -F`, at
explicit revs.

A fresh-context verifier subagent then re-derived every figure independently, with
the reasoning above withheld: both committer-date windows and their arithmetic, the
ancestry and interval placement of `7b47d2253` and `94ae28728`, the complete
per-literal occurrence sets on `origin/main` and on the branch tree (confirming the
edits added no new occurrence of either literal), the adjacency repair in part 2 and
that the relocated block's claims are unchanged, that every `31h28m` mention in the
two edited files is now hedged and window-separated, and that the corpus file
contains no stray non-comment line that would make the parser exit 2. It returned
PASS on all sixteen claims, and its repo-wide sweep is what surfaced the workflow
site noted above.

The edits also add no line over 80 columns to either file — the over-80 counts are
identical to `origin/main`'s (61 in the script, 13 in the corpus, all pre-existing).

## Related

Closes #2981

- #2917 — the parent issue, whose item 2 this completes
- #2930 — corrected the script half and left the corpus half behind
- #2855 — added the restoration markers and the comment block part 2 repairs
- #2847 — the standard requiring a figure that does not rot
