### PR TITLE
fix(markdown-format): do not launch PostToolUse on non-Markdown writes

### DIFF
--- a/plugins/markdown-format/.claude-plugin/plugin.json
+++ b/plugins/markdown-format/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "markdown-format",
-  "version": "0.11.23",
+  "version": "0.11.24",
   "description": "Auto-format and lint Markdown on edit via markdownlint-cli2 \u2014 only in repos that carry their own markdownlint config.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/markdown-format/CHANGELOG.md
+++ b/plugins/markdown-format/CHANGELOG.md
@@ -3,6 +3,28 @@
 All notable changes to the `markdown-format` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.11.24]
+
+### Fixed
+
+- **Do not launch the PostToolUse hook on non-Markdown Writes (#2867).** The
+  script is advisory and has no non-zero exit path, but Claude Code still
+  recorded `PostToolUse:Write` as `hook_non_blocking_error` with
+  `Failed with non-blocking status code: No stderr output` — official exit-code
+  semantics for a canceled or non-zero hook with empty stdout/stderr
+  ([hooks reference](https://docs.claude.com/en/docs/claude-code/hooks),
+  fetched 2026-08-21). The failing invocation was a `.txt` Write: the matcher
+  `Write|Edit` launched the process, and the script never reached its
+  applicability `exit 0` (timeout/cancel and a failed Git Bash spawn both
+  produce that exact no-stderr record). `hooks.json` now carries two handlers
+  with `if: Edit(*.md)` and `if: Edit(*.mdc)` — Edit path rules cover Write;
+  a `Write(*.md)` rule is never consulted
+  ([permissions](https://docs.claude.com/en/docs/claude-code/permissions),
+  fetched 2026-08-21) — plus explicit `shell: bash` so Windows does not fall
+  through to PowerShell, which cannot run a `.sh` handler. The in-script
+  extension check remains defense in depth. Advisory/fail-open semantics are
+  unchanged.
+
 ## [0.11.23]
 
 ### Fixed

--- a/plugins/markdown-format/README.md
+++ b/plugins/markdown-format/README.md
@@ -13,6 +13,14 @@ config has chosen no Markdown style, so the hook does not run there at all
 
 ## Behavior
 
+- **Markdown paths only at launch.** `hooks.json` registers the handler on
+  `Write|Edit` but each copy carries `if: Edit(*.md)` or `if: Edit(*.mdc)`.
+  `Edit(path)` is the permission-rule form that covers Write; a `Write(path)`
+  rule is never matched. A `.txt` Write therefore never starts the process —
+  it does not reach the script's in-script extension skip, and it cannot
+  produce a `hook_non_blocking_error` for work this hook does not do (#2867).
+  The script still checks the extension itself, because an `if` filter is one
+  rule per handler and fails open on an unparsable payload.
 - **Config opt-in.** The hook runs only when a markdownlint config file that
   `markdownlint-cli2` would discover automatically (`.markdownlint-cli2.jsonc`,
   `.markdownlint.json`, … — any of the ten documented names) exists between the

--- a/plugins/markdown-format/hooks/hooks.json
+++ b/plugins/markdown-format/hooks/hooks.json
@@ -7,6 +7,16 @@
           {
             "type": "command",
             "command": "\"${CLAUDE_PLUGIN_ROOT}\"/hooks/markdown-format.sh",
+            "if": "Edit(*.md)",
+            "shell": "bash",
+            "timeout": 15,
+            "statusMessage": "Formatting Markdown..."
+          },
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}\"/hooks/markdown-format.sh",
+            "if": "Edit(*.mdc)",
+            "shell": "bash",
             "timeout": 15,
             "statusMessage": "Formatting Markdown..."
           }

--- a/plugins/markdown-format/hooks/markdown-format.sh
+++ b/plugins/markdown-format/hooks/markdown-format.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 # PostToolUse hook: auto-format and lint Markdown via markdownlint-cli2.
 # Triggered on Write|Edit of *.md and *.mdc (Cursor MDC = markdown + frontmatter).
+# hooks.json also gates launch with if: Edit(*.md) / Edit(*.mdc) — Edit() is the
+# permission-rule form that covers Write as well; a Write(path) rule is never
+# matched (https://docs.claude.com/en/docs/claude-code/permissions, fetched
+# 2026-08-21). The in-script extension check stays: the if filter is one rule
+# per handler and fails open on an unparsable payload, so a non-Markdown path
+# can still reach this script.
 #
 # ADVISORY: always exits 0 — unfixable markdownlint violations surface via
 # additionalContext but never block the edit. Uses the consuming repo's own
@@ -43,8 +49,9 @@ emit_tel() {
 INPUT=$(hook::buffer_stdin) || exit 0
 
 # jq-free applicability pre-filter: never emit the jq notice for an edit this
-# hook would not process anyway (the Write|Edit matcher is broader than the
-# Markdown filter).
+# hook would not process anyway. hooks.json already gates launch with
+# if: Edit(*.md)/Edit(*.mdc); this check remains because that filter is one
+# rule per handler and fails open on an unparsable payload.
 RAW_FILE=$(hook::raw_file_path "$INPUT") || exit 0
 case "$RAW_FILE" in
 *.md | *.mdc) ;;

--- a/plugins/markdown-format/hooks/markdown-format.test.sh
+++ b/plugins/markdown-format/hooks/markdown-format.test.sh
@@ -234,6 +234,46 @@ else
   fail "non-md not skipped (rc=$RC_S out=$OUT_S)"
 fi
 
+# --- hooks.json: do not launch on non-Markdown Writes (#2867) ---------------
+# The script's extension skip is defense in depth. The reported failure was a
+# .txt Write that never reached that skip: Claude Code launched the handler
+# (matcher Write|Edit, no if) and recorded hook_non_blocking_error with empty
+# stderr — official semantics for a canceled / non-zero hook with no output.
+# Registration must refuse that launch. Official hooks + permissions (fetched
+# 2026-08-21): if is exactly one permission rule; Edit(path) covers Write;
+# Write(path) is never consulted; shell form without shell: bash falls through
+# to PowerShell on Windows when Git Bash is not detected.
+HOOKS_JSON="$HOOK_DIR/hooks.json"
+if command -v jq >/dev/null 2>&1 && [[ -f "$HOOKS_JSON" ]]; then
+  HANDLERS="$(jq -c '
+    [.hooks.PostToolUse[]? | select(.matcher == "Write|Edit") | .hooks[]?]
+  ' "$HOOKS_JSON")"
+  HANDLER_COUNT="$(jq 'length' <<<"$HANDLERS")"
+  IF_VALUES="$(jq -r '[.[].if] | sort | join(" ")' <<<"$HANDLERS")"
+  WRITE_IF="$(jq '[.[] | select(.if | startswith("Write("))] | length' <<<"$HANDLERS")"
+  ARGS_PRESENT="$(jq '[.[] | select(has("args"))] | length' <<<"$HANDLERS")"
+  SHELL_OK="$(jq '[.[] | select(.shell == "bash")] | length' <<<"$HANDLERS")"
+  CMD_OK="$(jq --arg needle '${CLAUDE_PLUGIN_ROOT}' '
+    [.[] | select(
+      (.command | contains($needle)) and
+      (.command | contains("markdown-format.sh")) and
+      (.command | contains("\"${CLAUDE_PLUGIN_ROOT}\""))
+    )] | length
+  ' <<<"$HANDLERS")"
+  if [[ "$HANDLER_COUNT" == "2" &&
+    "$IF_VALUES" == "Edit(*.md) Edit(*.mdc)" &&
+    "$WRITE_IF" == "0" &&
+    "$ARGS_PRESENT" == "0" &&
+    "$SHELL_OK" == "2" &&
+    "$CMD_OK" == "2" ]]; then
+    ok "hooks.json launches only for Edit(*.md) and Edit(*.mdc), shell form, shell bash"
+  else
+    fail "hooks.json launch gate: count=$HANDLER_COUNT if='$IF_VALUES' write_if=$WRITE_IF args=$ARGS_PRESENT shell=$SHELL_OK cmd=$CMD_OK"
+  fi
+else
+  fail "hooks.json launch-gate assertions need jq and $HOOKS_JSON"
+fi
+
 # --- Fire gate: non-existent .md skips --------------------------------------
 OUT_M="$(run_hook "$REPO/does-not-exist.md")"
 RC_M=$?


### PR DESCRIPTION
Closes #2867

## Summary

`hooks/markdown-format.sh` is advisory by construction: every branch ends at `exit 0`, and there is no `exit 1`. Claude Code still recorded a Stop-time `hook_non_blocking_error` for `PostToolUse:Write` with stderr `Failed with non-blocking status code: No stderr output`.

That sentence is not the hook's. Official hook exit-code semantics ([hooks reference](https://docs.claude.com/en/docs/claude-code/hooks), fetched 2026-08-21): any non-2 exit with empty or plain-text stdout is a non-blocking error, and the transcript prefixes the first line of stderr with `Failed with non-blocking status code:`. Empty stderr becomes `No stderr output`. A hook that reaches its `timeout` is canceled, output discarded, no decision rendered — the same empty-stderr record.

The failing invocation was a `.txt` Write in a non-repo directory. For that path the script exits at the jq-free applicability pre-filter. A non-zero status therefore means the process never reached any of its own exit paths.

## Fix

The defect is the launch scope, not a missing `exit 0`. `matcher: Write|Edit` started the handler on every edit, including files the script would immediately no-op. The process still has to spawn Git Bash, source `hook-utils.sh`, and fully buffer stdin (the Write payload includes file contents) inside a 15s `timeout`. On Windows Git Bash, especially under concurrent subagent load, a timeout/cancel or a failed spawn produces exactly the recorded shape: non-zero, no stderr, script never reached `exit 0`.

`hooks.json` now registers two handlers:

- `if: Edit(*.md)` and `if: Edit(*.mdc)` — official docs: `if` is exactly one permission rule; `Edit(path)` covers Write; a `Write(path)` rule is never consulted ([permissions](https://docs.claude.com/en/docs/claude-code/permissions), fetched 2026-08-21)
- `shell: bash` — shell form otherwise falls through to PowerShell on Windows when Git Bash is not detected, and PowerShell cannot run a `.sh` handler

The in-script extension check stays. The `if` filter is one rule per handler and fails open on an unparsable payload, so a non-Markdown path can still reach the script.

Not done, on purpose:

- No silent `exit 0` wrapper or EXIT trap. That would hide a real failure on a Markdown edit.
- No marketplace-wide rewrite of the bare-script command form. The reported invocation was a path this hook should not launch; the command string is unchanged. If that form is later shown fragile on Markdown edits, that is a fleet convention change, not this patch.

Advisory / fail-open semantics are unchanged. `markdown-format` 0.11.23 → 0.11.24.

## Verification

- `bash plugins/markdown-format/hooks/markdown-format.test.sh` — **PASS=157 FAIL=0** (includes the new `hooks.json` launch-gate assertion: two handlers, `Edit(*.md)` + `Edit(*.mdc)`, no `Write(` if, no `args`, `shell: bash`, quoted `${CLAUDE_PLUGIN_ROOT}`)
- Existing non-`.md` in-script skip still exits 0 with empty stdout
- `scripts/check-changelog-parity.sh --check` / `--check-bump origin/main` / `--check-preserved origin/main` / `--check-order` — all pass (52 prior headings preserved)
- `scripts/check-hook-exec-form.sh` — pass (still shell form, no bare exec-form name)

## Related

- Follow-up context from #2868 (degradation notice; already merged). Same session class, different defect.
- `claude-ops` `hook-failure-audit` is what surfaced the unsurfaced record (#2577 / #2849). Classification of this record is completed-non-zero / no-stderr, not an `execvpe` launch signature.
- Not a fleet rewrite of bash-format / eol-normalizer / typos-format / powershell-format / guardrails. Those share the `Write|Edit` matcher; this PR only changes the plugin that produced the record.