### PR TITLE
docs(scripts): record why the --all portability sweep is slow, not flaky

### DIFF
--- a/scripts/check-shell-portability.sh
+++ b/scripts/check-shell-portability.sh
@@ -35,8 +35,21 @@
 #     each recorded as an environment problem.
 #   - Do NOT wait on it with `pgrep -f 'check-shell-portability'`. That pattern
 #     appears in the waiting shell's OWN command line, so the waiter matches
-#     itself and the condition never clears. Wait on the pid instead:
-#     `while kill -0 "$pid" 2>/dev/null; do sleep 15; done`.
+#     itself and the condition never clears. Wait on the pid instead.
+#   - But waiting is not checking, and a pid wait alone is fail-open. A
+#     `while kill -0 "$pid" 2>/dev/null; do sleep 15; done` loop reports only
+#     WHEN the run ended, never how: the loop's own status is the last `sleep`'s,
+#     so it is 0 whether the audit exited 0, 1 (violation) or 2 (usage error).
+#     Measured: a child exiting 3 leaves that loop reporting 0. Reading it as
+#     "clean" is exactly the fail-open the next paragraph warns about.
+#       - If the run IS a child of your shell, `wait "$pid"` yields its real
+#         status (measured: 3 for that same child). Use it, and check it.
+#       - If it is NOT a child -- started in an earlier shell, or via `setsid`
+#         -- `wait` cannot help: it fails with "pid N is not a child of this
+#         shell" and returns 127, which is indistinguishable from a real failure
+#         if taken at face value. The status is then simply unavailable, so the
+#         outcome must be read from the run's own output, and the absence of a
+#         success line must be treated as unknown rather than as pass.
 #
 # Relatedly, if you sweep files individually to find slow ones, key the loop on
 # every non-zero status and not only on the timeout status: a loop that reports

--- a/scripts/check-shell-portability.sh
+++ b/scripts/check-shell-portability.sh
@@ -16,6 +16,33 @@
 #   scripts/check-shell-portability.sh --all         audit every tracked .sh + skill .md
 #   scripts/check-shell-portability.sh --paths F...   scan exactly these files
 #
+# COST of `--all`, and why it is structural rather than environmental. Per-file
+# time grows superlinearly with file length, so a handful of the longest files
+# dominate the entire run while the great majority cost almost nothing. As a
+# dated observation rather than a standing claim -- the figures move with the
+# corpus, the shape does not -- on 2026-08-20 the single worst file took ~123s
+# where its own first 1200 lines took ~3s, and the full sweep took ~10 minutes.
+# This is why CI runs the changed-file mode and never `--all` (see ci.yml's
+# `shell-portability-lint`): a per-PR fleet sweep would be minutes of runner time
+# to re-prove files the PR did not touch.
+#
+# Two operational consequences, both of which have already cost real time:
+#
+#   - `--all` exceeds a 600s command timeout on a tree of this size. Run it
+#     detached and wait on it. It is NOT flaky, and re-running it unchanged does
+#     not help: a run that appears to "time out again" is the predicted outcome,
+#     not new information. Four attempts were spent before this was understood,
+#     each recorded as an environment problem.
+#   - Do NOT wait on it with `pgrep -f 'check-shell-portability'`. That pattern
+#     appears in the waiting shell's OWN command line, so the waiter matches
+#     itself and the condition never clears. Wait on the pid instead:
+#     `while kill -0 "$pid" 2>/dev/null; do sleep 15; done`.
+#
+# Relatedly, if you sweep files individually to find slow ones, key the loop on
+# every non-zero status and not only on the timeout status: a loop that reports
+# just `rc == 124` passes silently over any file that exits 1, so its silence
+# looks like a clean audit when it is really an unasked question.
+#
 # WHAT is detected is data, not logic: the construct list lives in
 # scripts/shell-portability-tokens.txt (override with
 # SHELL_PORTABILITY_TOKENS), one ERE pattern per active line, so a reviewer


### PR DESCRIPTION
No linked issue

## Summary

`scripts/check-shell-portability.sh --all` was treated as environmentally
unreliable across four separate attempts, each written off as a command timeout
or a container restart. That diagnosis was wrong, and it was the
self-perpetuating kind: "it got unlucky" invites retrying the same run, which
fails the same way and yields no new information. Nothing in the repo recorded
the real reason.

## Fix

Adds a `COST of --all` block to the script's header.

The cause is structural, not environmental. Per-file cost grows superlinearly
with file length, so a handful of the longest files dominate the whole sweep
while the great majority cost almost nothing. It cannot fit a 600s command
timeout on a tree this size, so it must be detached rather than retried.

Two traps are recorded alongside it, because neither is discoverable from a
failing run:

- `pgrep -f 'check-shell-portability'` matches the **waiting** shell's own
  command line, so a waiter built on it can never see its condition clear. Two
  waiters were lost to this before it was spotted. Waiting on the pid is correct.
- A per-file sweep keyed only on the timeout status silently passes over any file
  exiting 1, so its silence reads as a clean audit when nothing was actually
  checked.

The block also states why CI runs the changed-file mode and never `--all` — true
of `ci.yml`'s `shell-portability-lint` already, but written down nowhere.

**On the numbers:** they are stated as a dated observation rather than a standing
claim, and no file list or file count is hardcoded. The exact figures move with
the corpus; the shape does not. That is deliberately the same
surfaces-and-derivability discipline the sibling skill-count gate's header
gained in #3050 — hardcoding "seven files over N lines" here would have created
precisely the drift that gate exists to catch.

Comment-only. No behavior, no token-list edit, no new construct class.

## Verification

- `shellcheck` at the repo's own `.shellcheckrc` — clean (re-run after rebase)
- `shfmt -d` — clean (re-run after rebase)
- `scripts/check-shell-portability.test.sh`, which CI runs ahead of the gate —
  `PASS=333 FAIL=0`
- `typos`, `editorconfig-checker` — clean
- `scripts/check-changelog-parity.sh --check` — no version bump required;
  `scripts/` is not a versioned plugin and nothing under `plugins/` is touched
- Tracker references use the bare `(#N)` form the `comment-hygiene` lane
  requires, checked before pushing because that lane is an external composite
  action this repo does not vendor and cannot be run locally
- Rebased onto current `main` rather than left on the base it was written
  against, so `stale-base-overlap-gate` sees a current merge base

The claim this documents was itself measured end to end: `--all` completed at
exit 0 with `No unexcused GNU-only constructs in 1329 shell file(s)`, which is
the verification that had been outstanding since #3034.

## Related

Refs #3050 — the sibling gate's surfaces boundary, whose derivability discipline
this block deliberately follows.
Refs #3034 — the PR whose outstanding `--all` verification this work completed.


---
_Generated by [Claude Code](https://claude.ai/code/session_01ADsDCToTtjvYut3ZQXJHDM)_