### PR TITLE
docs(context-guard): record the cloud/headless capture verdict and make the gap legible

### DIFF
--- a/plugins/context-guard/.claude-plugin/plugin.json
+++ b/plugins/context-guard/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "context-guard",
-  "version": "0.7.16",
+  "version": "0.7.17",
   "description": "Per-session context-window observability plus the first shipped consumer: a statusline wrapper tees each session's context_window fields to a per-session snapshot file, a zone resolver classifies usage into smart/acceptable/dumb bands (percentage bands plus window-class token bands, conservative-min combination, zones.json SSOT with shipped defaults), a reader contract fixes how consuming sessions interpret the snapshots, and zone-crossing hooks report once per transition into a worse zone across two channels \u2014 the continuation menu to the operator, who owns that choice, and to the model only the zone determination plus the counter-steer that a zone word is not a decay signal (advisory by default; an optional blocking mode gates new mutating work on a fresh dumb-zone snapshot with handoff-writing exempt), with a PostCompact hook persisting an evidence-degraded marker.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/context-guard/CHANGELOG.md
+++ b/plugins/context-guard/CHANGELOG.md
@@ -5,6 +5,48 @@ All notable changes to the `context-guard` plugin.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.17]
+
+### Added
+
+- **The cloud/headless capture verdict is now a shipped reference, and `unknown` there is documented
+  as structural (#2957).** The snapshot rides the statusline tee, so a session with no configured
+  `statusLine` has no instrument at all — cloud and headless sessions by default. Measured in a live
+  Claude Code on the web container on 2026-08-21: no `statusLine` in any settings scope, no
+  `<session_id>.json` snapshot, and `context-zone.sh` answering `unknown`. One correction to the
+  reported symptom, and it is the finding the rest rests on: `~/.claude/context-guard/` *does* exist
+  there, created by the `PostCompact` hook — plugin hooks run fine in cloud, only the statusline
+  writer is silent, which is why hook stdin was the first channel checked. New
+  `reference/cloud-headless-capture.md` records the writer-side channel inventory: every channel
+  checked with its live URL and the date read (all 2026-08-21), what each does and does not carry,
+  and what would have to change upstream. **Verdict: no documented channel other than the status
+  line carries per-session context-window telemetry.** Hook stdin carries `session_id`, `prompt_id`,
+  `transcript_path`, `cwd`, `permission_mode`, `effort`, `hook_event_name` and event-specific
+  fields, and no context, token, usage, or window field on any event. Also rejected with the reason
+  recorded: `subagentStatusLine` (subagent rows only, and itself a status-line surface),
+  non-interactive JSON/stream output (per-invocation and after the fact), OpenTelemetry (a
+  cumulative token counter, no occupancy gauge), and the session transcript — reachable from every
+  hook through the documented `transcript_path` and carrying exactly the right numbers, but its
+  entry format is documented as internal and version-unstable, so a capture built on it would
+  warrant a zone with nothing and would break on a Claude Code release rather than on a change here.
+  A wrong zone is strictly worse than `unknown`.
+
+### Changed
+
+- **`reference/reader-contract.md` tells consumers how to report a missing instrument (#2957).** A
+  new cloud-and-headless section states that `unknown` in a session with no configured `statusLine`
+  is structural and permanent, to be reported as "no instrument in this environment" and never as a
+  defect or a broken install; that no zone may be synthesized from another source, naming the two
+  reachable near-substitutes and how each fails toward a confident wrong answer; and that `unknown`
+  carries no direction, so a fork or handoff trigger in such a session must come from somewhere else
+  and must not be presented as instrument-backed. It also gives the discriminator the previous text
+  lacked: structural absence and a broken install both print `unknown`, and only the writer side
+  separates them — read `statusLine` from every scope that can carry it.
+- **`/context-guard:setup` `check` stops prescribing a remediation that cannot work (#2957).** No
+  `statusLine` in a session that refreshes none is now INFO with the structural explanation instead
+  of printed wiring the operator cannot make run, and an absent snapshot with no `statusLine`
+  configured anywhere is INFO rather than the FAIL branch that assumes correct wiring.
+
 ## [0.7.16]
 
 ### Added

--- a/plugins/context-guard/CHANGELOG.md
+++ b/plugins/context-guard/CHANGELOG.md
@@ -10,42 +10,73 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 
 - **The cloud/headless capture verdict is now a shipped reference, and `unknown` there is documented
-  as structural (#2957).** The snapshot rides the statusline tee, so a session with no configured
-  `statusLine` has no instrument at all — cloud and headless sessions by default. Measured in a live
+  as structural (#2957).** The snapshot rides the statusline tee, so a session that never runs a
+  statusline has no instrument at all — cloud and headless sessions by default. Measured in a live
   Claude Code on the web container on 2026-08-21: no `statusLine` in any settings scope, no
-  `<session_id>.json` snapshot, and `context-zone.sh` answering `unknown`. One correction to the
+  `<session_id>.json` snapshot, and `context-zone.sh` answering `unknown`. Measured from the other
+  side the same day, so the cloud finding is not an inference: a `statusLine` written into the live
+  cloud session's own user settings, with `refreshInterval: 2` and a probe that logs every
+  invocation, was **never invoked once** over ~7 minutes, and the identical wiring under a scratch
+  `HOME` exercised with `claude -p` behaved the same. One correction to the
   reported symptom, and it is the finding the rest rests on: `~/.claude/context-guard/` *does* exist
   there, created by the `PostCompact` hook — plugin hooks run fine in cloud, only the statusline
   writer is silent, which is why hook stdin was the first channel checked. New
   `reference/cloud-headless-capture.md` records the writer-side channel inventory: every channel
   checked with its live URL and the date read (all 2026-08-21), what each does and does not carry,
   and what would have to change upstream. **Verdict: no documented channel other than the status
-  line carries per-session context-window telemetry.** Hook stdin carries `session_id`, `prompt_id`,
-  `transcript_path`, `cwd`, `permission_mode`, `effort`, `hook_event_name` and event-specific
-  fields, and no context, token, usage, or window field on any event. Also rejected with the reason
-  recorded: `subagentStatusLine` (subagent rows only, and itself a status-line surface),
-  non-interactive JSON/stream output (per-invocation and after the fact), OpenTelemetry (a
-  cumulative token counter, no occupancy gauge), and the session transcript — reachable from every
-  hook through the documented `transcript_path` and carrying exactly the right numbers, but its
-  entry format is documented as internal and version-unstable, so a capture built on it would
-  warrant a zone with nothing and would break on a Claude Code release rather than on a change here.
-  A wrong zone is strictly worse than `unknown`.
+  line delivers per-session context-window occupancy to a local writer.** Hook stdin carries
+  `session_id`, `prompt_id`, `transcript_path`, `cwd`, `permission_mode`, `effort`,
+  `hook_event_name` and event-specific fields, and no context, token, usage, or window field on any
+  event — **except `PostToolUse` on the `Agent` tool, whose `tool_response` carries `totalTokens`
+  and a `usage` breakdown for the *subagent's* final API request, and nothing about the main
+  session's window.** Also rejected with the reason recorded: `subagentStatusLine` (subagent rows
+  only, and itself a status-line surface), non-interactive JSON/stream output (per-invocation and
+  after the fact), the OpenTelemetry token *metric* (a cumulative counter, no occupancy gauge), the
+  OpenTelemetry `claude_code.api_request` *event*, and the session transcript. The last two are the
+  near-misses and each gets its own section rather than a table cell, because each really does
+  carry live per-session occupancy. The `api_request` event carries `input_tokens`,
+  `output_tokens`, `cache_read_tokens`, `cache_creation_tokens`, `query_source` and `event.sequence`
+  with `session.id` on by default — the same three input addends the statusline page gives as the
+  `used_percentage` formula — but it carries no `context_window_size` and no percentage, and the
+  resolver needs a denominator: measured, a snapshot with mapped `current_usage`, both token totals
+  and a `cli_version` but no `context_window_size` resolves `unknown`, while adding one to the
+  identical file resolves `acceptable`. It also has no local sink (`prometheus` is metrics-only,
+  `console` writes to Claude Code's own stdout, and Claude Code strips `OTEL_*` from every
+  subprocess including hooks), so nothing hook-local can consume it. The transcript is reachable
+  from every hook through the documented `transcript_path` and carries exactly the right numbers,
+  and the rejection no longer rests on "a reader would break on a release": a shape-validating
+  reader degrades to writing nothing, which is `unknown`, the same fail-open posture this contract
+  mandates everywhere else. It is declined instead on silent semantic drift — a field can keep its
+  name, type and magnitude while ceasing to mean full-context occupancy, which no shape check
+  detects — plus an unbounded re-verification obligation against a format its own docs call
+  internal and unsupported.
 
 ### Changed
 
 - **`reference/reader-contract.md` tells consumers how to report a missing instrument (#2957).** A
-  new cloud-and-headless section states that `unknown` in a session with no configured `statusLine`
-  is structural and permanent, to be reported as "no instrument in this environment" and never as a
-  defect or a broken install; that no zone may be synthesized from another source, naming the two
-  reachable near-substitutes and how each fails toward a confident wrong answer; and that `unknown`
-  carries no direction, so a fork or handoff trigger in such a session must come from somewhere else
-  and must not be presented as instrument-backed. It also gives the discriminator the previous text
-  lacked: structural absence and a broken install both print `unknown`, and only the writer side
-  separates them — read `statusLine` from every scope that can carry it.
-- **`/context-guard:setup` `check` stops prescribing a remediation that cannot work (#2957).** No
-  `statusLine` in a session that refreshes none is now INFO with the structural explanation instead
-  of printed wiring the operator cannot make run, and an absent snapshot with no `statusLine`
-  configured anywhere is INFO rather than the FAIL branch that assumes correct wiring.
+  new cloud-and-headless section states that `unknown` in a session that never runs a statusline is
+  structural and permanent, to be reported as "no instrument in this environment" and never as a
+  defect or a broken install; that no zone may be synthesized from another source, naming each
+  reachable near-substitute and the thing it requires the reader to invent or trust; and that
+  `unknown` carries no direction, so a fork or handoff trigger in such a session must come from
+  somewhere else and must not be presented as instrument-backed. It also gives the discriminator the
+  previous text lacked: structural absence and a broken install both print `unknown`, and only the
+  writer side separates them — read `statusLine` from every scope that can carry it, **managed
+  settings included**, and treat a configured `statusLine` whose status line is *disabled* as
+  structural too. Claude Code turns the status line off entirely under a managed `disableAllHooks`
+  or an untrusted folder, and under `allowManagedHooksOnly` narrowing it runs a managed value if one
+  is deployed and otherwise skips yours without warning — a state that reads as a broken install
+  unless it is checked first, and whose remediation is policy or trust, never wiring.
+- **`/context-guard:setup` `check` stops prescribing a remediation that cannot work, and stops
+  contradicting itself when one would (#2957).** No `statusLine` in a session that runs none is
+  INFO with the structural explanation instead of printed wiring the operator cannot make run. The
+  matching snapshot-absent branch is now gated on the same condition rather than on the bare
+  absence of a `statusLine`: it reports structural absence only where step 3 took the terminal-less
+  exception, and otherwise reports the ordinary not-yet-wired state and points at the wiring step 3
+  just printed — previously the two steps could print wiring and then say nothing was broken, in
+  the same report, on the single most common state the check exists to diagnose. `check` also reads
+  managed settings as a `statusLine` scope and reports a policy- or trust-disabled status line as
+  INFO rather than letting it fall through to the wiring-defect FAIL.
 
 ## [0.7.16]
 

--- a/plugins/context-guard/CHANGELOG.md
+++ b/plugins/context-guard/CHANGELOG.md
@@ -62,21 +62,28 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   somewhere else and must not be presented as instrument-backed. It also gives the discriminator the
   previous text lacked: structural absence and a broken install both print `unknown`, and only the
   writer side separates them — read `statusLine` from every scope that can carry it, **managed
-  settings included**, and treat a configured `statusLine` whose status line is *disabled* as
-  structural too. Claude Code turns the status line off entirely under a managed `disableAllHooks`
-  or an untrusted folder, and under `allowManagedHooksOnly` narrowing it runs a managed value if one
-  is deployed and otherwise skips yours without warning — a state that reads as a broken install
-  unless it is checked first, and whose remediation is policy or trust, never wiring.
+  settings included**, and treat a configured `statusLine` whose status line is *disabled* **or
+  whose environment is terminal-less** as structural too. Claude Code turns the status line off
+  entirely under a managed `disableAllHooks` or an untrusted folder, and under
+  `allowManagedHooksOnly` narrowing it runs a managed value if one is deployed and otherwise
+  skips yours without warning — a state that reads as a broken install unless it is checked
+  first, and whose remediation is policy or trust, never wiring. A configured, not-disabled
+  `statusLine` in a cloud or headless session is the same structural class: the command exists
+  and is still never invoked, which is the case this release measured.
 - **`/context-guard:setup` `check` stops prescribing a remediation that cannot work, and stops
-  contradicting itself when one would (#2957).** No `statusLine` in a session that runs none is
-  INFO with the structural explanation instead of printed wiring the operator cannot make run. The
-  matching snapshot-absent branch is now gated on the same condition rather than on the bare
-  absence of a `statusLine`: it reports structural absence only where step 3 took the terminal-less
-  exception, and otherwise reports the ordinary not-yet-wired state and points at the wiring step 3
-  just printed — previously the two steps could print wiring and then say nothing was broken, in
-  the same report, on the single most common state the check exists to diagnose. `check` also reads
-  managed settings as a `statusLine` scope and reports a policy- or trust-disabled status line as
-  INFO rather than letting it fall through to the wiring-defect FAIL.
+  contradicting itself when one would (#2957).** Terminal-less detection is orthogonal to all
+  four wiring states, not nested under "no `statusLine` configured": a correctly-wired shim in
+  a cloud or headless session is INFO (structural) rather than PASS-then-FAIL, and step 7 does
+  not print wiring those branches already forbade. The matching snapshot-absent **or stale**
+  branch is gated on the same condition rather than on the bare absence of a `statusLine`: it
+  reports structural absence only where step 3 took the terminal-less exception, and otherwise
+  reports the ordinary not-yet-wired state and points at the wiring step 3 just printed —
+  previously the two steps could print wiring and then say nothing was broken, in the same
+  report, on the single most common state the check exists to diagnose. `check` also reads
+  managed settings as a `statusLine` scope, reports a policy- or trust-disabled status line as
+  INFO rather than letting it fall through to the wiring-defect FAIL, and routes a managed
+  effective `statusLine` to the policy administrator instead of printing an operator edit for
+  that file.
 
 ## [0.7.16]
 

--- a/plugins/context-guard/README.md
+++ b/plugins/context-guard/README.md
@@ -39,7 +39,11 @@ tool that needs it — so long-running workflows can route heavy work away from 
 - **Reader contract** (`reference/reader-contract.md`) — the authoritative consumer contract: the
   snapshot path pattern, file shape, the 10-minute staleness rule, fail-open capability detection,
   the zones.json shape, session-id discovery via `${CLAUDE_SESSION_ID}`, and the
-  zone-is-not-a-compaction-indicator rule.
+  zone-is-not-a-compaction-indicator rule. Its companion
+  `reference/cloud-headless-capture.md` is the writer-side channel inventory: why the statusline is
+  the only capture channel, which other channels were checked and rejected (with sources and
+  dates), and why `unknown` in a session with no configured `statusLine` — a cloud or headless
+  session by default — is structural rather than a defect.
 
 ## Behavior
 

--- a/plugins/context-guard/README.md
+++ b/plugins/context-guard/README.md
@@ -42,8 +42,9 @@ tool that needs it — so long-running workflows can route heavy work away from 
   zone-is-not-a-compaction-indicator rule. Its companion
   `reference/cloud-headless-capture.md` is the writer-side channel inventory: why the statusline is
   the only capture channel, which other channels were checked and rejected (with sources and
-  dates), and why `unknown` in a session with no configured `statusLine` — a cloud or headless
-  session by default — is structural rather than a defect.
+  dates) — including the two that do carry live occupancy and still cannot supply a snapshot — and
+  why `unknown` in a session that runs no statusline, a cloud or headless session by default, is
+  structural rather than a defect.
 
 ## Behavior
 

--- a/plugins/context-guard/reference/cloud-headless-capture.md
+++ b/plugins/context-guard/reference/cloud-headless-capture.md
@@ -1,0 +1,36 @@
+# Context guard — capture channels in cloud and headless sessions
+
+Why the statusline tee is not the only capture source, what each candidate channel does and does
+not carry, and how a consumer tells a *structurally absent* instrument from a *broken* one.
+
+`reference/reader-contract.md` remains the authoritative reader-side contract: snapshot path
+pattern, staleness rule, zone bands, combination rule. This file is the **writer-side channel
+inventory** — it explains where a snapshot can come from, and what to expect when none can.
+
+## Current-state facts (measured, not inferred)
+
+Measured **2026-08-21** inside a live Claude Code on the web container
+(`CLAUDE_CODE_ENTRYPOINT=remote`, `CLAUDE_CODE_REMOTE_ENVIRONMENT_TYPE=cloud_default`,
+`claude --version` → `2.1.235 (Claude Code)`).
+
+| Observation | Command | Result |
+|-------------|---------|--------|
+| Is a statusline configured? | `grep -rn statusLine ~/.claude/settings.json ~/.claude/launcher-settings.json ~/.claude/remote-settings.json ~/.claude/policy-limits.json` | no match in any scope; `/etc/claude-code/managed-settings.json` does not exist |
+| Does the contract directory exist? | `ls -la ~/.claude/context-guard/` | exists, containing only `context/` |
+| Does a snapshot exist? | `ls -la ~/.claude/context-guard/context/` | only `<session_id>.compacted` (the `PostCompact` marker); **no `<session_id>.json`** |
+| What does the resolver return? | `bash scripts/context-zone.sh <session_id>` | `unknown` |
+
+The issue's central claim is **confirmed with one correction**: `~/.claude/context-guard/` *does*
+exist here, but only because the `PostCompact` hook created it. The **snapshot** the reader needs
+is absent, and the resolver prints `unknown`.
+
+The correction matters, because it is also the finding that unblocks the fix: **plugin hooks do
+run in this environment.** The `.compacted` marker in that directory was written by
+`hooks/post-compact-mark.sh` during an auto-compaction of this very session. The statusline is the
+only context-guard writer that is silent in cloud — not the hook layer.
+
+## Channels checked
+
+Each row records what was checked, on what date, and what the channel does and does not carry.
+
+<!-- channel inventory continues in the sections below -->

--- a/plugins/context-guard/reference/cloud-headless-capture.md
+++ b/plugins/context-guard/reference/cloud-headless-capture.md
@@ -207,15 +207,22 @@ that runs it (<https://code.claude.com/docs/en/statusline>,
    if one is deployed; otherwise it skips your value without warning, the status line is disabled".
    A configured `statusLine` that never runs looks exactly like a broken install unless this branch
    is checked first.
-4. **A `statusLine` is configured, the status line is not disabled, and no fresh snapshot exists**
-   → a real defect: wiring, the installed shim, or `jq`. Invoke `/context-guard:setup` via the
-   Skill tool with `check` for the full diagnosis.
+4. **A `statusLine` is configured, the status line is not disabled, and the environment is
+   terminal-less** → also structural. The command exists and is not policy-disabled, and is
+   still never invoked. This is the measured cloud case: a `statusLine` written into a live
+   cloud session's user settings was never invoked. Report as "no instrument in this
+   environment"; do not offer wiring as a remediation.
+5. **A `statusLine` is configured, the status line is not disabled, the environment is one
+   that runs a statusline, and no fresh snapshot exists** → a real defect: wiring, the
+   installed shim, or `jq`. Invoke `/context-guard:setup` via the Skill tool with `check` for
+   the full diagnosis.
 
-A cloud or headless session lands on branch 2 by default: no `statusLine` is configured. It also
-lands on the structural side when one *is* configured — measured above, a `statusLine` written into
-a live cloud session's user settings was never invoked. The status line is a terminal-interface
+A cloud or headless session lands on branch 2 by default: no `statusLine` is configured. When
+one *is* configured it lands on branch 4 — measured above, a `statusLine` written into a live
+cloud session's user settings was never invoked. The status line is a terminal-interface
 surface: the page describes it rendering above the footer badges and reading `COLUMNS` / `LINES`
-for terminal dimensions. Configuring one there is not a remediation to offer.
+for terminal dimensions. Configuring one there is not a remediation to offer. It does **not**
+land on branch 5: that branch is a real defect only where a status line would actually run.
 
 ## What would have to change upstream
 

--- a/plugins/context-guard/reference/cloud-headless-capture.md
+++ b/plugins/context-guard/reference/cloud-headless-capture.md
@@ -9,11 +9,23 @@ inventory** — where a snapshot can come from, and what to expect where none ca
 
 ## Verdict
 
-**As of 2026-08-21, no documented Claude Code channel other than the status line carries
-per-session context-window telemetry.** Hook stdin — the named candidate — carries no context,
-token, usage, or window field on any event. In a session where no `statusLine` is configured, no
-snapshot can be written, so `context-zone.sh` answers `unknown` and every zone consumer takes its
-conservative path. **That `unknown` is structural, not a defect and not a broken install.**
+**As of 2026-08-21, no documented Claude Code channel other than the status line delivers
+per-session context-window occupancy to a local writer.** Two other channels do carry real
+occupancy numbers for the running session, and neither can be turned into a snapshot: the
+OpenTelemetry `claude_code.api_request` log event carries live per-session token counts but no
+window size and reaches only an out-of-process receiver, and the session transcript carries the
+same numbers behind an explicitly unsupported entry format. Both are recorded in full below rather
+than waved off.
+
+Hook stdin — the named candidate — carries no context, token, usage, or window field on any event,
+**except `PostToolUse` on the `Agent` tool, whose `tool_response` carries `totalTokens` and a
+`usage` breakdown for the *subagent's* final API request — nothing about the main session's
+window.**
+
+In a session where no `statusLine` is configured, or where one is configured and the environment
+never runs it, no snapshot is written, so `context-zone.sh` answers `unknown` and every zone
+consumer takes its conservative path. **That `unknown` is structural, not a defect and not a broken
+install.**
 
 The evidence for each channel is below, with the live URL and the date it was read.
 
@@ -25,10 +37,13 @@ Measured **2026-08-21** inside a live Claude Code on the web container
 
 | Observation | Command | Result |
 |-------------|---------|--------|
-| Is a status line configured? | `grep -rn statusLine ~/.claude/settings.json ~/.claude/launcher-settings.json ~/.claude/remote-settings.json ~/.claude/policy-limits.json` | no match in any scope; `/etc/claude-code/managed-settings.json` does not exist |
+| Is a status line configured? | `grep -rn statusLine ~/.claude/settings.json ~/.claude/launcher-settings.json ~/.claude/remote-settings.json ~/.claude/policy-limits.json .claude/settings.json .claude/settings.local.json /etc/claude-code/managed-settings.json` | no match in any scope that exists; the local and managed files do not exist in this container |
 | Does the contract directory exist? | `ls -la ~/.claude/context-guard/` | exists, containing only `context/` |
 | Does a snapshot exist? | `ls -la ~/.claude/context-guard/context/` | only `<session_id>.compacted` (the `PostCompact` marker); **no `<session_id>.json`** |
 | What does the resolver return? | `bash scripts/context-zone.sh <session_id>` | `unknown` |
+| Does a **configured** `statusLine` run in a cloud session? | wrote a `statusLine` into the live session's `~/.claude/settings.json` with `refreshInterval: 2`, pointing at a probe that appends its stdin to a log *before* handing it to the tee, then exercised the session for ~7 minutes and restored the file | **the probe was never invoked once** — no log entry, no `<session_id>.json`. The probe itself was verified working by feeding it a payload by hand (it logged, teed a snapshot, and printed a statusline row) |
+| Does a **configured** `statusLine` run in a headless session? | the identical `statusLine` in a scratch `HOME`, exercised with `claude -p '…' --output-format json` | **same** — the probe was never invoked, and `~/.claude/context-guard/` was never created under that `HOME` |
+| Does the resolver accept an occupancy-only snapshot with no window size? | synthetic snapshots under a scratch `HOME` | **no.** With `cli_version`, `current_usage` and both token totals present but `context_window_size` absent and `used_percentage` null → `unknown`; adding a `context_window_size` to the otherwise identical file → `acceptable`. A snapshot with no `current_usage` is rejected by the trust gate outright, whatever else it carries |
 
 The central claim is **confirmed with one correction**: `~/.claude/context-guard/` *does* exist in
 a cloud container, but only because a hook created it. The **snapshot** the reader needs is absent,
@@ -40,6 +55,17 @@ tokens in a 200000 window, `used_percentage` 60 — produced a snapshot and reso
 while the real session id resolved `unknown` moments earlier. Nothing about `context-zone.sh`,
 `statusline-tee.sh`, `jq`, or the contract path is broken here. There is simply nothing calling the
 tee, because nothing calls a statusline.
+
+**The cloud row is a measurement, not an inference.** The earlier version of this file established
+only that no `statusLine` *is* configured in cloud and inferred the rest. The row above closes that
+gap from the other side: one *was* configured, in the user scope of a live cloud session, and it
+never ran. The write was live rather than pending a restart — Claude Code "watches your settings
+files and reloads them when they change", the reload "covers user, project, local, and managed
+settings", and `statusLine` is not among the few keys documented as read once at session start
+(<https://code.claude.com/docs/en/settings>, read 2026-08-21). The headless half was measured the
+same day by the same method: the identical `statusLine` written into a scratch `HOME`, exercised
+with `claude -p '…' --output-format json`, again never invoked the probe and never created
+`~/.claude/context-guard/` at all.
 
 The correction matters. The `.compacted` marker in that directory was written by
 `hooks/post-compact-mark.sh` during an auto-compaction of that session, which proves **plugin hooks
@@ -54,18 +80,60 @@ from those pages, not recalled.
 
 | Channel | Source read | Carries | Does **not** carry |
 |---|---|---|---|
-| Hook stdin (all events) | <https://code.claude.com/docs/en/hooks> | Common input fields: `session_id`, `prompt_id`, `transcript_path`, `cwd`, `permission_mode`, `effort`, `hook_event_name`, plus `agent_id` / `agent_type` under an agent. Event-specific fields such as `tool_name`, `tool_input`, `tool_use_id` | **Any context-window, token-count, usage, or percentage-of-window field, on any event.** `effort` is a reasoning-effort level, not consumption |
-| Status line stdin | <https://code.claude.com/docs/en/statusline> | The whole `context_window` object — `total_input_tokens`, `total_output_tokens`, `context_window_size`, `used_percentage`, `remaining_percentage`, `current_usage` — plus top-level `version` | Nothing this plugin needs. This is the one sufficient channel, and it exists only where a `statusLine` is configured and refreshing |
+| Hook stdin (all events) | <https://code.claude.com/docs/en/hooks> | Common input fields: `session_id`, `prompt_id`, `transcript_path`, `cwd`, `permission_mode`, `effort`, `hook_event_name`, plus `agent_id` / `agent_type` under an agent. Event-specific fields such as `tool_name`, `tool_input`, `tool_use_id`. **One event carries token figures:** `PostToolUse` on the `Agent` tool receives `totalTokens` ("Token count from the subagent's final API request: input, output, and cache tokens combined. This isn't a total across the whole run") and a `usage` object (`input_tokens`, `output_tokens`, `cache_creation_input_tokens`, `cache_read_input_tokens`) in `tool_response` | Any context-window, token-count, usage, or percentage-of-window field for the **main session**, on any event. The `Agent` exception is subagent-scoped and single-request-scoped — the page says outright it "isn't a total across the whole run" — and it is absent entirely for background subagents. `effort` is a reasoning-effort level, not consumption |
+| Status line stdin | <https://code.claude.com/docs/en/statusline> | The whole `context_window` object — `total_input_tokens`, `total_output_tokens`, `context_window_size`, `used_percentage`, `remaining_percentage`, `current_usage` — plus top-level `version` | Nothing this plugin needs. This is the one sufficient channel, and it exists only where a `statusLine` is configured *and* the environment runs it |
 | `subagentStatusLine` stdin | <https://code.claude.com/docs/en/statusline> | A `tasks` array whose entries carry `tokenCount` and `contextWindowSize` per subagent row | Any figure for the **main session**. It describes subagent rows in the agent panel, and it is a status-line-family surface, so it is absent wherever the status line is |
 | Non-interactive / Agent SDK output | <https://code.claude.com/docs/en/headless> | `--output-format json` returns result, session ID, usage and `total_cost_usd` for **that invocation**; `stream-json` emits per-event metadata | Live occupancy of an already-running interactive session. It reports on a run the caller starts, after the fact — it cannot answer "how full is this session's window right now" |
-| OpenTelemetry metrics and events | <https://code.claude.com/docs/en/monitoring-usage> | `claude_code.token.usage`, a **counter** with `type` attributes `input` / `output` / `cacheRead` / `cacheCreation` | Any gauge of current occupancy or percentage of window. Every documented metric is a counter of cumulative activity; a cumulative total is not observable as current occupancy — precisely the failure the resolver's token-shape version gate exists to prevent |
-| Session transcript file | <https://code.claude.com/docs/en/sessions> | The JSONL at `~/.claude/projects/<project>/<session-id>.jsonl`, reachable from every hook through the documented `transcript_path` field | A **supported** shape to parse. See below — this is the near-miss and it is disqualified deliberately |
+| OpenTelemetry **metrics** | <https://code.claude.com/docs/en/monitoring-usage> | `claude_code.token.usage`, a **counter** with `type` attributes `input` / `output` / `cacheRead` / `cacheCreation` | Any gauge of current occupancy or percentage of window. Every documented metric is a counter of cumulative activity, and a cumulative total is not observable as current occupancy |
+| OpenTelemetry **events** (`claude_code.api_request`) | <https://code.claude.com/docs/en/monitoring-usage> | **Real live occupancy, per session.** The event carries `input_tokens`, `output_tokens`, `cache_read_tokens` and `cache_creation_tokens` for each request, `query_source` naming the subsystem that issued it (`"repl_main_thread"`, `"compact"`, or a subagent name), `event.sequence` for ordering within a session, and `session.id` as a standard attribute (`OTEL_METRICS_INCLUDE_SESSION_ID`, default **true**). The three input addends on the latest `repl_main_thread` event are the same sum the statusline page gives for `used_percentage` | `context_window_size`, or any percentage — see below. And any local delivery: events go only to an OTLP receiver or the `console` exporter (`prometheus` accepts metrics only, and `console` writes to Claude Code's own stdout), and Claude Code "doesn't pass `OTEL_*` environment variables to the subprocesses it spawns, including the Bash tool, hooks, MCP servers, and language servers" |
+| Session transcript file | <https://code.claude.com/docs/en/sessions> | The JSONL at `~/.claude/projects/<project>/<session-id>.jsonl`, reachable from every hook through the documented `transcript_path` field | A **supported** shape to parse. See below — this is the second near-miss and it is disqualified deliberately |
 | Cloud session environment | <https://code.claude.com/docs/en/claude-code-on-the-web> | Confirmation that cloud sessions run hooks and read committed settings files, and that `/context` and `/compact` work there | Any statement that a status line runs in a cloud session, and any cloud-specific telemetry surface. The page's context-management section lists `/compact`, `/context`, `/clear` and never mentions `statusLine` |
+
+## The OTel `api_request` event carries occupancy, and still cannot be a capture path
+
+This is the channel that most nearly falsifies the verdict, so its rejection is recorded in full
+rather than folded into a table cell. It is **not** rejected on the grounds that OpenTelemetry only
+exposes cumulative counters — that is true of the *metrics* and false of the *events*.
+
+`claude_code.api_request` is a documented log event
+(<https://code.claude.com/docs/en/monitoring-usage>, read 2026-08-21) carrying `input_tokens`,
+`output_tokens`, `cache_read_tokens` and `cache_creation_tokens` per request, plus `query_source`
+identifying the issuing subsystem and `event.sequence` for ordering. `session.id` is a standard
+attribute on every event and is on by default. Filtering to the newest `repl_main_thread` event for
+a session therefore yields the current main-thread occupancy — the same three input addends the
+statusline page names as the `used_percentage` formula
+(<https://code.claude.com/docs/en/statusline>, read 2026-08-21): "`input_tokens +
+cache_creation_input_tokens + cache_read_input_tokens`". This channel really does supply live,
+per-session occupancy for a running interactive session.
+
+Two disqualifiers hold anyway, and both were measured rather than assumed.
+
+**It carries no denominator.** The event has no `context_window_size` and no percentage. The
+resolver needs one or the other: the percentage shape reads `used_percentage`, and the token shape
+selects a band row by window class from `context_window_size`. Measured under a scratch `HOME`: a
+snapshot carrying `cli_version`, a mapped `current_usage`, both token totals, a null
+`used_percentage` and **no** `context_window_size` resolves `unknown`; adding a
+`context_window_size` to the otherwise identical file resolves `acceptable`. A writer built on this
+event would have to invent that number from a hard-coded per-model window map, which is exactly the
+fabricated denominator this contract forbids — and it would go wrong silently the first time a
+model shipped with a different window.
+
+**It has no local delivery.** Events reach an OTLP receiver or the `console` exporter; `prometheus`
+is listed for metrics only, and `console` writes to Claude Code's own stdout rather than to a file
+a hook could read. There is no in-process or on-disk sink. Worse for a hook-local writer, the same
+page states that Claude Code "doesn't pass `OTEL_*` environment variables to the subprocesses it
+spawns, including the Bash tool, hooks, MCP servers, and language servers", so a hook cannot even
+discover where the telemetry is going. Making this a capture path means standing up and operating
+an out-of-process collector, and a plugin that ships a zone instrument only for operators who run
+an OTLP pipeline has not solved the problem this file exists for.
+
+The plugin therefore does **not** ship an OTel-derived capture path. The channel is recorded here
+because it is genuinely the closest documented substitute, and a future reader deserves the real
+reason rather than a claim about counters that its own citation disproves.
 
 ## The transcript is reachable, and still not a viable source
 
-This is the closest thing to a second channel, so the rejection is recorded in full rather than
-summarized.
+The second near-miss, and the rejection is likewise recorded in full.
 
 Every hook receives `transcript_path`, and the sessions page explicitly lists reading it as one of
 the supported ways to "React to session events". The file is live: in the measured container it was
@@ -74,21 +142,30 @@ being appended to continuously, and each assistant entry carries a `usage` objec
 addends the status line page says `used_percentage` is computed from. A hook could read the last
 such entry and write a snapshot with no status line involved.
 
-It is rejected because the same page disqualifies the parse
-(<https://code.claude.com/docs/en/sessions>, read 2026-08-21):
+The sessions page disqualifies the parse (<https://code.claude.com/docs/en/sessions>, read
+2026-08-21):
 
 > Each line is a JSON object for a message, tool use, or metadata entry. The entry format is
 > internal to Claude Code and changes between versions, so scripts that parse these files directly
 > can break on any release.
 
-`transcript_path` is a documented **path**. The bytes behind it are documented as internal and
-version-unstable. A capture path built on them would be a zone instrument whose accuracy is
-warranted by nothing, and this contract's whole posture is that a consumer is never throttled on
-data it cannot trust and a zone is never fabricated. A wrong zone is strictly worse than `unknown`:
-`unknown` routes the consumer to its conservative path, while a stale or misread occupancy can read
-`smart` on a nearly full window and route heavy work into a degraded context. The failure would
-also be silent and version-triggered — it would arrive on a Claude Code release, not on a change to
-this plugin.
+**That warning alone is not sufficient grounds, and this file will not pretend it is.** A reader
+that validates shape before emitting — all three keys present, integral, non-negative, their sum
+inside a known window, the entry's timestamp recent, and nothing emitted on any assertion failure —
+degrades on a breaking format change to writing *no snapshot*, which resolves to `unknown`. That is
+the same fail-open posture this contract mandates everywhere else, and this file already calls
+`unknown` an acceptable outcome. "It would produce a confident wrong zone" is not what a
+shape-validating reader does.
+
+The decision stands on the failure a shape check cannot catch: **silent semantic drift.** The
+disclaimer covers meaning as well as structure. `input_tokens` can keep its name, its type and its
+plausible magnitude while ceasing to denote full-context occupancy — a per-turn delta after a
+restructuring, a post-summarization figure, a count excluding some newly separate block. Every
+shape assertion still passes, the reader still emits, and the zone is wrong with no signal
+anywhere. Against a format whose maintainers have explicitly declined to promise stability, the
+only defense is re-verifying the *semantics* of three fields against a live session on every Claude
+Code release — an unbounded maintenance obligation this plugin would be taking on unilaterally, for
+a channel whose owners have told it not to.
 
 The plugin therefore does **not** ship a transcript-derived capture path.
 
@@ -99,9 +176,9 @@ The plugin therefore does **not** ship a transcript-derived capture path.
   reason to ask the operator to fix something.
 - **The conservative path is still correct.** Nothing here changes the fail-open rule: `unknown`
   means take the conservative route.
-- **Do not synthesize a zone from any other source.** No documented substitute exists, and the two
-  reachable near-substitutes — the cumulative OTel counter and the transcript's internal entry
-  format — both fail in the direction that produces a confident wrong answer.
+- **Do not synthesize a zone from any other source.** The three reachable near-substitutes — the
+  cumulative OTel counter, the OTel `api_request` event with no window size, and the transcript's
+  internal entry format — each require inventing or trusting something the channel does not supply.
 - **Cost of the gap.** The instrument is absent exactly where sessions are most disposable, so an
   instrument-driven handoff or fork trigger cannot fire there. A consumer that wants a handoff
   trigger in a cloud or headless session must drive it from something other than a zone reading —
@@ -111,22 +188,34 @@ The plugin therefore does **not** ship a transcript-derived capture path.
 ## Distinguishing structural absence from breakage
 
 Both states print `unknown`, so the discriminator is the writer side, and it is doc-backed:
-the status line runs only where a `statusLine` command is configured
-(<https://code.claude.com/docs/en/statusline>, read 2026-08-21).
+the status line runs only where a `statusLine` command is configured and the environment is one
+that runs it (<https://code.claude.com/docs/en/statusline>,
+<https://code.claude.com/docs/en/settings>, both read 2026-08-21).
 
 1. Read `statusLine` from every settings scope that can carry it — user `~/.claude/settings.json`,
-   project `.claude/settings.json`, local `.claude/settings.local.json`.
+   project `.claude/settings.json`, local `.claude/settings.local.json`, and managed settings
+   (`/etc/claude-code/managed-settings.json` and the platform equivalents, where `statusLine` is
+   also a valid key).
 2. **No `statusLine` in any scope** → structural. No snapshot can be written for this session by
    any mechanism this plugin ships. `unknown` is correct and final until a status line is
-   configured *and* the environment refreshes one.
-3. **A `statusLine` is configured but no fresh snapshot exists** → a real defect: wiring, the
-   installed shim, or `jq`. Invoke `/context-guard:setup` via the Skill tool with `check` for the
-   full diagnosis.
+   configured *and* the environment runs one.
+3. **A `statusLine` is configured but the status line is disabled** → also structural, and the
+   remediation is policy or trust rather than wiring. Claude Code turns the feature off entirely
+   when managed settings set `disableAllHooks`, or when the folder is not trusted under the same
+   workspace-trust rule that gates hooks in settings files; and it narrows the source to managed
+   settings when `allowManagedHooksOnly` is set. Under narrowing, "Claude Code runs a managed value
+   if one is deployed; otherwise it skips your value without warning, the status line is disabled".
+   A configured `statusLine` that never runs looks exactly like a broken install unless this branch
+   is checked first.
+4. **A `statusLine` is configured, the status line is not disabled, and no fresh snapshot exists**
+   → a real defect: wiring, the installed shim, or `jq`. Invoke `/context-guard:setup` via the
+   Skill tool with `check` for the full diagnosis.
 
-A cloud or headless session lands on branch 2 by default: no `statusLine` is configured, and the
-status line is a terminal-interface surface — the page describes it rendering above the footer
-badges and reading `COLUMNS` / `LINES` for terminal dimensions. Configuring one there is not a
-remediation to offer.
+A cloud or headless session lands on branch 2 by default: no `statusLine` is configured. It also
+lands on the structural side when one *is* configured — measured above, a `statusLine` written into
+a live cloud session's user settings was never invoked. The status line is a terminal-interface
+surface: the page describes it rendering above the footer badges and reading `COLUMNS` / `LINES`
+for terminal dimensions. Configuring one there is not a remediation to offer.
 
 ## What would have to change upstream
 
@@ -138,11 +227,17 @@ a change to Claude Code, not to this plugin:
   receives `session_id`, so a `PostToolBatch` or `UserPromptSubmit` hook could write the existing
   snapshot shape with no new contract on the reader side.
 - **A documented, stable transcript entry schema** — at minimum a versioned, supported shape for
-  the per-message `usage` object — which would convert the near-miss above into a real channel.
+  the per-message `usage` object, with its *semantics* pinned and not only its field names — which
+  would convert that near-miss into a real channel.
 - **A documented status-line equivalent that runs without a terminal**, or a statement that cloud
-  sessions refresh a configured `statusLine`. Neither is documented today.
-- **A current-occupancy gauge in the OpenTelemetry metric set**, as opposed to the existing
-  cumulative token counter.
+  sessions run a configured `statusLine`. The statusline page documents neither: it describes the
+  status line as "a customizable bar at the bottom of Claude Code" rendering "in its own row above
+  the built-in footer badges", sized from the `COLUMNS` and `LINES` terminal dimensions, and names
+  no non-terminal equivalent and no cloud behavior (<https://code.claude.com/docs/en/statusline>,
+  read 2026-08-21).
+- **A `context_window_size` attribute on the `claude_code.api_request` event, plus a local sink.**
+  The event already carries the occupancy numerator; a denominator and a file- or stdio-based
+  delivery a hook could read would make it sufficient. Either half alone is not enough.
 
-Re-check this file against the pages above when Claude Code's hooks or status line reference
-changes. The finding is dated, not permanent.
+Re-check this file against the pages above when Claude Code's hooks, status line, settings or
+telemetry reference changes. The finding is dated, not permanent.

--- a/plugins/context-guard/reference/cloud-headless-capture.md
+++ b/plugins/context-guard/reference/cloud-headless-capture.md
@@ -34,6 +34,13 @@ The central claim is **confirmed with one correction**: `~/.claude/context-guard
 a cloud container, but only because a hook created it. The **snapshot** the reader needs is absent,
 and the resolver prints `unknown`.
 
+**The reader side is healthy; only the writer channel is missing.** In the same container, feeding
+the resolver one synthetic statusline payload under a scratch `HOME` — 120000 input + 3000 output
+tokens in a 200000 window, `used_percentage` 60 — produced a snapshot and resolved `acceptable`,
+while the real session id resolved `unknown` moments earlier. Nothing about `context-zone.sh`,
+`statusline-tee.sh`, `jq`, or the contract path is broken here. There is simply nothing calling the
+tee, because nothing calls a statusline.
+
 The correction matters. The `.compacted` marker in that directory was written by
 `hooks/post-compact-mark.sh` during an auto-compaction of that session, which proves **plugin hooks
 do run in this environment**. The status line is the only context-guard writer that is silent in

--- a/plugins/context-guard/reference/cloud-headless-capture.md
+++ b/plugins/context-guard/reference/cloud-headless-capture.md
@@ -1,36 +1,141 @@
 # Context guard — capture channels in cloud and headless sessions
 
-Why the statusline tee is not the only capture source, what each candidate channel does and does
-not carry, and how a consumer tells a *structurally absent* instrument from a *broken* one.
+Why the statusline tee is this plugin's only capture source, which other channels were checked and
+rejected, and how a consumer tells a *structurally absent* instrument from a *broken* one.
 
 `reference/reader-contract.md` remains the authoritative reader-side contract: snapshot path
 pattern, staleness rule, zone bands, combination rule. This file is the **writer-side channel
-inventory** — it explains where a snapshot can come from, and what to expect when none can.
+inventory** — where a snapshot can come from, and what to expect where none can.
+
+## Verdict
+
+**As of 2026-08-21, no documented Claude Code channel other than the status line carries
+per-session context-window telemetry.** Hook stdin — the named candidate — carries no context,
+token, usage, or window field on any event. In a session where no `statusLine` is configured, no
+snapshot can be written, so `context-zone.sh` answers `unknown` and every zone consumer takes its
+conservative path. **That `unknown` is structural, not a defect and not a broken install.**
+
+The evidence for each channel is below, with the live URL and the date it was read.
 
 ## Current-state facts (measured, not inferred)
 
 Measured **2026-08-21** inside a live Claude Code on the web container
 (`CLAUDE_CODE_ENTRYPOINT=remote`, `CLAUDE_CODE_REMOTE_ENVIRONMENT_TYPE=cloud_default`,
-`claude --version` → `2.1.235 (Claude Code)`).
+`claude --version` reporting `2.1.235 (Claude Code)`).
 
 | Observation | Command | Result |
 |-------------|---------|--------|
-| Is a statusline configured? | `grep -rn statusLine ~/.claude/settings.json ~/.claude/launcher-settings.json ~/.claude/remote-settings.json ~/.claude/policy-limits.json` | no match in any scope; `/etc/claude-code/managed-settings.json` does not exist |
+| Is a status line configured? | `grep -rn statusLine ~/.claude/settings.json ~/.claude/launcher-settings.json ~/.claude/remote-settings.json ~/.claude/policy-limits.json` | no match in any scope; `/etc/claude-code/managed-settings.json` does not exist |
 | Does the contract directory exist? | `ls -la ~/.claude/context-guard/` | exists, containing only `context/` |
 | Does a snapshot exist? | `ls -la ~/.claude/context-guard/context/` | only `<session_id>.compacted` (the `PostCompact` marker); **no `<session_id>.json`** |
 | What does the resolver return? | `bash scripts/context-zone.sh <session_id>` | `unknown` |
 
-The issue's central claim is **confirmed with one correction**: `~/.claude/context-guard/` *does*
-exist here, but only because the `PostCompact` hook created it. The **snapshot** the reader needs
-is absent, and the resolver prints `unknown`.
+The central claim is **confirmed with one correction**: `~/.claude/context-guard/` *does* exist in
+a cloud container, but only because a hook created it. The **snapshot** the reader needs is absent,
+and the resolver prints `unknown`.
 
-The correction matters, because it is also the finding that unblocks the fix: **plugin hooks do
-run in this environment.** The `.compacted` marker in that directory was written by
-`hooks/post-compact-mark.sh` during an auto-compaction of this very session. The statusline is the
-only context-guard writer that is silent in cloud — not the hook layer.
+The correction matters. The `.compacted` marker in that directory was written by
+`hooks/post-compact-mark.sh` during an auto-compaction of that session, which proves **plugin hooks
+do run in this environment**. The status line is the only context-guard writer that is silent in
+cloud — the hook layer is alive. That is why hook stdin was the first channel checked, and why its
+field set is the decisive negative result rather than an assumption.
 
 ## Channels checked
 
-Each row records what was checked, on what date, and what the channel does and does not carry.
+Every row was read from the live page on **2026-08-21**. Claims below are quoted or paraphrased
+from those pages, not recalled.
 
-<!-- channel inventory continues in the sections below -->
+| Channel | Source read | Carries | Does **not** carry |
+|---|---|---|---|
+| Hook stdin (all events) | <https://code.claude.com/docs/en/hooks> | Common input fields: `session_id`, `prompt_id`, `transcript_path`, `cwd`, `permission_mode`, `effort`, `hook_event_name`, plus `agent_id` / `agent_type` under an agent. Event-specific fields such as `tool_name`, `tool_input`, `tool_use_id` | **Any context-window, token-count, usage, or percentage-of-window field, on any event.** `effort` is a reasoning-effort level, not consumption |
+| Status line stdin | <https://code.claude.com/docs/en/statusline> | The whole `context_window` object — `total_input_tokens`, `total_output_tokens`, `context_window_size`, `used_percentage`, `remaining_percentage`, `current_usage` — plus top-level `version` | Nothing this plugin needs. This is the one sufficient channel, and it exists only where a `statusLine` is configured and refreshing |
+| `subagentStatusLine` stdin | <https://code.claude.com/docs/en/statusline> | A `tasks` array whose entries carry `tokenCount` and `contextWindowSize` per subagent row | Any figure for the **main session**. It describes subagent rows in the agent panel, and it is a status-line-family surface, so it is absent wherever the status line is |
+| Non-interactive / Agent SDK output | <https://code.claude.com/docs/en/headless> | `--output-format json` returns result, session ID, usage and `total_cost_usd` for **that invocation**; `stream-json` emits per-event metadata | Live occupancy of an already-running interactive session. It reports on a run the caller starts, after the fact — it cannot answer "how full is this session's window right now" |
+| OpenTelemetry metrics and events | <https://code.claude.com/docs/en/monitoring-usage> | `claude_code.token.usage`, a **counter** with `type` attributes `input` / `output` / `cacheRead` / `cacheCreation` | Any gauge of current occupancy or percentage of window. Every documented metric is a counter of cumulative activity; a cumulative total is not observable as current occupancy — precisely the failure the resolver's token-shape version gate exists to prevent |
+| Session transcript file | <https://code.claude.com/docs/en/sessions> | The JSONL at `~/.claude/projects/<project>/<session-id>.jsonl`, reachable from every hook through the documented `transcript_path` field | A **supported** shape to parse. See below — this is the near-miss and it is disqualified deliberately |
+| Cloud session environment | <https://code.claude.com/docs/en/claude-code-on-the-web> | Confirmation that cloud sessions run hooks and read committed settings files, and that `/context` and `/compact` work there | Any statement that a status line runs in a cloud session, and any cloud-specific telemetry surface. The page's context-management section lists `/compact`, `/context`, `/clear` and never mentions `statusLine` |
+
+## The transcript is reachable, and still not a viable source
+
+This is the closest thing to a second channel, so the rejection is recorded in full rather than
+summarized.
+
+Every hook receives `transcript_path`, and the sessions page explicitly lists reading it as one of
+the supported ways to "React to session events". The file is live: in the measured container it was
+being appended to continuously, and each assistant entry carries a `usage` object whose
+`input_tokens`, `cache_creation_input_tokens` and `cache_read_input_tokens` are exactly the three
+addends the status line page says `used_percentage` is computed from. A hook could read the last
+such entry and write a snapshot with no status line involved.
+
+It is rejected because the same page disqualifies the parse
+(<https://code.claude.com/docs/en/sessions>, read 2026-08-21):
+
+> Each line is a JSON object for a message, tool use, or metadata entry. The entry format is
+> internal to Claude Code and changes between versions, so scripts that parse these files directly
+> can break on any release.
+
+`transcript_path` is a documented **path**. The bytes behind it are documented as internal and
+version-unstable. A capture path built on them would be a zone instrument whose accuracy is
+warranted by nothing, and this contract's whole posture is that a consumer is never throttled on
+data it cannot trust and a zone is never fabricated. A wrong zone is strictly worse than `unknown`:
+`unknown` routes the consumer to its conservative path, while a stale or misread occupancy can read
+`smart` on a nearly full window and route heavy work into a degraded context. The failure would
+also be silent and version-triggered — it would arrive on a Claude Code release, not on a change to
+this plugin.
+
+The plugin therefore does **not** ship a transcript-derived capture path.
+
+## What this means for consumers
+
+- **`unknown` in a session with no configured `statusLine` is the expected steady state.** Report
+  it as "no instrument in this environment", never as a broken install, a missing dependency, or a
+  reason to ask the operator to fix something.
+- **The conservative path is still correct.** Nothing here changes the fail-open rule: `unknown`
+  means take the conservative route.
+- **Do not synthesize a zone from any other source.** No documented substitute exists, and the two
+  reachable near-substitutes — the cumulative OTel counter and the transcript's internal entry
+  format — both fail in the direction that produces a confident wrong answer.
+- **Cost of the gap.** The instrument is absent exactly where sessions are most disposable, so an
+  instrument-driven handoff or fork trigger cannot fire there. A consumer that wants a handoff
+  trigger in a cloud or headless session must drive it from something other than a zone reading —
+  an explicit operator request, or an observation the consumer makes itself. It must not treat
+  `unknown` as evidence of a full window; `unknown` carries no direction.
+
+## Distinguishing structural absence from breakage
+
+Both states print `unknown`, so the discriminator is the writer side, and it is doc-backed:
+the status line runs only where a `statusLine` command is configured
+(<https://code.claude.com/docs/en/statusline>, read 2026-08-21).
+
+1. Read `statusLine` from every settings scope that can carry it — user `~/.claude/settings.json`,
+   project `.claude/settings.json`, local `.claude/settings.local.json`.
+2. **No `statusLine` in any scope** → structural. No snapshot can be written for this session by
+   any mechanism this plugin ships. `unknown` is correct and final until a status line is
+   configured *and* the environment refreshes one.
+3. **A `statusLine` is configured but no fresh snapshot exists** → a real defect: wiring, the
+   installed shim, or `jq`. Invoke `/context-guard:setup` via the Skill tool with `check` for the
+   full diagnosis.
+
+A cloud or headless session lands on branch 2 by default: no `statusLine` is configured, and the
+status line is a terminal-interface surface — the page describes it rendering above the footer
+badges and reading `COLUMNS` / `LINES` for terminal dimensions. Configuring one there is not a
+remediation to offer.
+
+## What would have to change upstream
+
+Any **one** of these would make a cloud- and headless-compatible capture path possible, and each is
+a change to Claude Code, not to this plugin:
+
+- **A context field on hook stdin.** The smallest sufficient change: add the `context_window`
+  object (or its `used_percentage` alone) to the documented common input fields. Every hook already
+  receives `session_id`, so a `PostToolBatch` or `UserPromptSubmit` hook could write the existing
+  snapshot shape with no new contract on the reader side.
+- **A documented, stable transcript entry schema** — at minimum a versioned, supported shape for
+  the per-message `usage` object — which would convert the near-miss above into a real channel.
+- **A documented status-line equivalent that runs without a terminal**, or a statement that cloud
+  sessions refresh a configured `statusLine`. Neither is documented today.
+- **A current-occupancy gauge in the OpenTelemetry metric set**, as opposed to the existing
+  cumulative token counter.
+
+Re-check this file against the pages above when Claude Code's hooks or status line reference
+changes. The finding is dated, not permanent.

--- a/plugins/context-guard/reference/reader-contract.md
+++ b/plugins/context-guard/reference/reader-contract.md
@@ -438,42 +438,61 @@ above the staleness window, so idle sessions' files are never deleted out from u
 
 ## Cloud and headless sessions (`unknown` is structural)
 
-The single capture channel is the statusline tee, so **a session with no `statusLine` configured
-has no instrument at all** — no snapshot is ever written for it, and this contract resolves
-`unknown` for that session permanently. Cloud and headless sessions are that case by default.
+The single capture channel is the statusline tee, so **a session that never runs a statusline has
+no instrument at all** — no snapshot is ever written for it, and this contract resolves `unknown`
+for that session permanently. Cloud and headless sessions are that case by default: no `statusLine`
+is configured there, and configuring one does not help. Measured 2026-08-21 in both, a `statusLine`
+written into the session's own user settings was never invoked.
 
 This is not a degraded install and not a missing dependency. It is the absence of the only
-documented surface that carries per-session context-window telemetry: as of **2026-08-21**, hook
-stdin carries no context, token, usage, or window field on any event, and no other documented
-channel carries current occupancy either. `reference/cloud-headless-capture.md` is the writer-side
+documented surface that **delivers per-session context-window occupancy to a local writer**: as of
+**2026-08-21**, hook stdin carries no context, token, usage, or window field on any event, except
+`PostToolUse` on the `Agent` tool, whose `tool_response` carries `totalTokens` and a `usage`
+breakdown for the *subagent's* final API request and nothing about the main session's window. Two
+other channels do carry live occupancy for the running session — the OpenTelemetry
+`claude_code.api_request` log event and the session transcript — and neither can be turned into a
+snapshot; `reference/cloud-headless-capture.md` records why in full. That file is the writer-side
 channel inventory — every channel checked, its live URL, the date read, what it does and does not
-carry, and what would have to change upstream. Re-check it when Claude Code's hooks or statusline
-reference changes; the finding is dated, not permanent.
+carry, and what would have to change upstream. Re-check it when Claude Code's hooks, statusline,
+settings or telemetry reference changes; the finding is dated, not permanent.
 
 **What a consumer must do.** Nothing changes about the resolution rules — `unknown` still means
 take the conservative route. What changes is how a consumer *reports* it:
 
 - Report `unknown` in such a session as **"no instrument in this environment"**, never as a defect,
   a broken install, or a reason to ask the operator to fix something.
-- **Never synthesize a zone from another source.** The two reachable near-substitutes — Claude
-  Code's cumulative OpenTelemetry token counter, and the session transcript reachable through the
-  documented `transcript_path` hook field — both fail in the direction that yields a confident
-  wrong answer, and the transcript's entry format is documented as internal and version-unstable.
-  A wrong zone is strictly worse than `unknown`: `unknown` routes to the conservative path, while a
-  misread occupancy can read `smart` on a nearly full window.
+- **Never synthesize a zone from another source.** Each reachable near-substitute requires
+  inventing or trusting something the channel does not supply: the OpenTelemetry
+  `claude_code.api_request` event carries live per-session token counts but no window size and no
+  local sink, so a zone from it needs a fabricated denominator; the session transcript reachable
+  through the documented `transcript_path` hook field carries the right numbers behind an entry
+  format its own docs call internal and version-unstable, where a field can keep its name and stop
+  meaning full-context occupancy with nothing to detect it; and the OpenTelemetry token metric is
+  a cumulative counter, not occupancy. A wrong zone is strictly worse than `unknown`: `unknown`
+  routes to the conservative path, while a misread occupancy can read `smart` on a nearly full
+  window.
 - **`unknown` carries no direction.** It is not evidence of a full window and not evidence of an
   empty one. A consumer that wants a fork or handoff trigger in an environment with no instrument
   must drive it from something else — an explicit operator request, or an observation it makes
   itself — and must not present that trigger as instrument-backed.
 
 **Telling structural absence from breakage.** Both print `unknown`, and the discriminator is on the
-writer side: the statusline runs only where a `statusLine` command is configured. Read `statusLine`
-from every scope that can carry it — user `~/.claude/settings.json`, project
-`.claude/settings.json`, local `.claude/settings.local.json`. **No `statusLine` in any scope** is
-structural, and offering statusline wiring as the remediation is wrong in an environment that
-refreshes no statusline. **A `statusLine` configured but no fresh snapshot** is a real defect
-(wiring, installed shim, or `jq`) — invoke `/context-guard:setup` via the Skill tool with `check`
-for the diagnosis.
+writer side: the statusline runs only where a `statusLine` command is configured *and* the
+environment is one that runs it. Read `statusLine` from every scope that can carry it — user
+`~/.claude/settings.json`, project `.claude/settings.json`, local `.claude/settings.local.json`,
+and managed settings, where `statusLine` is also a valid key.
+
+- **No `statusLine` in any scope** is structural, and offering statusline wiring as the remediation
+  is wrong in an environment that runs no statusline.
+- **A `statusLine` configured but the status line disabled** is also structural, and the
+  remediation is policy or trust rather than wiring. Claude Code turns the status line off entirely
+  when managed settings set `disableAllHooks` or the folder is not trusted, and narrows the source
+  to managed settings when `allowManagedHooksOnly` is set — under narrowing it runs a managed value
+  if one is deployed and otherwise skips yours *without warning*. This state looks exactly like a
+  broken install unless it is checked first.
+- **A `statusLine` configured, not disabled, and no fresh snapshot** is a real defect (wiring,
+  installed shim, or `jq`) — invoke `/context-guard:setup` via the Skill tool with `check` for the
+  diagnosis.
 
 ## Invariants and boundaries
 

--- a/plugins/context-guard/reference/reader-contract.md
+++ b/plugins/context-guard/reference/reader-contract.md
@@ -436,6 +436,45 @@ fail-open behavior, not a bug — an idle session asking for a zone gets a fresh
 statusline refresh of waking. The writer's stale-file pruning cutoff (14 days) is deliberately far
 above the staleness window, so idle sessions' files are never deleted out from under them.
 
+## Cloud and headless sessions (`unknown` is structural)
+
+The single capture channel is the statusline tee, so **a session with no `statusLine` configured
+has no instrument at all** — no snapshot is ever written for it, and this contract resolves
+`unknown` for that session permanently. Cloud and headless sessions are that case by default.
+
+This is not a degraded install and not a missing dependency. It is the absence of the only
+documented surface that carries per-session context-window telemetry: as of **2026-08-21**, hook
+stdin carries no context, token, usage, or window field on any event, and no other documented
+channel carries current occupancy either. `reference/cloud-headless-capture.md` is the writer-side
+channel inventory — every channel checked, its live URL, the date read, what it does and does not
+carry, and what would have to change upstream. Re-check it when Claude Code's hooks or statusline
+reference changes; the finding is dated, not permanent.
+
+**What a consumer must do.** Nothing changes about the resolution rules — `unknown` still means
+take the conservative route. What changes is how a consumer *reports* it:
+
+- Report `unknown` in such a session as **"no instrument in this environment"**, never as a defect,
+  a broken install, or a reason to ask the operator to fix something.
+- **Never synthesize a zone from another source.** The two reachable near-substitutes — Claude
+  Code's cumulative OpenTelemetry token counter, and the session transcript reachable through the
+  documented `transcript_path` hook field — both fail in the direction that yields a confident
+  wrong answer, and the transcript's entry format is documented as internal and version-unstable.
+  A wrong zone is strictly worse than `unknown`: `unknown` routes to the conservative path, while a
+  misread occupancy can read `smart` on a nearly full window.
+- **`unknown` carries no direction.** It is not evidence of a full window and not evidence of an
+  empty one. A consumer that wants a fork or handoff trigger in an environment with no instrument
+  must drive it from something else — an explicit operator request, or an observation it makes
+  itself — and must not present that trigger as instrument-backed.
+
+**Telling structural absence from breakage.** Both print `unknown`, and the discriminator is on the
+writer side: the statusline runs only where a `statusLine` command is configured. Read `statusLine`
+from every scope that can carry it — user `~/.claude/settings.json`, project
+`.claude/settings.json`, local `.claude/settings.local.json`. **No `statusLine` in any scope** is
+structural, and offering statusline wiring as the remediation is wrong in an environment that
+refreshes no statusline. **A `statusLine` configured but no fresh snapshot** is a real defect
+(wiring, installed shim, or `jq`) — invoke `/context-guard:setup` via the Skill tool with `check`
+for the diagnosis.
+
 ## Invariants and boundaries
 
 - **Per-session semantics.** One file per session id; no cross-session last-writer-wins collapse.

--- a/plugins/context-guard/reference/reader-contract.md
+++ b/plugins/context-guard/reference/reader-contract.md
@@ -490,9 +490,14 @@ and managed settings, where `statusLine` is also a valid key.
   to managed settings when `allowManagedHooksOnly` is set — under narrowing it runs a managed value
   if one is deployed and otherwise skips yours *without warning*. This state looks exactly like a
   broken install unless it is checked first.
-- **A `statusLine` configured, not disabled, and no fresh snapshot** is a real defect (wiring,
-  installed shim, or `jq`) — invoke `/context-guard:setup` via the Skill tool with `check` for the
-  diagnosis.
+- **A `statusLine` configured, not disabled, in an environment that does not run a statusline**
+  (cloud, headless `claude -p`, other terminal-less) is also structural. The command exists and
+  is not policy-disabled, and is still never invoked — measured 2026-08-21, a `statusLine`
+  written into a live cloud session's own user settings was never invoked. Report as "no
+  instrument in this environment", never as a defect.
+- **A `statusLine` configured, not disabled, in an environment that runs a statusline, and no
+  fresh snapshot** is a real defect (wiring, installed shim, or `jq`) — invoke
+  `/context-guard:setup` via the Skill tool with `check` for the diagnosis.
 
 ## Invariants and boundaries
 

--- a/plugins/context-guard/skills/setup/SKILL.md
+++ b/plugins/context-guard/skills/setup/SKILL.md
@@ -78,7 +78,15 @@ zone bands, zones.json shape) are owned by
    exists, say so explicitly and print the edit for the shadowing file (or note that removing
    the override is the alternative). Distinguish FOUR states:
    - **No `statusLine` configured** — the wrapper is not running because nothing is. Print the
-     standalone wiring from the template below (the shim is then the whole statusline).
+     standalone wiring from the template below (the shim is then the whole statusline). **One
+     exception, and it changes the finding rather than the remediation:** the statusline is a
+     terminal-interface surface, so a session with no terminal interface — Claude Code on the web,
+     a self-hosted cloud environment, a `claude -p` run — refreshes no statusline no matter what is
+     wired. Where you can tell you are in such a session, report this as **INFO: no capture channel
+     in this environment**, say that `unknown` is the correct and permanent zone here, and do NOT
+     print wiring the operator cannot make run. `reference/cloud-headless-capture.md` records why
+     no substitute channel exists (every channel checked, with sources and dates) and
+     `reference/reader-contract.md`'s cloud-and-headless section carries the consumer rule.
    - **`statusLine` present, command references neither the shim nor this plugin's
      `statusline-tee.sh`** — wrapper missing. Print the wrapped wiring below with the user's
      current command preserved as the wrapped command.
@@ -100,6 +108,11 @@ zone bands, zones.json shape) are owned by
      `bash "${CLAUDE_PLUGIN_ROOT}/scripts/context-zone.sh" ${CLAUDE_SESSION_ID}`.
    - Fresh but `used_percentage` or `current_usage` null → INFO: documented early-session or
      post-`/compact` statusline state; the resolver correctly answers `unknown`. Not a defect.
+   - Absent while step 3 found **no `statusLine` in any scope** → INFO, never FAIL: nothing is
+     writing snapshots because nothing is configured to. This is the structural-absence branch, and
+     it is the default state of a cloud or headless session. Say that `unknown` is the correct
+     answer here and that no other channel can supply one — do not report a defect and do not send
+     the operator to fix an install that is not broken.
    - Absent or stale while step 3 reported correct wiring → FAIL: the wrapper is wired but not
      running (the statusline refreshes only in interactive sessions; also re-check steps 2 and 3 —
      a shim that is wired but not installed produces exactly this). Note the file only updates

--- a/plugins/context-guard/skills/setup/SKILL.md
+++ b/plugins/context-guard/skills/setup/SKILL.md
@@ -71,8 +71,10 @@ zone bands, zones.json shape) are owned by
      wiring in step 3 is the only wiring this version can offer.
 3. **Statusline wiring state** — read (never write) every settings scope that can carry a
    `statusLine` (user `~/.claude/settings.json`, project `.claude/settings.json`, local
-   `.claude/settings.local.json`) and determine which one owns the EFFECTIVE command (the most
-   specific scope wins). All wiring states below are evaluated against that effective command,
+   `.claude/settings.local.json`, and managed settings, where `statusLine` is also a valid key)
+   and determine which one owns the EFFECTIVE command (the most specific scope wins among the
+   three non-managed scopes; a managed value outranks all of them). All wiring states below are
+   evaluated against that effective command,
    and the printed edit in step 7 targets THAT scope's file — wiring the user file while a
    project-level `statusLine` shadows it would apply cleanly and never run; when a shadow
    exists, say so explicitly and print the edit for the shadowing file (or note that removing
@@ -80,11 +82,13 @@ zone bands, zones.json shape) are owned by
    - **No `statusLine` configured** — the wrapper is not running because nothing is. Print the
      standalone wiring from the template below (the shim is then the whole statusline). **One
      exception, and it changes the finding rather than the remediation:** the statusline is a
-     terminal-interface surface, so a session with no terminal interface — Claude Code on the web,
-     a self-hosted cloud environment, a `claude -p` run — refreshes no statusline no matter what is
-     wired. Where you can tell you are in such a session, report this as **INFO: no capture channel
-     in this environment**, say that `unknown` is the correct and permanent zone here, and do NOT
-     print wiring the operator cannot make run.
+     terminal-interface surface, so a session with no terminal interface does not run a statusline
+     even when one is wired. Measured 2026-08-21 for Claude Code on the web and for a `claude -p`
+     run — a configured `statusLine` was never invoked in either — and expected on the same
+     reasoning, though not measured, for other non-terminal environments such as a self-hosted
+     cloud runner. Where you can tell you are in such a session, report this as **INFO: no capture
+     channel in this environment**, say that `unknown` is the correct and permanent zone here, and
+     do NOT print wiring the operator cannot make run.
      `${CLAUDE_PLUGIN_ROOT}/reference/cloud-headless-capture.md` records why no substitute channel
      exists (every channel checked, with sources and dates) and the cloud-and-headless section of
      `${CLAUDE_PLUGIN_ROOT}/reference/reader-contract.md` carries the consumer rule.
@@ -102,6 +106,15 @@ zone bands, zones.json shape) are owned by
    - **`statusLine` invokes `~/.claude/context-guard/bin/statusline-shim.sh`** — PASS. No path
      comparison against `${CLAUDE_PLUGIN_ROOT}` applies or is meaningful here; the shim resolves
      the tee at run time.
+
+   Orthogonal to all four, and checked BEFORE reporting any of them as working: the status line
+   can be **turned off with a `statusLine` still configured**. Claude Code disables it entirely
+   when managed settings set `disableAllHooks` or the folder is not trusted, and narrows the
+   source to managed settings when `allowManagedHooksOnly` is set — under narrowing it runs a
+   managed value if one is deployed and otherwise "skips your value without warning, the status
+   line is disabled". Report that state as **INFO: the status line is disabled by policy or
+   workspace trust**, name which of the three conditions applies, and route the operator to policy
+   or trust — it is not a wiring defect, and printing wiring will not fix it.
 4. **Live-session snapshot freshness** — this session's id is `${CLAUDE_SESSION_ID}`. Probe
    `~/.claude/context-guard/context/${CLAUDE_SESSION_ID}.json`:
    - Exists and `captured_at` is within the reader contract's 10-minute staleness window → PASS
@@ -109,15 +122,23 @@ zone bands, zones.json shape) are owned by
      `bash "${CLAUDE_PLUGIN_ROOT}/scripts/context-zone.sh" ${CLAUDE_SESSION_ID}`.
    - Fresh but `used_percentage` or `current_usage` null → INFO: documented early-session or
      post-`/compact` statusline state; the resolver correctly answers `unknown`. Not a defect.
-   - Absent while step 3 found **no `statusLine` in any scope** → INFO, never FAIL: nothing is
-     writing snapshots because nothing is configured to. This is the structural-absence branch, and
-     it is the default state of a cloud or headless session. Say that `unknown` is the correct
-     answer here and that no other channel can supply one — do not report a defect and do not send
-     the operator to fix an install that is not broken.
-   - Absent or stale while step 3 reported correct wiring → FAIL: the wrapper is wired but not
-     running (the statusline refreshes only in interactive sessions; also re-check steps 2 and 3 —
-     a shim that is wired but not installed produces exactly this). Note the file only updates
-     while this session is interactive.
+   - Absent while step 3 found **no `statusLine` in any scope** → INFO, not FAIL: nothing is
+     writing snapshots because nothing is configured to. Which INFO depends on the SAME condition
+     step 3 branched on, and the two reports must agree — never print step 3's wiring and then say
+     nothing is broken.
+     - **If step 3 took the terminal-less exception** (you could tell this session refreshes no
+       statusline) this is structural: `unknown` is correct and permanent here, no other channel
+       can supply one, and there is nothing to fix. Do not report a defect and do not send the
+       operator to fix an install that is not broken.
+     - **Otherwise** this is the not-yet-wired state — the ordinary state of a fresh local install,
+       and the single most common reason `check` is run. The remediation is the wiring step 3 just
+       printed; point at it, say snapshots start on the next statusline refresh once it is applied,
+       and do NOT call this structural.
+   - Absent or stale while step 3 reported correct wiring **and did not find the status line
+     disabled** → FAIL: the wrapper is wired but not running (the statusline refreshes only in
+     interactive sessions; also re-check steps 2 and 3 — a shim that is wired but not installed
+     produces exactly this). Note the file only updates while this session is interactive. If step
+     3 found the status line disabled by policy or trust, this is that INFO instead, not a FAIL.
    - If the literal string `${CLAUDE_SESSION_ID}` appears unexpanded above, report that this
      Claude Code version lacks the substitution and consumers will take the conservative path —
      probe the newest file in `~/.claude/context-guard/context/` instead, labeled as such.

--- a/plugins/context-guard/skills/setup/SKILL.md
+++ b/plugins/context-guard/skills/setup/SKILL.md
@@ -74,24 +74,17 @@ zone bands, zones.json shape) are owned by
    `.claude/settings.local.json`, and managed settings, where `statusLine` is also a valid key)
    and determine which one owns the EFFECTIVE command (the most specific scope wins among the
    three non-managed scopes; a managed value outranks all of them). All wiring states below are
-   evaluated against that effective command,
-   and the printed edit in step 7 targets THAT scope's file — wiring the user file while a
-   project-level `statusLine` shadows it would apply cleanly and never run; when a shadow
-   exists, say so explicitly and print the edit for the shadowing file (or note that removing
-   the override is the alternative). Distinguish FOUR states:
+   evaluated against that effective command. The printed edit in step 7 targets THAT scope's
+   file **except** when the owning scope is managed: that file is administrator-controlled, the
+   operator running this skill generally cannot change it, and no lower-scope edit can override
+   it. In that case name the managed source, say the operator cannot change it from here, and
+   route to the policy administrator — do not print an operator edit for the managed file.
+   Wiring the user file while a project-level `statusLine` shadows it would apply cleanly and
+   never run; when a non-managed shadow exists, say so explicitly and print the edit for the
+   shadowing file (or note that removing the override is the alternative). Distinguish FOUR
+   states:
    - **No `statusLine` configured** — the wrapper is not running because nothing is. Print the
-     standalone wiring from the template below (the shim is then the whole statusline). **One
-     exception, and it changes the finding rather than the remediation:** the statusline is a
-     terminal-interface surface, so a session with no terminal interface does not run a statusline
-     even when one is wired. Measured 2026-08-21 for Claude Code on the web and for a `claude -p`
-     run — a configured `statusLine` was never invoked in either — and expected on the same
-     reasoning, though not measured, for other non-terminal environments such as a self-hosted
-     cloud runner. Where you can tell you are in such a session, report this as **INFO: no capture
-     channel in this environment**, say that `unknown` is the correct and permanent zone here, and
-     do NOT print wiring the operator cannot make run.
-     `${CLAUDE_PLUGIN_ROOT}/reference/cloud-headless-capture.md` records why no substitute channel
-     exists (every channel checked, with sources and dates) and the cloud-and-headless section of
-     `${CLAUDE_PLUGIN_ROOT}/reference/reader-contract.md` carries the consumer rule.
+     standalone wiring from the template below (the shim is then the whole statusline).
    - **`statusLine` present, command references neither the shim nor this plugin's
      `statusline-tee.sh`** — wrapper missing. Print the wrapped wiring below with the user's
      current command preserved as the wrapped command.
@@ -107,14 +100,31 @@ zone bands, zones.json shape) are owned by
      comparison against `${CLAUDE_PLUGIN_ROOT}` applies or is meaningful here; the shim resolves
      the tee at run time.
 
-   Orthogonal to all four, and checked BEFORE reporting any of them as working: the status line
-   can be **turned off with a `statusLine` still configured**. Claude Code disables it entirely
-   when managed settings set `disableAllHooks` or the folder is not trusted, and narrows the
-   source to managed settings when `allowManagedHooksOnly` is set — under narrowing it runs a
-   managed value if one is deployed and otherwise "skips your value without warning, the status
-   line is disabled". Report that state as **INFO: the status line is disabled by policy or
-   workspace trust**, name which of the three conditions applies, and route the operator to policy
-   or trust — it is not a wiring defect, and printing wiring will not fix it.
+   Orthogonal to all four, and checked BEFORE reporting any of them as working, TWO
+   environment-side states that make a configured command inert:
+
+   - **The session is terminal-less.** The statusline is a terminal-interface surface, so a
+     session with no terminal interface does not run a statusline even when one is wired.
+     Measured 2026-08-21 for Claude Code on the web and for a `claude -p` run — a configured
+     `statusLine` was never invoked in either — and expected on the same reasoning, though not
+     measured, for other non-terminal environments such as a self-hosted cloud runner. Where
+     you can tell you are in such a session, report this as **INFO: no capture channel in this
+     environment** regardless of which of the four wiring states applies, say that `unknown` is
+     the correct and permanent zone here, and do NOT print wiring the operator cannot make run.
+     A correctly-wired shim in a cloud or headless session is still never invoked; classifying
+     that wiring as PASS and the missing snapshot as a wiring FAIL is the defect this exception
+     exists to prevent.
+     `${CLAUDE_PLUGIN_ROOT}/reference/cloud-headless-capture.md` records why no substitute
+     channel exists (every channel checked, with sources and dates) and the cloud-and-headless
+     section of `${CLAUDE_PLUGIN_ROOT}/reference/reader-contract.md` carries the consumer rule.
+   - **The status line is turned off with a `statusLine` still configured.** Claude Code
+     disables it entirely when managed settings set `disableAllHooks` or the folder is not
+     trusted, and narrows the source to managed settings when `allowManagedHooksOnly` is set —
+     under narrowing it runs a managed value if one is deployed and otherwise "skips your value
+     without warning, the status line is disabled". Report that state as **INFO: the status
+     line is disabled by policy or workspace trust**, name which of the three conditions
+     applies, and route the operator to policy or trust — it is not a wiring defect, and
+     printing wiring will not fix it.
 4. **Live-session snapshot freshness** — this session's id is `${CLAUDE_SESSION_ID}`. Probe
    `~/.claude/context-guard/context/${CLAUDE_SESSION_ID}.json`:
    - Exists and `captured_at` is within the reader contract's 10-minute staleness window → PASS
@@ -122,23 +132,27 @@ zone bands, zones.json shape) are owned by
      `bash "${CLAUDE_PLUGIN_ROOT}/scripts/context-zone.sh" ${CLAUDE_SESSION_ID}`.
    - Fresh but `used_percentage` or `current_usage` null → INFO: documented early-session or
      post-`/compact` statusline state; the resolver correctly answers `unknown`. Not a defect.
-   - Absent while step 3 found **no `statusLine` in any scope** → INFO, not FAIL: nothing is
-     writing snapshots because nothing is configured to. Which INFO depends on the SAME condition
-     step 3 branched on, and the two reports must agree — never print step 3's wiring and then say
-     nothing is broken.
+   - Absent or stale while step 3 found **no `statusLine` in any scope** → INFO, not FAIL:
+     nothing is writing snapshots because nothing is configured to, whether the file is missing
+     or a leftover from an earlier session has gone stale. Which INFO depends on the SAME
+     condition step 3 branched on, and the two reports must agree — never print step 3's wiring
+     and then say nothing is broken.
      - **If step 3 took the terminal-less exception** (you could tell this session refreshes no
        statusline) this is structural: `unknown` is correct and permanent here, no other channel
        can supply one, and there is nothing to fix. Do not report a defect and do not send the
        operator to fix an install that is not broken.
-     - **Otherwise** this is the not-yet-wired state — the ordinary state of a fresh local install,
-       and the single most common reason `check` is run. The remediation is the wiring step 3 just
-       printed; point at it, say snapshots start on the next statusline refresh once it is applied,
-       and do NOT call this structural.
+     - **Otherwise** this is the not-yet-wired state — the ordinary state of a fresh local
+       install, and the single most common reason `check` is run. The remediation is the wiring
+       step 3 just printed; point at it, say snapshots start on the next statusline refresh once
+       it is applied, and do NOT call this structural.
    - Absent or stale while step 3 reported correct wiring **and did not find the status line
-     disabled** → FAIL: the wrapper is wired but not running (the statusline refreshes only in
-     interactive sessions; also re-check steps 2 and 3 — a shim that is wired but not installed
-     produces exactly this). Note the file only updates while this session is interactive. If step
-     3 found the status line disabled by policy or trust, this is that INFO instead, not a FAIL.
+     disabled and did not take the terminal-less exception** → FAIL: the wrapper is wired but
+     not running (the statusline refreshes only in interactive sessions; also re-check steps 2
+     and 3 — a shim that is wired but not installed produces exactly this). Note the file only
+     updates while this session is interactive. If step 3 found the status line disabled by
+     policy or trust, or took the terminal-less exception, this is that INFO instead, not a
+     FAIL — including the measured cloud case of a correctly-wired `statusLine` that is never
+     invoked.
    - If the literal string `${CLAUDE_SESSION_ID}` appears unexpanded above, report that this
      Claude Code version lacks the substitution and consumers will take the conservative path —
      probe the newest file in `~/.claude/context-guard/context/` instead, labeled as such.
@@ -173,10 +187,14 @@ zone bands, zones.json shape) are owned by
      default) leaves it inert while the injection hook still runs. Report it separately: an armed
      hook set with an advisory posture is a different runtime state from an inert hook set, and
      only one of the two is a defect.
-7. **Print the operator edit** — always print the applicable statusline edit for the settings
-   file that owns the effective command (step 3), marked clearly as the operator's to apply. The
-   wiring target is the SHIM's fixed path — never `${CLAUDE_PLUGIN_ROOT}`, which is version-pinned
-   and belongs in no operator file:
+7. **Print the operator edit** — print the applicable statusline edit for the settings file
+   that owns the effective command (step 3), marked clearly as the operator's to apply, **except**
+   when step 3 took the terminal-less exception, found the status line disabled by policy or
+   trust, or found the effective command owned by managed settings. Those branches already
+   forbade printing wiring the operator cannot make run (or cannot change); printing it here
+   would recommend the exact ineffective remediation they suppress. When this step does print,
+   the wiring target is the SHIM's fixed path — never `${CLAUDE_PLUGIN_ROOT}`, which is
+   version-pinned and belongs in no operator file:
 
    **Unwrap before you compose.** `<current statusline command>` below means the operator's OWN
    renderer, never the raw effective `command` string. Recover it by peeling off the wrapping this
@@ -375,9 +393,9 @@ result (a no-op on Windows ACL volumes; the wiring invokes it through `bash` any
 - The shim is **inert until wired**: installing it starts nothing. Only the operator's
   `settings.json` edit — step 7 of `check`, which this skill never applies — puts it on the
   statusline path. Say that explicitly when reporting the write.
-- After installing, print the wiring edit (`check` step 7) so the operator's next action is in
-  front of them, and note that a statusline already wired to the shim needs NO change now or on
-  any future plugin update.
+- After installing, print the wiring edit (`check` step 7) — honoring that step's exceptions —
+  so the operator's next action is in front of them when there is one, and note that a
+  statusline already wired to the shim needs NO change now or on any future plugin update.
 
 ### B. Seed or refresh the zones SSOT
 

--- a/plugins/context-guard/skills/setup/SKILL.md
+++ b/plugins/context-guard/skills/setup/SKILL.md
@@ -84,9 +84,10 @@ zone bands, zones.json shape) are owned by
      a self-hosted cloud environment, a `claude -p` run — refreshes no statusline no matter what is
      wired. Where you can tell you are in such a session, report this as **INFO: no capture channel
      in this environment**, say that `unknown` is the correct and permanent zone here, and do NOT
-     print wiring the operator cannot make run. `reference/cloud-headless-capture.md` records why
-     no substitute channel exists (every channel checked, with sources and dates) and
-     `reference/reader-contract.md`'s cloud-and-headless section carries the consumer rule.
+     print wiring the operator cannot make run.
+     `${CLAUDE_PLUGIN_ROOT}/reference/cloud-headless-capture.md` records why no substitute channel
+     exists (every channel checked, with sources and dates) and the cloud-and-headless section of
+     `${CLAUDE_PLUGIN_ROOT}/reference/reader-contract.md` carries the consumer rule.
    - **`statusLine` present, command references neither the shim nor this plugin's
      `statusline-tee.sh`** — wrapper missing. Print the wrapped wiring below with the user's
      current command preserved as the wrapped command.


### PR DESCRIPTION
Closes #2957

## Summary

`context-guard`'s context-zone snapshot is written by a statusline tee. In a session with no
configured `statusLine` — cloud and headless sessions by default — nothing writes the snapshot,
`context-zone.sh` resolves `unknown`, and every zone consumer silently takes its conservative path.
The instrument-driven handoff trigger is structurally silent exactly where sessions are most
disposable.

**Verdict: no documented channel delivers per-session context-window occupancy to a local writer
the way the status line does.** No capture path is shipped. What ships instead is the channel
inventory behind that verdict, plus the changes that make the resulting `unknown` legible as
structural rather than broken.

One correction to the issue's own premise, and the rest rests on it: `~/.claude/context-guard/`
**does** exist in cloud — the `PostCompact` hook creates it. Plugin hooks run fine there; only the
statusline writer is silent. That is why hook stdin was the first channel checked, and it makes the
hooks-reference negative a measured result rather than an assumption.

## Fix

**`reference/cloud-headless-capture.md` (new)** — every channel checked, each with the URL read and
the date, what it does and does not carry, and what would have to change upstream. The two that
came closest are documented as near-misses with the reason each fails:

- **OpenTelemetry.** The `claude_code.api_request` **log event** does carry live per-session token
  occupancy — `input_tokens` + `cache_read_tokens` + `cache_creation_tokens`, `session.id`,
  `query_source: "repl_main_thread"` — the same addends the statusline page uses. It is rejected
  because it carries **no denominator**: no `context_window_size` and no percentage, and both
  resolver shapes need one. Measured ablation, included in the doc: a snapshot with real tokens and
  `used_percentage: null` resolves `acceptable` when `context_window_size` is present and `unknown`
  when it is absent. A writer would have to invent a per-model window map. It also needs an
  out-of-process OTLP receiver, and `OTEL_*` variables are not passed to hooks or Bash subprocesses,
  so nothing hook-local can even discover where the telemetry goes.
- **The session transcript.** Reachable from every hook via `transcript_path` and carrying exactly
  the right numbers. A shape-validating reader would degrade to `unknown` rather than to a wrong
  zone, so the "it would break" argument alone does not carry. It is declined on the ground that
  does survive: **silent semantic drift** — field names surviving while ceasing to mean
  full-context occupancy, which no shape check detects — against a format the docs mark internal and
  version-unstable, plus an unbounded re-verification obligation.

**`reference/reader-contract.md`** — new cloud/headless section: `unknown` there is structural and
permanent, reported as "no instrument in this environment" and never as a defect; no zone may be
synthesized from another source; and because `unknown` carries no direction, a fork or handoff
trigger in such a session must come from elsewhere and must not be presented as instrument-backed.

**A four-branch discriminator**, because both a broken install and a structurally-absent instrument
print `unknown`. It now includes the state that was missing: **a `statusLine` configured but the
status line disabled** — `disableAllHooks`, `allowManagedHooksOnly` narrowing with no managed value
deployed, or an untrusted workspace. Claude Code skips the value without warning, so that state
prints `unknown` *with* a `statusLine` present and would otherwise land on the "real defect" branch.
The scope list now spans user / launcher / remote / policy-limits / project / local / managed, and
managed outranks all others.

**`skills/setup/SKILL.md`** — `check` no longer contradicts itself. Its new INFO branch is gated on
the same condition step 3 uses: terminal-less → structural, `unknown` is correct and permanent;
otherwise → the ordinary not-yet-wired state, remediated by the wiring step 3 prints. Previously an
ordinary local install that simply had not wired the statusline was told nothing was broken.

## Verification

**The cloud question was settled empirically rather than inferred.** A `statusLine` was wired into
this live cloud session's own settings pointing at a probe that logs stdin before teeing, and
exercised for ~7 minutes: never invoked once, no snapshot written. The probe was proven working by
hand-feeding it a payload. The same experiment under a scratch `HOME` with
`claude -p … --output-format json` gave the same result. Settings were restored byte-identical
afterwards, verified with `diff`. Other non-terminal environments (self-hosted runners) are labelled
as expected-but-not-measured rather than asserted.

Reader-side health confirmed in the same container: one synthetic statusline payload through the tee
produced a snapshot and resolved `acceptable`, while the real session id resolved `unknown` moments
earlier. Nothing in the resolver, tee, `jq`, or contract path is broken — there is simply nothing
calling the tee.

| Gate | Result |
|---|---|
| `validate-plugins.sh`, both generator `--check`s | exit 0 |
| `check-changelog-parity.sh` × 4 modes | exit 0; 0.7.17 inserted above 0.7.16, 41 headings preserved, nothing absorbed |
| `check-changed-skills.sh origin/main` | exit 0 |
| `markdownlint-cli2`, `typos` | 0 issues |
| context-guard suite — context-zone, statusline-tee, statusline-shim, zone-crossing-inject, zone-gate, post-compact-mark | exit 0, 260 assertions |
| `plugin-quality/zones-inline-drift.test.sh` | exit 0 |

An independent fresh-context audit fetched all cited pages itself rather than trusting the channel
table, reproduced all three container measurements verbatim, and found the original verdict
falsifiable — it had rejected OpenTelemetry on grounds true of its metrics and false of its events.
That, and five smaller defects, are fixed here. The audit's own proposed disqualifier for OTel was
in turn wrong in mechanism, and the correction above is the measured ablation that replaced it.

No behavior changed: `zones.json`, `context-zone.sh`, `statusline-tee.sh` and all hooks are
untouched; the diff is documentation plus one manifest version line and the setup-check wording.

## Related

Refs #2994 (AI Hero course journey roadmap)
Refs #2901 (lane 3 — handoff trigger criteria, where this was surfaced)


---
_Generated by [Claude Code](https://claude.ai/code/session_01QbfCrj3X9FfGL7VRZYmrn4)_