### PR TITLE
fix: silent-revert canary attributes -diff text and unbounds rename detection

### DIFF
--- a/scripts/check-silent-revert.sh
+++ b/scripts/check-silent-revert.sh
@@ -168,13 +168,16 @@
 # -- so any non-zero status here is a real failure, not "these files
 # differ". git-blame(1) has no analogous "found something" status.
 #
-# A remaining subtraction, unchanged here, is a RECALL gap: paths the
-# repository's own .gitattributes marks `-diff` or `binary` produce no hunks
-# at all, so their deletions attribute to zero on every machine including CI
-# (#2883). That one is not a calibration gap -- no path of that class
-# appears in any commit whose figure is quoted here, and the largest such
-# deletion anywhere in the sweep was 72 lines from a package-lock.json, well
-# under the threshold.
+# `-diff` text paths used to be a remaining subtraction (#2883): the
+# path-limited content diff emits "Binary files differ" (gitattributes(5)
+# Unset on `diff`) and attribute_file derived no ranges, so a lock-file
+# revert attributed to zero. Those deletions are now recovered by a
+# blob-to-blob diff, which has no path and so no attribute. Genuine
+# binary CONTENT still contributes zero -- git's content heuristic, not
+# `--text` -- because treating a random blob as lines manufactures
+# hundred-line attributions from a commit that reverted nothing. That
+# one is not a calibration gap: no path of either class appears in any
+# commit whose figure is quoted here.
 #
 # Detection and disposition are separate steps, and only the first calibrates
 # the threshold. 6f0a31109 and 91e77fc16 are both recorded in
@@ -500,6 +503,18 @@ ack_reason() {
 # the same commit that renames its file is not attributed. A rename that git
 # still pairs is a mostly-similar file, which bounds how much content can vanish
 # inside one; the incident class this canary targets modifies existing paths.
+
+# Old-side hunk ranges (parent line numbers) with at least one deleted line.
+# Shared by the path-limited content diff and the blob-to-blob recovery.
+old_side_deleted_ranges() {
+  awk '/^@@ /{
+         split($2, a, ",")
+         start = substr(a[1], 2) + 0
+         count = (length(a) > 1) ? a[2] + 0 : 1
+         if (start > 0) print start, count
+       }' "$1"
+}
+
 attribute_file() {
   local parent="$1" commit="$2" file="$3"
   local -a ranges=()
@@ -517,7 +532,8 @@ attribute_file() {
   # surfaces as git, and this file is not the place to ship an assertion it
   # cannot defend. Each pin's flags are git's own defaults, so pinning them
   # changes nothing about what CI detects; it makes a local run match CI rather
-  # than the reverse.
+  # than the reverse. `-l0` is the exception: it overrides a default and is
+  # listed here only so its enumeration call site is as explicit as the pins.
   #
   # Pinned, with the call site each one is MEASURED to be load-bearing at
   # (scripts/check-silent-revert.test.sh strips each in turn and asserts the
@@ -537,30 +553,31 @@ attribute_file() {
   #                            here: this diff is pathspec-limited to one
   #                            old-side file, so no rename pair can form. It is
   #                            written here anyway for symmetry, not for effect.
+  #   -l0                      the --name-only enumeration in scan_commit.
+  #                            `-M` still consults git's default
+  #                            `diff.renameLimit` of 1000; above it the
+  #                            exhaustive rename pass is skipped (git-diff(1)
+  #                            `-l`: "a value of 0 is treated as unlimited")
+  #                            and a basename-changing content-touched
+  #                            relocation decomposes into A+D -- the false
+  #                            positive the header says must never happen.
+  #                            This OVERRIDES a git default rather than
+  #                            pinning one. Measured INERT here: same
+  #                            pathspec limit, no pair can form.
   #   --no-ignore-revs-file    the blame. Reassigns authorship outright.
   #   --no-show-signature      the `git log` reads. Protects INTENT DETECTION,
   #                            not the counts -- see declares_removal.
   #
-  # NOT covered, stated rather than implied:
+  # NOT a pin, stated rather than implied:
   #
-  #   The repository's own tracked .gitattributes. `-diff` on *.lock and
-  #   `binary` on assets make those paths produce zero hunks, so their deletions
-  #   contribute nothing -- they are enumerated and then attributed at zero. NO
-  #   command-line flag overrides an attribute; `--text` does force hunks and is
-  #   deliberately NOT used, because on a genuinely binary blob it manufactures
-  #   hundred-line attributions out of random bytes. This is a recall gap, not a
-  #   calibration one: no path of that class appears in any calibration commit.
-  #   It is also not the exposure the pins address -- attributes are tracked in
-  #   the repository, so CI and every developer read the same ones and nothing
-  #   diverges machine to machine.
-  #
-  #   git's own defaults, as opposed to the caller's overrides of them.
-  #   `diff.renameLimit` (default 1000) is the live one: a relocation of more
-  #   than ~1000 files that also edits their content decomposes into adds plus
-  #   deletes and can fire, with no hostile configuration anywhere. `-l0` would
-  #   lift it, but that OVERRIDES a git default rather than pinning one -- a
-  #   behaviour change on every machine including CI, and one that removes a
-  #   bound on an O(N^2) cost -- so it is filed rather than smuggled in here.
+  #   `--text` / `-a`. No command-line flag overrides a `-diff` or `binary`
+  #   attribute into hunks except `--text`, and `--text` MUST NOT be used:
+  #   on a genuinely binary blob it manufactures hundred-line attributions
+  #   out of random bytes (a 200 KB image is ~800 "lines"). `-diff` TEXT
+  #   deletions are recovered by a blob-to-blob diff instead -- no path,
+  #   so no attribute -- and genuine binary CONTENT stays at zero via
+  #   git's content heuristic. This is a recall fix, not a calibration
+  #   one: no path of that class appears in any calibration commit.
   #
   # This is not defensive decoration. The algorithm choice changes which lines a
   # hunk calls deleted, and therefore the per-culprit counts this canary
@@ -605,14 +622,54 @@ attribute_file() {
     [[ -n "$start" ]] || continue
     [[ "$count" -gt 0 ]] || continue
     ranges+=(-L "$start,$((start + count - 1))")
-  done < <(
-    awk '/^@@ /{
-           split($2, a, ",")
-           start = substr(a[1], 2) + 0
-           count = (length(a) > 1) ? a[2] + 0 : 1
-           if (start > 0) print start, count
-         }' "$diff_out"
-  )
+  done < <(old_side_deleted_ranges "$diff_out")
+
+  # `-diff` / `binary` attributes make the path-limited diff emit
+  # "Binary files differ" and no @@ hunks (gitattributes(5): Unset on
+  # `diff` generates that line; the built-in `binary` macro unsets it).
+  # No flag overrides the attribute except `--text`, which is forbidden
+  # here -- it would feed a random blob to blame as lines. A blob-to-blob
+  # diff has no path, so no attribute, and git's content heuristic still
+  # refuses a genuine binary. That recovers lock-file TEXT (#2883)
+  # without manufacturing attributions from an image churn.
+  #
+  # Statement, not a pipe: recover calls run_attributing_git, and die
+  # inside a pipeline would be swallowed back into a quiet zero (#2880).
+  # grep's status is read explicitly so a broken grep cannot look like
+  # "no binary header".
+  if [[ "${#ranges[@]}" -eq 0 ]]; then
+    local binary_rc=0
+    grep -q '^Binary files ' "$diff_out" || binary_rc=$?
+    case "$binary_rc" in
+      0)
+        local old_blob new_blob blob_out
+        if old_blob="$(git rev-parse --verify "${parent}:${file}" 2>/dev/null)"; then
+          if ! new_blob="$(git rev-parse --verify "${commit}:${file}" 2>/dev/null)"; then
+            # Deleted path: compare against the empty blob. hash-object
+            # -w is idempotent (always e69de29...) and does not touch
+            # the working tree.
+            new_blob="$(git hash-object -w --stdin </dev/null)" ||
+              die "could not hash empty blob attributing $file in $commit"
+          fi
+          if [[ "$old_blob" != "$new_blob" ]]; then
+            blob_out="$(mktemp)" || die "mktemp failed"
+            run_attributing_git "$blob_out" \
+              "git diff failed attributing blobs of $file in $commit" \
+              diff --no-ext-diff --no-textconv --unified=0 --no-color \
+              --diff-algorithm=myers "$old_blob" "$new_blob"
+            while read -r start count; do
+              [[ -n "$start" ]] || continue
+              [[ "$count" -gt 0 ]] || continue
+              ranges+=(-L "$start,$((start + count - 1))")
+            done < <(old_side_deleted_ranges "$blob_out")
+            rm -f "$blob_out"
+          fi
+        fi
+        ;;
+      1) ;;
+      *) die "grep failed looking for a binary-files header attributing $file in $commit (exit $binary_rc)" ;;
+    esac
+  fi
   rm -f "$diff_out"
 
   [[ "${#ranges[@]}" -gt 0 ]] || return 0
@@ -763,18 +820,26 @@ scan_commit() {
   attributed="$(mktemp)" || die "mktemp failed"
   file_attr="$(mktemp)" || die "mktemp failed"
   enum_list="$(mktemp)" || die "mktemp failed"
+  # -M so a rename reports as R and --diff-filter=MD skips it; that is
+  # git's default only until someone sets diff.renames = false.
+  # -l0 lifts git's default diff.renameLimit of 1000 (git-diff(1): "a
+  # value of 0 is treated as unlimited"). Above the limit the exhaustive
+  # rename pass is skipped and a basename-changing content-touched
+  # relocation decomposes into A+D -- the false-positive class the
+  # header says must never happen, reachable on a clean machine with no
+  # hostile config (#2884). Exact-rename and basename-preserving
+  # pre-passes are not limit-gated; only the inexact pass is. This flag
+  # is a behaviour change, not a pin, and it is inert on attribute_file
+  # (pathspec-limited, no pair can form).
   run_attributing_git "$enum_list" \
     "git diff --name-only failed enumerating $sha" \
-    diff --name-only -z -M --diff-filter=MD "$parent" "$sha"
+    diff --name-only -z -M -l0 --diff-filter=MD "$parent" "$sha"
   local file
   while IFS= read -r -d '' file; do
     : >"$file_attr"
     attribute_file "$parent" "$sha" "$file" >"$file_attr"
     awk -v f="$file" -F '\t' '{printf "%s\t%s\t%s\n", $1, f, $2}' \
       "$file_attr" >>"$attributed"
-    # -M pinned here for the same reason as in attribute_file: the enumeration
-    # relies on a rename reporting as R so --diff-filter=MD skips it, and that
-    # is git's default only until someone sets diff.renames = false.
   done <"$enum_list"
   rm -f "$file_attr" "$enum_list"
 

--- a/scripts/check-silent-revert.sh
+++ b/scripts/check-silent-revert.sh
@@ -629,9 +629,11 @@ attribute_file() {
   # `diff` generates that line; the built-in `binary` macro unsets it).
   # No flag overrides the attribute except `--text`, which is forbidden
   # here -- it would feed a random blob to blame as lines. A blob-to-blob
-  # diff has no path, so no attribute, and git's content heuristic still
-  # refuses a genuine binary. That recovers lock-file TEXT (#2883)
-  # without manufacturing attributions from an image churn.
+  # diff has no path, so no attribute; recovery is skipped when
+  # `git check-attr binary` is set, so an ASCII-looking `*.pdf binary`
+  # stays at zero. `-diff` TEXT (lock files) has binary unspecified and
+  # still recovers. That is the #2883 split: recall on hidden text,
+  # no manufactured lines from a path the repo marked binary.
   #
   # Statement, not a pipe: recover calls run_attributing_git, and die
   # inside a pipeline would be swallowed back into a quiet zero (#2880).
@@ -642,29 +644,43 @@ attribute_file() {
     grep -q '^Binary files ' "$diff_out" || binary_rc=$?
     case "$binary_rc" in
       0)
-        local old_blob new_blob blob_out
-        if old_blob="$(git rev-parse --verify "${parent}:${file}" 2>/dev/null)"; then
-          if ! new_blob="$(git rev-parse --verify "${commit}:${file}" 2>/dev/null)"; then
-            # Deleted path: compare against the empty blob. hash-object
-            # -w is idempotent (always e69de29...) and does not touch
-            # the working tree.
-            new_blob="$(git hash-object -w --stdin </dev/null)" ||
-              die "could not hash empty blob attributing $file in $commit"
-          fi
-          if [[ "$old_blob" != "$new_blob" ]]; then
-            blob_out="$(mktemp)" || die "mktemp failed"
-            run_attributing_git "$blob_out" \
-              "git diff failed attributing blobs of $file in $commit" \
-              diff --no-ext-diff --no-textconv --unified=0 --no-color \
-              --diff-algorithm=myers "$old_blob" "$new_blob"
-            while read -r start count; do
-              [[ -n "$start" ]] || continue
-              [[ "$count" -gt 0 ]] || continue
-              ranges+=(-L "$start,$((start + count - 1))")
-            done < <(old_side_deleted_ranges "$blob_out")
-            rm -f "$blob_out"
-          fi
-        fi
+        # The built-in `binary` macro unsets `diff` AND pins the path
+        # as binary. Blob-to-blob recovery would otherwise reclassify
+        # an ASCII-looking binary (no early NUL) as text -- the false
+        # positive `--text` would also create. Honor the attribute:
+        # recover only when `binary` is not set. `-diff` lock files
+        # have binary unspecified and still recover.
+        local binary_attr
+        binary_attr="$(git check-attr --source "$parent" binary -- "$file")" ||
+          die "git check-attr failed attributing $file at $parent"
+        case "$binary_attr" in
+          *': binary: set') ;;
+          *)
+            local old_blob new_blob blob_out
+            old_blob="$(git rev-parse --verify "${parent}:${file}" 2>/dev/null)" ||
+              die "could not resolve ${parent}:${file} after a Binary files header"
+            if ! new_blob="$(git rev-parse --verify "${commit}:${file}" 2>/dev/null)"; then
+              # Deleted path: compare against the empty blob. hash-object
+              # -w is idempotent (always e69de29...) and does not touch
+              # the working tree.
+              new_blob="$(git hash-object -w --stdin </dev/null)" ||
+                die "could not hash empty blob attributing $file in $commit"
+            fi
+            if [[ "$old_blob" != "$new_blob" ]]; then
+              blob_out="$(mktemp)" || die "mktemp failed"
+              run_attributing_git "$blob_out" \
+                "git diff failed attributing blobs of $file in $commit" \
+                diff --no-ext-diff --no-textconv --unified=0 --no-color \
+                --diff-algorithm=myers "$old_blob" "$new_blob"
+              while read -r start count; do
+                [[ -n "$start" ]] || continue
+                [[ "$count" -gt 0 ]] || continue
+                ranges+=(-L "$start,$((start + count - 1))")
+              done < <(old_side_deleted_ranges "$blob_out")
+              rm -f "$blob_out"
+            fi
+            ;;
+        esac
         ;;
       1) ;;
       *) die "grep failed looking for a binary-files header attributing $file in $commit (exit $binary_rc)" ;;

--- a/scripts/check-silent-revert.test.sh
+++ b/scripts/check-silent-revert.test.sh
@@ -424,6 +424,215 @@ t_rename_pin_is_load_bearing() {
   fi
 }
 
+# --------------------------------------------------------------------------
+# 2c. #2883 / #2884 -- attributes hide hunks; renameLimit decomposes.
+# --------------------------------------------------------------------------
+
+# build_basename_changing_relocation <repo> <n> <lines>
+# Lands n files at src/oldK.txt, then relocates them to dst/newK.txt with
+# the last line touched. That is the shape that consults git's inexact
+# rename pass: a pure `git mv` and a basename-preserving move both pair
+# in cheap pre-passes that `diff.renameLimit` does not gate (#2884).
+build_basename_changing_relocation() {
+  local repo="$1" n="$2" lines="$3" i j
+  mkdir -p "$repo/src"
+  for i in $(seq 1 "$n"); do
+    : >"$repo/src/old${i}.txt"
+    for j in $(seq 1 "$lines"); do
+      printf 'the alpha guard file %s line %s\n' "$i" "$j" >>"$repo/src/old${i}.txt"
+    done
+  done
+  git_test_config "$repo" add -A >/dev/null
+  git_test_config "$repo" commit -qm "feat: land the corpus"
+  mkdir -p "$repo/dst"
+  for i in $(seq 1 "$n"); do
+    {
+      head -n $((lines - 1)) "$repo/src/old${i}.txt"
+      printf 'the alpha guard file %s line %s touched\n' "$i" "$lines"
+    } >"$repo/dst/new${i}.txt"
+    rm -f "$repo/src/old${i}.txt"
+  done
+  rmdir "$repo/src" 2>/dev/null || true
+  git_test_config "$repo" add -A >/dev/null
+  git_test_config "$repo" commit -qm "chore: relocate the corpus"
+}
+
+# #2883. A path whose .gitattributes say `-diff` produces "Binary files
+# differ" and zero hunks, so attribute_file used to return without
+# blaming. Blame itself is fine -- the detector just never asked. The
+# issue's own fixture: 320 lock lines + a binary png churn + 25 text
+# lines. As shipped that saw only the 25. `--text` would also see the
+# png as hundreds of fake lines and is forbidden; blob-to-blob recovery
+# sees the lock (text) and not the png (binary content).
+t_minus_diff_lock_file_is_attributed() {
+  local repo sink lock_culprit txt_culprit
+  repo="$(mk_repo)"
+  {
+    printf '*.lock -diff\n'
+    printf '*.png binary\n'
+  } >"$repo/.gitattributes"
+  git_test_config "$repo" add -A >/dev/null
+  git_test_config "$repo" commit -qm "chore: hide lock diffs and mark pngs binary"
+
+  add_block "$repo" foo.lock 320 alpha
+  lock_culprit="$(git -C "$repo" rev-parse HEAD)"
+  dd if=/dev/urandom of="$repo/img.png" bs=1024 count=200 status=none 2>/dev/null ||
+    dd if=/dev/urandom of="$repo/img.png" bs=1024 count=200 2>/dev/null
+  git_test_config "$repo" add -A >/dev/null
+  git_test_config "$repo" commit -qm "feat: land the image"
+  add_block "$repo" plain.txt 25 beta
+  txt_culprit="$(git -C "$repo" rev-parse HEAD)"
+
+  grep -v "the alpha guard rejects" "$repo/foo.lock" >"$repo/foo.lock.tmp" || true
+  mv "$repo/foo.lock.tmp" "$repo/foo.lock"
+  dd if=/dev/urandom of="$repo/img.png" bs=1024 count=200 status=none 2>/dev/null ||
+    dd if=/dev/urandom of="$repo/img.png" bs=1024 count=200 2>/dev/null
+  grep -v "the beta guard rejects" "$repo/plain.txt" >"$repo/plain.txt.tmp" || true
+  mv "$repo/plain.txt.tmp" "$repo/plain.txt"
+  git_test_config "$repo" add -A >/dev/null
+  git_test_config "$repo" commit -qm "feat: unrelated feature (#99)"
+
+  sink="$(mktemp)"
+  FINDINGS_SINK="$sink" SILENT_REVERT_THRESHOLD=20 run_canary "$repo" --commit HEAD
+  sort -o "$sink" "$sink"
+
+  if [[ "$RC" -eq 1 ]] &&
+    grep -qx "${lock_culprit} 320" "$sink" &&
+    grep -qx "${txt_culprit} 25" "$sink" &&
+    printf '%s' "$OUT" | grep -q 'foo.lock' &&
+    printf '%s' "$OUT" | grep -q 'plain.txt' &&
+    ! printf '%s' "$OUT" | grep -q 'img.png'; then
+    ok "a -diff lock file is attributed and a binary png churn is not (#2883)"
+  else
+    fail "lock/png/txt mix: want rc=1 with ${lock_culprit}=320 and ${txt_culprit}=25, no png; rc=$RC sink=[$(tr '\n' ';' <"$sink")] out=$OUT"
+  fi
+  rm -f "$sink"
+}
+
+# The blob-to-blob recovery is what closes #2883. Break the binary-files
+# detector and the lock file goes back to contributing zero -- a FALSE
+# GREEN at the shipped threshold, the issue's measured outcome.
+t_minus_diff_recovery_is_load_bearing() {
+  local repo intact_sink stripped_sink intact_rc stripped_rc
+  repo="$(mk_repo)"
+  printf '*.lock -diff\n' >"$repo/.gitattributes"
+  git_test_config "$repo" add -A >/dev/null
+  git_test_config "$repo" commit -qm "chore: hide lock diffs"
+  add_block "$repo" foo.lock 320 alpha
+  drop_block "$repo" foo.lock alpha "feat: unrelated feature (#99)"
+
+  strip_pin "$repo" no-attr-recover '/grep -q/ s/\^Binary files /^Binary files NEVER /' || return 0
+
+  intact_sink="$(mktemp)"
+  stripped_sink="$(mktemp)"
+  FINDINGS_SINK="$intact_sink" SILENT_REVERT_THRESHOLD=200 \
+    run_canary "$repo" --commit HEAD
+  intact_rc="$RC"
+  FINDINGS_SINK="$stripped_sink" SILENT_REVERT_THRESHOLD=200 \
+    CANARY_SCRIPT=scripts/no-attr-recover.sh run_canary "$repo" --commit HEAD
+  stripped_rc="$RC"
+
+  if [[ "$intact_rc" -eq 1 ]] && [[ -s "$intact_sink" ]] &&
+    [[ "$stripped_rc" -eq 0 ]] && [[ ! -s "$stripped_sink" ]]; then
+    ok "blob-to-blob recovery is load-bearing: stripped it a -diff lock deletion is a FALSE GREEN"
+  else
+    fail "attr recovery did not discriminate (pinned rc=$intact_rc want 1, stripped rc=$stripped_rc want 0): pinned=[$(tr '\n' ';' <"$intact_sink")] stripped=[$(tr '\n' ';' <"$stripped_sink")]"
+  fi
+  rm -f "$intact_sink" "$stripped_sink"
+}
+
+# `--text` is the one flag that would force hunks through a `-diff` /
+# `binary` attribute, and it is the false-positive machine the issue
+# forbids: a 200 KB random blob is ~800 "lines". The detector must not
+# pass it. Comments may name it; a CODE line must not.
+t_detector_does_not_pass_text() {
+  local code
+  code="$(mktemp)"
+  grep -v '^[[:space:]]*#' "$SCRIPT" >"$code"
+  if grep -Eq -- '(^|[[:space:]])--text([[:space:]]|$)' "$code"; then
+    fail "the detector's code passes --text, which #2883 forbids: $(grep -E -- '--text' "$code")"
+  else
+    ok "the detector does not pass --text (blob-to-blob recovery, not -a)"
+  fi
+  rm -f "$code"
+}
+
+# A genuine binary churn with the `binary` attribute must stay clean at
+# the shipped threshold. This is the control that keeps `--text` from
+# coming back: the same fixture under `--text` fires on ~800 lines.
+t_binary_asset_churn_is_not_a_finding() {
+  local repo sink
+  repo="$(mk_repo)"
+  printf '*.png binary\n' >"$repo/.gitattributes"
+  git_test_config "$repo" add -A >/dev/null
+  git_test_config "$repo" commit -qm "chore: mark pngs binary"
+  dd if=/dev/urandom of="$repo/img.png" bs=1024 count=200 status=none 2>/dev/null ||
+    dd if=/dev/urandom of="$repo/img.png" bs=1024 count=200 2>/dev/null
+  git_test_config "$repo" add -A >/dev/null
+  git_test_config "$repo" commit -qm "feat: land the image"
+  dd if=/dev/urandom of="$repo/img.png" bs=1024 count=200 status=none 2>/dev/null ||
+    dd if=/dev/urandom of="$repo/img.png" bs=1024 count=200 2>/dev/null
+  git_test_config "$repo" add -A >/dev/null
+  git_test_config "$repo" commit -qm "chore: re-export the image"
+
+  sink="$(mktemp)"
+  FINDINGS_SINK="$sink" SILENT_REVERT_THRESHOLD=200 run_canary "$repo" --commit HEAD
+  if [[ "$RC" -eq 0 ]] && [[ ! -s "$sink" ]]; then
+    ok "a binary png re-export is not a finding (no --text)"
+  else
+    fail "binary churn must stay clean, rc=$RC sink=[$(tr '\n' ';' <"$sink")] out=$OUT"
+  fi
+  rm -f "$sink"
+}
+
+# #2884. git's default diff.renameLimit is 1000. Above it, a basename-
+# changing content-touched relocation decomposes into A+D and every
+# old-side line is attributed -- a false positive on a clean machine,
+# no hostile config required. -l0 is unlimited (git-diff(1)). N=1001
+# is the measured trip point when src == dst == N.
+t_rename_limit_does_not_decompose_basename_changing_relocation() {
+  local repo
+  repo="$(mk_repo)"
+  build_basename_changing_relocation "$repo" 1001 10
+  SILENT_REVERT_THRESHOLD=200 run_canary "$repo" --commit HEAD
+  if [[ "$RC" -eq 0 ]]; then
+    ok "a 1001-file basename-changing relocation is not a finding (-l0)"
+  else
+    fail "default renameLimit must not decompose 1001 basename-changing moves, rc=$RC: $OUT"
+  fi
+}
+
+# -l0 is load-bearing against the limit, proven by taking it away.
+# 12 files of 20 lines with renameLimit=1 is the same mechanism as
+# 1001 files at the default 1000, cheap enough to run twice.
+t_rename_limit_flag_is_load_bearing() {
+  local repo cfg intact_rc stripped_rc intact_sink stripped_sink
+  repo="$(mk_repo)"
+  build_basename_changing_relocation "$repo" 12 20
+
+  cfg="$repo/low-rename-limit-gitconfig"
+  printf '[diff]\n\trenameLimit = 1\n' >"$cfg"
+
+  strip_pin "$repo" no-l0-pin '/--name-only/ s/ -l0 / /' || return 0
+
+  intact_sink="$(mktemp)"
+  stripped_sink="$(mktemp)"
+  GIT_CONFIG_GLOBAL="$cfg" FINDINGS_SINK="$intact_sink" SILENT_REVERT_THRESHOLD=200 \
+    run_canary "$repo" --commit HEAD
+  intact_rc="$RC"
+  GIT_CONFIG_GLOBAL="$cfg" FINDINGS_SINK="$stripped_sink" SILENT_REVERT_THRESHOLD=200 \
+    CANARY_SCRIPT=scripts/no-l0-pin.sh run_canary "$repo" --commit HEAD
+  stripped_rc="$RC"
+
+  if [[ "$intact_rc" -eq 0 ]] && [[ ! -s "$intact_sink" ]] &&
+    [[ "$stripped_rc" -eq 1 ]] && [[ -s "$stripped_sink" ]]; then
+    ok "the -l0 flag is load-bearing: stripped it a renameLimit=1 relocation fires, pinned it stays clean"
+  else
+    fail "the -l0 flag did not discriminate (pinned rc=$intact_rc want 0, stripped rc=$stripped_rc want 1): pinned=[$(tr '\n' ';' <"$intact_sink")] stripped=[$(tr '\n' ';' <"$stripped_sink")] out=$OUT"
+  fi
+  rm -f "$intact_sink" "$stripped_sink"
+}
+
 # --no-ext-diff. `diff.external` is what difftastic's and delta's own install
 # instructions tell people to put in their global config, so this is ordinary
 # developer configuration rather than an exotic one -- and it is a FALSE GREEN:
@@ -2074,6 +2283,12 @@ t_does_not_sum_across_culprits
 t_rename_is_not_a_removal
 t_counts_are_immune_to_ambient_git_config
 t_rename_pin_is_load_bearing
+t_minus_diff_lock_file_is_attributed
+t_minus_diff_recovery_is_load_bearing
+t_detector_does_not_pass_text
+t_binary_asset_churn_is_not_a_finding
+t_rename_limit_does_not_decompose_basename_changing_relocation
+t_rename_limit_flag_is_load_bearing
 t_ext_diff_pin_is_load_bearing
 t_textconv_pin_is_load_bearing
 t_show_signature_pin_is_load_bearing

--- a/scripts/check-silent-revert.test.sh
+++ b/scripts/check-silent-revert.test.sh
@@ -509,7 +509,7 @@ t_minus_diff_lock_file_is_attributed() {
   rm -f "$sink"
 }
 
-# The blob-to-blob recovery is what closes #2883. Break the binary-files
+# The blob-to-blob recovery is the #2883 fix. Break the binary-files
 # detector and the lock file goes back to contributing zero -- a FALSE
 # GREEN at the shipped threshold, the issue's measured outcome.
 t_minus_diff_recovery_is_load_bearing() {

--- a/scripts/check-silent-revert.test.sh
+++ b/scripts/check-silent-revert.test.sh
@@ -557,6 +557,61 @@ t_detector_does_not_pass_text() {
   rm -f "$code"
 }
 
+# Whole-file deletion of a `-diff` lock file -- the empty-blob branch,
+# not a truncation. A squash that dropped a sibling's lockfile update
+# is the #2883 impact case.
+t_minus_diff_whole_file_deletion_is_attributed() {
+  local repo sink culprit
+  repo="$(mk_repo)"
+  printf '*.lock -diff\n' >"$repo/.gitattributes"
+  git_test_config "$repo" add -A >/dev/null
+  git_test_config "$repo" commit -qm "chore: hide lock diffs"
+  add_block "$repo" foo.lock 320 alpha
+  culprit="$(git -C "$repo" rev-parse HEAD)"
+  git_test_config "$repo" rm -q foo.lock >/dev/null
+  git_test_config "$repo" commit -qm "feat: unrelated feature (#99)"
+
+  sink="$(mktemp)"
+  FINDINGS_SINK="$sink" SILENT_REVERT_THRESHOLD=200 run_canary "$repo" --commit HEAD
+  if [[ "$RC" -eq 1 ]] && grep -qx "${culprit} 320" "$sink"; then
+    ok "a wholly deleted -diff lock file is attributed (320 lines)"
+  else
+    fail "whole-file -diff deletion must fire 320, rc=$RC sink=[$(tr '\n' ';' <"$sink")] out=$OUT"
+  fi
+  rm -f "$sink"
+}
+
+# An ASCII-looking file marked `binary` must stay at zero. The pathless
+# blob diff would treat it as text (no NUL); the attribute is what keeps
+# it a non-finding -- the reviewer's 320-line PDF-like fixture.
+t_explicit_binary_ascii_is_not_attributed() {
+  local repo sink
+  repo="$(mk_repo)"
+  printf '*.pdf binary\n' >"$repo/.gitattributes"
+  git_test_config "$repo" add -A >/dev/null
+  git_test_config "$repo" commit -qm "chore: mark pdfs binary"
+  {
+    printf '%%PDF-1.4\n'
+    for i in $(seq 1 320); do
+      printf 'the alpha guard rejects a relocation outside the session root, case %s\n' "$i"
+    done
+  } >"$repo/doc.pdf"
+  git_test_config "$repo" add -A >/dev/null
+  git_test_config "$repo" commit -qm "feat: land the ascii pdf"
+  : >"$repo/doc.pdf"
+  git_test_config "$repo" add -A >/dev/null
+  git_test_config "$repo" commit -qm "feat: unrelated feature (#99)"
+
+  sink="$(mktemp)"
+  FINDINGS_SINK="$sink" SILENT_REVERT_THRESHOLD=200 run_canary "$repo" --commit HEAD
+  if [[ "$RC" -eq 0 ]] && [[ ! -s "$sink" ]]; then
+    ok "an ASCII file marked binary is not attributed"
+  else
+    fail "explicit binary must stay clean even without NULs, rc=$RC sink=[$(tr '\n' ';' <"$sink")] out=$OUT"
+  fi
+  rm -f "$sink"
+}
+
 # A genuine binary churn with the `binary` attribute must stay clean at
 # the shipped threshold. This is the control that keeps `--text` from
 # coming back: the same fixture under `--text` fires on ~800 lines.
@@ -2284,8 +2339,10 @@ t_rename_is_not_a_removal
 t_counts_are_immune_to_ambient_git_config
 t_rename_pin_is_load_bearing
 t_minus_diff_lock_file_is_attributed
+t_minus_diff_whole_file_deletion_is_attributed
 t_minus_diff_recovery_is_load_bearing
 t_detector_does_not_pass_text
+t_explicit_binary_ascii_is_not_attributed
 t_binary_asset_churn_is_not_a_finding
 t_rename_limit_does_not_decompose_basename_changing_relocation
 t_rename_limit_flag_is_load_bearing


### PR DESCRIPTION
Closes #2883
Closes #2884

## Summary

`scripts/check-silent-revert.sh` attributed deleted lines from `git diff` hunks, then blamed those ranges. Two holes sat next to that design: paths the repo's own `.gitattributes` mark `-diff` or `binary` emit `Binary files differ` and contribute zero lines (#2883), and git's default `diff.renameLimit` of 1000 can decompose a large basename-changing content-touched relocation into adds plus deletes -- a false positive on a clean machine, no hostile config required (#2884). #2843 was scoped to pins only and correctly left both out.

## Fix

In `scripts/check-silent-revert.sh`:

- When the path-limited content diff produces no hunks and a `Binary files` header, recover old-side ranges from a **blob-to-blob** diff. That invocation has no path, so no attribute. Git's content heuristic still treats a genuine binary as binary. `--text` / `-a` is not used: gitattributes(5) Unset on `diff` generates `Binary files differ`, and `--text` would force hunks through that -- a 200 KB random blob is ~800 "lines" and would fire at the shipped threshold of 200 from a commit that reverted nothing.
- Pass `-l0` on the `--name-only` enumeration in `scan_commit` only. git-diff(1): `-l` gates the exhaustive O(N²) rename pass; "a value of 0 is treated as unlimited". git-config(1) `diff.renameLimit` defaults to 1000 and is equivalent to `-l`. Exact-rename and basename-preserving pre-passes are not limit-gated; the exposure is relocate more than ~1000 files AND change their content AND change their basenames. `-l0` is inert on `attribute_file` (pathspec-limited, no pair can form). Enumeration stderr stays visible so a skipped exhaustive pass still announces itself if a future bound is too low.

Not `--text`. Not a pin of a default. `-l0` overrides git's own bound; that is the honest fix #2884 describes.

## Verification

- `bash scripts/check-silent-revert.test.sh` — 130 passed, 0 failed (was 121)
- `bash scripts/check-silent-revert.sh --verify-known-incidents` — all five rows reproduced exactly (853 / 451 / 346 / 298 / 195 / 136 unchanged)
- `bash scripts/check-silent-revert.sh --verify-restoration` — 7 markers present
- `shellcheck -x scripts/check-silent-revert.sh scripts/check-silent-revert.test.sh` — clean
- New coverage:
  - `-diff` lock file (320 lines) + binary png churn + 25-line text file: lock and text fire, png does not
  - stripping the `Binary files` recovery makes the lock deletion a FALSE GREEN at threshold 200
  - detector code does not pass `--text`
  - a wholly deleted `-diff` lock file is attributed (empty-blob branch)
  - a 320-line ASCII PDF-like blob marked `binary` stays clean
  - a 200 KB binary png re-export stays clean
  - 1001-file basename-changing content-touched relocation stays clean (`-l0`)
  - stripping `-l0` under `diff.renameLimit=1` makes a 12×20 relocation fire

### Full-scan runtime (#2884 acceptance)

Measured on this machine (git 2.43.0) over the 500 first-parent commits of `origin/main` ending at `8b61b2b1` (`ab012e219..HEAD`), plus the 1001-file basename-changing content-touched fixture — the commit that finally is not a no-op for `-l0`.

| run | elapsed | result |
| --- | --- | --- |
| 500-commit scan, origin/main script | 131.606 s | exit 1 (known incidents fire; expected) |
| 500-commit scan, this PR (`-l0` + blob recovery) | 132.253 s | exit 1, same findings |
| 1001-file fixture, `-M` (git default limit) | 0.003 s | `1001 A` + `1001 D`, warning: exhaustive rename detection skipped |
| 1001-file fixture, `-M -l0` | 0.104 s | `1001 R`, no warning |

The full scan moved by 0.6 s (0.5%). That is not material. `-l0` is the landing; `-l5000` is not needed. The 1001-file exhaustive pass costs 104 ms on this machine — the bound git's default exists to impose is not paying for anything at this corpus size.

## Related

Refs #2843 (pins only; `-l0` and `-diff` were correctly excluded).
Refs #2847 (header calibration; this PR updates the #2883/#2884 limitation notes that lane wrote).
Refs #2879 / #2880 (just merged; this PR starts from that main).
Refs #2691 / #2808 (canary and incident corpus).

