### PR TITLE
feat(work-items): document the re-decompose (rerouting) flow in decompose

### DIFF
--- a/docs/upstream/aihero-shipping-course.md
+++ b/docs/upstream/aihero-shipping-course.md
@@ -43,7 +43,7 @@ PARTIAL / REJECTED / OPEN.
 | B | /to-tickets deltas | C5–C8, C17 | work-items:decompose | ADOPTED | #2935 |
 | C | /implement + /tdd wiring, zero-assembly chain | C9–C11 | implementation:implement, tdd:principles, testing:write | OPEN | #2936 |
 | D | Two-axis review, spec lens, close-out review | C12–C16 | review:quality-gate/fanout | OPEN | #2937 |
-| E | Rerouting: tickets disposable, spec editable | — | work-items:decompose (re-decompose flow) | OPEN | #2949 |
+| E | Rerouting: tickets disposable, spec editable | — | work-items:decompose (re-decompose flow) | ADOPTED | #2949 |
 | F | /goal vs tickets posture | — | planning:draft-goal-condition | OPEN | #2938 |
 | W | Wayfinder deltas | C18–C20 | planning:wayfind | PARTIAL (C18+C19 adopted; C20 already-present) | #2939 |
 | X | Invocation doctrine (skills-repo delta PRs #878/#880) | C21–C23 | playbooks:skill-authoring, skill-quality:check | ADOPTED | #2940 |
@@ -99,6 +99,24 @@ consumer-configurable throughout.
   wrongly scoped item is closed + one Out-of-scope line, with no Decisions-so-far pointer.
 - **C20 ALREADY-PRESENT**: map body is a stable index not a mirror; Decisions-so-far is a
   pointer INDEX; Notes are links not recaps — recorded here, not restated in the skill docs.
+
+## Lane E (#2949)
+
+- **Rerouting recipe ADOPTED** (course "Rerouting" lesson) as a documented **re-decompose**
+  flow in `work-items:decompose` — a usage pattern of existing seam verbs, not a new
+  capability or skill: close unimplemented children not-planned with a superseding-direction
+  comment, keep implemented children untouched, re-interview/edit the spec, regenerate the
+  remaining slices through the normal draft→approve→publish steps, continue.
+  `/work-items:ship` routes to it when slices no longer fit the spec.
+- **Disposable-tickets / editable-spec doctrine ADOPTED** verbatim: slices are projections of
+  the spec at decomposition time; when the spec moves, stale projections are closed and
+  regenerated, never hand-patched.
+- **Reroute boundary ADOPTED**: post-ship wrongness is a new idea → new spec (new container or
+  topic), never a patch to the closed one — aligned with the archival-by-closure drift
+  doctrine (Lane A). Added beyond the course: small drift is an ordinary body edit, not a
+  reroute; claimed in-flight items are coordinated with, not closed from under their holder.
+- **Both spec homes covered**: the flow works against the topic Brief (no container) and the
+  tracker container body (Lane A's spec-on-tracker model).
 
 ## Decided at interview (2026-08-17, not per-lane)
 

--- a/plugins/work-items/.claude-plugin/plugin.json
+++ b/plugins/work-items/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "work-items",
-  "version": "0.36.0",
+  "version": "0.36.1",
   "description": "Manages development work items through a provider-neutral tracker seam that ships with the plugin (bundled dispatcher plus github and local-markdown adapters; seam plugin-dir canonical, adapters consumer-local-first): dashboard, taxonomy-labeled creation, a race-safe assignee-plus-lease claim protocol, recurring-schedule checks, TODO scanning, stale-lease auditing, plan decomposition into vertical-slice items, a macro-journey router over spec containers (rollup, per-container execution shape, next-step routing), raw-intake triage (issues and unsolicited PRs through raw, verified, briefed, autonomous-eligible states), plus the two work-items loop lanes of the loop-lane convention: a self-paced autonomous work-loop drain (work-class admission gate, adaptive item cap, PR-only) and an attended attend-queue escalation lane. The re-runnable setup skill binds the provider (.work-item-tracker.json), seeds the recurring-schedule seam (.github/recurring-schedule.json), and remaps canonical role labels.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/work-items/CHANGELOG.md
+++ b/plugins/work-items/CHANGELOG.md
@@ -3,6 +3,27 @@
 All notable changes to the `work-items` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.36.1]
+
+### Added
+
+- **Re-decompose (rerouting) flow in `/work-items:decompose` (#2949):** a
+  documented usage pattern of existing seam verbs — not a new capability —
+  for when mid-flight review shows the destination is wrong. Five steps:
+  close unimplemented children as not-planned (provider-mechanic close, each
+  with a one-line comment linking the superseding direction; claimed items
+  are coordinated with, never closed from under their holder), keep
+  implemented children untouched, re-interview/edit the spec where it lives
+  (container body under the spec-on-tracker model, or the topic Brief when no
+  container exists), regenerate the remaining slices through the normal
+  draft → approve → publish steps (`create-item --parent --blocked-by`), and
+  continue on the updated frontier. Doctrine: **tickets are disposable, the
+  spec is editable** — slices are projections of the spec at decomposition
+  time and are re-projected, never hand-patched, when the spec moves. Bounds:
+  post-ship wrongness is a new spec, never a patch to a closed container;
+  small drift is an ordinary body edit, not a reroute. `/work-items:ship`'s
+  existing re-slice route lands on this flow.
+
 ## [0.36.0]
 
 ### Added

--- a/plugins/work-items/skills/decompose/SKILL.md
+++ b/plugins/work-items/skills/decompose/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: "Break a plan, spec, or PRD into independently-grabbable work items using vertical-slice (tracer-bullet) decomposition, with HITL/AFK classification and dependency ordering. Use when: 'decompose', 'break a plan into tickets', 'decompose into tickets', 'create issues from plan', 'decompose this PRD', 'split this plan into work items', 'turn the plan into tickets', 'vertical-slice this plan', 'publish the spec as a container', 'spec container', 'publish the brief to the tracker'. Reads a PLAN.md / PRD.md / item body / conversation, drafts thin end-to-end slices, classifies each AFK (agent-ready) vs HITL (needs-human), gets approval, then publishes blockers-first via the seam with native dependency edges — optionally (opt-in at approval) under a spec container item carrying the Brief, with slices as native sub-items. Sibling skills: /work-items:track (backlog CRUD), /work-items:work (auto-select + execute), /work-items:triage (raw intake), /work-items:scan-todos (TODO sweep)."
+description: "Break a plan, spec, or PRD into independently-grabbable work items using vertical-slice (tracer-bullet) decomposition, with HITL/AFK classification and dependency ordering. Use when: 'decompose', 'break a plan into tickets', 'decompose into tickets', 'create issues from plan', 'decompose this PRD', 'split this plan into work items', 'turn the plan into tickets', 'vertical-slice this plan', 'publish the spec as a container', 'spec container', 'publish the brief to the tracker', 're-decompose', 'reroute the plan', 're-slice', 'the spec changed — redo the tickets'. Reads a PLAN.md / PRD.md / item body / conversation, drafts thin end-to-end slices, classifies each AFK (agent-ready) vs HITL (needs-human), gets approval, then publishes blockers-first via the seam with native dependency edges — optionally (opt-in at approval) under a spec container item carrying the Brief, with slices as native sub-items. Also owns the re-decompose (rerouting) flow for when mid-flight review shows the spec is wrong: close obsolete unimplemented slices, keep implemented ones, edit the spec, regenerate the rest. Sibling skills: /work-items:track (backlog CRUD), /work-items:work (auto-select + execute), /work-items:triage (raw intake), /work-items:scan-todos (TODO sweep)."
 argument-hint: "[source] — empty = topic PLAN.md; prd = topic PRD.md; #<number> = item body; or conversation context"
 user-invocable: true
 disable-model-invocation: false
@@ -257,3 +257,50 @@ item (or a new container).
 ### 5. Report
 
 After publishing, present summary: N items created, dependency graph, which are AFK vs HITL, and the suggested execution order — **work the frontier** (unblocked slices first).
+
+## Re-decompose (rerouting)
+
+Mid-flight review sometimes shows the **destination** is wrong — the spec no longer describes what
+should be built, so the remaining slices point somewhere nobody wants to go. Rerouting is a usage
+pattern of this skill and the existing seam verbs, not a separate capability or skill:
+`/work-items:ship` routes here when slices no longer fit the spec, and the flow below is what it
+routes to.
+
+The doctrine, stated once: **tickets are disposable, the spec is editable.** The two artifacts have
+different lifetimes — that is why they are separate. A slice is a projection of the spec at
+decomposition time; when the spec moves, stale projections are closed and regenerated from the
+edited spec, never hand-patched into meaning something the spec no longer says.
+
+1. **Close unimplemented children.** Enumerate the journey's remaining slices — via the seam
+   (`"$TRACKER" list-sub-items "<container-id>" --state all`) when a container exists, or the
+   topic PLAN.md's published-slice list when the spec lives only in the Brief — and close every
+   not-yet-started slice the new direction obsoletes. Closing is a provider-mechanic operation
+   (the bound adapter's operations reference, with the provider's not-planned state reason where
+   it has one — GitHub: `not planned`), each close carrying a one-line comment linking the
+   superseding direction (the container, or the item/PR that records the new direction). Skip
+   items with an active claim: coordinate with the claim holder — or route a stale lease to
+   `/work-items:track audit` — before closing work in flight.
+2. **Keep implemented children untouched.** Completed slices and their merged PRs are history, not
+   error — the reroute changes where the journey goes next, never what already landed. Do not
+   reopen, re-close, relabel, or edit them.
+3. **Re-interview / edit the spec.** The editable spec lives where the journey put it: the
+   **container body** (spec-on-tracker — an ordinary body edit through the bound adapter, behind
+   the same user approval as any tracker write) or the **topic Brief** (PLAN.md via the
+   tier-selected lookup) when no container was published. Re-run the interview machinery
+   (`/planning:interview` when installed, else a direct question round) or apply the user's
+   directed edits. The edited spec is what legitimizes the reroute — never regenerate slices
+   against a spec that still says the old thing.
+4. **Regenerate remaining slices.** Run this skill's normal Steps 2–4 against the edited spec:
+   draft the replacement slices, present for approval (the gate is mandatory here exactly as for
+   a fresh decomposition), then publish via the seam — `create-item` with
+   `--parent "<container-id>"` (when the container exists) and `--blocked-by` wiring the new
+   native blocker edges. Replacement slices are born triaged like any others.
+5. **Continue.** The journey resumes on the updated frontier — `/work-items:ship` re-states
+   position and routes the next item.
+
+**When NOT to reroute.** A spec that turns out wrong **after ship** is a new idea, not a routing
+error: open a new spec (a new container or a new topic), never patch the closed one — the
+container-lifecycle drift doctrine applies (a closed container is never edited into a living doc).
+And small drift — wording, a stale count, one acceptance criterion sharpened — is an ordinary body
+edit to the spec or slice, not a reroute: rerouting is for destination changes that obsolete
+slices.

--- a/plugins/work-items/skills/decompose/SKILL.md
+++ b/plugins/work-items/skills/decompose/SKILL.md
@@ -272,9 +272,13 @@ decomposition time; when the spec moves, stale projections are closed and regene
 edited spec, never hand-patched into meaning something the spec no longer says.
 
 1. **Close unimplemented children.** Enumerate the journey's remaining slices — via the seam
-   (`"$TRACKER" list-sub-items "<container-id>" --state all`) when a container exists, or the
-   topic PLAN.md's published-slice list when the spec lives only in the Brief — and close every
-   not-yet-started slice the new direction obsoletes. Closing is a provider-mechanic operation
+   (`"$TRACKER" list-sub-items "<container-id>" --state all`) when a container exists. When the
+   spec lives only in the Brief, no durable slice list exists outside the tracker (the publish
+   step records no slice IDs in PLAN.md), so reconstruct the set with a provider search (the
+   bound adapter's operations reference) for open items whose body cites the topic slug — the
+   `## Parent` provenance line every published slice carries — and confirm the reconstructed
+   set with the user before closing anything. Then close every not-yet-started slice the new
+   direction obsoletes. Closing is a provider-mechanic operation
    (the bound adapter's operations reference, with the provider's not-planned state reason where
    it has one — GitHub: `not planned`), each close carrying a one-line comment linking the
    superseding direction (the container, or the item/PR that records the new direction). Skip
@@ -295,8 +299,11 @@ edited spec, never hand-patched into meaning something the spec no longer says.
    a fresh decomposition), then publish via the seam — `create-item` with
    `--parent "<container-id>"` (when the container exists) and `--blocked-by` wiring the new
    native blocker edges. Replacement slices are born triaged like any others.
-5. **Continue.** The journey resumes on the updated frontier — `/work-items:ship` re-states
-   position and routes the next item.
+5. **Continue.** The journey resumes on the updated frontier. With a container,
+   `/work-items:ship` re-states position and routes the next item; a Brief-only journey
+   continues straight to the next unblocked slice (`/work-items:work`, or the Step 5 report's
+   frontier ordering) — `/work-items:ship` is a router over a container and has nothing to
+   stand on without one.
 
 **When NOT to reroute.** A spec that turns out wrong **after ship** is a new idea, not a routing
 error: open a new spec (a new container or a new topic), never patch the closed one — the

--- a/plugins/work-items/skills/decompose/evals/evals.json
+++ b/plugins/work-items/skills/decompose/evals/evals.json
@@ -83,6 +83,21 @@
         "Resolves the container label from the binding's config.container_label (default work-map) and adds the human-gated label instead of hard-coding label strings or making the container claimable",
         "States the close-at-ship ritual (close-out review against the container body, archival by closure) rather than leaving the container open as living documentation"
       ]
+    },
+    {
+      "id": 7,
+      "name": "re-decompose-reroute-disposable-tickets-editable-spec",
+      "prompt": "/work-items:decompose — mid-flight review showed our spec container's remaining direction is wrong: the export feature should stream, not batch. Two sub-items are already merged, one is claimed and in progress by another session, three are untouched. Close out the old tickets and cut new ones for the streaming direction.",
+      "expected_output": "Runs the re-decompose (rerouting) flow, not a fresh decomposition. Enumerates the container's children via the seam (list-sub-items --state all). The three untouched slices the new direction obsoletes are closed as not-planned through the bound adapter, each with a one-line comment linking the superseding direction. The claimed in-flight slice is NOT closed out from under its holder — the skill coordinates with the claim holder (or routes a stale lease to /work-items:track audit) before touching it. The two merged slices stay untouched — not reopened, relabeled, or edited. The spec is edited FIRST (the container body via an approved adapter body edit — or the topic Brief when no container exists) before any slices are regenerated; regeneration runs the normal draft steps and the approval gate holds — nothing publishes unapproved — with new slices created via create-item --parent --blocked-by. The disposable-tickets/editable-spec doctrine is what governs: slices are re-projected from the edited spec, never hand-patched. If the journey had already shipped, the skill would refuse to patch the closed container and open a new spec instead.",
+      "files": [],
+      "expectations": [
+        "Closes only the obsoleted unimplemented slices, as not-planned via the bound adapter, each with a one-line comment linking the superseding direction",
+        "Does not close the actively claimed slice out from under its holder — coordinates with the claim holder or routes a stale lease to /work-items:track audit first",
+        "Leaves already-implemented (merged) children untouched — no reopen, relabel, or edit",
+        "Edits the spec (container body via approved adapter edit, or topic Brief) before regenerating slices, never regenerating against the unedited spec",
+        "Holds the mandatory approval gate on regenerated slices and publishes them via create-item with --parent and native --blocked-by edges",
+        "Would treat post-ship wrongness as a new spec (new container or topic), never a patch to a closed container"
+      ]
     }
   ]
 }


### PR DESCRIPTION
Closes #2949

## Summary

Absorbs the course's rerouting recipe (Lane E of spec container #2933) into `/work-items:decompose` as a documented **re-decompose** flow — a usage pattern of existing seam verbs, not a new capability or skill. `/work-items:ship`'s existing "slices no longer fit the spec" route now lands on an owned, documented flow.

## Fix

- **`plugins/work-items/skills/decompose/SKILL.md`** — new `## Re-decompose (rerouting)` section covering the five steps with seam verbs named: (1) close unimplemented children as not-planned (provider-mechanic close through the bound adapter, one-line comment linking the superseding direction; claimed items are coordinated with — or routed to `/work-items:track audit` on a stale lease — never closed from under their holder), (2) keep implemented children untouched, (3) re-interview/edit the spec where it lives (container body under the spec-on-tracker model, or the topic Brief when no container exists), (4) regenerate remaining slices through the normal draft → approve → publish steps (`create-item --parent --blocked-by`, mandatory approval gate), (5) continue on the updated frontier. The disposable-tickets/editable-spec doctrine is stated once; the "when NOT to reroute" bounds cover post-ship wrongness (new spec, never a patch to a closed container) and small drift (ordinary body edit). Frontmatter description gains re-decompose trigger phrases.
- **`docs/upstream/aihero-shipping-course.md`** — Lane E verdict row flipped to ADOPTED; new `## Lane E (#2949)` section records the per-concept verdicts.
- **`plugins/work-items/CHANGELOG.md`** / **`plugin.json`** — work-items 0.36.1.

Acceptance criteria of #2949: re-decompose section with seam verbs named ✔; doctrine stated once ✔; works against both spec homes (topic Brief and tracker container) ✔.

## Verification

- `markdownlint-cli2` over the three changed markdown files: 0 issues.
- `jq empty` on the bumped `plugin.json`: valid.
- `plugins/work-items/tests/no-hardcoded-priority-scheme.test.sh`: PASS.
- `plugins/work-items/tools/work-item-tracker/work-item-tracker.test.sh`: 6/6 suites, all PASS (32 cases).

## Related

Refs #2933 (spec container — Lane E), #2934 (Lane A spec-on-tracker model the flow builds on), #3010 (the `/work-items:ship` router whose re-slice route lands here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CnzwTKoTa6xNY7iyEzMYpm

---
_Generated by [Claude Code](https://claude.ai/code/session_01CnzwTKoTa6xNY7iyEzMYpm)_