### PR TITLE
fix(skill-quality): stop check 21 passing silently under mawk (0.17.1)

### DIFF
--- a/plugins/skill-quality/.claude-plugin/plugin.json
+++ b/plugins/skill-quality/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "skill-quality",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "Skill-authoring QA tooling: a static contract checker that runs twenty-four deterministic checks over a Claude Code skill (frontmatter, explicit invocation mode, per-skill listing-entry cap, trigger-keyword preservation, line caps, broken internal refs, markdownlint, gotchas surface, evals presence, precompute opportunity, completion-criteria signal, injection shell-declaration, fresh-eyes declaration conformance), a shared skill-listing budget reporter across a set of skills, and a bundled evals.json schema plus a deterministic eval-quality lint (duplicate case identities, missing fixtures, empty or vague grading criteria, set-coverage warnings). Runs against any repo's skills directory via the convention-resolution ladder \u2014 no baked layout.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/skill-quality/CHANGELOG.md
+++ b/plugins/skill-quality/CHANGELOG.md
@@ -3,6 +3,24 @@
 All notable changes to the `skill-quality` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.17.1]
+
+### Fixed
+
+- **`check`: Check 21 no longer silently passes under mawk (#3005).** The fresh-eyes scanner's
+  embedded awk program used ERE interval expressions, two of them immediately followed by a group
+  (`^ {0,3}(...)`). mawk 1.3.4 panics on that construct — `REcompile() - panic: values still on
+  machine stack` — and dies before emitting a single record, so on a stock Debian/Ubuntu box every
+  malformed `fresh-eyes-exempt` directive PASSed and the whole check reported a clean run over a
+  file it never scanned. mawk 1.3.3, which does not implement intervals at all, degrades the same
+  way for the same regexes by matching the braces as literal text. The scanner is now written
+  interval-free throughout — the three-space indent cap as three optional spaces, the ordered-marker
+  digit cap as one digit plus eight optional ones — preserving the exact CommonMark bounds it
+  already enforced. This is the portability shape Check 23 was written to in `#2963`; gawk behavior
+  is unchanged, and `check-skill.test.sh` gains 21 passing assertions on mawk with no regressions.
+  A source-level guard assertion now fails the suite if any interval expression returns, because a
+  gawk CI runner cannot observe this class of break any other way.
+
 ## [0.17.0]
 
 ### Added

--- a/plugins/skill-quality/CHANGELOG.md
+++ b/plugins/skill-quality/CHANGELOG.md
@@ -18,8 +18,12 @@ All notable changes to the `skill-quality` plugin are documented here. Format fo
   digit cap as one digit plus eight optional ones — preserving the exact CommonMark bounds it
   already enforced. This is the portability shape Check 23 was written to in `#2963`; gawk behavior
   is unchanged, and `check-skill.test.sh` gains 21 passing assertions on mawk with no regressions.
-  A source-level guard assertion now fails the suite if any interval expression returns, because a
-  gawk CI runner cannot observe this class of break any other way.
+  A source-level guard assertion now fails the suite if an interval returns to any awk-consumed
+  regex — the embedded programs' regex literals and the judge regex passed with `-v` — in `{n}`,
+  `{n,}` or `{n,m}` form, since mawk panics on an exact-count interval before a group exactly as it
+  does on a bounded one. It is scoped to awk rather than the whole file because Bash's own `[[ =~ ]]`
+  regexes may use intervals freely, and it is deliberately source-level rather than behavioral
+  because a gawk CI runner cannot observe this class of break any other way.
 
 ## [0.17.0]
 

--- a/plugins/skill-quality/scripts/check-skill.sh
+++ b/plugins/skill-quality/scripts/check-skill.sh
@@ -1022,11 +1022,21 @@ for fe_file in "${FRESH_EYES_FILES[@]}"; do
     # Start of file counts as a paragraph break, so an indented block opening on
     # line one is recognized as one.
     BEGIN { fe_blank = 1; cm_in_comment = 0 }
+    # NO ERE INTERVALS IN THIS PROGRAM. The three-space indent cap is written as
+    # three optional spaces (" ? ? ?") and the ordered-marker digit cap as one
+    # digit plus eight optional ones, never as {0,3} / {1,9}. Two mawk failures
+    # motivate the rule, and both are silent: mawk 1.3.4 PANICS ("REcompile() -
+    # panic: values still on machine stack") when an interval is immediately
+    # followed by a group, killing the program before it emits a record, so every
+    # malformed directive PASSes; mawk 1.3.3 does not implement intervals at all
+    # and matches them as literal characters, so the same scan quietly never
+    # fires. Both leave check 21 reporting a clean run over a file it never read.
+    # Same portability intent as the [[:space:]] note above, one layer deeper.
     # Blockquote nesting depth of a raw line: the number of leading `>` markers,
     # each optionally followed by one space, under the three-space indent cap.
     function fe_depth_of(s,   d) {
       d = 0
-      while (match(s, /^ {0,3}> ?/)) { d++; s = substr(s, RSTART + RLENGTH) }
+      while (match(s, /^ ? ? ?> ?/)) { d++; s = substr(s, RSTART + RLENGTH) }
       return d
     }
     { sub(/\r$/, "") }
@@ -1079,8 +1089,8 @@ for fe_file in "${FRESH_EYES_FILES[@]}"; do
       if (!fe_fence || fe_open_pre) {
         do {
           fe_pre = $0
-          sub(/^ {0,3}> ?/, "", $0)
-          sub(/^ {0,3}([-*+]|[0-9]{1,9}[.)])[ \t]+/, "", $0)
+          sub(/^ ? ? ?> ?/, "", $0)
+          sub(/^ ? ? ?([-*+]|[0-9][0-9]?[0-9]?[0-9]?[0-9]?[0-9]?[0-9]?[0-9]?[0-9]?[.)])[ \t]+/, "", $0)
         } while ($0 != fe_pre)
       }
       fe_stripped = ($0 != fe_raw)
@@ -1091,7 +1101,7 @@ for fe_file in "${FRESH_EYES_FILES[@]}"; do
     # it does when it cannot tell are stated once in the Parsing contract section
     # of skills/check/reference/fresh-eyes-declarations.md — that doc is the claim
     # this code implements; do not restate it here.
-    /^ {0,3}(```+|~~~+)/ {
+    /^ ? ? ?(```+|~~~+)/ {
       fe_run = $0
       sub(/^ */, "", fe_run)
       fe_char = substr(fe_run, 1, 1)

--- a/plugins/skill-quality/scripts/check-skill.test.sh
+++ b/plugins/skill-quality/scripts/check-skill.test.sh
@@ -2990,8 +2990,9 @@ fi
 # same silent-failure class open.
 #
 # Scoped to what awk actually compiles, because Bash is not mawk and its own
-# [[ =~ ]] regexes may use intervals freely — the frontmatter date check below
-# does, and rejecting it would be a false positive. Two surfaces reach awk:
+# [[ =~ ]] regexes may use intervals freely — check-skill.sh dates a frontmatter
+# synced: value with one, and rejecting it would be a false positive on correct
+# code. Two surfaces reach awk:
 # slash-delimited regex literals inside the embedded programs, and the judge
 # regex handed across with -v.
 INTERVAL_RE='\{[0-9]+(,[0-9]*)?\}'

--- a/plugins/skill-quality/scripts/check-skill.test.sh
+++ b/plugins/skill-quality/scripts/check-skill.test.sh
@@ -2972,23 +2972,43 @@ else
   fail "setup skill should be attributed to class (ii) (rc=$rc): $out"
 fi
 
-# Portability guard: no ERE interval expressions in the checker source.
+# Portability guard: no ERE interval expressions in the checker's awk regexes.
 #
 # Every other assertion here is black-box, but this failure mode is invisible to
 # a black-box run on the CI runner: gawk compiles intervals happily, so a
-# reintroduced {n,m} passes the whole suite on CI and only breaks for consumers
-# on mawk — silently, because mawk 1.3.4 panics out of the awk program before it
-# emits a record and mawk 1.3.3 matches the braces as literal text. Either way
-# the affected check reports a clean run over a file it never scanned, which is
-# the worst shape a gate can fail in. A source-level assertion is the only form
-# that fires on a gawk runner, so it is deliberately implementation-aware.
+# reintroduced interval passes the whole suite on CI and only breaks for
+# consumers on mawk — silently, because mawk 1.3.4 panics out of the awk program
+# before it emits a record and mawk 1.3.3 matches the braces as literal text.
+# Either way the affected check reports a clean run over a file it never
+# scanned, which is the worst shape a gate can fail in. A source-level assertion
+# is the only form that fires on a gawk runner, so it is deliberately
+# implementation-aware.
 #
-# Comment lines are exempt: the rule itself is documented in prose that names the
-# forbidden syntax.
-if interval_hits="$(grep -nE '^[[:space:]]*[^#[:space:]].*\{[0-9]+,[0-9]*\}' "$SUT")"; then
-  fail "checker source must contain no ERE interval expressions (mawk-portability): ${interval_hits//$'\n'/ | }"
+# All three interval forms are rejected, {n} included: mawk panics on an
+# exact-count interval before a group (a{3}(b)) exactly as it does on the
+# a{0,3}(b) that motivated this guard, so a comma-only pattern would leave the
+# same silent-failure class open.
+#
+# Scoped to what awk actually compiles, because Bash is not mawk and its own
+# [[ =~ ]] regexes may use intervals freely — the frontmatter date check below
+# does, and rejecting it would be a false positive. Two surfaces reach awk:
+# slash-delimited regex literals inside the embedded programs, and the judge
+# regex handed across with -v.
+INTERVAL_RE='\{[0-9]+(,[0-9]*)?\}'
+interval_hits="$(
+  {
+    # Regex literals in the embedded awk programs, comment lines exempt (the
+    # rule is documented in prose that necessarily names the forbidden syntax).
+    grep -nE "/[^/]*${INTERVAL_RE}[^/]*/" "$SUT" | grep -vE '^[0-9]+:[[:space:]]*#'
+    # The judge regex is a POSIX ERE that awk compiles, even though it is
+    # written as a shell string and never appears between slashes.
+    grep -nE "^[[:space:]]*FRESH_EYES_JUDGE_RE=.*${INTERVAL_RE}" "$SUT"
+  } 2>/dev/null
+)"
+if [[ -n "$interval_hits" ]]; then
+  fail "awk regexes must contain no ERE interval expressions (mawk-portability): ${interval_hits//$'\n'/ | }"
 else
-  pass "checker source is free of ERE interval expressions (mawk-portable)"
+  pass "awk regexes are free of ERE interval expressions (mawk-portable)"
 fi
 
 if [[ $fails -ne 0 ]]; then

--- a/plugins/skill-quality/scripts/check-skill.test.sh
+++ b/plugins/skill-quality/scripts/check-skill.test.sh
@@ -2972,6 +2972,25 @@ else
   fail "setup skill should be attributed to class (ii) (rc=$rc): $out"
 fi
 
+# Portability guard: no ERE interval expressions in the checker source.
+#
+# Every other assertion here is black-box, but this failure mode is invisible to
+# a black-box run on the CI runner: gawk compiles intervals happily, so a
+# reintroduced {n,m} passes the whole suite on CI and only breaks for consumers
+# on mawk — silently, because mawk 1.3.4 panics out of the awk program before it
+# emits a record and mawk 1.3.3 matches the braces as literal text. Either way
+# the affected check reports a clean run over a file it never scanned, which is
+# the worst shape a gate can fail in. A source-level assertion is the only form
+# that fires on a gawk runner, so it is deliberately implementation-aware.
+#
+# Comment lines are exempt: the rule itself is documented in prose that names the
+# forbidden syntax.
+if interval_hits="$(grep -nE '^[[:space:]]*[^#[:space:]].*\{[0-9]+,[0-9]*\}' "$SUT")"; then
+  fail "checker source must contain no ERE interval expressions (mawk-portability): ${interval_hits//$'\n'/ | }"
+else
+  pass "checker source is free of ERE interval expressions (mawk-portable)"
+fi
+
 if [[ $fails -ne 0 ]]; then
   printf '%d assertion(s) failed\n' "$fails" >&2
   exit 1


### PR DESCRIPTION
Closes #3005

## Summary

Check 21 (fresh-eyes declaration conformance) silently passed every file it was given on any machine
whose `awk` is mawk — the Ubuntu/Debian default. Its embedded awk program used ERE interval
expressions, and mawk aborts the program before it emits a single record, so malformed
`fresh-eyes-exempt` directives that should FAIL were reported as a clean run. Silent-pass is the worst
shape a gate can fail in, and the plugin advertises running "against any repo", so this made that
claim false for a large share of consumers.

## Fix

The issue attributed the break to mawk not implementing ERE intervals. That turned out to be the wrong
diagnosis for the container in question, and the correction narrowed the fix. `awk` there is **mawk
1.3.4 20240123**, which *does* implement intervals. Isolating each construct:

| Pattern | Result |
|---|---|
| `^ {0,3}> ?` — interval + literal | compiles |
| `^ {0,3}[abc]` — interval + bracket class | compiles |
| `^ {0,3}[0-9]{1,9}` — interval + interval | compiles |
| `^ *([-*+])` — star + group | compiles |
| `^ ? ? ?([-*+])` — optionals + group | compiles |
| `^ {0,3}([-*+])[ \t]+` — **interval + group** | **panics** |

The trigger is specific: an ERE interval immediately followed by a parenthesized group panics mawk
1.3.4's regex compiler with `REcompile() - panic: values still on machine stack`. The panic is fatal,
which is the silent-pass mechanism. Sweeping every `.sh` file in the repo for that shape finds exactly
two sites, both in this scanner — the list-marker strip and fence detection — which is why check 23,
written interval-free in #2963, was unaffected.

The scanner is now interval-free **throughout**, not just at the two panicking sites. The two
surviving `{0,3}` sites compiled fine under 1.3.4, but mawk **1.3.3** implements no intervals at all
and matches the braces as literal text, degrading exactly the same way — a second silent failure mode
for the same regexes on an older but still widely deployed mawk. The rewrite preserves the exact
CommonMark bounds already enforced: the three-space indent cap becomes three optional spaces, the
ordered-marker digit cap one digit plus eight optional ones. Both bounds were verified to still reject
out-of-range input (4 spaces does not match; a 10-digit marker is not stripped).

The two alternatives the issue floated at triage were declined deliberately. A loud `gawk required`
exit would make the "runs against any repo" claim false on stock Debian/Ubuntu rather than fixing it,
and `command -v gawk || awk` leaves the silent-pass path live wherever gawk is absent.

### The portability guard

A source-level guard assertion fails the suite if an interval returns to any awk-consumed regex. It is
deliberately implementation-aware rather than black-box: gawk compiles intervals happily, so a
reintroduced interval would pass the entire suite on the CI runner and break only for consumers. No
behavioral assertion can observe this class of break on gawk.

Two properties of the guard came out of the review cycle (see the resolved threads):

- **All three interval forms are rejected**, `{n}` included, not just the comma forms. mawk panics on
  `a{3}(b)` exactly as it does on `a{0,3}(b)` — verified directly — so a comma-only pattern would have
  left the same silent-failure class open.
- **It is scoped to what awk actually compiles**, not to the whole file. Bash is not mawk, and
  `check-skill.sh` legitimately uses an interval in a `[[ =~ ]]` regex to date a frontmatter `synced:`
  value; an unscoped broadening would have failed the suite on correct code. The two surfaces that do
  reach awk are covered: slash-delimited regex literals inside the embedded programs, and
  `FRESH_EYES_JUDGE_RE`, which is a POSIX ERE awk compiles via `-v` but which never appears between
  slashes and would be missed by a literal-only or line-range scan.

## Verification

Run in the affected environment (`awk` → `/usr/bin/mawk`, mawk 1.3.4 20240123):

- **Premise reproduced on `origin/main` @ `d9f15d4f` first** — `check-skill.test.sh` failed 21
  assertions, all Check 21, emitting the `REcompile()` panic.
- **`check-skill.test.sh`: 96 → 118 passing, 0 failures, 0 panics.** Diffing the baseline and
  post-fix `ok` sets shows exactly +21 newly passing from the scanner fix, **zero** assertions that
  regressed from passing to failing, plus the new guard assertion.
- **Guard proven to fail, not just to pass.** Reintroducing the original bug drove the suite to 22
  failures — the 21 restored panics plus the guard naming the file and line. After the review
  hardening, each of `{n}`, `{n,}` and `{n,m}` was reintroduced in turn and the guard caught every
  one, while the clean tree still passes with the Bash date regex untouched. Tree restored after each
  probe.
- **`scripts/check-changed-skills.test.sh`: PASS=13 FAIL=0** — the other suite that exercises
  `check-skill.sh`, whose fixtures have broken on a checker change before.
- **Behavioral sanity on real skills** — the fixed checker now genuinely emits fresh-eyes records
  under mawk (previously none at all), and `skill-quality/skills/check`, `work-items/skills/work`
  and `source-control/skills/pull-request` all still PASS with 0 errors.
- **Full local gate, all green:** `validate-plugins.sh`; `generate-catalog.mjs --check` and
  `generate-cheatsheet.mjs --check`; `check-changelog-parity.sh` in all four modes, including
  `--check-preserved origin/main` (36 headings compared, all preserved) and `--check-bump
  origin/main`; `check-changed-skills.sh origin/main`; both portability lints; `markdownlint-cli2` on
  the touched CHANGELOG (0 issues); `typos` on the touched plugin (clean); `shellcheck` on both
  touched scripts (clean).
- Version collision re-checked against `origin/main` immediately before each push — main is on
  skill-quality 0.17.0, so 0.17.1 is uncontested.

These counts are reproducible from a clean checkout on any mawk box with
`bash plugins/skill-quality/scripts/check-skill.test.sh`.

## Related

- Refs #2963 — established the interval-free scanner shape in check 23 that this change adopts for
  check 21.
- Refs #2994 — the AI Hero course journey roadmap this queue item belongs to.
- Observation for a possible follow-up, deliberately **not** changed here: `scripts/check-changelog-parity.sh:195`
  and `plugins/markdown-format/hooks/markdown-format.test.sh:72` also use ERE intervals in awk. Both
  were verified to compile cleanly under mawk 1.3.4 (they precede literals and classes, not groups),
  so neither is broken today, but both would degrade on mawk 1.3.3. They sit in a different plugin
  and a repo-level script, each needing its own version bump, so folding them in would widen this
  diff past the issue's scope.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QbfCrj3X9FfGL7VRZYmrn4