### PR TITLE
fix(ai-slop): emit a parseable ISO-8601 date, and close three precision gaps found in post-merge verification

### DIFF
--- a/docs/conventions/detector-findings/CHANGELOG.md
+++ b/docs/conventions/detector-findings/CHANGELOG.md
@@ -4,6 +4,35 @@ Notable changes to the detector-findings contract (SemVer). Changing a producer-
 the coexistence obligations, or an enforceability verdict is a major bump; additive guidance or a new
 adopter row is a minor bump; docs-only clarification is a patch.
 
+## 2.4.1 — 2026-08-21
+
+Two clarifications to prose this contract already had. **Patch under its own rule**: no
+producer-owned field's rule moves, no coexistence obligation changes, no enforceability verdict
+changes, no adopter row is added, and nothing a producer emits or a consumer parses is different.
+Both passages are corrected to say what the consumer already does.
+
+- **"Auto-applicability is settled per rule, at contract time" stated its criterion unqualified.**
+  The opening sentence read as a fence over every finding — "a fix is auto-applied only when it is
+  contained to its `Location`, high-confidence, and not a call for architectural judgment" — while
+  the section directly above it, and the Declared-dispositions table, both turn on the fact that
+  `fix-pass-mode.md` "Step 4" states that fence under its **correctness-class** heading and a
+  cleanup-class row never passes through it. Read literally the sentence contradicted its own
+  neighbours. It is now scoped to the correctness class, with the consequence this contract owns
+  (settle it once per rule, in the crosswalk) marked as the class-independent half. **This wording
+  predates the 2.4.0 release**: it entered with the crosswalk in #2737 on 2026-08-15, and 2.4.0 only
+  put a second passage beside it that made the tension legible.
+- **The `Auto-applicable: No` bullet described the cleanup route as `/simplify`-only.** It said the
+  route "hands that class wholesale to `/simplify`". Step 4 has two branches — `/simplify` when it
+  is available in the session, otherwise the cleanup findings applied directly, one file at a time —
+  and the bullet named one. Its conclusion is unaffected and was never at risk: a `No` cell cannot
+  restrain the route under *either* branch, which is why the bullet was written. The correction
+  states both branches and why the cell reaches neither: on the first no consumer reads it, and on
+  the second the reader is the cleanup route, whose fence is the file rather than auto-applicability.
+
+The same `/simplify`-only description appears in 2.4.0's own entry below and in
+`plugins/review/CHANGELOG.md`. Those are published entries recording what was written at the time
+and are deliberately left as they stand; this note is the correction's home.
+
 ## 2.4.0 — 2026-08-21
 
 A producer can now name the skill that owns its findings' remediation (#3033). New section, "When

--- a/docs/conventions/detector-findings/README.md
+++ b/docs/conventions/detector-findings/README.md
@@ -305,11 +305,12 @@ already covers is pure cost.
   can. Reaching it would trade a misapply for a non-apply, not close the gap.
 - **`Auto-applicable: No` has no path to the route that actually misapplies these rows.** Step 4's
   surface-instead-of-auto-applying fence sits under its **correctness-class** heading. A prose-style
-  row classifies as cleanup by content, and the cleanup route hands that class wholesale to
-  `/simplify`, which — Step 4's own words — "rediscovers cleanups from the working-tree diff — it
-  does NOT read the findings files". A cell no consumer reads on that path cannot restrain it. That is the
-  mechanical half of the gap: the crosswalk can already say a rule is not auto-applicable and still
-  not stop the apply.
+  row classifies as cleanup by content, and the cleanup route prefers `/simplify` — which, in Step
+  4's own words, "rediscovers cleanups from the working-tree diff — it does NOT read the findings
+  files" — and **applies the rows itself, one file at a time, when `/simplify` is absent**. The cell
+  restrains neither branch: on the first no consumer reads it, and on the second the reader is the
+  cleanup route, whose fence is the file, not auto-applicability. That is the mechanical half of the
+  gap: the crosswalk can already say a rule is not auto-applicable and still not stop the apply.
 
 **Producer obligation — one declaration, in the crosswalk row.** A rule whose remediation is
 contained to `Location` but owned by the producer's own remediation surface **leads its
@@ -393,11 +394,14 @@ about repairs nobody claims.
 
 ## Auto-applicability is settled per rule, at contract time
 
-`fix-pass-mode.md` "Step 4" owns the criterion — a fix is auto-applied only when it is contained to
-its `Location`, high-confidence, and not a call for architectural judgment. What this contract owns
-is the consequence for a detector author: **settle it once per rule in the crosswalk, not per finding
-at apply time.** A rule's remediation shape does not vary run to run, so a per-finding decision is
-the same decision taken repeatedly with less evidence.
+`fix-pass-mode.md` "Step 4" owns the criterion, and it binds the **correctness class**: a
+correctness-class fix is auto-applied only when it is contained to its `Location`, high-confidence,
+and not a call for architectural judgment. That scope is not a caveat on the criterion but the whole
+of where it lives — Step 4 states the fence under its correctness-class heading, and the two sections
+above turn on the fact that a cleanup-class row never passes through it. What this contract owns is
+the consequence for a detector author, which is class-independent: **settle it once per rule in the
+crosswalk, not per finding at apply time.** A rule's remediation shape does not vary run to run, so a
+per-finding decision is the same decision taken repeatedly with less evidence.
 
 Three rule shapes are never auto-applicable, and saying so is the contract's intent rather than a
 limitation to route around:

--- a/plugins/ai-slop/.claude-plugin/plugin.json
+++ b/plugins/ai-slop/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "ai-slop",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Detects and removes AI-writing tells (slop) in checked-in markdown prose: em dashes, emoji formatting, AI vocabulary, negative parallelisms, chatbot phrases, filler, stacked hedging, citation artifacts, and the rest of a catalog distilled from Wikipedia's Signs of AI writing. Read-only audit by default with a deterministic detector plus a judgment rubric; an explicit fix action rewrites findings behind a semantic-diff guard. Findings conform to the detector-findings convention so the review fanout fix relay can consume them.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/ai-slop/CHANGELOG.md
+++ b/plugins/ai-slop/CHANGELOG.md
@@ -37,14 +37,21 @@ None changes what the detector finds or what the fix flow rewrites.
   missed. Its prompt now carries the same sentence, and the expectation names the premise it rests
   on so a run that rewrites and re-runs but persists nothing no longer passes.
 
-  **The fix flow's re-emit wording was checked and left alone.** It states re-emission without
-  repeating step 5's gate, which reads at first like the deeper defect — but `persist-findings.md`
-  "Surfaces, and when the file is written at all" is the enumerated list of when a file is written,
-  and tracked-ness is not on it. Step 5's clause is the audit flow's own phrasing of the condition
-  that list does carry (nothing scanned, write nothing), which holds because the audit's default
-  target *is* the repo's tracked markdown. A fix pass always follows a non-empty scan, so the
-  unconditional re-emit is not in conflict with the gate. The defect was in the eval, and only
-  there.
+  **The fix flow's re-emit wording is left alone here, and the question stays open.** It states
+  re-emission without repeating step 5's gate. `persist-findings.md` "Surfaces, and when the file is
+  written at all" enumerates when a file is written and tracked-ness is not on that list, which is
+  the reading under which the two never conflict — but that reading is not established, and this
+  entry does not claim it is. Against it: step 1 scopes "the repo's tracked markdown" to the
+  **empty-target** branch, while every eval case passes a path argument, so "examined tracked files"
+  and "nothing scanned" are not obviously the same condition; and cases 4 and 5 word tracked-ness as
+  gating ("since the audit examined a tracked file"), which an inert precondition would not need.
+  `persist-findings.md`'s precedence clause also names the convention README rather than this
+  `SKILL.md`, so its list is not authoritative over step 5.
+
+  What is settled is the eval: case 2 grades persistence and lacked the premise its siblings carry,
+  which is a gap under either reading. Whether tracked-ness is a substantive gate is a question about
+  this skill's own wording, and if it is, the fix belongs in `context/persist-findings.md` rather
+  than in the fix flow.
 
 ## [0.3.2]
 

--- a/plugins/ai-slop/CHANGELOG.md
+++ b/plugins/ai-slop/CHANGELOG.md
@@ -1,5 +1,51 @@
 # Changelog
 
+## [0.3.3]
+
+Three corrections found by re-reading what 0.3.1 and the 2.4.0 contract release actually shipped.
+None changes what the detector finds or what the fix flow rewrites.
+
+- **`emit-findings.sh` stamped a `date:` that is ISO-8601 in neither profile.** The format string
+  was `%Y-%m-%dT%H-%M-%SZ` — an extended-form date joined to a hyphenated time — so every emitted
+  file carried `date: 2026-08-21T13-24-36Z`. The consumer parses this field:
+  `fix-pass-mode.md` "Step 1" reads a value only when it is a full ISO-8601 date-time with an
+  explicit UTC designator or numeric offset, and classes anything else UNREADABLE. Nothing was
+  dropped, because every clause on that path fails open — an unreadable `date:` keeps the candidate,
+  at a bounded cost of one extra pass — but the staleness note Step 4's cleanup route asks for was
+  degrading silently, since it judges age only from files that declare a readable one. Now
+  `%Y-%m-%dT%H:%M:%SZ`.
+- **The unit suite had pinned the malformed shape as the contract.** `detect.test.sh` asserted the
+  hyphenated time under the name "colon-free UTC date", so the bug was guarded rather than caught.
+  The colon-free rule is real but belongs to the FILE NAME, where it exists to keep the path
+  Windows-safe (`persist-findings.md` "Where the file goes"); it never bound this frontmatter field,
+  whose owner (`default-mode.md` "Findings-file shape") asks for `<ISO-8601 UTC>` plainly. The
+  assertion now pins the extended form and says which document it answers to.
+- **The Purpose section described the relay's cleanup route as `/simplify`-only.** Step 4 of
+  `fix-pass-mode.md` reads "Invoke the `/simplify` skill when available in the session; otherwise
+  apply the cleanup findings directly, one file at a time" — two branches, and the Purpose section
+  named one. The paragraph's conclusion is unchanged and was never at risk: what makes routing these
+  rows to `/ai-slop:audit fix` correct is that *neither* branch loads this skill's rewrite guide, so
+  the omitted branch strengthens the argument rather than weakening it. This is a precision fix to
+  rationale, not a behavior change; the audit flow's step 6 already carried the two-branch wording,
+  and the Purpose section is now consistent with it.
+- **Eval case 2 graded persistence without stating the premise persistence needs.** Its fourth
+  expectation requires the findings file to be re-emitted after the last fixed file, but
+  `SKILL.md` step 5 gates persistence on the audit having "examined tracked files" and the prompt
+  asserted no such thing. 0.3.0 established the remedy for exactly this and applied it to cases 4
+  and 5: a case cannot verify real repository state, so a case that grades the persistence step
+  states the premise instead of constructing it. Case 2 is the third such case and was the one
+  missed. Its prompt now carries the same sentence, and the expectation names the premise it rests
+  on so a run that rewrites and re-runs but persists nothing no longer passes.
+
+  **The fix flow's re-emit wording was checked and left alone.** It states re-emission without
+  repeating step 5's gate, which reads at first like the deeper defect — but `persist-findings.md`
+  "Surfaces, and when the file is written at all" is the enumerated list of when a file is written,
+  and tracked-ness is not on it. Step 5's clause is the audit flow's own phrasing of the condition
+  that list does carry (nothing scanned, write nothing), which holds because the audit's default
+  target *is* the repo's tracked markdown. A fix pass always follows a non-empty scan, so the
+  unconditional re-emit is not in conflict with the gate. The defect was in the eval, and only
+  there.
+
 ## [0.3.2]
 
 The catalog's cited source page lists an **Ineffective indicators** section — signals that

--- a/plugins/ai-slop/skills/audit/SKILL.md
+++ b/plugins/ai-slop/skills/audit/SKILL.md
@@ -26,9 +26,10 @@ rule inventory ([`reference/catalog.md`](reference/catalog.md), distilled from W
    and persist as a conforming findings file. **What the relay APPLIES is narrow; what it ROUTES
    is not.** `rule-utm-params` alone is auto-applicable, and every other rule is
    `/ai-slop:audit fix` work — but the crosswalk now declares that ownership, so the relay hands
-   those rows to this skill's `fix` action rather than to its cleanup route, which is a
-   code-simplification skill that never loads this skill's rewrite guide. The findings file is
-   how a consumer *sees* them and how they reach the one surface that can rewrite them.
+   those rows to this skill's `fix` action rather than to its cleanup route, which prefers
+   `/simplify`, a code-simplification skill, and applies the rows itself when `/simplify` is
+   absent. Neither branch loads this skill's rewrite guide. The findings file is how a consumer
+   *sees* them and how they reach the one surface that can rewrite them.
 2. **Judgment rubric**: the catalog's `v1: rubric` tells, applied by reading the prose. Rubric
    findings reach the human report only, never the findings file.
 

--- a/plugins/ai-slop/skills/audit/evals/evals.json
+++ b/plugins/ai-slop/skills/audit/evals/evals.json
@@ -17,14 +17,14 @@
     {
       "id": 2,
       "name": "fix-runs-semantic-guard",
-      "prompt": "/ai-slop:audit fix evals/fixtures/fix-guarded-rewrite.md relative to the skill directory. Work on a copy so the committed fixture stays byte-identical.",
+      "prompt": "/ai-slop:audit fix evals/fixtures/fix-guarded-rewrite.md relative to the skill directory. Treat the audited file as tracked in the repo under audit. Work on a copy so the committed fixture stays byte-identical.",
       "expected_output": "The fixture's four findings — two em dashes (lines 3 and 7) and two filler phrases ('It is worth noting that' on line 3, 'Due to the fact that' on line 4) — are rewritten in one per-file pass, the before/after pair is verified by a fresh-context semantic-diff subagent that reverts semantic loss or ambiguity, then the detector re-runs and the findings file is re-emitted so no stale findings survive.",
       "files": ["evals/fixtures/fix-guarded-rewrite.md"],
       "expectations": [
         "Applies rewrites only because fix was explicitly requested",
         "Verifies the rewritten file with a fresh-context semantic-diff subagent and reverts flagged hunks",
         "Preserves every claim the fixture makes — that the cache invalidates on write, that the reader never sees a stale entry, that writes are rare, and that the policy is least-recently-used",
-        "Re-runs the detector and re-emits the findings file after the last fixed file",
+        "Re-runs the detector and re-emits the findings file after the last fixed file, on the stated premise that the audited file is tracked — persistence is live for this run, so a pass that rewrites and re-runs but persists nothing does not satisfy this case",
         "Leaves `evals/fixtures/fix-guarded-rewrite.md` byte-identical after the run — the rewrites land on a copy"
       ]
     },

--- a/plugins/ai-slop/skills/audit/scripts/detect.test.sh
+++ b/plugins/ai-slop/skills/audit/scripts/detect.test.sh
@@ -441,10 +441,16 @@ assert_contains "emit: reports destination" "$out" "wrote $FOUT"
 fcontent="$(cat "$FOUT")"
 assert_contains "emit: frontmatter type" "$fcontent" "type: review-findings"
 assert_contains "emit: frontmatter branch" "$fcontent" "branch: test-branch"
-if LC_ALL=C grep -qE '^date: [0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}-[0-9]{2}-[0-9]{2}Z$' "$FOUT"; then
-  pass "emit: colon-free UTC date"
+# The `date:` frontmatter field is PARSED by the consumer: fix-pass-mode.md
+# "Step 1" reads a value only if it is a full ISO-8601 date-time with an explicit
+# UTC designator, so the time portion needs COLONS. This assertion previously
+# pinned a hyphenated time (`T05-45-10Z`), which is ISO-8601 in neither the
+# extended nor the basic profile — it encoded the emitter's bug as the contract.
+# The colon-free rule belongs to the FILE NAME (Windows-safe), not to this field.
+if LC_ALL=C grep -qE '^date: [0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$' "$FOUT"; then
+  pass "emit: ISO-8601 extended UTC date"
 else
-  fail "emit: colon-free UTC date" "colon-free timestamp" "$(grep '^date:' "$FOUT")"
+  fail "emit: ISO-8601 extended UTC date" "YYYY-MM-DDThh:mm:ssZ" "$(grep '^date:' "$FOUT")"
 fi
 assert_contains "emit: finding cell leads with qualified rule id" "$fcontent" "ai-slop/audit/rule-em-dash"
 # detect.sh sanitizes prose pipes to / at excerpt production; the cell must

--- a/plugins/ai-slop/skills/audit/scripts/emit-findings.sh
+++ b/plugins/ai-slop/skills/audit/scripts/emit-findings.sh
@@ -105,7 +105,12 @@ if [[ -e "$OUT" ]]; then
 fi
 mkdir -p "$(dirname "$OUT")"
 
-DATE_UTC="$(date -u +%Y-%m-%dT%H-%M-%SZ)"
+# ISO-8601 EXTENDED, colons in the time portion. The consumer parses this field:
+# fix-pass-mode.md "Step 1" reads a value only if it is "a full ISO-8601
+# date-time carrying an explicit UTC designator (Z) or a numeric offset", and
+# calls anything else UNREADABLE. The colon-free rule this convention states
+# elsewhere binds the FILE NAME (Windows-safe), never this frontmatter field.
+DATE_UTC="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 
 LC_ALL=C awk -v branch="$BRANCH" -v date_utc="$DATE_UTC" '
   # Tier/Action mirror of the severity crosswalk (see header comment).


### PR DESCRIPTION
No linked issue.

## Summary

Four independent corrections, each found by an adversarial verification pass on a merged PR (#3063, #3068) rather than by review of this diff. One is a real defect in emitted output; three are precision gaps in prose that describes behavior accurately elsewhere.

Nothing here changes routing, classification, or what any detector rule fires on.

## Fix

**1 — the findings emitter wrote a timestamp nothing can parse.** `emit-findings.sh` used `%Y-%m-%dT%H-%M-%SZ`, producing `date: 2026-08-21T13-36-00Z` — hyphens where ISO-8601 needs colons in the time portion. The consumer (`fix-pass-mode.md` Step 1) classes an unparseable `date:` as UNREADABLE and fails **open**, so it cost one extra pass and dropped nothing; the staleness check simply degraded silently.

Measured by running both emitters and parsing the output with a real parser, not by reading the format string:

```
MAIN    date: 2026-08-21T13-36-00Z   fromisoformat -> ValueError
BRANCH  date: 2026-08-21T13:36:00Z   fromisoformat -> datetime(2026,8,21,13,36, tzinfo=UTC)
```

**The bug was guarded by a passing test.** `detect.test.sh` asserted `T[0-9]{2}-[0-9]{2}-[0-9]{2}Z` under the name `"emit: colon-free UTC date"`, and main's suite was green *with* the bug. The replacement is discriminating — run against main's emitter it fails exactly one case:

```
FAIL: emit: ISO-8601 extended UTC date
  expected: YYYY-MM-DDThh:mm:ssZ
  actual:   date: 2026-08-21T13-37-13Z
```

Neither pattern matches both forms.

Colons rather than the ISO basic form because the field's owner, `default-mode.md` "Findings-writer contract", binds colon-free to the **file name** (`TS="$(date -u +%Y%m%dT%H%M%SZ)"   # colon-free, Windows-safe`, used as `${TS}-<topic>.md`) while its findings-file shape asks for `date: <ISO-8601 UTC>` three lines below. The strongest corroboration is that a sibling adopter already does it: `testing:audit`'s `cant-fail-scan.sh` emits `%Y-%m-%dT%H:%M:%SZ` for the same `type: review-findings` frontmatter. `ai-slop` was the outlier.

**2 — the cleanup route described as `/simplify`-only.** Step 4 actually reads: *"Invoke the `/simplify` skill when available in the session; otherwise apply the cleanup findings directly, one file at a time."* Two live passages omitted the second branch. Both now name it, and say why the `Auto-applicable` cell reaches neither: on the `/simplify` branch no consumer reads it, and on the direct-apply branch the fence is the file, not auto-applicability. The conclusion was never at risk — a `No` cell cannot restrain the cleanup route under either branch — so this is precision, not a behavior change.

**Two further occurrences are deliberately left as written.** `docs/conventions/detector-findings/CHANGELOG.md` and `plugins/review/CHANGELOG.md` are published entries for released versions. They record what was written at the time; the correction is a closing note in the new 2.4.1 entry naming both locations, not an edit to history.

**3 — an unqualified fence sentence.** The contract said "Step 4 owns the criterion — a fix is auto-applied only when it is contained…", reading as an unconditional rule, while the surrounding text establishes it binds the **correctness class** only. Now scoped explicitly, with the class-independent half (settle it once per rule in the crosswalk) preserved verbatim.

**Pre-existing, and proven so** rather than asserted — it entered with the crosswalk in #2737 on 2026-08-15, six days before #3068:

```
$ git log -S'"Step 4" owns the criterion' -- docs/conventions/detector-findings/README.md
c8470efd  2026-08-15  docs(conventions): harden detector-findings with the rule-id to severity crosswalk (#2737)
```

**4 — ai-slop eval case 2 lacked the tracked-file premise its siblings carry.** It grades findings-file re-emission, which `SKILL.md` step 5 gates on the audit having "examined tracked files", but carried no premise — while cases 4 and 5 both do. Case 2 now carries the sibling sentence verbatim, and its expectation mirrors case 5's discriminating form, so a run that rewrites and re-runs but persists nothing no longer passes.

**The fix flow's re-emit wording is left alone, and the entry records the question as open rather than settled.** An earlier revision of the 0.3.3 entry argued the two conditions were equivalent because the audit's default target *is* the repo's tracked markdown. That argument does not hold: step 1 scopes that default to the **empty-target** branch, and every eval case passes a path argument. Cases 4 and 5 also word tracked-ness as gating, which an inert precondition would not need. The eval gap is real under either reading and stays fixed; the wording question is named, with the seam identified (`context/persist-findings.md`, not the fix flow), rather than closed by an argument the cited text does not support.

## Verification

| Gate | Result |
|---|---|
| Emitter run, before/after, real ISO-8601 parser | `ValueError` → tz-aware UTC instant |
| Branch test body vs main's emitter output | fails exactly 1 of 92 — discriminating |
| `detect.test.sh` | all 92 cases passed |
| `check-detector-findings-crosswalk.sh --check` + self-test | PASS — 22 rule rows |
| `check-changelog-parity.sh --check` / `--check-bump` / `--check-order` / `--check-preserved` | PASS — 83 changelogs; 16 headings preserved |
| `check-changed-skills.sh` | PASS — 0 errors (2 warnings pre-existing, untouched files) |
| `check-silent-revert.sh` | ok |
| `check-evals-quality.sh` + `check-jsonschema` | PASS — 0 warnings |
| `shellcheck`, `check-shell-portability.sh` | clean |
| `markdownlint-cli2` on every changed file | 0 issues |
| `plugins/review/` tree hash vs main | byte-identical — no bump needed there |
| `detect.sh` / `fixtures/` / `reference/` / `context/` subtree hashes | identical to base — no rule, ERE, threshold or fixture moved |

The findings-file **name** is unaffected: `DATE_UTC` appears only in the frontmatter path, while the name is composed separately per `persist-findings.md`'s own colon-free `%Y%m%dT%H%M%SZ`.

## Related

- #3063 — the eval-fixture work whose adversarial pass found item 4.
- #3068 — the producer-owned routing work whose adversarial pass found items 2 and 3.

Versions: `ai-slop` → **0.3.3** (main already ships 0.3.2, so 0.3.2 was unavailable). `detector-findings` → **2.4.1**, argued as patch against the contract's own rule: major is a producer-owned field's rule or an enforceability verdict, minor is additive guidance or a new adopter row. Items 2 and 3 move none of those — the `Auto-applicable` obligation is preserved verbatim and nothing a producer emits or a consumer parses differs.

### Adjacent, pre-existing, not fixed here

`plugins/overengineering/context/findings-artifact.md` specifies a **frontmatter** `date:` as "Colon-free UTC, Windows-safe, lexically sortable" — Windows-safety is a filename property and is meaningless for a frontmatter field. That artifact is a different type with a different consumer and is not a detector-findings adopter, so nothing here contradicts it, but after this PR it is the last surviving instance of the class item 1 fixed. Separately, `cant-fail-scan.test.sh` asserts only `"date: 20"`, which would pass against the hyphenated bug exactly as ai-slop's guard did; that producer's emitter is already correct, so nothing is broken, but the guard has the same non-discriminating shape.