### PR TITLE
fix(markdown-format): name a user-scope PATH target in the out-of-repo skip notice

### DIFF
--- a/plugins/markdown-format/.claude-plugin/plugin.json
+++ b/plugins/markdown-format/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "markdown-format",
-  "version": "0.11.22",
+  "version": "0.11.23",
   "description": "Auto-format and lint Markdown on edit via markdownlint-cli2 \u2014 only in repos that carry their own markdownlint config.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/markdown-format/CHANGELOG.md
+++ b/plugins/markdown-format/CHANGELOG.md
@@ -9,19 +9,19 @@ All notable changes to the `markdown-format` plugin are documented here. Format 
 
 - **Out-of-repo missing-tool notice no longer recommends `npm i -D` (#2868).** The skip
   notice still prints `PATH probed:` and still points at a repo-local
-  `npm i -D markdownlint-cli2` when the edit is inside a git working tree. When it is
-  not — a scratch project dir, a session scratchpad that still reaches the notice —
-  that command has no repository to install into. The notice now says so and names a
-  durable user-scope directory already on the probed PATH (`~/.bun/bin`, `~/.local/bin`,
-  `~/bin`, then any other existing writable `$HOME/…` entry), skipping version-manager
-  multishell prefixes (`fnm_multishells`, nvm, …). When the chosen target is bun's
-  default `globalBinDir` (`~/.bun/bin`;
+  `npm i -D markdownlint-cli2` when that command has a place to land: a git working
+  tree, or a `package.json` between the file and `REPO_ROOT` (an unpacked / non-git
+  Node project). A scratch dir with neither is not a repo-local install target; the
+  notice says so and names a durable user-scope directory already on the probed PATH
+  — only `~/.bun/bin`, `~/.local/bin`, or `~/bin`, never a generic `$HOME/…` fallback
+  (version-manager install/shim trees are not durable). When the chosen target is
+  exactly bun's default `globalBinDir` (`~/.bun/bin`;
   [bunfig `install.globalBinDir`](https://bun.com/docs/runtime/bunfig), fetched
   2026-08-21) it also names `bun install --global markdownlint-cli2`. The official
-  markdownlint-cli2 global form remains
+  markdownlint-cli2 global form
   [`npm install markdownlint-cli2 --global`](https://github.com/DavidAnson/markdownlint-cli2#install)
-  (fetched 2026-08-21); that is not cited unless npm's prefix is the chosen PATH
-  target, because an fnm/nvm `npm i -g` is the #2748 failure mode.
+  (fetched 2026-08-21) is documented here only; the notice never cites it, because
+  an fnm/nvm `npm i -g` is the #2748 failure mode.
 
 ## [0.11.22]
 

--- a/plugins/markdown-format/CHANGELOG.md
+++ b/plugins/markdown-format/CHANGELOG.md
@@ -3,6 +3,26 @@
 All notable changes to the `markdown-format` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.11.23]
+
+### Fixed
+
+- **Out-of-repo missing-tool notice no longer recommends `npm i -D` (#2868).** The skip
+  notice still prints `PATH probed:` and still points at a repo-local
+  `npm i -D markdownlint-cli2` when the edit is inside a git working tree. When it is
+  not — a scratch project dir, a session scratchpad that still reaches the notice —
+  that command has no repository to install into. The notice now says so and names a
+  durable user-scope directory already on the probed PATH (`~/.bun/bin`, `~/.local/bin`,
+  `~/bin`, then any other existing writable `$HOME/…` entry), skipping version-manager
+  multishell prefixes (`fnm_multishells`, nvm, …). When the chosen target is bun's
+  default `globalBinDir` (`~/.bun/bin`;
+  [bunfig `install.globalBinDir`](https://bun.com/docs/runtime/bunfig), fetched
+  2026-08-21) it also names `bun install --global markdownlint-cli2`. The official
+  markdownlint-cli2 global form remains
+  [`npm install markdownlint-cli2 --global`](https://github.com/DavidAnson/markdownlint-cli2#install)
+  (fetched 2026-08-21); that is not cited unless npm's prefix is the chosen PATH
+  target, because an fnm/nvm `npm i -g` is the #2748 failure mode.
+
 ## [0.11.22]
 
 ### Fixed

--- a/plugins/markdown-format/README.md
+++ b/plugins/markdown-format/README.md
@@ -88,9 +88,11 @@ the hook exits `0` and reports a once-per-session notice to both Claude
 (`additionalContext`) and you (`systemMessage`). Only the notice latches —
 the binary probe re-runs on every Markdown edit and recovers mid-session when
 the tool becomes resolvable. A missing-`markdownlint-cli2` notice includes a
-`PATH probed:` line naming the PATH the hook process actually searched. The
-hook never falls back to `npx`, installs a package, or performs a network
-request during a hook run.
+`PATH probed:` line naming the PATH the hook process actually searched. When
+the edited file is outside a repository the notice names a durable user-scope
+directory already on that PATH instead of recommending a repo-local
+`npm i -D`. The hook never falls back to `npx`, installs a package, or
+performs a network request during a hook run.
 
 Telemetry timing uses `EPOCHREALTIME` (Bash 5.0+); on older Bash the telemetry
 envelope is skipped while formatting still runs.

--- a/plugins/markdown-format/hooks/markdown-format.sh
+++ b/plugins/markdown-format/hooks/markdown-format.sh
@@ -504,6 +504,136 @@ resolve_repo_markdownlint() {
   return 1
 }
 
+# True when $1 (a PATH entry) is a version-manager / session-ephemeral prefix:
+# a global install there is not durably hook-visible (#2748 / #2868).
+path_entry_is_ephemeral() {
+  case "$1" in
+  *fnm_multishells* | */.nvm/* | */nvm/versions/* | */.fnm/* | */.asdf/installs/* | \
+    */.volta/tmp/*)
+    return 0
+    ;;
+  *)
+    return 1
+    ;;
+  esac
+}
+
+# Strip a trailing slash; on Git Bash, fold a drive-letter spelling to POSIX
+# so $HOME and PATH entries compare as the same directory.
+normalize_path_entry() {
+  local p="${1%/}" n
+  if command -v cygpath >/dev/null 2>&1; then
+    n="$(cygpath -u "$p" 2>/dev/null)" || n="$p"
+    p="${n%/}"
+  fi
+  printf '%s' "$p"
+}
+
+# True when the edited file sits inside a git working tree. git is preferred;
+# a .git walk covers a git-less host. CLAUDE_PROJECT_DIR alone is not a repo —
+# a scratch project dir has no package.json / node_modules for `npm i -D`.
+edit_is_in_git_repo() {
+  local dir parent
+  dir="$(cd "$(dirname -- "$1")" 2>/dev/null && pwd -P)" || return 1
+  if command -v git >/dev/null 2>&1 && in_git_working_tree "$dir"; then
+    return 0
+  fi
+  while :; do
+    [[ -e "$dir/.git" ]] && return 0
+    parent="$(dirname -- "$dir")"
+    [[ "$parent" != "$dir" ]] || return 1
+    dir="$parent"
+  done
+}
+
+# Pick a durable user-scope directory already on $PATH. Preference matches
+# directories an operator can put a hook-visible binary in without a
+# repository: ~/.bun/bin (bun's default globalBinDir), ~/.local/bin, ~/bin.
+# Version-manager multishell prefixes are skipped. Prints the chosen PATH
+# entry in the spelling that was on PATH, or returns 1.
+select_user_scope_path_target() {
+  local home rest entry norm_entry norm_home
+  local best_pref=99 best=""
+  home="${HOME:-}"
+  [[ -n "$home" ]] || return 1
+  norm_home="$(normalize_path_entry "$home")"
+  [[ -n "$norm_home" ]] || return 1
+
+  rest="${PATH:-}"
+  while [[ -n "$rest" ]]; do
+    if [[ "$rest" == *:* ]]; then
+      entry="${rest%%:*}"
+      rest="${rest#*:}"
+    else
+      entry="$rest"
+      rest=""
+    fi
+    [[ -n "$entry" ]] || continue
+    path_entry_is_ephemeral "$entry" && continue
+    norm_entry="$(normalize_path_entry "$entry")"
+    [[ -n "$norm_entry" ]] || continue
+    case "$norm_entry" in
+    "$norm_home/.bun/bin")
+      printf '%s' "$entry"
+      return 0
+      ;;
+    "$norm_home/.local/bin")
+      if ((best_pref > 2)); then
+        best_pref=2
+        best="$entry"
+      fi
+      ;;
+    "$norm_home/bin")
+      if ((best_pref > 3)); then
+        best_pref=3
+        best="$entry"
+      fi
+      ;;
+    "$norm_home"/*)
+      if [[ -d "$entry" && -w "$entry" ]] && ((best_pref > 10)); then
+        best_pref=10
+        best="$entry"
+      fi
+      ;;
+    *) ;;
+    esac
+  done
+  [[ -n "$best" ]] || return 1
+  printf '%s' "$best"
+}
+
+# Remediation sentence(s) for the missing-markdownlint notice. In a repository
+# the node_modules/.bin probe is the reliable route. Outside one, name a
+# user-scope directory already on the probed PATH instead of `npm i -D` (#2868).
+markdownlint_skip_remediation() {
+  local target norm_target
+  if edit_is_in_git_repo "$FILE"; then
+    printf '%s' "Hook processes inherit Claude Code's own environment, not the interactive shell's profile, so a version-manager install (nvm/rbenv) the Bash tool can see may be invisible here; a repo-local install (npm i -D markdownlint-cli2) is the reliable route. This hook does not invoke npx or download tools."
+    return 0
+  fi
+  printf '%s' "Hook processes inherit Claude Code's own environment, not the interactive shell's profile, so a version-manager install (nvm/rbenv) the Bash tool can see may be invisible here. This edit is outside a repository, so a repo-local install has no repository to install into"
+  if target="$(select_user_scope_path_target)"; then
+    norm_target="$(normalize_path_entry "$target")"
+    # bun's documented default globalBinDir is ~/.bun/bin
+    # (https://bun.com/docs/runtime/bunfig, install.globalBinDir, fetched
+    # 2026-08-21). markdownlint-cli2's own install docs name
+    # `npm install markdownlint-cli2 --global` as the global-CLI form
+    # (https://github.com/DavidAnson/markdownlint-cli2#install, fetched
+    # 2026-08-21); cite bun only when the chosen PATH target is that default.
+    case "$norm_target" in
+    */.bun/bin)
+      printf '%s' "; place a user-scope markdownlint-cli2 on the probed PATH (this hook would accept one at ${target}; bun install --global markdownlint-cli2 lands there by default)"
+      ;;
+    *)
+      printf '%s' "; place a user-scope markdownlint-cli2 on the probed PATH (this hook would accept one at ${target})"
+      ;;
+    esac
+  else
+    printf '%s' "; install markdownlint-cli2 onto a durable user-scope directory already on this hook's PATH"
+  fi
+  printf '%s' ". This hook does not invoke npx or download tools."
+}
+
 MDLINT=()
 if command -v markdownlint-cli2 >/dev/null 2>&1; then
   MDLINT=(markdownlint-cli2)
@@ -521,9 +651,14 @@ else
   # and agents stop retrying. The trailing PATH line is the probe diagnostic
   # (what this hook process actually searched); do not widen the probe to
   # nvm/rbenv layout guesses — that is a separate environment/bootstrap fix.
+  #
+  # Remediation is scoped (#2868): `npm i -D` is the reliable route only
+  # inside a repository. Outside one, name a durable user-scope directory
+  # already on the probed PATH rather than a repo-local install that cannot
+  # be followed.
   if hook::notice_once "markdown-format-markdownlint" "$INPUT"; then
     hook::emit_skip_notice PostToolUse \
-      "markdown-format: markdownlint-cli2 was not found on this hook's PATH or as a contained repository-local node_modules/.bin executable — Markdown lint skipped for this edit (probe re-runs on every Markdown edit; only this notice latches once per session — there is no skip latch). Hook processes inherit Claude Code's own environment, not the interactive shell's profile, so a version-manager install (nvm/rbenv) the Bash tool can see may be invisible here; a repo-local install (npm i -D markdownlint-cli2) is the reliable route. This hook does not invoke npx or download tools.
+      "markdown-format: markdownlint-cli2 was not found on this hook's PATH or as a contained repository-local node_modules/.bin executable — Markdown lint skipped for this edit (probe re-runs on every Markdown edit; only this notice latches once per session — there is no skip latch). $(markdownlint_skip_remediation)
 PATH probed: ${PATH:-<unset>}"
   fi
   emit_tel "skipped" '[]'

--- a/plugins/markdown-format/hooks/markdown-format.sh
+++ b/plugins/markdown-format/hooks/markdown-format.sh
@@ -504,20 +504,6 @@ resolve_repo_markdownlint() {
   return 1
 }
 
-# True when $1 (a PATH entry) is a version-manager / session-ephemeral prefix:
-# a global install there is not durably hook-visible (#2748 / #2868).
-path_entry_is_ephemeral() {
-  case "$1" in
-  *fnm_multishells* | */.nvm/* | */nvm/versions/* | */.fnm/* | */.asdf/installs/* | \
-    */.volta/tmp/*)
-    return 0
-    ;;
-  *)
-    return 1
-    ;;
-  esac
-}
-
 # Strip a trailing slash; on Git Bash, fold a drive-letter spelling to POSIX
 # so $HOME and PATH entries compare as the same directory.
 normalize_path_entry() {
@@ -530,8 +516,7 @@ normalize_path_entry() {
 }
 
 # True when the edited file sits inside a git working tree. git is preferred;
-# a .git walk covers a git-less host. CLAUDE_PROJECT_DIR alone is not a repo —
-# a scratch project dir has no package.json / node_modules for `npm i -D`.
+# a .git walk covers a git-less host.
 edit_is_in_git_repo() {
   local dir parent
   dir="$(cd "$(dirname -- "$1")" 2>/dev/null && pwd -P)" || return 1
@@ -546,11 +531,36 @@ edit_is_in_git_repo() {
   done
 }
 
-# Pick a durable user-scope directory already on $PATH. Preference matches
+# True when `npm i -D` has a place to land: a git working tree, or a package.json
+# between the file and REPO_ROOT (an unpacked / non-git Node project whose
+# CLAUDE_PROJECT_DIR last-resort root is exactly that case). A scratch dir
+# with no package.json is not a repo-local install target.
+edit_has_repo_local_install_target() {
+  local dir parent root=""
+  if edit_is_in_git_repo "$FILE"; then
+    return 0
+  fi
+  dir="$(cd "$(dirname -- "$FILE")" 2>/dev/null && pwd -P)" || return 1
+  if [[ -n "${REPO_ROOT:-}" ]]; then
+    root="$(cd "$REPO_ROOT" 2>/dev/null && pwd -P)" || root=""
+  fi
+  while :; do
+    [[ -f "$dir/package.json" ]] && return 0
+    if [[ -n "$root" && "$dir" == "$root" ]]; then
+      return 1
+    fi
+    parent="$(dirname -- "$dir")"
+    [[ "$parent" != "$dir" ]] || return 1
+    dir="$parent"
+  done
+}
+
+# Pick a durable user-scope directory already on $PATH. Only the three
 # directories an operator can put a hook-visible binary in without a
-# repository: ~/.bun/bin (bun's default globalBinDir), ~/.local/bin, ~/bin.
-# Version-manager multishell prefixes are skipped. Prints the chosen PATH
-# entry in the spelling that was on PATH, or returns 1.
+# repository, in preference order: ~/.bun/bin (bun's default globalBinDir),
+# ~/.local/bin, ~/bin. No generic $HOME/* fallback — a version-manager
+# install/shim tree under $HOME is not a durable target (#2868 review).
+# Prints the chosen PATH entry in the spelling that was on PATH, or returns 1.
 select_user_scope_path_target() {
   local home rest entry norm_entry norm_home
   local best_pref=99 best=""
@@ -569,7 +579,6 @@ select_user_scope_path_target() {
       rest=""
     fi
     [[ -n "$entry" ]] || continue
-    path_entry_is_ephemeral "$entry" && continue
     norm_entry="$(normalize_path_entry "$entry")"
     [[ -n "$norm_entry" ]] || continue
     case "$norm_entry" in
@@ -589,12 +598,6 @@ select_user_scope_path_target() {
         best="$entry"
       fi
       ;;
-    "$norm_home"/*)
-      if [[ -d "$entry" && -w "$entry" ]] && ((best_pref > 10)); then
-        best_pref=10
-        best="$entry"
-      fi
-      ;;
     *) ;;
     esac
   done
@@ -602,32 +605,30 @@ select_user_scope_path_target() {
   printf '%s' "$best"
 }
 
-# Remediation sentence(s) for the missing-markdownlint notice. In a repository
-# the node_modules/.bin probe is the reliable route. Outside one, name a
-# user-scope directory already on the probed PATH instead of `npm i -D` (#2868).
+# Remediation sentence(s) for the missing-markdownlint notice. When a
+# repo-local install can land (git tree or package.json), that is the
+# reliable route. Otherwise name a durable user-scope directory already
+# on the probed PATH instead of `npm i -D` (#2868).
 markdownlint_skip_remediation() {
-  local target norm_target
-  if edit_is_in_git_repo "$FILE"; then
+  local target norm_target norm_home bun_bin
+  if edit_has_repo_local_install_target; then
     printf '%s' "Hook processes inherit Claude Code's own environment, not the interactive shell's profile, so a version-manager install (nvm/rbenv) the Bash tool can see may be invisible here; a repo-local install (npm i -D markdownlint-cli2) is the reliable route. This hook does not invoke npx or download tools."
     return 0
   fi
   printf '%s' "Hook processes inherit Claude Code's own environment, not the interactive shell's profile, so a version-manager install (nvm/rbenv) the Bash tool can see may be invisible here. This edit is outside a repository, so a repo-local install has no repository to install into"
   if target="$(select_user_scope_path_target)"; then
     norm_target="$(normalize_path_entry "$target")"
-    # bun's documented default globalBinDir is ~/.bun/bin
+    norm_home="$(normalize_path_entry "${HOME:-}")"
+    bun_bin="$norm_home/.bun/bin"
+    # bun's documented default globalBinDir is exactly ~/.bun/bin
     # (https://bun.com/docs/runtime/bunfig, install.globalBinDir, fetched
-    # 2026-08-21). markdownlint-cli2's own install docs name
-    # `npm install markdownlint-cli2 --global` as the global-CLI form
-    # (https://github.com/DavidAnson/markdownlint-cli2#install, fetched
-    # 2026-08-21); cite bun only when the chosen PATH target is that default.
-    case "$norm_target" in
-    */.bun/bin)
+    # 2026-08-21). Cite bun only for that exact directory, never a nested
+    # `*/.bun/bin` suffix.
+    if [[ -n "$norm_home" && "$norm_target" == "$bun_bin" ]]; then
       printf '%s' "; place a user-scope markdownlint-cli2 on the probed PATH (this hook would accept one at ${target}; bun install --global markdownlint-cli2 lands there by default)"
-      ;;
-    *)
+    else
       printf '%s' "; place a user-scope markdownlint-cli2 on the probed PATH (this hook would accept one at ${target})"
-      ;;
-    esac
+    fi
   else
     printf '%s' "; install markdownlint-cli2 onto a durable user-scope directory already on this hook's PATH"
   fi

--- a/plugins/markdown-format/hooks/markdown-format.test.sh
+++ b/plugins/markdown-format/hooks/markdown-format.test.sh
@@ -942,12 +942,12 @@ else
 fi
 if printf '%s' "$OUT_OUTREPO" | jq -e --arg bun "$FAKE_HOME/.bun/bin" --arg fnm "$FAKE_HOME/AppData/Local/fnm_multishells/5796_x/bin" '
   (.hookSpecificOutput.additionalContext | contains("outside a repository")) and
-  (.hookSpecificOutput.additionalContext | contains($bun)) and
+  (.hookSpecificOutput.additionalContext | contains("would accept one at " + $bun)) and
   (.hookSpecificOutput.additionalContext | contains("bun install --global markdownlint-cli2")) and
   (.hookSpecificOutput.additionalContext | contains("PATH probed:")) and
   ((.hookSpecificOutput.additionalContext | contains("npm i -D markdownlint-cli2")) | not) and
   ((.hookSpecificOutput.additionalContext | contains("is the reliable route")) | not) and
-  ((.hookSpecificOutput.additionalContext | contains($fnm)) | not)
+  ((.hookSpecificOutput.additionalContext | contains("would accept one at " + $fnm)) | not)
 ' >/dev/null 2>&1; then
   ok "out-of-repo missing markdownlint names ~/.bun/bin, not npm i -D or fnm"
 else
@@ -962,7 +962,8 @@ OUT_LOCALBIN="$(cd "$UNRELATED" && printf '{"tool_input":{"file_path":"%s"}}' "$
     PATH="$FAKE_HOME/bin:$FAKE_HOME/.local/bin:$PATH" \
     CLAUDE_PLUGIN_OPTION_MARKDOWN_FORMAT_ENABLED=true bash "$HOOK")"
 if printf '%s' "$OUT_LOCALBIN" | jq -e --arg local "$FAKE_HOME/.local/bin" --arg homebin "$FAKE_HOME/bin" '
-  (.hookSpecificOutput.additionalContext | contains($local)) and
+  (.hookSpecificOutput.additionalContext | contains("would accept one at " + $local)) and
+  ((.hookSpecificOutput.additionalContext | contains("would accept one at " + $homebin)) | not) and
   ((.hookSpecificOutput.additionalContext | contains("bun install --global")) | not) and
   ((.hookSpecificOutput.additionalContext | contains("npm i -D markdownlint-cli2")) | not)
 ' >/dev/null 2>&1; then
@@ -982,8 +983,9 @@ if printf '%s' "$OUT_NOTARGET" | jq -e --arg bun "$FAKE_HOME/.bun/bin" --arg fnm
   (.hookSpecificOutput.additionalContext | contains("outside a repository")) and
   (.hookSpecificOutput.additionalContext | contains("durable user-scope directory already on this hook")) and
   ((.hookSpecificOutput.additionalContext | contains("npm i -D markdownlint-cli2")) | not) and
-  ((.hookSpecificOutput.additionalContext | contains($bun)) | not) and
-  ((.hookSpecificOutput.additionalContext | contains($fnm)) | not)
+  ((.hookSpecificOutput.additionalContext | contains("would accept one at")) | not) and
+  ((.hookSpecificOutput.additionalContext | contains("would accept one at " + $bun)) | not) and
+  ((.hookSpecificOutput.additionalContext | contains("would accept one at " + $fnm)) | not)
 ' >/dev/null 2>&1; then
   ok "out-of-repo notice without a user-scope PATH target invents none"
 else

--- a/plugins/markdown-format/hooks/markdown-format.test.sh
+++ b/plugins/markdown-format/hooks/markdown-format.test.sh
@@ -972,6 +972,46 @@ else
   fail "out-of-repo ~/.local/bin preference wrong: $OUT_LOCALBIN"
 fi
 
+# A generic writable $HOME/… PATH entry (mise install tree, nested .bun/bin)
+# is not a named target — only ~/.bun/bin, ~/.local/bin, ~/bin qualify.
+PD_GENERIC="$(mktemp -d "$WORK/pd.XXXXXX")"
+mkdir -p "$FAKE_HOME/share/mise/installs/node/22/bin" "$FAKE_HOME/foo/.bun/bin"
+OUT_GENERIC="$(cd "$UNRELATED" && printf '{"tool_input":{"file_path":"%s"}}' "$OUTREPO/note.md" |
+  env BASH_ENV="$NO_MDLINT_ENV" CLAUDE_PROJECT_DIR="$OUTREPO" \
+    CLAUDE_PLUGIN_DATA="$PD_GENERIC" HOME="$FAKE_HOME" \
+    PATH="$FAKE_HOME/share/mise/installs/node/22/bin:$FAKE_HOME/foo/.bun/bin:$PATH" \
+    CLAUDE_PLUGIN_OPTION_MARKDOWN_FORMAT_ENABLED=true bash "$HOOK")"
+if printf '%s' "$OUT_GENERIC" | jq -e --arg mise "$FAKE_HOME/share/mise/installs/node/22/bin" --arg nested "$FAKE_HOME/foo/.bun/bin" '
+  (.hookSpecificOutput.additionalContext | contains("outside a repository")) and
+  ((.hookSpecificOutput.additionalContext | contains("would accept one at " + $mise)) | not) and
+  ((.hookSpecificOutput.additionalContext | contains("would accept one at " + $nested)) | not) and
+  ((.hookSpecificOutput.additionalContext | contains("bun install --global")) | not) and
+  ((.hookSpecificOutput.additionalContext | contains("npm i -D markdownlint-cli2")) | not)
+' >/dev/null 2>&1; then
+  ok "out-of-repo notice does not name a generic or nested \$HOME PATH entry"
+else
+  fail "out-of-repo generic PATH fallback leaked into notice: $OUT_GENERIC"
+fi
+
+# Non-git project with package.json: npm i -D still has a place to land.
+printf '{}\n' >"$OUTREPO/package.json"
+PD_PKGJSON="$(mktemp -d "$WORK/pd.XXXXXX")"
+OUT_PKGJSON="$(cd "$UNRELATED" && printf '{"tool_input":{"file_path":"%s"}}' "$OUTREPO/note.md" |
+  env BASH_ENV="$NO_MDLINT_ENV" CLAUDE_PROJECT_DIR="$OUTREPO" \
+    CLAUDE_PLUGIN_DATA="$PD_PKGJSON" HOME="$FAKE_HOME" \
+    PATH="$FAKE_HOME/.bun/bin:$PATH" \
+    CLAUDE_PLUGIN_OPTION_MARKDOWN_FORMAT_ENABLED=true bash "$HOOK")"
+if printf '%s' "$OUT_PKGJSON" | jq -e '
+  (.hookSpecificOutput.additionalContext | contains("npm i -D markdownlint-cli2")) and
+  (.hookSpecificOutput.additionalContext | contains("is the reliable route")) and
+  ((.hookSpecificOutput.additionalContext | contains("outside a repository")) | not)
+' >/dev/null 2>&1; then
+  ok "non-git project with package.json still names repo-local npm i -D"
+else
+  fail "non-git package.json lost npm i -D guidance: $OUT_PKGJSON"
+fi
+rm -f "$OUTREPO/package.json"
+
 # No durable user-scope PATH entry: do not invent a path or recommend npm i -D.
 PD_NOTARGET="$(mktemp -d "$WORK/pd.XXXXXX")"
 OUT_NOTARGET="$(cd "$UNRELATED" && printf '{"tool_input":{"file_path":"%s"}}' "$OUTREPO/note.md" |

--- a/plugins/markdown-format/hooks/markdown-format.test.sh
+++ b/plugins/markdown-format/hooks/markdown-format.test.sh
@@ -904,7 +904,91 @@ if printf '%s' "$OUT_NO_MDLINT" | jq -e '
 else
   fail "missing markdownlint latch/PATH diagnostic wrong: $OUT_NO_MDLINT"
 fi
+# In-repo missing-tool: repo-local `npm i -D` is still the reliable route (#2868).
+if printf '%s' "$OUT_NO_MDLINT" | jq -e '
+  (.hookSpecificOutput.additionalContext | contains("npm i -D markdownlint-cli2")) and
+  (.hookSpecificOutput.additionalContext | contains("is the reliable route"))
+' >/dev/null 2>&1; then
+  ok "in-repo missing markdownlint names repo-local npm i -D"
+else
+  fail "in-repo missing markdownlint lost npm i -D guidance: $OUT_NO_MDLINT"
+fi
 if [[ ! -e "$NPX_MARKER" ]]; then ok "missing markdownlint never invokes npx"; else fail "missing markdownlint invoked npx"; fi
+
+# --- Out-of-repo missing-tool notice (#2868) --------------------------------
+# A non-git project dir (CLAUDE_PROJECT_DIR set so membership admits the file)
+# has no repository for `npm i -D`. The notice must name a durable user-scope
+# directory already on the probed PATH, never the repo-local command, and must
+# not name an ephemeral version-manager prefix that happens to sit earlier
+# on PATH.
+OUTREPO="$WORK/out-of-repo-project"
+mkdir -p "$OUTREPO"
+printf '{ "config": { "MD013": false } }\n' >"$OUTREPO/.markdownlint-cli2.jsonc"
+printf '# Note\n' >"$OUTREPO/note.md"
+FAKE_HOME="$WORK/fake-home"
+mkdir -p "$FAKE_HOME/.bun/bin" "$FAKE_HOME/.local/bin" "$FAKE_HOME/bin" \
+  "$FAKE_HOME/AppData/Local/fnm_multishells/5796_x/bin"
+PD_OUTREPO="$(mktemp -d "$WORK/pd.XXXXXX")"
+OUT_OUTREPO="$(cd "$UNRELATED" && printf '{"tool_input":{"file_path":"%s"}}' "$OUTREPO/note.md" |
+  env BASH_ENV="$NO_MDLINT_ENV" CLAUDE_PROJECT_DIR="$OUTREPO" \
+    CLAUDE_PLUGIN_DATA="$PD_OUTREPO" HOME="$FAKE_HOME" \
+    PATH="$FAKE_HOME/AppData/Local/fnm_multishells/5796_x/bin:$FAKE_HOME/.local/bin:$FAKE_HOME/.bun/bin:$PATH" \
+    CLAUDE_PLUGIN_OPTION_MARKDOWN_FORMAT_ENABLED=true bash "$HOOK")"
+RC_OUTREPO=$?
+if [[ $RC_OUTREPO -eq 0 ]]; then
+  ok "out-of-repo missing markdownlint exits 0"
+else
+  fail "out-of-repo missing markdownlint exit $RC_OUTREPO"
+fi
+if printf '%s' "$OUT_OUTREPO" | jq -e --arg bun "$FAKE_HOME/.bun/bin" --arg fnm "$FAKE_HOME/AppData/Local/fnm_multishells/5796_x/bin" '
+  (.hookSpecificOutput.additionalContext | contains("outside a repository")) and
+  (.hookSpecificOutput.additionalContext | contains($bun)) and
+  (.hookSpecificOutput.additionalContext | contains("bun install --global markdownlint-cli2")) and
+  (.hookSpecificOutput.additionalContext | contains("PATH probed:")) and
+  ((.hookSpecificOutput.additionalContext | contains("npm i -D markdownlint-cli2")) | not) and
+  ((.hookSpecificOutput.additionalContext | contains("is the reliable route")) | not) and
+  ((.hookSpecificOutput.additionalContext | contains($fnm)) | not)
+' >/dev/null 2>&1; then
+  ok "out-of-repo missing markdownlint names ~/.bun/bin, not npm i -D or fnm"
+else
+  fail "out-of-repo missing markdownlint remediation wrong: $OUT_OUTREPO"
+fi
+
+# Preference: with no ~/.bun/bin on PATH, name ~/.local/bin over ~/bin.
+PD_LOCALBIN="$(mktemp -d "$WORK/pd.XXXXXX")"
+OUT_LOCALBIN="$(cd "$UNRELATED" && printf '{"tool_input":{"file_path":"%s"}}' "$OUTREPO/note.md" |
+  env BASH_ENV="$NO_MDLINT_ENV" CLAUDE_PROJECT_DIR="$OUTREPO" \
+    CLAUDE_PLUGIN_DATA="$PD_LOCALBIN" HOME="$FAKE_HOME" \
+    PATH="$FAKE_HOME/bin:$FAKE_HOME/.local/bin:$PATH" \
+    CLAUDE_PLUGIN_OPTION_MARKDOWN_FORMAT_ENABLED=true bash "$HOOK")"
+if printf '%s' "$OUT_LOCALBIN" | jq -e --arg local "$FAKE_HOME/.local/bin" --arg homebin "$FAKE_HOME/bin" '
+  (.hookSpecificOutput.additionalContext | contains($local)) and
+  ((.hookSpecificOutput.additionalContext | contains("bun install --global")) | not) and
+  ((.hookSpecificOutput.additionalContext | contains("npm i -D markdownlint-cli2")) | not)
+' >/dev/null 2>&1; then
+  ok "out-of-repo notice prefers ~/.local/bin over ~/bin"
+else
+  fail "out-of-repo ~/.local/bin preference wrong: $OUT_LOCALBIN"
+fi
+
+# No durable user-scope PATH entry: do not invent a path or recommend npm i -D.
+PD_NOTARGET="$(mktemp -d "$WORK/pd.XXXXXX")"
+OUT_NOTARGET="$(cd "$UNRELATED" && printf '{"tool_input":{"file_path":"%s"}}' "$OUTREPO/note.md" |
+  env BASH_ENV="$NO_MDLINT_ENV" CLAUDE_PROJECT_DIR="$OUTREPO" \
+    CLAUDE_PLUGIN_DATA="$PD_NOTARGET" HOME="$FAKE_HOME" \
+    PATH="$FAKE_HOME/AppData/Local/fnm_multishells/5796_x/bin:$PATH" \
+    CLAUDE_PLUGIN_OPTION_MARKDOWN_FORMAT_ENABLED=true bash "$HOOK")"
+if printf '%s' "$OUT_NOTARGET" | jq -e --arg bun "$FAKE_HOME/.bun/bin" --arg fnm "$FAKE_HOME/AppData/Local/fnm_multishells/5796_x/bin" '
+  (.hookSpecificOutput.additionalContext | contains("outside a repository")) and
+  (.hookSpecificOutput.additionalContext | contains("durable user-scope directory already on this hook")) and
+  ((.hookSpecificOutput.additionalContext | contains("npm i -D markdownlint-cli2")) | not) and
+  ((.hookSpecificOutput.additionalContext | contains($bun)) | not) and
+  ((.hookSpecificOutput.additionalContext | contains($fnm)) | not)
+' >/dev/null 2>&1; then
+  ok "out-of-repo notice without a user-scope PATH target invents none"
+else
+  fail "out-of-repo no-target remediation wrong: $OUT_NOTARGET"
+fi
 
 # --- Monorepo workspace node_modules/.bin walk (#2732) ----------------------
 # Hide PATH markdownlint; plant the shim only under packages/pkg/node_modules


### PR DESCRIPTION
Closes #2868

## Summary

The missing-`markdownlint-cli2` skip notice recommended `npm i -D markdownlint-cli2` as the reliable route even when the edited file sat outside a repository — a scratch project dir or a session scratchpad that still reaches the notice. That command has no repository to install into, and `resolve_repo_markdownlint` only accepts a shim contained under the repo root.

The notice still printed `PATH probed:` (the #2740 diagnostic) but never named a durable user-scope directory already on that PATH.

## Fix

`npm i -D markdownlint-cli2` remains the reliable route when it has a place to land: a git working tree, or a `package.json` between the file and `REPO_ROOT` (an unpacked / non-git Node project). A scratch dir with neither is not a repo-local install target; the notice says so and names a durable user-scope directory already on the probed PATH:

- only `~/.bun/bin`, `~/.local/bin`, or `~/bin` — no generic `$HOME/…` fallback
- when the chosen target is exactly bun's default `globalBinDir` (`~/.bun/bin`; [bunfig `install.globalBinDir`](https://bun.com/docs/runtime/bunfig), fetched 2026-08-21), also name `bun install --global markdownlint-cli2`

The official markdownlint-cli2 global form remains [`npm install markdownlint-cli2 --global`](https://github.com/DavidAnson/markdownlint-cli2#install) (fetched 2026-08-21); the notice never cites it (an fnm/nvm `npm i -g` is the #2748 failure mode).

`markdown-format` 0.11.22 → 0.11.23. Prior CHANGELOG headings preserved.

Review follow-up on `2d6ca483`: keep `npm i -D` for non-git + `package.json`; drop the generic PATH fallback; cite bun only for exactly `~/.bun/bin`; correct the CHANGELOG npm-global claim.

## Verification

- `bash plugins/markdown-format/hooks/markdown-format.test.sh` — **PASS=156 FAIL=0**
- In-repo missing-tool notice still contains `npm i -D markdownlint-cli2` / `is the reliable route`
- Non-git project with `package.json` still names `npm i -D`
- Out-of-repo notice names `would accept one at ~/.bun/bin` (preferring it over an earlier `fnm_multishells` entry), cites `bun install --global markdownlint-cli2`, and does **not** contain `npm i -D markdownlint-cli2`
- Out-of-repo notice prefers `~/.local/bin` over `~/bin` and does not cite bun then
- Out-of-repo notice does not name a generic mise tree or nested `~/foo/.bun/bin`
- Out-of-repo notice with only an ephemeral PATH entry invents no target and still omits `npm i -D`
- `scripts/check-changelog-parity.sh --check` / `--check-bump origin/main` / `--check-preserved origin/main` / `--check-order` — all pass (51 prior headings preserved)

## Test plan

Same evidence as Verification. The hook suite is the contract for notice wording; changelog-parity is the versioning gate.

## Related

- Follow-up to #2740 (PATH diagnostic) and #2748 (PATH-layer / version-manager invisibility). Does not widen the probe.

https://cursor.com/agents/bc-b73592b5-a134-576f-8d75-aa88906423d3