### PR TITLE
docs(context-guard): document the verified auto-compact surfaces and zone interplay

### DIFF
--- a/plugins/context-guard/.claude-plugin/plugin.json
+++ b/plugins/context-guard/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "context-guard",
-  "version": "0.7.15",
+  "version": "0.7.16",
   "description": "Per-session context-window observability plus the first shipped consumer: a statusline wrapper tees each session's context_window fields to a per-session snapshot file, a zone resolver classifies usage into smart/acceptable/dumb bands (percentage bands plus window-class token bands, conservative-min combination, zones.json SSOT with shipped defaults), a reader contract fixes how consuming sessions interpret the snapshots, and zone-crossing hooks report once per transition into a worse zone across two channels \u2014 the continuation menu to the operator, who owns that choice, and to the model only the zone determination plus the counter-steer that a zone word is not a decay signal (advisory by default; an optional blocking mode gates new mutating work on a fresh dumb-zone snapshot with handoff-writing exempt), with a PostCompact hook persisting an evidence-degraded marker.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/context-guard/CHANGELOG.md
+++ b/plugins/context-guard/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to the `context-guard` plugin.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.16]
+
+### Added
+
+- **The auto-compact configuration surfaces and their interplay with zones are now documented
+  (#2995).** `reference/reader-contract.md` said no auto-compaction threshold is documented and
+  stopped there, which left readers with the impression that the trigger is entirely opaque. The
+  *default* is unpublished, but the trigger is operator-tunable, and none of the surfaces that tune
+  it appeared anywhere in the plugin. The contract now names all three — `autoCompactWindow`
+  (`settings.json`, 100,000–1,000,000 tokens, no numeric default), `CLAUDE_CODE_AUTO_COMPACT_WINDOW`
+  (environment, highest precedence), and `autoCompactEnabled` / `DISABLE_AUTO_COMPACT` — each
+  verified 2026-08-17 against two independent pools (the official settings reference and the shipped
+  binary's schema strings). Added with them: the **bands-below-the-trigger** rule and its rationale
+  (a firing means the boundary decision was reached too late), the explicit position that
+  auto-compact nonetheless stays *enabled* as a last-resort safety net because unattended sessions
+  have no human at the boundary, and the vendored Boris §64 rot figure recorded as a named
+  practitioner anchor — carrying its Opus 5 amendment — never as an adopted number. The README
+  points at the contract for all of it. Documentation only; no behavior change.
+- **The evidence-degraded marker's `trigger` field now has consumer guidance.** The field's values
+  were documented; what a consumer should *do* with them was not. The contract now states that
+  consumers deliberately do not differentiate on `trigger` (evidence degradation is
+  trigger-independent) and records the track-on-event condition under which that stance would be
+  revisited, with the recorded field as its observable.
+
 ## [0.7.15]
 
 ### Fixed

--- a/plugins/context-guard/CHANGELOG.md
+++ b/plugins/context-guard/CHANGELOG.md
@@ -13,16 +13,37 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   (#2995).** `reference/reader-contract.md` said no auto-compaction threshold is documented and
   stopped there, which left readers with the impression that the trigger is entirely opaque. The
   *default* is unpublished, but the trigger is operator-tunable, and none of the surfaces that tune
-  it appeared anywhere in the plugin. The contract now names all three — `autoCompactWindow`
+  it appeared anywhere in the plugin. The contract now names all four — `autoCompactWindow`
   (`settings.json`, 100,000–1,000,000 tokens, no numeric default), `CLAUDE_CODE_AUTO_COMPACT_WINDOW`
-  (environment, highest precedence), and `autoCompactEnabled` / `DISABLE_AUTO_COMPACT` — each
+  (environment, highest precedence, plain integer only), `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE`
+  (percentage of the window, lower-only), and `autoCompactEnabled` / `DISABLE_AUTO_COMPACT` —
   verified 2026-08-17 against two independent pools (the official settings reference and the shipped
-  binary's schema strings). Added with them: the **bands-below-the-trigger** rule and its rationale
+  binary's schema strings) and re-verified 2026-08-19 against the live settings, env-vars, and
+  model-config pages. Added with them: the **bands-below-the-trigger** rule and its rationale
   (a firing means the boundary decision was reached too late), the explicit position that
   auto-compact nonetheless stays *enabled* as a last-resort safety net because unattended sessions
   have no human at the boundary, and the vendored Boris §64 rot figure recorded as a named
   practitioner anchor — carrying its Opus 5 amendment — never as an adopted number. The README
   points at the contract for all of it. Documentation only; no behavior change.
+- **The trigger comparison is stated in the percentage shape, not occupancy.** The contract already
+  forbids equating its two zone shapes without normalizing; the new guidance now honors that rule
+  explicitly. A configured auto-compact window is a fill threshold in the percentage shape's
+  input-token accounting, not the token shape's occupancy, so the worked example normalizes: a
+  400,000-token window on a 1M-class model puts the trigger at 40% of the full window — inside the
+  shipped `smart` band, meaning auto-compact fires while every zone still reads green. Records the
+  docs' own consequence with it: `used_percentage` always measures against the model's **full**
+  context window, so a lowered auto-compact window stops being visible in the percentage at all.
+
+### Changed
+
+- **The "no documented threshold" paragraph carries a dated refinement.** Upstream is now more
+  specific than the "when approaching context limits" phrasing the paragraph quotes: with no window
+  configured, compaction fires at the model's context limit, with enumerated exceptions that fire
+  earlier (cloud sessions, 200K-boundary model/configuration combinations, unrecognized model IDs).
+  A percentage default is implied by `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` but still unpublished as a
+  number, so the conclusion is unchanged — the bands stay declared judgment defaults — while the
+  trigger is now documented as model- and environment-dependent, which is why no single band set is
+  correct everywhere. Verified 2026-08-19.
 - **The evidence-degraded marker's `trigger` field now has consumer guidance.** The field's values
   were documented; what a consumer should *do* with them was not. The contract now states that
   consumers deliberately do not differentiate on `trigger` (evidence degradation is

--- a/plugins/context-guard/CHANGELOG.md
+++ b/plugins/context-guard/CHANGELOG.md
@@ -39,11 +39,14 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - **The "no documented threshold" paragraph carries a dated refinement.** Upstream is now more
   specific than the "when approaching context limits" phrasing the paragraph quotes: with no window
   configured, compaction fires at the model's context limit, with enumerated exceptions that fire
-  earlier (cloud sessions, 200K-boundary model/configuration combinations, unrecognized model IDs).
-  A percentage default is implied by `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` but still unpublished as a
-  number, so the conclusion is unchanged — the bands stay declared judgment defaults — while the
-  trigger is now documented as model- and environment-dependent, which is why no single band set is
-  correct everywhere. Verified 2026-08-19.
+  earlier (cloud sessions, 200K-boundary model/configuration combinations, unrecognized model IDs,
+  and Sonnet 5 at "about 967K tokens by default" on its 1M window). That Sonnet 5 figure is the one
+  published number in the set; at ~97% of the window it sits well above the shipped `dumb` band, so
+  it is recorded as context rather than as a reason to move the bands. A percentage default is
+  implied by `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` but still unpublished as a number, so the conclusion
+  is unchanged — the bands stay declared judgment defaults — while the trigger is now documented as
+  model- and environment-dependent, which is why no single band set is correct everywhere. Verified
+  2026-08-19.
 - **The evidence-degraded marker's `trigger` field now has consumer guidance.** The field's values
   were documented; what a consumer should *do* with them was not. The contract now states that
   consumers deliberately do not differentiate on `trigger` (evidence degradation is

--- a/plugins/context-guard/README.md
+++ b/plugins/context-guard/README.md
@@ -58,7 +58,11 @@ tool that needs it — so long-running workflows can route heavy work away from 
   or missing `jq` all resolve `unknown` — consumers take their conservative path on data they
   cannot trust, never a fabricated zone. The shipped bands are declared judgment defaults: no
   official auto-compaction threshold is documented (verified 2026-07-24); `zones.json` is the
-  tuning path.
+  tuning path. The trigger itself is operator-tunable even though its default is unpublished —
+  `autoCompactWindow`, `CLAUDE_CODE_AUTO_COMPACT_WINDOW`, and `autoCompactEnabled` /
+  `DISABLE_AUTO_COMPACT` — and bands belong **below** whatever it resolves to, so the session
+  reaches a boundary decision before the harness compacts for it. The reader contract owns those
+  surfaces, their verification dates, and the rationale.
 - **Integrity boundary (stated honestly).** The snapshot directory is owner-only where POSIX
   modes work; on Windows ACL volumes the `chmod` is a no-op and other local users could forge
   snapshots. Zones are routing hints — consumers must never attach security or egress decisions

--- a/plugins/context-guard/README.md
+++ b/plugins/context-guard/README.md
@@ -59,10 +59,12 @@ tool that needs it — so long-running workflows can route heavy work away from 
   cannot trust, never a fabricated zone. The shipped bands are declared judgment defaults: no
   official auto-compaction threshold is documented (verified 2026-07-24); `zones.json` is the
   tuning path. The trigger itself is operator-tunable even though its default is unpublished —
-  `autoCompactWindow`, `CLAUDE_CODE_AUTO_COMPACT_WINDOW`, and `autoCompactEnabled` /
-  `DISABLE_AUTO_COMPACT` — and bands belong **below** whatever it resolves to, so the session
-  reaches a boundary decision before the harness compacts for it. The reader contract owns those
-  surfaces, their verification dates, and the rationale.
+  `autoCompactWindow`, `CLAUDE_CODE_AUTO_COMPACT_WINDOW`, `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE`, and
+  `autoCompactEnabled` / `DISABLE_AUTO_COMPACT` — and bands belong **below** whatever it resolves
+  to, normalized into the percentage shape, so the session reaches a boundary decision before the
+  harness compacts for it. Note that `used_percentage` always measures against the model's *full*
+  window, so a lowered auto-compact window no longer shows up in the percentage. The reader
+  contract owns those surfaces, their verification dates, and the rationale.
 - **Integrity boundary (stated honestly).** The snapshot directory is owner-only where POSIX
   modes work; on Windows ACL volumes the `chmod` is a no-op and other local users could forge
   snapshots. Zones are routing hints — consumers must never attach security or egress decisions

--- a/plugins/context-guard/reference/reader-contract.md
+++ b/plugins/context-guard/reference/reader-contract.md
@@ -257,6 +257,18 @@ markers older than 14 days on each write — the same cutoff the tee applies to 
 above any live session's horizon, so a marker is never deleted out from under the session it
 describes.
 
+**Do not differentiate on `trigger` — the field is recorded for a future decision, not a current
+one.** Evidence degradation is trigger-independent: the marker's rationale is that the evidence is
+already gone from the model-visible context, which holds identically for a steered `/compact` and
+an auto-compact. Consumers therefore treat all three values the same, and that sameness is
+deliberate, not an omission. The field is captured anyway (`hooks/post-compact-mark.sh`) so the
+stance is falsifiable: it is the observable for a **track-on-event** condition recorded in
+[`docs/upstream/aihero-course.md`](https://github.com/melodic-software/claude-code-plugins/blob/main/docs/upstream/aihero-course.md)
+lane 3 — revisit consumer differentiation ONLY on real evidence that steered, boundary-timed
+compactions preserve enough to grade work on, never on the intuition that a steered summary must
+be better. A hook cannot observe intent, and a marker written conditionally stops being evidence,
+so there is no boundary-timed carve-out in the writer either (as-of 2026-08-17).
+
 ## Zone is NOT a compaction indicator
 
 A compacted session's `used_percentage` **resets downward** while the evidence in its
@@ -280,6 +292,49 @@ Two adjacent caveats, same fetch: the doc warns the statusline percentage "may d
 the next request; and with `autoCompactEnabled: false` no compaction ever fires (the session hard
 -stops at the window instead), which makes the dumb band the *only* tripwire — strictly more
 load-bearing, never less.
+
+### The trigger has no documented threshold, but it IS operator-tunable
+
+No *default* threshold is documented (above), yet the point at which auto-compact fires is a
+configured value the operator can read and set. Three surfaces govern it. Verified 2026-08-17
+against two independent pools — the official
+[settings reference](https://code.claude.com/docs/en/settings) and the shipped binary's own schema
+strings (v2.1.233):
+
+| Surface | Kind | What it does |
+|---|---|---|
+| `autoCompactWindow` | `settings.json` key | How full the window gets before auto-compact fires, **in tokens, `100000` to `1000000`** (binary schema: `.int().min(1e5).max(1e6).optional()`). **No numeric default** — unset means a window tuned for the model, deliberately not published as a number. Written by the `/autocompact` command; the `--autocompact` flag sets it for one launch (both require Claude Code ≥ 2.1.221). |
+| `CLAUDE_CODE_AUTO_COMPACT_WINDOW` | environment variable | Same units and range; **highest precedence** — overrides the command, the flag, and the setting while it is set. |
+| `autoCompactEnabled` / `DISABLE_AUTO_COMPACT` | `settings.json` key (default `true`, shown in `/config` as **Auto-compact**) / environment variable | Turns auto-compact off entirely. Distinct from `DISABLE_COMPACT`, which disables *all* compaction including `/compact`. |
+
+**Tune bands BELOW the effective trigger, never above it.** Whatever the trigger resolves to on a
+machine, the `dumb` band should be reached first. A zone reading exists so the session arrives at a
+boundary decision — finish the phase, `/clear`, write a handoff — while that decision is still
+being made deliberately; if auto-compact fires first, the harness has already made a lossy choice
+on the session's behalf and the boundary was reached too late. Auto-compact offers no steering
+hook, so a firing is best read diagnostically: **it means the boundary was missed**, not that the
+window was managed. Operators who lower `autoCompactWindow` are moving the trigger, so the bands in
+`zones.json` move with it — a 400000-token trigger on a 1M window puts the shipped 1M `dumb`
+boundary (400000 occupancy) exactly *at* the trigger rather than below it, which forfeits the
+margin.
+
+That diagnostic reading is adopted; the prescription that usually travels with it is not. **Leave
+auto-compact enabled.** Disabling it is a defensible operator choice on an attended machine, but it
+is not this plugin's guidance: unattended cloud and autonomous sessions have no human at the
+boundary, and for them a degraded continuation beats a hard stall at the window. The shipped ladder
+is instrumentation, not prohibition — observable zones, then advisory injection, then an opt-in
+blocking gate with a grace budget — with auto-compact remaining the last-resort safety net beneath
+all of it (as-of 2026-08-17).
+
+**On folklore numbers.** A widely-cited practitioner anchor — the vendored Boris playbook, §64,
+attributing the compromise to Thariq — reports context rot setting in around 300–400k tokens on
+1M-context models and suggests `CLAUDE_CODE_AUTO_COMPACT_WINDOW=400000`. Recorded here as a **named
+anchor, never an adopted number**, and it comes with its own amendment: that calibration is
+Opus 4.7-era, and the Opus 5 prompting guide (verified 2026-08-08) states the 1M window's
+instruction following, tool calling, and reasoning "stay consistent throughout the window", which
+removes the degradation premise for that specific figure. A lowered window remains a legitimate
+cost and compaction-timing choice on its own terms. The bands this contract ships stay declared
+judgment defaults; `zones.json` is the tuning path.
 
 ## Zones (machine-scope tuning, optional)
 

--- a/plugins/context-guard/reference/reader-contract.md
+++ b/plugins/context-guard/reference/reader-contract.md
@@ -292,8 +292,13 @@ now more specific than "when approaching context limits" — with no window conf
 fires **at the model's context limit**, with enumerated exceptions that fire earlier (cloud
 sessions compact as the conversation *approaches* the limit; Sonnet 4.6 / Opus 4.6 without extended
 context, and Opus 4.8 / Opus 5 running on a 200K window, compact at the 200K boundary; a
-`CLAUDE_CODE_DISABLE_1M_CONTEXT=1` session on a native-1M model likewise; an unrecognized model ID
-compacts at whatever window Claude Code assumes for it). A *percentage* default is implied by
+`CLAUDE_CODE_DISABLE_1M_CONTEXT=1` session on a native-1M model likewise; **Sonnet 5 compacts at
+the threshold for its configuration — "about 967K tokens by default" on its 1M window, i.e. before
+the window fills**; an unrecognized model ID compacts at whatever window Claude Code assumes for
+it). That Sonnet 5 figure is the one published number in the set, and it sits at ~97% of the
+window — comfortably above the shipped `dumb` band, so it does not disturb the margin that the
+bands-below-the-trigger rule protects, the way a lowered window does. A *percentage* default is
+implied by
 `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE`'s "values above the default percentage are ignored" but is still
 not published as a number — so the conclusion is unchanged: the bands remain declared judgment
 defaults. What this does change is that the trigger is **model- and environment-dependent**, so no
@@ -301,8 +306,8 @@ single band set is correct everywhere.
 
 Two adjacent caveats, same fetch: the doc warns the statusline percentage "may differ from
 `/context` output due to when each is calculated" — the value is as-of the last API response, not
-the next request; and with `autoCompactEnabled: false` no compaction ever fires (the session hard
--stops at the window instead), which makes the dumb band the *only* tripwire — strictly more
+the next request; and with `autoCompactEnabled: false` no compaction ever fires (the session
+hard-stops at the window instead), which makes the dumb band the *only* tripwire — strictly more
 load-bearing, never less.
 
 ### The trigger has no documented threshold, but it IS operator-tunable
@@ -346,8 +351,8 @@ on the session's behalf and the boundary was reached too late. Auto-compact offe
 hook, so a firing is best read diagnostically: **it means the boundary was missed**, not that the
 window was managed. Lowering the window moves the trigger, so the bands in `zones.json` must move
 with it — normalized into the percentage shape. A 400000-token window on a 1M-class model puts the
-trigger at **40% of the full window**, which is *inside* the shipped `smart` band (≤ 50): auto-
-compact would fire while every zone still reads green. Keeping bands below that trigger means
+trigger at **40% of the full window**, which is *inside* the shipped `smart` band (≤ 50), so
+auto-compact would fire while every zone still reads green. Keeping bands below that trigger means
 pulling the percentage bands under 40, not comparing 400000 against the same-looking `dumb`
 occupancy number — those two 400000s are different quantities.
 

--- a/plugins/context-guard/reference/reader-contract.md
+++ b/plugins/context-guard/reference/reader-contract.md
@@ -287,6 +287,18 @@ with a declared margin (if compaction triggers at ≥ 90% as its phrasing implie
 leads it by ≥ 15 points), not doc-derived constants. `zones.json` is the correction path if
 compaction is ever observed earlier.
 
+*Refinement, verified 2026-08-19 (model-config, "Default auto-compact thresholds"):* the docs are
+now more specific than "when approaching context limits" — with no window configured, compaction
+fires **at the model's context limit**, with enumerated exceptions that fire earlier (cloud
+sessions compact as the conversation *approaches* the limit; Sonnet 4.6 / Opus 4.6 without extended
+context, and Opus 4.8 / Opus 5 running on a 200K window, compact at the 200K boundary; a
+`CLAUDE_CODE_DISABLE_1M_CONTEXT=1` session on a native-1M model likewise; an unrecognized model ID
+compacts at whatever window Claude Code assumes for it). A *percentage* default is implied by
+`CLAUDE_AUTOCOMPACT_PCT_OVERRIDE`'s "values above the default percentage are ignored" but is still
+not published as a number — so the conclusion is unchanged: the bands remain declared judgment
+defaults. What this does change is that the trigger is **model- and environment-dependent**, so no
+single band set is correct everywhere.
+
 Two adjacent caveats, same fetch: the doc warns the statusline percentage "may differ from
 `/context` output due to when each is calculated" — the value is as-of the last API response, not
 the next request; and with `autoCompactEnabled: false` no compaction ever fires (the session hard
@@ -295,17 +307,36 @@ load-bearing, never less.
 
 ### The trigger has no documented threshold, but it IS operator-tunable
 
-No *default* threshold is documented (above), yet the point at which auto-compact fires is a
-configured value the operator can read and set. Three surfaces govern it. Verified 2026-08-17
-against two independent pools — the official
+No *default* threshold is published as a number (above), yet the point at which auto-compact fires
+is a configured value the operator can read and set. **Four** surfaces govern it. Verified
+2026-08-17 against two independent pools — the official
 [settings reference](https://code.claude.com/docs/en/settings) and the shipped binary's own schema
-strings (v2.1.233):
+strings (v2.1.233) — and re-verified 2026-08-19 against the live settings,
+[env-vars](https://code.claude.com/docs/en/env-vars), and
+[model-config](https://code.claude.com/docs/en/model-config) pages:
 
 | Surface | Kind | What it does |
 |---|---|---|
-| `autoCompactWindow` | `settings.json` key | How full the window gets before auto-compact fires, **in tokens, `100000` to `1000000`** (binary schema: `.int().min(1e5).max(1e6).optional()`). **No numeric default** — unset means a window tuned for the model, deliberately not published as a number. Written by the `/autocompact` command; the `--autocompact` flag sets it for one launch (both require Claude Code ≥ 2.1.221). |
-| `CLAUDE_CODE_AUTO_COMPACT_WINDOW` | environment variable | Same units and range; **highest precedence** — overrides the command, the flag, and the setting while it is set. |
-| `autoCompactEnabled` / `DISABLE_AUTO_COMPACT` | `settings.json` key (default `true`, shown in `/config` as **Auto-compact**) / environment variable | Turns auto-compact off entirely. Distinct from `DISABLE_COMPACT`, which disables *all* compaction including `/compact`. |
+| `autoCompactWindow` | `settings.json` key | How full the window gets before auto-compact fires, **in tokens, `100000` to `1000000`** (binary schema: `.int().min(1e5).max(1e6).optional()`). **No numeric default** — unset means a window tuned for the model, deliberately not published as a number. Written by the `/autocompact` command; the `--autocompact` flag sets it for one launch and, unlike the command, is not preempted by a higher-priority settings scope. |
+| `CLAUDE_CODE_AUTO_COMPACT_WINDOW` | environment variable | Same units and range; **highest precedence** — overrides the command, the flag, and the setting while set. **Accepts a plain integer only**: the command and flag take `500k` / `1M` / a bare `500` meaning thousands, but the variable reads `500k` as `500` and clamps to the 100K minimum. |
+| `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` | environment variable | Sets the **percentage (1–100) of the auto-compact window** at which compaction triggers. **Can only lower the threshold** — values above the default percentage are ignored. Applies only in sessions that compact *before* the model's context limit, and to subagents as well as the main conversation. |
+| `autoCompactEnabled` / `DISABLE_AUTO_COMPACT` | `settings.json` key (default `true`, shown in `/config` as **Auto-compact**) / environment variable | Turns auto-compact off entirely. (`DISABLE_COMPACT`, which disables *all* compaction including `/compact`, comes from the 2026-08-17 binary-strings pool; it is not listed on the env-vars page as of 2026-08-19 — treat it as unconfirmed by docs.) |
+
+Claude Code caps the window at the model's actual context window, so a configured value above it
+does not extend anything.
+
+**Normalize before comparing — the trigger is not in occupancy.** The two zone shapes answer
+different questions and must never be equated (see "Occupancy and combination rule"), and the
+trigger belongs to the **percentage** shape's accounting, not the token shape's: `used_percentage`
+is input-token-based and answers *distance to compaction*, while the token bands measure
+**occupancy** (`total_input_tokens + total_output_tokens`) and answer *distance to quality loss*.
+A configured window is a fill threshold, so compare it against the percentage shape and let the
+occupancy bands move independently.
+
+One consequence is load-bearing enough to state on its own, and it is the docs' own warning
+(env-vars, verified 2026-08-19): **`used_percentage` always measures against the model's full
+context window**, so once the auto-compact window is lowered, *the percentage no longer indicates
+when compaction will run*. A consumer reading only the percentage will not see the trigger coming.
 
 **Tune bands BELOW the effective trigger, never above it.** Whatever the trigger resolves to on a
 machine, the `dumb` band should be reached first. A zone reading exists so the session arrives at a
@@ -313,10 +344,12 @@ boundary decision — finish the phase, `/clear`, write a handoff — while that
 being made deliberately; if auto-compact fires first, the harness has already made a lossy choice
 on the session's behalf and the boundary was reached too late. Auto-compact offers no steering
 hook, so a firing is best read diagnostically: **it means the boundary was missed**, not that the
-window was managed. Operators who lower `autoCompactWindow` are moving the trigger, so the bands in
-`zones.json` move with it — a 400000-token trigger on a 1M window puts the shipped 1M `dumb`
-boundary (400000 occupancy) exactly *at* the trigger rather than below it, which forfeits the
-margin.
+window was managed. Lowering the window moves the trigger, so the bands in `zones.json` must move
+with it — normalized into the percentage shape. A 400000-token window on a 1M-class model puts the
+trigger at **40% of the full window**, which is *inside* the shipped `smart` band (≤ 50): auto-
+compact would fire while every zone still reads green. Keeping bands below that trigger means
+pulling the percentage bands under 40, not comparing 400000 against the same-looking `dumb`
+occupancy number — those two 400000s are different quantities.
 
 That diagnostic reading is adopted; the prescription that usually travels with it is not. **Leave
 auto-compact enabled.** Disabling it is a defensible operator choice on an attended machine, but it


### PR DESCRIPTION
Closes #2995

## Summary

The reader contract stated that no auto-compaction threshold is documented and stopped there, which reads as "the trigger is opaque". The *default* is unpublished, but the trigger is operator-tunable — and none of the surfaces that tune it appeared anywhere in the plugin. Consumers tuning zone bands therefore had no guidance on how the bands relate to the auto-compact trigger, and the PostCompact marker's `trigger` field had documented values but no consumer guidance.

Documentation only; no behavior change. context-guard 0.7.15 → 0.7.16.

## Fix

**`reference/reader-contract.md` — the four auto-compact config surfaces.** Verified 2026-08-17 against two independent pools (the official settings reference and the shipped binary's schema strings, v2.1.233), and re-verified 2026-08-19 against the live settings, env-vars, and model-config pages:

| Surface | Kind | What it does |
|---|---|---|
| `autoCompactWindow` | `settings.json` | Tokens, `100000`–`1000000`; **no numeric default** (model-tuned when unset). Written by `/autocompact`; `--autocompact` sets it for one launch and, unlike the command, isn't preempted by a higher-priority settings scope. |
| `CLAUDE_CODE_AUTO_COMPACT_WINDOW` | environment | Same units; **highest precedence**. Plain integer only — `500k` reads as `500` and clamps to the 100K minimum. |
| `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` | environment | Percentage (1–100) of the auto-compact window at which compaction triggers; **lower-only**. Applies to subagents too. |
| `autoCompactEnabled` / `DISABLE_AUTO_COMPACT` | `settings.json` (default `true`) / environment | Off switch. (`DISABLE_COMPACT` is recorded as binary-strings-sourced and **unconfirmed by docs** as of 2026-08-19.) |

**The bands-below-the-trigger rule, with rationale.** Whatever the trigger resolves to, `dumb` should be reached first: auto-compact offers no steering hook, so a firing means the boundary decision was reached too late.

**Comparisons are normalized into the percentage shape, never occupancy.** The contract already forbids equating its two zone shapes; the new guidance honors that explicitly. A configured window is a fill threshold in the percentage shape's input-token accounting, not the token shape's occupancy. Worked example: a 400,000-token window on a 1M-class model puts the trigger at **40% of the full window — inside the shipped `smart` band (≤ 50)**, so auto-compact fires while every zone still reads green. Recorded with the docs' own consequence: `used_percentage` **always** measures against the model's full context window, so a lowered window stops being visible in the percentage at all.

**Only the diagnostic half of the house stance is adopted.** The prescription that usually travels with it (disable auto-compact) is explicitly rejected: unattended cloud and autonomous sessions have no human at the boundary, and a degraded continuation beats a hard stall at the window. Auto-compact stays enabled as the last-resort safety net beneath the instrumented ladder.

**The Boris §64 rot figure (300–400k; `CLAUDE_CODE_AUTO_COMPACT_WINDOW=400000`) is recorded as a named practitioner anchor, never an adopted number** — carrying its own amendment, that the calibration is Opus 4.7-era and the Opus 5 prompting guide (verified 2026-08-08) removes its degradation premise. Consistent with claim-ladder bucket ii.

**The marker's `trigger` field now has consumer guidance.** Consumers deliberately do *not* differentiate on it — evidence degradation is trigger-independent, holding identically for a steered `/compact` and an auto-compact. The field is captured anyway so the stance is falsifiable: it is the observable for the track-on-event condition recorded in `docs/upstream/aihero-course.md` lane 3.

**A dated refinement to the adjacent "no documented threshold" paragraph.** Upstream is now more specific than the "when approaching context limits" phrasing that paragraph quotes: an unconfigured session compacts **at** the model's context limit, with five enumerated earlier-firing exceptions — including Sonnet 5 at "about 967K tokens by default". The conclusion is unchanged (no percentage default is published, so the bands stay declared judgment defaults), but the trigger is now documented as model- and environment-dependent, which is why no single band set is correct everywhere.

**`README.md`** gains a pointer naming the four surfaces, the below-the-trigger rule, and the full-window percentage caveat, deferring to the contract as SSOT.

## Verification

Every claim about shipped behavior was checked against the hooks' **emitted strings**, not their header comments: `hooks/post-compact-mark.sh` regex-captures `manual|auto`, defaults `unknown`, and writes the marker unconditionally (no boundary-timed carve-out), matching what the contract now states. Every upstream claim was checked against a live fetch of the primary page, not from memory.

Full local gate, re-run after each of the three commits:

- `scripts/validate-plugins.sh` — all manifests + catalog pass
- `generate-catalog.mjs --check` / `generate-cheatsheet.mjs --check` — both in sync
- `check-changelog-parity.sh` all four modes — `--check`, `--check-order`, `--check-bump origin/main`, `--check-preserved origin/main` (**40 headings compared, all preserved** — the entry was inserted above `## [0.7.15]`, not over it)
- `check-changed-skills.sh origin/main` — no skills touched
- `markdownlint-cli2` on every touched file — 0 issues
- `typos` on `plugins/context-guard/` — clean
- Test suites of everything the change could affect: `zones-inline-drift.test.sh` 11/0, `context-zone.test.sh` 73/0, `statusline-tee.test.sh` 47/0, `statusline-shim.test.sh` 36/0 — **167 passed, 0 failed**. The drift suite matters here specifically: the reader contract's operable-floor values are inlined by consumers, and none of them were altered.

### Review rounds

Four findings raised across three review passes, all verified against primary sources before acting, all fixed and resolved:

1. *(Codex, P2)* The worked example equated occupancy with the trigger's input-token accounting — breaking the contract's own "never equate them without normalizing" rule. Fixed in `a4168554`.
2. *(Claude, Important)* The surface table omitted `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE`. Confirmed against a live fetch and added in `a4168554`.
3. *(Claude, Important)* The refinement named three of upstream's five default-threshold exceptions, dropping Sonnet 5's. Fixed in `7c88cee5`.
4. *(Claude, Nit)* `auto-compact` split across a soft line break rendered as "auto- compact". Fixed in `7c88cee5`, along with a pre-existing instance of the same defect (`hard` / `-stops`) a few lines above.

## Related

- Refs #2901 (lane 3, the verification that produced verdicts C1–C3)
- Refs #2973 (adjacent reader-contract drift fix, merged as #3040)
- Refs #2994 (the durable AI Hero course roadmap this item sits in)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QbfCrj3X9FfGL7VRZYmrn4