### PR TITLE
fix: silent-revert canary asserts clean-row figures and fails closed on git errors

### DIFF
--- a/scripts/check-silent-revert.sh
+++ b/scripts/check-silent-revert.sh
@@ -156,17 +156,25 @@
 # still describes a fixed corpus after main moves, which it does several times
 # a day.
 #
-# Those totals are FLOORS rather than exact counts, and the reason is
-# structural. attribute_file discards git's stderr on both commands that
-# produce a count, so a file whose diff or blame FAILED is indistinguishable
-# from one that had nothing to attribute, and the failure can only ever
-# subtract lines, never invent them (#2880). A second subtraction carries the
-# same one-way sign: paths the repository's own .gitattributes marks `-diff` or
-# `binary` produce no hunks at all, so their deletions attribute to zero on
-# every machine including CI (#2883). That one is a RECALL gap rather than a
-# calibration gap -- no path of that class appears in any commit whose figure
-# is quoted here, and the largest such deletion anywhere in the sweep was 72
-# lines from a package-lock.json, well under the threshold.
+# A completed scan's counts are exact for every path the detector can see.
+# attribute_file used to discard git's stderr on both commands that produce a
+# count, so a file whose diff or blame FAILED was indistinguishable from one
+# that had nothing to attribute, and the failure could only ever subtract
+# lines, never invent them (#2880). A non-zero status is now a hard error
+# (exit 2) rather than a quiet zero; stderr stays discarded on success so
+# expected git noise does not train anyone to ignore the canary.
+# git-diff(1) of two commits exits 0 on success even when the files differ
+# -- `--exit-code` is the option that would turn a difference into status 1
+# -- so any non-zero status here is a real failure, not "these files
+# differ". git-blame(1) has no analogous "found something" status.
+#
+# A remaining subtraction, unchanged here, is a RECALL gap: paths the
+# repository's own .gitattributes marks `-diff` or `binary` produce no hunks
+# at all, so their deletions attribute to zero on every machine including CI
+# (#2883). That one is not a calibration gap -- no path of that class
+# appears in any commit whose figure is quoted here, and the largest such
+# deletion anywhere in the sweep was 72 lines from a package-lock.json, well
+# under the threshold.
 #
 # Detection and disposition are separate steps, and only the first calibrates
 # the threshold. 6f0a31109 and 91e77fc16 are both recorded in
@@ -189,9 +197,11 @@
 #
 # The incident attributions -- 853, 451, 346 and 298 -- are re-measured on
 # every CI run, because scripts/silent-revert-incidents.txt records each one
-# and the replay asserts it exactly. The shipped replay cannot assert 447 or
-# 323: an acknowledged commit short-circuits before it is attributed, which is
-# the same step that keeps it off a reader's screen.
+# and the replay asserts it exactly. The two clean-row figures -- 195 and
+# 136 -- are asserted the same way as each row's largest sub-threshold
+# attribution (#2879). The shipped replay cannot assert 447 or 323: an
+# acknowledged commit short-circuits before it is attributed, which is the
+# same step that keeps it off a reader's screen.
 #
 # State the uncomfortable part plainly: the cleared fires and the real
 # incidents OVERLAP. The smallest true finding is 298 -- #2642's share of
@@ -572,25 +582,38 @@ attribute_file() {
   # numbers talking about the same thing. Found via #2833, whose exact-count
   # replay assertions turned a silent divergence into a red build.
   #
-  # The rename-detection exposure the note above calls load-bearing is real --
-  # `diff.renames = false` in a developer's config decomposes a `git mv` into
-  # delete + add and makes relocating a large recent file fire -- but it is the
-  # ENUMERATION in scan_commit that -M actually defends, not this diff. See the
-  # pin table above.
+# The rename-detection exposure the note above calls load-bearing is real --
+# `diff.renames = false` in a developer's config decomposes a `git mv` into
+# delete + add and makes relocating a large recent file fire -- but it is the
+# ENUMERATION in scan_commit that -M actually defends, not this diff. See the
+# pin table above.
+  #
+  # Status is checked separately from output (#2880). A failed diff used to
+  # be byte-identical to "this file had no deleted lines": stderr discarded,
+  # no @@ headers, no ranges, return 0. That is the quiet pass the header
+  # contract forbids. git-diff(1) `--exit-code` is deliberately NOT passed
+  # -- without it, two-commit diff exits 0 on success even when the files
+  # differ -- so a non-zero status here is a real failure.
+  local diff_out
+  diff_out="$(mktemp)" || die "mktemp failed"
+  run_attributing_git "$diff_out" \
+    "git diff failed attributing $file in $commit" \
+    diff --no-ext-diff --no-textconv --unified=0 --no-color \
+    --diff-algorithm=myers -M "$parent" "$commit" -- "$file"
+
   while read -r start count; do
     [[ -n "$start" ]] || continue
     [[ "$count" -gt 0 ]] || continue
     ranges+=(-L "$start,$((start + count - 1))")
   done < <(
-    git diff --no-ext-diff --no-textconv --unified=0 --no-color \
-      --diff-algorithm=myers -M "$parent" "$commit" -- "$file" 2>/dev/null |
-      awk '/^@@ /{
-             split($2, a, ",")
-             start = substr(a[1], 2) + 0
-             count = (length(a) > 1) ? a[2] + 0 : 1
-             if (start > 0) print start, count
-           }'
+    awk '/^@@ /{
+           split($2, a, ",")
+           start = substr(a[1], 2) + 0
+           count = (length(a) > 1) ? a[2] + 0 : 1
+           if (start > 0) print start, count
+         }' "$diff_out"
   )
+  rm -f "$diff_out"
 
   [[ "${#ranges[@]}" -gt 0 ]] || return 0
 
@@ -639,12 +662,46 @@ attribute_file() {
   # outright. That case owns the figures; do not restate them here.
   # --no-ext-diff is deliberately NOT here: blame accepts it but never runs an
   # external diff driver, so it would be decoration.
-  git blame --no-ignore-revs-file --no-textconv --line-porcelain \
-    "${ranges[@]}" "$parent" -- "$file" 2>/dev/null |
-    awk '
-      /^[0-9a-f]+ [0-9]+ [0-9]+/ { if (length($1) == 40) { sha = $1; next } }
-      /^\t/ { if (sha != "") printf "%s\t%s\n", sha, substr($0, 2) }
-    '
+  #
+  # Same fail-closed contract as the diff above (#2880). git-blame(1) exits 0
+  # on success and a fatal status (typically 128) on error -- there is no
+  # `--exit-code` analogue that would make "lines were attributed" a
+  # non-zero success. Stderr stays discarded on success.
+  local blame_out
+  blame_out="$(mktemp)" || die "mktemp failed"
+  run_attributing_git "$blame_out" \
+    "git blame failed attributing $file at $parent" \
+    blame --no-ignore-revs-file --no-textconv --line-porcelain \
+    "${ranges[@]}" "$parent" -- "$file"
+  awk '
+    /^[0-9a-f]+ [0-9]+ [0-9]+/ { if (length($1) == 40) { sha = $1; next } }
+    /^\t/ { if (sha != "") printf "%s\t%s\n", sha, substr($0, 2) }
+  ' "$blame_out"
+  rm -f "$blame_out"
+}
+
+# run_attributing_git <stdout-file> <fail-label> <git-args...>
+#
+# Runs `git <args>` with stdout in the file and stderr discarded on
+# success. A non-zero status is exit 2 ("the canary could not run"), and
+# the captured stderr is attached to the die message so the failure has a
+# distinct signature from "this file had nothing to attribute" (#2880).
+#
+# Call it as a statement, never through a pipe: `die` inside a pipeline
+# lands in a subshell and would be swallowed back into a quiet zero.
+run_attributing_git() {
+  local out_file="$1" what="$2"
+  shift 2
+  local err_file rc=0
+  err_file="$(mktemp)" || die "mktemp failed"
+  git "$@" >"$out_file" 2>"$err_file" || rc=$?
+  if [[ "$rc" -ne 0 ]]; then
+    local err
+    err="$(cat "$err_file")"
+    rm -f "$err_file"
+    die "$what (exit $rc): ${err:-no stderr}"
+  fi
+  rm -f "$err_file"
 }
 
 # ---------------------------------------------------------------------------
@@ -693,16 +750,24 @@ scan_commit() {
   fi
 
   # Attribute every deleted line across every modified/deleted file.
-  local attributed
+  #
+  # Redirect, never a pipe: `die` inside attribute_file must not land in a
+  # subshell. A piped failure used to be byte-identical to "this file had
+  # nothing to attribute" (#2880).
+  local attributed file_attr
   attributed="$(mktemp)" || die "mktemp failed"
+  file_attr="$(mktemp)" || die "mktemp failed"
   local file
   while IFS= read -r -d '' file; do
-    attribute_file "$parent" "$sha" "$file" |
-      awk -v f="$file" -F '\t' '{printf "%s\t%s\t%s\n", $1, f, $2}' >>"$attributed"
+    : >"$file_attr"
+    attribute_file "$parent" "$sha" "$file" >"$file_attr"
+    awk -v f="$file" -F '\t' '{printf "%s\t%s\t%s\n", $1, f, $2}' \
+      "$file_attr" >>"$attributed"
     # -M pinned here for the same reason as in attribute_file: the enumeration
     # relies on a rename reporting as R so --diff-filter=MD skips it, and that
     # is git's default only until someone sets diff.renames = false.
   done < <(git diff --name-only -z -M --diff-filter=MD "$parent" "$sha")
+  rm -f "$file_attr"
 
   # Keep only lines whose culprit is inside the recency window.
   local in_window
@@ -710,6 +775,16 @@ scan_commit() {
   if [[ -s "$attributed" ]]; then
     awk -F '\t' 'NR == FNR { w[$1] = 1; next } ($1 in w)' \
       "$window_file" "$attributed" >"$in_window"
+  fi
+
+  # ATTRIBUTION_SINK records every in-window culprit, including those
+  # below the threshold. FINDINGS_SINK (written by report_finding) stays
+  # threshold-filtered -- that is what a `fires` row asserts. A `clean`
+  # row asserts the largest remaining attribution (#2879), which lives
+  # here and nowhere else.
+  if [[ -n "${ATTRIBUTION_SINK:-}" ]]; then
+    awk -F '\t' '{c[$1]++} END {for (k in c) print k, c[k]}' \
+      "$in_window" >>"$ATTRIBUTION_SINK"
   fi
 
   local findings=0 culprit count
@@ -819,6 +894,24 @@ report_finding() {
 # exit 2 (cannot run), never a FAIL and never a pass: an expectation silently
 # misread is the same false-green this whole file exists to remove.
 #
+# WHAT A `clean` ROW ACTUALLY ASSERTS (#2879)
+# ------------------------------------------
+# Exit status alone proves only "this commit still produces no finding
+# above the threshold". The note beside it names a specific culprit and a
+# specific sub-threshold line count -- the closest miss, the figure a
+# threshold change would trip first -- and nothing used to check that
+# number. Pinning the detector's diff flags moved 129 to 136 on this
+# file's previous closest-miss row; the `fires` sibling of that drift
+# went red and was corrected, the `clean` row stayed green.
+#
+# So a `clean` row may carry the same bracketed field. The replay then
+# asserts the run's largest *in-window, sub-threshold* attribution is
+# EXACTLY that set -- same culprit, same count. The row's pass/fail
+# does not change: nothing above the threshold is still what makes it
+# clean. The field only checks the number the note treats as measured
+# fact. Ties (two culprits at the same max) must all be listed, the
+# same extras-and-omissions rule the fires path uses.
+#
 # Do NOT loosen a count to a minimum or a tolerance to make CI pass. If a
 # number legitimately changes, measure the new one and record it with the
 # reason -- that is a decision, not a threshold.
@@ -862,13 +955,41 @@ parse_attribution_field() {
   done
 }
 
+# Keep the largest in-window attribution(s) from a `<sha> <count>` file.
+# Ties (same max count, different culprits) are all kept, so a recorded
+# field that names only one of two equal maxima fails the exact-set
+# compare. An empty file yields empty output: a recorded field then
+# fails the compare rather than matching by accident.
+#
+# Call it with a plain redirect, never through a pipe -- the same
+# discipline parse_attribution_field documents.
+largest_attributions() {
+  local src="$1"
+  awk '
+    {
+      n = $2 + 0
+      if (n > max) {
+        max = n
+        delete keep
+        keep[$1] = n
+      } else if (n == max && max > 0) {
+        keep[$1] = n
+      }
+    }
+    END {
+      for (s in keep) print s, keep[s]
+    }
+  ' "$src"
+}
+
 verify_known_incidents() {
   [[ -f "$INCIDENTS_FILE" ]] || die "incident file not found: $INCIDENTS_FILE"
 
   local rc=0 expect sha rest note attribution
-  local expected_file observed_file verified=0
+  local expected_file observed_file all_attr_file verified=0
   expected_file="$(mktemp)" || die "mktemp failed"
   observed_file="$(mktemp)" || die "mktemp failed"
+  all_attr_file="$(mktemp)" || die "mktemp failed"
 
   # `read` returns non-zero at EOF even when it populated the variables, so a
   # final line with no trailing newline would otherwise never enter the body
@@ -911,16 +1032,31 @@ verify_known_incidents() {
 
     : >"$expected_file"
     if [[ -n "$attribution" ]]; then
-      [[ "$expect" = "fires" ]] ||
-        die "row for $sha in $INCIDENTS_FILE records an attribution on a '$expect' row; only 'fires' rows have findings"
+      case "$expect" in
+        fires | clean) ;;
+        *)
+          die "row for $sha in $INCIDENTS_FILE records an attribution on a '$expect' row; only 'fires' and 'clean' rows may carry one"
+          ;;
+      esac
       parse_attribution_field "$attribution" >"$expected_file"
       sort -o "$expected_file" "$expected_file"
     fi
 
     local out status
     : >"$observed_file"
-    out="$(FINDINGS_SINK="$observed_file" scan_commit "$sha" 2>&1)"
+    : >"$all_attr_file"
+    out="$(FINDINGS_SINK="$observed_file" ATTRIBUTION_SINK="$all_attr_file" \
+      scan_commit "$sha" 2>&1)"
     status=$?
+    # A scan that could not run (exit 2) is not a row FAIL and not a
+    # pass. Treating it as either would turn a blame/diff failure into
+    # "the canary reproduced the incidents" or "the row was wrong" --
+    # the quiet-success path #2880 closes, reached from the replay.
+    if [[ "$status" -eq 2 ]]; then
+      printf '%s\n' "$out"
+      rm -f "$expected_file" "$observed_file" "$all_attr_file"
+      die "scan of $sha could not run"
+    fi
     sort -o "$observed_file" "$observed_file"
 
     case "$expect" in
@@ -946,19 +1082,35 @@ verify_known_incidents() {
         fi
         ;;
       clean)
-        if [[ "$status" -eq 0 ]]; then
-          printf 'ok   %s stays clean as recorded  (%s)\n' "${sha:0:9}" "$note"
-        else
+        if [[ "$status" -ne 0 ]]; then
           printf 'FAIL %s should stay clean and fired  (%s)\n' "${sha:0:9}" "$note"
           printf '%s\n' "$out"
           rc=1
+        elif [[ -n "$attribution" ]]; then
+          largest_attributions "$all_attr_file" >"$observed_file"
+          sort -o "$observed_file" "$observed_file"
+          if ! cmp -s "$expected_file" "$observed_file"; then
+            printf 'FAIL %s stays clean, but NOT as recorded  (%s)\n' "${sha:0:9}" "$note"
+            printf '     recorded largest sub-threshold attribution:\n'
+            sed 's/^/       /' "$expected_file"
+            printf '     what the detector reported:\n'
+            sed 's/^/       /' "$observed_file"
+            printf '     A clean row whose figure has moved is not a reproduction.\n'
+            printf '     Do NOT edit the row to match; find out why the attribution moved.\n'
+            rc=1
+          else
+            printf 'ok   %s stays clean as recorded, largest sub-threshold attribution reproduced exactly  (%s)\n' \
+              "${sha:0:9}" "$note"
+          fi
+        else
+          printf 'ok   %s stays clean as recorded  (%s)\n' "${sha:0:9}" "$note"
         fi
         ;;
       *) die "unknown expectation '$expect' in $INCIDENTS_FILE" ;;
     esac
   done <"$INCIDENTS_FILE"
 
-  rm -f "$expected_file" "$observed_file"
+  rm -f "$expected_file" "$observed_file" "$all_attr_file"
 
   # Zero rows verified is a broken input, not a pass. An empty file, a
   # comments-only file, or a file whose only row was dropped by a missing

--- a/scripts/check-silent-revert.sh
+++ b/scripts/check-silent-revert.sh
@@ -582,11 +582,11 @@ attribute_file() {
   # numbers talking about the same thing. Found via #2833, whose exact-count
   # replay assertions turned a silent divergence into a red build.
   #
-# The rename-detection exposure the note above calls load-bearing is real --
-# `diff.renames = false` in a developer's config decomposes a `git mv` into
-# delete + add and makes relocating a large recent file fire -- but it is the
-# ENUMERATION in scan_commit that -M actually defends, not this diff. See the
-# pin table above.
+  # The rename-detection exposure the note above calls load-bearing is real --
+  # `diff.renames = false` in a developer's config decomposes a `git mv` into
+  # delete + add and makes relocating a large recent file fire -- but it is the
+  # ENUMERATION in scan_commit that -M actually defends, not this diff. See the
+  # pin table above.
   #
   # Status is checked separately from output (#2880). A failed diff used to
   # be byte-identical to "this file had no deleted lines": stderr discarded,
@@ -754,9 +754,18 @@ scan_commit() {
   # Redirect, never a pipe: `die` inside attribute_file must not land in a
   # subshell. A piped failure used to be byte-identical to "this file had
   # nothing to attribute" (#2880).
-  local attributed file_attr
+  #
+  # The enumeration diff is the same contract. A failed `git diff --name-only`
+  # used to feed the loop nothing (process substitution discards status),
+  # so scan_commit reported `ok` -- the quiet pass, reached before
+  # attribute_file ever ran.
+  local attributed file_attr enum_list
   attributed="$(mktemp)" || die "mktemp failed"
   file_attr="$(mktemp)" || die "mktemp failed"
+  enum_list="$(mktemp)" || die "mktemp failed"
+  run_attributing_git "$enum_list" \
+    "git diff --name-only failed enumerating $sha" \
+    diff --name-only -z -M --diff-filter=MD "$parent" "$sha"
   local file
   while IFS= read -r -d '' file; do
     : >"$file_attr"
@@ -766,8 +775,8 @@ scan_commit() {
     # -M pinned here for the same reason as in attribute_file: the enumeration
     # relies on a rename reporting as R so --diff-filter=MD skips it, and that
     # is git's default only until someone sets diff.renames = false.
-  done < <(git diff --name-only -z -M --diff-filter=MD "$parent" "$sha")
-  rm -f "$file_attr"
+  done <"$enum_list"
+  rm -f "$file_attr" "$enum_list"
 
   # Keep only lines whose culprit is inside the recency window.
   local in_window

--- a/scripts/check-silent-revert.test.sh
+++ b/scripts/check-silent-revert.test.sh
@@ -1115,16 +1115,17 @@ t_replay_asserts_the_recorded_attribution() {
     fi
   done
 
-  # An attribution on a `clean` row is nonsense -- clean rows have no findings.
-  printf 'clean %s [%s=40] attribution on a clean row\n' "$sha" "$culprit" \
+  # A `fires` commit labeled `clean` still fails on status -- the new
+  # attribution field does not change pass/fail semantics (#2879).
+  printf 'clean %s [%s=40] attribution on a firing commit\n' "$sha" "$culprit" \
     >"$repo/scripts/inc.txt"
   SILENT_REVERT_THRESHOLD=20 SILENT_REVERT_INCIDENTS=scripts/inc.txt \
     run_canary "$repo" --verify-known-incidents
   out="$OUT"
-  if [[ "$RC" -eq 2 ]]; then
-    ok "an attribution recorded on a 'clean' row exits 2"
+  if [[ "$RC" -eq 1 ]] && printf '%s' "$out" | grep -q 'should stay clean and fired'; then
+    ok "a firing commit labeled clean still fails on status, attribution or not"
   else
-    fail "expected rc=2 for an attribution on a clean row, got rc=$RC: $out"
+    fail "expected rc=1 for a firing commit on a clean row, got rc=$RC: $out"
   fi
 
   # And a `fires` row with no attribution keeps working -- the field is optional
@@ -1137,6 +1138,154 @@ t_replay_asserts_the_recorded_attribution() {
     ok "a fires row with no attribution field still replays on exit status alone"
   else
     fail "an attribution-less row must still work, rc=$RC: $out"
+  fi
+}
+
+# A `clean` row's note names a specific sub-threshold count. Without a
+# field to assert it, that figure rots silently -- 129 drifted to 136
+# on the corpus's previous closest miss and the row stayed green (#2879).
+t_replay_asserts_clean_row_attribution() {
+  local repo out culprit other sha
+  repo="$(mk_repo)"
+  add_block "$repo" feature.txt 15 alpha
+  culprit="$(git -C "$repo" rev-parse HEAD)"
+  other="$(git -C "$repo" rev-parse HEAD~1)"
+  drop_block "$repo" feature.txt alpha "docs: ordinary iteration (#99)"
+  sha="$(git -C "$repo" rev-parse HEAD)"
+
+  # True culprit and true count, under the threshold: the row stays clean
+  # AND the figure is checked.
+  printf 'clean %s [%s=15] closest miss\n' "$sha" "$culprit" >"$repo/scripts/inc.txt"
+  SILENT_REVERT_THRESHOLD=20 SILENT_REVERT_INCIDENTS=scripts/inc.txt \
+    run_canary "$repo" --verify-known-incidents
+  out="$OUT"
+  if [[ "$RC" -eq 0 ]] && printf '%s' "$out" | grep -q 'largest sub-threshold attribution reproduced exactly'; then
+    ok "replay passes when a clean row's largest sub-threshold attribution reproduces"
+  else
+    fail "clean-row attribution should have passed, rc=$RC: $out"
+  fi
+
+  # Right culprit, WRONG count -- the 129 -> 136 shape.
+  printf 'clean %s [%s=14] stale count\n' "$sha" "$culprit" >"$repo/scripts/inc.txt"
+  SILENT_REVERT_THRESHOLD=20 SILENT_REVERT_INCIDENTS=scripts/inc.txt \
+    run_canary "$repo" --verify-known-incidents
+  out="$OUT"
+  if [[ "$RC" -eq 1 ]] && printf '%s' "$out" | grep -q 'stays clean, but NOT as recorded'; then
+    ok "replay fails when a clean row's recorded line count no longer reproduces"
+  else
+    fail "a wrong clean-row count must fail the replay, rc=$RC: $out"
+  fi
+
+  # Right count, WRONG culprit.
+  printf 'clean %s [%s=15] wrong culprit\n' "$sha" "$other" >"$repo/scripts/inc.txt"
+  SILENT_REVERT_THRESHOLD=20 SILENT_REVERT_INCIDENTS=scripts/inc.txt \
+    run_canary "$repo" --verify-known-incidents
+  out="$OUT"
+  if [[ "$RC" -eq 1 ]] && printf '%s' "$out" | grep -q 'stays clean, but NOT as recorded'; then
+    ok "replay fails when a clean row's figure is attributed to a different culprit"
+  else
+    fail "a wrong clean-row culprit must fail the replay, rc=$RC: $out"
+  fi
+
+  # A clean row with no field still replays on exit status alone -- the
+  # field is optional so a row can be pinned before its attribution is
+  # measured.
+  printf 'clean %s no attribution recorded\n' "$sha" >"$repo/scripts/inc.txt"
+  SILENT_REVERT_THRESHOLD=20 SILENT_REVERT_INCIDENTS=scripts/inc.txt \
+    run_canary "$repo" --verify-known-incidents
+  out="$OUT"
+  if [[ "$RC" -eq 0 ]] && printf '%s' "$out" | grep -q 'stays clean as recorded'; then
+    ok "a clean row with no attribution field still replays on exit status alone"
+  else
+    fail "an attribution-less clean row must still work, rc=$RC: $out"
+  fi
+}
+
+# A failed diff or blame used to be indistinguishable from "this file had
+# nothing to attribute": stderr discarded, empty output, return 0. That
+# is the quiet pass the header contract forbids (#2880).
+t_attribute_file_git_failure_is_exit_2() {
+  local repo real_git shimdir sha out
+  repo="$(mk_repo)"
+  add_block "$repo" feature.txt 40 alpha
+  drop_block "$repo" feature.txt alpha "feat: drop (#99)"
+  sha="$(git -C "$repo" rev-parse HEAD)"
+
+  real_git="$(command -v git)"
+  shimdir="$(mktemp -d)"
+  TMPDIRS+=("$shimdir")
+  cat >"$shimdir/git" <<EOF
+#!/usr/bin/env bash
+real_git=$(printf '%q' "$real_git")
+if [[ "\${CANARY_INJECT_BLAME_FAIL:-}" == 1 && "\$1" == blame ]]; then
+  echo "fatal: injected blame failure" >&2
+  exit 128
+fi
+if [[ "\${CANARY_INJECT_DIFF_FAIL:-}" == 1 && "\$1" == diff ]]; then
+  for a in "\$@"; do
+    if [[ "\$a" == --unified=0 ]]; then
+      echo "fatal: injected diff failure" >&2
+      exit 128
+    fi
+  done
+fi
+if [[ "\${CANARY_INJECT_GIT_WARN:-}" == 1 ]]; then
+  if [[ "\$1" == blame ]]; then
+    echo "warning: injected git noise that must not leak" >&2
+  elif [[ "\$1" == diff ]]; then
+    for a in "\$@"; do
+      if [[ "\$a" == --unified=0 ]]; then
+        echo "warning: injected git noise that must not leak" >&2
+        break
+      fi
+    done
+  fi
+fi
+exec "\$real_git" "\$@"
+EOF
+  chmod +x "$shimdir/git"
+
+  CANARY_INJECT_BLAME_FAIL=1 PATH="$shimdir:$PATH" \
+    SILENT_REVERT_THRESHOLD=20 run_canary "$repo" --commit HEAD
+  out="$OUT"
+  if [[ "$RC" -eq 2 ]] && printf '%s' "$out" | grep -q 'git blame failed attributing'; then
+    ok "a failed blame is exit 2, not a quiet zero-attribution pass"
+  else
+    fail "expected rc=2 on injected blame failure, rc=$RC: $out"
+  fi
+
+  CANARY_INJECT_DIFF_FAIL=1 PATH="$shimdir:$PATH" \
+    SILENT_REVERT_THRESHOLD=20 run_canary "$repo" --commit HEAD
+  out="$OUT"
+  if [[ "$RC" -eq 2 ]] && printf '%s' "$out" | grep -q 'git diff failed attributing'; then
+    ok "a failed content diff is exit 2, not a quiet zero-attribution pass"
+  else
+    fail "expected rc=2 on injected diff failure, rc=$RC: $out"
+  fi
+
+  # The same failure, reached through the replay, must stay exit 2 -- not
+  # degrade into a row FAIL (exit 1) or a green reproduction.
+  printf 'fires %s [%s=40] a real drop\n' "$sha" "$(git -C "$repo" rev-parse HEAD~1)" \
+    >"$repo/scripts/inc.txt"
+  CANARY_INJECT_BLAME_FAIL=1 PATH="$shimdir:$PATH" \
+    SILENT_REVERT_THRESHOLD=20 SILENT_REVERT_INCIDENTS=scripts/inc.txt \
+    run_canary "$repo" --verify-known-incidents
+  out="$OUT"
+  if [[ "$RC" -eq 2 ]] && printf '%s' "$out" | grep -q 'could not run'; then
+    ok "a failed blame during replay is exit 2, not a row FAIL or a pass"
+  else
+    fail "expected rc=2 on injected blame failure in replay, rc=$RC: $out"
+  fi
+
+  # Success still discards git stderr -- un-suppressing wholesale would
+  # train readers to ignore the canary.
+  CANARY_INJECT_GIT_WARN=1 PATH="$shimdir:$PATH" \
+    SILENT_REVERT_THRESHOLD=20 run_canary "$repo" --commit HEAD
+  out="$OUT"
+  if [[ "$RC" -eq 1 ]] && ! printf '%s' "$out" | grep -q 'injected git noise'; then
+    ok "successful attribution still discards git stderr"
+  else
+    fail "git stderr leaked on success, or the finding disappeared, rc=$RC: $out"
   fi
 }
 
@@ -1829,6 +1978,23 @@ t_shipped_data_files_are_wellformed() {
     fail "a shipped fires row is missing or has a malformed [<sha>=<lines>] attribution field"
   fi
 
+  # Same pin for `clean` rows (#2879). The field is optional in the grammar
+  # so a row can be recorded before its figure is measured, but every
+  # shipped clean row must carry one -- otherwise the note's number is
+  # prose again and the next flag pin rots it silently.
+  local clean_rows
+  clean_rows="$(grep -cE '^clean[[:space:]]' "$inc")"
+  bad=0
+  [[ "$clean_rows" -ge 1 ]] || bad=1
+  grep -E '^clean[[:space:]]' "$inc" |
+    grep -qvE '^clean[[:space:]]+[0-9a-f]{40}[[:space:]]+\[[0-9a-f]{40}=[0-9]+(,[0-9a-f]{40}=[0-9]+)*\][[:space:]]' &&
+    bad=1
+  if [[ "$bad" -eq 0 ]]; then
+    ok "every shipped clean row carries a well-formed attribution field ($clean_rows rows)"
+  else
+    fail "a shipped clean row is missing or has a malformed [<sha>=<lines>] attribution field"
+  fi
+
   # Every shipped `fires` row must carry at least one marker (#2855).
   #
   # --verify-restoration enforces this at run time too, but only in the canary
@@ -1901,6 +2067,8 @@ t_root_commit_is_handled
 t_empty_range_is_clean
 t_replay_fails_on_broken_expectation
 t_replay_asserts_the_recorded_attribution
+t_replay_asserts_clean_row_attribution
+t_attribute_file_git_failure_is_exit_2
 t_replay_refuses_a_zero_row_or_truncated_file
 t_restoration_reports_present_and_absent_markers
 t_restoration_refuses_a_malformed_corpus

--- a/scripts/check-silent-revert.test.sh
+++ b/scripts/check-silent-revert.test.sh
@@ -405,7 +405,11 @@ t_rename_pin_is_load_bearing() {
   cfg="$repo/no-renames-gitconfig"
   printf '[diff]\n\trenames = false\n' >"$cfg"
 
-  strip_pin "$repo" no-rename-pin '/git diff/ s/ -M / /g' || return 0
+  # The load-bearing -M is on the --name-only enumeration, now invoked
+  # through run_attributing_git so a failed status cannot hide in a
+  # process substitution (#2880). Address that argv line, not a `git diff`
+  # spelling -- the content-diff -M is inert (pathspec-limited).
+  strip_pin "$repo" no-rename-pin '/--name-only/ s/ -M / /g' || return 0
 
   GIT_CONFIG_GLOBAL="$cfg" run_canary "$repo" --commit HEAD
   intact_rc="$RC"
@@ -1232,6 +1236,14 @@ if [[ "\${CANARY_INJECT_DIFF_FAIL:-}" == 1 && "\$1" == diff ]]; then
     fi
   done
 fi
+if [[ "\${CANARY_INJECT_ENUM_FAIL:-}" == 1 && "\$1" == diff ]]; then
+  for a in "\$@"; do
+    if [[ "\$a" == --name-only ]]; then
+      echo "fatal: injected enumeration failure" >&2
+      exit 128
+    fi
+  done
+fi
 if [[ "\${CANARY_INJECT_GIT_WARN:-}" == 1 ]]; then
   if [[ "\$1" == blame ]]; then
     echo "warning: injected git noise that must not leak" >&2
@@ -1264,6 +1276,17 @@ EOF
     ok "a failed content diff is exit 2, not a quiet zero-attribution pass"
   else
     fail "expected rc=2 on injected diff failure, rc=$RC: $out"
+  fi
+
+  # The enumeration path is the same quiet-pass: a failed --name-only used
+  # to feed the loop nothing and report `ok` before attribute_file ran.
+  CANARY_INJECT_ENUM_FAIL=1 PATH="$shimdir:$PATH" \
+    SILENT_REVERT_THRESHOLD=20 run_canary "$repo" --commit HEAD
+  out="$OUT"
+  if [[ "$RC" -eq 2 ]] && printf '%s' "$out" | grep -q 'git diff --name-only failed enumerating'; then
+    ok "a failed file-enumeration diff is exit 2, not a quiet ok"
+  else
+    fail "expected rc=2 on injected enumeration failure, rc=$RC: $out"
   fi
 
   # The same failure, reached through the replay, must stay exit 2 -- not

--- a/scripts/check-silent-revert.test.sh
+++ b/scripts/check-silent-revert.test.sh
@@ -557,8 +557,11 @@ t_textconv_pin_is_load_bearing() {
   fi
 
   strip_pin "$repo" no-textconv-pin 's/ --no-textconv//g' || return 0
-  strip_pin "$repo" blame-textconv-unpinned '/git blame/ s/ --no-textconv//' || return 0
-  strip_pin "$repo" diff-textconv-unpinned '/git diff --no-ext-diff/,+1 s/ --no-textconv//' || return 0
+  # These address the run_attributing_git argv lines, not a `git blame` /
+  # `git diff` spelling -- the detector now invokes both through a helper
+  # so a failed status cannot hide in a pipe (#2880).
+  strip_pin "$repo" blame-textconv-unpinned '/blame --no-ignore-revs-file/ s/ --no-textconv//' || return 0
+  strip_pin "$repo" diff-textconv-unpinned '/diff --no-ext-diff/ s/ --no-textconv//' || return 0
 
   clean_sink="$(mktemp)"
   intact_sink="$(mktemp)"

--- a/scripts/silent-revert-incidents.txt
+++ b/scripts/silent-revert-incidents.txt
@@ -35,6 +35,14 @@
 # measured -- but every `fires` row below carries one, and a malformed field is
 # exit 2 rather than a failure or a pass.
 #
+# A `clean` row may carry the same field. There it records the row's
+# largest *sub-threshold* in-window attribution, and the replay asserts
+# that exact culprit and count (#2879). The row is still clean because
+# nothing crossed the threshold; the field only checks the number the
+# note treats as measured fact. Without it, pinning the detector's diff
+# flags moved 129 to 136 on this file's previous closest-miss row and
+# nothing went red.
+#
 # Every count is a BLAME ATTRIBUTION: the number of lines the reverting squash
 # deleted that `git blame` credits to that one culprit. Not the squash's
 # diffstat, and not what the culprit itself added.
@@ -190,30 +198,29 @@ marker cc58cbc53fbbb2cca68e071507b82d3e3ff896ff plugins/repo-fleet-hygiene/skill
 marker cc58cbc53fbbb2cca68e071507b82d3e3ff896ff plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.sh gql_page_end=$((gql_page_start + MERGED_PR_GRAPHQL_ALIAS_PAGE))
 
 # --- Verified-legitimate commits that must stay quiet -------------------------
-# Neither figure in this section is asserted by the replay. A `clean` row's
-# assertion is the ABSENCE of findings, so it carries no bracketed attribution
-# field for a count to live in (#2879) -- the numbers below are hand-measured
-# prose, and the first row's previous occupant drifting from a recorded 129 to
-# a measured 136 without anything going red is exactly that gap. Re-measure
-# before trusting either number.
+# A `clean` row's pass/fail is still the ABSENCE of a finding above the
+# threshold. The bracketed field is a different assertion (#2879): it
+# records the row's largest sub-threshold in-window attribution, and the
+# replay demands that exact culprit and count. The numbers below are
+# therefore no longer hand-measured prose. A completed scan is an exact
+# count for every path the detector can see -- a diff or blame that fails
+# is now exit 2 rather than a silently dropped file (#2880).
 #
 # The closest sub-threshold miss in 500 commits, re-measured at the pinned git
-# invocations (#2843): no fewer than 195 lines -- a floor rather than an exact
-# count, because attribute_file drops git blame's stderr (#2880), so any line
-# blame fails on is silently not counted -- of Pat Pattison research text that
+# invocations (#2843): 195 lines of Pat Pattison research text that
 # #2183 had just restored, rewritten by #2189's follow-up chapter-audit pass
 # five lines short of the 200-line threshold. Ordinary iteration on very
 # recent work. If a threshold change ever makes this fire, the canary has
 # started taxing normal development.
-clean 9a2307c431ad22b2e8f758976109bf4e59010d6b feat(songwriting) rewrote 195 lines of research text #2183 had just restored
+clean 9a2307c431ad22b2e8f758976109bf4e59010d6b [3584ae1fa00ec73208ccbc2725674607b1c0d1d6=195] feat(songwriting) rewrote 195 lines of research text #2183 had just restored
 
 # The previously pinned closest miss, kept as a second verified-quiet guard --
-# four other corpus commits score between it and the row above: no fewer than
-# 136 lines (the same #2880 floor), 109 of them the persist-findings context
-# doc that #2715 (squash commit 6370a44e7) had just added, rewritten 26
-# minutes later by #2737's crosswalk hardening. An earlier version of this row
-# credited the content to #2679, which is a closed issue in this repo, not a
-# pull request; the commit's own body names the work it builds on ("Builds on
-# merged #2715 → #2692 → #2690; rebased onto `main`") and the blamed lines
-# trace to the commit that landed #2715.
-clean c8470efd09d78d924a962483ff8a0b7809180e11 docs(conventions) rewrote 136 lines of a doc #2715 had just added
+# four other corpus commits score between it and the row above: 136 lines,
+# 109 of them the persist-findings context doc that #2715 (squash commit
+# 6370a44e7) had just added, rewritten 26 minutes later by #2737's
+# crosswalk hardening. An earlier version of this row credited the content
+# to #2679, which is a closed issue in this repo, not a pull request; the
+# commit's own body names the work it builds on ("Builds on merged #2715 →
+# #2692 → #2690; rebased onto `main`") and the blamed lines trace to the
+# commit that landed #2715.
+clean c8470efd09d78d924a962483ff8a0b7809180e11 [6370a44e75986a12ec2a79a2e8deec39558f6f53=136] docs(conventions) rewrote 136 lines of a doc #2715 had just added


### PR DESCRIPTION
Closes #2879
Closes #2880

## Summary

The silent-revert canary's `clean` rows named a specific sub-threshold line count in their notes, but the grammar rejected an attribution field on those rows, so the figure was prose. Pinning the detector's diff flags moved 129 to 136 on the previous closest-miss row and nothing went red. Independently, `attribute_file` discarded git stderr on both commands that produce a count, so a failed diff or blame was byte-identical to "this file had nothing to attribute" and every corpus figure was a lower bound.

## Fix

In `scripts/check-silent-revert.sh`:

- A `clean` row may carry the same bracketed `[<sha>=<n>]` field a `fires` row does. The replay asserts the run's largest in-window sub-threshold attribution is exactly that set. The row's pass/fail is unchanged: nothing above the threshold is still what makes it clean.
- `attribute_file` checks git diff/blame status separately from output. A non-zero status is exit 2 ("the canary could not run") with the captured stderr on the die message. Successful runs still discard stderr. `git-diff(1)` of two commits exits 0 on success even when the files differ (`--exit-code` is what would turn a difference into status 1), so any non-zero status here is a real failure. `git-blame(1)` has no analogous "found something" status.
- `attribute_file` is no longer piped into awk, so `die` cannot land in a subshell and be swallowed back into a quiet zero.

The two shipped clean rows now record their measured maxima: `3584ae1fa…=195` on `9a2307c43` and `6370a44e7…=136` on `c8470efd0`.

Not in scope: `-diff`/`binary` paths (#2883) and `diff.renameLimit` (#2884).

## Verification

- `bash scripts/check-silent-revert.test.sh` — 121 passed, 0 failed
- `bash scripts/check-silent-revert.sh --verify-known-incidents` — both clean rows print `largest sub-threshold attribution reproduced exactly`
- `bash scripts/check-silent-revert.sh --verify-restoration` — 7 markers present
- `shellcheck -x scripts/check-silent-revert.sh scripts/check-silent-revert.test.sh` — clean
- New coverage:
  - a clean row whose recorded count or culprit has moved fails (`stays clean, but NOT as recorded`) — the 129 → 136 shape
  - a firing commit labeled clean still fails on status
  - a failed blame or content diff is exit 2, including when reached through the replay
  - successful attribution still discards git stderr
  - every shipped clean row carries a well-formed attribution field

## Related

Refs #2833 (why the attribution field exists on `fires` rows).
Refs #2843 (pinned diff/blame flags that moved the unasserted clean-row figure).
Refs #2874 / #2875 (reader defects just merged; this PR starts from that main).
Refs #2883 (recall gap for `-diff`/`binary` paths — not this PR).
Refs #2884 (`diff.renameLimit` — not this PR).
Refs #2808 (canary and incident corpus).