### PR TITLE
feat: close the three deferred batch-simplify repo-mode questions

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,18 +96,27 @@ scripts/affected-tests.sh --explain       # ... and say why each one was selecte
 scripts/affected-tests.sh path/to/file.sh # explicit paths instead of a diff
 ```
 
-It maps a changed file to its co-located `*.test.sh`, to any suite that names
-it, and to its dependents transitively — and it fans a shared-lib change out to
-every carrying plugin by reading the `copies=(...)` array out of that lib's
+It maps a changed file to its co-located suite, to any suite that names it, and
+to its dependents transitively — and it fans a shared-lib change out to every
+carrying plugin by reading the `copies=(...)` array out of that lib's
 `scripts/sync-*.sh` manifest, the same manifest CI's `*-sync` lanes enforce. The
 fan-out is derived on every run, never transcribed, so a new carrying plugin is
 covered the moment it exists.
 
+All four ecosystems that carry suites here are selected, each by its own naming
+convention: shell `*.test.sh`, Node `*.test.js` and `*.test.mjs`, Python
+`test_*.py`, and Pester `*.Tests.ps1`. Only the shell suites are executed by
+`--run`, because the others are driven by lane-specific invocations that cannot
+be derived from a suite path; those are named as `NOT RUN` and `--run` exits 3
+rather than reporting success over suites that never executed.
+
 A changed file that maps to nothing is an **error**, not an empty selection —
 "zero suites" must never be read as "nothing to run". Path classes that
-genuinely carry no shell suite are recorded, with the CI lane that does cover
-them, in [`scripts/affected-tests-no-suite.txt`](scripts/affected-tests-no-suite.txt);
-`--allow-unmapped` is the escape hatch for everything else.
+genuinely carry no suite are recorded, with the CI lane that does cover them, in
+[`scripts/affected-tests-no-suite.txt`](scripts/affected-tests-no-suite.txt);
+`--allow-unmapped` is the escape hatch for everything else. That list is for
+prose and manifests, never for code: a source file with no coverage is supposed
+to fail here.
 
 The runner is deliberately sequential: parallelising it measured sublinear
 (the suites are spawn-bound), and several guardrails suites assert wall-clock

--- a/plugins/code-tidying/.claude-plugin/plugin.json
+++ b/plugins/code-tidying/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "code-tidying",
-  "version": "0.12.1",
+  "version": "0.13.0",
   "description": "Code tidying and comment hygiene: /code-tidying:tidy proactively hunts a rotated, glob-scoped lane for Beck-style tidyings under a research-backed scope budget and ships one tight PR; /code-tidying:batch-simplify sweeps a time window, a branch, or an entire repository through grouped, dependency-ordered simplification waves with a never-drop deferred-items contract; /code-tidying:dissolve-comments enforces self-describing expressive code over a diff — deletes zero-information comments, dissolves code-expressible ones into names and structure behind a tests gate (safe mode restricts applied edits to removals), and keeps only terse load-bearing comments code cannot express; /code-tidying:audit-comment-residue is a read-only classifier that flags history, plan, conversational, and ticket/PR residue in code comments for author-applied deletion. Project-specific tidy lanes are scaffolded into a tracked .claude/tidy-lanes/ config folder by a re-runnable setup skill.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/code-tidying/CHANGELOG.md
+++ b/plugins/code-tidying/CHANGELOG.md
@@ -3,6 +3,42 @@
 All notable changes to the `code-tidying` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.13.0]
+
+### Added
+
+- **`batch-simplify` narrows any scope to a path.** The argument grammar is now
+  `[<scope>] [<path>...] [docs]`: a scope selects the file universe (a time window, the branch diff,
+  or the whole repository) and a path selects a region of it. Narrowing is orthogonal to scope
+  rather than a repo-only sub-mode, because binding it to `repo` would assert that only the
+  whole-repository universe may be narrowed — leaving "what I changed this week, but only under
+  `plugins/knowledge`" unreachable and forcing a second grammar change later. The path is applied as
+  a native git pathspec on each mode's own discovery command, so merge-base semantics for branch
+  mode and `--since` for a time window still hold over the narrowed set, and repo mode's
+  confirmation gate and tracked-modification refusal still fire on the narrowed inventory. Purely
+  additive: a path argument previously fell through to the ask-the-user rule in every mode, so no
+  existing invocation changes meaning. A token counts as a path only if it **resolves** — without
+  that condition the addition would have weakened the token-exact typo guard, turning `rebranch`
+  from an explicit question into a silent sweep of nothing.
+- **`repo <lane>` is explicitly rejected**, with the rationale recorded in the reference spoke. A
+  lane in the sibling `/code-tidying:tidy` is a seven-part object (scope globs, merge semantics,
+  watch-for patterns, extra exclusions, verification commands, commit type, research sources) of
+  which this skill would use only the globs; reusing the word would leave `lane` meaning two
+  different things in sibling skills of one plugin. Paths also compose where lanes do not — lanes
+  exist only in repos that have configured `.claude/tidy-lanes/`.
+
+### Changed
+
+- **The hotspot-ranking question is recorded as settled** in `context/repo-mode.md`. The spoke
+  previously argued only against the weak forms (churn alone, churn weighted by file size), leaving
+  the strong form — churn weighted by a complexity or code-health measure, which is what "hotspot
+  analysis" usually means — unaddressed and so open in practice. It is now rejected on a reason that
+  reaches the strong form: ranking answers "where should I look first", a triage question repo mode
+  has already answered by sweeping every group and filing High-only with no cap, so reordering work
+  that is all going to happen anyway has no consumer. The one condition under which reopening would
+  be coherent is named: ordering only matters under truncation or resume, so a truncation knob would
+  have to land first.
+
 ## [0.12.1]
 
 ### Changed

--- a/plugins/code-tidying/skills/batch-simplify/SKILL.md
+++ b/plugins/code-tidying/skills/batch-simplify/SKILL.md
@@ -41,7 +41,9 @@ Trigger: the remaining argument, lowercased and whitespace-normalized, **equals*
 
 Match the whole argument, never a substring: an argument that merely *contains* "branch" — a path, a filename, a future scope value — is not a branch-mode request, and routing it there silently sweeps the wrong file set.
 
-**Detection heuristic** (after stripping the `docs` flag and any path tokens): empty remaining argument → default `48h` time window; matches `^\d+[hdw]$` → time-window mode; equals a branch trigger phrase → branch mode; equals `repo` → repo mode; anything else → ask the user rather than guessing.
+**Detection heuristic** (after stripping the `docs` flag): read the **first** remaining token as the scope — matches `^\d+[hdw]$` → time-window mode; equals a branch trigger phrase → branch mode; equals `repo` → repo mode. Empty argument → default `48h`. Every token after the scope is a path.
+
+Decide the scope **before** testing any token as a path, never after. Stripping paths first lets a repository that happens to contain a directory named `repo` or `branch` swallow the scope keyword — `/code-tidying:batch-simplify repo` would resolve `repo` as a path, find no scope left, and silently run the 48-hour default narrowed to that directory instead of the whole-repository sweep that was asked for. If the first token is not a scope, the scope defaults to `48h` and *every* token is a path; a token that resolves to nothing is neither a scope nor a path, so it falls through to asking the user rather than guessing. To sweep a directory genuinely named `repo`, spell it `./repo`.
 
 ### Mode 3: Whole repository
 
@@ -52,6 +54,8 @@ Trigger: the remaining argument, lowercased and whitespace-normalized, **equals*
 Any scope accepts one or more trailing paths: `48h plugins/knowledge`, `branch src/`, `repo plugins/code-tidying`. Narrowing is orthogonal to scope because the two answer different questions — the scope decides *which universe* (changed recently, changed on this branch, everything), the path decides *which region of it*. Binding paths to one mode would assert that only that universe may be narrowed, which nothing supports.
 
 Apply the path as a native pathspec on that mode's own discovery command (`-- <path>`), never as a filter over the results: the pathspec is what makes the mode's own semantics — merge-base for branch, `--since` for a window — hold over the narrowed set.
+
+Resolve each path against the **invocation directory**, then express it **repo-root-relative** before handing it to a root-anchored command. Repo mode runs `git -C <repo-root>`, and `-C` changes directory before the pathspec is applied: a bare `code-tidying` typed from inside `plugins/` resolves locally but would be read at the root as a top-level `code-tidying`, sweeping the wrong set or nothing at all while reporting a clean run.
 
 A token counts as a path only if it **resolves** to an existing file or directory. A token that resolves to nothing is neither a path nor a scope, so it falls through to the ask-the-user rule — which is what keeps a mistyped scope or path an explicit question instead of a silent sweep of nothing.
 
@@ -96,7 +100,7 @@ Requires being on a non-default branch. If on the default branch, report the err
 { git log --since="${NORMALIZED_TIME_WINDOW} ago" --diff-filter=ACDMR --name-only --pretty=format:""; git diff --diff-filter=ACDMR --name-only HEAD; } | sort -u | grep -v '^$'
 ```
 
-**Repo mode** — the file universe is `git -C "$(git rev-parse --show-toplevel)" ls-files --cached --others --exclude-standard [-- <path>...]`, anchored to the repo root so a run started in a subdirectory still sweeps the whole tree. Refuse to start if any file in that universe carries tracked modifications, naming them; scope that check to the swept universe and exclude the working-notes location from both the check and the sweep — a whole-tree refusal would block the checklist this skill writes as its own first step, and would block every resume.
+**Repo mode** — the file universe is `git -C "$(git rev-parse --show-toplevel)" ls-files --cached --others --exclude-standard [-- <path>...]`, with any `<path>` converted to repo-root-relative first (the `-C` makes the pathspec root-anchored, so a path typed relative to a subdirectory would otherwise be read against the wrong base), anchored to the repo root so a run started in a subdirectory still sweeps the whole tree. Refuse to start if any file in that universe carries tracked modifications, naming them; scope that check to the swept universe and exclude the working-notes location from both the check and the sweep — a whole-tree refusal would block the checklist this skill writes as its own first step, and would block every resume.
 
 ### Phase 2: Filter to code files
 

--- a/plugins/code-tidying/skills/batch-simplify/SKILL.md
+++ b/plugins/code-tidying/skills/batch-simplify/SKILL.md
@@ -53,7 +53,7 @@ Any scope accepts one or more trailing paths: `48h plugins/knowledge`, `branch s
 
 Apply the path as a native pathspec on that mode's own discovery command (`-- <path>`), never as a filter over the results: the pathspec is what makes the mode's own semantics — merge-base for branch, `--since` for a window — hold over the narrowed set.
 
-A token counts as a path only if it **resolves** to an existing file or directory. A token that resolves to nothing is neither a path nor a scope, so it falls through to the ask-the-user rule — which is what keeps a typo (`brnach`) an explicit question instead of a silent sweep of nothing.
+A token counts as a path only if it **resolves** to an existing file or directory. A token that resolves to nothing is neither a path nor a scope, so it falls through to the ask-the-user rule — which is what keeps a mistyped scope or path an explicit question instead of a silent sweep of nothing.
 
 `repo <lane>` is deliberately **not** accepted; use a path. Rationale in [context/reference.md](context/reference.md) "Why narrowing is a path, not a lane".
 

--- a/plugins/code-tidying/skills/batch-simplify/SKILL.md
+++ b/plugins/code-tidying/skills/batch-simplify/SKILL.md
@@ -1,8 +1,8 @@
 ---
-description: "Batch-run simplification across changed files — or across an entire repository — grouped by ecosystem and dependency order. Use when: 'batch simplify', 'simplify recent changes', 'simplify everything', 'forgot to run simplify', 'catch up on simplify', 'simplify my branch changes', 'simplify the whole repo', or after a multi-session sprint. Accepts a time window (`24h`, `7d`), `branch` to diff the current branch vs the default branch, or `repo` for a confirmed whole-repository sweep; optional `docs` flag includes .md files for post-migration or post-refactor doc sweeps. Skip for single-file cleanup — use /simplify instead."
+description: "Batch-run simplification across changed files — or across an entire repository — grouped by ecosystem and dependency order. Use when: 'batch simplify', 'simplify recent changes', 'simplify everything', 'forgot to run simplify', 'catch up on simplify', 'simplify my branch changes', 'simplify the whole repo', 'simplify just this folder', 'simplify everything under <path>', or after a multi-session sprint. Accepts a time window (`24h`, `7d`), `branch` to diff the current branch vs the default branch, or `repo` for a confirmed whole-repository sweep; any scope narrows to one or more trailing paths; optional `docs` flag includes .md files for post-migration or post-refactor doc sweeps. Skip for single-file cleanup — use /simplify instead."
 user-invocable: true
 disable-model-invocation: false
-argument-hint: "[time-window | branch | repo] [docs] (e.g., /batch-simplify 72h, /batch-simplify branch docs, /batch-simplify repo — default: 48h)"
+argument-hint: "[time-window | branch | repo] [path...] [docs] (e.g., /batch-simplify 72h, /batch-simplify branch docs, /batch-simplify repo plugins/foo — default: 48h)"
 shell: bash
 metadata:
   workflow-stage: review
@@ -23,7 +23,7 @@ For any batch run (Phases 1-8), copy `templates/checklist.md` into your project'
 
 ## Arguments
 
-`$ARGUMENTS` — optional scope for the file scan. Three modes:
+`$ARGUMENTS` — optional scope for the file scan: `[<scope>] [<path>...] [docs]`. The scope picks a *universe* (three modes below); a path narrows it to a *region*. They are independent, so any scope takes any path.
 
 ### Mode 1: Time window (default)
 
@@ -41,11 +41,21 @@ Trigger: the remaining argument, lowercased and whitespace-normalized, **equals*
 
 Match the whole argument, never a substring: an argument that merely *contains* "branch" — a path, a filename, a future scope value — is not a branch-mode request, and routing it there silently sweeps the wrong file set.
 
-**Detection heuristic** (after stripping the `docs` flag): empty remaining argument → default `48h` time window; matches `^\d+[hdw]$` → time-window mode; equals a branch trigger phrase → branch mode; equals `repo` → repo mode; anything else → ask the user rather than guessing.
+**Detection heuristic** (after stripping the `docs` flag and any path tokens): empty remaining argument → default `48h` time window; matches `^\d+[hdw]$` → time-window mode; equals a branch trigger phrase → branch mode; equals `repo` → repo mode; anything else → ask the user rather than guessing.
 
 ### Mode 3: Whole repository
 
-Trigger: the remaining argument, lowercased and whitespace-normalized, **equals** `repo`. Sweeps every non-excluded file in the repository rather than a diff — including untracked files that are not ignored, so newly added work is swept too. Explicit entry only: it never auto-escalates from another mode, and it confirms the inventory with the user after Phase 4 — once grouping and wave planning have produced the numbers that gate reports — and before any group is dispatched. `repo <path>` is deliberately not accepted; a trailing token falls through to the ask-the-user rule above. Repo-scale machinery — grouping, waves, concurrency, resume, delivery — lives in [context/repo-mode.md](context/repo-mode.md), loaded only when this mode fires.
+Trigger: the remaining argument, lowercased and whitespace-normalized, **equals** `repo`. Sweeps every non-excluded file in the repository rather than a diff — including untracked files that are not ignored, so newly added work is swept too. Explicit entry only: it never auto-escalates from another mode, and it confirms the inventory with the user after Phase 4 — once grouping and wave planning have produced the numbers that gate reports — and before any group is dispatched. A trailing path narrows the sweep (see **Narrowing to a path**) without changing any of the above — the confirmation gate still fires, on the narrowed inventory. Repo-scale machinery — grouping, waves, concurrency, resume, delivery — lives in [context/repo-mode.md](context/repo-mode.md), loaded only when this mode fires.
+
+### Narrowing to a path
+
+Any scope accepts one or more trailing paths: `48h plugins/knowledge`, `branch src/`, `repo plugins/code-tidying`. Narrowing is orthogonal to scope because the two answer different questions — the scope decides *which universe* (changed recently, changed on this branch, everything), the path decides *which region of it*. Binding paths to one mode would assert that only that universe may be narrowed, which nothing supports.
+
+Apply the path as a native pathspec on that mode's own discovery command (`-- <path>`), never as a filter over the results: the pathspec is what makes the mode's own semantics — merge-base for branch, `--since` for a window — hold over the narrowed set.
+
+A token counts as a path only if it **resolves** to an existing file or directory. A token that resolves to nothing is neither a path nor a scope, so it falls through to the ask-the-user rule — which is what keeps a typo (`brnach`) an explicit question instead of a silent sweep of nothing.
+
+`repo <lane>` is deliberately **not** accepted; use a path. Rationale in [context/reference.md](context/reference.md) "Why narrowing is a path, not a lane".
 
 ### Flag: `docs`
 
@@ -67,7 +77,7 @@ Strip token-wise, never by substring: a substring strip mutates any argument tha
 
 ### Phase 1: Discover changed code files
 
-Both modes union committed history with uncommitted changes (staged + unstaged) so nothing is missed.
+Both modes union committed history with uncommitted changes (staged + unstaged) so nothing is missed. When a path was given, append `-- <path>...` to every git command in this phase, including the working-tree `git diff`, so the narrowing holds over both halves of the union.
 
 **Branch mode** (argument matches the branch/feature-branch/all-commits pattern):
 
@@ -86,7 +96,7 @@ Requires being on a non-default branch. If on the default branch, report the err
 { git log --since="${NORMALIZED_TIME_WINDOW} ago" --diff-filter=ACDMR --name-only --pretty=format:""; git diff --diff-filter=ACDMR --name-only HEAD; } | sort -u | grep -v '^$'
 ```
 
-**Repo mode** — the file universe is `git -C "$(git rev-parse --show-toplevel)" ls-files --cached --others --exclude-standard`, anchored to the repo root so a run started in a subdirectory still sweeps the whole tree. Refuse to start if any file in that universe carries tracked modifications, naming them; scope that check to the swept universe and exclude the working-notes location from both the check and the sweep — a whole-tree refusal would block the checklist this skill writes as its own first step, and would block every resume.
+**Repo mode** — the file universe is `git -C "$(git rev-parse --show-toplevel)" ls-files --cached --others --exclude-standard [-- <path>...]`, anchored to the repo root so a run started in a subdirectory still sweeps the whole tree. Refuse to start if any file in that universe carries tracked modifications, naming them; scope that check to the swept universe and exclude the working-notes location from both the check and the sweep — a whole-tree refusal would block the checklist this skill writes as its own first step, and would block every resume.
 
 ### Phase 2: Filter to code files
 

--- a/plugins/code-tidying/skills/batch-simplify/context/reference.md
+++ b/plugins/code-tidying/skills/batch-simplify/context/reference.md
@@ -70,3 +70,23 @@ do not maintain a command table here. In order:
    `Makefile`, or manifest to pick them).
 
 Include the group's verification step in each simplifier agent's prompt so the agent self-verifies before returning; Phase 7 re-runs it as the safety net.
+
+## Why narrowing is a path, not a lane (Arguments)
+
+`repo <lane>` was the other candidate narrowing surface, and it is deliberately
+rejected.
+
+A lane in the sibling `/code-tidying:tidy` is a seven-part object: scope globs,
+merge semantics, watch-for patterns, lane-specific extra exclusions,
+verification commands, a Conventional Commits type, and preferred research
+sources. This skill would consume exactly one of those parts — the scope globs
+— and ignore the other six. Reusing the word for "a place to get globs from"
+would leave `lane` meaning two different things in sibling skills of one
+plugin, which is the kind of drift that makes a vocabulary stop carrying
+information.
+
+A path also composes where a lane does not. Lanes are defined per project in
+`.claude/tidy-lanes/`, so a lane-only surface would be unusable in any repo
+that has not set them up, while every repo has paths. Anyone who does want
+lane-shaped sweeps already has the surface for it: `/code-tidying:tidy` owns
+lane rotation under a scope budget, and this skill owns the wide sweep.

--- a/plugins/code-tidying/skills/batch-simplify/context/repo-mode.md
+++ b/plugins/code-tidying/skills/batch-simplify/context/repo-mode.md
@@ -78,15 +78,28 @@ Order groups by dependency constraint only: shared and canonical libraries befor
 consumes them. Simplifying a shared helper after its callers means the callers were reviewed against
 a shape that no longer exists.
 
-**Churn ranking is deliberately not used**, and a later reader should not add it back as an
-improvement. Ordering by change frequency alone is a documented false-positive generator — the files
-that change most are frequently the ones that are supposed to change most, and ranking them as
-problems surfaces noise ahead of signal. Weighting churn by file size amplifies that error rather
-than correcting it, because size correlates with legitimate churn. Dependency order has a defensible
-reason to exist: correctness. Churn order does not.
+**Hotspot ranking is deliberately not used. This is a settled decision, not an open question**, and
+a later reader should not add it back as an improvement.
+
+Ordering by change frequency alone is a documented false-positive generator — the files that change
+most are frequently the ones that are supposed to change most, and ranking them as problems surfaces
+noise ahead of signal. Weighting churn by file size amplifies that error rather than correcting it,
+because size correlates with legitimate churn.
+
+The strongest form of the idea — churn weighted by a complexity or code-health measure, which is what
+"hotspot analysis" usually means — is rejected for a different and more decisive reason than the weak
+forms, and rejecting only the weak ones would leave it open. Hotspot ranking answers *where should I
+look first*, which is a triage question. Repo mode has already answered it: the sweep covers every
+group in the universe, and filing is High-only with no numeric cap. A ranking that reorders work
+which is all going to happen anyway changes nothing about what gets found. It has no consumer here.
 
 Ordering only changes outcomes when a run is truncated or resumed, since an untruncated run reaches
-every group regardless. That is the whole of its job here.
+every group regardless. That is the whole of its job here — and it is why the two are coupled: a
+truncation knob is the only thing that would GIVE ranking a consumer. So reopening this coherently
+means landing that knob first and accepting what it implies (a repo sweep that deliberately stops
+early), then bringing a ranking signal with a second criterion beyond frequency. Adding the ranking
+on its own, in the order the idea usually arrives, buys a documented false-positive mode and nothing
+else.
 
 ## Concurrency
 

--- a/plugins/code-tidying/skills/batch-simplify/evals/evals.json
+++ b/plugins/code-tidying/skills/batch-simplify/evals/evals.json
@@ -66,7 +66,8 @@
         "Does NOT treat 'rebranch' as a branch-mode request (substring containment is not a match)",
         "Does not silently fall back to the 48h default for an argument it cannot classify",
         "Asks the user what scope was intended, per the detection heuristic's unknown-argument rule",
-        "The docs flag is stripped token-wise: a token is dropped only when it equals 'docs', so an argument containing those letters is left intact for the mode parser"
+        "The docs flag is stripped token-wise: a token is dropped only when it equals 'docs', so an argument containing those letters is left intact for the mode parser",
+        "Does NOT treat 'rebranch' as a path: a token counts as a path only when it resolves to an existing file or directory, so a non-resolving token still falls through to the ask-the-user rule rather than narrowing the sweep to nothing"
       ]
     },
     {
@@ -112,6 +113,47 @@
         "Files work items for High-priority deferrals only, with no numeric cap, one item per concern rather than per site",
         "Delivers one independently mergeable pull request per wave, merged before the next wave opens — not one repository-wide pull request",
         "Keeps concurrency to a 4-6 simplifier soft cap and degrades to sequential under rate-limit pressure rather than retrying"
+      ]
+    },
+    {
+      "id": 9,
+      "name": "path-narrows-a-non-repo-scope",
+      "prompt": "/batch-simplify 7d plugins/knowledge",
+      "expected_output": "Runs the 7-day time-window mode narrowed to plugins/knowledge. Scope and path are independent: the scope still selects which universe (changed in 7 days), the path selects which region of it, and narrowing is not reserved to repo mode.",
+      "files": [],
+      "expectations": [
+        "Routes '7d' to time-window mode and treats 'plugins/knowledge' as a path, not as an unknown scope",
+        "Does NOT refuse the path on the grounds that narrowing belongs to repo mode",
+        "Passes the path as a native git pathspec (-- plugins/knowledge) on the discovery commands rather than filtering results afterwards",
+        "Applies the pathspec to BOTH halves of the union — the git log window and the working-tree git diff",
+        "Normalizes '7d' to '7 days' for git's approxidate parser"
+      ]
+    },
+    {
+      "id": 10,
+      "name": "path-narrows-repo-mode-without-loosening-its-gate",
+      "prompt": "/batch-simplify repo plugins/code-tidying",
+      "expected_output": "Enters repo mode narrowed to plugins/code-tidying. The narrowing changes the file universe only; the confirmation gate, the tracked-modification refusal and the repo-mode spoke all still apply, now over the narrowed inventory.",
+      "files": [],
+      "expectations": [
+        "Routes 'repo' to repo mode with 'plugins/code-tidying' as a path rather than asking the user",
+        "Adds the pathspec to git ls-files --cached --others --exclude-standard, still anchored to the repository root",
+        "Still presents an inventory summary and waits for confirmation before dispatching any simplifier",
+        "Scopes the tracked-modification refusal to the narrowed universe, not the whole tree",
+        "Still loads context/repo-mode.md for the repo-scale machinery"
+      ]
+    },
+    {
+      "id": 11,
+      "name": "a-non-resolving-token-is-not-a-path",
+      "prompt": "/batch-simplify repo plugins/does-not-exist",
+      "expected_output": "Does not sweep. 'plugins/does-not-exist' resolves to nothing, so it is neither a path nor a scope and falls through to the ask-the-user rule. Treating it as a path would silently sweep an empty universe and report a clean run over nothing.",
+      "files": [],
+      "expectations": [
+        "Checks that the token resolves to an existing file or directory before accepting it as a path",
+        "Asks the user what was meant rather than sweeping an empty file universe",
+        "Does NOT report 'no code files found' as though the run had succeeded",
+        "Does not fall back to an unnarrowed whole-repository sweep, which would be wider than what was asked for"
       ]
     }
   ]

--- a/scripts/affected-tests.sh
+++ b/scripts/affected-tests.sh
@@ -1,7 +1,11 @@
 #!/usr/bin/env bash
-# Select the shell test suites (**/*.test.sh) that cover a set of changed files,
-# so a developer can run what their change actually affects instead of the whole
-# corpus. The full corpus is tens of minutes of wall clock on a Windows box
+# Select the test suites that cover a set of changed files, so a developer can
+# run what their change actually affects instead of the whole corpus. Four
+# ecosystems carry suites here and each names them differently: shell
+# **/*.test.sh, Node **/*.test.js and **/*.test.mjs, Python **/test_*.py, and
+# Pester **/*.Tests.ps1.
+#
+# The full corpus is tens of minutes of wall clock on a Windows box
 # (Git Bash pays ~140ms per process spawn, and these suites are spawn-bound),
 # which is long enough that nobody runs it locally and regressions reach CI.
 #
@@ -14,7 +18,9 @@
 #   scripts/affected-tests.sh --print-fanout P   print the copy set DERIVED for shared source P
 #
 # Exit: 0 selected (or nothing to do); 1 an unmapped changed file, or a failing
-# suite under --run; 2 usage or a broken derivation.
+# suite under --run; 2 usage or a broken derivation; 3 --run ran every shell
+# suite it selected but ALSO selected suites in other ecosystems, whose runner
+# it deliberately will not guess (see the --run note at the foot of this file).
 #
 # DIRECTION: over-selection is safe, under-selection is not. Every rule below is
 # deliberately generous — a basename match counts even when it lands in a
@@ -29,15 +35,28 @@
 # --allow-unmapped is the one-flag escape.
 #
 # SELECTION RULES
-#   R1 self          a changed *.test.sh selects itself.
-#   R2 co-located    <dir>/<stem>.<ext> selects <dir>/<stem>.test.sh when it
-#                    exists — the dominant convention in this repo (foo.sh ->
-#                    foo.test.sh, foo.py -> foo.test.sh, foo.mjs -> foo.test.sh).
-#   R3 referenced    any *.test.sh whose text contains the file's basename is a
-#                    covering suite (it names the file, so it exercises it).
-#   R4 dependents    any other *.sh whose text contains the file's basename is a
-#                    dependent; R2/R3 are then applied to IT, transitively. This
-#                    is what carries a lib change out to the hooks that source it.
+#   R1 self          a changed suite selects itself, in any ecosystem.
+#   R2 co-located    <dir>/<stem>.<ext> selects the sibling suites covering it,
+#                    under each ecosystem's OWN naming convention: <stem>.test.sh,
+#                    <stem>.test.js, <stem>.test.mjs, <stem>.Tests.ps1, and
+#                    <dir>/test_<stem>.py — the last also with `-` folded to `_`,
+#                    which is how this repo names the Python suites covering its
+#                    hyphenated scripts (check-manifest-duplicate-keys.py ->
+#                    test_check_manifest_duplicate_keys.py). EVERY match is taken,
+#                    never just the first: a .py can carry both a test_<stem>.py
+#                    and a wrapping <stem>.test.sh, and stopping at one
+#                    under-selects, which is the unsafe direction.
+#   R3 referenced    any SUITE whose text contains the file's basename is a
+#                    covering suite (it names the file, so it exercises it). This
+#                    rule is a text match and therefore language-agnostic: a
+#                    Pester suite dot-sourcing Foo.ps1 and a Node suite importing
+#                    foo.js are found exactly the way a shell suite is. Widening
+#                    the corpus is what taught it the other three ecosystems; the
+#                    rule itself did not change.
+#   R4 dependents    any other source file (.sh .js .mjs .py .ps1 .psm1) whose
+#                    text contains the file's basename is a dependent; R2/R3 are
+#                    then applied to IT, transitively. This is what carries a lib
+#                    change out to the hooks that source it.
 #   R5 shared-lib    a file that is the `src=` of a scripts/sync-*.sh selects
 #                    every path in that script's `copies=(...)` array, and then
 #                    R2/R3/R4 on each copy. The copy set is DERIVED from the sync
@@ -55,8 +74,29 @@
 # basename match carries no coverage signal (SKILL.md alone appears in 20
 # unrelated suites). Such files fall through to R2, then to the no-suite list.
 #
-# The transitive walk has no depth cap. It terminates on the visited set, and
-# its worst case is selecting every suite — the safe direction.
+# The transitive walk has no depth cap WITHIN one ecosystem. It terminates on
+# the visited set, and its worst case is selecting every suite — the safe
+# direction.
+#
+# ACROSS ecosystems it takes exactly one hop, and this asymmetry is load-bearing
+# rather than tidiness. Within a language, "B's text contains A's basename" is a
+# real dependency: shell sources shell, Node imports Node. Across languages it
+# usually is not — a .ps1 that happens to contain the characters "paths.js" is
+# not loading it — so chaining those coincidences compounds them. Measured
+# before this rule existed, with the corpus widened to four ecosystems and the
+# walk left uncapped: EVERY .js file in the repo selected the same 156 of 439
+# suites, and one selected 376, because the walk crossed js -> ps1 -> sh and
+# saturated on the hubs at the far end (Assert-CheckResult.ps1, hook-utils.sh).
+# An answer that is identical for every file in a language carries no
+# information about which file changed, which is the tool failing at its whole
+# job even though it fails in the "safe" direction.
+#
+# So a cross-language match is still FOLLOWED — one hop, far enough to apply
+# R2/R3 and pick up the suite covering it, which is what keeps a .sh wrapper
+# around a .py helper working — but it does not become a launching point for
+# further walking. This costs nothing that was ever load-bearing: before the
+# corpus was widened, the reverse lookup was `-- '*.sh'`, so cross-language
+# edges did not exist at all and no shell-to-shell chain is shortened by this.
 #
 # KNOWN LIMIT, in the safe direction: R3/R4 look the basename up with
 # `git grep -o -F`, which is an unanchored SUBSTRING search — not a token match
@@ -298,22 +338,64 @@ add_suite() {
   return 0
 }
 
-# colocated_suite <path> -> echo the sibling .test.sh, if any.
-colocated_suite() {
-  local p="$1" stem
-  case "$p" in
-  *.test.sh)
-    printf '%s' "$p"
-    return 0
-    ;;
+# is_suite_path <path> -> 0 when the path IS a test suite, in any ecosystem this
+# repo actually carries. The conventions are READ from the corpus, not invented:
+# shell and Node co-locate <stem>.test.<ext>, Pester suffixes <Stem>.Tests.ps1,
+# and Python PREFIXES test_<stem>.py — which is why the Python arm has to test
+# the basename rather than the whole path.
+is_suite_path() {
+  case "$1" in
+  *.test.sh | *.test.js | *.test.mjs | *.Tests.ps1) return 0 ;;
   *) ;;
   esac
+  case "${1##*/}" in
+  test_*.py) return 0 ;;
+  *) ;;
+  esac
+  return 1
+}
+
+# lang_family <path> -> the ecosystem a path belongs to, for the one-hop rule
+# above. Anything unrecognized gets its own bucket rather than a shared "other":
+# two unrelated extensions must not read as the same language and license a walk
+# between them.
+lang_family() {
+  case "$1" in
+  *.sh | *.bash) printf 'sh' ;;
+  *.js | *.mjs | *.cjs) printf 'node' ;;
+  *.py) printf 'py' ;;
+  *.ps1 | *.psm1) printf 'ps' ;;
+  *) printf 'ext:%s' "${1##*.}" ;;
+  esac
+}
+
+# colocated_suites <path> -> every sibling suite covering it, one per line.
+# PLURAL on purpose: one source file can carry suites in two ecosystems at once
+# — a .py with both a co-located test_<stem>.py and a wrapping <stem>.test.sh
+# that drives it — and returning only the first is an under-selection, the one
+# direction this tool treats as unsafe.
+colocated_suites() {
+  local p="$1" stem dir base candidate
+  if is_suite_path "$p"; then
+    printf '%s\n' "$p"
+    return 0
+  fi
   # An extensionless path keeps its whole name as the stem, which is what
   # ${p%.*} already yields when there is no dot to strip.
   stem="${p%.*}"
-  if [[ -f "$stem.test.sh" ]]; then
-    printf '%s' "$stem.test.sh"
-  fi
+  dir="${p%/*}"
+  [[ "$dir" == "$p" ]] && dir="."
+  base="${stem##*/}"
+  for candidate in \
+    "$stem.test.sh" \
+    "$stem.test.js" \
+    "$stem.test.mjs" \
+    "$stem.Tests.ps1" \
+    "$dir/test_$base.py" \
+    "$dir/test_${base//-/_}.py"; do
+    [[ -f "$candidate" ]] && printf '%s\n' "$candidate"
+  done
+  return 0
 }
 
 # select_for <changed-path> -> populate SUITES, and set SEED_HITS to the number
@@ -325,6 +407,16 @@ select_for() {
   local -a frontier=()
   local -a next=()
   local p b sib copy line matched_path matched_name grep_rc
+  local origin_family matched_family
+  # PATTERN_ORIGIN maps a batched basename back to the ecosystem of the file
+  # that contributed it, and PATTERN_TERM records whether that file was itself
+  # reached across a language boundary (and so must not launch a further walk).
+  # When two files in DIFFERENT families contribute the same basename, the
+  # origin collapses to '*' and the pattern is treated as same-family against
+  # anything — the over-selecting direction, which is the safe one.
+  local -A PATTERN_ORIGIN=()
+  local -A PATTERN_TERM=()
+  local -A TERMINAL=()
   # The visited set is PER SEED, not shared across seeds. Sharing it made a
   # changed file that an earlier seed had already walked past look unvisited-
   # and-unmapped, which is the fail-open direction: the file would be reported
@@ -355,16 +447,26 @@ select_for() {
       [[ -n "${VISITED[$p]:-}" ]] && continue
       VISITED["$p"]=1
       # R1/R2
-      sib="$(colocated_suite "$p")"
-      if [[ -n "$sib" ]]; then
+      while IFS= read -r sib; do
+        [[ -n "$sib" ]] || continue
         if [[ "$sib" == "$p" ]]; then
           add_suite "$sib" "changed suite" || true
         else
           add_suite "$sib" "co-located with $p" || true
         fi
-      fi
+      done < <(colocated_suites "$p")
       b="${p##*/}"
       is_structural "$b" && continue
+      origin_family="$(lang_family "$p")"
+      if [[ -z "${PATTERN_ORIGIN[$b]:-}" ]]; then
+        PATTERN_ORIGIN["$b"]="$origin_family"
+        PATTERN_TERM["$b"]="${TERMINAL[$p]:-0}"
+      else
+        [[ "${PATTERN_ORIGIN[$b]}" == "$origin_family" ]] || PATTERN_ORIGIN["$b"]='*'
+        # Any non-terminal contributor wins: the walk continues. Over-selection
+        # is the safe direction, so a tie resolves toward more walking.
+        [[ "${TERMINAL[$p]:-0}" == "0" ]] && PATTERN_TERM["$b"]=0
+      fi
       printf '%s\n' "$b" >>"$WORK_DIR/patterns"
     done
 
@@ -382,7 +484,8 @@ select_for() {
     # unsafe: a broken lookup reported a narrow selection, or "no suites
     # selected", at exit 0. Same reasoning as changed_from_diff below.
     grep_rc=0
-    git grep --untracked -o -F -f "$WORK_DIR/patterns" -- '*.sh' >"$WORK_DIR/hits" || grep_rc=$?
+    git grep --untracked -o -F -f "$WORK_DIR/patterns" \
+      -- '*.sh' '*.js' '*.mjs' '*.py' '*.ps1' '*.psm1' >"$WORK_DIR/hits" || grep_rc=$?
     # Exit 1 is "no match" and is completely ordinary — most seeds reach a level
     # with no further dependents. Only above 1 is git itself failing.
     if [[ "$grep_rc" -gt 1 ]]; then
@@ -395,12 +498,29 @@ select_for() {
       matched_path="${line%:*}"
       matched_name="${line##*:}"
       [[ -n "$matched_path" ]] || continue
-      case "$matched_path" in
-      *.test.sh) add_suite "$matched_path" "references $matched_name" || true ;;
-      *)
-        [[ -n "${VISITED[$matched_path]:-}" ]] || next+=("$matched_path")
-        ;;
-      esac
+      if is_suite_path "$matched_path"; then
+        # A suite is taken whatever language it is written in: a .test.sh that
+        # drives a .py helper is exactly the cross-language coverage this must
+        # keep finding.
+        add_suite "$matched_path" "references $matched_name" || true
+      elif [[ "${PATTERN_TERM[$matched_name]:-0}" == "1" ]]; then
+        # Reached across a language boundary already; it contributed its own
+        # suites via R2/R3 and stops here.
+        :
+      else
+        matched_family="$(lang_family "$matched_path")"
+        if [[ -n "${VISITED[$matched_path]:-}" ]]; then
+          :
+        else
+          if [[ "${PATTERN_ORIGIN[$matched_name]:-*}" == '*' ||
+            "$matched_family" == "${PATTERN_ORIGIN[$matched_name]:-*}" ]]; then
+            TERMINAL["$matched_path"]=0
+          else
+            TERMINAL["$matched_path"]=1
+          fi
+          next+=("$matched_path")
+        fi
+      fi
     done <"$WORK_DIR/hits"
 
     frontier=(${next[@]+"${next[@]}"})
@@ -615,19 +735,51 @@ fi
 # these suites in parallel was measured sublinear (they are spawn-bound and the
 # box saturates), and several guardrails suites assert wall-clock ceilings that
 # fail spuriously under concurrency. Selection, not parallelism, is the lever.
-echo "Running ${#selected[@]} selected suite(s) sequentially." >&2
-failed=0
+# Only *.test.sh is executable HERE. The other three ecosystems are run by their
+# own lanes, with lane-specific invocations this script cannot derive from a
+# suite path: `python -m unittest` against a named module, `npm test`, a bare
+# `node --test`, vitest, Pester. Guessing one is strictly worse than declining
+# to: the wrong runner either errors in a way that reads as the SUITE failing,
+# or exits 0 having run nothing, which is a PASS the change never earned. So
+# they are named and NOT run, and the exit code says so rather than reporting
+# success over suites that never executed.
+declare -a runnable=() delegated=()
 for s in "${selected[@]}"; do
-  echo "=== $s ==="
-  if bash "$s"; then
-    echo "PASS: $s"
-  else
-    echo "FAIL: $s" >&2
-    failed=1
-  fi
+  case "$s" in
+  *.test.sh) runnable+=("$s") ;;
+  *) delegated+=("$s") ;;
+  esac
 done
+
+failed=0
+if [[ ${#runnable[@]} -gt 0 ]]; then
+  echo "Running ${#runnable[@]} selected shell suite(s) sequentially." >&2
+  for s in "${runnable[@]}"; do
+    echo "=== $s ==="
+    if bash "$s"; then
+      echo "PASS: $s"
+    else
+      echo "FAIL: $s" >&2
+      failed=1
+    fi
+  done
+fi
+
+if [[ ${#delegated[@]} -gt 0 ]]; then
+  echo "NOT RUN: ${#delegated[@]} selected suite(s) belong to an ecosystem this" >&2
+  echo "runner does not execute. They are SELECTED, not skipped — run each from" >&2
+  echo "its own lane:" >&2
+  for s in "${delegated[@]}"; do
+    echo "  - $s" >&2
+  done
+fi
+
 if [[ "$failed" -ne 0 ]]; then
   echo "One or more selected suites failed." >&2
   exit 1
 fi
-echo "All ${#selected[@]} selected suites passed or were skipped."
+if [[ ${#delegated[@]} -gt 0 ]]; then
+  echo "${#runnable[@]} shell suite(s) passed or were skipped; ${#delegated[@]} still need their own lane." >&2
+  exit 3
+fi
+echo "All ${#runnable[@]} selected suites passed or were skipped."

--- a/scripts/affected-tests.sh
+++ b/scripts/affected-tests.sh
@@ -78,25 +78,30 @@
 # the visited set, and its worst case is selecting every suite — the safe
 # direction.
 #
-# ACROSS ecosystems it takes exactly one hop, and this asymmetry is load-bearing
-# rather than tidiness. Within a language, "B's text contains A's basename" is a
-# real dependency: shell sources shell, Node imports Node. Across languages it
-# usually is not — a .ps1 that happens to contain the characters "paths.js" is
-# not loading it — so chaining those coincidences compounds them. Measured
-# before this rule existed, with the corpus widened to four ecosystems and the
-# walk left uncapped: EVERY .js file in the repo selected the same 156 of 439
-# suites, and one selected 376, because the walk crossed js -> ps1 -> sh and
-# saturated on the hubs at the far end (Assert-CheckResult.ps1, hook-utils.sh).
-# An answer that is identical for every file in a language carries no
-# information about which file changed, which is the tool failing at its whole
-# job even though it fails in the "safe" direction.
+# ACROSS ecosystems each path may take exactly ONE language transition, and this
+# asymmetry is load-bearing rather than tidiness. Within a language, "B's text
+# contains A's basename" is a real dependency: shell sources shell, Node imports
+# Node. Across languages it usually is not — a .ps1 that happens to contain the
+# characters "paths.js" is not loading it — so chaining those coincidences
+# compounds them. Measured before this rule existed, with the corpus widened to
+# four ecosystems and the walk left uncapped: EVERY .js file in the repo selected
+# the same 156 of 439 suites, and one selected 376, because the walk crossed
+# js -> ps1 -> sh and saturated on the hubs at the far end
+# (Assert-CheckResult.ps1, hook-utils.sh). An answer identical for every file in
+# a language carries no information about which file changed, which is the tool
+# failing at its whole job even though it fails in the "safe" direction.
 #
-# So a cross-language match is still FOLLOWED — one hop, far enough to apply
-# R2/R3 and pick up the suite covering it, which is what keeps a .sh wrapper
-# around a .py helper working — but it does not become a launching point for
-# further walking. This costs nothing that was ever load-bearing: before the
-# corpus was widened, the reverse lookup was `-- '*.sh'`, so cross-language
-# edges did not exist at all and no shell-to-shell chain is shortened by this.
+# The budget is one TRANSITION per path, not one hop. A crossed-to file keeps
+# walking its OWN language freely; what it may not do is cross a second time.
+# The distinction matters and the weaker "one hop then stop" rule was wrong:
+# helper.py -> runner.sh -> command.sh -> command.test.sh is a real chain whose
+# second edge is shell-to-shell, and stopping dead at runner.sh dropped
+# command.test.sh — an under-selection, the direction this file calls unsafe. It
+# is the repeated re-crossing that saturates, not depth within one language.
+#
+# This costs nothing that was ever load-bearing: before the corpus was widened
+# the reverse lookup was `-- '*.sh'`, so cross-language edges did not exist at
+# all and no shell-to-shell chain is shortened by any of this.
 #
 # KNOWN LIMIT, in the safe direction: R3/R4 look the basename up with
 # `git grep -o -F`, which is an unanchored SUBSTRING search — not a token match
@@ -386,13 +391,18 @@ colocated_suites() {
   dir="${p%/*}"
   [[ "$dir" == "$p" ]] && dir="."
   base="${stem##*/}"
-  for candidate in \
-    "$stem.test.sh" \
-    "$stem.test.js" \
-    "$stem.test.mjs" \
-    "$stem.Tests.ps1" \
-    "$dir/test_$base.py" \
-    "$dir/test_${base//-/_}.py"; do
+  local -a candidates=(
+    "$stem.test.sh"
+    "$stem.test.js"
+    "$stem.test.mjs"
+    "$stem.Tests.ps1"
+    "$dir/test_$base.py"
+  )
+  # The hyphen fold is a SECOND candidate only when there is a hyphen to fold;
+  # otherwise it is character-for-character the previous entry and would emit
+  # the same path twice.
+  [[ "$base" == *-* ]] && candidates+=("$dir/test_${base//-/_}.py")
+  for candidate in ${candidates[@]+"${candidates[@]}"}; do
     [[ -f "$candidate" ]] && printf '%s\n' "$candidate"
   done
   return 0
@@ -407,16 +417,16 @@ select_for() {
   local -a frontier=()
   local -a next=()
   local p b sib copy line matched_path matched_name grep_rc
-  local origin_family matched_family
-  # PATTERN_ORIGIN maps a batched basename back to the ecosystem of the file
-  # that contributed it, and PATTERN_TERM records whether that file was itself
-  # reached across a language boundary (and so must not launch a further walk).
-  # When two files in DIFFERENT families contribute the same basename, the
-  # origin collapses to '*' and the pattern is treated as same-family against
-  # anything — the over-selecting direction, which is the safe one.
+  local origin_family matched_family hop_state
+  # PATTERN_ORIGIN maps a batched basename back to the ecosystem of the file that
+  # contributed it, and PATTERN_CROSSED records whether that file had already
+  # spent its one language transition. When two files in DIFFERENT families
+  # contribute the same basename, the origin collapses to '*' and the pattern is
+  # treated as same-family against anything — the over-selecting direction, which
+  # is the safe one.
   local -A PATTERN_ORIGIN=()
-  local -A PATTERN_TERM=()
-  local -A TERMINAL=()
+  local -A PATTERN_CROSSED=()
+  local -A CROSSED=()
   # The visited set is PER SEED, not shared across seeds. Sharing it made a
   # changed file that an earlier seed had already walked past look unvisited-
   # and-unmapped, which is the fail-open direction: the file would be reported
@@ -460,12 +470,13 @@ select_for() {
       origin_family="$(lang_family "$p")"
       if [[ -z "${PATTERN_ORIGIN[$b]:-}" ]]; then
         PATTERN_ORIGIN["$b"]="$origin_family"
-        PATTERN_TERM["$b"]="${TERMINAL[$p]:-0}"
+        PATTERN_CROSSED["$b"]="${CROSSED[$p]:-0}"
       else
         [[ "${PATTERN_ORIGIN[$b]}" == "$origin_family" ]] || PATTERN_ORIGIN["$b"]='*'
-        # Any non-terminal contributor wins: the walk continues. Over-selection
-        # is the safe direction, so a tie resolves toward more walking.
-        [[ "${TERMINAL[$p]:-0}" == "0" ]] && PATTERN_TERM["$b"]=0
+        # Any contributor that has NOT yet crossed wins: the walk keeps its
+        # budget. Over-selection is the safe direction, so a tie resolves toward
+        # more walking.
+        [[ "${CROSSED[$p]:-0}" == "0" ]] && PATTERN_CROSSED["$b"]=0
       fi
       printf '%s\n' "$b" >>"$WORK_DIR/patterns"
     done
@@ -484,8 +495,13 @@ select_for() {
     # unsafe: a broken lookup reported a narrow selection, or "no suites
     # selected", at exit 0. Same reasoning as changed_from_diff below.
     grep_rc=0
+    # Every extension lang_family() names must appear here. If it classifies a
+    # path into a family but nothing ever greps that path's content, the file is
+    # silently under-covered while LOOKING supported — fail-open, and the reason
+    # .bash and .cjs are in this list despite the repo carrying none today.
     git grep --untracked -o -F -f "$WORK_DIR/patterns" \
-      -- '*.sh' '*.js' '*.mjs' '*.py' '*.ps1' '*.psm1' >"$WORK_DIR/hits" || grep_rc=$?
+      -- '*.sh' '*.bash' '*.js' '*.mjs' '*.cjs' '*.py' '*.ps1' '*.psm1' \
+      >"$WORK_DIR/hits" || grep_rc=$?
     # Exit 1 is "no match" and is completely ordinary — most seeds reach a level
     # with no further dependents. Only above 1 is git itself failing.
     if [[ "$grep_rc" -gt 1 ]]; then
@@ -503,24 +519,33 @@ select_for() {
         # drives a .py helper is exactly the cross-language coverage this must
         # keep finding.
         add_suite "$matched_path" "references $matched_name" || true
-      elif [[ "${PATTERN_TERM[$matched_name]:-0}" == "1" ]]; then
-        # Reached across a language boundary already; it contributed its own
-        # suites via R2/R3 and stops here.
-        :
-      else
-        matched_family="$(lang_family "$matched_path")"
-        if [[ -n "${VISITED[$matched_path]:-}" ]]; then
-          :
-        else
-          if [[ "${PATTERN_ORIGIN[$matched_name]:-*}" == '*' ||
-            "$matched_family" == "${PATTERN_ORIGIN[$matched_name]:-*}" ]]; then
-            TERMINAL["$matched_path"]=0
-          else
-            TERMINAL["$matched_path"]=1
-          fi
-          next+=("$matched_path")
-        fi
+        continue
       fi
+      matched_family="$(lang_family "$matched_path")"
+      origin_family="${PATTERN_ORIGIN[$matched_name]:-*}"
+      if [[ "$origin_family" == '*' || "$matched_family" == "$origin_family" ]]; then
+        # Same-family edge: a real dependency, and it spends no budget.
+        hop_state="${PATTERN_CROSSED[$matched_name]:-0}"
+      elif [[ "${PATTERN_CROSSED[$matched_name]:-0}" == "1" ]]; then
+        # This would be a SECOND language transition for the chain reaching here.
+        continue
+      else
+        hop_state=1
+      fi
+      [[ -n "${VISITED[$matched_path]:-}" ]] && continue
+      # AGGREGATE, never assign. One path can be hit several times in a single
+      # round by different patterns — a shell wrapper naming both a shell helper
+      # and a JS file — and those hits can disagree about whether the chain
+      # reaching it has already crossed. A plain assignment let whichever hit
+      # `git grep` happened to emit last decide, so an unrelated cross-family
+      # mention could spend a path's budget and cut its own same-family walk
+      # short: order-dependent UNDER-selection, the direction this file calls
+      # unsafe. The path keeps the most permissive state any contributor gives
+      # it, matching how PATTERN_CROSSED already resolves its own ties.
+      if [[ "${CROSSED[$matched_path]:-1}" != "0" ]]; then
+        CROSSED["$matched_path"]="$hop_state"
+      fi
+      next+=("$matched_path")
     done <"$WORK_DIR/hits"
 
     frontier=(${next[@]+"${next[@]}"})

--- a/scripts/affected-tests.sh
+++ b/scripts/affected-tests.sh
@@ -53,7 +53,11 @@
 #                    foo.js are found exactly the way a shell suite is. Widening
 #                    the corpus is what taught it the other three ecosystems; the
 #                    rule itself did not change.
-#   R4 dependents    any other source file (.sh .js .mjs .py .ps1 .psm1) whose
+#   R4 dependents    any other source file (.sh .bash .js .mjs .cjs .py .ps1
+#                    .psm1 — the same set the reverse-lookup pathspec searches,
+#                    and the same set lang_family() names; all three move
+#                    together or a path is classified into a family nothing ever
+#                    greps) whose
 #                    text contains the file's basename is a dependent; R2/R3 are
 #                    then applied to IT, transitively. This is what carries a lib
 #                    change out to the hooks that source it.

--- a/scripts/affected-tests.test.sh
+++ b/scripts/affected-tests.test.sh
@@ -622,9 +622,9 @@ printf 'echo "runs Far.ps1"\n' >"$repo/eco/hop/far-runner.sh"
 suite_body far-runner >"$repo/eco/hop/far-runner.test.sh"
 run_sel "$repo" eco/hop/origin.js
 if ! has_line "$OUT" eco/hop/far-runner.test.sh; then
-  ok "a cross-language match does not chain into a second hop"
+  ok "a chain that already crossed languages cannot cross a second time"
 else
-  fail "cross-language walk chained past one hop (rc=$RC): $OUT"
+  fail "cross-language walk took a second transition (rc=$RC): $OUT"
 fi
 
 # --- --run refuses to guess a runner for another ecosystem -----------------
@@ -652,6 +652,66 @@ if [[ "$RC" -eq 0 ]] && has_line "$out" plugins/disk-hygiene/lib/test_hook_telem
   ok "live: a .py beside its test_<stem>.py is no longer UNMAPPED"
 else
   fail "live python co-located selection (rc=$RC): $out"
+fi
+
+# --- crossing once does not stop the walk in the destination language ------
+# The cap is one language TRANSITION per path, not one hop. A weaker
+# "stop dead after crossing" rule looks equivalent and is not: helper.py ->
+# runner.sh -> command.sh -> command.test.sh is a real chain whose SECOND edge is
+# shell-to-shell, and stopping at runner.sh drops command.test.sh. That is an
+# under-selection, which this tool treats as the unsafe direction, so the
+# destination-language walk has to keep going.
+repo="$(mk_repo)"
+mkdir -p "$repo/eco/chain"
+printf 'def helper():\n    return 1\n' >"$repo/eco/chain/helper.py"
+# The shell wrapper that drives the Python helper: one crossing, py -> sh.
+printf 'echo "runs helper.py"\n' >"$repo/eco/chain/runner.sh"
+# A shell dependent of the wrapper: the SECOND edge, shell -> shell.
+# shellcheck disable=SC2016 # deliberate: the emitted fixture must expand these, not this shell
+printf 'source "$(dirname "$0")/runner.sh"\n' >"$repo/eco/chain/command.sh"
+suite_body command >"$repo/eco/chain/command.test.sh"
+
+run_sel "$repo" eco/chain/helper.py
+if [[ "$RC" -eq 0 ]] && has_line "$OUT" eco/chain/command.test.sh; then
+  ok "after crossing languages once, the same-family walk continues"
+else
+  fail "py -> sh -> sh chain lost its suite (rc=$RC): $OUT"
+fi
+
+# --- the crossing budget is aggregated per path, never assigned ------------
+# One path can be hit several times in a single round by different patterns, and
+# those hits can disagree about whether the chain reaching it has already
+# crossed. Assigning rather than aggregating let whichever hit `git grep` emitted
+# LAST decide, so an incidental cross-family mention could spend a path's budget
+# and block its own genuine crossing later — order-dependent under-selection.
+#
+# Reaching two families in ONE round takes a cross-family sync manifest, since
+# R5 seeds every copy alongside the source. zed.sh names the shell source first
+# and the JS copy second, so a last-write-wins bug resolves to "already crossed".
+repo2="$(mk_repo)"
+mkdir -p "$repo2/eco/agg" "$repo2/plugins/alpha/hooks"
+{
+  printf '#!/usr/bin/env bash\n'
+  printf '# Fixture sync manifest whose copies land in ANOTHER language.\n'
+  printf 'src="lib/mixed.sh"\n'
+  printf 'copies=(plugins/*/hooks/mixed.js)\n'
+} >"$repo2/scripts/sync-mixed.sh"
+printf 'mixed_helper() { echo mixed; }\n' >"$repo2/lib/mixed.sh"
+printf 'export const mixed = 1;\n' >"$repo2/plugins/alpha/hooks/mixed.js"
+
+# Names the shell source FIRST, the JS copy SECOND — so the cross-family hit is
+# the one a last-write-wins bug would keep.
+printf 'source "lib/mixed.sh"\n# also mirrors mixed.js\n' >"$repo2/eco/agg/zed.sh"
+# A genuine crossing OUT of zed.sh, which is exactly what a wrongly-spent budget
+# would block. Its suite is the assertion.
+printf 'import subprocess  # drives zed.sh\n' >"$repo2/eco/agg/zed_user.py"
+printf 'import zed_user\n' >"$repo2/eco/agg/test_zed_user.py"
+
+run_sel "$repo2" lib/mixed.sh
+if has_line "$OUT" eco/agg/test_zed_user.py; then
+  ok "a path's crossing budget survives an unrelated cross-family hit"
+else
+  fail "crossing budget was spent by an incidental hit (rc=$RC): $OUT"
 fi
 
 printf '\nPASS=%d FAIL=%d\n' "$PASS" "$FAIL"

--- a/scripts/affected-tests.test.sh
+++ b/scripts/affected-tests.test.sh
@@ -516,5 +516,143 @@ else
   fail "live co-located selection too wide or wrong (rc=$RC, count=$count): $out"
 fi
 
+# --- per-ecosystem suite naming --------------------------------------------
+# The selector was shell-only: R2 looked for <stem>.test.sh and nothing else,
+# and the reverse lookup searched `-- '*.sh'`. Every one of the ~180 non-shell
+# suites in this repo was therefore invisible, so a .py sitting NEXT TO its own
+# test_<stem>.py was reported UNMAPPED — a false "nothing covers this" that
+# trains people to reach for --allow-unmapped and erodes the fail-loud contract.
+# Each ecosystem names its suites differently, so each needs its own case.
+repo="$(mk_repo)"
+mkdir -p "$repo/eco"
+
+# Python: the suite PREFIXES the stem, and this repo folds `-` to `_` for the
+# suites covering its hyphenated scripts.
+printf 'def helper():\n    return 1\n' >"$repo/eco/widget_mod.py"
+printf 'import widget_mod\n' >"$repo/eco/test_widget_mod.py"
+printf 'def helper():\n    return 1\n' >"$repo/eco/check-thing.py"
+printf 'import importlib\n' >"$repo/eco/test_check_thing.py"
+
+# Node: co-located <stem>.test.js / .test.mjs.
+printf 'export const a = 1;\n' >"$repo/eco/gadget.js"
+printf 'import { a } from "./gadget.js";\n' >"$repo/eco/gadget.test.js"
+printf 'export const b = 2;\n' >"$repo/eco/probe.mjs"
+printf 'import { b } from "./probe.mjs";\n' >"$repo/eco/probe.test.mjs"
+
+# Pester: the suite SUFFIXES the stem and lives in a mirrored tree, so it is
+# found by the reference rule (it dot-sources the file) rather than by R2.
+mkdir -p "$repo/eco/ps" "$repo/eco/pstests"
+printf 'function Get-Thing { 1 }\n' >"$repo/eco/ps/Get-Thing.ps1"
+printf ". (Join-Path \$PSScriptRoot 'Get-Thing.ps1')\nDescribe 'Get-Thing' { }\n" >"$repo/eco/pstests/Get-Thing.Tests.ps1"
+
+run_sel "$repo" eco/widget_mod.py
+if [[ "$RC" -eq 0 ]] && has_line "$OUT" eco/test_widget_mod.py; then
+  ok "python: a co-located test_<stem>.py is selected"
+else
+  fail "python co-located (rc=$RC): $OUT"
+fi
+
+run_sel "$repo" eco/check-thing.py
+if [[ "$RC" -eq 0 ]] && has_line "$OUT" eco/test_check_thing.py; then
+  ok "python: a hyphenated stem finds its underscore-folded suite"
+else
+  fail "python hyphen fold (rc=$RC): $OUT"
+fi
+
+run_sel "$repo" eco/gadget.js
+if [[ "$RC" -eq 0 ]] && has_line "$OUT" eco/gadget.test.js; then
+  ok "node: a co-located <stem>.test.js is selected"
+else
+  fail "node co-located (rc=$RC): $OUT"
+fi
+
+run_sel "$repo" eco/probe.mjs
+if [[ "$RC" -eq 0 ]] && has_line "$OUT" eco/probe.test.mjs; then
+  ok "node: a co-located <stem>.test.mjs is selected"
+else
+  fail "node .mjs co-located (rc=$RC): $OUT"
+fi
+
+run_sel "$repo" eco/ps/Get-Thing.ps1
+if [[ "$RC" -eq 0 ]] && has_line "$OUT" eco/pstests/Get-Thing.Tests.ps1; then
+  ok "powershell: a Pester suite in a mirrored tree is found by reference"
+else
+  fail "pester reference (rc=$RC): $OUT"
+fi
+
+# --- a changed non-shell suite selects ITSELF (R1 is not shell-only) --------
+run_sel "$repo" eco/test_widget_mod.py
+if [[ "$RC" -eq 0 ]] && has_line "$OUT" eco/test_widget_mod.py; then
+  ok "a changed non-shell suite selects itself"
+else
+  fail "non-shell self-selection (rc=$RC): $OUT"
+fi
+
+# --- BOTH covering suites, not just the first ------------------------------
+# A .py can be covered twice over: by a co-located test_<stem>.py AND by a
+# <stem>.test.sh that drives it. Returning only the first is an under-selection,
+# the one direction this tool treats as unsafe, so both must come back.
+printf 'def helper():\n    return 1\n' >"$repo/eco/dual.py"
+printf 'import dual\n' >"$repo/eco/test_dual.py"
+suite_body dual >"$repo/eco/dual.test.sh"
+run_sel "$repo" eco/dual.py
+if [[ "$RC" -eq 0 ]] &&
+  has_line "$OUT" eco/test_dual.py &&
+  has_line "$OUT" eco/dual.test.sh; then
+  ok "a file covered in two ecosystems selects BOTH suites"
+else
+  fail "dual-ecosystem coverage (rc=$RC): $OUT"
+fi
+
+# --- cross-language matches are followed exactly one hop -------------------
+# Widening the corpus to four ecosystems introduced an edge that never existed
+# when the reverse lookup was `-- '*.sh'`: a match ACROSS languages. Left
+# uncapped, those coincidental matches chained (js -> ps1 -> sh) and saturated
+# on the far-end hubs — measured at every .js in the repo selecting the same 156
+# of 439 suites. One hop still reaches the suite covering the crossed-to file,
+# which is what keeps a .sh wrapper around a .py helper working; what it must
+# NOT do is keep walking from there and drag in that file's own dependents.
+mkdir -p "$repo/eco/hop"
+printf 'export const c = 3;\n' >"$repo/eco/hop/origin.js"
+# A .ps1 that merely MENTIONS the js basename — not a real dependency.
+printf "# mentions origin.js in a comment only\nfunction Get-Far { 2 }\n" >"$repo/eco/hop/Far.ps1"
+# A shell file that depends on the .ps1, with its own suite. Reaching this suite
+# would require a SECOND cross-language hop, which the rule forbids.
+printf 'echo "runs Far.ps1"\n' >"$repo/eco/hop/far-runner.sh"
+suite_body far-runner >"$repo/eco/hop/far-runner.test.sh"
+run_sel "$repo" eco/hop/origin.js
+if ! has_line "$OUT" eco/hop/far-runner.test.sh; then
+  ok "a cross-language match does not chain into a second hop"
+else
+  fail "cross-language walk chained past one hop (rc=$RC): $OUT"
+fi
+
+# --- --run refuses to guess a runner for another ecosystem -----------------
+# Selected-but-not-run must never report as success. The invocations differ per
+# lane (python -m unittest against a named module, npm test, node --test,
+# vitest, Pester) and cannot be derived from a suite path; a guessed runner
+# either errors as though the suite failed, or exits 0 having run nothing, which
+# is a PASS the change never earned. Exit 3 says "ran the shell ones, these
+# still need their own lane".
+OUT="$(cd "$repo" && bash scripts/affected-tests.sh --run eco/gadget.js 2>&1)"
+RC=$?
+if [[ "$RC" -eq 3 ]] && printf '%s' "$OUT" | grep -q 'NOT RUN'; then
+  ok "--run reports a non-shell suite as NOT RUN and exits 3"
+else
+  fail "--run should exit 3 naming the unrun suite (rc=$RC): $OUT"
+fi
+
+# --- LIVE repo: the false-UNMAPPED regression this all exists to fix -------
+# hook_telemetry.py sits directly beside test_hook_telemetry.py and was still
+# reported UNMAPPED. Asserted against the LIVE repo, not a fixture: the point is
+# that the tool tracks THIS corpus's real conventions.
+out="$(cd "$REPO_ROOT" && bash scripts/affected-tests.sh plugins/disk-hygiene/lib/hook_telemetry.py 2>/dev/null)"
+RC=$?
+if [[ "$RC" -eq 0 ]] && has_line "$out" plugins/disk-hygiene/lib/test_hook_telemetry.py; then
+  ok "live: a .py beside its test_<stem>.py is no longer UNMAPPED"
+else
+  fail "live python co-located selection (rc=$RC): $out"
+fi
+
 printf '\nPASS=%d FAIL=%d\n' "$PASS" "$FAIL"
 ((FAIL == 0))


### PR DESCRIPTION
No linked issue

## Summary

Closes the three questions deferred out of the repo-mode work in #3012, which merged without them
recorded anywhere. Two are behavior changes, one is a decision that was open in practice; none was
filed as a tracker item, by explicit choice, so this PR is where they get settled.

*Body updated after review: the cross-language rule was revised from "one hop" to "one transition"
in response to review findings, and the numbers below are re-measured against the shipped design.
Placeholder names are written without angle brackets because those were stripped from the original
body in transit.*

## Fix

**Q25 — per-ecosystem test selection (`scripts/affected-tests.sh`).** The selector was shell-only in
two places: R2 looked for a co-located `STEM.test.sh` and nothing else, and the reverse lookup
searched only `*.sh`. The ~180 non-shell suites in this repo were therefore invisible, so a source
file sitting *next to* its own suite was reported `UNMAPPED` — `plugins/disk-hygiene/lib/hook_telemetry.py`
did exactly that with `test_hook_telemetry.py` in the same directory. A false "nothing covers this"
is worse than noise: it trains people toward `--allow-unmapped`, which erodes the fail-loud contract
the tool exists to hold.

R2 now knows each ecosystem's own naming (Node `STEM.test.js` / `STEM.test.mjs`, Pester
`STEM.Tests.ps1`, Python `test_STEM.py` including the `-` → `_` fold this repo uses for hyphenated
scripts) and returns *every* match rather than the first. R3/R4 needed no rule change — they are
text matches, so widening the corpus taught them the other three languages for free.

Widening the corpus introduced one new failure mode, capped rather than waved through on the
"over-selection is safe" doctrine. Cross-language matches are mostly coincidental (a `.ps1`
containing the characters `paths.js` is not loading it) and chaining them compounds: measured with
the walk left uncapped, **every** `.js` in the repo selected the same 156 of 439 suites and one
selected 376, saturating on far-end hubs via `js → ps1 → sh`. An answer identical for every file in
a language carries no information about which file changed.

The cap is **one language transition per path**, not one hop. A crossed-to file keeps walking its
own language freely and may only not cross again. The stricter "stop dead after crossing" rule this
PR originally shipped was wrong in the unsafe direction and was corrected during review:
`helper.py → runner.sh → command.sh → command.test.sh` is a real chain whose second edge is
shell-to-shell, and stopping at `runner.sh` dropped `command.test.sh`. Within-language walking is
untouched, so no shell-to-shell chain is shortened.

`--run` deliberately does not guess a runner for the other ecosystems. Their invocations are
lane-specific (`python -m unittest` against a named module, `npm test`, `node --test`, vitest,
Pester) and are not derivable from a suite path; a wrong runner either errors as though the suite
failed, or exits 0 having run nothing — a PASS the change never earned. They are named as `NOT RUN`
and `--run` exits 3 rather than reporting success over suites that never executed.

**Q26 — narrowing surface (user-reserved, decided by Kyle this session).** Implemented as an argument
orthogonal to scope — `[scope] [path...] [docs]` — rather than a repo-only `repo PATH` sub-mode.
Scope selects a universe, path selects a region of it; binding paths to `repo` alone would assert
that only the everything-universe may be narrowed, leaving "what I changed this week, but only under
`plugins/knowledge`" unreachable and forcing a second grammar change later. Purely additive — the
heuristic ended `anything else → ask the user`, so a path was previously refused in every mode.

A token counts as a path only if it **resolves**; without that condition the addition would have
weakened the token-exact typo guard, turning `rebranch` from an explicit question into a silent
sweep of nothing. Scope is read **before** any token is tested as a path (review finding), so a
repository containing a directory named `repo` or `branch` cannot swallow the scope keyword. A
narrowed path is normalized repo-root-relative before the root-anchored `git -C` call (review
finding), since `-C` changes directory before the pathspec applies.

`repo LANE` is explicitly rejected: a lane in the sibling `/code-tidying:tidy` is a seven-part object
of which this skill would use only the scope globs, and lanes exist only in repos that have
configured `.claude/tidy-lanes/`.

**Q21 — hotspot ranking.** The spoke argued only against the weak forms (churn alone, churn × file
size), leaving the strong form — churn weighted by complexity or code health, which is what "hotspot
analysis" usually means — unaddressed and so open in practice. Now rejected on a reason that reaches
it: ranking answers "where should I look first", a triage question repo mode already answered by
sweeping every group and filing High-only with no cap, so reordering work that is all going to
happen anyway has no consumer. The one condition under which reopening is coherent is named — a
truncation knob would have to land first.

## Verification

- `scripts/affected-tests.test.sh` — **44 pass, 0 fail** (was 32; 12 new cases covering each
  ecosystem, dual-coverage, the one-transition rule, the crossing-budget aggregation, exit 3, and
  the live `hook_telemetry.py` regression).
- Both new rules are verified **discriminating**, not merely passing: reverting to the stop-dead
  rule fails the same-family-continues case, and removing the aggregation guard fails the
  crossing-budget case.
- Selection discriminates across packages where it previously did not: **154 / 186 / 2** suites for
  `.js` files in three different packages, against an identical 156 for all of them uncapped. Wider
  than the stricter rule's 64/101/2, which is the accepted cost of not dropping real chains — the
  property the cap must preserve is discrimination, not smallness.
- Python and PowerShell selections are tight (0–3 suites), matching the shell baseline; a shared
  shell lib already fans out to 97 for comparison.
- `scripts/validate-plugins.sh` — passed.
- `scripts/check-changelog-parity.sh` — all four modes (`--check`, `--check-order`, `--check-bump`,
  `--check-preserved`) passed.
- `scripts/check-changed-skills.sh origin/main` — `batch-simplify` PASS, 0 errors, 0 failed.
- `scripts/check-skill-portability.sh origin/main`, `scripts/check-shell-portability.sh origin/main`
  — no unexcused tokens/constructs.
- `markdownlint-cli2` on all touched markdown — 0 issues. `typos` clean repo-wide.
- `shellcheck` and `shfmt -d` clean on both touched shell files.
- CI: 48 checks, 47 success + 1 skipped, zero failures.

## Related

- Refs #3012 — the merged repo-mode PR these three questions were deferred out of. Not reopened;
  this is a separate change on a branch re-based onto the merged `main`.
- `scripts/affected-tests.sh` is repo-owned and deliberately absent from the `code-tidying`
  changelog: repo scripts ship with the repo, not the plugin, so a consumer installing the plugin
  never receives them.