### PR TITLE
chore: re-pin the pr-issue-linkage caller to v0.14.2

### DIFF
--- a/.github/workflows/pr-issue-linkage.yml
+++ b/.github/workflows/pr-issue-linkage.yml
@@ -28,8 +28,10 @@ concurrency:
 
 jobs:
   pr-issue-linkage:
-    permissions: {}
-    uses: melodic-software/ci-workflows/.github/workflows/pr-issue-linkage.yml@e94438746c300b02385a7f8a2a2dcd19a7f4ad4a # v0.10.2
+    permissions:
+      pull-requests: read
+      actions: read
+    uses: melodic-software/ci-workflows/.github/workflows/pr-issue-linkage.yml@7107b34832a7b6db5d08d3b132621c599fbe5e50 # v0.14.2
     with:
       runner: ubuntu-24.04
       # dependabot PR bodies cannot carry the closing-keyword + `## Related`


### PR DESCRIPTION
## Summary

Re-pins the `pr-issue-linkage` caller workflow from the ci-workflows reusable at v0.10.2 to v0.14.2, converging this repo with the fleet per standards sync audit Phase 3.6 (approved decision 3-A). The reusable at v0.14.2 is byte-identical to v0.15.0.

## Fix

Two changes in `.github/workflows/pr-issue-linkage.yml` only:

- `uses:` ref updated `e94438746c300b02385a7f8a2a2dcd19a7f4ad4a # v0.10.2` → `7107b34832a7b6db5d08d3b132621c599fbe5e50 # v0.14.2`.
- The linkage job's `permissions: {}` raised to the v0.14.2 contract's required reads: `pull-requests: read` and `actions: read`.

No policy edit: the synced runner-policy copy at `.github/standards/runner-policy/policy.json` already allowlists the v0.14.2 SHA with the required caller permissions.

## Verification

- `grep -c "pr-issue-linkage.yml@7107b348" .github/standards/runner-policy/policy.json` → 1 (entry pre-exists).
- `grep -c 7107b348 .github/workflows/pr-issue-linkage.yml` → 1; no `e9443874` remains.
- `git diff --stat` on the commit: exactly one file changed (4 insertions, 2 deletions).

## Related

No linked issue — cross-repo work tracked in the standards audit topic.

- melodic-software/standards docs/topics/standards-sync-audit/ (Phase 3.6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013NhxMDn7vZdbs7Cq32m56M
