### PR TITLE
fix(work-items): five adapter defects found by validating against the real provider contracts

### DIFF
--- a/plugins/work-items/.claude-plugin/plugin.json
+++ b/plugins/work-items/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "work-items",
-  "version": "0.39.8",
+  "version": "0.39.9",
   "description": "Manages development work items through a provider-neutral tracker seam that ships with the plugin (bundled dispatcher plus github, local-markdown, jira, gitea, and linear adapters; seam plugin-dir canonical, adapters consumer-local-first): dashboard, taxonomy-labeled creation, a race-safe assignee-plus-lease claim protocol, recurring-schedule checks, TODO scanning, stale-lease auditing, plan decomposition into vertical-slice items, a macro-journey router over spec containers (rollup, per-container execution shape, next-step routing), raw-intake triage (issues and unsolicited PRs through raw, verified, briefed, autonomous-eligible states), plus the two work-items loop lanes of the loop-lane convention: a self-paced autonomous work-loop drain (work-class admission gate, adaptive item cap, PR-only) and an attended attend-queue escalation lane. The re-runnable setup skill binds the provider (.work-item-tracker.json), seeds the recurring-schedule seam (.github/recurring-schedule.json), and remaps canonical role labels.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/work-items/CHANGELOG.md
+++ b/plugins/work-items/CHANGELOG.md
@@ -58,6 +58,37 @@ parameter, request-body field, and response field the adapter reads matches the 
   `/orgs/{owner}/labels`, treating the 404 a user-owned repo returns as "no org labels" rather
   than an error.
 
+- **Every large list could silently return ZERO items.** Found by the ceiling regression test
+  written for the fix above, not by inspection. Both adapters accumulated paged results as
+  `jq --argjson acc "$ACC"`, which puts an **unboundedly growing array on jq's command line**.
+  Past `ARG_MAX` the kernel refuses the exec — `jq: Argument list too long` — and because the
+  assignment was unchecked, the accumulator was left empty and the verb **reported an empty
+  list while exiting 0**. A repository or team large enough to trip it looked simply empty.
+  The final envelope emit had the same shape, at the one point where the array is guaranteed
+  to be at its largest. Nine sites across `list-items`, `list-sub-items`, `create-item` and the
+  lease helper now pass the accumulator through **stdin** and only the bounded new element in
+  argv, and every one of them fails loudly rather than degrading to empty. On
+  `linear:list-sub-items` this was the worst of the set: an empty child list is what the
+  closed-children invariant reads as "nothing open under this container".
+- **The declared list ceiling counted requested page size, not rows returned.** Under the clamp
+  above the two diverge: with `page_size` 100 against a server capping at 50,
+  `PAGE * page_size` reaches 1000 after ten pages that returned 500 issues, so the walk stopped
+  half way and announced a ceiling it had never reached. For labels it was worse than a short
+  answer — every label in the unreached rows read as nonexistent and was refused. Both ceilings
+  now count rows actually collected.
+- **The org-label walk ignored the header the repo-label walk beside it obeys.** An earlier
+  draft of the org-label fix used a largest-page-seen heuristic, which always spent one extra
+  request and, against same-sized consecutive pages, walked to the ceiling and reported a
+  truncation that had not happened — turning a genuinely missing label into a misleading "the
+  label list was truncated" message. It now uses `X-Total-Count` exactly as its sibling does.
+  Caught by review; the regression test pins the request count at one, where the heuristic
+  made twenty.
+- **The new `linear` label walk had no ceiling**, unlike every other paginated loop in this
+  seam. A server that kept answering `hasNextPage` with a fresh cursor would have hung
+  `create-item` indefinitely. Bounded now, and — like `gitea` — it distinguishes "not found
+  because truncated" from "not found because absent", since telling someone to create a label
+  that already exists sends them to do the wrong thing.
+
 Each fix ships with regression cases verified to fail against the unfixed file. The `gitea` mock
 transport gained `-D` header support so the `X-Total-Count` path is exercised rather than
 silently falling back.

--- a/plugins/work-items/CHANGELOG.md
+++ b/plugins/work-items/CHANGELOG.md
@@ -3,6 +3,71 @@
 All notable changes to the `work-items` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.39.9]
+
+### Fixed
+
+Five defects in the `linear` and `gitea` adapters, all of the same class: **both adapters are
+tested only against mock transports whose responses the tests themselves author**, so a wrong
+field name, argument, enum value, endpoint path, or termination signal passes every suite and
+fails on the first real call. Neither adapter has ever run against a live server. Found by
+validating both against their providers' real published contracts — Linear's GraphQL schema
+(`@linear/sdk` 90.0.0 plus the SDL, cross-checked and byte-identical) and Gitea's own generated
+Swagger at `v1.22.6`, with the handler source consulted where the spec is silent.
+
+The validation also cleared the whole surface it did not find fault with: **all 17 Linear
+operations validate against the real schema** under `graphql-js`, including argument types,
+nested selections, enum members, and variable coercion — proven sensitive by a negative control
+in which 10 of 10 deliberately-injected faults were caught. Every Gitea path, method, query
+parameter, request-body field, and response field the adapter reads matches the spec.
+
+- **`linear` accepted a `page_size` the API rejects.** Config validation took any positive
+  integer while Linear caps every connection's `first` at 250 — a value the adapter's own
+  comment already documented. Validation passed and the *first* live call failed, which is the
+  failure mode config validation exists to prevent. Now bounded, with the cap named in the
+  refusal.
+- **`linear` could not resolve workspace-level labels, and lost labels past the first page.**
+  Label ids were read from `team.labels(first: 250)` — one page, no `pageInfo`, no loop, where
+  250 is Linear's per-page *maximum* rather than a comfortable ceiling — and `Team.labels` is
+  documented only as *"Labels associated with the team"*, while `IssueLabel.team` says *"If
+  null, the label is a workspace-level label available to all teams"*. Because an unresolved
+  name is refused rather than dropped, both defects surfaced as a hard exit on a label that
+  exists. Resolution now walks the **root** `issueLabels` connection — the one documented to
+  return both scopes — filtered to this team or workspace-level, fully paginated, and stops on
+  a null cursor rather than restarting from page 1.
+- **`gitea` silently truncated every list on instances with a lower paging cap.**
+  `ToCorrectPageSize` clamps `limit` to `[api] MAX_RESPONSE_ITEMS` (stock 50), so where
+  `config.gitea.page_size` exceeds an instance's cap *every* page came back short — and
+  "short page means last page" ended the walk after page 1 with nothing said, since the
+  ceiling warning never fired either. The issue-list and label-list handlers do send
+  `X-Total-Count` (`ctx.SetTotalCountHeader`), so the transport now captures response headers
+  and both walks use that count as the authoritative end-of-list signal. The short-page
+  heuristic remains the fallback where no header is sent, so behaviour is unchanged on
+  instances that send none, and no extra request is ever spent.
+- **`gitea` fetched pull requests only to throw them away.** `list-items` omitted the
+  `type=issues` query parameter that this endpoint actually supports, so PRs consumed the page
+  budget and — worse — the declared ceiling counted raw rows rather than items, making a
+  PR-heavy repo report *"reached the declared ceiling of 1000 items"* having collected far
+  fewer. The client-side PR filter stays as belt and braces.
+- **`gitea` refused organization-wide labels it would happily have applied.**
+  `GetLabelsByRepoID` backs `/repos/{o}/{r}/labels` with `WHERE repo_id = ?`, so an org label
+  never appears there, yet `NewIssueWithIndex` accepts any label whose `OrgID == repo.OwnerID`.
+  The asymmetry was user-visible and backwards: `get-item` and `list-items` *do* report org
+  labels in `.labels[]`, so the tracker returned a label name it would then refuse to write
+  back, telling the operator to create a label that already exists. `create-item` now merges
+  `/orgs/{owner}/labels`, treating the 404 a user-owned repo returns as "no org labels" rather
+  than an error.
+
+Each fix ships with regression cases verified to fail against the unfixed file. The `gitea` mock
+transport gained `-D` header support so the `X-Total-Count` path is exercised rather than
+silently falling back.
+
+Four Linear behaviours remain unverifiable without a live credential and are recorded rather
+than guessed: whether `assigneeId: null` semantically unassigns (the schema permits the null;
+the resolver's behaviour is not in the schema), Linear's default comment ordering, and the
+instance-configuration-dependent halves of the Gitea findings (`MAX_RESPONSE_ITEMS`,
+`ALLOW_CROSS_REPOSITORY_DEPENDENCIES`). Forgejo parity is still assumed rather than measured.
+
 ## [0.39.8]
 
 ### Changed

--- a/plugins/work-items/tools/work-item-tracker/adapters/gitea/common.sh
+++ b/plugins/work-items/tools/work-item-tracker/adapters/gitea/common.sh
@@ -311,9 +311,16 @@ wit_gitea_auth_header() {
 wit_gitea_http() {
   local method="$1" path="$2" body="${3:-}"
   local url="https://$WIT_GITEA_HOST/api/v1$path"
-  local auth raw rc
+  local auth raw rc hdrs
   auth="$(wit_gitea_auth_header)" || exit "$?"
-  local curl_args=(-sS -X "$method" -H "Accept: application/json" --proto '=https' -w $'\n%{http_code}' -K -)
+  # Headers are dumped to a private temp file rather than read via curl's `%header{}`
+  # write-out, which needs curl 7.83+; this adapter targets no such floor. `-D` has been
+  # there since forever. The file is per-call and removed before returning.
+  hdrs="$(mktemp)" || {
+    printf 'gitea: could not create a temp file for response headers\n' >&2
+    exit "$EX_INTERNAL"
+  }
+  local curl_args=(-sS -X "$method" -H "Accept: application/json" --proto '=https' -D "$hdrs" -w $'\n%{http_code}' -K -)
   if [[ -n "$body" ]]; then
     curl_args+=(-H "Content-Type: application/json" --data "$body")
   fi
@@ -321,11 +328,24 @@ wit_gitea_http() {
     "$WIT_GITEA_CURL_BIN" "${curl_args[@]}" 2>/dev/null)"
   rc=$?
   if ((rc != 0)); then
+    rm -f "$hdrs"
     printf 'gitea: request to %s failed (curl exit %s) — network or endpoint unavailable\n' "$path" "$rc" >&2
     exit "$EX_UNAVAILABLE"
   fi
   WIT_GITEA_STATUS="${raw##*$'\n'}"
   WIT_GITEA_BODY="$(printf '%s' "${raw%$'\n'*}" | wit_strip_cr)"
+  # X-Total-Count, when the endpoint sends one. The issue-list and label-list handlers do
+  # (`ctx.SetTotalCountHeader`); the dependency-list handler does not. Empty means "this
+  # endpoint gave no authoritative count", never "zero" — callers MUST distinguish the two,
+  # because reading absent-as-zero would end a listing before it began.
+  # shellcheck disable=SC2034  # read by list-items.sh and create-item.sh; this file is sourced-only
+  WIT_GITEA_TOTAL_COUNT=""
+  if [[ -s "$hdrs" ]]; then
+    # shellcheck disable=SC2034  # ditto
+    WIT_GITEA_TOTAL_COUNT="$(wit_strip_cr <"$hdrs" |
+      sed -n 's/^[Xx]-[Tt]otal-[Cc]ount:[[:space:]]*\([0-9][0-9]*\).*$/\1/p' | tail -1)"
+  fi
+  rm -f "$hdrs"
 }
 
 # wit_gitea_require_ok <context> — map WIT_GITEA_STATUS to a
@@ -442,7 +462,15 @@ wit_gitea_blocked_by_count() {
     wit_gitea_require_ok "listing dependencies of $owner/$repo#$index"
     got="$(jq 'length' <<<"$WIT_GITEA_BODY" 2>/dev/null)" || got=0
     total=$((total + $(jq '[.[] | select(.state != "closed")] | length' <<<"$WIT_GITEA_BODY" 2>/dev/null || echo 0)))
-    # A short page is the last page. Gitea sends no total-count header on this endpoint.
+    # A short page is the last page. This endpoint genuinely sends no total-count header —
+    # `routers/api/v1/repo/issue_dependency.go` calls neither SetTotalCountHeader nor
+    # SetLinkHeader, unlike the issue and label list handlers — so unlike those two there is
+    # no authoritative signal to prefer. The residual risk is bounded and stated rather than
+    # papered over: gitea clamps `limit` to `[api] MAX_RESPONSE_ITEMS` (stock 50), so an
+    # instance whose cap is below config.gitea.page_size would under-count an issue carrying
+    # MORE blockers than that cap. Paging one extra time to be sure would cost an extra
+    # request PER ITEM inside list-items (this is already the N+1 path), which is a real
+    # regression against a case that needs 50+ blockers on a single issue to appear.
     ((got < WIT_GITEA_PAGE_SIZE)) && break
     page=$((page + 1))
     # The same overall bound list-items uses, so a pathological dependency graph cannot

--- a/plugins/work-items/tools/work-item-tracker/adapters/gitea/create-item.sh
+++ b/plugins/work-items/tools/work-item-tracker/adapters/gitea/create-item.sh
@@ -108,7 +108,21 @@ if [[ -n "$LABELS" ]]; then
   ALL_LABELS="$WIT_GITEA_BODY"
   PAGE=2
   LABELS_TRUNCATED=0
-  while (($(jq 'length' <<<"$WIT_GITEA_BODY") == WIT_GITEA_PAGE_SIZE)); do
+  # This handler calls ctx.SetTotalCountHeader (routers/api/v1/repo/label.go), so when the
+  # header is present it decides when the list is exhausted. That matters more here than in
+  # list-items: gitea clamps `limit` to `[api] MAX_RESPONSE_ITEMS` (stock 50), and under the
+  # old page-length test an instance whose cap is below config.gitea.page_size stopped after
+  # page 1 — making a label past that point indistinguishable from a nonexistent one, so the
+  # operator was told to create a label that already exists. SEEN/-n mirror list-items: an
+  # empty header means "no count sent", never zero.
+  LABEL_SEEN="$(jq 'length' <<<"$WIT_GITEA_BODY" 2>/dev/null)" || LABEL_SEEN=0
+  LABEL_TOTAL="$WIT_GITEA_TOTAL_COUNT"
+  while :; do
+    if [[ -n "$LABEL_TOTAL" ]]; then
+      ((LABEL_SEEN >= LABEL_TOTAL)) && break
+    else
+      (($(jq 'length' <<<"$WIT_GITEA_BODY") < WIT_GITEA_PAGE_SIZE)) && break
+    fi
     # Bounded like every other paginated loop in this adapter: a server that keeps
     # answering a full page would otherwise spin forever with ALL_LABELS growing
     # without limit.
@@ -119,8 +133,42 @@ if [[ -n "$LABELS" ]]; then
     wit_gitea_http GET "/repos/$WIT_GITEA_OWNER/$WIT_GITEA_REPO/labels?page=$PAGE&limit=$WIT_GITEA_PAGE_SIZE"
     wit_gitea_require_ok "listing labels in $REPO (page $PAGE)"
     ALL_LABELS="$(jq -c --argjson acc "$ALL_LABELS" '$acc + .' <<<"$WIT_GITEA_BODY")"
+    LABEL_SEEN=$((LABEL_SEEN + $(jq 'length' <<<"$WIT_GITEA_BODY" 2>/dev/null || echo 0)))
+    # An empty page ends the walk whatever the header claimed — a count that never gets
+    # satisfied must not turn into an unbounded loop.
+    (($(jq 'length' <<<"$WIT_GITEA_BODY" 2>/dev/null || echo 0) == 0)) && break
     PAGE=$((PAGE + 1))
   done
+  # ORGANIZATION-WIDE labels are usable on this repo's issues and are NOT in the repo label
+  # list. `GetLabelsByRepoID` backs /repos/{o}/{r}/labels with `WHERE repo_id = ?`, so an org
+  # label never appears there — but `NewIssueWithIndex` accepts any label whose
+  # `OrgID == repo.OwnerID`. The asymmetry was user-visible and backwards: get-item and
+  # list-items DO report an org label in `.labels[]` (it is on the issue), so the tracker
+  # returned a label name it would then refuse to write back, telling the operator to create
+  # a label that already exists. A user-owned repo has no org and answers 404 here, which is
+  # not an error — it just means there are no org labels to merge.
+  wit_gitea_http GET "/orgs/$WIT_GITEA_OWNER/labels?page=1&limit=$WIT_GITEA_PAGE_SIZE"
+  if [[ "$WIT_GITEA_STATUS" != "404" ]]; then
+    wit_gitea_require_ok "listing organization labels for $WIT_GITEA_OWNER"
+    ORG_PAGE="$WIT_GITEA_BODY"
+    ORG_EFFECTIVE=0
+    ORG_PAGE_NUM=2
+    while :; do
+      ALL_LABELS="$(jq -c --argjson acc "$ALL_LABELS" '$acc + .' <<<"$ORG_PAGE")"
+      ORG_GOT="$(jq 'length' <<<"$ORG_PAGE" 2>/dev/null)" || ORG_GOT=0
+      ((ORG_GOT > ORG_EFFECTIVE)) && ORG_EFFECTIVE="$ORG_GOT"
+      ((ORG_GOT == 0)) && break
+      ((ORG_GOT < ORG_EFFECTIVE)) && break
+      if ((ORG_PAGE_NUM * WIT_GITEA_PAGE_SIZE > WIT_GITEA_LIST_ITEMS_MAX)); then
+        LABELS_TRUNCATED=1
+        break
+      fi
+      wit_gitea_http GET "/orgs/$WIT_GITEA_OWNER/labels?page=$ORG_PAGE_NUM&limit=$WIT_GITEA_PAGE_SIZE"
+      wit_gitea_require_ok "listing organization labels for $WIT_GITEA_OWNER (page $ORG_PAGE_NUM)"
+      ORG_PAGE="$WIT_GITEA_BODY"
+      ORG_PAGE_NUM=$((ORG_PAGE_NUM + 1))
+    done
+  fi
   MISSING="$(jq -rc --arg names "$LABELS" --argjson all "$ALL_LABELS" \
     '[($names | split(",") | .[] | select(length > 0)) as $n | select([$all[].name] | index($n) | not) | $n]' <<<'null')"
   if [[ "$MISSING" != "[]" ]]; then

--- a/plugins/work-items/tools/work-item-tracker/adapters/gitea/create-item.sh
+++ b/plugins/work-items/tools/work-item-tracker/adapters/gitea/create-item.sh
@@ -123,16 +123,25 @@ if [[ -n "$LABELS" ]]; then
     else
       (($(jq 'length' <<<"$WIT_GITEA_BODY") < WIT_GITEA_PAGE_SIZE)) && break
     fi
-    # Bounded like every other paginated loop in this adapter: a server that keeps
-    # answering a full page would otherwise spin forever with ALL_LABELS growing
-    # without limit.
-    if ((PAGE * WIT_GITEA_PAGE_SIZE > WIT_GITEA_LIST_ITEMS_MAX)); then
+    # Bounded like every other paginated loop in this adapter: a server that keeps answering
+    # a full page would otherwise spin forever with ALL_LABELS growing without limit. Measured
+    # against labels ACTUALLY FETCHED rather than `PAGE * page_size`, which diverge under the
+    # clamp: with page_size 100 against a cap of 50 the requested arithmetic declares
+    # truncation after 500 labels, and here that is not merely a short answer — it makes every
+    # label in rows 501-1000 read as nonexistent and refused.
+    if ((LABEL_SEEN > WIT_GITEA_LIST_ITEMS_MAX)); then
       LABELS_TRUNCATED=1
       break
     fi
     wit_gitea_http GET "/repos/$WIT_GITEA_OWNER/$WIT_GITEA_REPO/labels?page=$PAGE&limit=$WIT_GITEA_PAGE_SIZE"
     wit_gitea_require_ok "listing labels in $REPO (page $PAGE)"
-    ALL_LABELS="$(jq -c --argjson acc "$ALL_LABELS" '$acc + .' <<<"$WIT_GITEA_BODY")"
+    # Accumulator on stdin, page in argv: the reverse puts an unboundedly growing array on
+    # jq's command line, and past ARG_MAX the exec fails outright — leaving ALL_LABELS empty,
+    # which here means every requested label reads as nonexistent and is refused.
+    ALL_LABELS="$(jq -c --argjson page "$WIT_GITEA_BODY" '. + $page' <<<"$ALL_LABELS")" || {
+      printf 'create-item.sh: could not accumulate label page %s for %s\n' "$PAGE" "$REPO" >&2
+      exit "$EX_INTERNAL"
+    }
     LABEL_SEEN=$((LABEL_SEEN + $(jq 'length' <<<"$WIT_GITEA_BODY" 2>/dev/null || echo 0)))
     # An empty page ends the walk whatever the header claimed — a count that never gets
     # satisfied must not turn into an unbounded loop.
@@ -150,16 +159,32 @@ if [[ -n "$LABELS" ]]; then
   wit_gitea_http GET "/orgs/$WIT_GITEA_OWNER/labels?page=1&limit=$WIT_GITEA_PAGE_SIZE"
   if [[ "$WIT_GITEA_STATUS" != "404" ]]; then
     wit_gitea_require_ok "listing organization labels for $WIT_GITEA_OWNER"
+    # Same walk as the repo labels above, and deliberately the SAME SHAPE: this endpoint sets
+    # X-Total-Count too, so the header decides. An earlier draft here used a largest-page-seen
+    # heuristic instead, which was wrong twice over — it always spent one extra request (the
+    # page that establishes the baseline can never be shorter than it), and against same-sized
+    # consecutive pages it walked to the ceiling and reported a truncation that had not
+    # happened, turning a genuinely-missing label name into a misleading "the label list was
+    # truncated" message.
     ORG_PAGE="$WIT_GITEA_BODY"
-    ORG_EFFECTIVE=0
+    ORG_TOTAL="$WIT_GITEA_TOTAL_COUNT"
+    ORG_SEEN=0
     ORG_PAGE_NUM=2
     while :; do
-      ALL_LABELS="$(jq -c --argjson acc "$ALL_LABELS" '$acc + .' <<<"$ORG_PAGE")"
+      ALL_LABELS="$(jq -c --argjson page "$ORG_PAGE" '. + $page' <<<"$ALL_LABELS")" || {
+        printf 'create-item.sh: could not accumulate org label page %s for %s\n' \
+          "$ORG_PAGE_NUM" "$WIT_GITEA_OWNER" >&2
+        exit "$EX_INTERNAL"
+      }
       ORG_GOT="$(jq 'length' <<<"$ORG_PAGE" 2>/dev/null)" || ORG_GOT=0
-      ((ORG_GOT > ORG_EFFECTIVE)) && ORG_EFFECTIVE="$ORG_GOT"
+      ORG_SEEN=$((ORG_SEEN + ORG_GOT))
       ((ORG_GOT == 0)) && break
-      ((ORG_GOT < ORG_EFFECTIVE)) && break
-      if ((ORG_PAGE_NUM * WIT_GITEA_PAGE_SIZE > WIT_GITEA_LIST_ITEMS_MAX)); then
+      if [[ -n "$ORG_TOTAL" ]]; then
+        ((ORG_SEEN >= ORG_TOTAL)) && break
+      else
+        ((ORG_GOT < WIT_GITEA_PAGE_SIZE)) && break
+      fi
+      if ((ORG_SEEN > WIT_GITEA_LIST_ITEMS_MAX)); then
         LABELS_TRUNCATED=1
         break
       fi

--- a/plugins/work-items/tools/work-item-tracker/adapters/gitea/create-item.test.sh
+++ b/plugins/work-items/tools/work-item-tracker/adapters/gitea/create-item.test.sh
@@ -147,4 +147,35 @@ gitea_seed "/issues" 423 '{"message":"repo is archived"}'
 rc="$(gitea_run "$S" --title "t")"
 assert_eq "archived repo → exit 7" "7" "$rc"
 
+# --- ORGANIZATION-WIDE labels resolve ---
+# `GetLabelsByRepoID` backs /repos/{o}/{r}/labels with `WHERE repo_id = ?`, so an org label
+# never appears there — yet `NewIssueWithIndex` accepts any label whose OrgID == repo.OwnerID.
+# The old lookup therefore refused a label that would have applied, and the asymmetry was
+# user-visible and backwards: get-item and list-items DO report org labels in `.labels[]`,
+# so the tracker returned a name it would then refuse to write back.
+gitea_reset_routes
+gitea_seed_total "/repos/acme/webapp/labels" 200 '[{"id":1,"name":"type: fix"}]' 1
+gitea_seed_total "/orgs/acme/labels" 200 '[{"id":9,"name":"priority: high"}]' 1
+gitea_seed "/issues" 201 '{"number":7,"title":"t","state":"open","assignees":[],"labels":[],"html_url":"https://gitea.example/acme/webapp/issues/7","repository":{"full_name":"acme/webapp"}}'
+rc="$(gitea_run "$S" --title "t" --labels "priority: high")"
+assert_eq "an org-wide label resolves → exit 0" "0" "$rc"
+assert_contains "the org label endpoint was consulted" "$(gitea_requests)" "/orgs/acme/labels"
+
+# A user-owned repo has no organization: /orgs/<user>/labels answers 404, which is not an
+# error — there are simply no org labels to merge. A repo label must still resolve.
+gitea_reset_routes
+gitea_seed_total "/repos/acme/webapp/labels" 200 '[{"id":1,"name":"type: fix"}]' 1
+gitea_seed "/orgs/acme/labels" 404 '{"message":"user redirect does not exist"}'
+gitea_seed "/issues" 201 '{"number":8,"title":"t","state":"open","assignees":[],"labels":[],"html_url":"https://gitea.example/acme/webapp/issues/8","repository":{"full_name":"acme/webapp"}}'
+rc="$(gitea_run "$S" --title "t" --labels "type: fix")"
+assert_eq "a 404 from /orgs is not an error → exit 0" "0" "$rc"
+
+# And a name that exists in neither place is still refused, not silently dropped.
+gitea_reset_routes
+gitea_seed_total "/repos/acme/webapp/labels" 200 '[{"id":1,"name":"type: fix"}]' 1
+gitea_seed_total "/orgs/acme/labels" 200 '[{"id":9,"name":"priority: high"}]' 1
+rc="$(gitea_run "$S" --title "t" --labels "nonexistent")"
+assert_eq "a label in neither scope → exit 5" "5" "$rc"
+assert_contains "and it is named" "$(gitea_err)" "nonexistent"
+
 [[ $FAILED -eq 0 ]] || exit 1

--- a/plugins/work-items/tools/work-item-tracker/adapters/gitea/create-item.test.sh
+++ b/plugins/work-items/tools/work-item-tracker/adapters/gitea/create-item.test.sh
@@ -161,6 +161,21 @@ rc="$(gitea_run "$S" --title "t" --labels "priority: high")"
 assert_eq "an org-wide label resolves → exit 0" "0" "$rc"
 assert_contains "the org label endpoint was consulted" "$(gitea_requests)" "/orgs/acme/labels"
 
+# The org walk must honour X-Total-Count like the repo walk above it, not a
+# largest-page-seen heuristic. Two things that heuristic got wrong, both asserted here:
+# it always spent one extra request (the page that sets the baseline can never be shorter
+# than it), and because this mock answers by URL substring rather than by call count, a
+# same-sized second page kept it walking to the ceiling — reporting a truncation that had
+# not happened and turning a genuinely-missing label into a misleading message.
+gitea_reset_routes
+gitea_seed_total "/repos/acme/webapp/labels" 200 '[{"id":1,"name":"type: fix"}]' 1
+gitea_seed_total "/orgs/acme/labels" 200 '[{"id":9,"name":"priority: high"}]' 1
+gitea_seed "/issues" 201 '{"number":7,"title":"t","state":"open","assignees":[],"labels":[],"html_url":"https://gitea.example/acme/webapp/issues/7","repository":{"full_name":"acme/webapp"}}'
+rc="$(gitea_run "$S" --title "t" --labels "priority: high")"
+assert_eq "the count is satisfied on page 1 → exit 0" "0" "$rc"
+assert_eq "and exactly one org-label request was made" "1" \
+  "$(grep -c '/orgs/acme/labels' <<<"$(gitea_requests)")"
+
 # A user-owned repo has no organization: /orgs/<user>/labels answers 404, which is not an
 # error — there are simply no org labels to merge. A repo label must still resolve.
 gitea_reset_routes

--- a/plugins/work-items/tools/work-item-tracker/adapters/gitea/list-items.sh
+++ b/plugins/work-items/tools/work-item-tracker/adapters/gitea/list-items.sh
@@ -82,8 +82,17 @@ while :; do
   }
   # Belt and braces: `type=issues` should mean gitea sends no PRs, but a PR arriving as a work
   # item would be claimed and worked like one, so the filter stays.
-  COLLECTED="$(jq -c --argjson acc "$COLLECTED" \
-    '$acc + [ .[] | select(.pull_request == null) ]' <<<"$WIT_GITEA_BODY")"
+  # The ACCUMULATOR travels on stdin and only the (page-size-bounded) page travels in argv.
+  # The other way round — `--argjson acc "$COLLECTED"` — puts an unboundedly growing array on
+  # jq's command line, and past ARG_MAX the kernel refuses the exec: jq dies with "Argument
+  # list too long", the unchecked assignment leaves COLLECTED empty, and list-items reports
+  # ZERO issues while exiting 0. A big repo silently looked empty.
+  COLLECTED="$(jq -c --argjson page "$WIT_GITEA_BODY" \
+    '. + [ $page[] | select(.pull_request == null) ]' <<<"$COLLECTED")" || {
+    printf 'list-items.sh: could not accumulate page %s for %s — refusing to report a partial list as complete\n' \
+      "$PAGE" "$REPO" >&2
+    exit "$EX_INTERNAL"
+  }
   SEEN=$((SEEN + GOT))
   ((GOT == 0)) && break
   if [[ -n "$WIT_GITEA_TOTAL_COUNT" ]]; then
@@ -95,9 +104,13 @@ while :; do
     ((GOT < WIT_GITEA_PAGE_SIZE)) && break
   fi
   PAGE=$((PAGE + 1))
-  # The declared ceiling from capabilities.json. Exceeding it is a DOCUMENTED
-  # truncation, not an error (CONTRACT.md "Adapter contract") — but it is never silent.
-  if ((PAGE * WIT_GITEA_PAGE_SIZE > WIT_GITEA_LIST_ITEMS_MAX)); then
+  # The declared ceiling from capabilities.json. Exceeding it is a DOCUMENTED truncation, not
+  # an error (CONTRACT.md "Adapter contract") — but it is never silent. Measured against rows
+  # ACTUALLY RETURNED, not against `PAGE * page_size`: under the clamp this whole change is
+  # about, those two diverge. With page_size 100 against a server capping at 50, the requested
+  # arithmetic reaches 1000 after ten pages that returned only 500 issues, so the walk stopped
+  # half way and announced it had hit a ceiling it never reached.
+  if ((SEEN > WIT_GITEA_LIST_ITEMS_MAX)); then
     printf 'list-items.sh: reached the declared ceiling of %s items for %s; results are truncated\n' \
       "$WIT_GITEA_LIST_ITEMS_MAX" "$REPO" >&2
     break
@@ -122,8 +135,18 @@ while IFS= read -r raw; do
     printf 'list-items.sh: could not normalize a gitea issue in %s\n' "$REPO" >&2
     exit "$EX_INTERNAL"
   }
-  ITEMS="$(jq -c --argjson acc "$ITEMS" --argjson one "$ONE" '$acc + [$one]' <<<'null')"
+  # Accumulator on stdin, one item in argv — see the note on the page accumulation above.
+  ITEMS="$(jq -c --argjson one "$ONE" '. + [$one]' <<<"$ITEMS")" || {
+    printf 'list-items.sh: could not accumulate a normalized issue in %s — refusing to report a partial list as complete\n' "$REPO" >&2
+    exit "$EX_INTERNAL"
+  }
 done < <(jq -c '.[]' <<<"$COLLECTED")
 
-jq -cn --arg sv "$WIT_SCHEMA_VERSION" --argjson items "$ITEMS" \
-  '{schema_version: $sv, items: $items}'
+# The envelope is built with ITEMS on STDIN for the same ARG_MAX reason as the accumulation
+# above — this is the one place where the array is guaranteed to be at its largest, so it is
+# the likeliest to blow the command line. A failure here must not emit a truncated or empty
+# envelope with a success status.
+jq -c --arg sv "$WIT_SCHEMA_VERSION" '{schema_version: $sv, items: .}' <<<"$ITEMS" || {
+  printf 'list-items.sh: could not emit the item envelope for %s\n' "$REPO" >&2
+  exit "$EX_INTERNAL"
+}

--- a/plugins/work-items/tools/work-item-tracker/adapters/gitea/list-items.sh
+++ b/plugins/work-items/tools/work-item-tracker/adapters/gitea/list-items.sh
@@ -60,20 +60,40 @@ wit_gitea_scope_parts "$REPO"
 # it passes through. STATE is already constrained to those three by the parse above.
 PAGE=1
 COLLECTED='[]'
+# SEEN counts raw rows returned so far, for comparison against gitea's own X-Total-Count.
+# `services/convert.ToCorrectPageSize` silently clamps `limit` to `[api] MAX_RESPONSE_ITEMS`
+# (stock 50), so on an instance whose cap is below config.gitea.page_size EVERY page comes
+# back short — and "short page means last page" then ended the loop after page 1 and returned
+# a truncated list with nothing said, because the ceiling guard below never fired either.
+# This endpoint's handler calls ctx.SetTotalCountHeader, so when the header is present it is
+# the authoritative end-of-list signal and the clamp stops mattering. The short-page heuristic
+# stays as the fallback for anything that does not send one; it costs no extra request.
+SEEN=0
 while :; do
-  wit_gitea_http GET "/repos/$WIT_GITEA_OWNER/$WIT_GITEA_REPO/issues?state=$STATE&page=$PAGE&limit=$WIT_GITEA_PAGE_SIZE"
+  # `type=issues` is a real query parameter on this endpoint (enum: issues|pulls). Without it
+  # gitea returns pull requests too, which are then dropped below — so PRs consumed the page
+  # budget and, worse, the declared ceiling counted rows rather than items, making a PR-heavy
+  # repo report "reached the declared ceiling of 1000 items" having collected far fewer.
+  wit_gitea_http GET "/repos/$WIT_GITEA_OWNER/$WIT_GITEA_REPO/issues?state=$STATE&type=issues&page=$PAGE&limit=$WIT_GITEA_PAGE_SIZE"
   wit_gitea_require_ok "listing issues in $REPO"
   GOT="$(jq 'length' <<<"$WIT_GITEA_BODY" 2>/dev/null)" || {
     printf 'list-items.sh: gitea returned a non-array issue list for %s\n' "$REPO" >&2
     exit "$EX_INTERNAL"
   }
-  # Gitea's issue list includes PULL REQUESTS: a PR is an issue with `pull_request`
-  # populated. The seam's items are issues, and a PR arriving as a work item would be
-  # claimed and worked like one, so they are dropped here rather than downstream.
+  # Belt and braces: `type=issues` should mean gitea sends no PRs, but a PR arriving as a work
+  # item would be claimed and worked like one, so the filter stays.
   COLLECTED="$(jq -c --argjson acc "$COLLECTED" \
     '$acc + [ .[] | select(.pull_request == null) ]' <<<"$WIT_GITEA_BODY")"
-  # A short page is the last page: Gitea sends no total-count header on this endpoint.
-  ((GOT < WIT_GITEA_PAGE_SIZE)) && break
+  SEEN=$((SEEN + GOT))
+  ((GOT == 0)) && break
+  if [[ -n "$WIT_GITEA_TOTAL_COUNT" ]]; then
+    # Authoritative: stop when gitea says we have them all. An EMPTY header is "no count was
+    # sent", never zero — hence the -n test rather than an arithmetic compare, which would
+    # read a missing header as "0 items" and end the listing on its first pass.
+    ((SEEN >= WIT_GITEA_TOTAL_COUNT)) && break
+  else
+    ((GOT < WIT_GITEA_PAGE_SIZE)) && break
+  fi
   PAGE=$((PAGE + 1))
   # The declared ceiling from capabilities.json. Exceeding it is a DOCUMENTED
   # truncation, not an error (CONTRACT.md "Adapter contract") — but it is never silent.

--- a/plugins/work-items/tools/work-item-tracker/adapters/gitea/list-items.test.sh
+++ b/plugins/work-items/tools/work-item-tracker/adapters/gitea/list-items.test.sh
@@ -177,4 +177,26 @@ else
   pass "and no extra page was requested"
 fi
 
+# --- the declared ceiling counts ROWS RETURNED, not pages × requested size ---
+# These diverge under exactly the clamp this change is about. With page_size 100 against a
+# server capping at 50, `PAGE * page_size` reaches 1000 after ten pages that returned only
+# 500 issues — so the walk stopped half way and announced it had hit a ceiling it never
+# reached. Simulated here by asking for 100 and having the mock answer 50 every time, with a
+# total-count far above the ceiling so only the ceiling can end the walk.
+gitea_reset_routes
+gitea_write_binding '{"page_size":100}'
+CLAMPED_PAGE="$(jq -cn '[range(50)] | map({number: (. + 1), title: "i", state: "open", assignees: [], labels: [], html_url: "https://gitea.example/acme/webapp/issues/1", repository: {full_name: "acme/webapp"}})')"
+gitea_seed "/dependencies" 200 '[]'
+gitea_seed_total "/issues?state=open&type=issues" 200 "$CLAMPED_PAGE" 9999
+rc="$(gitea_run "$S")"
+assert_eq "a clamped walk still reaches the declared ceiling → exit 0" "0" "$rc"
+COLLECTED_N="$(jq -r '.items | length' <<<"$(gitea_out)")"
+if ((COLLECTED_N > 1000)); then
+  pass "more than the ceiling's worth of rows was collected before truncating ($COLLECTED_N)"
+else
+  fail "more than the ceiling's worth of rows was collected before truncating" ">1000" "$COLLECTED_N"
+fi
+assert_contains "and the truncation is announced" "$(gitea_err)" "truncated"
+gitea_write_binding
+
 [[ $FAILED -eq 0 ]] || exit 1

--- a/plugins/work-items/tools/work-item-tracker/adapters/gitea/list-items.test.sh
+++ b/plugins/work-items/tools/work-item-tracker/adapters/gitea/list-items.test.sh
@@ -135,4 +135,46 @@ gitea_seed "/issues?" 429 '{"message":"slow down"}'
 rc="$(gitea_run "$S")"
 assert_eq "rate limited → exit 8" "8" "$rc"
 
+# --- the list asks gitea to exclude PRs, rather than fetching and discarding them ---
+# `type` is a real query parameter on this endpoint (enum: issues|pulls). Without it gitea
+# returns pull requests too: they consumed the page budget, and the declared ceiling counted
+# ROWS rather than items, so a PR-heavy repo reported "reached the declared ceiling of 1000
+# items" having collected far fewer than 1000 issues.
+gitea_reset_routes
+gitea_seed "/issues?" 200 '[]'
+gitea_run "$S" >/dev/null 2>&1
+assert_contains "the list requests type=issues" "$(gitea_requests)" "type=issues"
+
+# --- X-Total-Count is authoritative when gitea sends it ---
+# gitea clamps `limit` to [api] MAX_RESPONSE_ITEMS (stock 50). On an instance whose cap is
+# below config.gitea.page_size EVERY page comes back short, so "short page means last page"
+# ended the walk after page 1 and returned a truncated list with nothing said — the ceiling
+# guard never fires either. This endpoint's handler calls ctx.SetTotalCountHeader, so the
+# header settles it. Page 1 is deliberately SHORT (1 row) while the count says 2.
+gitea_reset_routes
+gitea_seed_total "/issues?state=open&type=issues&page=1" 200 \
+  '[{"number":1,"title":"one","state":"open","assignees":[],"labels":[],"html_url":"https://gitea.example/acme/web/issues/1","repository":{"full_name":"acme/web"}}]' 2
+gitea_seed_total "/issues?state=open&type=issues&page=2" 200 \
+  '[{"number":2,"title":"two","state":"open","assignees":[],"labels":[],"html_url":"https://gitea.example/acme/web/issues/2","repository":{"full_name":"acme/web"}}]' 2
+gitea_seed "/dependencies" 200 '[]'
+rc="$(gitea_run "$S")"
+assert_eq "a clamped short page does not end the walk → exit 0" "0" "$rc"
+assert_eq "both items are collected" "2" "$(jq -r '.items | length' <<<"$(gitea_out)")"
+assert_contains "page 2 was requested" "$(gitea_requests)" "page=2"
+
+# Without the header the short-page heuristic still applies, unchanged — one page, no
+# speculative extra request.
+gitea_reset_routes
+gitea_seed "/issues?state=open&type=issues&page=1" 200 \
+  '[{"number":1,"title":"one","state":"open","assignees":[],"labels":[],"html_url":"https://gitea.example/acme/web/issues/1","repository":{"full_name":"acme/web"}}]'
+gitea_seed "/dependencies" 200 '[]'
+rc="$(gitea_run "$S")"
+assert_eq "no header → short page still ends the walk" "0" "$rc"
+assert_eq "exactly one item" "1" "$(jq -r '.items | length' <<<"$(gitea_out)")"
+if [[ "$(gitea_requests)" == *"page=2"* ]]; then
+  fail "and no extra page was requested" "no page=2" "page=2 requested"
+else
+  pass "and no extra page was requested"
+fi
+
 [[ $FAILED -eq 0 ]] || exit 1

--- a/plugins/work-items/tools/work-item-tracker/adapters/gitea/mock.sh
+++ b/plugins/work-items/tools/work-item-tracker/adapters/gitea/mock.sh
@@ -35,19 +35,31 @@ fix="$(dirname "$d")"
 cfg="$(cat)"
 url="$(printf '%s' "$cfg" | sed -n 's/^url = "\(.*\)"$/\1/p')"
 method="GET"
+dumpfile=""
 prev=""
 for a in "$@"; do
   if [[ "$prev" == "-X" ]]; then method="$a"; fi
+  # The adapter passes -D <file> to capture response headers; honour it so the
+  # X-Total-Count path is exercised rather than silently falling back.
+  if [[ "$prev" == "-D" ]]; then dumpfile="$a"; fi
   prev="$a"
 done
 printf '%s %s\n' "$method" "$url" >>"$fix/requests"
-while IFS=$'\t' read -r pat status body; do
+while IFS=$'\t' read -r pat status body headers; do
   [[ -n "$pat" ]] || continue
   if [[ "$url" == *"$pat"* ]]; then
+    if [[ -n "$dumpfile" ]]; then
+      printf 'HTTP/1.1 %s\r\n' "$status" >"$dumpfile"
+      [[ -z "$headers" ]] || printf '%s\r\n' "$headers" >>"$dumpfile"
+      printf '\r\n' >>"$dumpfile"
+    fi
     printf '%s\n%s' "$body" "$status"
     exit 0
   fi
 done <"$fix/routes"
+# Even an unseeded URL must leave a well-formed header dump, or the adapter would read
+# a stale file from a previous call.
+[[ -z "$dumpfile" ]] || printf 'HTTP/1.1 599\r\n\r\n' >"$dumpfile"
 # An unseeded URL is a test bug, not a provider condition: answer 599 so the verb
 # fails loudly rather than treating an empty body as a valid response.
 printf '%s\n%s' '{"message":"unseeded url in mock"}' '599'
@@ -71,7 +83,15 @@ gitea_write_binding() {
 # gitea_seed <url-substring> <status> <body-json> — add a route. Seeded order is match
 # order, so seed the most specific substring first.
 gitea_seed() {
-  printf '%s\t%s\t%s\n' "$1" "$2" "$3" >>"$GITEA_FIX/routes"
+  printf '%s\t%s\t%s\t%s\n' "$1" "$2" "$3" "${4:-}" >>"$GITEA_FIX/routes"
+}
+
+# gitea_seed_total <url-substring> <status> <body-json> <x-total-count> — the same, plus
+# the X-Total-Count header gitea's issue-list and label-list handlers really send
+# (ctx.SetTotalCountHeader). Seeded separately because the dependency-list handler sends
+# none, and the adapter must behave differently in the two cases.
+gitea_seed_total() {
+  gitea_seed "$1" "$2" "$3" "X-Total-Count: $4"
 }
 
 # gitea_reset_routes — drop every seeded route and the recorded request log.

--- a/plugins/work-items/tools/work-item-tracker/adapters/linear/common.sh
+++ b/plugins/work-items/tools/work-item-tracker/adapters/linear/common.sh
@@ -780,8 +780,12 @@ wit_linear_lease_comments() {
       # tool speaking the same v1 shape), so a malformed handle is reachable input, not a
       # theoretical one.
       [[ "$handle" =~ ^[0-9]+$ ]] || handle="$(wit_linear_handle "$(jq -r '.createdAt' <<<"$node")")"
-      all="$(jq -c --argjson acc "$all" --argjson h "$handle" --arg c "$cid" --argjson l "$lease" \
-        '$acc + [{handle: $h, comment_id: $c, lease: $l}]' <<<'null')" || {
+      # The accumulator travels on STDIN and only the new entry in argv. A lease set is small
+      # in practice, but the reverse shape puts a growing array on jq's command line, and past
+      # ARG_MAX the exec fails outright — which on this particular helper is the worst
+      # available outcome, per the paragraph above.
+      all="$(jq -c --argjson h "$handle" --arg c "$cid" --argjson l "$lease" \
+        '. + [{handle: $h, comment_id: $c, lease: $l}]' <<<"$all")" || {
         # Belt and braces: whatever else ever makes this jq fail, it must not degrade to
         # an empty accumulator that reads as "no leases". Fail loudly instead.
         printf 'linear: could not accumulate lease comments on %s — refusing to report an empty lease set\n' \

--- a/plugins/work-items/tools/work-item-tracker/adapters/linear/common.sh
+++ b/plugins/work-items/tools/work-item-tracker/adapters/linear/common.sh
@@ -275,8 +275,17 @@ wit_need_linear_config() {
   # not a fall-through to the default.
   wit_linear_nonempty_array "$WIT_LINEAR_DONE_TYPES" ||
     bad+=" done_state_types(must be a non-empty array)"
-  [[ "$WIT_LINEAR_PAGE_SIZE" =~ ^[1-9][0-9]*$ ]] ||
+  # Bounded, not just positive. Linear caps every connection's `first` at 250
+  # (WIT_LINEAR_DEFAULT_PAGE_SIZE's comment above says so), so an unbounded check accepts a
+  # page_size the API rejects — config validation passes and the FIRST live call fails, which
+  # is the failure mode config validation exists to prevent. Caught by validating the adapter's
+  # operations against Linear's published schema; every read verb passes this value as `first`.
+  if [[ "$WIT_LINEAR_PAGE_SIZE" =~ ^[1-9][0-9]*$ ]]; then
+    [[ "$WIT_LINEAR_PAGE_SIZE" -le 250 ]] ||
+      bad+=" page_size:'$WIT_LINEAR_PAGE_SIZE'(exceeds linear's cap of 250 for a connection's first)"
+  else
     bad+=" page_size:'$WIT_LINEAR_PAGE_SIZE'(must be a positive integer)"
+  fi
   # TTLs bound lease liveness arithmetic; a non-integer would make every comparison
   # error out and silently read as "not live", handing every item to the next claimer.
   [[ "$WIT_LINEAR_LEASE_TTL_HOURS" =~ ^[0-9]+$ ]] ||

--- a/plugins/work-items/tools/work-item-tracker/adapters/linear/common.test.sh
+++ b/plugins/work-items/tools/work-item-tracker/adapters/linear/common.test.sh
@@ -196,6 +196,31 @@ for bad_scope in '""' '"a b"' '"../../etc/passwd"' '"x;id"' '123' 'null'; do
     "$(config_rc "$(jq -c --argjson s "[$bad_scope]" '.scopes = $s' <<<"$GOOD")")"
 done
 
+# page_size is BOUNDED, not merely positive. Linear caps every connection's `first` at 250,
+# so accepting a larger value means config validation passes and the FIRST live call fails —
+# which is the failure mode config validation exists to prevent. Found by validating this
+# adapter's operations against Linear's published schema.
+assert_eq "page_size 250 (the cap) is accepted" "0" \
+  "$(config_rc "$(jq -c '.page_size = 250' <<<"$GOOD")")"
+assert_eq "page_size 251 → exit 3" "3" \
+  "$(config_rc "$(jq -c '.page_size = 251' <<<"$GOOD")")"
+assert_eq "page_size 500 → exit 3" "3" \
+  "$(config_rc "$(jq -c '.page_size = 500' <<<"$GOOD")")"
+assert_contains "and the cap is named in the refusal" \
+  "$(config_err "$(jq -c '.page_size = 500' <<<"$GOOD")")" "250"
+assert_eq "page_size 0 is still refused → exit 3" "3" \
+  "$(config_rc "$(jq -c '.page_size = 0' <<<"$GOOD")")"
+assert_eq "a fractional page_size → exit 3" "3" \
+  "$(config_rc "$(jq -c '.page_size = 12.5' <<<"$GOOD")")"
+assert_eq "a non-numeric page_size → exit 3" "3" \
+  "$(config_rc "$(jq -c '.page_size = "abc"' <<<"$GOOD")")"
+# A JSON *string* holding digits is accepted on purpose, not by oversight: every scalar in
+# this binding is read through `jq -r` and validated by regex, so "50" and 50 are the same
+# value by the time validation sees them. lease_ttl_hours and lease_ttl_minutes are lenient
+# the same way. Asserted so a later reader does not "fix" the leniency in one place only.
+assert_eq "a digit-string page_size is accepted, as elsewhere in the binding" "0" \
+  "$(config_rc "$(jq -c '.page_size = "50"' <<<"$GOOD")")"
+
 # --- the credential itself ---
 
 # Unset env var → exit 4 (auth), never a request with an empty credential.

--- a/plugins/work-items/tools/work-item-tracker/adapters/linear/create-item.sh
+++ b/plugins/work-items/tools/work-item-tracker/adapters/linear/create-item.sh
@@ -146,25 +146,49 @@ if [[ -n "$LABELS" ]]; then
   }'
   ALL_LABELS='[]'
   LABEL_CURSOR=""
+  LABEL_SEEN=0
+  LABEL_TRUNCATED=0
   while :; do
     wit_linear_gql "$LABEL_QUERY" \
       "$(jq -cn --arg t "$TEAM_UUID" --argjson f "$WIT_LINEAR_PAGE_SIZE" --arg a "$LABEL_CURSOR" \
         '{team: $t, first: $f, after: (if ($a | length) > 0 then $a else null end)}')" \
       "resolving labels for team $TARGET_TEAM"
     LABEL_PAGE="$(jq -c '.issueLabels // {nodes: [], pageInfo: {hasNextPage: false}}' <<<"$WIT_LINEAR_DATA")"
-    ALL_LABELS="$(jq -c --argjson acc "$ALL_LABELS" --argjson page "$LABEL_PAGE" \
-      '$acc + ($page.nodes // [])' <<<'null')"
+    # Accumulator on stdin, page in argv. The reverse puts an unboundedly growing array on
+    # jq's command line; past ARG_MAX the exec fails, ALL_LABELS is left empty, and every
+    # requested label then reads as nonexistent and is refused.
+    ALL_LABELS="$(jq -c --argjson page "$LABEL_PAGE" '. + ($page.nodes // [])' <<<"$ALL_LABELS")" || {
+      printf 'create-item.sh: could not accumulate a label page for team %s\n' "$TARGET_TEAM" >&2
+      exit "$EX_INTERNAL"
+    }
+    LABEL_SEEN=$((LABEL_SEEN + $(jq '(.nodes // []) | length' <<<"$LABEL_PAGE" 2>/dev/null || echo 0)))
     [[ "$(jq -r '.pageInfo.hasNextPage // false' <<<"$LABEL_PAGE")" == "true" ]] || break
     LABEL_CURSOR="$(jq -r '.pageInfo.endCursor // ""' <<<"$LABEL_PAGE")"
     # endCursor is nullable in the schema; without a cursor the next request would restart
     # from the beginning and loop forever, so stop rather than spin.
     [[ -n "$LABEL_CURSOR" ]] || break
+    # Bounded like every other paginated loop in this seam. hasNextPage plus a fresh cursor is
+    # the server's word, and a server that keeps saying "there is more" would otherwise hang
+    # create-item indefinitely with ALL_LABELS growing without limit.
+    if ((LABEL_SEEN > WIT_LINEAR_LIST_ITEMS_MAX)); then
+      LABEL_TRUNCATED=1
+      break
+    fi
   done
   MISSING="$(jq -rc --arg names "$LABELS" --argjson all "$ALL_LABELS" \
     '[($names | split(",") | .[] | select(length > 0)) as $n | select([$all[].name] | index($n) | not) | $n]' <<<'null')"
   if [[ "$MISSING" != "[]" ]]; then
-    printf 'create-item.sh: label(s) not found on team %s or at workspace level: %s — create them first, or drop them from --labels\n' \
-      "$TARGET_TEAM" "$MISSING" >&2
+    # The ceiling changes what "not found" is allowed to mean. Stopping early makes an unseen
+    # label indistinguishable from a nonexistent one, and telling someone to create a label
+    # that already exists sends them to do the wrong thing — so say which case this is. Same
+    # distinction the gitea adapter draws for the same reason.
+    if ((LABEL_TRUNCATED)); then
+      printf 'create-item.sh: label(s) not found in the first %s labels visible to team %s: %s — the label list was truncated at the declared ceiling, so these may exist beyond it; narrow --labels or raise the ceiling rather than re-creating them\n' \
+        "$WIT_LINEAR_LIST_ITEMS_MAX" "$TARGET_TEAM" "$MISSING" >&2
+    else
+      printf 'create-item.sh: label(s) not found on team %s or at workspace level: %s — create them first, or drop them from --labels\n' \
+        "$TARGET_TEAM" "$MISSING" >&2
+    fi
     exit "$EX_NOT_FOUND"
   fi
   # first(...) — a name present both team-scoped and workspace-level resolves to one id, not two.

--- a/plugins/work-items/tools/work-item-tracker/adapters/linear/create-item.sh
+++ b/plugins/work-items/tools/work-item-tracker/adapters/linear/create-item.sh
@@ -107,7 +107,7 @@ fi
 # filed without its type or priority label is invisible to the selection tiers that
 # would have picked it up.
 wit_linear_gql \
-  'query($key: String!) { teams(filter: { key: { eq: $key } }, first: 1) { nodes { id labels(first: 250) { nodes { id name } } } } }' \
+  'query($key: String!) { teams(filter: { key: { eq: $key } }, first: 1) { nodes { id } } }' \
   "$(jq -cn --arg k "$TARGET_TEAM" '{key: $k}')" \
   "resolving team $TARGET_TEAM"
 TEAM_NODE="$(jq -c '.teams.nodes[0] // empty' <<<"$WIT_LINEAR_DATA")"
@@ -119,16 +119,57 @@ TEAM_UUID="$(jq -r '.id' <<<"$TEAM_NODE")"
 
 LABEL_IDS='[]'
 if [[ -n "$LABELS" ]]; then
-  ALL_LABELS="$(jq -c '.labels.nodes // []' <<<"$TEAM_NODE")"
+  # Labels come from the ROOT `issueLabels` connection, PAGINATED. Two defects this shape
+  # replaces, both found by validating this adapter against Linear's published schema:
+  #
+  #  1. The old query asked `team.labels(first: 250)` with no pageInfo and no loop. 250 is
+  #     Linear's per-page maximum, not a "surely enough" number, so a team past that count
+  #     silently lost labels — and because an unresolved name is REFUSED below, the failure
+  #     was not a dropped label but a hard exit on a label that exists.
+  #  2. `Team.labels` is documented only as "Labels associated with the team", while
+  #     `IssueLabel.team` says "If null, the label is a workspace-level label available to
+  #     all teams" and the root `issueLabels` query is the one documented to return "both
+  #     workspace-level and team-scoped labels". A workspace label is valid on this team's
+  #     issues, so refusing it was wrong.
+  #
+  # Filtering to this team OR workspace-level (`team: { null: true }`) keeps the resolution
+  # scoped — a same-named label on some other team is still not silently borrowed.
+  LABEL_QUERY='query($team: ID!, $first: Int!, $after: String) {
+    issueLabels(
+      filter: { or: [{ team: { id: { eq: $team } } }, { team: { null: true } }] }
+      first: $first
+      after: $after
+    ) {
+      nodes { id name }
+      pageInfo { hasNextPage endCursor }
+    }
+  }'
+  ALL_LABELS='[]'
+  LABEL_CURSOR=""
+  while :; do
+    wit_linear_gql "$LABEL_QUERY" \
+      "$(jq -cn --arg t "$TEAM_UUID" --argjson f "$WIT_LINEAR_PAGE_SIZE" --arg a "$LABEL_CURSOR" \
+        '{team: $t, first: $f, after: (if ($a | length) > 0 then $a else null end)}')" \
+      "resolving labels for team $TARGET_TEAM"
+    LABEL_PAGE="$(jq -c '.issueLabels // {nodes: [], pageInfo: {hasNextPage: false}}' <<<"$WIT_LINEAR_DATA")"
+    ALL_LABELS="$(jq -c --argjson acc "$ALL_LABELS" --argjson page "$LABEL_PAGE" \
+      '$acc + ($page.nodes // [])' <<<'null')"
+    [[ "$(jq -r '.pageInfo.hasNextPage // false' <<<"$LABEL_PAGE")" == "true" ]] || break
+    LABEL_CURSOR="$(jq -r '.pageInfo.endCursor // ""' <<<"$LABEL_PAGE")"
+    # endCursor is nullable in the schema; without a cursor the next request would restart
+    # from the beginning and loop forever, so stop rather than spin.
+    [[ -n "$LABEL_CURSOR" ]] || break
+  done
   MISSING="$(jq -rc --arg names "$LABELS" --argjson all "$ALL_LABELS" \
     '[($names | split(",") | .[] | select(length > 0)) as $n | select([$all[].name] | index($n) | not) | $n]' <<<'null')"
   if [[ "$MISSING" != "[]" ]]; then
-    printf 'create-item.sh: label(s) not found on team %s: %s — create them first, or drop them from --labels\n' \
+    printf 'create-item.sh: label(s) not found on team %s or at workspace level: %s — create them first, or drop them from --labels\n' \
       "$TARGET_TEAM" "$MISSING" >&2
     exit "$EX_NOT_FOUND"
   fi
+  # first(...) — a name present both team-scoped and workspace-level resolves to one id, not two.
   LABEL_IDS="$(jq -c --arg names "$LABELS" --argjson all "$ALL_LABELS" \
-    '[($names | split(",") | .[] | select(length > 0)) as $n | ($all[] | select(.name == $n) | .id)]' <<<'null')"
+    '[($names | split(",") | .[] | select(length > 0)) as $n | (first($all[] | select(.name == $n)) | .id)]' <<<'null')"
 fi
 
 # --type is accepted and cannot be honored: Linear has no issue-type axis in the

--- a/plugins/work-items/tools/work-item-tracker/adapters/linear/create-item.test.sh
+++ b/plugins/work-items/tools/work-item-tracker/adapters/linear/create-item.test.sh
@@ -19,13 +19,17 @@ assert_usage_error "$S" --title "t" --repo
 lin_fixture_init
 trap 'rm -rf "$LIN_FIX"' EXIT
 
-TEAM_NODE='{"teams":{"nodes":[{"id":"uuid-team-eng","labels":{"nodes":[{"id":"uuid-label-fix","name":"type: fix"},{"id":"uuid-label-hi","name":"priority: high"}]}}]}}'
+TEAM_NODE='{"teams":{"nodes":[{"id":"uuid-team-eng"}]}}'
+# Labels come from the ROOT issueLabels connection now, not team.labels — see the
+# pagination/workspace-label cases below for why.
+LABEL_PAGE='{"issueLabels":{"nodes":[{"id":"uuid-label-fix","name":"type: fix"},{"id":"uuid-label-hi","name":"priority: high"}],"pageInfo":{"hasNextPage":false,"endCursor":null}}}'
 
 seed_create() {
   lin_reset
   lin_data 'issueRelationCreate' '{"issueRelationCreate":{"success":true}}'
   lin_data 'issueCreate' '{"issueCreate":{"success":true,"issue":{"id":"uuid-issue-12","number":12,"team":{"key":"ENG"}}}}'
   lin_data 'teams(filter:' "$TEAM_NODE"
+  lin_data 'issueLabels(' "$LABEL_PAGE"
   lin_seed_issue 12 started
 }
 
@@ -114,5 +118,48 @@ lin_data 'teams(filter:' "$TEAM_NODE"
 lin_seed 'issueCreate' 200 '{"errors":[{"message":"forbidden","extensions":{"type":"Forbidden"}}]}'
 rc="$(lin_run "$S" --title "t")"
 assert_eq "GraphQL forbidden → exit 4" "4" "$rc"
+
+# --- label lookup PAGINATES ---
+# The old shape asked team.labels(first: 250) once, with no pageInfo and no loop. 250 is
+# Linear's per-page MAXIMUM, not a comfortable ceiling — so a workspace past that count lost
+# labels, and because an unresolved name is refused, the symptom was a hard exit on a label
+# that exists rather than a quietly dropped one. Routes sharing a pattern are call-ordered,
+# so these two seedings are page 1 and page 2.
+lin_reset
+lin_data 'issueCreate' '{"issueCreate":{"success":true,"issue":{"id":"uuid-issue-12","number":12,"team":{"key":"ENG"}}}}'
+lin_data 'teams(filter:' "$TEAM_NODE"
+lin_data 'issueLabels(' '{"issueLabels":{"nodes":[{"id":"uuid-label-fix","name":"type: fix"}],"pageInfo":{"hasNextPage":true,"endCursor":"cur-1"}}}'
+lin_data 'issueLabels(' '{"issueLabels":{"nodes":[{"id":"uuid-label-p2","name":"on: page-two"}],"pageInfo":{"hasNextPage":false,"endCursor":null}}}'
+lin_seed_issue 12 started
+rc="$(lin_run "$S" --title "paged" --labels "on: page-two")"
+assert_eq "a label on page 2 resolves → exit 0" "0" "$rc"
+assert_contains "and its id is sent" "$(lin_bodies)" '"labelIds":["uuid-label-p2"]'
+assert_contains "the second page was requested with the cursor" "$(lin_bodies)" 'cur-1'
+
+# --- WORKSPACE-level labels are reachable ---
+# `Team.labels` is documented only as "Labels associated with the team", while IssueLabel.team
+# says "If null, the label is a workspace-level label available to all teams" — and the ROOT
+# issueLabels query is the one documented to return both. A workspace label is valid on this
+# team's issues, so the old team-scoped lookup refused a label that would have applied.
+lin_reset
+lin_data 'issueCreate' '{"issueCreate":{"success":true,"issue":{"id":"uuid-issue-12","number":12,"team":{"key":"ENG"}}}}'
+lin_data 'teams(filter:' "$TEAM_NODE"
+lin_data 'issueLabels(' '{"issueLabels":{"nodes":[{"id":"uuid-label-ws","name":"workspace: wide"}],"pageInfo":{"hasNextPage":false,"endCursor":null}}}'
+lin_seed_issue 12 started
+rc="$(lin_run "$S" --title "ws" --labels "workspace: wide")"
+assert_eq "a workspace-level label resolves → exit 0" "0" "$rc"
+assert_contains "the filter admits team-null labels" "$(lin_bodies)" 'null'
+assert_contains "and the workspace label id is sent" "$(lin_bodies)" '"labelIds":["uuid-label-ws"]'
+
+# A nullable endCursor with hasNextPage true must STOP, not restart from the beginning —
+# without a cursor the next request repeats page 1 forever.
+lin_reset
+lin_data 'issueCreate' '{"issueCreate":{"success":true,"issue":{"id":"uuid-issue-12","number":12,"team":{"key":"ENG"}}}}'
+lin_data 'teams(filter:' "$TEAM_NODE"
+lin_data 'issueLabels(' '{"issueLabels":{"nodes":[{"id":"uuid-label-fix","name":"type: fix"}],"pageInfo":{"hasNextPage":true,"endCursor":null}}}'
+lin_seed_issue 12 started
+rc="$(lin_run "$S" --title "x" --labels "type: fix")"
+assert_eq "a null endCursor terminates rather than looping" "0" "$rc"
+assert_eq "and asked for labels exactly once" "1" "$(grep -c 'issueLabels(' <<<"$(lin_bodies)")"
 
 [[ $FAILED -eq 0 ]] || exit 1

--- a/plugins/work-items/tools/work-item-tracker/adapters/linear/create-item.test.sh
+++ b/plugins/work-items/tools/work-item-tracker/adapters/linear/create-item.test.sh
@@ -162,4 +162,30 @@ rc="$(lin_run "$S" --title "x" --labels "type: fix")"
 assert_eq "a null endCursor terminates rather than looping" "0" "$rc"
 assert_eq "and asked for labels exactly once" "1" "$(grep -c 'issueLabels(' <<<"$(lin_bodies)")"
 
+# --- the label walk is BOUNDED, and says which kind of "not found" it means ---
+# A null cursor stops the walk (above); a server that keeps supplying VALID ones does not,
+# and without a ceiling create-item would hang with ALL_LABELS growing. Routes sharing a
+# pattern are call-ordered and the last one repeats, so a single always-more page is exactly
+# the misbehaving server this bound exists for: 50 labels per page against a ceiling of 1000
+# means the walk stops on page 21 rather than never.
+lin_reset
+lin_data 'teams(filter:' "$TEAM_NODE"
+ENDLESS_PAGE="$(jq -cn '{issueLabels: {nodes: ([range(50)] | map({id: "uuid-\(.)", name: "filler: \(.)"})), pageInfo: {hasNextPage: true, endCursor: "always-more"}}}')"
+lin_data 'issueLabels(' "$ENDLESS_PAGE"
+rc="$(lin_run "$S" --title "x" --labels "never: present")"
+assert_eq "an endless label feed terminates → exit 5" "5" "$rc"
+# The message must distinguish truncated-so-it-might-exist from absent-so-create-it. A bare
+# "create them first" against a truncated list sends someone to create a label that is
+# already there — the same wrong-direction failure the org-label fix removes for gitea.
+assert_contains "and says the list was truncated, not that the label is absent" \
+  "$(lin_err)" "truncated at the declared ceiling"
+if [[ "$(lin_err)" == *"create them first"* ]]; then
+  fail "and does not tell the operator to create it" "no create-them-first" "create-them-first shown"
+else
+  pass "and does not tell the operator to create it"
+fi
+# 1000/50 = 20 full pages, and the 21st is what pushes LABEL_SEEN past the ceiling.
+assert_eq "the walk stopped at the ceiling rather than running on" "21" \
+  "$(grep -c 'issueLabels(' <<<"$(lin_bodies)")"
+
 [[ $FAILED -eq 0 ]] || exit 1

--- a/plugins/work-items/tools/work-item-tracker/adapters/linear/list-items.sh
+++ b/plugins/work-items/tools/work-item-tracker/adapters/linear/list-items.sh
@@ -78,7 +78,13 @@ while :; do
     }
     KEEP="$(jq -r --arg s "$STATE" 'if $s == "all" or .state == $s then "yes" else "no" end' <<<"$ONE")"
     [[ "$KEEP" == "yes" ]] || continue
-    ITEMS="$(jq -c --argjson acc "$ITEMS" --argjson one "$ONE" '$acc + [$one]' <<<'null')"
+    # Accumulator on stdin, one item in argv. The reverse puts an unboundedly growing array
+    # on jq's command line; past ARG_MAX the exec fails and the unchecked assignment would
+    # leave ITEMS empty — a large team silently listing as zero issues while exiting 0.
+    ITEMS="$(jq -c --argjson one "$ONE" '. + [$one]' <<<"$ITEMS")" || {
+      printf 'list-items.sh: could not accumulate a normalized issue — refusing to report a partial list as complete\n' >&2
+      exit "$EX_INTERNAL"
+    }
   done < <(jq -c '.nodes[]?' <<<"$PAGE")
   COUNT=$((COUNT + $(jq '.nodes | length' <<<"$PAGE")))
   [[ "$(jq -r '.pageInfo.hasNextPage // false' <<<"$PAGE")" == "true" ]] || break
@@ -93,5 +99,10 @@ while :; do
   fi
 done
 
-jq -cn --arg sv "$WIT_SCHEMA_VERSION" --argjson items "$ITEMS" \
-  '{schema_version: $sv, items: $items}'
+# ITEMS travels on STDIN, not argv: this is where the array is largest, so it is the likeliest
+# place to exceed ARG_MAX, and a failed exec here would otherwise emit nothing while the
+# caller read the empty output as "no items".
+jq -c --arg sv "$WIT_SCHEMA_VERSION" '{schema_version: $sv, items: .}' <<<"$ITEMS" || {
+  printf 'list-items.sh: could not emit the item envelope\n' >&2
+  exit "$EX_INTERNAL"
+}

--- a/plugins/work-items/tools/work-item-tracker/adapters/linear/list-sub-items.sh
+++ b/plugins/work-items/tools/work-item-tracker/adapters/linear/list-sub-items.sh
@@ -78,13 +78,26 @@ while :; do
     # Every child carries the container as parent_id. The normalizer already derives it
     # from the child's own `parent`, but it is forced here so a child whose selection
     # omitted the parent cannot emit a null and break sub-map traversal.
-    ITEMS="$(jq -c --argjson acc "$ITEMS" --argjson one "$ONE" --arg p "$PARENT_ID" \
-      '$acc + [$one + {parent_id: $p}]' <<<'null')"
+    # Accumulator on stdin, one item in argv. The reverse puts an unboundedly growing array
+    # on jq's command line; past ARG_MAX the exec fails and the unchecked assignment would
+    # leave ITEMS empty — a container with many children reporting none, which the
+    # closed-children invariant would then read as "nothing open under it".
+    ITEMS="$(jq -c --argjson one "$ONE" --arg p "$PARENT_ID" \
+      '. + [$one + {parent_id: $p}]' <<<"$ITEMS")" || {
+      printf 'list-sub-items.sh: could not accumulate a child of %s — refusing to report a partial child list as complete\n' \
+        "$PARENT_ID" >&2
+      exit "$EX_INTERNAL"
+    }
   done < <(jq -c '.nodes[]?' <<<"$PAGE")
   [[ "$(jq -r '.pageInfo.hasNextPage // false' <<<"$PAGE")" == "true" ]] || break
   CURSOR="$(jq -r '.pageInfo.endCursor // ""' <<<"$PAGE")"
   [[ -n "$CURSOR" ]] || break
 done
 
-jq -cn --arg sv "$WIT_SCHEMA_VERSION" --argjson items "$ITEMS" \
-  '{schema_version: $sv, items: $items}'
+# ITEMS travels on STDIN, not argv — see list-items.sh. An empty envelope emitted because the
+# exec failed would read as "this container has no children", which the closed-children
+# invariant would then treat as "nothing open under it".
+jq -c --arg sv "$WIT_SCHEMA_VERSION" '{schema_version: $sv, items: .}' <<<"$ITEMS" || {
+  printf 'list-sub-items.sh: could not emit the child envelope for %s\n' "$PARENT_ID" >&2
+  exit "$EX_INTERNAL"
+}


### PR DESCRIPTION
No linked issue

## Summary

The `linear` and `gitea` adapters are tested **only** against mock transports whose responses the
tests themselves author, and neither has ever run against a live server. A wrong field name,
argument, enum value, endpoint path, or termination signal therefore passes every suite and fails
on the first real call — precisely when a credential finally arrives. This validates both against
their providers' real published contracts and fixes what that turned up, plus five findings from
three review rounds and one defect those findings' own regression test uncovered.

`work-items` 0.39.7 → **0.39.9** (0.39.8 was claimed by #3069 mid-flight).

## Fix

**What was clean matters as much as what was not.** All **17** linear operations validate against
the real schema under `graphql-js` — argument names and types, nested selections, enum members,
variable coercion, connection shapes — and the harness was proven sensitive rather than vacuously
green by a negative control catching **10 of 10** injected faults. Every gitea path, method, query
parameter, request-body field and response field the adapter reads matches the spec, including the
nested `jq` paths.

**The most serious defect here was not in the original code — it was reachable only once a fix
made it reachable.** Both adapters accumulated paged results as `jq --argjson acc "$ACC"`, putting
an unboundedly growing array on jq's **command line**. Past `ARG_MAX` the kernel refuses the exec
(`Argument list too long`), and because the assignment was unchecked, the accumulator was left
empty and the verb **reported an empty list while exiting 0**. A repository or team large enough
to trip it simply looked empty. The final envelope emit had the same shape, at the one point where
the array is guaranteed to be at its largest. Nine sites now pass the accumulator through
**stdin** and only the bounded new element in argv, and every one fails loudly. On
`linear:list-sub-items` this was the worst of the set: an empty child list is exactly what the
closed-children invariant reads as "nothing open under this container". It surfaced only because a
reviewer's ceiling finding forced a walk past 1000 rows for the first time.

The five contract defects:

- **`linear` accepted a `page_size` the API rejects** — validation took any positive integer while
  Linear caps `first` at 250, a cap the adapter's own comment already documented. Config
  validation passing and the *first* live call failing is what config validation exists to prevent.
- **`linear` could not resolve workspace-level labels, and lost labels past page 1** — ids came
  from `team.labels(first: 250)`, one page, no `pageInfo`, no loop, where 250 is the per-page
  *maximum*; and `Team.labels` is documented only as *"Labels associated with the team"* while
  `IssueLabel.team` says *"If null, the label is a workspace-level label available to all teams"*.
  Since an unresolved name is **refused**, both surfaced as a hard exit on a label that exists.
  Resolution now walks the **root** `issueLabels` connection, filtered to this team or
  workspace-level, fully paginated, stopping on a null cursor and bounded by the declared ceiling.
- **`gitea` silently truncated every list on instances with a lower paging cap** —
  `ToCorrectPageSize` clamps `limit` to `[api] MAX_RESPONSE_ITEMS` (stock 50), so every page came
  back short and "short means last" ended the walk after page 1 with nothing said. The issue-list
  and label-list handlers **do** send `X-Total-Count`; the dependency-list handler does not. The
  transport now captures response headers and both walks use that count, with the short-page
  heuristic kept as the fallback — no behaviour change where no header is sent, no extra request.
- **`gitea` fetched pull requests only to discard them** — `type=issues` went unused, so PRs ate
  the page budget and the ceiling counted rows rather than items.
- **`gitea` refused organization-wide labels it would have applied** — `GetLabelsByRepoID` uses
  `WHERE repo_id = ?`, yet `NewIssueWithIndex` accepts any label whose `OrgID == repo.OwnerID`.
  Backwards and user-visible: reads *report* org labels, so the tracker returned a name it would
  then refuse to write back. `create-item` now merges `/orgs/{owner}/labels`, treating a
  user-owned repo's 404 as "no org labels".

Plus the review findings: both list ceilings now count **rows collected** rather than
`PAGE × requested size` (they diverge under the clamp, so a walk stopped at 500 while announcing a
1000-item ceiling); the org-label walk uses `X-Total-Count` like its sibling instead of a
largest-page-seen heuristic that made **20** requests where 1 suffices and reported truncations
that never happened; and the new linear label walk is bounded, since a server answering
`hasNextPage` with fresh cursors would otherwise hang `create-item` indefinitely.

Every truncating ceiling now distinguishes *truncated-so-it-might-exist* from
*absent-so-create-it* — a bare "create them first" against a truncated list sends someone to
create a label that is already there.

Two design notes. I first fixed gitea pagination by learning the effective page size from the
responses, which is correct but costs an extra request on **every** listing — inside
`blocked_by_count` that turns `list-items` from N+1 into 2N+1. The tests caught it. Header capture
uses `-D` to a temp file rather than curl's `%header{}` write-out, which needs curl 7.83+ and this
repo lints for portability.

## Verification

- **Reproducible sources.** Linear: `npm pack @linear/sdk` → 90.0.0, cross-checked against the
  published SDL, byte-identical including doc strings. Gitea: its own generated
  `templates/swagger/v1_json.tmpl` at tag `v1.22.6`, plus handler source where the spec is silent
  (`routers/api/v1/repo/{issue,label,issue_dependency}.go`, `services/convert/utils.go`,
  `modules/setting/api.go`), and a drift check against `v1.26.0`.
- **Every fix has regression cases verified to fail against the unfixed file.** The linear label
  cases go red with exit 5 — the real-world symptom; the ceiling case collects 500 rows before and
  1050 after; the org-label case makes 20 requests before and 1 after. The linear ceiling's
  negative control is unusual and worth naming: removing the bound does not produce a wrong
  answer, it produces the hang — the suite is killed at 25s, exit 124.
- The gitea mock gained `-D` header support so the `X-Total-Count` path is exercised rather than
  silently falling back; a mock ignoring the flag would have made the new code untestable and the
  tests vacuous.
- Full sweep clean; `shellcheck -x`, `shfmt -d`, `typos`, `markdownlint-cli2`, changelog parity
  and `--check-bump origin/main` all clean.
- **Two of my own mistakes are corrected in-branch rather than papered over.** An assertion was
  passing for the wrong reason — `jq 'length'` on the response *envelope* counts keys (2), not
  items; it is `.items | length` now. And I added the linear label ceiling in one review round and
  failed to test it, which the next round caught.
- **Suite timing, not hangs:** `gitea/list-items.test.sh` ~48s (1050-row walk) and
  `linear/create-item.test.sh` ~20s (21-page ceiling walk). Both need real scale to exercise what
  they cover.

**Recorded rather than guessed** — these need a live credential and are not schema contradictions:
whether `assigneeId: null` semantically unassigns (the schema permits the null; the resolver is
not in the schema), Linear's default comment ordering, and the instance-configuration-dependent
halves of the gitea findings (`MAX_RESPONSE_ITEMS`, `ALLOW_CROSS_REPOSITORY_DEPENDENCIES`).
Forgejo parity remains assumed rather than measured.

## Related

- Refs #2933 — spec container. This is the static substitute for the live conformance evidence its
  last open item cannot obtain
- Refs #2946 — the Linear adapter item; this materially strengthens the evidence base it closes on
- Refs #2952 — the Gitea adapter item, whose live conformance was descoped; static validation is
  now the only validation that adapter will get, which is why these fixes are in scope
- Refs #3067 — the preceding PR on this branch, merged as `2e873531`
- Refs #3069 — claimed `work-items` 0.39.8 mid-flight, hence 0.39.9 here

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CnzwTKoTa6xNY7iyEzMYpm