### PR TITLE
feat(knowledge): harden docpage-digest pipeline (0.13.5)

### DIFF
--- a/plugins/knowledge/.claude-plugin/plugin.json
+++ b/plugins/knowledge/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "knowledge",
-  "version": "0.13.4",
+  "version": "0.13.5",
   "description": "Ingest external knowledge into durable, synthesized artifacts. Ships a book-distillation pipeline (PDF/EPUB into concept-organized, author-attributed skill reference files), a video-digest pipeline (watch a single public video from YouTube or X, formerly Twitter: transcript, link harvest, and repo-applicability synthesis), a course-digest pipeline (extract and synthesize online video courses \u2014 Dometrain, Teachable \u2014 into repo-applicable recommendations), a docpage-digest pipeline (single online documentation page into a verified knowledge slice with dual verification \u2014 one cross-vendor verifier \u2014 and an interview handoff), and a map-corpus pipeline (multi-resource corpus into a classified link map, deterministic node manifests, gate-verified relevance inventory, and an approved queue of docpage-digest runs), plus a re-runnable setup action; a configurable library directory governs where synthesized artifacts land in the consuming repo.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/knowledge/CHANGELOG.md
+++ b/plugins/knowledge/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to the `knowledge` plugin are recorded here. The `version` i
 `.claude-plugin/plugin.json` is the delivery vehicle — a consumer receives a change
 only after that version increases.
 
+## [0.13.5]
+
+### Changed
+
+- **`docpage-digest` pipeline hardening from the 9-slice cloud-fleet corpus run
+  (#3015).** Fence mandate: every verbatim quote is a column-0 fenced container
+  under a bold `**CN.**` label — blockquotes and inline code spans are forbidden
+  quote carriers (the PostToolUse hook rewrites list markers inside blockquotes
+  and strips a trailing space from a bare code span). Ships
+  `scripts/check-fences-exact.py` and `scripts/check-snippets.py` as standing
+  gates alongside the quote gate; both fail loud on zero-parse and compare
+  payloads without `.strip()`, with negative-control suites that must fail
+  known-bad fixtures before a PASS is believed. Pin the tree on agent-REPORTED
+  completion, never file presence; a hash manifest freezes the tree for the
+  verification window and each arm restates the hashes it audited; a verdict
+  file on disk is an intermediate write, never a report. Subagent-death /
+  usage-limit ladder (retry window → inline-with-disclosure → degraded marker +
+  re-run trigger) sits beside the existing degraded-verifier rule, which covers
+  a missing cross-vendor arm, not a session that cannot spawn. `SKILL.md`
+  enumerates each gate's blind spots. Format and pin-manifest shape live in
+  `context/pipeline-hardening.md`.
+
 ## [0.13.4]
 
 ### Changed

--- a/plugins/knowledge/skills/docpage-digest/SKILL.md
+++ b/plugins/knowledge/skills/docpage-digest/SKILL.md
@@ -155,6 +155,11 @@ path stays inside `<work-root>/digests/` before writing.
 - **Verbatim means verbatim:** in "Key claims (verbatim)", a truncated quote carries an ellipsis,
   joined source lines declare their join convention, and no escaping may alter characters —
   verifiers diff quotes character-for-character against the source.
+- **Fence mandate:** every verbatim quote — Key claims and Prompt snippets — lives in a
+  column-0 fenced container. Key-claim labels are bold `**CN.**`. Blockquotes and inline code
+  spans are forbidden as quote carriers: the PostToolUse markdownlint hook rewrites `*` list
+  markers and renumbers lists inside blockquoted quotes, and a bare code span cannot hold a
+  trailing space through that hook. Format: [context/pipeline-hardening.md](context/pipeline-hardening.md).
 
 ## Phase 4 — Dual verification
 
@@ -170,11 +175,16 @@ Verdicts land in `<work-root>/verification/` and are **append-only historical re
 wrong verdict gets a dated corrections-applied file beside it, never a rewrite. Corrections
 apply to the digests; re-verify what changed.
 
-**No tree moves until every dispatched arm has reported.** Editing a slice mid-audit voids that
-audit: the verifier's findings stop describing bytes that exist. (A prior run edited three digests
-minutes after one arm reported while the other was still auditing; that arm re-hashed its pinned
-files at the end of its audit, found three no longer matched, and returned BLOCKED — the slice had
-to be re-pinned and the arm re-run.)
+**Pin on agent-REPORTED completion, never file presence.** A digest file on disk does not mean
+its agent is done — one unit's agent rewrote its file seven minutes after a presence-based pin.
+Pin the tree only after every dispatched digest agent has *returned*, then write
+`<work-root>/verification/pin-manifest.json` (path + sha256 per frozen file; shape in
+[context/pipeline-hardening.md](context/pipeline-hardening.md)). That manifest freezes the tree
+for the verification window. Each arm hashes what it audits and states those hashes in its
+verdict; a mismatch is BLOCKED, not a content finding. **A verdict file on disk is an
+intermediate write, never a report** — do not apply corrections or re-pin because a file
+appeared; wait for the arm to return. Editing a slice mid-audit voids that audit: the verifier's
+findings stop describing bytes that exist.
 
 **Every correction round leaves an applied record, and the next round reads it.** The record is
 dated, lands beside the verdicts, and names what changed and why; any finding the round surfaced but
@@ -190,12 +200,22 @@ and no later round could read them.)
 
 **A mechanical gate reports only what it parsed, and only the fields it checks.** Any script used as
 a verification gate errors loudly on input it cannot recognize, and a clean result is read as
-covering just the rows and fields it actually exercised. **The ordering is not negotiable:** a gate
-that silently skips what it cannot parse is fixed *before* it is made a required artifact, or the
-mandate converts a visible gap into an invisible pass. (Both arms independently caught the campaign's
-quote checker printing "all checks clean" over a digest whose 14 claims it could not parse at all;
-a separate command-replay gate read only the first number in each `→ N lines, M files` pair, so it
-reported clean on a class it was structurally blind to.)
+covering just the rows and fields it actually exercised. **A gate is a claim that needs its own
+evidence:** do not believe a PASS until that gate's negative-control suite has failed the known-bad
+fixtures (empty, unparsable, zero-parse, indented fence, fabricated payload). **The ordering is
+not negotiable:** a gate that silently skips what it cannot parse is fixed *before* it is made a
+required artifact, or the mandate converts a visible gap into an invisible pass. (Both arms
+independently caught the campaign's quote checker printing "all checks clean" over a digest whose
+14 claims it could not parse at all; `gate-family-consistency.sh` printed PASS after `mktemp`
+failed and it parsed zero claims; `gate-coverage.sh` printed OK over blank inventories.)
+
+**Standing gates (required, after the pin):**
+[`scripts/check-fences-exact.py`](scripts/check-fences-exact.py) and
+[`scripts/check-snippets.py`](scripts/check-snippets.py) — invocation in
+[context/pipeline-hardening.md](context/pipeline-hardening.md). They stand alongside the quote
+gate. Prerequisite: `python3` (3.9+). A PASS covers only what each script prints. Their
+negative-control evidence is `scripts/test_check_fences_exact.py` and
+`scripts/test_check_snippets.py`.
 
 **Commands are replayable in every pipeline artifact, not just digest rows.** INDEX rows, applied
 records, verdicts, rulings and handoffs carry commands too, in the same command-plus-raw-count form,
@@ -217,7 +237,19 @@ this shape by hand, and only by choosing to look.)
 **Degraded-verifier fallback (never silent):** when the cross-vendor verifier is unavailable
 (not installed, sandbox-broken, quota), substitute a second same-vendor verifier briefed as an
 adversarial refuter, and RECORD the degradation and its reason in the verdict file header. A
-verification record that hides its degraded provenance is worse than a missing one.
+verification record that hides its degraded provenance is worse than a missing one. That rule
+covers a *missing* cross-vendor arm, not a session that cannot spawn.
+
+**Subagent-death / usage-limit ladder** (dominant failure mode, ahead of content defects — lost
+agents, killed completion reports, mid-audit kills, slot exhaustion, refused fan-out):
+
+1. **Retry window** — re-dispatch the same brief once; record the death and the retry.
+2. **Inline-with-disclosure** — if the retry also dies, complete that unit inline and record
+   `inline-with-disclosure` naming the dead slot and the unit.
+3. **Degraded marker + re-run trigger** — if inline is impossible, write the marker and name the
+   unfinished units; do not tick the phase complete.
+
+Silence is not a rung. Detail: [context/pipeline-hardening.md](context/pipeline-hardening.md).
 
 ## Phase 5 — Interview handoff
 
@@ -249,14 +281,37 @@ only when a THIRD profile lands (Rule of Three) — two points make a line, not 
 - **Does not summarize ad hoc.** A quick "what does this page say" wants a plain fetch, not this
   pipeline.
 
+## Standing-gate blind spots
+
+A gate only covers what it parses; its blind spot is where defects live. Unparsed sections are
+the attack surface. Presence-non-empty is not finished (35 unsubstituted `@@SRC@@` placeholders
+passed a parity gate). Phrase-greps miss fluent-prose instances (a basis-by-reference detector
+matched zero of four real instances).
+
+- **Quote gate** (campaign `check-quotes.py`, per-line `.strip()`): indented-fence corruption and
+  trailing-space loss pass; Prompt snippets are unparsed.
+- **`check-fences-exact.py`:** only `**CN.**` + the following column-0 fence under Key claims.
+  Blind to Prompt snippets, prose quotes, unlabelled fences, tag correctness, join-convention
+  honesty.
+- **`check-snippets.py`:** only fences under Prompt snippets. Blind to Key claims, unfenced
+  restatements, omitted real prompts, a lying none-marker.
+- **Command-replay:** first number of each `→ N lines, M files` pair; POSIX-quoted commands
+  replayed through cmd.exe (`check-commands.py` v1).
+- **Presence-non-empty / parity:** unsubstituted placeholders pass; blank inventories can print
+  OK.
+
 ## Gotchas
 
 - **Verify the fetch channel per page.** A raw-markdown channel that worked for one doc can 404
   for the next; the profile records precedent, not a guarantee.
 - **Digest-unit parity is the invariant.** INDEX.md rows, digest files, and checklist entries
-  must agree; a dropped section is silent corpus loss the verifiers are told to catch.
+  must agree; a dropped section is silent corpus loss the verifiers are told to catch. Parity
+  that only checks presence-non-empty will not catch unsubstituted placeholders.
 - **Verdicts are append-only.** Fixing a digest after verification means a corrections-applied
-  file plus re-verification of the changed digests — never editing the verdict.
+  file plus re-verification of the changed digests — never editing the verdict. A verdict file
+  on disk is not a report.
+- **Pin on report, not presence.** Hash-manifest the tree after agents return; each arm restates
+  the hashes it audited.
 - **Model-pinned briefs drift.** The conditional framing above exists because a spawn-time model
   override silently invalidates "you are X" text; always condition, never assert.
 - **Applicability tags are claims.** A profile may define an applicability filter; its

--- a/plugins/knowledge/skills/docpage-digest/context/pipeline-hardening.md
+++ b/plugins/knowledge/skills/docpage-digest/context/pipeline-hardening.md
@@ -1,0 +1,118 @@
+# Docpage-digest pipeline hardening
+
+Spoke for the interview-ratified contract in `SKILL.md` (fence mandate, standing
+gates, freeze/pin, subagent-death ladder). The skill file owns the binding
+rules and each gate's blind spots; this file owns the format, invocation, and
+pin-manifest shape so `SKILL.md` stays a procedure.
+
+**Prerequisite:** `python3` (3.9+) on PATH for the two standing gates under
+`scripts/`. Missing Python means say so and stop — there is no agent-judgment
+fallback for a deterministic quote/snippet check.
+
+## Fence mandate
+
+Every verbatim quote — Key claims and Prompt snippets — lives in a **column-0
+fenced container**. Labels on Key claims are bold `**CN.**` (C1, C2, …).
+
+Why fencing is the only remedy that held:
+
+- A *blockquote* quote is rewritten by the markdownlint-cli2 PostToolUse hook
+  (`*` list markers become `-`; ordered lists renumber).
+- A *bare inline code span* cannot hold a trailing space through that hook
+  (three attested sites).
+- `check-quotes.py`'s per-line `.strip()` then hid indented-fence corruption
+  introduced by a REPAIR pass.
+
+Shape (Key claims):
+
+- A `## Key claims` (or `## Key claims (verbatim)`) heading.
+- One `**CN.**` label per claim, optional tag after the label.
+- Immediately after, a column-0 fence whose payload is the quote *bytes* —
+  trailing spaces kept, no indent on the opener, no `.strip()` anywhere.
+
+Shape (Prompt snippets):
+
+- A `## Prompt snippets` (or `## Prompt snippets (exact)`) heading.
+- Each snippet is a column-0 fence. A recognised none-marker (`none`, `n/a`,
+  `(none)`, `no prompt snippets`) is the only legal empty form.
+
+Blockquotes and inline code spans are forbidden as quote carriers.
+
+## Standing gates
+
+Run after the pin (below), before verifier arms are believed complete:
+
+```text
+python3 "${CLAUDE_PLUGIN_ROOT}/skills/docpage-digest/scripts/check-fences-exact.py" \
+  --source <work-root>/source.md \
+  --digest <work-root>/digests/01-….md \
+  --digest <work-root>/digests/02-….md
+
+python3 "${CLAUDE_PLUGIN_ROOT}/skills/docpage-digest/scripts/check-snippets.py" \
+  --source <work-root>/source.md \
+  --digest <work-root>/digests/01-….md \
+  --digest <work-root>/digests/02-….md
+```
+
+Use `source.txt` when the original is a PDF extraction. Repeat `--digest` once
+per digest file. A PASS prints the files, counts, and fields exercised; read it
+as covering only that. Zero parsed claims or an unparsed Prompt-snippets
+section is a failure, never a skip.
+
+**A gate is a claim that needs its own evidence.** Do not believe a PASS until
+that gate's negative-control suite has failed the known-bad fixtures. For these
+two gates the evidence is `scripts/test_check_fences_exact.py` and
+`scripts/test_check_snippets.py` (empty input, zero-parse, indented fence,
+stripped trailing space, blockquote/inline substitutes, fabricated
+quote/snippet). A newly written gate is not a required artifact until that
+suite is green — the ordering is the one `SKILL.md` already states.
+
+## Freeze / pin
+
+Pin the tree on **agent-REPORTED completion**, never on file presence. A digest
+file appearing on disk does not mean its agent is done (a unit's agent rewrote
+its file seven minutes after a presence-based pin).
+
+After every dispatched digest agent has *returned*:
+
+1. Hash each frozen path (digests, INDEX.md, source.\*).
+2. Write `<work-root>/verification/pin-manifest.json`:
+
+```json
+{
+  "schema": "docpage-pin/v1",
+  "pinned_at": "<ISO-8601 Z>",
+  "pinned_on": "agent-reported-completion",
+  "files": [
+    {"path": "source.md", "sha256": "<hex64>"},
+    {"path": "INDEX.md", "sha256": "<hex64>"},
+    {"path": "digests/01-slug.md", "sha256": "<hex64>"}
+  ]
+}
+```
+
+That manifest freezes the tree for the verification window. Each arm hashes
+what it audits and states those hashes in its verdict. A mismatch is BLOCKED,
+not a content finding — re-pin and re-run the arm.
+
+**A verdict file on disk is an intermediate write, never a report.** Do not
+apply corrections, re-pin, or tick an arm complete because a verdict file
+appeared. Wait for the arm to return.
+
+## Subagent-death / usage-limit ladder
+
+Dominant failure mode of the cloud-fleet run, ahead of any content defect
+(lost agents, killed completion reports, mid-audit kills, slot exhaustion,
+refused fan-out). `SKILL.md`'s degraded-verifier rule covers a *missing*
+cross-vendor arm, not a session that cannot spawn.
+
+1. **Retry window** — re-dispatch the same brief once; record the death and
+   the retry.
+2. **Inline-with-disclosure** — if the retry also dies, the orchestrator
+   completes that unit inline and records `inline-with-disclosure` naming the
+   dead slot and the unit.
+3. **Degraded marker + re-run trigger** — if inline is impossible, write the
+   marker on the checklist (and the verdict header if an arm is what died)
+   and name the unfinished units. Do not tick the phase complete.
+
+Silence is not a rung.

--- a/plugins/knowledge/skills/docpage-digest/evals/evals.json
+++ b/plugins/knowledge/skills/docpage-digest/evals/evals.json
@@ -5,11 +5,14 @@
       "id": 1,
       "name": "full-pipeline-docs-url",
       "prompt": "Run /knowledge:docpage-digest https://platform.claude.com/docs/en/build-with-claude/effort",
-      "expected_output": "Resolves library_dir work root, selects the Anthropic docs profile, fetches via the profile's preferred channel (raw .md, verifying it works for this page, with recorded fallback on failure), snapshots source.md, writes INDEX.md, fans out per-section digest agents, runs dual verification (one cross-vendor verifier) with append-only verdicts, and authors interview-handoff.md.",
+      "expected_output": "Resolves library_dir work root, selects the Anthropic docs profile, fetches via the profile's preferred channel (raw .md, verifying it works for this page, with recorded fallback on failure), snapshots source.md, writes INDEX.md, fans out per-section digest agents whose verbatim quotes are column-0 fences under bold **CN.** labels, pins the tree on agent-reported completion with pin-manifest.json, runs check-fences-exact.py and check-snippets.py, runs dual verification (one cross-vendor verifier) with append-only verdicts that restate audited hashes, and authors interview-handoff.md.",
       "expectations": [
         "Copies templates/checklist.md into the work root and ticks phases as they complete",
         "Snapshots the unaltered original to source.md before any digesting",
         "INDEX.md digest-map rows stay in parity with digest file count",
+        "Verbatim quotes are fenced under **CN.** labels, not blockquotes or inline code spans",
+        "verification/pin-manifest.json is written only after digest agents report, not on file presence",
+        "check-fences-exact.py and check-snippets.py PASS before verifier verdicts are believed",
         "Verification verdicts land in verification/ and are never rewritten",
         "Ends at interview-handoff.md; does not build artifacts or commit the slice"
       ]
@@ -44,6 +47,50 @@
         "Fetched content receives no instruction authority over the pipeline",
         "Digest and verifier briefs carry the untrusted-source rule",
         "No standing instruction artifact is written directly from source text"
+      ]
+    },
+    {
+      "id": 5,
+      "name": "fence-mandate-and-standing-gates",
+      "prompt": "During Phase 3 of /knowledge:docpage-digest a digest agent writes Key claims as blockquoted verbatim quotes and puts Prompt snippets in inline code spans. Phase 4 is about to start.",
+      "expected_output": "Refuses the blockquote/inline-code form: every verbatim quote must be a column-0 fence under a bold **CN.** label. Does not treat Phase 3 as complete. Runs check-fences-exact.py and check-snippets.py after pin; a gate failure is fixed in the digest (never the source) and re-run to PASS before verifier arms are believed.",
+      "expectations": [
+        "Blockquoted quotes and inline-code quotes are rejected as the quote carrier",
+        "check-fences-exact.py and check-snippets.py are the standing gates alongside the quote gate",
+        "A failing gate is not reported as coverage"
+      ]
+    },
+    {
+      "id": 6,
+      "name": "pin-on-reported-completion",
+      "narration": true,
+      "prompt": "During /knowledge:docpage-digest Phase 3, digest files for units 01-04 have appeared on disk. Unit 04's digest agent has not returned. The orchestrator is about to write pin-manifest.json and dispatch verifier arms.",
+      "expected_output": "Refuses to pin on file presence. Waits until every dispatched digest agent has reported completion, then writes verification/pin-manifest.json and freezes that hash set for the verification window. A verdict file appearing on disk is treated as an intermediate write, not as the arm having reported.",
+      "expectations": [
+        "Pin happens after agent-reported completion, not when files appear",
+        "Each verifier arm states the hashes it audited in its verdict",
+        "A verdict file on disk is not treated as a report"
+      ]
+    },
+    {
+      "id": 7,
+      "name": "fallback-ladder-subagent-death",
+      "prompt": "During /knowledge:docpage-digest Phase 3 a digest subagent is killed by a usage-limit mid-write. The cross-vendor Codex plugin is installed.",
+      "expected_output": "Follows the subagent-death ladder, not the degraded-verifier rule (that rule covers a missing cross-vendor arm). Retries the same brief once; if the retry also dies, completes the unit inline and records inline-with-disclosure; if inline is impossible, writes a degraded marker plus a re-run trigger and does not tick Phase 3 complete.",
+      "expectations": [
+        "Does not silently skip the dead unit or tick the phase complete",
+        "Does not substitute the degraded-verifier (missing-arm) rule for a spawn/kill failure",
+        "Names the rung taken: retry, inline-with-disclosure, or degraded marker + re-run trigger"
+      ]
+    },
+    {
+      "id": 8,
+      "name": "gate-pass-needs-negative-control",
+      "prompt": "A newly written check-quotes-style gate for /knowledge:docpage-digest prints PASS. No negative-control fixture has been run against it.",
+      "expected_output": "Does not believe the PASS. A gate is a claim that needs its own evidence: the negative-control suite (empty input, zero-parse, indented fence, fabricated payload) must fail those fixtures before the gate is a required artifact or a PASS is read as coverage.",
+      "expectations": [
+        "PASS without negative-control evidence is not treated as coverage",
+        "A gate that parsed zero claims and printed PASS is a defect, not a clean run"
       ]
     }
   ]

--- a/plugins/knowledge/skills/docpage-digest/scripts/check-fences-exact.py
+++ b/plugins/knowledge/skills/docpage-digest/scripts/check-fences-exact.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""Standing gate: Key-claims fences are exact source bytes.
+
+Parses bold ``**CN.**`` labels under a Key claims heading and diffs each
+following column-0 fence payload against the immutable source. Payloads are
+NOT stripped — a per-line ``.strip()`` is how indented-fence corruption and a
+load-bearing trailing space earned a clean quote-gate result.
+
+A clean run prints exactly what it exercised. Zero parsed claims is a failure,
+never PASS. Unrecognised input is exit 2.
+
+Exit codes:
+  0  all checks passed
+  1  one or more named check failures
+  2  unusable input
+  3  internal gate bug
+
+Stdlib only. Python 3.9+.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from typing import List, Optional
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from digest_fences import (  # noqa: E402
+    Failures,
+    MIN_PYTHON,
+    extract_fences,
+    fail,
+    find_section,
+    parse_claims,
+    payload_in_source,
+    read_text,
+)
+
+PROG = "check-fences-exact"
+
+
+def check_digest(path: str, source: str, failures: Failures) -> int:
+    """Return the number of claims fully exercised on this digest."""
+    text = read_text(path, PROG, "digest")
+    found = find_section(text, "Key claims")
+    if found is None:
+        failures.add(
+            f"{path}: no '## Key claims' heading; this gate parses that "
+            f"section only and will not PASS over an unparsed digest.")
+        return 0
+    _title, body, heading_line = found
+    try:
+        claims = parse_claims(body, start_line=heading_line + 1)
+    except ValueError as exc:
+        failures.add(f"{path}: {exc}")
+        return 0
+    if not claims:
+        failures.add(
+            f"{path}: parsed ZERO claims under Key claims. A clean result "
+            f"over nothing parsed is the quote-gate defect this gate exists "
+            f"to refuse.")
+        return 0
+
+    seen = {}
+    exercised = 0
+    for claim in claims:
+        label = f"{path}: C{claim.number} (line {claim.label_line})"
+        if claim.number in seen:
+            failures.add(f"{label}: duplicate **C{claim.number}.** "
+                         f"(first at line {seen[claim.number]}).")
+            continue
+        seen[claim.number] = claim.label_line
+        if claim.unfenced_blockquote:
+            failures.add(
+                f"{label}: quote is a blockquote, not a fence. The "
+                f"markdownlint PostToolUse hook rewrites list markers and "
+                f"renumbers lists inside blockquoted verbatim quotes.")
+            continue
+        if claim.unfenced_inline_code:
+            failures.add(
+                f"{label}: quote is an inline code span, not a fence. A "
+                f"bare code span cannot hold a trailing space through the "
+                f"hook.")
+            continue
+        if claim.fence is None:
+            failures.add(
+                f"{label}: no fenced container follows the label. Every "
+                f"verbatim quote is a column-0 fence under **CN.**.")
+            continue
+        if claim.fence.indented:
+            failures.add(
+                f"{label}: fence opener at line {claim.fence.start_line} is "
+                f"indented. Indented-fence corruption is a defect; this gate "
+                f"does not strip indent to make it pass.")
+            continue
+        if not payload_in_source(claim.fence.payload, source):
+            shown = claim.fence.payload.replace("\n", "\\n")
+            if len(shown) > 80:
+                shown = shown[:80] + "…"
+            failures.add(
+                f"{label}: fence payload is not an exact contiguous "
+                f"substring of the source (no strip applied). Payload "
+                f"starts {shown!r}.")
+            continue
+        exercised += 1
+
+    try:
+        section_fences = extract_fences(body, start_line=heading_line + 1)
+    except ValueError as exc:
+        failures.add(f"{path}: {exc}")
+        return exercised
+    claimed_starts = {c.fence.start_line for c in claims if c.fence}
+    for fence in section_fences:
+        if fence.start_line not in claimed_starts:
+            failures.add(
+                f"{path}: unlabelled fence at line {fence.start_line} under "
+                f"Key claims; this gate only attests **CN.**-labelled "
+                f"fences, so an unlabelled one is unparsed surface.")
+
+    return exercised
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog=PROG,
+        description="Gate Key-claims fence payloads against the source, "
+                    "without stripping.")
+    parser.add_argument("--source", required=True,
+                        help="Immutable source.md / source.txt")
+    parser.add_argument("--digest", action="append", default=[],
+                        dest="digests",
+                        help="Digest file (repeatable)")
+    args = parser.parse_args(argv)
+    if not args.digests:
+        fail(PROG, 2, "no --digest given; nothing to parse is not a PASS.")
+
+    source = read_text(args.source, PROG, "source")
+    failures = Failures(PROG)
+    exercised = 0
+    for path in args.digests:
+        exercised += check_digest(path, source, failures)
+
+    if failures.items:
+        print(f"{PROG}: FAILED -- {len(failures.items)} failure(s) across "
+              f"{len(args.digests)} digest(s); {exercised} claim fence(s) "
+              f"matched the source exactly.")
+        return 1
+
+    print(
+        f"{PROG}: PASS -- exercised: source {args.source!r}, "
+        f"{len(args.digests)} digest(s), {exercised} **CN.** fence "
+        f"payload(s) compared as exact contiguous source substrings with "
+        f"NO per-line strip (trailing spaces and indent preserved). "
+        f"Checked: Key claims heading present, ≥1 labelled claim, column-0 "
+        f"fence per label, no unlabelled fences, no blockquote/inline-code "
+        f"substitutes. Nothing outside Key claims / **CN.** / fence "
+        f"payloads was checked.")
+    return 0
+
+
+if __name__ == "__main__":
+    if sys.version_info < MIN_PYTHON:
+        sys.stderr.write(
+            f"{PROG}: ERROR: Python {MIN_PYTHON[0]}.{MIN_PYTHON[1]}+ "
+            f"required.\n")
+        sys.exit(2)
+    try:
+        sys.exit(main())
+    except SystemExit:
+        raise
+    except Exception as exc:
+        sys.stderr.write(
+            f"{PROG}: ERROR: internal failure {type(exc).__name__}: {exc}. "
+            f"This is a gate bug; the run is NOT clean.\n")
+        sys.exit(3)

--- a/plugins/knowledge/skills/docpage-digest/scripts/check-fences-exact.py
+++ b/plugins/knowledge/skills/docpage-digest/scripts/check-fences-exact.py
@@ -94,6 +94,11 @@ def check_digest(path: str, source: str, failures: Failures) -> int:
                 f"indented. Indented-fence corruption is a defect; this gate "
                 f"does not strip indent to make it pass.")
             continue
+        if claim.fence.payload == "":
+            failures.add(
+                f"{label}: fence payload is empty. An unfinished "
+                f"placeholder is not a quote.")
+            continue
         if not payload_in_source(claim.fence.payload, source):
             shown = claim.fence.payload.replace("\n", "\\n")
             if len(shown) > 80:

--- a/plugins/knowledge/skills/docpage-digest/scripts/check-fences-exact.test.sh
+++ b/plugins/knowledge/skills/docpage-digest/scripts/check-fences-exact.test.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Cross-platform wrapper so plugin-gate (plugins/**/*.test.sh) runs the
+# check-fences-exact negative-control suite. The Python floor is parsed from
+# digest_fences.py rather than restated here.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ENGINE="$SCRIPT_DIR/digest_fences.py"
+FLOOR="$(sed -n 's/^MIN_PYTHON = (\([0-9]*\), \([0-9]*\)).*/\1.\2/p' "$ENGINE")"
+if [[ -z "$FLOOR" ]]; then
+  echo "FAIL: could not parse MIN_PYTHON from $ENGINE" >&2
+  exit 1
+fi
+
+PYTHON=""
+for candidate in python3 python; do
+  resolved="$(command -v "$candidate" 2>/dev/null)" || continue
+  lower="$(printf '%s' "$resolved" | tr '[:upper:]' '[:lower:]')"
+  if [[ "$lower" == *windowsapps* && ! -s "$resolved" ]]; then
+    continue
+  fi
+  if "$candidate" -c "import sys; floor = tuple(int(part) for part in '$FLOOR'.split('.')); raise SystemExit(0 if sys.version_info >= floor else 1)"; then
+    PYTHON="$candidate"
+    break
+  fi
+done
+if [[ -z "$PYTHON" ]]; then
+  echo "SKIP: Python ${FLOOR}+ not found" >&2
+  exit 0
+fi
+
+"$PYTHON" "$SCRIPT_DIR/test_check_fences_exact.py" -v

--- a/plugins/knowledge/skills/docpage-digest/scripts/check-snippets.py
+++ b/plugins/knowledge/skills/docpage-digest/scripts/check-snippets.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Standing gate: Prompt-snippets fences are exact source bytes.
+
+Parses the Prompt snippets section — the section the campaign quote gate
+never walked, so five snippets fabricated from recall shipped under
+"682/682 CLEAN". Each column-0 fence payload must be an exact contiguous
+substring of the source. Payloads are NOT stripped.
+
+A missing section, or a section with unparsed non-empty content and zero
+fences, is a failure — never PASS. A recognised none-marker is a clean
+zero-snippet run and is named as such.
+
+Exit codes:
+  0  all checks passed
+  1  one or more named check failures
+  2  unusable input
+  3  internal gate bug
+
+Stdlib only. Python 3.9+.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from typing import List, Optional
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from digest_fences import (  # noqa: E402
+    Failures,
+    MIN_PYTHON,
+    extract_fences,
+    fail,
+    find_section,
+    is_none_section,
+    payload_in_source,
+    read_text,
+)
+
+PROG = "check-snippets"
+
+
+def check_digest(path: str, source: str, failures: Failures) -> int:
+    """Return the number of snippet fences fully exercised on this digest."""
+    text = read_text(path, PROG, "digest")
+    found = find_section(text, "Prompt snippets")
+    if found is None:
+        failures.add(
+            f"{path}: no '## Prompt snippets' heading. This is the section "
+            f"no prior gate parsed; absence is a failure, not a skip.")
+        return 0
+    _title, body, heading_line = found
+    if is_none_section(body):
+        return 0
+    try:
+        fences = extract_fences(body, start_line=heading_line + 1)
+    except ValueError as exc:
+        failures.add(f"{path}: {exc}")
+        return 0
+    if not fences:
+        failures.add(
+            f"{path}: Prompt snippets has non-empty content but parsed "
+            f"ZERO fences. Unparsed section content is the attack surface "
+            f"(fabricated-from-recall snippets shipped here). Use a "
+            f"column-0 fence or a recognised none-marker.")
+        return 0
+
+    exercised = 0
+    for fence in fences:
+        label = f"{path}: snippet fence at line {fence.start_line}"
+        if fence.indented:
+            failures.add(
+                f"{label}: opener is indented. Indented-fence corruption "
+                f"is a defect; this gate does not strip indent to pass.")
+            continue
+        if not payload_in_source(fence.payload, source):
+            shown = fence.payload.replace("\n", "\\n")
+            if len(shown) > 80:
+                shown = shown[:80] + "…"
+            failures.add(
+                f"{label}: payload is not an exact contiguous substring "
+                f"of the source (no strip applied). Payload starts "
+                f"{shown!r}.")
+            continue
+        exercised += 1
+    return exercised
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog=PROG,
+        description="Gate Prompt-snippets fence payloads against the source.")
+    parser.add_argument("--source", required=True,
+                        help="Immutable source.md / source.txt")
+    parser.add_argument("--digest", action="append", default=[],
+                        dest="digests",
+                        help="Digest file (repeatable)")
+    args = parser.parse_args(argv)
+    if not args.digests:
+        fail(PROG, 2, "no --digest given; nothing to parse is not a PASS.")
+
+    source = read_text(args.source, PROG, "source")
+    failures = Failures(PROG)
+    exercised = 0
+    for path in args.digests:
+        exercised += check_digest(path, source, failures)
+
+    if failures.items:
+        print(f"{PROG}: FAILED -- {len(failures.items)} failure(s) across "
+              f"{len(args.digests)} digest(s); {exercised} snippet fence(s) "
+              f"matched the source exactly.")
+        return 1
+
+    print(
+        f"{PROG}: PASS -- exercised: source {args.source!r}, "
+        f"{len(args.digests)} digest(s), {exercised} Prompt-snippets fence "
+        f"payload(s) compared as exact contiguous source substrings with "
+        f"NO per-line strip. Checked: Prompt snippets heading present, "
+        f"each fence column-0 and in-source (or a recognised none-marker). "
+        f"Nothing outside Prompt snippets / fence payloads was checked.")
+    return 0
+
+
+if __name__ == "__main__":
+    if sys.version_info < MIN_PYTHON:
+        sys.stderr.write(
+            f"{PROG}: ERROR: Python {MIN_PYTHON[0]}.{MIN_PYTHON[1]}+ "
+            f"required.\n")
+        sys.exit(2)
+    try:
+        sys.exit(main())
+    except SystemExit:
+        raise
+    except Exception as exc:
+        sys.stderr.write(
+            f"{PROG}: ERROR: internal failure {type(exc).__name__}: {exc}. "
+            f"This is a gate bug; the run is NOT clean.\n")
+        sys.exit(3)

--- a/plugins/knowledge/skills/docpage-digest/scripts/check-snippets.py
+++ b/plugins/knowledge/skills/docpage-digest/scripts/check-snippets.py
@@ -53,6 +53,12 @@ def check_digest(path: str, source: str, failures: Failures) -> int:
     _title, body, heading_line = found
     if is_none_section(body):
         return 0
+    if not body.strip():
+        failures.add(
+            f"{path}: Prompt snippets body is blank. A recognised "
+            f"none-marker is the only legal empty form; silence is not "
+            f"an assertion.")
+        return 0
     try:
         fences = extract_fences(body, start_line=heading_line + 1)
     except ValueError as exc:
@@ -73,6 +79,11 @@ def check_digest(path: str, source: str, failures: Failures) -> int:
             failures.add(
                 f"{label}: opener is indented. Indented-fence corruption "
                 f"is a defect; this gate does not strip indent to pass.")
+            continue
+        if fence.payload == "":
+            failures.add(
+                f"{label}: payload is empty. An unfinished placeholder "
+                f"is not a snippet.")
             continue
         if not payload_in_source(fence.payload, source):
             shown = fence.payload.replace("\n", "\\n")

--- a/plugins/knowledge/skills/docpage-digest/scripts/check-snippets.test.sh
+++ b/plugins/knowledge/skills/docpage-digest/scripts/check-snippets.test.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Cross-platform wrapper so plugin-gate (plugins/**/*.test.sh) runs the
+# check-snippets negative-control suite. The Python floor is parsed from
+# digest_fences.py rather than restated here.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ENGINE="$SCRIPT_DIR/digest_fences.py"
+FLOOR="$(sed -n 's/^MIN_PYTHON = (\([0-9]*\), \([0-9]*\)).*/\1.\2/p' "$ENGINE")"
+if [[ -z "$FLOOR" ]]; then
+  echo "FAIL: could not parse MIN_PYTHON from $ENGINE" >&2
+  exit 1
+fi
+
+PYTHON=""
+for candidate in python3 python; do
+  resolved="$(command -v "$candidate" 2>/dev/null)" || continue
+  lower="$(printf '%s' "$resolved" | tr '[:upper:]' '[:lower:]')"
+  if [[ "$lower" == *windowsapps* && ! -s "$resolved" ]]; then
+    continue
+  fi
+  if "$candidate" -c "import sys; floor = tuple(int(part) for part in '$FLOOR'.split('.')); raise SystemExit(0 if sys.version_info >= floor else 1)"; then
+    PYTHON="$candidate"
+    break
+  fi
+done
+if [[ -z "$PYTHON" ]]; then
+  echo "SKIP: Python ${FLOOR}+ not found" >&2
+  exit 0
+fi
+
+"$PYTHON" "$SCRIPT_DIR/test_check_snippets.py" -v

--- a/plugins/knowledge/skills/docpage-digest/scripts/digest_fences.py
+++ b/plugins/knowledge/skills/docpage-digest/scripts/digest_fences.py
@@ -87,14 +87,16 @@ def iter_h2_sections(text: str) -> Iterator[Tuple[str, str, int]]:
     lines = split_lines(text)
     starts: List[Tuple[int, str]] = []
     in_fence = False
+    open_ticks = 0
     for idx, line in enumerate(lines):
-        is_open, _indented = _is_fence_opener(line)
+        is_open, _indented, ticks = _is_fence_opener(line)
         if in_fence:
-            if _is_fence_closer(line):
+            if _is_fence_closer(line, open_ticks):
                 in_fence = False
             continue
         if is_open:
             in_fence = True
+            open_ticks = ticks
             continue
         match = ATX_H2.match(line)
         if match:
@@ -114,17 +116,31 @@ def find_section(text: str, prefix: str) -> Optional[Tuple[str, str, int]]:
     return None
 
 
-def _is_fence_opener(line: str) -> Tuple[bool, bool]:
-    """Return (is_opener, indented)."""
+def _is_fence_opener(line: str) -> Tuple[bool, bool, int]:
+    """Return (is_opener, indented, backtick-run-length)."""
     stripped = line.lstrip(" \t")
-    if stripped.startswith("```"):
-        return True, (len(line) != len(stripped))
-    return False, False
+    if not stripped.startswith("```"):
+        return False, False, 0
+    ticks = 0
+    for char in stripped:
+        if char != "`":
+            break
+        ticks += 1
+    return True, (len(line) != len(stripped)), ticks
 
 
-def _is_fence_closer(line: str) -> bool:
+def _is_fence_closer(line: str, min_ticks: int) -> bool:
+    """CommonMark: a closer is backticks-only, length >= the opener."""
     stripped = line.lstrip(" \t")
-    return stripped.startswith("```") and stripped.strip("` \t") == ""
+    if not stripped.startswith("`"):
+        return False
+    ticks = 0
+    for char in stripped:
+        if char != "`":
+            break
+        ticks += 1
+    rest = stripped[ticks:].strip(" \t")
+    return rest == "" and ticks >= min_ticks
 
 
 def extract_fences(text: str, *, start_line: int = 1) -> List[Fence]:
@@ -133,7 +149,7 @@ def extract_fences(text: str, *, start_line: int = 1) -> List[Fence]:
     fences: List[Fence] = []
     i = 0
     while i < len(lines):
-        is_open, indented = _is_fence_opener(lines[i])
+        is_open, indented, ticks = _is_fence_opener(lines[i])
         if not is_open:
             i += 1
             continue
@@ -142,7 +158,7 @@ def extract_fences(text: str, *, start_line: int = 1) -> List[Fence]:
         body_lines: List[str] = []
         closed = False
         while i < len(lines):
-            if _is_fence_closer(lines[i]):
+            if _is_fence_closer(lines[i], ticks):
                 closed = True
                 break
             body_lines.append(lines[i])

--- a/plugins/knowledge/skills/docpage-digest/scripts/digest_fences.py
+++ b/plugins/knowledge/skills/docpage-digest/scripts/digest_fences.py
@@ -79,10 +79,23 @@ def split_lines(text: str) -> List[str]:
 
 
 def iter_h2_sections(text: str) -> Iterator[Tuple[str, str, int]]:
-    """Yield (heading-rest, section-body, heading-line-number) for each ``## ``."""
+    """Yield (heading-rest, section-body, heading-line-number) for each ``## ``.
+
+    H2-looking lines inside a fence are payload, not section boundaries —
+    a verbatim quote of a docs heading must not truncate Key claims.
+    """
     lines = split_lines(text)
     starts: List[Tuple[int, str]] = []
+    in_fence = False
     for idx, line in enumerate(lines):
+        is_open, _indented = _is_fence_opener(line)
+        if in_fence:
+            if _is_fence_closer(line):
+                in_fence = False
+            continue
+        if is_open:
+            in_fence = True
+            continue
         match = ATX_H2.match(line)
         if match:
             starts.append((idx, match.group(1)))
@@ -164,6 +177,8 @@ def parse_claims(section_body: str, *, start_line: int = 1) -> List[Claim]:
             unclosed = False
         fence = fences[0] if fences else None
         prose = block if not fences else block.split("```", 1)[0]
+        # Forbidden carriers are defects even when a later fence is valid —
+        # a leftover blockquote/inline quote is still hook-corruptible.
         has_bq = bool(re.search(r"(?m)^>", prose))
         has_inline = bool(re.search(r"(?<!`)`[^`\n]+`(?!`)", prose))
         if unclosed:
@@ -173,17 +188,15 @@ def parse_claims(section_body: str, *, start_line: int = 1) -> List[Claim]:
             label_line=start_line + idx,
             rest=match.group(2),
             fence=fence,
-            unfenced_blockquote=has_bq and fence is None,
-            unfenced_inline_code=has_inline and fence is None,
+            unfenced_blockquote=has_bq,
+            unfenced_inline_code=has_inline,
         ))
     return claims
 
 
 def is_none_section(body: str) -> bool:
-    text = body.strip()
-    if not text:
-        return True
-    return text.lower() in NONE_MARKERS
+    """True only for an explicit none-marker. Blank is not an assertion."""
+    return body.strip().lower() in NONE_MARKERS
 
 
 def payload_in_source(payload: str, source: str) -> bool:
@@ -193,7 +206,10 @@ def payload_in_source(payload: str, source: str) -> bool:
     spaces/tabs on that line is a *lost trailing space*, not a match —
     ``"keep me" in "keep me \\n"`` is True, and that is the hook defect.
     Mid-line substrings whose remainder is real text still match.
+    An empty payload is never a match (``str.find('')`` is always 0).
     """
+    if not payload:
+        return False
     start = 0
     while True:
         idx = source.find(payload, start)

--- a/plugins/knowledge/skills/docpage-digest/scripts/digest_fences.py
+++ b/plugins/knowledge/skills/docpage-digest/scripts/digest_fences.py
@@ -1,0 +1,210 @@
+"""Shared fence and section parsing for the docpage-digest standing gates.
+
+Stdlib only. Python 3.9+. Both gates stay standalone-runnable: they insert
+this directory on sys.path and import from here. Parsing is exact — no
+``.strip()`` on fence payloads — because a per-line strip is how indented-fence
+corruption and a load-bearing trailing space earned a clean quote-gate result.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from typing import Iterator, List, NamedTuple, NoReturn, Optional, Tuple
+
+MIN_PYTHON = (3, 9)
+
+CLAIM_LABEL = re.compile(r"^\*\*C(\d+)\.\*\*(.*)$")
+ATX_H2 = re.compile(r"^##[ \t]+(.+?)\s*$")
+NONE_MARKERS = frozenset({
+    "none",
+    "n/a",
+    "(none)",
+    "no prompt snippets",
+    "no snippets",
+    "none.",
+})
+
+
+class Failures:
+    """Named check failures, echoed to stderr as they land under ``prog``."""
+
+    def __init__(self, prog: str):
+        self.prog = prog
+        self.items: List[str] = []
+
+    def add(self, message: str) -> None:
+        self.items.append(message)
+        sys.stderr.write(f"{self.prog}: FAIL: {message}\n")
+
+
+class Fence(NamedTuple):
+    start_line: int  # 1-based, opener
+    indented: bool
+    payload: str  # exact body; no strip; no closer-line newline
+
+
+class Claim(NamedTuple):
+    number: int
+    label_line: int
+    rest: str
+    fence: Optional[Fence]
+    unfenced_blockquote: bool
+    unfenced_inline_code: bool
+
+
+def fail(prog: str, code: int, message: str) -> NoReturn:
+    sys.stderr.write(f"{prog}: ERROR: {message}\n")
+    raise SystemExit(code)
+
+
+def read_text(path: str, prog: str, what: str) -> str:
+    try:
+        with open(path, "rb") as fh:
+            raw = fh.read()
+    except OSError as exc:
+        fail(prog, 2, f"cannot read {what} {path!r}: {exc}")
+    if not raw:
+        fail(prog, 2, f"{what} {path!r} is empty (0 bytes).")
+    try:
+        return raw.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        fail(prog, 2, f"{what} {path!r} is not UTF-8: {exc}")
+
+
+def split_lines(text: str) -> List[str]:
+    if text.endswith("\n"):
+        return text[:-1].split("\n")
+    return text.split("\n")
+
+
+def iter_h2_sections(text: str) -> Iterator[Tuple[str, str, int]]:
+    """Yield (heading-rest, section-body, heading-line-number) for each ``## ``."""
+    lines = split_lines(text)
+    starts: List[Tuple[int, str]] = []
+    for idx, line in enumerate(lines):
+        match = ATX_H2.match(line)
+        if match:
+            starts.append((idx, match.group(1)))
+    for i, (idx, title) in enumerate(starts):
+        end = starts[i + 1][0] if i + 1 < len(starts) else len(lines)
+        body = "\n".join(lines[idx + 1:end])
+        yield title, body, idx + 1
+
+
+def find_section(text: str, prefix: str) -> Optional[Tuple[str, str, int]]:
+    """First H2 whose title starts with ``prefix`` (case-insensitive)."""
+    wanted = prefix.lower()
+    for title, body, line in iter_h2_sections(text):
+        if title.lower().startswith(wanted):
+            return title, body, line
+    return None
+
+
+def _is_fence_opener(line: str) -> Tuple[bool, bool]:
+    """Return (is_opener, indented)."""
+    stripped = line.lstrip(" \t")
+    if stripped.startswith("```"):
+        return True, (len(line) != len(stripped))
+    return False, False
+
+
+def _is_fence_closer(line: str) -> bool:
+    stripped = line.lstrip(" \t")
+    return stripped.startswith("```") and stripped.strip("` \t") == ""
+
+
+def extract_fences(text: str, *, start_line: int = 1) -> List[Fence]:
+    """Column-aware fence walk. An indented opener is recorded, not repaired."""
+    lines = split_lines(text)
+    fences: List[Fence] = []
+    i = 0
+    while i < len(lines):
+        is_open, indented = _is_fence_opener(lines[i])
+        if not is_open:
+            i += 1
+            continue
+        opener_line = start_line + i
+        i += 1
+        body_lines: List[str] = []
+        closed = False
+        while i < len(lines):
+            if _is_fence_closer(lines[i]):
+                closed = True
+                break
+            body_lines.append(lines[i])
+            i += 1
+        if not closed:
+            raise ValueError(f"unclosed fence opening at line {opener_line}")
+        fences.append(Fence(opener_line, indented, "\n".join(body_lines)))
+        i += 1
+    return fences
+
+
+def parse_claims(section_body: str, *, start_line: int = 1) -> List[Claim]:
+    """Parse ``**CN.**`` labels and the fence that must follow each one."""
+    lines = split_lines(section_body)
+    label_idxs: List[int] = []
+    for i, line in enumerate(lines):
+        if CLAIM_LABEL.match(line):
+            label_idxs.append(i)
+    claims: List[Claim] = []
+    for n, idx in enumerate(label_idxs):
+        match = CLAIM_LABEL.match(lines[idx])
+        assert match is not None
+        end = label_idxs[n + 1] if n + 1 < len(label_idxs) else len(lines)
+        block = "\n".join(lines[idx + 1:end])
+        block_start = start_line + idx + 1
+        try:
+            fences = extract_fences(block, start_line=block_start)
+        except ValueError:
+            fences = []
+            unclosed = True
+        else:
+            unclosed = False
+        fence = fences[0] if fences else None
+        prose = block if not fences else block.split("```", 1)[0]
+        has_bq = bool(re.search(r"(?m)^>", prose))
+        has_inline = bool(re.search(r"(?<!`)`[^`\n]+`(?!`)", prose))
+        if unclosed:
+            fence = None
+        claims.append(Claim(
+            number=int(match.group(1)),
+            label_line=start_line + idx,
+            rest=match.group(2),
+            fence=fence,
+            unfenced_blockquote=has_bq and fence is None,
+            unfenced_inline_code=has_inline and fence is None,
+        ))
+    return claims
+
+
+def is_none_section(body: str) -> bool:
+    text = body.strip()
+    if not text:
+        return True
+    return text.lower() in NONE_MARKERS
+
+
+def payload_in_source(payload: str, source: str) -> bool:
+    """Exact contiguous match. No strip, no whitespace forgiveness.
+
+    A payload that is a prefix of a source line and leaves only trailing
+    spaces/tabs on that line is a *lost trailing space*, not a match —
+    ``"keep me" in "keep me \\n"`` is True, and that is the hook defect.
+    Mid-line substrings whose remainder is real text still match.
+    """
+    start = 0
+    while True:
+        idx = source.find(payload, start)
+        if idx < 0:
+            return False
+        rest_of_line = source[idx + len(payload):].split("\n", 1)[0]
+        lost_trailing = (
+            bool(rest_of_line)
+            and rest_of_line.strip(" \t") == ""
+            and not (payload.endswith(" ") or payload.endswith("\t"))
+        )
+        if not lost_trailing:
+            return True
+        start = idx + 1

--- a/plugins/knowledge/skills/docpage-digest/scripts/test_check_fences_exact.py
+++ b/plugins/knowledge/skills/docpage-digest/scripts/test_check_fences_exact.py
@@ -202,6 +202,52 @@ this was never in the source
         proc = self.run_gate(text, 1)
         self.assertIn(b"duplicate", proc.stderr)
 
+    def test_empty_fence_payload_fails(self):
+        text = f"""## Key claims (verbatim)
+
+**C1.** `cc-applicable`
+
+```
+```
+"""
+        proc = self.run_gate(text, 1)
+        self.assertIn(b"empty", proc.stderr)
+
+    def test_blockquote_plus_later_fence_still_fails(self):
+        text = f"""## Key claims (verbatim)
+
+**C1.** `cc-applicable`
+
+> fabricated quote
+
+```
+{KEEP}
+```
+"""
+        proc = self.run_gate(text, 1)
+        self.assertIn(b"blockquote", proc.stderr)
+
+    def test_heading_inside_fence_does_not_truncate_section(self):
+        source = write(self.dir, "src2.md", "## Configuration\nkeep me \n")
+        text = f"""## Key claims (verbatim)
+
+**C1.** `cc-applicable`
+
+```
+## Configuration
+```
+
+## Prompt snippets (exact)
+
+none
+"""
+        digest = write(self.dir, "d2.md", text)
+        proc = subprocess.run(
+            [sys.executable, GATE, "--source", source, "--digest", digest],
+            capture_output=True)
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertIn(b"PASS", proc.stdout)
+
     def test_star_list_inside_fence_is_not_rewritten(self):
         # The defect the hook caused in a blockquote; a fence holds "* ".
         proc = self.run_gate(CLEAN, 0)

--- a/plugins/knowledge/skills/docpage-digest/scripts/test_check_fences_exact.py
+++ b/plugins/knowledge/skills/docpage-digest/scripts/test_check_fences_exact.py
@@ -17,11 +17,13 @@ import unittest
 HERE = os.path.dirname(os.path.abspath(__file__))
 GATE = os.path.join(HERE, "check-fences-exact.py")
 
-# Trailing space on "keep me " is load-bearing — the hook strips it from a
-# bare code span; a fence must preserve it.
+# Trailing space on KEEP is load-bearing — the hook strips it from a
+# bare code span; a fence must preserve it. The space lives inside the
+# quotes so this file has no physical trailing whitespace (editorconfig).
+KEEP = "keep me "
 SOURCE = (
     "Intro line.\n"
-    "keep me \n"
+    + KEEP + "\n"
     "A list:\n"
     "* star item\n"
     "1. one\n"
@@ -59,7 +61,7 @@ class GateHarness(unittest.TestCase):
         return proc
 
 
-CLEAN = """# Unit
+CLEAN = f"""# Unit
 
 ## Summary
 
@@ -70,7 +72,7 @@ A summary.
 **C1.** `cc-applicable`
 
 ```
-keep me 
+{KEEP}
 ```
 
 **C2.** `cc-applicable`
@@ -133,21 +135,22 @@ class TestFailLoudZeroParse(GateHarness):
 class TestFenceContract(GateHarness):
     def test_indented_fence_fails(self):
         # REPAIR-pass corruption: indent the fence. strip() would hide this.
-        text = CLEAN.replace("```\nkeep me \n```", "    ```\n    keep me \n    ```")
+        text = CLEAN.replace(
+            f"```\n{KEEP}\n```", f"    ```\n    {KEEP}\n    ```")
         proc = self.run_gate(text, 1)
         self.assertIn(b"indented", proc.stderr)
 
     def test_trailing_space_stripped_fails(self):
-        text = CLEAN.replace("keep me \n```", "keep me\n```")
+        text = CLEAN.replace(f"{KEEP}\n```", "keep me\n```")
         proc = self.run_gate(text, 1)
         self.assertIn(b"not an exact contiguous substring", proc.stderr)
 
     def test_blockquote_instead_of_fence(self):
-        text = """## Key claims (verbatim)
+        text = f"""## Key claims (verbatim)
 
 **C1.** `cc-applicable`
 
-> keep me 
+> {KEEP}
 """
         proc = self.run_gate(text, 1)
         self.assertIn(b"blockquote", proc.stderr)
@@ -182,12 +185,12 @@ this was never in the source
         self.assertIn(b"unlabelled fence", proc.stderr)
 
     def test_duplicate_label(self):
-        text = """## Key claims (verbatim)
+        text = f"""## Key claims (verbatim)
 
 **C1.** `cc-applicable`
 
 ```
-keep me 
+{KEEP}
 ```
 
 **C1.** `cc-applicable`

--- a/plugins/knowledge/skills/docpage-digest/scripts/test_check_fences_exact.py
+++ b/plugins/knowledge/skills/docpage-digest/scripts/test_check_fences_exact.py
@@ -253,6 +253,48 @@ none
         proc = self.run_gate(CLEAN, 0)
         self.assertIn(b"PASS", proc.stdout)
 
+    def test_longer_outer_fence_keeps_inner_backtick_run(self):
+        # CommonMark: a 3-tick line inside a 4-tick wrapper is payload.
+        # Closing on any 3+ tick-only line truncated this to "" or to the
+        # prose prefix — a false empty-payload FAIL or a false PASS.
+        inner = "Wrap code like this:\n```\nprint(1)\n```"
+        source = write(self.dir, "src-nested.md", inner + "\n")
+        text = f"""## Key claims (verbatim)
+
+**C1.** `cc-applicable`
+
+````
+{inner}
+````
+"""
+        digest = write(self.dir, "d-nested.md", text)
+        proc = subprocess.run(
+            [sys.executable, GATE, "--source", source, "--digest", digest],
+            capture_output=True)
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertIn(b"PASS", proc.stdout)
+        self.assertIn(b"1 **CN.**", proc.stdout)
+
+    def test_four_tick_wrapper_around_immediate_inner_fence(self):
+        # Truncation at the first inner ``` used to yield payload "" and
+        # fail the empty-payload check on a valid verbatim quote.
+        inner = "```\nprint(1)\n```"
+        source = write(self.dir, "src-immediate.md", inner + "\n")
+        text = f"""## Key claims (verbatim)
+
+**C1.** `cc-applicable`
+
+````
+{inner}
+````
+"""
+        digest = write(self.dir, "d-immediate.md", text)
+        proc = subprocess.run(
+            [sys.executable, GATE, "--source", source, "--digest", digest],
+            capture_output=True)
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertIn(b"PASS", proc.stdout)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/plugins/knowledge/skills/docpage-digest/scripts/test_check_fences_exact.py
+++ b/plugins/knowledge/skills/docpage-digest/scripts/test_check_fences_exact.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""Negative-control suite for check-fences-exact.py.
+
+These cases are why the gate is a required artifact: PASS is not believed
+until the known-bad fixtures fail. Run: python test_check_fences_exact.py
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+GATE = os.path.join(HERE, "check-fences-exact.py")
+
+# Trailing space on "keep me " is load-bearing — the hook strips it from a
+# bare code span; a fence must preserve it.
+SOURCE = (
+    "Intro line.\n"
+    "keep me \n"
+    "A list:\n"
+    "* star item\n"
+    "1. one\n"
+    "prompt example here\n"
+)
+
+
+def write(dirpath: str, name: str, text: str) -> str:
+    path = os.path.join(dirpath, name)
+    with open(path, "w", encoding="utf-8", newline="\n") as fh:
+        fh.write(text)
+    return path
+
+
+class GateHarness(unittest.TestCase):
+    def setUp(self):
+        self.dir = tempfile.mkdtemp()
+        self.source = write(self.dir, "source.md", SOURCE)
+
+    def tearDown(self):
+        shutil.rmtree(self.dir, ignore_errors=True)
+
+    def run_gate(self, digest_text: str, expect_code: int,
+                 extra_args=None):
+        digest = write(self.dir, "digest.md", digest_text)
+        cmd = [sys.executable, GATE, "--source", self.source,
+               "--digest", digest]
+        if extra_args:
+            cmd.extend(extra_args)
+        proc = subprocess.run(cmd, capture_output=True)
+        if proc.returncode != expect_code:
+            raise AssertionError(
+                f"exit {proc.returncode}, expected {expect_code}; "
+                f"stdout={proc.stdout!r} stderr={proc.stderr!r}")
+        return proc
+
+
+CLEAN = """# Unit
+
+## Summary
+
+A summary.
+
+## Key claims (verbatim)
+
+**C1.** `cc-applicable`
+
+```
+keep me 
+```
+
+**C2.** `cc-applicable`
+
+```
+* star item
+```
+
+## Prompt snippets (exact)
+
+```
+prompt example here
+```
+"""
+
+
+class TestCleanPass(GateHarness):
+    def test_clean_pass_names_coverage(self):
+        proc = self.run_gate(CLEAN, 0)
+        out = proc.stdout.decode()
+        self.assertIn("PASS", out)
+        self.assertIn("2 **CN.**", out)
+        self.assertIn("NO per-line strip", out)
+        self.assertIn("Nothing outside Key claims", out)
+
+    def test_trailing_space_preserved(self):
+        # SOURCE has "keep me \\n" — the fence payload must keep the space.
+        proc = self.run_gate(CLEAN, 0)
+        self.assertIn(b"PASS", proc.stdout)
+
+
+class TestFailLoudZeroParse(GateHarness):
+    def test_no_digest_arg_is_unusable(self):
+        proc = subprocess.run(
+            [sys.executable, GATE, "--source", self.source],
+            capture_output=True)
+        self.assertEqual(proc.returncode, 2)
+        self.assertIn(b"no --digest", proc.stderr)
+
+    def test_empty_source_is_unusable(self):
+        empty = write(self.dir, "empty.md", "")
+        digest = write(self.dir, "d.md", CLEAN)
+        proc = subprocess.run(
+            [sys.executable, GATE, "--source", empty, "--digest", digest],
+            capture_output=True)
+        self.assertEqual(proc.returncode, 2)
+        self.assertIn(b"empty", proc.stderr)
+
+    def test_missing_key_claims_heading(self):
+        proc = self.run_gate("# Unit\n\nNo claims section.\n", 1)
+        self.assertIn(b"no '## Key claims'", proc.stderr)
+
+    def test_zero_claims_is_failure_not_pass(self):
+        proc = self.run_gate(
+            "## Key claims (verbatim)\n\nNo labelled claims here.\n", 1)
+        self.assertIn(b"parsed ZERO claims", proc.stderr)
+        self.assertNotIn(b"PASS", proc.stdout)
+
+
+class TestFenceContract(GateHarness):
+    def test_indented_fence_fails(self):
+        # REPAIR-pass corruption: indent the fence. strip() would hide this.
+        text = CLEAN.replace("```\nkeep me \n```", "    ```\n    keep me \n    ```")
+        proc = self.run_gate(text, 1)
+        self.assertIn(b"indented", proc.stderr)
+
+    def test_trailing_space_stripped_fails(self):
+        text = CLEAN.replace("keep me \n```", "keep me\n```")
+        proc = self.run_gate(text, 1)
+        self.assertIn(b"not an exact contiguous substring", proc.stderr)
+
+    def test_blockquote_instead_of_fence(self):
+        text = """## Key claims (verbatim)
+
+**C1.** `cc-applicable`
+
+> keep me 
+"""
+        proc = self.run_gate(text, 1)
+        self.assertIn(b"blockquote", proc.stderr)
+
+    def test_inline_code_instead_of_fence(self):
+        text = """## Key claims (verbatim)
+
+**C1.** `cc-applicable`
+
+`keep me `
+"""
+        proc = self.run_gate(text, 1)
+        self.assertIn(b"inline code span", proc.stderr)
+
+    def test_fabricated_quote_fails(self):
+        text = """## Key claims (verbatim)
+
+**C1.** `cc-applicable`
+
+```
+this was never in the source
+```
+"""
+        proc = self.run_gate(text, 1)
+        self.assertIn(b"not an exact contiguous substring", proc.stderr)
+
+    def test_unlabelled_fence_is_unparsed_surface(self):
+        text = CLEAN.replace(
+            "## Prompt snippets",
+            "```\nIntro line.\n```\n\n## Prompt snippets")
+        proc = self.run_gate(text, 1)
+        self.assertIn(b"unlabelled fence", proc.stderr)
+
+    def test_duplicate_label(self):
+        text = """## Key claims (verbatim)
+
+**C1.** `cc-applicable`
+
+```
+keep me 
+```
+
+**C1.** `cc-applicable`
+
+```
+* star item
+```
+"""
+        proc = self.run_gate(text, 1)
+        self.assertIn(b"duplicate", proc.stderr)
+
+    def test_star_list_inside_fence_is_not_rewritten(self):
+        # The defect the hook caused in a blockquote; a fence holds "* ".
+        proc = self.run_gate(CLEAN, 0)
+        self.assertIn(b"PASS", proc.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/knowledge/skills/docpage-digest/scripts/test_check_snippets.py
+++ b/plugins/knowledge/skills/docpage-digest/scripts/test_check_snippets.py
@@ -20,9 +20,10 @@ import unittest
 HERE = os.path.dirname(os.path.abspath(__file__))
 GATE = os.path.join(HERE, "check-snippets.py")
 
+KEEP = "keep me "
 SOURCE = (
     "Intro line.\n"
-    "keep me \n"
+    + KEEP + "\n"
     "You are a helpful assistant.\n"
     "prompt example here\n"
 )
@@ -56,14 +57,14 @@ class GateHarness(unittest.TestCase):
         return proc
 
 
-CLEAN = """# Unit
+CLEAN = f"""# Unit
 
 ## Key claims (verbatim)
 
 **C1.** `cc-applicable`
 
 ```
-keep me 
+{KEEP}
 ```
 
 ## Prompt snippets (exact)
@@ -141,12 +142,12 @@ this prompt was recalled, not copied
         self.assertIn(b"indented", proc.stderr)
 
     def test_key_claims_only_does_not_satisfy_this_gate(self):
-        text = """## Key claims (verbatim)
+        text = f"""## Key claims (verbatim)
 
 **C1.** `cc-applicable`
 
 ```
-keep me 
+{KEEP}
 ```
 """
         proc = self.run_gate(text, 1)

--- a/plugins/knowledge/skills/docpage-digest/scripts/test_check_snippets.py
+++ b/plugins/knowledge/skills/docpage-digest/scripts/test_check_snippets.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""Negative-control suite for check-snippets.py.
+
+The campaign quote gate never parsed Prompt snippets; five fabricated
+snippets shipped under a clean count. These cases are the evidence that
+this gate fails that class before its PASS is believed.
+
+Run: python test_check_snippets.py
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+GATE = os.path.join(HERE, "check-snippets.py")
+
+SOURCE = (
+    "Intro line.\n"
+    "keep me \n"
+    "You are a helpful assistant.\n"
+    "prompt example here\n"
+)
+
+
+def write(dirpath: str, name: str, text: str) -> str:
+    path = os.path.join(dirpath, name)
+    with open(path, "w", encoding="utf-8", newline="\n") as fh:
+        fh.write(text)
+    return path
+
+
+class GateHarness(unittest.TestCase):
+    def setUp(self):
+        self.dir = tempfile.mkdtemp()
+        self.source = write(self.dir, "source.md", SOURCE)
+
+    def tearDown(self):
+        shutil.rmtree(self.dir, ignore_errors=True)
+
+    def run_gate(self, digest_text: str, expect_code: int):
+        digest = write(self.dir, "digest.md", digest_text)
+        proc = subprocess.run(
+            [sys.executable, GATE, "--source", self.source,
+             "--digest", digest],
+            capture_output=True)
+        if proc.returncode != expect_code:
+            raise AssertionError(
+                f"exit {proc.returncode}, expected {expect_code}; "
+                f"stdout={proc.stdout!r} stderr={proc.stderr!r}")
+        return proc
+
+
+CLEAN = """# Unit
+
+## Key claims (verbatim)
+
+**C1.** `cc-applicable`
+
+```
+keep me 
+```
+
+## Prompt snippets (exact)
+
+```
+You are a helpful assistant.
+```
+
+```
+prompt example here
+```
+"""
+
+
+class TestCleanPass(GateHarness):
+    def test_clean_pass_names_coverage(self):
+        proc = self.run_gate(CLEAN, 0)
+        out = proc.stdout.decode()
+        self.assertIn("PASS", out)
+        self.assertIn("2 Prompt-snippets", out)
+        self.assertIn("NO per-line strip", out)
+        self.assertIn("Nothing outside Prompt snippets", out)
+
+    def test_recognised_none_is_clean_zero(self):
+        text = """## Prompt snippets (exact)
+
+none
+"""
+        proc = self.run_gate(text, 0)
+        out = proc.stdout.decode()
+        self.assertIn("PASS", out)
+        self.assertIn("0 Prompt-snippets", out)
+
+
+class TestFailLoudUnparsed(GateHarness):
+    def test_no_digest_arg_is_unusable(self):
+        proc = subprocess.run(
+            [sys.executable, GATE, "--source", self.source],
+            capture_output=True)
+        self.assertEqual(proc.returncode, 2)
+        self.assertIn(b"no --digest", proc.stderr)
+
+    def test_missing_section_fails(self):
+        proc = self.run_gate("# Unit\n\n## Summary\n\nNo snippets heading.\n", 1)
+        self.assertIn(b"no '## Prompt snippets'", proc.stderr)
+
+    def test_unparsed_prose_zero_fences_fails(self):
+        # The shipped-under-CLEAN class: section exists, no fence, recall text.
+        text = """## Prompt snippets (exact)
+
+You are a helpful assistant.
+"""
+        proc = self.run_gate(text, 1)
+        self.assertIn(b"parsed ZERO fences", proc.stderr)
+        self.assertNotIn(b"PASS", proc.stdout)
+
+    def test_fabricated_snippet_fails(self):
+        text = """## Prompt snippets (exact)
+
+```
+this prompt was recalled, not copied
+```
+"""
+        proc = self.run_gate(text, 1)
+        self.assertIn(b"not an exact contiguous substring", proc.stderr)
+
+    def test_indented_snippet_fence_fails(self):
+        text = """## Prompt snippets (exact)
+
+    ```
+    You are a helpful assistant.
+    ```
+"""
+        proc = self.run_gate(text, 1)
+        self.assertIn(b"indented", proc.stderr)
+
+    def test_key_claims_only_does_not_satisfy_this_gate(self):
+        text = """## Key claims (verbatim)
+
+**C1.** `cc-applicable`
+
+```
+keep me 
+```
+"""
+        proc = self.run_gate(text, 1)
+        self.assertIn(b"no '## Prompt snippets'", proc.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/knowledge/skills/docpage-digest/scripts/test_check_snippets.py
+++ b/plugins/knowledge/skills/docpage-digest/scripts/test_check_snippets.py
@@ -141,6 +141,21 @@ this prompt was recalled, not copied
         proc = self.run_gate(text, 1)
         self.assertIn(b"indented", proc.stderr)
 
+    def test_blank_section_is_not_a_none_marker(self):
+        text = "## Prompt snippets (exact)\n\n"
+        proc = self.run_gate(text, 1)
+        self.assertIn(b"blank", proc.stderr)
+        self.assertNotIn(b"PASS", proc.stdout)
+
+    def test_empty_snippet_fence_fails(self):
+        text = """## Prompt snippets (exact)
+
+```
+```
+"""
+        proc = self.run_gate(text, 1)
+        self.assertIn(b"empty", proc.stderr)
+
     def test_key_claims_only_does_not_satisfy_this_gate(self):
         text = f"""## Key claims (verbatim)
 

--- a/plugins/knowledge/skills/docpage-digest/scripts/test_check_snippets.py
+++ b/plugins/knowledge/skills/docpage-digest/scripts/test_check_snippets.py
@@ -168,6 +168,23 @@ this prompt was recalled, not copied
         proc = self.run_gate(text, 1)
         self.assertIn(b"no '## Prompt snippets'", proc.stderr)
 
+    def test_longer_outer_fence_keeps_inner_backtick_run(self):
+        inner = "Wrap code like this:\n```\nprint(1)\n```"
+        source = write(self.dir, "src-nested.md", inner + "\n")
+        text = f"""## Prompt snippets (exact)
+
+````
+{inner}
+````
+"""
+        digest = write(self.dir, "d-nested.md", text)
+        proc = subprocess.run(
+            [sys.executable, GATE, "--source", source, "--digest", digest],
+            capture_output=True)
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertIn(b"PASS", proc.stdout)
+        self.assertIn(b"1 Prompt-snippets", proc.stdout)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/plugins/knowledge/skills/docpage-digest/templates/checklist.md
+++ b/plugins/knowledge/skills/docpage-digest/templates/checklist.md
@@ -23,9 +23,12 @@ collision check reads them to tell a resume from a slug collision.
       for a markdown or rendered-text channel, or `source.pdf` **plus** its `source.txt`
       extraction for a PDF original (both are originals; name the extraction tooling above)
 - [ ] Phase 2: Inventory — `INDEX.md` written (headings, themes, digest map, status rows)
-- [ ] Phase 3: Digest fan-out — one agent per digest unit → `digests/NN-slug.md` (fixed structure)
-- [ ] Phase 4: Dual verification — Verifier A (same-vendor) + Verifier B (cross-vendor) verdicts
-      in `verification/` (append-only; degraded fallback recorded, never silent)
+- [ ] Phase 3: Digest fan-out — one agent per digest unit → `digests/NN-slug.md` (fixed
+      structure; verbatim quotes in column-0 fences under bold `**CN.**` labels)
+- [ ] Phase 4: Dual verification — pin-manifest written on agent-reported completion; standing
+      gates (`check-fences-exact.py`, `check-snippets.py`) PASS; Verifier A (same-vendor) +
+      Verifier B (cross-vendor) verdicts in `verification/` (append-only; each arm states the
+      hashes it audited; degraded fallback / death-ladder recorded, never silent)
 - [ ] Phase 5: Interview handoff — `interview-handoff.md` authored and its own commands replayed
       (every Phase 4 check precedes it); `/planning:interview` run or artifact presented
 
@@ -33,4 +36,6 @@ collision check reads them to tell a resume from a slug collision.
 
 - Phase 4 Verifier B — degrade per SKILL.md only when the cross-vendor verifier is genuinely
   unavailable; record reason in the verdict header
+- Phase 3/4 subagent death — SKILL.md ladder (retry window → inline-with-disclosure → degraded
+  marker + re-run trigger); do not tick the phase complete on a degraded marker
 - Phase 5 interview invocation — skip (present artifact only) when the planning plugin is absent


### PR DESCRIPTION
Closes #3015

## Summary

Lands the interview-ratified `/knowledge:docpage-digest` pipeline-hardening bundle from the 9-slice cloud-fleet corpus run. Knowledge plugin `0.13.4` → `0.13.5`. Keeps the `0.13.4` / #3014 heading.

## Fix

1. **Fence mandate.** Every verbatim quote is a column-0 fenced container under a bold `**CN.**` label. Blockquotes and inline code spans are forbidden quote carriers.
2. **Standing gates.** Ships `scripts/check-fences-exact.py` and `scripts/check-snippets.py` alongside the quote gate. Both fail loud on zero-parse and compare payloads without `.strip()`. Negative-control suites (`test_check_*.py`) are the evidence a PASS needs.
3. **Freeze/pin.** Pin on agent-REPORTED completion, never file presence. `verification/pin-manifest.json` freezes the tree; each arm restates the hashes it audited. A verdict file on disk is an intermediate write, never a report.
4. **Subagent-death ladder.** Retry window → inline-with-disclosure → degraded marker + re-run trigger. Distinct from the existing degraded-verifier rule (missing cross-vendor arm).
5. **Gate-as-claim + blind spots.** `SKILL.md` enumerates each gate's parse surface. Format and pin-manifest shape live in `context/pipeline-hardening.md`.

## Verification

- `bash plugins/knowledge/skills/docpage-digest/scripts/check-fences-exact.test.sh` — 14/14 PASS (zero-parse, indented fence, lost trailing space, blockquote/inline substitutes, fabricated quote).
- `bash plugins/knowledge/skills/docpage-digest/scripts/check-snippets.test.sh` — 8/8 PASS (missing section, unparsed prose, fabricated snippet, indented fence, recognised none-marker).
- `scripts/check-changelog-parity.sh --check`, `--check-order`, `--check-bump origin/main` PASS. Newest heading is `## [0.13.5]`; `## [0.13.4]` (#3014) is retained.
- `CHECK_SKILL_SKILLS_ROOT=plugins/knowledge/skills` `check-skill.sh --require-evals docpage-digest` PASS (0 errors). Trigger phrases preserved. Script tests invoked by the checker.
- `npx markdownlint-cli2` on the four markdown files: 0 issues.
- `check-evals-quality.sh` PASS (only the pre-existing Q4 narration warn on eval id=2).

## Related

Refs the 9-slice interview + dual-validator pass recorded in the issue body. Profile amendments already landed as #3014 / 0.13.4. Graduation-gate residual-verification is out of scope (operator decision record; binds graduation, not this skill PR).