### PR TITLE
fix(plugin-quality): require retrieval channel on emitted work-item citations

### DIFF
--- a/plugins/plugin-quality/.claude-plugin/plugin.json
+++ b/plugins/plugin-quality/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "plugin-quality",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "description": "Post-use behavioral audit of Claude Code plugin components: a six-step audit workflow (evidence capture, grounded mapping in a fresh subagent, blindspot pass, interactive contract lock, presence-gated review seams, work-item emit with draft+confirm) over any skill, agent, hook, command, or config you have actually used — zone-informed by context-guard snapshots when present, conservative when not.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/plugin-quality/CHANGELOG.md
+++ b/plugins/plugin-quality/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to the `plugin-quality` plugin.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.6]
+
+### Changed
+
+- **Emitted work-item bodies keep the retrieval channel on every doc citation
+  (#2864).** `reference/config.md`'s markdown-item body schema asked only for
+  "evidence + doc citations". The auditor's output contract and `audit` step 3
+  already require URL, fetch date, retrieval channel, and a byte count or line
+  number, and treat a citation missing either field as unverified — then the
+  emit schema dropped those fields, so a maintainer reading the filed item
+  could not tell a rung-1 `curl` from summarizer output. The body schema now
+  requires the same four citation parts, and a citation that omits the channel
+  or the count is emitted as **unverified**.
+
 ## [0.6.5]
 
 ### Changed

--- a/plugins/plugin-quality/reference/config.md
+++ b/plugins/plugin-quality/reference/config.md
@@ -92,10 +92,13 @@ prs: []
 resolution: null
 ```
 
-Body sections: **Summary**, **Findings** (each with evidence + doc citations), **Suggested
-remediations** (cheapest first), **Evidence packet** (path), **Audit contract** (locked scope +
-assumptions). Claim protocol for consumers of such a directory: set `status: claimed` +
-`claimed_by` + `claimed_at`; a claim older than `lease_ttl_hours` may be reclaimed.
+Body sections: **Summary**, **Findings** (each with evidence + doc citations — URL, fetch
+date, the retrieval channel it came over (rung-1 `curl` of the `.md`, or rung-2
+`WebFetch`), and a byte count or line number; a citation that omits the channel or the
+count is emitted as **unverified**), **Suggested remediations** (cheapest first),
+**Evidence packet** (path), **Audit contract** (locked scope + assumptions). Claim
+protocol for consumers of such a directory: set `status: claimed` + `claimed_by` +
+`claimed_at`; a claim older than `lease_ttl_hours` may be reclaimed.
 
 ### Compat reconciliation (recorded 2026-07-24)
 

--- a/plugins/plugin-quality/scripts/citation-contract-drift.test.sh
+++ b/plugins/plugin-quality/scripts/citation-contract-drift.test.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Drift check: the citation fields the auditor produces and the audit skill
+# consumes must also appear on the emitted work-item body schema. Issue 2864
+# was exactly this drop — produce and consume required a retrieval channel
+# plus a byte count or line number; config.md's body sections did not.
+#
+# Asserts the load-bearing phrases in all three files after normalization
+# (backticks/emphasis stripped, whitespace flattened). A wording change on
+# one surface fails this lane until the other two move with it.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+AUDITOR="$SCRIPT_DIR/../agents/auditor.md"
+SKILL="$SCRIPT_DIR/../skills/audit/SKILL.md"
+CONFIG="$SCRIPT_DIR/../reference/config.md"
+
+PASS=0
+FAIL=0
+fail() {
+  echo "FAIL: $*" >&2
+  FAIL=$((FAIL + 1))
+}
+ok() {
+  echo "ok: $*"
+  PASS=$((PASS + 1))
+}
+
+norm() {
+  tr -d '`*' <"$1" | tr '\n' ' ' | tr -s ' '
+}
+
+for f in "$AUDITOR" "$SKILL" "$CONFIG"; do
+  if [[ ! -r "$f" ]]; then
+    echo "FAIL: required file missing or unreadable: $f" >&2
+    exit 1
+  fi
+done
+
+AUDITOR_N=$(norm "$AUDITOR")
+SKILL_N=$(norm "$SKILL")
+CONFIG_N=$(norm "$CONFIG")
+
+# all_three <label> <fixed-phrase>
+all_three() {
+  local label="$1" phrase="$2" where=""
+  [[ "$AUDITOR_N" == *"$phrase"* ]] || where="auditor.md"
+  [[ "$SKILL_N" == *"$phrase"* ]] || where="${where:+$where and }audit/SKILL.md"
+  [[ "$CONFIG_N" == *"$phrase"* ]] || where="${where:+$where and }reference/config.md"
+  if [[ -z "$where" ]]; then
+    ok "$label"
+  else
+    fail "$label: phrase not found in $where: '$phrase'"
+  fi
+}
+
+all_three "retrieval channel" "retrieval channel"
+# auditor.md says "the fetched byte count or the line number"; the skill and
+# emit schema say "byte count or line number". Both halves must appear.
+all_three "byte count" "byte count"
+all_three "line number" "line number"
+all_three "unverified on a missing field" "unverified"
+
+# The emit schema is the surface that dropped the channel. Pin the body
+# paragraph itself, not just a mention somewhere in config.md.
+CONFIG_BODY=$(printf '%s' "$CONFIG_N" | sed -n 's/.*Body sections: \(.*\) Claim protocol.*/\1/p')
+if [[ -z "$CONFIG_BODY" ]]; then
+  fail "config.md body-sections paragraph not found"
+else
+  ok "config.md body-sections paragraph present"
+fi
+
+body_has() {
+  local label="$1" phrase="$2"
+  if [[ "$CONFIG_BODY" == *"$phrase"* ]]; then
+    ok "emit body $label"
+  else
+    fail "emit body $label: phrase not in Body sections paragraph: '$phrase'"
+  fi
+}
+
+body_has "URL" "URL"
+body_has "fetch date" "fetch date"
+body_has "retrieval channel" "retrieval channel"
+body_has "byte-or-line locator" "byte count or line number"
+body_has "rung-1 curl" "rung-1 curl"
+body_has "rung-2 WebFetch" "rung-2 WebFetch"
+body_has "omitted field emitted unverified" "emitted as unverified"
+
+echo
+echo "PASS=$PASS FAIL=$FAIL"
+[[ $FAIL -eq 0 ]]

--- a/plugins/plugin-quality/scripts/citation-contract-drift.test.sh
+++ b/plugins/plugin-quality/scripts/citation-contract-drift.test.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 # Drift check: the citation fields the auditor produces and the audit skill
-# consumes must also appear on the emitted work-item body schema. Issue 2864
-# was exactly this drop — produce and consume required a retrieval channel
-# plus a byte count or line number; config.md's body sections did not.
+# consumes must also appear on the emitted work-item body schema. The
+# emit-schema gap was exactly this drop — produce and consume required a
+# retrieval channel plus a byte count or line number; config.md's body
+# sections did not.
 #
 # Asserts the load-bearing phrases in all three files after normalization
 # (backticks/emphasis stripped, whitespace flattened). A wording change on


### PR DESCRIPTION
Closes #2864

## Summary

The `plugin-quality` emit schema dropped the retrieval channel that the auditor and the audit skill already require on every doc citation. A maintainer reading a filed work item could not tell a rung-1 `curl` from summarizer output.

## Fix

`reference/config.md`'s markdown-item body now requires the same citation parts as `agents/auditor.md`: URL, fetch date, retrieval channel (rung-1 `curl` or rung-2 `WebFetch`), and a byte count or line number. A citation that omits the channel or the count is emitted as **unverified**, matching `skills/audit/SKILL.md` step 3. Plugin version is 0.6.7 (0.6.6 shipped on main as the hooks-reference retarget). A three-way drift test locks the phrases across auditor, skill, and emit schema.

## Verification

- `bash plugins/plugin-quality/scripts/citation-contract-drift.test.sh` — 12/12 pass on this tree; 11 fail against `origin/main`'s `config.md` (discriminating).
- `bash plugins/plugin-quality/scripts/zones-inline-drift.test.sh`
- `bash plugins/plugin-quality/scripts/packet-seal.test.sh`
- `bash plugins/plugin-quality/scripts/packet-prune.test.sh`
- `bash scripts/check-changelog-parity.sh --check`
- `bash scripts/check-changelog-parity.sh --check-bump origin/main`
- `bash scripts/check-changelog-parity.sh --check-preserved origin/main`
- `bash scripts/check-changelog-parity.sh --check-order`
- `shellcheck` on the new drift test; `markdownlint-cli2` on the edited markdown

## Related

Refs #2854 and PR #2858, which put the channel requirement on the produce and consume boundaries. This issue is the emit-schema gap that the fresh-context verification pass on that PR declined as out of scope. The owning convention is `docs/conventions/upstream-drift/README.md` (no change here).
