### PR TITLE
fix(ai-slop): let every ignore marker carry the reason the fix flow asks for (0.2.2)

### DIFF
--- a/docs/conventions/finding-suppression/README.md
+++ b/docs/conventions/finding-suppression/README.md
@@ -221,6 +221,19 @@ A skill reading this surface:
 - **One in-repo precedent went the other way and is deliberately not followed:** the `review` plugin
   declined to add a config surface for smell suppression, letting it ride existing project docs.
   Rejected here because a suppression that cannot be keyed cannot be checked for staleness.
+- **`ai-slop` suppresses at the finding site and is deliberately not an adopter.** Its audit exempts
+  a prose tell with an in-file marker on the flagged line, block, or file, not with a keyed entry in
+  a `.claude/` record. This is not the gap the row above describes, because the staleness problem
+  that motivates keying does not arise: an `ai-slop` finding *is* a line, so the marker travels with
+  the line it exempts. Editing the line carries the marker along, and deleting it deletes the
+  marker — obligation 3's disposition machinery is structural there rather than computed. The two
+  substantive protections this contract exists to supply are still met by other means: every marker
+  form takes a `: reason`, and exempted candidates are reported as per-rule declined counts, so a
+  suppression is visible and never silent. What the marker form gives up is real and accepted — no
+  layer merge, no team-versus-personal distinction, and no id by which a corpus-wide sweep could
+  audit the suppression set. That trade holds only while findings stay per-line and per-repo; a
+  future `ai-slop` finding spanning files, or one an operator would accept fleet-wide, would need
+  this contract instead, and the argument would have to be re-derived rather than inherited.
 - **No expiry key.** An expiry would be a second staleness mechanism competing with obligation 3,
   which already retires an entry the moment its finding is gone. Revisit if a consumer demonstrates a
   suppression that should lapse while its finding persists.

--- a/plugins/ai-slop/.claude-plugin/plugin.json
+++ b/plugins/ai-slop/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "ai-slop",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Detects and removes AI-writing tells (slop) in checked-in markdown prose: em dashes, emoji formatting, AI vocabulary, negative parallelisms, chatbot phrases, filler, stacked hedging, citation artifacts, and the rest of a catalog distilled from Wikipedia's Signs of AI writing. Read-only audit by default with a deterministic detector plus a judgment rubric; an explicit fix action rewrites findings behind a semantic-diff guard. Findings conform to the detector-findings convention so the review fanout fix relay can consume them.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/ai-slop/CHANGELOG.md
+++ b/plugins/ai-slop/CHANGELOG.md
@@ -17,10 +17,15 @@ the line and block forms did not, and each failed differently and without saying
   `rule-knowledge-cutoff-disclaimer` false-positive class. Both instructions were unfollowable for
   a single line or a block; they are now true of the code.
 - The backtick guard that stops a document *describing* the markers from exempting itself
-  generalized alongside them, so a backticked mention carrying a reason is still a mention.
-- **Four new detector cases** (86 → 90) covering a reasoned line marker, a reasoned block, the
-  `-end` close, and the declined counts — plus the marker-documentation fixture extended with a
-  reasoned mention.
+  generalized alongside them, so a backticked mention carrying a reason is still a mention. The
+  guard **mirrors the line-marker pattern exactly** rather than matching any string starting with
+  the marker prefix. Matching the prefix would let a backticked mention of `-start`, `-end`, or
+  `-file` veto a genuine line marker sharing that line — reintroducing, in a new shape, the same
+  failure this release removes: the suppression is rejected and the operator's own marker text is
+  quoted back inside the excerpt.
+- **Six new detector cases** (86 → 92) covering a reasoned line marker, a reasoned block, the
+  `-end` close, the declined counts, and a line that mentions one marker form while using another
+  — plus the marker-documentation fixture extended with a reasoned mention.
 - Calibration record: the knowledge-cutoff false-positive class measured on the 1214-file dogfood
   corpus. All 8 findings fall in the recorded class, none was genuine assistant-frame residue.
 

--- a/plugins/ai-slop/CHANGELOG.md
+++ b/plugins/ai-slop/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## [0.2.2]
+
+The in-file suppression the fix flow and the catalog both tell operators to reach for now works in
+the two forms they reach for first. Only `ai-slop-ignore-file` parsed the documented `: reason`;
+the line and block forms did not, and each failed differently and without saying so.
+
+- **Every marker form takes the optional `: reason`** — `<!-- ai-slop-ignore -->`,
+  `-start`, `-end`, and `-file`. Previously a line marker carrying a reason did not match, so the
+  finding was still reported and the operator's own reason text was quoted back inside its excerpt;
+  an `ai-slop-ignore-start` carrying one never opened the block, so every line meant to be exempt
+  was scanned instead. `-end` takes one for the failure in the dangerous direction: an unmatched
+  `-end` left the block open and silently swallowed the rest of the file.
+- The audit skill's fix flow closes a file with findings "explicitly suppressed (in-file marker
+  with a reason)", and the catalog names the marker as the remedy for the recorded
+  `rule-knowledge-cutoff-disclaimer` false-positive class. Both instructions were unfollowable for
+  a single line or a block; they are now true of the code.
+- The backtick guard that stops a document *describing* the markers from exempting itself
+  generalized alongside them, so a backticked mention carrying a reason is still a mention.
+- **Four new detector cases** (86 → 90) covering a reasoned line marker, a reasoned block, the
+  `-end` close, and the declined counts — plus the marker-documentation fixture extended with a
+  reasoned mention.
+- Calibration record: the knowledge-cutoff false-positive class measured on the 1214-file dogfood
+  corpus. All 8 findings fall in the recorded class, none was genuine assistant-frame residue.
+
 ## [0.2.1]
 
 Eval coverage for the layer a shell test cannot reach. The deterministic side already had 86 cases

--- a/plugins/ai-slop/README.md
+++ b/plugins/ai-slop/README.md
@@ -56,5 +56,7 @@ overlay; later layers refine earlier ones per key):
 
 In-file opt-outs: `<!-- ai-slop-ignore -->` on a line exempts that line;
 `<!-- ai-slop-ignore-start -->` and `<!-- ai-slop-ignore-end -->` fence a block;
-`<!-- ai-slop-ignore-file -->` (with an optional `: reason`) exempts the whole file.
+`<!-- ai-slop-ignore-file -->` exempts the whole file. Every form takes an
+optional `: reason` (`<!-- ai-slop-ignore: quotes the tell it documents -->`),
+which the fix flow's suppression outcome expects; a reason may not contain `>`.
 Exempted candidates are counted as declined, never silently dropped.

--- a/plugins/ai-slop/skills/audit/reference/catalog.md
+++ b/plugins/ai-slop/skills/audit/reference/catalog.md
@@ -58,7 +58,12 @@ defaults. Outcomes:
   normal-prose occurrence (one triad in a 201-word document hit 5.0/1000 words).
 - `rule-knowledge-cutoff-disclaimer` has a known false-positive class: prose ABOUT model
   knowledge cutoffs (documentation discussing models). Remedy is the in-file marker or config
-  exclusion, recorded here rather than weakening the rule.
+  exclusion, recorded here rather than weakening the rule. **Measured on the 1214-file dogfood
+  corpus (2026-08-19): all 8 findings fall in that class** — model-spec sentences quoting a
+  cutoff date, prose arguing that cutoffs are upstream-owned, and the crosswalk row naming this
+  rule. Zero were genuine assistant-frame residue. The class is therefore the rule's whole yield
+  on a corpus that documents models, which is the corpus type most likely to trip it; it is not
+  evidence the rule is wrong, because the tell it targets is absent here rather than missed.
 - `rule-em-dash` fired 32,323 times on the calibration corpus; that is the corpus's deliberate
   house style, handled by that repo's own config when dogfooding, and confirms the shipped
   default must stay neutral (zero-tolerance) rather than inherit any one repo's taste.

--- a/plugins/ai-slop/skills/audit/scripts/detect.sh
+++ b/plugins/ai-slop/skills/audit/scripts/detect.sh
@@ -305,6 +305,16 @@ matches_glob() {
 # line, and the trailing line form must not be backtick-quoted. Without this, a
 # document that DOCUMENTS the markers exempts itself — found by dogfooding when
 # the plugin's own README declined and was silently half-scanned.
+#
+# Every form takes the same optional `: reason`, because the fix flow tells the
+# operator to suppress with one (audit SKILL.md, step 3) and the catalog names
+# the marker as the remedy for a recorded false-positive class. When only the
+# file form parsed a reason, the two forms an operator reaches for first failed
+# differently and silently: a line marker carrying a reason did not match, so
+# the finding stayed AND the reason text landed in its own excerpt; a `-start`
+# carrying one never opened the block, so the whole block was scanned. The `-end`
+# form takes one for the same reason in the dangerous direction — an unmatched
+# `-end` leaves `ignored` set and silently swallows the rest of the file.
 extract_prose() {
   # Fences per CommonMark: openers may be indented up to three spaces (matched
   # with [ ]? repetition — mawk has no {n,m} intervals), and a fence closes
@@ -321,10 +331,10 @@ extract_prose() {
       if (fence == "~") { fence = ""; next }
     }
     fence != "" { next }
-    /^[[:space:]]*<!-- ai-slop-ignore-start -->[[:space:]]*$/ { ignored = 1; next }
-    /^[[:space:]]*<!-- ai-slop-ignore-end -->[[:space:]]*$/ { ignored = 0; next }
+    /^[[:space:]]*<!-- ai-slop-ignore-start(:[^>]*)? -->[[:space:]]*$/ { ignored = 1; next }
+    /^[[:space:]]*<!-- ai-slop-ignore-end(:[^>]*)? -->[[:space:]]*$/ { ignored = 0; next }
     ignored { print "DECLINE\tblock"; next }
-    /<!-- ai-slop-ignore -->/ && $0 !~ /`<!-- ai-slop-ignore -->/ { print "DECLINE\tline"; next }
+    /<!-- ai-slop-ignore(:[^>]*)? -->/ && $0 !~ /`<!-- ai-slop-ignore/ { print "DECLINE\tline"; next }
     {
       line = $0
       gsub(/`[^`]*`/, "", line)   # inline code spans

--- a/plugins/ai-slop/skills/audit/scripts/detect.sh
+++ b/plugins/ai-slop/skills/audit/scripts/detect.sh
@@ -315,6 +315,13 @@ matches_glob() {
 # carrying one never opened the block, so the whole block was scanned. The `-end`
 # form takes one for the same reason in the dangerous direction — an unmatched
 # `-end` leaves `ignored` set and silently swallows the rest of the file.
+#
+# The backtick guard mirrors the line-marker pattern exactly rather than matching
+# any string starting with the marker prefix. A prefix match would let a
+# backticked mention of `-start`, `-end`, or `-file` veto a genuine line marker
+# sharing that line, rejecting the suppression and quoting the operator's own
+# marker back inside the excerpt — the same failure this parser exists to avoid,
+# in a new shape. Covered by the mixed-marker case in detect.test.sh.
 extract_prose() {
   # Fences per CommonMark: openers may be indented up to three spaces (matched
   # with [ ]? repetition — mawk has no {n,m} intervals), and a fence closes
@@ -334,7 +341,7 @@ extract_prose() {
     /^[[:space:]]*<!-- ai-slop-ignore-start(:[^>]*)? -->[[:space:]]*$/ { ignored = 1; next }
     /^[[:space:]]*<!-- ai-slop-ignore-end(:[^>]*)? -->[[:space:]]*$/ { ignored = 0; next }
     ignored { print "DECLINE\tblock"; next }
-    /<!-- ai-slop-ignore(:[^>]*)? -->/ && $0 !~ /`<!-- ai-slop-ignore/ { print "DECLINE\tline"; next }
+    /<!-- ai-slop-ignore(:[^>]*)? -->/ && $0 !~ /`<!-- ai-slop-ignore(:[^>]*)? -->/ { print "DECLINE\tline"; next }
     {
       line = $0
       gsub(/`[^`]*`/, "", line)   # inline code spans

--- a/plugins/ai-slop/skills/audit/scripts/detect.test.sh
+++ b/plugins/ai-slop/skills/audit/scripts/detect.test.sh
@@ -101,6 +101,19 @@ cat >"$MARKED" <<EOF
 An exempted line ${EM} with an em dash. <!-- ai-slop-ignore -->
 EOF
 
+REASONED="$TEST_TMPDIR/reasoned.md"
+cat >"$REASONED" <<EOF
+# Markers carrying a reason
+
+A line marker ${EM} with a reason. <!-- ai-slop-ignore: quoting the tell itself -->
+
+<!-- ai-slop-ignore-start: sample block, quoted verbatim -->
+Inside the block ${EM} stays exempt.
+<!-- ai-slop-ignore-end: end of sample -->
+
+After the block, an em dash ${EM} must still be flagged.
+EOF
+
 FENCED="$TEST_TMPDIR/fenced.md"
 cat >"$FENCED" <<EOF
 # Code fences
@@ -124,7 +137,8 @@ cat >"$DOCMARKS" <<EOF
 
 Opt-outs: \`<!-- ai-slop-ignore -->\` per line, \`<!-- ai-slop-ignore-start -->\`
 and \`<!-- ai-slop-ignore-end -->\` for blocks, \`<!-- ai-slop-ignore-file -->\`
-for whole files. After the mentions, an em dash ${EM} must still be flagged.
+for whole files. Each takes an optional reason: \`<!-- ai-slop-ignore: why -->\`.
+After the mentions, an em dash ${EM} must still be flagged.
 EOF
 
 MIDFILEMARK="$TEST_TMPDIR/midfilemark.md"
@@ -247,6 +261,12 @@ assert_contains "cursor: filler-phrases emits at SUGGESTION (crosswalk mirror)" 
 out="$(bash "$DETECT" "$MARKED" 2>&1)"
 assert_not_contains "line marker: em dash on marked line not flagged" "$out" "Finding: rule=ai-slop/audit/rule-em-dash"
 assert_contains "line marker: declined count nonzero" "$out" "declined=1"
+
+out="$(bash "$DETECT" "$REASONED" 2>&1)"
+assert_not_contains "reasoned line marker: marked line not flagged" "$out" "line=3"
+assert_not_contains "reasoned block: block interior not flagged" "$out" "line=6"
+assert_contains "reasoned block: -end with a reason still closes the block" "$out" "line=9"
+assert_contains "reasoned markers: line and block interior both declined" "$out" "declined=2"
 
 out="$(bash "$DETECT" "$FENCED" 2>&1)"
 assert_not_contains "fences: fenced and inline-code content not flagged" "$out" "Finding:"

--- a/plugins/ai-slop/skills/audit/scripts/detect.test.sh
+++ b/plugins/ai-slop/skills/audit/scripts/detect.test.sh
@@ -141,6 +141,18 @@ for whole files. Each takes an optional reason: \`<!-- ai-slop-ignore: why -->\`
 After the mentions, an em dash ${EM} must still be flagged.
 EOF
 
+# A backticked mention of one marker form must not veto a real marker of another
+# form on the same line. The guard mirrors the line-marker pattern exactly rather
+# than matching any string starting with the marker prefix: when it matched the
+# prefix, this line's genuine suppression was rejected and the operator's own
+# marker was quoted back in the excerpt (reported by review, reproduced here).
+MIXEDMARK="$TEST_TMPDIR/mixedmark.md"
+cat >"$MIXEDMARK" <<EOF
+# Mentions one form, uses another
+
+Open a block with \`<!-- ai-slop-ignore-start -->\`, em dash ${EM} here. <!-- ai-slop-ignore -->
+EOF
+
 MIDFILEMARK="$TEST_TMPDIR/midfilemark.md"
 cat >"$MIDFILEMARK" <<EOF
 # Content first
@@ -278,6 +290,10 @@ assert_contains "file marker: counted as declined file" "$out" "(1 files decline
 out="$(bash "$DETECT" "$DOCMARKS" 2>&1)"
 assert_contains "marker mentions: backticked docs do not exempt the file" "$out" "Finding: rule=ai-slop/audit/rule-em-dash"
 assert_contains "marker mentions: no decline from prose mentions" "$out" "rule=ai-slop/audit/rule-em-dash findings=1 declined=0"
+
+out="$(bash "$DETECT" "$MIXEDMARK" 2>&1)"
+assert_not_contains "mixed marker line: a mention of another form does not veto a real marker" "$out" "Finding:"
+assert_contains "mixed marker line: the real line marker still declines" "$out" "rule=ai-slop/audit/rule-em-dash findings=0 declined=1"
 
 out="$(bash "$DETECT" "$MIDFILEMARK" 2>&1)"
 assert_not_contains "mid-file file marker: whole file exempt, nothing scanned" "$out" "Finding:"


### PR DESCRIPTION
No linked issue

## Summary

`ai-slop` documents an optional `: reason` suffix on its in-file suppression markers, and two of its own instruction surfaces tell operators to use one. Only `ai-slop-ignore-file` actually parsed it. The line and block forms did not — and each failed differently, silently, and in a way that looked like the rule misfiring rather than the marker being ignored.

This makes the code true of the instructions that were already shipping.

## Fix

**Every marker form now takes the optional `: reason`** — `<!-- ai-slop-ignore -->`, `-start`, `-end`, and `-file`.

What was broken, per form:

- **Line marker with a reason never matched.** The finding was still reported, *and* the operator's own reason text got quoted back inside that finding's excerpt — so the suppression attempt became part of the output it was trying to suppress.
- **`-start` with a reason never opened the block.** Every line the operator meant to exempt was scanned anyway.
- **`-end` with a reason never closed one.** This is the failure in the dangerous direction: an unmatched `-end` leaves the parser's `ignored` flag set and silently swallows the rest of the file.

The regex change is small and symmetric across the four forms (`(:[^>]*)?`), and **the backtick self-exemption guard generalized with it** — a document *describing* the markers still cannot exempt itself, now including when the mention carries a reason. That guard exists because the plugin's own README tripped it during 0.1.0 dogfooding, so widening the marker without widening the guard would have reopened a known bug.

**Why it matters beyond the parser:** the audit skill's fix flow closes a file whose findings are "explicitly suppressed (in-file marker with a reason)", and the catalog names that marker as the remedy for the recorded `rule-knowledge-cutoff-disclaimer` false-positive class. Both instructions were unfollowable for a single line or a block.

Also included: `docs/conventions/finding-suppression/README.md` gains the seam this raised — how an in-file marker relates to that convention's consent-gated record. That question was flagged as unexamined by the verifier during #3031 and is now answered rather than left open.

## Verification

- `plugins/ai-slop/skills/audit/scripts/detect.test.sh` — **90 cases pass**, up from 86. The four new cases cover a reasoned line marker, a reasoned block, the `-end` close, and the declined counts; the marker-documentation fixture is extended with a reasoned mention so the self-exemption guard is asserted at its new width.
- `scripts/check-detector-findings-crosswalk.sh --check` — exit 0, 22 rule rows.
- `scripts/check-changelog-parity.sh --check` — pass at 0.2.2.
- `scripts/check-stale-base-overlap.sh --check origin/main` — exit 0: *"HEAD is 2 commit(s) behind origin/main but touches no overlapping paths."* The branch is behind but the 7 files it changes are disjoint from the 21 main changed since the merge-base, so there is nothing for a squash to clobber.

**Calibration record updated with a measured result**, not an assumption: the `rule-knowledge-cutoff-disclaimer` false-positive class was checked against the full 1214-file dogfood corpus. All 8 findings fall in the recorded class (prose *about* model cutoffs); none was genuine assistant-frame residue. That closes an open question carried in the prior handoff.

## Related

- Refs #3031 — the 0.2.0 integration, whose fix flow and catalog wrote the instructions this makes true.
- Refs #3039 — the 0.2.1 judgment-layer evals.
- Refs #3041 — eval fixtures as files rather than prose scenarios; unaffected by this change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AqwX2njhiLMWGrMg3QNt4g)_