### PR TITLE
fix(context-guard): describe the 0.5.0 audience split in the reader contract

### DIFF
--- a/plugins/context-guard/.claude-plugin/plugin.json
+++ b/plugins/context-guard/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "context-guard",
-  "version": "0.7.14",
+  "version": "0.7.15",
   "description": "Per-session context-window observability plus the first shipped consumer: a statusline wrapper tees each session's context_window fields to a per-session snapshot file, a zone resolver classifies usage into smart/acceptable/dumb bands (percentage bands plus window-class token bands, conservative-min combination, zones.json SSOT with shipped defaults), a reader contract fixes how consuming sessions interpret the snapshots, and zone-crossing hooks report once per transition into a worse zone across two channels \u2014 the continuation menu to the operator, who owns that choice, and to the model only the zone determination plus the counter-steer that a zone word is not a decay signal (advisory by default; an optional blocking mode gates new mutating work on a fresh dumb-zone snapshot with handoff-writing exempt), with a PostCompact hook persisting an evidence-degraded marker.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/context-guard/CHANGELOG.md
+++ b/plugins/context-guard/CHANGELOG.md
@@ -20,6 +20,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   and the I23 rationale for the split. Verified against `hooks/zone-crossing-inject.sh`'s actual
   emission rather than its header summary. Documentation only; no behavior change.
 
+## [0.7.14]
+
 ### Changed
 
 - **Both zone-crossing message channels compressed** (owner report: the operator message was

--- a/plugins/context-guard/CHANGELOG.md
+++ b/plugins/context-guard/CHANGELOG.md
@@ -5,7 +5,20 @@ All notable changes to the `context-guard` plugin.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.7.14]
+## [0.7.15]
+
+### Fixed
+
+- **`reference/reader-contract.md` described pre-0.5.0 advisory injection (#2973).** The
+  zone-crossing hooks section still called the injection "a minimal generic continuation tree plus
+  a presence-gated pointer to `session-flow:workflow`'s router", as one undifferentiated block —
+  the shape before the 0.5.0 audience split moved the menu off the model channel. The reference
+  therefore misdescribed shipped behavior to every reader of the seam. It now states what each
+  channel carries — `additionalContext`: the determination plus the counter-steer, and the
+  durable-note addendum in `dumb`; `systemMessage`: the same crossing plus the continuation menu
+  and the router pointer — that neither the menu nor the pointer ever reaches the model channel,
+  and the I23 rationale for the split. Verified against `hooks/zone-crossing-inject.sh`'s actual
+  emission rather than its header summary. Documentation only; no behavior change.
 
 ### Changed
 

--- a/plugins/context-guard/reference/reader-contract.md
+++ b/plugins/context-guard/reference/reader-contract.md
@@ -187,9 +187,25 @@ not validation.
 Since 0.4.0 the plugin itself ships hooks over its own seam — the first shipped consumer:
 
 - **Advisory injection** (`PostToolBatch` + `UserPromptSubmit`): on a transition into a zone worse
-  than any this session has already reported, inject continuation guidance (a minimal generic
-  continuation tree plus a presence-gated pointer to `session-flow:workflow`'s router). Silent
-  while the zone is unchanged, improving, or `unknown`. **Hysteresis** (since 0.7.0): the gate is
+  than any this session has already reported, report the crossing on **two channels with two
+  audiences** (the 0.5.0 audience split). The **model channel** (`additionalContext`) carries the
+  determination and a counter-steer — the reading is a measurement rather than an instruction, real
+  degradation shows up in the model's own output and never in a zone word, and the model is told to
+  keep working the task in hand — plus, in `dumb`, a note to write each expensive conclusion to a
+  durable note against a short compaction distance. The **operator channel** (`systemMessage`)
+  carries the same crossing plus the continuation menu that is the human's call to make (continue /
+  `/clear` / handoff-then-`/clear`, with a hand-written resume note as the standalone-install
+  fallback / `/compact`) and the presence-gated pointer to `session-flow:workflow`'s router.
+  **Neither the menu nor the router pointer ever reaches the model channel.** A menu injected into
+  model context manufactures the model's own initiative to stop, summarize, or hand off — a live
+  finding under the instruction-audit catalog's I23 (`claude-config`, `reference/criteria.md`),
+  whose Remediate clause prescribes exactly this shape: state the counter-steer plainly, and where
+  the harness must surface a budget, pair it with a reassurance rather than with an exit menu. The
+  measurement decides only *when to ask*; the model still decides whether to stop. The model
+  channel states that continuation is the operator's CALL, never that the operator has SEEN the
+  menu — no documented hook behavior tells a hook whether an operator is present, so a delivery
+  claim would be a fact the hook cannot know. Silent while the zone is unchanged, improving, or
+  `unknown`. **Hysteresis** (since 0.7.0): the gate is
   the worst zone already *reported*, not the zone last *seen*. That marker decays only when the
   session returns to `smart` — the bottom of the ladder (**since 0.7.2**; 0.7.0 asked instead for an
   improvement of at least two ranks, which no band but `dumb` could ever satisfy, so a session that


### PR DESCRIPTION
Closes #2973

## Summary

`reference/reader-contract.md`'s zone-crossing hooks section described the advisory injection as it worked **before** the 0.5.0 audience split — as one undifferentiated block carrying "a minimal generic continuation tree plus a presence-gated pointer to `session-flow:workflow`'s router". Since 0.5.0 the menu has been operator-channel only, so the reference told every reader of the seam that the model receives an exit menu it has not received for many versions. Surfaced by the fresh-context verifier during AI Hero course lane 2 (#2900).

## Fix

The section now states what each channel actually carries, and why:

- **Model channel (`additionalContext`)** — the determination plus the counter-steer (the reading is a measurement rather than an instruction; real degradation shows up in the model's own output, never in a zone word; keep working the task in hand), plus the durable-note addendum in `dumb`.
- **Operator channel (`systemMessage`)** — the same crossing plus the continuation menu that is the human's call (continue / `/clear` / handoff-then-`/clear`, with the hand-written resume note as the standalone-install fallback / `/compact`) and the presence-gated router pointer.
- **Neither the menu nor the router pointer ever reaches the model channel** — with the I23 rationale stated where the split is described (`claude-config`, `reference/criteria.md`): a menu injected into model context manufactures the model's own initiative to stop, summarize, or hand off, and I23's Remediate clause prescribes exactly this shape — counter-steer plainly stated, reassurance rather than an exit menu.
- The model channel says continuation is the operator's **call**, never that the operator has **seen** the menu, since no documented hook behavior tells a hook whether an operator is present.

## Verification

- **Verified against the hook's actual emission**, not its header summary: `hooks/zone-crossing-inject.sh` builds `guidance` (model) and `operator` (operator) separately and emits both via `hook::emit_channels` — the rewritten prose tracks those two strings, including the `dumb`-only addendum and the option-3 manual fallback.
- **Third acceptance criterion swept**: `grep` over the whole contract for injection/menu/channel prose found the content described in exactly one place (the section rewritten here). The other injection mentions cover hysteresis and the compaction marker and are accurate — no other section describes pre-0.5.0 behavior.
- `bash plugins/context-guard/hooks/zone-crossing-inject.test.sh` — PASS=53 FAIL=0 (hook untouched; run because this doc is its contract).
- `bash scripts/validate-plugins.sh` — all manifests + catalog validated; `generate-catalog.mjs --check` in sync.
- `bash scripts/check-changelog-parity.sh --check` / `--check-bump origin/main` / `--check-order` — all green.
- `bash scripts/check-changed-skills.sh origin/main` — no changed skills under `plugins/*/skills/` (this is a plugin-level `reference/` file).
- `bash scripts/check-cross-plugin-source-drift.sh` — exit 0.
- `npx markdownlint-cli2` on both changed markdown files — 0 issues; `typos` clean.
- **Version bump** `context-guard` 0.7.14 → 0.7.15 (patch — documentation accuracy, no behavior change).

## Related

- Refs #2900 (lane 2 decision record and the verifier finding), `docs/upstream/aihero-course.md` lane 2 rows
- Refs #2971 (the sibling router item, closed by PR #3029) — this is its lane 2 companion

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QbfCrj3X9FfGL7VRZYmrn4

---
_Generated by [Claude Code](https://claude.ai/code/session_01QbfCrj3X9FfGL7VRZYmrn4)_