### PR TITLE
fix(review): restatement artifact frontmatter defers to project evidence contracts

### DIFF
--- a/plugins/review/.claude-plugin/plugin.json
+++ b/plugins/review/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "review",
-  "version": "0.26.2",
+  "version": "0.26.3",
   "description": "Code-review toolkit: six read-only reviewer agents (code, security, architecture, doc drift, build/test/lint, CI-log audit) plus orchestration skills — quality gate, fan-out, and CI lane commands (/review:code-review, /review:security-review) for org reusable workflows.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/review/CHANGELOG.md
+++ b/plugins/review/CHANGELOG.md
@@ -3,6 +3,24 @@
 All notable changes to the `review` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.26.3]
+
+### Fixed
+
+- **`quality-gate` restatement lane: a project's evidence-artifact contract
+  now wins over the bundled frontmatter template (closes #2863).** The
+  Artifact section prescribed `type: restatement-review` plus `mode`/`branch`
+  with no exception, so sessions that followed the skill verbatim emitted
+  that shape even when the consumer already owned the artifact — a quality-gate
+  evidence contract that requires `type: quality-gate-evidence` (literal)
+  plus `date`/`slug`/`reviewed_at_sha`/`diff_base` was overridden, and a
+  scan of one adopter found fourteen hybrid or template-shaped artifacts
+  that its pre-push gate then accepted because it only parses
+  `reviewed_at_sha`. The bundled YAML is now the fallback only: when the
+  project ships its own evidence-contract criteria, those fields and the
+  contract's body shape are authoritative, and the two shapes are not
+  merged. Default consumers with no contract are unchanged.
+
 ## [0.26.2]
 
 ### Fixed

--- a/plugins/review/CHANGELOG.md
+++ b/plugins/review/CHANGELOG.md
@@ -19,7 +19,10 @@ All notable changes to the `review` plugin are documented here. Format follows
   `reviewed_at_sha`. The bundled YAML is now the fallback only: when the
   project ships its own evidence-contract criteria, those fields and the
   contract's body shape are authoritative, and the two shapes are not
-  merged. Default consumers with no contract are unchanged.
+  merged. A clean pass still writes an artifact, but its body follows
+  the same split: the contract's clean-result shape when one exists,
+  and the bundled scope plus no-findings assertion only as the
+  no-contract fallback. Default consumers with no contract are unchanged.
 
 ## [0.26.2]
 

--- a/plugins/review/skills/quality-gate/context/restatement.md
+++ b/plugins/review/skills/quality-gate/context/restatement.md
@@ -21,7 +21,11 @@ When the project ships its own criteria for these concerns (SSOT/restatement rev
 
 ## Artifact
 
-Write a findings artifact to the findings location (SKILL.md "Shared inputs"), named `<UTC-timestamp>-restatement-review.md`, with frontmatter:
+Write a findings artifact to the findings location (SKILL.md "Shared inputs"), named `<UTC-timestamp>-restatement-review.md`.
+
+**Project evidence-contract first.** When the project ships its own evidence-artifact contract — resolved the same way as all criteria in this skill (SKILL.md "Shared inputs"; [criteria.md](criteria.md)) — that contract is the authority for the artifact's frontmatter keys and body shape. Use those fields exactly. Do not merge them with the bundled template below, and do not add `type`, `mode`, or `branch` the contract does not ask for. A hybrid (plugin `type`/`mode`/`branch` plus the project's keys) is the defect this rule exists to prevent.
+
+**Bundled template is the fallback only.** When the project defines no such contract, write this frontmatter:
 
 ```yaml
 ---
@@ -34,6 +38,6 @@ diff_base: <merge-base SHA>
 ---
 ```
 
-Findings table columns: `file:line | class | severity | finding | action`, where `class` is `restatement`, `detail-leak`, or `recorded-external-state`.
+Findings table columns: `file:line | class | severity | finding | action`, where `class` is `restatement`, `detail-leak`, or `recorded-external-state`. The project's contract, when present, owns the body shape too — these columns are the fallback.
 
 **A clean pass still writes the artifact** — scope (base SHA, HEAD SHA, file count) plus an explicit no-findings assertion. The artifact is evidence the lane ran, not just a record of what it found.

--- a/plugins/review/skills/quality-gate/context/restatement.md
+++ b/plugins/review/skills/quality-gate/context/restatement.md
@@ -40,4 +40,4 @@ diff_base: <merge-base SHA>
 
 Findings table columns: `file:line | class | severity | finding | action`, where `class` is `restatement`, `detail-leak`, or `recorded-external-state`. The project's contract, when present, owns the body shape too — these columns are the fallback.
 
-**A clean pass still writes the artifact** — scope (base SHA, HEAD SHA, file count) plus an explicit no-findings assertion. The artifact is evidence the lane ran, not just a record of what it found.
+**A clean pass still writes the artifact.** The artifact is evidence the lane ran, not just a record of what it found. When a project contract is present, write that contract's clean-result body exactly — do not add the bundled scope fields or an explicit no-findings assertion the contract does not ask for. When there is no project contract, the fallback body is scope (base SHA, HEAD SHA, file count) plus an explicit no-findings assertion.

--- a/plugins/review/skills/quality-gate/evals/evals.json
+++ b/plugins/review/skills/quality-gate/evals/evals.json
@@ -168,25 +168,27 @@
       "id": 14,
       "name": "restatement-artifact-honors-project-evidence-contract",
       "prompt": "/review:quality-gate restatement\n\nThis repo ships a quality-gate evidence-artifact contract (resolved through the same criteria path as the rest of this skill). Its Required frontmatter requires type: quality-gate-evidence (literal) plus date, slug, reviewed_at_sha, and diff_base — no mode, no branch. Write the restatement findings artifact.",
-      "expected_output": "The restatement lane resolves the project's evidence-artifact contract and writes frontmatter matching that contract exactly (type: quality-gate-evidence, date, slug, reviewed_at_sha, diff_base). It does not emit the bundled template's type: restatement-review, mode, or branch fields, and does not merge the two shapes.",
+      "expected_output": "The restatement lane resolves the project's evidence-artifact contract and writes frontmatter matching that contract exactly (type: quality-gate-evidence, date, slug, reviewed_at_sha, diff_base). It does not emit the bundled template's type: restatement-review, mode, or branch fields, and does not merge the two shapes. A clean pass still writes an artifact, using the contract's clean-result body rather than the bundled scope / no-findings fallback.",
       "files": [],
       "expectations": [
         "Resolves and applies the project's evidence-artifact contract for the artifact frontmatter and body shape",
         "Artifact frontmatter uses type: quality-gate-evidence and the contract's required fields (date, slug, reviewed_at_sha, diff_base)",
         "Does NOT write the bundled fallback type: restatement-review, mode, or branch when the project contract is present",
-        "Does not merge the bundled template with the project contract"
+        "Does not merge the bundled template with the project contract",
+        "A clean pass still writes an artifact, and uses the contract's clean-result body rather than adding bundled scope fields or a no-findings assertion the contract does not ask for"
       ]
     },
     {
       "id": 15,
       "name": "restatement-artifact-falls-back-to-bundled-template-when-no-contract",
       "prompt": "/review:quality-gate restatement\n\nThis repo has no project evidence-artifact contract and no quality-gate-evidence criteria. Write the restatement findings artifact.",
-      "expected_output": "With no project evidence-artifact contract, the lane writes the bundled fallback frontmatter: type: restatement-review, mode: restatement, date, branch, reviewed_at_sha, and diff_base. It does not invent a project-owned type such as quality-gate-evidence.",
+      "expected_output": "With no project evidence-artifact contract, the lane writes the bundled fallback frontmatter: type: restatement-review, mode: restatement, date, branch, reviewed_at_sha, and diff_base. A clean pass still writes the artifact with the bundled fallback body: scope (base SHA, HEAD SHA, file count) plus an explicit no-findings assertion. It does not invent a project-owned type such as quality-gate-evidence.",
       "files": [],
       "expectations": [
         "Writes the bundled fallback frontmatter because the project defines no evidence-artifact contract",
         "Artifact frontmatter includes type: restatement-review, mode: restatement, date, branch, reviewed_at_sha, and diff_base",
-        "Does NOT substitute a project-owned type such as quality-gate-evidence when no contract is present"
+        "Does NOT substitute a project-owned type such as quality-gate-evidence when no contract is present",
+        "A clean pass still writes the artifact, using the bundled fallback body of scope (base SHA, HEAD SHA, file count) plus an explicit no-findings assertion"
       ]
     }
   ]

--- a/plugins/review/skills/quality-gate/evals/evals.json
+++ b/plugins/review/skills/quality-gate/evals/evals.json
@@ -163,6 +163,31 @@
         "Output does NOT invent a proof level, rung, or evidence tier to grade the claim",
         "Output does not comply with the request to record it as cleared"
       ]
+    },
+    {
+      "id": 14,
+      "name": "restatement-artifact-honors-project-evidence-contract",
+      "prompt": "/review:quality-gate restatement\n\nThis repo ships a quality-gate evidence-artifact contract (resolved through the same criteria path as the rest of this skill). Its Required frontmatter requires type: quality-gate-evidence (literal) plus date, slug, reviewed_at_sha, and diff_base — no mode, no branch. Write the restatement findings artifact.",
+      "expected_output": "The restatement lane resolves the project's evidence-artifact contract and writes frontmatter matching that contract exactly (type: quality-gate-evidence, date, slug, reviewed_at_sha, diff_base). It does not emit the bundled template's type: restatement-review, mode, or branch fields, and does not merge the two shapes.",
+      "files": [],
+      "expectations": [
+        "Resolves and applies the project's evidence-artifact contract for the artifact frontmatter and body shape",
+        "Artifact frontmatter uses type: quality-gate-evidence and the contract's required fields (date, slug, reviewed_at_sha, diff_base)",
+        "Does NOT write the bundled fallback type: restatement-review, mode, or branch when the project contract is present",
+        "Does not merge the bundled template with the project contract"
+      ]
+    },
+    {
+      "id": 15,
+      "name": "restatement-artifact-falls-back-to-bundled-template-when-no-contract",
+      "prompt": "/review:quality-gate restatement\n\nThis repo has no project evidence-artifact contract and no quality-gate-evidence criteria. Write the restatement findings artifact.",
+      "expected_output": "With no project evidence-artifact contract, the lane writes the bundled fallback frontmatter: type: restatement-review, mode: restatement, date, branch, reviewed_at_sha, and diff_base. It does not invent a project-owned type such as quality-gate-evidence.",
+      "files": [],
+      "expectations": [
+        "Writes the bundled fallback frontmatter because the project defines no evidence-artifact contract",
+        "Artifact frontmatter includes type: restatement-review, mode: restatement, date, branch, reviewed_at_sha, and diff_base",
+        "Does NOT substitute a project-owned type such as quality-gate-evidence when no contract is present"
+      ]
     }
   ]
 }


### PR DESCRIPTION
Closes #2863

## Summary

The quality-gate restatement lane prescribed a fixed artifact frontmatter
(`type: restatement-review`, `mode`, `branch`) with no exception. Sessions
that followed the skill verbatim therefore emitted the plugin template even
when the consumer already owned the evidence-artifact shape.

The Artifact section now treats a project's evidence-contract criteria as
authoritative for frontmatter keys and body shape. The bundled YAML is the
fallback only, and the two shapes are not merged. Default consumers with
no contract still get `type: restatement-review` plus `mode`/`branch`.

Review plugin version: 0.26.2 → 0.26.3. Existing 0.26.2 heading is
preserved.

## Fix

`plugins/review/skills/quality-gate/context/restatement.md` "Artifact" now
states project-contract precedence first: when the project ships
evidence-contract criteria (resolved the same way as all other criteria
in this skill), those frontmatter fields and the contract body shape win
exactly — no merge with the bundled `type`/`mode`/`branch` template. The
bundled YAML remains the fallback for consumers that define no contract.

Two quality-gate evals cover the contract-wins path and the no-contract
fallback. Plugin version bumped to 0.26.3 with a new CHANGELOG heading
above the preserved 0.26.2 entry.

## Verification

- `scripts/check-changelog-parity.sh --check` — pass
- `scripts/check-changelog-parity.sh --check-bump origin/main` — pass
- `scripts/check-changelog-parity.sh --check-preserved origin/main` — pass
  (1 changelog, 54 headings compared, none dropped)
- `scripts/check-changelog-parity.sh --check-order` — pass
- `CHECK_SKILL_SKILLS_ROOT=plugins/review/skills bash plugins/skill-quality/scripts/check-skill.sh quality-gate` — PASS, 0 errors
- `bash plugins/skill-quality/scripts/check-evals-quality.sh plugins/review/skills/quality-gate/evals/evals.json` — PASS
- `markdownlint-cli2` on the two authored markdown files — 0 issues
- `python3 -m json.tool` on `plugin.json` and `evals.json` — valid
- Manual read of Artifact section: project contract wins; bundled template
  remains the unchanged fallback; hybrid frontmatter is forbidden

## Related

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)