### PR TITLE
docs: materialize the project glossary, and close the two latent mawk-interval sites

### DIFF
--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -1,0 +1,96 @@
+# Glossary
+
+The project's ubiquitous language: terms this marketplace has deliberately resolved, so the same
+words carry the same meaning in conversation, skill bodies, docs, and commit messages.
+
+This file records **vocabulary only** — what a term is, and which names were considered and
+rejected for it. The reasoning behind a decision lives in the artifact that made it; entries cite
+that artifact rather than restating it. New terms are curated through
+`/domain-driven-design:curate-language` rather than hand-written, so the entry discipline stays
+uniform.
+
+This marketplace is a single language context, so there is no context map: every entry below
+applies repository-wide.
+
+## Terms
+
+**AFK criterion**
+
+The test of whether remaining work is scoped to run without a human at the keyboard — no decision
+still owed to it, no mid-flight approval it must stop for. A yes routes the delegation decision to
+`session-flow:orchestrate`; the criterion names the test, not the delegation.
+
+Avoid: away-from-keyboard check
+
+**asset rush**
+
+The failure mode where a session drives toward producing the deliverable while the job is still
+reaching shared understanding of what the deliverable should be. Names the critique that the
+interview-first pipeline answers.
+
+**context load**
+
+The tokens an agent pays to read a surface, charged on every session for always-loaded ones. Paired
+with cognitive load below; the two are distinct budgets and cutting one can overspend the other.
+
+**cognitive load**
+
+The attention a human maintainer pays to hold where things live across a doc set. Ten small
+fragment files can be cheap in context load and ruinous in cognitive load.
+
+Avoid: mental overhead
+
+**navigation pointer**
+
+A curated entry in an instruction file that routes a reader to a genuinely non-obvious, load-bearing
+document — stating where to look and when to look there. Distinct from a file-by-file inventory,
+which an agent can rebuild from the tree and which the memory audit flags.
+
+Avoid: highway, stale highway
+
+**phase boundary**
+
+The moment a stage has produced its artifact and the next has not begun — where the continuation
+router runs and where a compaction, if taken at all, is least destructive.
+
+**primary source**
+
+A record read directly from its origin, unmediated: the on-disk transcript, a live documentation
+page, a shipped script's actual emitted strings. Stays primary across compaction.
+
+Avoid: original source
+
+**secondary source**
+
+An account of a primary source rather than the source itself: the model-visible conversation after
+compaction, a header comment describing code beneath it, another agent's summary. Usable, but a
+claim resting on one is verified against the primary before it ships.
+
+**smart zone**
+
+The healthiest of `context-guard`'s three context zones (`smart` / `acceptable` / `dumb`), naming
+the band rather than any token figure — the band numbers are declared judgment defaults and tunable
+per consumer.
+
+## Rejected terms
+
+Names considered for a concept this project already owns, recorded so they are not reintroduced.
+Each maps to the term or doctrine that owns the concept.
+
+| Rejected | Owned by |
+|---|---|
+| design concept | **shared understanding** — the existing house term |
+| grill-execute-clear | the house workflow taxonomy, which already names the loop |
+| push vs point | **point, don't copy** (`discipline:point-dont-copy`) |
+| highway / stale highway | **navigation pointer** above; survives only as a quoted mnemonic |
+| cache *(the doc-restating-environment sense)* | `docs-hygiene:audit-derivability`'s derivable-from-environment doctrine; the word is overloaded here (plugin cache, prompt cache) |
+| sediment | the `docs-hygiene` audit family's pruning doctrine; collides with the code-sense use in `playbooks:fable-5` |
+| sycophancy | nothing — a generic LLM-behavior term with no distinct project meaning. Free-prose use is unaffected; it is simply not project vocabulary |
+
+## Provenance
+
+Every term above was graded and adopted in lane 6 of the AI Hero course vetting
+(2026-08-18). The decision rows, including the basis for each verdict and the rejected-term
+mappings, are in [`upstream/aihero-course.md`](upstream/aihero-course.md) under "Term adoption".
+Materialization of this file was tracked as
+[#3000](https://github.com/melodic-software/claude-code-plugins/issues/3000).

--- a/docs/upstream/aihero-course.md
+++ b/docs/upstream/aihero-course.md
@@ -398,11 +398,14 @@ not re-verified.
 
 Course-dictionary and lesson vocabulary graded for entry into this project's ubiquitous
 language. Adoption decisions were made in-lane (register + two-validator audit pass); glossary
-materialization routes through `/domain-driven-design:curate-language`, whose
+materialization routed through `/domain-driven-design:curate-language`, whose
 convention-resolution ladder found no existing project glossary and more than one plausible
-home — creation is therefore a filed follow-on rather than an in-lane invention
-([#3000](https://github.com/melodic-software/claude-code-plugins/issues/3000)). ADOPTED terms
-are usable house vocabulary now; the rows are the record.
+home, so creation was deferred to a filed follow-on rather than invented in-lane
+([#3000](https://github.com/melodic-software/claude-code-plugins/issues/3000)). That is now
+**done**: the maintainer confirmed the placement and the ADOPTED terms live in
+[`docs/GLOSSARY.md`](../GLOSSARY.md), which also records the REJECT rows below as rejected
+synonyms mapped to the terms that own their concepts. The rows here remain the decision record —
+the glossary carries the vocabulary, this table carries why.
 
 | Term | Verdict | Basis |
 |---|---|---|

--- a/plugins/markdown-format/.claude-plugin/plugin.json
+++ b/plugins/markdown-format/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "markdown-format",
-  "version": "0.11.21",
+  "version": "0.11.22",
   "description": "Auto-format and lint Markdown on edit via markdownlint-cli2 \u2014 only in repos that carry their own markdownlint config.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/markdown-format/CHANGELOG.md
+++ b/plugins/markdown-format/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to the `markdown-format` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.11.22]
+
+### Fixed
+
+- **The duplicate-heading probe in `markdown-format.test.sh` no longer depends on ERE intervals.**
+  Its awk heading match used `#{1,6}`, which mawk 1.3.3 does not implement — it matches the braces
+  as literal text, so the probe would stop recognizing headings and the MD024 assertion would pass
+  vacuously rather than fail loudly. Rewritten as one hash plus five optional ones: same ATX bound
+  (1–6 hashes, 7 rejected), verified in both directions under mawk 1.3.4. Not broken on any mawk
+  shipping today — this closes the latent 1.3.3 case found while fixing the same class in
+  `skill-quality`'s check 21 (#3005).
+
 ## [0.11.21]
 
 ### Changed

--- a/plugins/markdown-format/hooks/markdown-format.test.sh
+++ b/plugins/markdown-format/hooks/markdown-format.test.sh
@@ -69,9 +69,13 @@ duplicate_line="$({
   awk '
     {
       sub(/\r$/, "")
-      if ($0 ~ /^#{1,6}[[:space:]]+/) {
+      # One hash plus five optional ones rather than `#{1,6}`: mawk 1.3.3
+      # implements no ERE intervals and matches the braces literally, so this
+      # duplicate-heading probe would stop recognizing headings and the assertion
+      # would pass vacuously. Same ATX bound (1-6 hashes), no interval.
+      if ($0 ~ /^##?#?#?#?#?[[:space:]]+/) {
         heading = $0
-        sub(/^#{1,6}[[:space:]]+/, "", heading)
+        sub(/^##?#?#?#?#?[[:space:]]+/, "", heading)
         if (seen[heading]++) { print NR; exit }
       }
     }

--- a/scripts/check-changelog-parity.sh
+++ b/scripts/check-changelog-parity.sh
@@ -192,7 +192,11 @@ rendered_lines() {
         }
         next
       }
-      if (match($0, /^ {0,3}`+/) || match($0, /^ {0,3}~+/)) {
+      # Three optional spaces rather than ` {0,3}`: mawk 1.3.3 implements no ERE
+      # intervals and matches the braces literally, so the fence would stop being
+      # recognized and this scanner would segment every changelog it reads
+      # wrongly. Same CommonMark bound (up to three leading spaces), no interval.
+      if (match($0, /^ ? ? ?`+/) || match($0, /^ ? ? ?~+/)) {
         seg = substr($0, RSTART, RLENGTH)
         sub(/^ +/, "", seg)
         mchar = substr(seg, 1, 1)


### PR DESCRIPTION
Closes #3000

## Summary

Materializes the project glossary that lane 6's term adoption deferred, and — at the maintainer's direction rather than as a filed follow-up — closes the two remaining ERE-interval sites in awk regexes that PR #3058 scoped out. Two commits, kept separate so neither is buried.

Documentation and test-probe hardening only; no runtime behavior change. `markdown-format` 0.11.21 → 0.11.22.

## Fix

**1. The glossary (#3000).** `curate-language`'s convention ladder found no existing glossary and more than one plausible home, so it deferred rather than inventing one — that was the entire blocker. The maintainer confirmed the flat `docs/GLOSSARY.md` placement, beside `CATALOG.md` and `SKILL-CHEAT-SHEET.md`, satisfying the ladder's step 4 ("ask when two or more plausible choices remain").

- **Seven ADOPTED terms**, each a 1–2 sentence what-it-IS definition: AFK criterion, asset rush, context load, cognitive load, navigation pointer, phase boundary, primary source, secondary source, smart zone.
- **The REJECT rows recorded as rejected synonyms**, each mapped to the term or doctrine that owns the concept — `design concept` → shared understanding, `highway / stale highway` → navigation pointer, `cache` (doc-restating sense) → audit-derivability's doctrine, `sediment`, `push vs point` → point-don't-copy, `grill-execute-clear`, and `sycophancy` (owned by nothing — recorded so it is not reintroduced as project vocabulary, with free-prose use explicitly unaffected).
- **Vocabulary only**, per the glossary contract: no decisions, specs, or open questions. The reasoning stays in the lane 6 table, which the glossary cites and which now links back — the issue's third acceptance criterion.
- **Single language context**, so no context map. Stated in the file so the absence reads as a decision rather than an omission.

**2. The two latent mawk-interval sites.** Both **compile** under mawk 1.3.4 — each interval precedes a literal or a bracket class, not a group, so neither hits the panic that broke check 21 — but mawk **1.3.3** implements no intervals at all and matches the braces as literal text. Each then degrades *silently*:

| Site | Unfixed behavior on mawk 1.3.3 |
|---|---|
| `scripts/check-changelog-parity.sh` — fence probe `^ {0,3}` | stops recognizing code fences, so the scanner segments every changelog it reads wrongly |
| `markdown-format.test.sh` — heading probe `#{1,6}` | stops recognizing headings, so the MD024 assertion passes vacuously — a test that cannot fail |

Both rewritten interval-free with identical bounds: three optional spaces, and one hash plus five optional ones.

Swept the repo for the same shape rather than trusting the two names. `ai-slop`'s `PATTERN_RULES` carry `[^.]{0,80}(...)` — the interval-then-group form that actually panics — but they reach `grep -E`, not awk, and that script's awk programs already avoid intervals deliberately. No change needed there; confirmed by reading its consumption sites.

## Verification

- **Bounds verified in both directions** under this container's mawk 1.3.4: 0/1/2/3 leading spaces match and 4 does not; 1–6 hashes match and 7 does not. A rewrite that stopped panicking while quietly widening the bound would be the same class of silent defect these fix.
- `plugins/markdown-format/hooks/markdown-format.test.sh` — **PASS=149 FAIL=0**
- `scripts/check-changelog-parity.test.sh` — **PASS=82 FAIL=0**
- `check-changelog-parity.sh` all four modes, re-run **after committing** so `--check-preserved` had something to compare: 83 changelogs newest-first, and **50 headings compared, all preserved**
- `scripts/validate-plugins.sh`; `generate-catalog.mjs --check` / `generate-cheatsheet.mjs --check` — in sync
- `check-changed-skills.sh origin/main` — no changed skills under `plugins/*/skills/`
- `markdownlint-cli2` (3 files) — 0 issues; `typos` clean; `shellcheck` and `shfmt -d` clean on both touched scripts
- `scripts/check-changelog-parity.sh` is a repo-level script with no plugin manifest, so it takes no version bump.

One self-inflicted defect caught and fixed before pushing: the new changelog entry initially replaced the `## [0.11.21]` heading instead of sitting above it, absorbing that release's notes. `grep '^## \['` now reads 0.11.22 → 0.11.21 → 0.11.20 → 0.11.19, and `--check-preserved` confirms it.

## Related

- Refs #2904 (lane 6, the term-adoption decisions), `docs/upstream/aihero-course.md` "Term adoption"
- Refs #3005 / PR #3058 — established the interval-free shape and named these two sites as out of its scope
- Refs #2994 — the AI Hero course roadmap this queue item belongs to

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QbfCrj3X9FfGL7VRZYmrn4

---
_Generated by [Claude Code](https://claude.ai/code/session_01QbfCrj3X9FfGL7VRZYmrn4)_