### PR TITLE
docs(ci): separate the absence and replay windows in the canary comment

### DIFF
--- a/.github/workflows/silent-revert-canary.yml
+++ b/.github/workflows/silent-revert-canary.yml
@@ -151,9 +151,12 @@ jobs:
 
       # The other half of the proof (#2855). The replay above asserts every
       # recorded incident is still DETECTED; this asserts the content those
-      # incidents deleted is on the tree TODAY. Both are needed, and the gap
-      # between them has already cost 31h28m: the content #2828 is about was
-      # missing from main while the replay printed `ok` and exited 0, two
+      # incidents deleted is on the tree TODAY. Both are needed, and #2828
+      # is the gap made real: its content sat off main for 31h28m, from
+      # f603880da to the 534eac138 (#2829) restore. This lane covered only
+      # the tail -- it merged at 7b47d2253 (#2808), 6h13m out from the
+      # restore -- and across that tail the replay still printed `ok` and
+      # exited 0 with the content gone: it answered the other question. Two
       # re-lands each missed it, and a hand audit found it, not this lane.
       #
       # ORDER IS LOAD-BEARING, and this step is deliberately LAST.


### PR DESCRIPTION
## Summary

`.github/workflows/silent-revert-canary.yml` was the third site of the claim #2917 set out to remove. Its comment charged the whole `31h28m` content-absence window to the replay's silence — so the workflow contradicted the two `scripts/` files the job it documents actually invokes. This brings the last of the three sites into agreement.

## Fix

Comment text only, in one hunk. No `run:`, `uses:`, `with:`, or any other executable YAML was touched (`git diff --numstat` = `6 3` on that one file; every `+`/`-` line begins with `      #`).

Before:

> incidents deleted is on the tree TODAY. Both are needed, and the gap
> between them has already cost 31h28m: the content #2828 is about was
> missing from main while the replay printed `ok` and exited 0, two
> re-lands each missed it, and a hand audit found it, not this lane.

After:

> incidents deleted is on the tree TODAY. Both are needed, and #2828
> is the gap made real: its content sat off main for 31h28m, from
> f603880da to the 534eac138 (#2829) restore. This lane covered only
> the tail -- it merged at 7b47d2253 (#2808), 6h13m out from the
> restore -- and across that tail the replay still printed `ok` and
> exited 0 with the content gone: it answered the other question. Two
> re-lands each missed it, and a hand audit found it, not this lane.

The load-bearing point is preserved rather than deleted: the replay's silence still did not mean the content was present. What changes is which window that silence is charged to. "Both are needed" is kept deliberately — the `ORDER IS LOAD-BEARING` paragraph immediately below reads off it. The wording is the workflow's own rather than a lift from either sibling; in particular it keeps this file's "not this lane" voice instead of the scripts' "not this canary" / "not this file".

## Verification

Both figures re-derived here from committer dates (`git show -s --format=%ct`), not carried over from the issue:

| window | from | to | seconds | rendered |
| --- | --- | --- | --- | --- |
| content absence | `f603880da` `1786752447` | `534eac138` `1786865745` | `113298` | 31h28m |
| replay presence | `7b47d2253` `1786843322` | `534eac138` `1786865745` | `22423` | 6h13m |

`113298s` = 31h28m18s and `22423s` = 6h13m43s; both are floored to the minute, matching the convention the two sibling files already use. `7b47d2253` is an ancestor of `main` (`git merge-base --is-ancestor` exit 0) and its committer epoch falls strictly inside the absence interval, which is what makes "only the tail" true.

Repo-wide sweep for further sites: swept all tracked files for `31h28m`, `31h`, `6h13m`, `113298`, `22423`, the three incident shas, and numberless restatements (`exited 0 for`, ``printed `ok` ``, `while the replay`, `absence window`). **No fourth site exists.** The only near-hit outside the three known files is `plugins/claude-ops/skills/lanes/scripts/restart-consumer.test.sh:572` — "`lock-held` and exited 0 forever" about a Task Scheduler consumer — an unrelated sentence that merely shares the words. No follow-up issue needed.

The change is comment-only, so no test asserts it; CI is the verification of record for the surrounding workflow, and the shell suites were not run locally (they run badly on this machine's platform).

## The other two sites

Both siblings are already on `main` and untouched here — #2930 corrected `scripts/check-silent-revert.sh`, and #2986 (merged as `0e9ed8eb0`) corrected `scripts/silent-revert-incidents.txt`. This branch is merged up to a `main` that carries both, so all three passages can be read side by side in one tree. The workflow was the last holdout.

## Related

- #2917 — the parent issue that named this claim
- #2930 — corrected `scripts/check-silent-revert.sh`
- #2986 — corrected `scripts/silent-revert-incidents.txt`
- #2847 — the standard this follows: state the claim that stays true rather than renumbering a figure that rots

Closes #2988
