### PR TITLE
fix(scripts): give the maintenance-child guard a positive control

### DIFF
--- a/scripts/check-contract-slice-prune.test.sh
+++ b/scripts/check-contract-slice-prune.test.sh
@@ -381,30 +381,82 @@ rm -rf "$repo"
 # every child process the traced commands start, so a maintenance (or legacy
 # auto-gc) fork is caught deterministically here rather than probabilistically
 # in a cleanup race.
+#
+# The assertion is a NEGATIVE, so it needs a positive control or it passes for
+# exactly the reason it should report nothing (#2982): an absent trace, or a
+# fixture command that failed inside git_q's output suppression, leaves the
+# grep nothing to match and the case reports `ok` while observing nothing. The
+# control is the traced sequence's exit status, a non-empty trace, and both
+# halves of the pattern the negative depends on:
+#
+#   * a `child_start` event that the fixture is KNOWN to produce — `git merge`
+#     runs `git stash create` as a subprocess (builtin/merge.c save_state(),
+#     reached once a REAL merge is needed and before the "no changes"
+#     early-out, so it does not depend on the worktree being dirty; observed on
+#     git 2.55 and unchanged in the 2.54 source, which is what CI runs).
+#     Asserting that specific event, rather than any child_start, keeps an
+#     ambient child from some unrelated config (fsmonitor, a credential helper,
+#     a hook) from standing in for it, and re-proves the divergent-histories
+#     premise below: a merge that degraded to a fast-forward or to
+#     already-up-to-date never reaches save_state. The cost of pinning it is a
+#     new failure mode — a git that stops shelling out to `git stash create`
+#     red-lines this case, blaming the fixture. That is loud and diagnosable,
+#     which is the trade this case is built on.
+#   * the maintenance half of the pattern, checked against a verbatim capture
+#     of the event git logs when the fork happens. Both greps read one pattern
+#     variable, so a pattern that no longer matches a real maintenance child
+#     fails here instead of silently never matching anything again.
+#
+# What no control here can prove is that git still SPELLS the fork this way;
+# proving that would mean spawning a real detached maintenance child, i.e.
+# re-creating the very race (#2918) this suite exists to keep out.
 repo="$(mk_repo)"
 trace="$(mktemp)"
 printf 'edit\n' >>"$repo/README.md"
 (
   cd "$repo" || exit 1
   export GIT_TRACE2_EVENT="$trace"
-  git_q add -A
-  git_q commit -m traced-commit
-  git_q checkout -b side
+  # git_q swallows stdout, stderr and — left unchecked — failure itself, so
+  # every fixture command the assertion depends on is routed through a form
+  # that aborts the sequence. The diagnosis stays a bare echo: fail() called in
+  # here would increment the subshell's own copy of FAIL and the suite would
+  # still exit 0. The outer branch below is what red-lines the run.
+  git_must() { git_q "$@" || { echo "traced fixture command failed: git $*" >&2; exit 1; }; }
+  git_must add -A
+  git_must commit -m traced-commit
+  git_must checkout -b side
   printf 'side\n' >>README.md
-  git_q add -A
-  git_q commit -m side
-  git_q checkout work
+  git_must add -A
+  git_must commit -m side
+  git_must checkout work
   printf 'diverge\n' >other.md
-  git_q add -A
-  git_q commit -m diverge
+  git_must add -A
+  git_must commit -m diverge
   # Divergent histories force a REAL merge commit; a fast-forward could skip
   # the post-merge hook point this guard exists to observe.
-  git_q merge side
+  git_must merge side
 )
-if grep -Eq '"child_start".*"(maintenance|gc)"' "$trace"; then
+traced_rc=$?
+maint_child='"child_start".*"(maintenance|gc)"'
+# Verbatim capture from a fixture run with maintenance.auto left ON — every
+# field git emits, in git's order. A reduced sample would let a pattern whose
+# adjacency assumptions only hold in the reduction pass this control while
+# never matching a real event again.
+maint_sample='{"event":"child_start","sid":"20260817T200830.792683Z-H2a3dd3cb-P0000acb8","thread":"main","time":"2026-08-17T20:08:30.824996Z","file":"run-command.c","line":741,"child_id":0,"child_class":"?","use_shell":false,"argv":["git","maintenance","run","--auto","--no-quiet","--detach"]}'
+# `|| true` so the count survives a future `set -e`: grep -c exits 1 on zero.
+child_starts="$(grep -c '"child_start"' "$trace" 2>/dev/null || true)"
+if ((traced_rc != 0)); then
+  fail "the traced fixture sequence failed (exit $traced_rc) — the maintenance assertion would observe nothing"
+elif [[ ! -s "$trace" ]]; then
+  fail "GIT_TRACE2_EVENT produced no trace — the maintenance assertion would observe nothing"
+elif ! grep -Eq '"child_start".*"argv":\["git","stash","create"' "$trace"; then
+  fail "the trace records no stash-create child from the fixture merge — child_start events are not reaching the trace, or the merge degraded to a fast-forward, so the maintenance assertion cannot fire"
+elif ! grep -Eq "$maint_child" <<<"$maint_sample"; then
+  fail "the maintenance pattern no longer matches the event git logs on the fork — the assertion below can never fire"
+elif grep -Eq "$maint_child" "$trace"; then
   fail "a fixture commit/merge spawned a background maintenance/gc child (cleanup race #2918)"
 else
-  ok "fixture git commands spawn no background maintenance"
+  ok "fixture git commands spawn no background maintenance ($child_starts child_start event(s) traced)"
 fi
 rm -f "$trace"
 rm -rf "$repo"


### PR DESCRIPTION
Closes #2982

## Summary

The `GIT_TRACE2_EVENT` regression guard in
`scripts/check-contract-slice-prune.test.sh` (added by #2929 for the #2918
cleanup race) asserts a NEGATIVE — that no `child_start` event names a
`maintenance` or `gc` child — and never asserted that the trace was produced at
all. `git_q` suppresses stdout and stderr and its exit status was unchecked, so
a failed fixture `commit`/`merge` was invisible: the trace would be empty or
missing, the grep would match nothing, and the case would report `ok` for
exactly the reason it should have reported nothing. This adds the positive
control, so an unproduced trace or a failed fixture command fails loudly
instead of passing vacuously.

## Fix

Four preconditions are now evaluated before the negative, each with its own
diagnosis, plus one `ok` line that carries the control's evidence:

1. **Exit status of the fixture sequence.** Every traced fixture command goes
   through `git_must`, a local wrapper that aborts the subshell on failure; the
   outer code reads the subshell's status into `traced_rc`. The diagnosis
   inside the subshell stays a bare `echo` on purpose — calling `fail()` in
   there would increment the subshell's own copy of `FAIL` and the suite's
   final `((FAIL == 0))` would still be true, which is the same class of
   silent-success bug this PR is fixing.
2. **A non-empty trace file.** Distinct message, so a dead `GIT_TRACE2_EVENT`
   is diagnosed as such rather than as git child behaviour.
3. **The specific `child_start` the fixture is known to produce** — the merge's
   `["git","stash","create"]` child. Pinning the control to that event rather
   than to any `child_start` means an ambient child from unrelated config
   (fsmonitor, a credential helper, a hook) cannot stand in for it, and it
   re-proves #2929's divergent-histories premise: a merge that degraded to a
   fast-forward or to already-up-to-date never reaches `save_state()`.
4. **The maintenance half of the pattern.** The negative needs two literals on
   one line, `"child_start"` and `"maintenance"|"gc"`; precondition 3 only
   proves the first is live. The pattern is therefore hoisted into one variable
   used by both a check against a **verbatim** capture of the event git logs on
   the fork and the real assertion against the trace, so a pattern that has
   drifted off that shape fails loudly instead of silently never matching
   again. The sample keeps every field git emits (`sid`, `thread`, `time`,
   `file`, `line`, `child_id`, `child_class`, `use_shell`, `argv`) on purpose: a
   trimmed sample would let a pattern whose adjacency assumptions hold only in
   the trimmed form pass the control while never matching a real event —
   demonstrated below.

The `ok` line reports the traced `child_start` count, so the control's evidence
lands in the CI log instead of being asserted invisibly.

What no control here can prove is that git still *spells* the fork that way.
The only assertion that would is spawning a real detached maintenance child —
i.e. re-creating #2918's race inside the suite that exists to keep it out. The
comment says so explicitly rather than leaving a reader to assume the coverage
is total.

### Why a `child_start` is guaranteed here

`git merge` runs `git stash create` as a subprocess: `builtin/merge.c`
`save_state()`, whose `start_command()` sits above the `else if (!len) /* no
changes */` early-out, called from the "at this point, we need a real merge"
section — so the child is spawned for every real merge regardless of whether
the worktree is dirty. Measured by running it on `2.55.0` (local); for
`v2.54.0` (what CI runs) the claim is a **source** check, not a run:
`save_state()` at `builtin/merge.c:341` in both tags, called at `:1784`
(2.54.0) and `:1778` (2.55.0), with the `start_command()` above the `no
changes` early-out in both.

Pinning to that child is a new failure mode this PR introduces: a future git
that stops shelling out to `git stash create` (say a merge-ort autostash
refactor) red-lines this case blaming the fixture. That is loud and
diagnosable, which is the trade the case is built on, and the comment says so
rather than leaving a reader to discover it.

That also re-proves #2929's divergent-histories premise as a side effect: a
merge that degraded to a fast-forward or to already-up-to-date never reaches
`save_state()`, so it traces no stash-create child and goes red instead of
quietly asserting nothing.

The guard depends on the trace2 event name `child_start` (both the control and
the negative). That name is emitted identically in both versions —
`trace2/tr2_tgt_event.c:343` in `v2.54.0` and `v2.55.0` alike — and a future
rename would now surface as precondition 3 going red rather than as the
negative going permanently vacuous.

## Verification

The suite itself was **not** run locally — it behaves badly on the authoring
machine, so CI is the verification of record here, as it was for #2929. The
guard block was instead copied verbatim into a throwaway harness outside the
repository, reproducing the suite's `ok`/`fail`/`FAIL` machinery, and run
against eight injected fixture conditions on git 2.55.0:

| injected condition | result |
| --- | --- |
| shipped `git_q` (with `maintenance.auto=false`) | `ok` — 1 `child_start` traced, suite GREEN |
| pre-#2929 `git_q` (maintenance fork restored) | `fail` — maintenance child, suite RED |
| fixture `commit` made to fail inside `git_q` | `fail` — traced sequence failed (exit 1), suite RED |
| `GIT_TRACE2_EVENT` not exported | `fail` — no trace produced, suite RED |
| merge degraded to a fast-forward | `fail` — no stash-create child, suite RED |
| fast-forward **plus** a spurious ambient `child_start` injected into the trace | `fail` — no stash-create child, suite RED (a foreign child cannot stand in) |
| maintenance pattern drifted off the event shape | `fail` — pattern no longer matches the captured event, suite RED |
| pattern that matches only a TRIMMED sample (`'"child_start","child_id":[0-9]+,"argv":\["git","(maintenance\|gc)"'`) | `fail` — suite RED against the verbatim sample; it would have passed a trimmed one while never matching a real event |
| pre-#2929 `git_q` **and** a failing fixture commit at once | `fail` — traced sequence failed, suite RED (ordering cannot turn either into a green) |

The pre-fix shape traces 5 `child_start` events (4 of them
`["git","maintenance","run","--auto","--no-quiet","--detach"]`, spawned by the
three commits and the merge); the shipped shape traces exactly 1, the merge's
`["git","stash","create"]`. Every `FAIL` increment propagated out of the case
into the suite total, so each red is a real nonzero exit rather than a message
printed beside a green run.

A fresh-context reviewer read the guard cold, with the author's reasoning
withheld, and was asked to find any remaining way the case can report `ok`
while observing nothing. Its first pass confirmed the four scenarios go red but
found two genuine holes — the control certified only the `"child_start"` half
of the negative's pattern, and a bare `child_start` count could be satisfied by
an ambient child while the merge silently degraded — plus a latent abort if a
future hardening pass added `set -e` (`grep -c` exits 1 on a zero count).
Preconditions 3 and 4 and the `|| true` above are the response to those. Its
second pass confirmed the revision is non-vacuous and strictly stronger, and
caught one more: the sample it was checking the pattern against was a
*reduction*, not a capture, so a pattern relying on adjacency that holds only
in the reduction would pass the control while the negative stayed dead. The
sample is now a verbatim capture, the sample check uses a here-string rather
than a `printf | grep` pipeline (removing a SIGPIPE-under-`pipefail` class),
and the stash-create pattern drops a trailing `\]` whose escaping is
POSIX-undefined for an ordinary character.

Two knowingly accepted looser edges: `child_starts` is decorative (it feeds the
`ok` message only), and a compound failure — a real maintenance fork *and* a
degraded merge — reports the precondition-3 message rather than the regression
one. Both are still RED; only the diagnosis is less precise.

`shellcheck --rcfile=.shellcheckrc` is clean on the modified file and `bash -n`
parses it. One file changed; no behaviour change to `git_q` or to any other
case.

**CI closed the cross-version gap.** `contract-slice-prune-gate` on this PR
runs `git version 2.54.0` and logged:

```
ok: fixture git commands spawn no background maintenance (1 child_start event(s) traced)
check-contract-slice-prune.test.sh: 34 passed, 0 failed
```

So the `save_state()` stash-create child the control pins on is present on the
CI git version as measured, not merely as read from its source, and the control
does not red-line spuriously there.

## Related

- #2918 — the cleanup-race flake this guard exists to prevent regressing
- #2929 — the PR that added the guard and the `git_q` fix it verifies
