### PR TITLE
docs(scripts): name the surfaces the skill-count gate cannot see

### DIFF
--- a/scripts/check-skill-count-claims.sh
+++ b/scripts/check-skill-count-claims.sh
@@ -66,9 +66,16 @@
 # actually bit: the PR that introduced this gate carried a hand-written
 # version-and-assertion table in its body, and that table went stale within the
 # hour when a merge with main renumbered two plugins. A reviewer caught it. So
-# when prose about this repo lives on GitHub rather than on disk -- a PR or issue
-# body, a release note, a wiki page -- derive its counts at write time or expect
+# when prose describing the CURRENT repo lives on GitHub rather than on disk --
+# a PR or issue body, a wiki page -- derive its counts at write time or expect
 # them to drift, and do not read a green gate as covering them.
+#
+# The dated-record carve-out stated above for CHANGELOG.md travels off-disk with
+# the count. A GitHub release note states what was true of the release it
+# describes, so its denominator is that tree, and later divergence is history
+# rather than drift -- rewriting it to match today's tree would falsify it for
+# exactly the reason the changelog is not scanned. Off-disk surfaces get the same
+# current-state test as the scanned ones, not a broader one.
 #
 # Nothing else was scoped out WITHIN the files it reads. Counts of agents,
 # commands and hooks would be class A too, and the grammar generalizes to them by

--- a/scripts/check-skill-count-claims.sh
+++ b/scripts/check-skill-count-claims.sh
@@ -60,10 +60,21 @@
 #     that is a materially larger job than this one and is deliberately not
 #     attempted here.
 #
-# Nothing else was scoped out. Counts of agents, commands and hooks would be
-# class A too, and the grammar generalizes to them by swapping the noun -- but
-# no plugin makes such a claim today (checked across every README and manifest),
-# so the noun stays `skills` rather than shipping unexercised machinery.
+# SURFACES, not just classes: this gate reads FILES IN THE REPO. A count written
+# anywhere else is class A -- derivable from the tree -- and still unguarded,
+# because nothing here can see it. A pull-request description is the case that
+# actually bit: the PR that introduced this gate carried a hand-written
+# version-and-assertion table in its body, and that table went stale within the
+# hour when a merge with main renumbered two plugins. A reviewer caught it. So
+# when prose about this repo lives on GitHub rather than on disk -- a PR or issue
+# body, a release note, a wiki page -- derive its counts at write time or expect
+# them to drift, and do not read a green gate as covering them.
+#
+# Nothing else was scoped out WITHIN the files it reads. Counts of agents,
+# commands and hooks would be class A too, and the grammar generalizes to them by
+# swapping the noun -- but no plugin makes such a claim today (checked across
+# every README and manifest), so the noun stays `skills` rather than shipping
+# unexercised machinery.
 #
 # Direction is over-flag, not under-flag, within that closed set: a false
 # positive costs one line in scripts/skill-count-claim-exemptions.txt with the


### PR DESCRIPTION
No linked issue

## Summary

The skill-count gate's header states which *class* of stale count it holds
(repository-derivable) and which it does not (document-internal), then asserts
"Nothing else was scoped out" — which reads as completeness the gate does not
have. It never named the *surface* boundary: the gate reads files in the repo,
so a class-A count written anywhere else is equally derivable and equally
unguarded, because nothing here can see it.

## Fix

Adds a `SURFACES, not just classes` paragraph to the header and qualifies the
"nothing else" sentence to the files the gate actually reads.

The omission has a measured cost, and it is this gate's own introduction that
paid it: PR #3034 carried a hand-written version-and-assertion table in its
body, and that table went stale within the hour when a merge with `main`
renumbered two plugins. Those counts were class A — plainly derivable from the
tree — and invisible to the gate, because a PR description is not a file in the
repo. A reviewer caught it, which is precisely the control this gate exists to
replace.

So the header now says: prose describing the CURRENT repo that lives on GitHub
rather than on disk — a PR or issue body, a wiki page — derives its counts at
write time or drifts, and a green gate must not be read as covering it.

A second commit narrows that list. The first draft included "a release note",
which contradicted a decision stated 40 lines above it in the same header:
`CHANGELOG.md` is deliberately not scanned, because a dated entry describes the
release it shipped with and rewriting it to match today's tree falsifies history
rather than fixing a claim. A GitHub release note is that same kind of record.
The header now states that carve-out explicitly as travelling off-disk with the
count, rather than leaving it implied — off-disk surfaces get the same
current-state test as the scanned ones, not a broader one. Raised by an
automated reviewer; the contradiction was real.

Comment-only change throughout. No behavior, no new surface scanned, no
token-list edit.

## Verification

- `shellcheck` at the repo's own `.shellcheckrc` (not a laxer severity) — clean
- `shfmt -d` — clean
- `scripts/check-skill-count-claims.test.sh` — all assertions passed
- `scripts/check-skill-count-claims.sh --check` — every claim matches the tree
- `typos`, `editorconfig-checker` — clean
- `scripts/check-changelog-parity.sh --check` and `--check-bump origin/main` —
  no version bump required; `scripts/` is not a versioned plugin, and this PR
  touches nothing under `plugins/`
- Tracker references in the added comment use the bare `(#N)` form the
  `comment-hygiene` lane requires, checked before pushing because that lane is
  an external composite action this repo does not vendor and so cannot be run
  locally

All of the above were re-run after the second commit, not just the first.

This body deliberately carries no hand-written counts of assertions, claims, or
versions — the exact failure mode the change documents. The numbers are in the
command output above, where they are regenerated rather than transcribed.

**This body was itself corrected once.** After the second commit it still
described the superseded wording, which is the same off-disk drift the change
documents, occurring in this PR's own description. Fixed here rather than left
as a demonstration.

## Related

Refs #3034 — the PR that introduced this gate, and whose own body supplied the
stale-count evidence cited above.
