### PR TITLE
fix(link-check): exclude bot-blocked hosts and repair two dead targets

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -13,3 +13,16 @@ CLAUDE_(PLUGIN_ROOT|PLUGIN_DATA|PROJECT_DIR|SKILL_DIR)
 # Synthetic ai-briefing eval fixtures use a fictional release feed. The URLs
 # are test data for ranking/deduplication behavior, not external dependencies.
 github\.com/meridian-labs/agent-cli/releases/tag/
+
+# Product UI on claude.ai blocks automated clients: 403 even with a browser
+# User-Agent (verified 2026-08-21). Docs on code.claude.com stay checked.
+^https?://claude\.ai/
+
+# ACM Digital Library blocks automated clients outright: 403 even with a
+# browser User-Agent (verified 2026-08-21). Recurring — new DOI citations
+# keep arriving; host-level so the weekly report does not re-file the next one.
+^https?://dl\.acm\.org/
+
+# Reddit blocks automated clients: 403 even with a browser User-Agent
+# (verified 2026-08-21). Community citations stay in the docs.
+^https?://(www\.)?reddit\.com/

--- a/plugins/plugin-quality/.claude-plugin/plugin.json
+++ b/plugins/plugin-quality/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "plugin-quality",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "description": "Post-use behavioral audit of Claude Code plugin components: a six-step audit workflow (evidence capture, grounded mapping in a fresh subagent, blindspot pass, interactive contract lock, presence-gated review seams, work-item emit with draft+confirm) over any skill, agent, hook, command, or config you have actually used — zone-informed by context-guard snapshots when present, conservative when not.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/plugin-quality/CHANGELOG.md
+++ b/plugins/plugin-quality/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to the `plugin-quality` plugin.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.6]
+
+### Changed
+
+- **Hooks-reference fragment retarget (#2907).** The audit hook checklist cited
+  `code.claude.com/docs/en/hooks#exit-codes`. That heading is gone; the current parent section is
+  `#exit-code-output`. Link only — no audit-step change.
+
 ## [0.6.5]
 
 ### Changed

--- a/plugins/plugin-quality/skills/audit/references/component-types/hook.md
+++ b/plugins/plugin-quality/skills/audit/references/component-types/hook.md
@@ -15,7 +15,7 @@ PreToolUse / PostToolUse / lifecycle hook scripts. Growable — add cases as you
 - **Exit-code semantics** — PreToolUse: 0 allow, 2 block; PostToolUse: 2 shows stderr to Claude.
   Does the script use them correctly, and fail closed where blocking matters? Verify the semantics
   against the current hooks reference, not memory.
-  Verified 2026-08-12 against [Hooks reference — Exit codes](https://code.claude.com/docs/en/hooks#exit-codes).
+  Verified 2026-08-21 against [Hooks reference — Exit code output](https://code.claude.com/docs/en/hooks#exit-code-output).
   Recheck when the hooks reference changelog or the `hooks` doc page changes in a Claude Code release
   this repo's `OFFICIAL-DOCS.md` index records.
 - **Fail-open vs fail-closed** on missing deps (jq), empty/timed-out stdin, parse errors.

--- a/plugins/songwriting/.claude-plugin/plugin.json
+++ b/plugins/songwriting/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "songwriting",
-  "version": "1.4.6",
+  "version": "1.4.7",
   "description": "Songwriting craft companion — nine concern-scoped lyric-craft skills (workflow router, rhyme, object-writing, metaphor, meter-prosody, song-form, co-write, diagnose, practice) applying Pat Pattison's methods, with an object-writing agent that performs the sensory exercise itself and per-skill emission boundaries that route generation to the skill that owns it, plus Suno v5.5 prompt engineering (style prompts, tagged lyrics, genre templates, troubleshooting).",
   "author": {
     "name": "Melodic Software",

--- a/plugins/songwriting/CHANGELOG.md
+++ b/plugins/songwriting/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to the `songwriting` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [1.4.7]
+
+### Changed
+
+- **Dead first-party beat-article link (#2907).** `suno.com/hub/how-to-make-beats` now 404s. The
+  `power-tips.md` "Tag order" citation points at the April 2026 Wayback snapshot that still
+  carries the quoted hierarchy sentence. The live slug is not rewritten to a different article.
+
 ## [1.4.6]
 
 ### Changed

--- a/plugins/songwriting/skills/suno/context/power-tips.md
+++ b/plugins/songwriting/skills/suno/context/power-tips.md
@@ -20,7 +20,7 @@ Pair with `tips.md` (lyric-side performance tricks) and `lyrics.md` "Per-section
 
 Practical: if mood matters more than genre for a specific song, lead with mood. If a single instrument is the song's signature, name it before the genre. Cheap to try.
 
-**Also first-party on ordering:** [how-to-make-beats](https://suno.com/hub/how-to-make-beats), fetched 2026-08-12 — Suno *"reads prompts as structured instructions. A clear hierarchy matters … A strong prompt follows this order: tempo, genre, rhythm style, instruments, and mood."* That prescribes an ordering of descriptor **categories** and is scoped to beat-making, so it corroborates "order is meaningful" without speaking to per-tag weight.
+**Also first-party on ordering:** [how-to-make-beats](https://web.archive.org/web/20260420183956/https://suno.com/hub/how-to-make-beats) (live `suno.com/hub/how-to-make-beats` 404s as of 2026-08-21; this April 2026 snapshot still carries the quote), fetched 2026-08-12 — Suno *"reads prompts as structured instructions. A clear hierarchy matters … A strong prompt follows this order: tempo, genre, rhythm style, instruments, and mood."* That prescribes an ordering of descriptor **categories** and is scoped to beat-making, so it corroborates "order is meaningful" without speaking to per-tag weight.
 
 **Recheck trigger:** Suno documents style-prompt ordering for v5 or later, **or** an r/SunoAI thread dated to the v5.x era tests front-loading on conversational prompts, **or** a re-read finds the cited post no longer carrying its Key Insight 1. Not a date.
 


### PR DESCRIPTION
Closes #2907

## Summary

Drains the rolling link-check report. Most of the 18 errors are recurring bot-blocks (403 even with a browser User-Agent). Those go in `.lycheeignore`, not fake URL rewrites and not the standards-synced `lychee.toml`. Two errors were real content defects and are fixed in place. Plugin version bumps are the changelog-parity delivery vehicle for those two in-plugin edits.

## Fix

**Excluded** (checker-side 403; verified 2026-08-21, both lychee-like and browser User-Agents):

- `claude.ai` — product UI refuses automated clients. Docs on `code.claude.com` stay checked.
- `dl.acm.org` — ACM Digital Library refuses automated clients. Host-level so the next DOI does not re-file the weekly report. Existing per-DOI entries in `lychee.toml` remain.
- `reddit.com` — Reddit refuses automated clients. Community citations stay in the docs.

**Fixed:**

- `hooks#exit-codes` → `#exit-code-output` (the official hooks page no longer has an `#exit-codes` heading; `#exit-code-output` is the current parent section). `plugin-quality` 0.6.5 → 0.6.6.
- `suno.com/hub/how-to-make-beats` 404s live. The April 2026 Wayback snapshot still carries the quoted hierarchy sentence; the live slug is not rewritten to a different article that lacks it. `songwriting` 1.4.6 → 1.4.7.

## Test plan

- Installed lychee 0.24.2 and ran it online with `--config lychee.toml` over the ten files #2907 named: `159 Total / 126 Unique / 140 OK / 0 Errors / 19 Excluded`.
- `scripts/check-changed-skills.sh origin/main` — 2 skills checked (`plugin-quality/audit`, `songwriting/suno`), 0 failed.
- `scripts/check-changelog-parity.sh --check-bump origin/main` — pass after the 0.6.6 / 1.4.7 bumps (first push failed PUBLISHED VERSION REUSE).
- `scripts/check-changelog-parity.sh --check-preserved origin/main` — 54 headings preserved.
- `curl` confirmed 403 on `claude.ai/code`, both ACM DOIs, and the Reddit threads; 404 on the live Suno slug; 200 on the Wayback snapshot and on `code.claude.com/docs/en/hooks` with `id="exit-code-output"` present in the served HTML.

## Verification

Same evidence as the test plan.

## Related

- Closes #2907 (native closing keyword is on the first line)
- Official lychee exclude docs: https://lychee.cli.rs/recipes/excluding-links/ (`.lycheeignore` is URL-regex, not path-regex)
- `lychee.toml` is standards-synced; consumer-owned excludes belong in `.lycheeignore`