### PR TITLE
feat(machine-health): add detect-only environment and PATH health check

### DIFF
--- a/plugins/machine-health/.claude-plugin/plugin.json
+++ b/plugins/machine-health/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "machine-health",
-  "version": "0.10.6",
+  "version": "0.11.0",
   "description": "Workstation health audit: OS-specific checks (disk, OS updates, security posture, CISA KEV correlation) run from a versioned catalog with trend-aware severity, approval-gated remediations, and dated markdown reports. Windows fully implemented; macOS/Linux scaffolded (report UNKNOWN and stop). Machine state persists in the plugin data directory; the report directory and check catalog are configurable.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/machine-health/CHANGELOG.md
+++ b/plugins/machine-health/CHANGELOG.md
@@ -3,6 +3,21 @@
 All notable changes to the `machine-health` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.11.0]
+
+### Added
+
+- **`environment-health` detect-only Windows check (#2866).** Eighteenth catalog check.
+  Reads persisted User (`HKCU:\Environment`) and Machine environment values and emits
+  mechanical shapes only: `DISABLE_AUTOUPDATER`, missing PATH directories, duplicate
+  PATH entries, shadowed executables (WARN when the winner is a lower-precedence scope
+  than User), User Path stored as `REG_SZ` rather than `REG_EXPAND_SZ`, User Path
+  length against the 2047-character legacy-editor ceiling (WARN at 1800, CRIT at 2047),
+  and credential-pattern variable **names** (`*_TOKEN`, `*_API_KEY`, `*_SECRET`,
+  `*_PASSWORD`) with scope only. Credential values are never read. No remediation
+  entry — registry writes remain unauthorized. Rubric:
+  `references/windows/check-catalog.md` § 18.
+
 ## [0.10.6]
 
 ### Changed

--- a/plugins/machine-health/CHANGELOG.md
+++ b/plugins/machine-health/CHANGELOG.md
@@ -14,8 +14,11 @@ All notable changes to the `machine-health` plugin are documented here. Format f
   than User), User Path stored as `REG_SZ` rather than `REG_EXPAND_SZ`, User Path
   length against the 2047-character legacy-editor ceiling (WARN at 1800, CRIT at 2047),
   and credential-pattern variable **names** (`*_TOKEN`, `*_API_KEY`, `*_SECRET`,
-  `*_PASSWORD`) with scope only. Credential values are never read. No remediation
-  entry — registry writes remain unauthorized. Rubric:
+  `*_PASSWORD`) with scope only. Credential values are never read. Missing-dir
+  and scope checks expand `%VAR%` tokens; `user_path_length` still measures the
+  unexpanded stored string. The check is trend-tracked as `user_path_length` but
+  is not in the generic upward-worsens upgrade list (composite WARN causes).
+  No remediation entry — registry writes remain unauthorized. Rubric:
   `references/windows/check-catalog.md` § 18.
 
 ## [0.10.6]

--- a/plugins/machine-health/README.md
+++ b/plugins/machine-health/README.md
@@ -6,7 +6,7 @@ from a versioned catalog, with trend-aware severity, narrow approval-gated remed
 dated markdown report per run. Fail-safe posture throughout: surface issues over silently fixing
 them, and every finding carries reproduction commands.
 
-Windows is fully implemented (17 checks, PowerShell 7.x). macOS and Linux are scaffolded as
+Windows is fully implemented (18 checks, PowerShell 7.x). macOS and Linux are scaffolded as
 honest `NOT_IMPLEMENTED` stubs — on those hosts the skill reports UNKNOWN and stops rather than
 pretending coverage.
 

--- a/plugins/machine-health/skills/audit/catalog/checks.jsonc
+++ b/plugins/machine-health/skills/audit/catalog/checks.jsonc
@@ -239,6 +239,19 @@
       "added_on": "2026-07-26",
       "crash_count": 0,
       "identical_streak": 0
+    },
+    {
+      "id": "environment-health",
+      "category": "config",
+      "os": ["windows"],
+      "script": "scripts/windows/checks/Test-EnvironmentHealth.ps1",
+      "severity_rules": "references/windows/check-catalog.md#18-environment-and-path-health",
+      "needs_admin": false,
+      "enabled": true,
+      "deprecated": false,
+      "added_on": "2026-08-21",
+      "crash_count": 0,
+      "identical_streak": 0
     }
   ]
 }

--- a/plugins/machine-health/skills/audit/references/windows/check-catalog.md
+++ b/plugins/machine-health/skills/audit/references/windows/check-catalog.md
@@ -334,8 +334,12 @@ All checks emit the schema in `references/shared/output-schema.md`, use `scripts
 - **What is in scope (mechanical shapes only):** persisted User and Machine environment
   values. Shadowing uses the process `$env:PATH` as the live search order and labels each
   entry `user` / `machine` / `both` / `unknown` from membership in the persisted Path
-  lists. The check does not attribute a vendor, decide whether `WindowsApps` belongs last,
-  or recommend editing `TEMP`/`TMP`.
+  lists. Persisted Path is read without expanding `%VAR%` tokens so `user_path_length`
+  measures the stored string (legacy-editor ceiling). Directory existence and scope
+  classification expand those tokens first — otherwise stock Machine Path entries
+  such as a `%SystemRoot%` system32 directory would false-positive as missing and be labeled
+  `unknown`. The check does not attribute a vendor, decide whether `WindowsApps`
+  belongs last, or recommend editing `TEMP`/`TMP`.
 
 - **Safety:** credential-pattern **values are never read**. The result reports `name` and
   `scope` only. `GetValue` is not called for those names, so a summary, note, or exception

--- a/plugins/machine-health/skills/audit/references/windows/check-catalog.md
+++ b/plugins/machine-health/skills/audit/references/windows/check-catalog.md
@@ -290,3 +290,59 @@ All checks emit the schema in `references/shared/output-schema.md`, use `scripts
   there is no POSIX implementation to register and the skill reports `UNKNOWN` wholesale on those
   hosts. A POSIX port derives the root the same way, appending the Unix segment (`claude-{uid}`) to
   `$CLAUDE_CODE_TMPDIR` then `$TMPDIR` then `/tmp`.
+
+---
+
+## 18. Environment and PATH health
+
+- **Script:** `scripts/windows/checks/Test-EnvironmentHealth.ps1`
+- **Category:** `config`
+- **Needs admin:** no. `HKCU:\Environment` is readable un-elevated; `HKLM:\...\Environment`
+  usually is too. If the machine key is unreadable the check keeps User-scope findings and
+  notes the gap — it does not ask for elevation.
+- **Remediation:** none. `references/windows/remediation-policy.md` bars registry cleanup of
+  any kind. This check ships with no remediation entry; every fix is a human action.
+- **Commands:**
+
+  ```powershell
+  Get-Item -LiteralPath 'HKCU:\Environment'
+  (Get-Item -LiteralPath 'HKCU:\Environment').GetValueKind('Path')
+  [Environment]::GetEnvironmentVariable('Path', 'User').Length
+  Get-ItemProperty -LiteralPath 'HKCU:\Environment' -Name DISABLE_AUTOUPDATER
+  Get-ChildItem Env: |
+      Where-Object Name -match '(_TOKEN|_API_KEY|_SECRET|_PASSWORD)$' |
+      Select-Object Name
+  ```
+
+- **Severity rubric:**
+  - `CRIT` — User Path length ≥ 2047 (legacy System Properties editor ceiling; further
+    appends are silently discarded).
+  - `WARN` — any of: User Path length ≥ 1800; User Path value kind is `REG_SZ` (`String`)
+    rather than `REG_EXPAND_SZ` (`ExpandString`); `DISABLE_AUTOUPDATER` set to a truthy
+    value (`1` / `true` / `yes` / `on`) in User or Machine scope; a persisted variable
+    **name** matching `*_TOKEN`, `*_API_KEY`, `*_SECRET`, `*_PASSWORD` (or those exact
+    names); an executable name resolvable from 2+ PATH directories whose winner is a
+    lower-precedence scope than User while a User-scope copy also exists.
+  - `INFO` — PATH entry pointing at a non-existent directory; duplicate PATH entries
+    (case-insensitive, trailing-slash-normalized, across User and Machine); executable
+    name present in 2+ PATH directories with a User-precedence winner; `DISABLE_AUTOUPDATER`
+    present but not truthy.
+  - `OK` — none of the above.
+  - `UNKNOWN` — `HKCU:\Environment` could not be read.
+  - Aggregated severity = max across findings.
+
+- **What is in scope (mechanical shapes only):** persisted User and Machine environment
+  values. Shadowing uses the process `$env:PATH` as the live search order and labels each
+  entry `user` / `machine` / `both` / `unknown` from membership in the persisted Path
+  lists. The check does not attribute a vendor, decide whether `WindowsApps` belongs last,
+  or recommend editing `TEMP`/`TMP`.
+
+- **Safety:** credential-pattern **values are never read**. The result reports `name` and
+  `scope` only. `GetValue` is not called for those names, so a summary, note, or exception
+  cannot leak a secret the check never loaded. The check never writes: no `Set-Item`,
+  `Set-ItemProperty`, `SetEnvironmentVariable`, or Path rewrite.
+
+- **Notes:** `DISABLE_AUTOUPDATER` is the Claude Code / Electron auto-update kill switch.
+  A User-scope `=1` silently freezes the installed binary — the defect that motivated
+  this check. Duplicate and missing PATH entries are INFO because presence is a shape,
+  not a verdict that the entry should be removed.

--- a/plugins/machine-health/skills/audit/scripts/windows/checks/Test-EnvironmentHealth.ps1
+++ b/plugins/machine-health/skills/audit/scripts/windows/checks/Test-EnvironmentHealth.ps1
@@ -1,0 +1,469 @@
+#Requires -Version 7.4
+<#
+.SYNOPSIS
+Check: persisted environment-variable and PATH health. Emits a CheckResult JSON
+on stdout.
+
+See references/windows/check-catalog.md#18-environment-and-path-health for rubric.
+
+.DESCRIPTION
+Detect-only. Reads HKCU:\Environment and (when readable)
+HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment. Never
+writes a registry value, never calls SetEnvironmentVariable, never rewrites
+PATH. Credential-pattern variable values are never read.
+
+Findings are mechanical shapes: DISABLE_AUTOUPDATER presence, missing PATH
+directories, duplicate PATH entries, shadowed executables, User Path stored
+as REG_SZ, User Path length against the 2047-character legacy-editor
+ceiling, and credential-pattern variable names (name + scope only).
+#>
+[CmdletBinding()]
+param([switch]$Human)
+
+Set-StrictMode -Version 3.0
+$ErrorActionPreference = 'Continue'
+. (Join-Path $PSScriptRoot '..\lib\Write-HealthResult.ps1')
+
+$sw = [System.Diagnostics.Stopwatch]::StartNew()
+$id = 'environment-health'
+$category = 'config'
+$userKeyPath = 'HKCU:\Environment'
+$machineKeyPath = 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment'
+$commands = @(
+    "Get-Item -LiteralPath '$userKeyPath'"
+    "(Get-Item -LiteralPath '$userKeyPath').GetValueKind('Path')"
+    "[Environment]::GetEnvironmentVariable('Path', 'User').Length"
+    "Get-ItemProperty -LiteralPath '$userKeyPath' -Name DISABLE_AUTOUPDATER"
+    "Get-ChildItem Env: | Where-Object Name -match '(_TOKEN|_API_KEY|_SECRET|_PASSWORD)$' | Select-Object Name"
+)
+
+# Legacy System Properties editor truncates a User Path REG_SZ/REG_EXPAND_SZ
+# at 2047 characters. WARN before that ceiling so a human can act; CRIT at
+# the ceiling because further appends are silently lost.
+$userPathWarnChars = 1800
+$userPathCritChars = 2047
+
+function Test-CredentialVariableName {
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param([Parameter(Mandatory = $true)] [string] $Name)
+
+    return [bool]($Name -match '(?i)(_TOKEN|_API_KEY|_SECRET|_PASSWORD)$' -or
+        $Name -in @('TOKEN', 'API_KEY', 'SECRET', 'PASSWORD'))
+}
+
+function Test-TruthyEnvValue {
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param([string] $Value)
+
+    if ([string]::IsNullOrWhiteSpace($Value)) { return $false }
+    return [bool]($Value.Trim() -match '^(?i:1|true|yes|on)$')
+}
+
+function Get-NormalizedPathEntry {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param([Parameter(Mandatory = $true)] [string] $PathEntry)
+
+    return $PathEntry.Trim().TrimEnd('\', '/').ToLowerInvariant()
+}
+
+function Split-PathEntries {
+    [CmdletBinding()]
+    [OutputType([string[]])]
+    param([string] $Raw)
+
+    if ([string]::IsNullOrWhiteSpace($Raw)) { return @() }
+    return @($Raw -split ';' | ForEach-Object { $_.Trim() } | Where-Object { $_ })
+}
+
+function Get-DefaultPathext {
+    [CmdletBinding()]
+    [OutputType([System.Collections.Generic.List[string]])]
+    param()
+
+    $raw = $env:PATHEXT
+    if ([string]::IsNullOrWhiteSpace($raw)) {
+        $raw = '.COM;.EXE;.BAT;.CMD;.VBS;.VBE;.JS;.JSE;.WSF;.WSH;.MSC;.CPL'
+    }
+    $list = [System.Collections.Generic.List[string]]::new()
+    foreach ($e in @($raw -split ';')) {
+        $t = $e.Trim().ToLowerInvariant()
+        if ($t) { $list.Add($t) }
+    }
+    return , $list
+}
+
+function Read-PersistentEnvironment {
+    <#
+    .SYNOPSIS
+    Read one Environment registry key as name/kind/value rows.
+
+    .DESCRIPTION
+    Credential-pattern names are recorded with value=$null and never passed
+    to GetValue. That is the whole point of the check's safety rule: a
+    later summary, notes, or exception message cannot leak a secret that
+    was never loaded.
+    #>
+    [CmdletBinding()]
+    [OutputType([pscustomobject[]])]
+    param(
+        [Parameter(Mandatory = $true)] [string] $LiteralPath,
+        [Parameter(Mandatory = $true)] [string] $Scope
+    )
+
+    $key = Get-Item -LiteralPath $LiteralPath -ErrorAction Stop
+    $rows = [System.Collections.Generic.List[pscustomobject]]::new()
+    foreach ($name in @($key.GetValueNames())) {
+        if ([string]::IsNullOrWhiteSpace($name)) { continue }
+        $isCredential = Test-CredentialVariableName $name
+        $kind = $key.GetValueKind($name).ToString()
+        $value = $null
+        if (-not $isCredential) {
+            # 1 = RegistryValueOptions.DoNotExpandEnvironmentNames. Numeric so
+            # the check does not depend on Microsoft.Win32.Registry at parse
+            # time (Pester on a non-Windows host still has to load this file).
+            $raw = $key.GetValue($name, $null, 1)
+            if ($raw -is [string[]]) { $value = ($raw -join ';') }
+            elseif ($null -ne $raw) { $value = [string]$raw }
+        }
+        $rows.Add([pscustomobject]@{
+                name       = $name
+                scope      = $Scope
+                kind       = $kind
+                value      = $value
+                credential = $isCredential
+            })
+    }
+    return , $rows
+}
+
+function Get-PathScope {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $true)] [string] $Normalized,
+        [Parameter(Mandatory = $true)] [hashtable] $UserNorm,
+        [Parameter(Mandatory = $true)] [hashtable] $MachineNorm
+    )
+
+    $inUser = $UserNorm.ContainsKey($Normalized)
+    $inMachine = $MachineNorm.ContainsKey($Normalized)
+    if ($inUser -and -not $inMachine) { return 'user' }
+    if ($inMachine -and -not $inUser) { return 'machine' }
+    if ($inUser -and $inMachine) { return 'both' }
+    return 'unknown'
+}
+
+function Test-ScopeLowerThanExpected {
+    <#
+    .SYNOPSIS
+    True when the winning PATH entry is a lower-precedence scope than another
+    copy of the same executable.
+
+    .DESCRIPTION
+    Persisted composition is User then Machine, so User is the higher
+    precedence scope. A Machine (or unknown) winner while a User copy also
+    exists means the live search order disagrees with that expectation —
+    typically a process PATH that lists a system directory first.
+    'both' counts as User-precedence (the directory is on the User Path).
+    #>
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param(
+        [Parameter(Mandatory = $true)] [string] $WinnerScope,
+        [Parameter(Mandatory = $true)] [string[]] $OtherScopes
+    )
+
+    $userPresent = $OtherScopes -contains 'user' -or $OtherScopes -contains 'both'
+    if (-not $userPresent) { return $false }
+    return $WinnerScope -in @('machine', 'unknown')
+}
+
+function New-FindingList {
+    [CmdletBinding()]
+    [OutputType([System.Collections.Generic.List[object]])]
+    param()
+    # Unary comma: an empty List enumerates to nothing, so a bare return
+    # would bind $null and the next .Count would throw under StrictMode.
+    return , [System.Collections.Generic.List[object]]::new()
+}
+
+try {
+    $userVars = @()
+    $machineVars = @()
+    $machineReadable = $true
+    $machineError = $null
+
+    $userVars = Read-PersistentEnvironment -LiteralPath $userKeyPath -Scope 'user'
+
+    try {
+        $machineVars = Read-PersistentEnvironment -LiteralPath $machineKeyPath -Scope 'machine'
+    } catch {
+        $machineReadable = $false
+        $machineError = $_.Exception.Message
+        Write-Verbose "Test-EnvironmentHealth: machine Environment unreadable. $machineError"
+    }
+
+    $allVars = [System.Collections.Generic.List[pscustomobject]]::new()
+    foreach ($row in $userVars) { $allVars.Add($row) }
+    foreach ($row in $machineVars) { $allVars.Add($row) }
+
+    $disableFindings = New-FindingList
+    foreach ($row in $allVars) {
+        if ($row.name -ne 'DISABLE_AUTOUPDATER') { continue }
+        $disableFindings.Add([pscustomobject]@{
+                scope           = $row.scope
+                set             = $true
+                disables_updates = Test-TruthyEnvValue $row.value
+            })
+    }
+
+    $credentialFindings = New-FindingList
+    foreach ($row in $allVars) {
+        if (-not $row.credential) { continue }
+        $credentialFindings.Add([pscustomobject]@{
+                name  = $row.name
+                scope = $row.scope
+            })
+    }
+
+    $userPathRow = $null
+    foreach ($row in $userVars) {
+        if ($row.name -eq 'Path') { $userPathRow = $row; break }
+    }
+    $machinePathRow = $null
+    foreach ($row in $machineVars) {
+        if ($row.name -eq 'Path') { $machinePathRow = $row; break }
+    }
+
+    $userPathKind = $null
+    $userPathRaw = ''
+    if ($null -ne $userPathRow) {
+        $userPathKind = $userPathRow.kind
+        $userPathRaw = [string]$userPathRow.value
+    }
+    $userPathIsExpand = $userPathKind -eq 'ExpandString'
+    $userPathLength = $userPathRaw.Length
+
+    $machinePathRaw = ''
+    if ($null -ne $machinePathRow) { $machinePathRaw = [string]$machinePathRow.value }
+    $userEntries = [System.Collections.Generic.List[string]]::new()
+    foreach ($e in @(Split-PathEntries $userPathRaw)) { $userEntries.Add($e) }
+    $machineEntries = [System.Collections.Generic.List[string]]::new()
+    foreach ($e in @(Split-PathEntries $machinePathRaw)) { $machineEntries.Add($e) }
+
+    $userNorm = @{}
+    foreach ($e in $userEntries) { $userNorm[(Get-NormalizedPathEntry $e)] = $true }
+    $machineNorm = @{}
+    foreach ($e in $machineEntries) { $machineNorm[(Get-NormalizedPathEntry $e)] = $true }
+
+    $persistedEntries = [System.Collections.Generic.List[pscustomobject]]::new()
+    foreach ($e in $userEntries) {
+        $persistedEntries.Add([pscustomobject]@{ path = $e; scope = 'user'; norm = (Get-NormalizedPathEntry $e) })
+    }
+    foreach ($e in $machineEntries) {
+        $persistedEntries.Add([pscustomobject]@{ path = $e; scope = 'machine'; norm = (Get-NormalizedPathEntry $e) })
+    }
+
+    $missingDirs = New-FindingList
+    foreach ($e in $persistedEntries) {
+        $exists = $false
+        try {
+            $exists = Test-Path -LiteralPath $e.path -PathType Container -ErrorAction Stop
+        } catch {
+            $exists = $false
+        }
+        if (-not $exists) {
+            $missingDirs.Add([pscustomobject]@{ path = $e.path; scope = $e.scope })
+        }
+    }
+
+    $duplicateFindings = New-FindingList
+    $byNorm = $persistedEntries | Group-Object -Property norm
+    foreach ($g in $byNorm) {
+        if ($g.Count -lt 2) { continue }
+        $scopes = @($g.Group | ForEach-Object { $_.scope } | Select-Object -Unique)
+        $duplicateFindings.Add([pscustomobject]@{
+                path   = $g.Group[0].path
+                count  = $g.Count
+                scopes = @($scopes)
+            })
+    }
+
+    # Live search order is the process PATH (what CreateProcess actually
+    # walks). Scope labels still come from the persisted User/Machine lists
+    # so a conda-prepended directory is 'unknown' rather than mislabeled.
+    $processEntries = [System.Collections.Generic.List[string]]::new()
+    foreach ($p in @(Split-PathEntries $env:PATH)) { $processEntries.Add($p) }
+    if ($processEntries.Count -eq 0) {
+        foreach ($p in @($userEntries) + @($machineEntries)) { $processEntries.Add($p) }
+    }
+
+    $pathext = Get-DefaultPathext
+    $nameToHits = @{}
+    foreach ($dir in $processEntries) {
+        $exists = $false
+        try { $exists = Test-Path -LiteralPath $dir -PathType Container -ErrorAction SilentlyContinue } catch { $exists = $false }
+        if (-not $exists) { continue }
+
+        $files = @()
+        try {
+            $files = @(Get-ChildItem -LiteralPath $dir -File -ErrorAction SilentlyContinue)
+        } catch {
+            Write-Verbose "Test-EnvironmentHealth: listing '$dir' failed. $($_.Exception.Message)"
+            continue
+        }
+
+        $norm = Get-NormalizedPathEntry $dir
+        $scope = Get-PathScope -Normalized $norm -UserNorm $userNorm -MachineNorm $machineNorm
+        foreach ($f in $files) {
+            $ext = $f.Extension.ToLowerInvariant()
+            if ($ext -and $ext -notin $pathext) { continue }
+            $exeName = $f.Name.ToLowerInvariant()
+            if (-not $nameToHits.ContainsKey($exeName)) {
+                $nameToHits[$exeName] = [System.Collections.Generic.List[pscustomobject]]::new()
+            }
+            $nameToHits[$exeName].Add([pscustomobject]@{
+                    path  = $dir
+                    scope = $scope
+                    file  = $f.Name
+                })
+        }
+    }
+
+    $shadowed = New-FindingList
+    foreach ($exeName in ($nameToHits.Keys | Sort-Object)) {
+        $hits = $nameToHits[$exeName]
+        $uniqueNorms = [System.Collections.Generic.List[string]]::new()
+        foreach ($h in $hits) {
+            $n = Get-NormalizedPathEntry $h.path
+            if (-not $uniqueNorms.Contains($n)) { $uniqueNorms.Add($n) }
+        }
+        if ($uniqueNorms.Count -lt 2) { continue }
+        $winner = $hits[0]
+        $others = [System.Collections.Generic.List[pscustomobject]]::new()
+        $otherScopes = [System.Collections.Generic.List[string]]::new()
+        $otherPaths = [System.Collections.Generic.List[string]]::new()
+        for ($i = 1; $i -lt $hits.Count; $i++) {
+            $others.Add($hits[$i])
+            $otherScopes.Add($hits[$i].scope)
+            $otherPaths.Add($hits[$i].path)
+        }
+        $warn = Test-ScopeLowerThanExpected -WinnerScope $winner.scope -OtherScopes @($otherScopes)
+        $shadowed.Add([pscustomobject]@{
+                name         = $winner.file
+                winner_path  = $winner.path
+                winner_scope = $winner.scope
+                other_paths  = $otherPaths
+                warn         = $warn
+            })
+    }
+
+    # Severity ladder (most severe first). No finding here writes anything;
+    # CRIT is reserved for the User Path length ceiling because further
+    # appends are silently discarded by the legacy editor. Everything else
+    # is a shape a human decides what to do with.
+    $severity = 'OK'
+    $reasons = [System.Collections.Generic.List[string]]::new()
+
+    if ($userPathLength -ge $userPathCritChars) {
+        $severity = 'CRIT'
+        $reasons.Add("User PATH length $userPathLength (legacy-editor ceiling $userPathCritChars)")
+    } elseif ($userPathLength -ge $userPathWarnChars) {
+        $severity = 'WARN'
+        $reasons.Add("User PATH length $userPathLength (WARN at $userPathWarnChars)")
+    }
+
+    if ($userPathKind -eq 'String') {
+        if ($severity -eq 'OK') { $severity = 'WARN' }
+        elseif ($severity -eq 'INFO') { $severity = 'WARN' }
+        $reasons.Add('User Path is REG_SZ (breaks %TOKEN% expansion)')
+    }
+
+    $truthyDisable = New-FindingList
+    foreach ($d in $disableFindings) {
+        if ($d.disables_updates) { $truthyDisable.Add($d) }
+    }
+    if ($truthyDisable.Count -gt 0) {
+        if ($severity -eq 'OK') { $severity = 'WARN' }
+        elseif ($severity -eq 'INFO') { $severity = 'WARN' }
+        $scopes = [System.Collections.Generic.List[string]]::new()
+        foreach ($d in $truthyDisable) { $scopes.Add($d.scope) }
+        $reasons.Add("DISABLE_AUTOUPDATER set ($($scopes -join ', '))")
+    }
+
+    if ($credentialFindings.Count -gt 0) {
+        if ($severity -eq 'OK') { $severity = 'WARN' }
+        elseif ($severity -eq 'INFO') { $severity = 'WARN' }
+        $reasons.Add("$($credentialFindings.Count) credential-named variable(s)")
+    }
+
+    $shadowWarns = New-FindingList
+    foreach ($s in $shadowed) {
+        if ($s.warn) { $shadowWarns.Add($s) }
+    }
+    if ($shadowWarns.Count -gt 0) {
+        if ($severity -eq 'OK') { $severity = 'WARN' }
+        elseif ($severity -eq 'INFO') { $severity = 'WARN' }
+        $reasons.Add("$($shadowWarns.Count) shadowed executable(s) with lower-precedence winner")
+    }
+
+    $infoBits = [System.Collections.Generic.List[string]]::new()
+    if ($missingDirs.Count -gt 0) { $infoBits.Add("$($missingDirs.Count) missing PATH dir(s)") }
+    if ($duplicateFindings.Count -gt 0) { $infoBits.Add("$($duplicateFindings.Count) duplicate PATH entry group(s)") }
+    $shadowInfo = $shadowed.Count - $shadowWarns.Count
+    if ($shadowInfo -gt 0) { $infoBits.Add("$shadowInfo shadowed executable name(s)") }
+    $falsyDisable = New-FindingList
+    foreach ($d in $disableFindings) {
+        if (-not $d.disables_updates) { $falsyDisable.Add($d) }
+    }
+    if ($falsyDisable.Count -gt 0) { $infoBits.Add('DISABLE_AUTOUPDATER set but not truthy') }
+
+    if ($severity -eq 'OK' -and $infoBits.Count -gt 0) {
+        $severity = 'INFO'
+        foreach ($b in $infoBits) { $reasons.Add($b) }
+    } elseif ($infoBits.Count -gt 0) {
+        foreach ($b in $infoBits) { $reasons.Add($b) }
+    }
+
+    if ($severity -eq 'OK') {
+        $summary = 'Environment and PATH look healthy.'
+    } else {
+        $summary = ($reasons -join '; ')
+        if ($summary.Length -gt 240) { $summary = $summary.Substring(0, 237) + '...' }
+    }
+
+    $notes = 'Detect-only. No remediation — registry writes are never authorized.'
+    if (-not $machineReadable) {
+        $notes = "$notes Machine Environment unreadable; User-scope findings only."
+    }
+
+    $result = New-HealthResult -Id $id -Category $category -Os 'windows' `
+        -Severity $severity -Summary $summary -Commands $commands `
+        -Detail @{
+        disable_autoupdater      = $disableFindings
+        missing_path_dirs        = $missingDirs
+        duplicate_path_entries   = $duplicateFindings
+        shadowed_executables     = $shadowed
+        credential_named_vars    = $credentialFindings
+        user_path_kind           = $userPathKind
+        user_path_is_expand_sz   = $userPathIsExpand
+        user_path_length         = $userPathLength
+        machine_scope_readable   = $machineReadable
+        process_path_entry_count = $processEntries.Count
+    } `
+        -NeedsAdmin $false -RanSuccessfully $true `
+        -Notes $notes `
+        -DurationMs ([int]$sw.ElapsedMilliseconds)
+} catch {
+    $result = New-HealthResult -Id $id -Category $category -Os 'windows' `
+        -Severity 'UNKNOWN' -Summary 'Environment and PATH health check failed.' -Commands $commands `
+        -RanSuccessfully $false -ErrorMessage $_.Exception.Message `
+        -DurationMs ([int]$sw.ElapsedMilliseconds)
+}
+
+$sw.Stop()
+$result.duration_ms = [int]$sw.ElapsedMilliseconds
+$result | Write-HealthResult -Human:$Human

--- a/plugins/machine-health/skills/audit/scripts/windows/checks/Test-EnvironmentHealth.ps1
+++ b/plugins/machine-health/skills/audit/scripts/windows/checks/Test-EnvironmentHealth.ps1
@@ -69,6 +69,28 @@ function Get-NormalizedPathEntry {
     return $PathEntry.Trim().TrimEnd('\', '/').ToLowerInvariant()
 }
 
+function Get-ExpandedPathEntry {
+    <#
+    .SYNOPSIS
+    Expand %VAR% tokens in a persisted PATH entry for filesystem and scope use.
+
+    .DESCRIPTION
+    Read-PersistentEnvironment keeps REG_EXPAND_SZ values unexpanded so
+    user_path_length measures the stored string (legacy-editor ceiling).
+    Existence checks and Get-PathScope must expand first: a stock Machine
+    Path stores `%SystemRoot%` plus a system32 fragment as a token, and
+    Test-Path / live $env:PATH comparisons against that raw token
+    false-positive as missing and mislabel scope as 'unknown'.
+    #>
+    [CmdletBinding()]
+    [OutputType([string])]
+    param([Parameter(Mandatory = $true)] [string] $PathEntry)
+
+    $expanded = [Environment]::ExpandEnvironmentVariables($PathEntry)
+    if ([string]::IsNullOrWhiteSpace($expanded)) { return $PathEntry }
+    return $expanded
+}
+
 function Split-PathEntries {
     [CmdletBinding()]
     [OutputType([string[]])]
@@ -255,23 +277,39 @@ try {
     foreach ($e in @(Split-PathEntries $machinePathRaw)) { $machineEntries.Add($e) }
 
     $userNorm = @{}
-    foreach ($e in $userEntries) { $userNorm[(Get-NormalizedPathEntry $e)] = $true }
+    foreach ($e in $userEntries) {
+        $userNorm[(Get-NormalizedPathEntry (Get-ExpandedPathEntry $e))] = $true
+    }
     $machineNorm = @{}
-    foreach ($e in $machineEntries) { $machineNorm[(Get-NormalizedPathEntry $e)] = $true }
+    foreach ($e in $machineEntries) {
+        $machineNorm[(Get-NormalizedPathEntry (Get-ExpandedPathEntry $e))] = $true
+    }
 
     $persistedEntries = [System.Collections.Generic.List[pscustomobject]]::new()
     foreach ($e in $userEntries) {
-        $persistedEntries.Add([pscustomobject]@{ path = $e; scope = 'user'; norm = (Get-NormalizedPathEntry $e) })
+        $expanded = Get-ExpandedPathEntry $e
+        $persistedEntries.Add([pscustomobject]@{
+                path     = $e
+                expanded = $expanded
+                scope    = 'user'
+                norm     = (Get-NormalizedPathEntry $expanded)
+            })
     }
     foreach ($e in $machineEntries) {
-        $persistedEntries.Add([pscustomobject]@{ path = $e; scope = 'machine'; norm = (Get-NormalizedPathEntry $e) })
+        $expanded = Get-ExpandedPathEntry $e
+        $persistedEntries.Add([pscustomobject]@{
+                path     = $e
+                expanded = $expanded
+                scope    = 'machine'
+                norm     = (Get-NormalizedPathEntry $expanded)
+            })
     }
 
     $missingDirs = New-FindingList
     foreach ($e in $persistedEntries) {
         $exists = $false
         try {
-            $exists = Test-Path -LiteralPath $e.path -PathType Container -ErrorAction Stop
+            $exists = Test-Path -LiteralPath $e.expanded -PathType Container -ErrorAction Stop
         } catch {
             $exists = $false
         }
@@ -298,7 +336,9 @@ try {
     $processEntries = [System.Collections.Generic.List[string]]::new()
     foreach ($p in @(Split-PathEntries $env:PATH)) { $processEntries.Add($p) }
     if ($processEntries.Count -eq 0) {
-        foreach ($p in @($userEntries) + @($machineEntries)) { $processEntries.Add($p) }
+        foreach ($p in @($userEntries) + @($machineEntries)) {
+            $processEntries.Add((Get-ExpandedPathEntry $p))
+        }
     }
 
     $pathext = Get-DefaultPathext

--- a/plugins/machine-health/skills/audit/scripts/windows/lib/Invoke-TrendAnalysis.ps1
+++ b/plugins/machine-health/skills/audit/scripts/windows/lib/Invoke-TrendAnalysis.ps1
@@ -186,8 +186,12 @@ function Test-WorseningTrend {
     $upwardWorsens = @(
         'disk-space', 'defender', 'event-log-errors',
         'winget-upgrades', 'windows-update', 'services', 'drivers',
-        'claude-temp-root', 'environment-health'
+        'claude-temp-root'
     )
+    # environment-health is mapped to user_path_length for history, but is
+    # not in $upwardWorsens: the check has several independent WARN causes
+    # (credential names, DISABLE_AUTOUPDATER, REG_SZ Path). A generic
+    # upgrade would turn those into CRIT whenever Path grew by >=5 chars.
     $downwardWorsens = @('battery', 'reliability')
 
     $delta = $cur - $prev

--- a/plugins/machine-health/skills/audit/scripts/windows/lib/Invoke-TrendAnalysis.ps1
+++ b/plugins/machine-health/skills/audit/scripts/windows/lib/Invoke-TrendAnalysis.ps1
@@ -157,6 +157,7 @@ function Get-TrendRelevantKey {
         'drivers' { return 'unsigned_in_store_count' }
         'reliability' { return 'stability_min_7d' }
         'claude-temp-root' { return 'total_gb' }
+        'environment-health' { return 'user_path_length' }
         default { return $null }
     }
 }
@@ -185,7 +186,7 @@ function Test-WorseningTrend {
     $upwardWorsens = @(
         'disk-space', 'defender', 'event-log-errors',
         'winget-upgrades', 'windows-update', 'services', 'drivers',
-        'claude-temp-root'
+        'claude-temp-root', 'environment-health'
     )
     $downwardWorsens = @('battery', 'reliability')
 

--- a/plugins/machine-health/skills/audit/tests/fixtures/windows/Environment/README.md
+++ b/plugins/machine-health/skills/audit/tests/fixtures/windows/Environment/README.md
@@ -25,3 +25,4 @@ from JSON and `-Human` output.
 | `path-length-warn.json` | User Path length ≥ 1800 and < 2047 |
 | `path-length-crit.json` | User Path length ≥ 2047 |
 | `credential-names.json` | `GITHUB_TOKEN` planted; value must never be emitted |
+| `expand-path-tokens.json` | Machine/User Path stored as `%VAR%/dir` tokens |

--- a/plugins/machine-health/skills/audit/tests/fixtures/windows/Environment/README.md
+++ b/plugins/machine-health/skills/audit/tests/fixtures/windows/Environment/README.md
@@ -1,0 +1,27 @@
+# Environment registry fixtures
+
+Synthetic snapshots of `HKCU:\Environment` and
+`HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment`.
+These are not captured CLIXML: a live `RegistryKey` does not round-trip
+through `Export-Clixml` in a form Pester can rehydrate on a non-Windows
+host, and the interesting cases (2047-character Path, a planted secret)
+must not come from a real workstation.
+
+Each `*.json` is a `{ "user": { Name: { kind, value } }, "machine": {...},
+"dirs": { token: { exists, files } } }` document. Tests replace `{token}`
+placeholders with materialized temp directories before mocking `Get-Item`.
+
+Credential fixtures use a planted value that tests assert is **absent**
+from JSON and `-Human` output.
+
+| File | Scenario |
+|---|---|
+| `healthy.json` | ExpandString User Path, existing dirs, no flags |
+| `disable-autoupdater.json` | User `DISABLE_AUTOUPDATER=1` |
+| `duplicate-and-missing-path.json` | Duplicate User Path entry + one missing dir |
+| `shadowed-exe.json` | Same `git.exe` in User and Machine Path dirs |
+| `shadow-machine-wins.json` | Process PATH lists Machine dir first |
+| `path-reg-sz.json` | User Path stored as `REG_SZ` (`String`) |
+| `path-length-warn.json` | User Path length ≥ 1800 and < 2047 |
+| `path-length-crit.json` | User Path length ≥ 2047 |
+| `credential-names.json` | `GITHUB_TOKEN` planted; value must never be emitted |

--- a/plugins/machine-health/skills/audit/tests/fixtures/windows/Environment/README.md
+++ b/plugins/machine-health/skills/audit/tests/fixtures/windows/Environment/README.md
@@ -1,7 +1,7 @@
 # Environment registry fixtures
 
-Synthetic snapshots of `HKCU:\Environment` and
-`HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment`.
+Synthetic snapshots of `HKCU:\Environment` and the machine Session Manager
+Environment key (PowerShell provider path under `HKLM:`).
 These are not captured CLIXML: a live `RegistryKey` does not round-trip
 through `Export-Clixml` in a form Pester can rehydrate on a non-Windows
 host, and the interesting cases (2047-character Path, a planted secret)

--- a/plugins/machine-health/skills/audit/tests/fixtures/windows/Environment/credential-names.json
+++ b/plugins/machine-health/skills/audit/tests/fixtures/windows/Environment/credential-names.json
@@ -1,0 +1,17 @@
+{
+  "user": {
+    "Path": { "kind": "ExpandString", "value": "{userBin}" },
+    "GITHUB_TOKEN": { "kind": "String", "value": "super-secret-gh-token-2866-must-never-appear" },
+    "MY_API_KEY": { "kind": "String", "value": "sk-planted-api-key-value-do-not-log" },
+    "ACME_SECRET": { "kind": "String", "value": "planted-secret-value-do-not-log" },
+    "DB_PASSWORD": { "kind": "String", "value": "planted-password-value-do-not-log" }
+  },
+  "machine": {
+    "Path": { "kind": "ExpandString", "value": "{machineBin}" }
+  },
+  "dirs": {
+    "userBin": { "exists": true, "files": ["user-tool.exe"] },
+    "machineBin": { "exists": true, "files": ["system-tool.exe"] }
+  },
+  "process_path": ["{userBin}", "{machineBin}"]
+}

--- a/plugins/machine-health/skills/audit/tests/fixtures/windows/Environment/disable-autoupdater.json
+++ b/plugins/machine-health/skills/audit/tests/fixtures/windows/Environment/disable-autoupdater.json
@@ -1,0 +1,14 @@
+{
+  "user": {
+    "Path": { "kind": "ExpandString", "value": "{userBin}" },
+    "DISABLE_AUTOUPDATER": { "kind": "String", "value": "1" }
+  },
+  "machine": {
+    "Path": { "kind": "ExpandString", "value": "{machineBin}" }
+  },
+  "dirs": {
+    "userBin": { "exists": true, "files": ["user-tool.exe"] },
+    "machineBin": { "exists": true, "files": ["system-tool.exe"] }
+  },
+  "process_path": ["{userBin}", "{machineBin}"]
+}

--- a/plugins/machine-health/skills/audit/tests/fixtures/windows/Environment/duplicate-and-missing-path.json
+++ b/plugins/machine-health/skills/audit/tests/fixtures/windows/Environment/duplicate-and-missing-path.json
@@ -1,0 +1,14 @@
+{
+  "user": {
+    "Path": { "kind": "ExpandString", "value": "{userBin};{missingDir};{userBin}" }
+  },
+  "machine": {
+    "Path": { "kind": "ExpandString", "value": "{machineBin}" }
+  },
+  "dirs": {
+    "userBin": { "exists": true, "files": ["user-tool.exe"] },
+    "machineBin": { "exists": true, "files": ["system-tool.exe"] },
+    "missingDir": { "exists": false, "files": [] }
+  },
+  "process_path": ["{userBin}", "{machineBin}"]
+}

--- a/plugins/machine-health/skills/audit/tests/fixtures/windows/Environment/expand-path-tokens.json
+++ b/plugins/machine-health/skills/audit/tests/fixtures/windows/Environment/expand-path-tokens.json
@@ -1,0 +1,13 @@
+{
+  "user": {
+    "Path": { "kind": "ExpandString", "value": "%MH_ENV_SYSROOT%/userBin" }
+  },
+  "machine": {
+    "Path": { "kind": "ExpandString", "value": "%MH_ENV_SYSROOT%/machineBin;%MH_ENV_MISSING%/ghost" }
+  },
+  "dirs": {
+    "userBin": { "exists": true, "files": ["git.exe"] },
+    "machineBin": { "exists": true, "files": ["git.exe"] }
+  },
+  "process_path": ["{userBin}", "{machineBin}"]
+}

--- a/plugins/machine-health/skills/audit/tests/fixtures/windows/Environment/healthy.json
+++ b/plugins/machine-health/skills/audit/tests/fixtures/windows/Environment/healthy.json
@@ -1,0 +1,13 @@
+{
+  "user": {
+    "Path": { "kind": "ExpandString", "value": "{userBin}" }
+  },
+  "machine": {
+    "Path": { "kind": "ExpandString", "value": "{machineBin}" }
+  },
+  "dirs": {
+    "userBin": { "exists": true, "files": ["user-tool.exe"] },
+    "machineBin": { "exists": true, "files": ["system-tool.exe"] }
+  },
+  "process_path": ["{userBin}", "{machineBin}"]
+}

--- a/plugins/machine-health/skills/audit/tests/fixtures/windows/Environment/path-length-crit.json
+++ b/plugins/machine-health/skills/audit/tests/fixtures/windows/Environment/path-length-crit.json
@@ -1,0 +1,13 @@
+{
+  "user": {
+    "Path": { "kind": "ExpandString", "value": "{userBin}", "pad_to": 2047 }
+  },
+  "machine": {
+    "Path": { "kind": "ExpandString", "value": "{machineBin}" }
+  },
+  "dirs": {
+    "userBin": { "exists": true, "files": ["user-tool.exe"] },
+    "machineBin": { "exists": true, "files": ["system-tool.exe"] }
+  },
+  "process_path": ["{userBin}", "{machineBin}"]
+}

--- a/plugins/machine-health/skills/audit/tests/fixtures/windows/Environment/path-length-warn.json
+++ b/plugins/machine-health/skills/audit/tests/fixtures/windows/Environment/path-length-warn.json
@@ -1,0 +1,13 @@
+{
+  "user": {
+    "Path": { "kind": "ExpandString", "value": "{userBin}", "pad_to": 1800 }
+  },
+  "machine": {
+    "Path": { "kind": "ExpandString", "value": "{machineBin}" }
+  },
+  "dirs": {
+    "userBin": { "exists": true, "files": ["user-tool.exe"] },
+    "machineBin": { "exists": true, "files": ["system-tool.exe"] }
+  },
+  "process_path": ["{userBin}", "{machineBin}"]
+}

--- a/plugins/machine-health/skills/audit/tests/fixtures/windows/Environment/path-reg-sz.json
+++ b/plugins/machine-health/skills/audit/tests/fixtures/windows/Environment/path-reg-sz.json
@@ -1,0 +1,13 @@
+{
+  "user": {
+    "Path": { "kind": "String", "value": "{userBin}" }
+  },
+  "machine": {
+    "Path": { "kind": "ExpandString", "value": "{machineBin}" }
+  },
+  "dirs": {
+    "userBin": { "exists": true, "files": ["user-tool.exe"] },
+    "machineBin": { "exists": true, "files": ["system-tool.exe"] }
+  },
+  "process_path": ["{userBin}", "{machineBin}"]
+}

--- a/plugins/machine-health/skills/audit/tests/fixtures/windows/Environment/shadow-machine-wins.json
+++ b/plugins/machine-health/skills/audit/tests/fixtures/windows/Environment/shadow-machine-wins.json
@@ -1,0 +1,13 @@
+{
+  "user": {
+    "Path": { "kind": "ExpandString", "value": "{userBin}" }
+  },
+  "machine": {
+    "Path": { "kind": "ExpandString", "value": "{machineBin}" }
+  },
+  "dirs": {
+    "userBin": { "exists": true, "files": ["git.exe"] },
+    "machineBin": { "exists": true, "files": ["git.exe"] }
+  },
+  "process_path": ["{machineBin}", "{userBin}"]
+}

--- a/plugins/machine-health/skills/audit/tests/fixtures/windows/Environment/shadowed-exe.json
+++ b/plugins/machine-health/skills/audit/tests/fixtures/windows/Environment/shadowed-exe.json
@@ -1,0 +1,13 @@
+{
+  "user": {
+    "Path": { "kind": "ExpandString", "value": "{userBin}" }
+  },
+  "machine": {
+    "Path": { "kind": "ExpandString", "value": "{machineBin}" }
+  },
+  "dirs": {
+    "userBin": { "exists": true, "files": ["git.exe"] },
+    "machineBin": { "exists": true, "files": ["git.exe"] }
+  },
+  "process_path": ["{userBin}", "{machineBin}"]
+}

--- a/plugins/machine-health/skills/audit/tests/helpers/Mock-Helpers.psm1
+++ b/plugins/machine-health/skills/audit/tests/helpers/Mock-Helpers.psm1
@@ -249,6 +249,52 @@ function New-MockWinGetPackage {
     }
 }
 
+function New-MockEnvironmentKey {
+    <#
+    .SYNOPSIS
+    RegistryKey-shaped stand-in for HKCU:\Environment / HKLM Environment.
+
+    .DESCRIPTION
+    Check scripts call GetValueNames, GetValueKind, and the 3-arg GetValue
+    (name, default, RegistryValueOptions). A real RegistryKey does not
+    Export-Clixml in a form tests can rehydrate, so this factory is the
+    fixture surface. Entries is Name -> @{ Kind = 'String'|'ExpandString';
+    Value = '...' }. Credential tests plant a Value that the check must
+    never read — GetValue still returns it if called, so a leak is visible.
+    #>
+    [CmdletBinding()]
+    [OutputType([pscustomobject])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [hashtable] $Entries
+    )
+
+    $map = [hashtable]::new([StringComparer]::OrdinalIgnoreCase)
+    foreach ($k in $Entries.Keys) { $map[$k] = $Entries[$k] }
+
+    $key = [pscustomobject]@{
+        _entries      = $map
+        GetValueCalls = [System.Collections.Generic.List[string]]::new()
+    }
+    $key | Add-Member -MemberType ScriptMethod -Name GetValueNames -Value {
+        @($this._entries.Keys | ForEach-Object { [string]$_ })
+    } -Force
+    $key | Add-Member -MemberType ScriptMethod -Name GetValueKind -Value {
+        param($Name)
+        if (-not $this._entries.ContainsKey($Name)) {
+            throw "Property $Name does not exist."
+        }
+        return $this._entries[$Name].Kind
+    } -Force
+    $key | Add-Member -MemberType ScriptMethod -Name GetValue -Value {
+        param($Name, $Default, $Options)
+        $this.GetValueCalls.Add([string]$Name)
+        if (-not $this._entries.ContainsKey($Name)) { return $Default }
+        return $this._entries[$Name].Value
+    } -Force
+    return $key
+}
+
 function New-MachineHealthTempDir {
     # Creates a uniquely-named scratch directory under the system temp root and
     # returns its path. Centralizes the pattern repeated across tests that need
@@ -277,6 +323,7 @@ Export-ModuleMember -Function @(
     'New-MockBattery'
     'New-MockDefenderComputerStatus'
     'New-MockDriver'
+    'New-MockEnvironmentKey'
     'New-MockEventLogRecord'
     'New-MockPartition'
     'New-MockPhysicalDisk'

--- a/plugins/machine-health/skills/audit/tests/windows/Scaffold.Tests.ps1
+++ b/plugins/machine-health/skills/audit/tests/windows/Scaffold.Tests.ps1
@@ -126,6 +126,17 @@ Describe 'Scaffold -- Mock factories' {
         $m.RealTimeProtectionEnabled | Should -BeTrue
         $m.AntivirusSignatureAge | Should -Be 1
     }
+
+    It 'New-MockEnvironmentKey exposes GetValueNames/GetValueKind/GetValue' {
+        $k = New-MockEnvironmentKey -Entries @{
+            Path              = @{ Kind = 'ExpandString'; Value = 'C:\bin' }
+            GITHUB_TOKEN      = @{ Kind = 'String'; Value = 'planted-secret' }
+        }
+        $k.GetValueNames() | Should -Contain 'Path'
+        $k.GetValueKind('Path') | Should -Be 'ExpandString'
+        $k.GetValue('Path', $null, 1) | Should -Be 'C:\bin'
+        $k.GetValueCalls | Should -Contain 'Path'
+    }
 }
 
 Describe 'Scaffold -- Invoke-FixtureRedaction' {

--- a/plugins/machine-health/skills/audit/tests/windows/checks/Test-EnvironmentHealth.Tests.ps1
+++ b/plugins/machine-health/skills/audit/tests/windows/checks/Test-EnvironmentHealth.Tests.ps1
@@ -128,6 +128,8 @@ Describe 'Test-EnvironmentHealth' -Tag 'check' {
     AfterEach {
         $env:PATH = $script:priorPath
         $env:PATHEXT = $script:priorPathext
+        Remove-Item Env:MH_ENV_SYSROOT -ErrorAction SilentlyContinue
+        Remove-Item Env:MH_ENV_MISSING -ErrorAction SilentlyContinue
         Remove-MachineHealthTempDir -Path $script:tmpDir
     }
 
@@ -175,6 +177,26 @@ Describe 'Test-EnvironmentHealth' -Tag 'check' {
             $result.detail.disable_autoupdater | Should -HaveCount 1
             $result.detail.disable_autoupdater[0].scope | Should -Be 'user'
             $result.detail.disable_autoupdater[0].disables_updates | Should -BeTrue
+        }
+    }
+
+    Context 'REG_EXPAND_SZ PATH tokens' {
+        It 'expands %VAR% before existence and scope checks; length stays unexpanded' {
+            $fx = Import-EnvironmentFixture -Name 'expand-path-tokens' -TempRoot $script:tmpDir
+            $env:PATH = $fx.ProcessPath
+            $env:MH_ENV_SYSROOT = $script:tmpDir
+            Remove-Item Env:MH_ENV_MISSING -ErrorAction SilentlyContinue
+            Install-EnvironmentMocks $fx
+
+            $result = Invoke-EnvironmentHealthAsObject
+            $result.severity | Should -Be 'INFO'
+            $result.detail.user_path_length | Should -Be ('%MH_ENV_SYSROOT%/userBin').Length
+            $result.detail.missing_path_dirs | Should -HaveCount 1
+            $result.detail.missing_path_dirs[0].path | Should -Be '%MH_ENV_MISSING%/ghost'
+            $result.detail.missing_path_dirs[0].scope | Should -Be 'machine'
+            $result.detail.shadowed_executables | Should -HaveCount 1
+            $result.detail.shadowed_executables[0].winner_scope | Should -Be 'user'
+            $result.detail.shadowed_executables[0].warn | Should -BeFalse
         }
     }
 

--- a/plugins/machine-health/skills/audit/tests/windows/checks/Test-EnvironmentHealth.Tests.ps1
+++ b/plugins/machine-health/skills/audit/tests/windows/checks/Test-EnvironmentHealth.Tests.ps1
@@ -1,0 +1,342 @@
+#Requires -Version 7.4
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.7.0' }
+<#
+.SYNOPSIS
+Tests for scripts/windows/checks/Test-EnvironmentHealth.ps1.
+
+.DESCRIPTION
+The check reads persisted Environment registry keys via Get-Item. Tests
+materialize fixtures/windows/Environment/*.json into temp directories and
+mock Get-Item to return New-MockEnvironmentKey objects. $env:PATH is
+redirected to the fixture's process_path so shadowing uses a known order
+and the host PATH cannot leak into the result.
+#>
+
+BeforeAll {
+    $script:TestsRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+    $script:SkillRoot = Split-Path -Parent $script:TestsRoot
+    $script:ScriptPath = Join-Path $script:SkillRoot 'scripts\windows\checks\Test-EnvironmentHealth.ps1'
+    $script:LibRoot = Join-Path $script:SkillRoot 'scripts\windows\lib'
+    $script:FixtureRoot = Join-Path $script:TestsRoot 'fixtures\windows\Environment'
+    . (Join-Path $script:LibRoot 'Assert-CheckResult.ps1')
+    Import-Module (Join-Path $script:TestsRoot 'helpers\Mock-Helpers.psm1') -Force
+    . (Join-Path $script:TestsRoot 'helpers\Invoke-CheckScript.ps1')
+
+    function Expand-FixturePathValue {
+        param($Spec, [hashtable] $TokenMap)
+        $value = [string]$Spec.value
+        foreach ($t in $TokenMap.Keys) {
+            $value = $value.Replace("{$t}", $TokenMap[$t])
+        }
+        $padTo = 0
+        if ($Spec.PSObject.Properties['pad_to'] -and $null -ne $Spec.pad_to) {
+            $padTo = [int]$Spec.pad_to
+        }
+        if ($padTo -gt $value.Length) {
+            $value = $value + ';' + ('x' * ($padTo - $value.Length - 1))
+            if ($value.Length -gt $padTo) { $value = $value.Substring(0, $padTo) }
+            elseif ($value.Length -lt $padTo) { $value += ('x' * ($padTo - $value.Length)) }
+        }
+        return $value
+    }
+
+    function Convert-FixtureScope {
+        param($ScopeObject, [hashtable] $TokenMap)
+        $entries = @{}
+        if ($null -eq $ScopeObject) { return $entries }
+        foreach ($prop in $ScopeObject.PSObject.Properties) {
+            $spec = $prop.Value
+            $kind = [string]$spec.kind
+            $value = Expand-FixturePathValue -Spec $spec -TokenMap $TokenMap
+            $entries[$prop.Name] = @{ Kind = $kind; Value = $value }
+        }
+        return $entries
+    }
+
+    function Import-EnvironmentFixture {
+        param(
+            [Parameter(Mandatory)] [string] $Name,
+            [Parameter(Mandatory)] [string] $TempRoot
+        )
+        $doc = Get-Content -LiteralPath (Join-Path $script:FixtureRoot "$Name.json") -Raw | ConvertFrom-Json
+        $tokenMap = @{}
+        foreach ($prop in $doc.dirs.PSObject.Properties) {
+            $token = $prop.Name
+            $spec = $prop.Value
+            $path = Join-Path $TempRoot $token
+            $tokenMap[$token] = $path
+            if ($spec.exists) {
+                New-Item -ItemType Directory -Path $path -Force | Out-Null
+                foreach ($file in @($spec.files)) {
+                    Set-Content -LiteralPath (Join-Path $path $file) -Value ''
+                }
+            }
+        }
+
+        $userEntries = Convert-FixtureScope -ScopeObject $doc.user -TokenMap $tokenMap
+        $machineEntries = Convert-FixtureScope -ScopeObject $doc.machine -TokenMap $tokenMap
+
+        $processParts = @()
+        foreach ($part in @($doc.process_path)) {
+            $expanded = [string]$part
+            foreach ($t in $tokenMap.Keys) {
+                $expanded = $expanded.Replace("{$t}", $tokenMap[$t])
+            }
+            $processParts += $expanded
+        }
+
+        return [pscustomobject]@{
+            UserKey     = New-MockEnvironmentKey -Entries $userEntries
+            MachineKey  = New-MockEnvironmentKey -Entries $machineEntries
+            ProcessPath = ($processParts -join ';')
+            TokenMap    = $tokenMap
+        }
+    }
+
+    function Install-EnvironmentMocks {
+        param($Fixture)
+        $script:UserKey = $Fixture.UserKey
+        $script:MachineKey = $Fixture.MachineKey
+        # GetNewClosure: MockWith runs in the mocked command's scope, so
+        # $script:UserKey would resolve against the check script (unset,
+        # StrictMode UNKNOWN) rather than this test file.
+        $userKey = $Fixture.UserKey
+        $machineKey = $Fixture.MachineKey
+        Mock Get-Item -ParameterFilter { $LiteralPath -eq 'HKCU:\Environment' } -MockWith (
+            { $userKey }.GetNewClosure()
+        )
+        Mock Get-Item -ParameterFilter { $LiteralPath -eq 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment' } -MockWith (
+            { $machineKey }.GetNewClosure()
+        )
+    }
+
+    function Invoke-EnvironmentHealthAsObject { Invoke-CheckScriptAsObject $script:ScriptPath }
+
+    function Invoke-EnvironmentHealthRaw {
+        return ((& $script:ScriptPath) | Where-Object { $_ }) -join "`n"
+    }
+}
+
+Describe 'Test-EnvironmentHealth' -Tag 'check' {
+    BeforeEach {
+        $script:tmpDir = New-MachineHealthTempDir -Prefix 'machine-health-env'
+        $script:priorPath = $env:PATH
+        $script:priorPathext = $env:PATHEXT
+        $env:PATHEXT = '.COM;.EXE;.BAT;.CMD'
+    }
+
+    AfterEach {
+        $env:PATH = $script:priorPath
+        $env:PATHEXT = $script:priorPathext
+        Remove-MachineHealthTempDir -Path $script:tmpDir
+    }
+
+    Context 'healthy fixture' {
+        It 'emits a schema-valid OK CheckResult' {
+            $fx = Import-EnvironmentFixture -Name 'healthy' -TempRoot $script:tmpDir
+            $env:PATH = $fx.ProcessPath
+            Install-EnvironmentMocks $fx
+
+            $result = Invoke-EnvironmentHealthAsObject
+            { Assert-CheckResult $result } | Should -Not -Throw
+            $result.id | Should -Be 'environment-health'
+            $result.category | Should -Be 'config'
+            $result.severity | Should -Be 'OK'
+            $result.ran_successfully | Should -BeTrue
+            $result.needs_admin | Should -BeFalse
+            $result.detail.user_path_is_expand_sz | Should -BeTrue
+            $result.detail.disable_autoupdater | Should -HaveCount 0
+            $result.detail.missing_path_dirs | Should -HaveCount 0
+            $result.detail.duplicate_path_entries | Should -HaveCount 0
+            $result.detail.shadowed_executables | Should -HaveCount 0
+            $result.detail.credential_named_vars | Should -HaveCount 0
+            $result.notes | Should -Match 'Detect-only'
+        }
+
+        It 'supports -Human without throwing' {
+            $fx = Import-EnvironmentFixture -Name 'healthy' -TempRoot $script:tmpDir
+            $env:PATH = $fx.ProcessPath
+            Install-EnvironmentMocks $fx
+
+            $out = & $script:ScriptPath -Human
+            ($out | Out-String) | Should -Match '\[OK\] environment-health'
+        }
+    }
+
+    Context 'DISABLE_AUTOUPDATER' {
+        It 'warns when User-scope DISABLE_AUTOUPDATER is truthy' {
+            $fx = Import-EnvironmentFixture -Name 'disable-autoupdater' -TempRoot $script:tmpDir
+            $env:PATH = $fx.ProcessPath
+            Install-EnvironmentMocks $fx
+
+            $result = Invoke-EnvironmentHealthAsObject
+            $result.severity | Should -Be 'WARN'
+            $result.summary | Should -Match 'DISABLE_AUTOUPDATER'
+            $result.detail.disable_autoupdater | Should -HaveCount 1
+            $result.detail.disable_autoupdater[0].scope | Should -Be 'user'
+            $result.detail.disable_autoupdater[0].disables_updates | Should -BeTrue
+        }
+    }
+
+    Context 'PATH missing and duplicate entries' {
+        It 'reports INFO for a missing dir and a duplicate User Path entry' {
+            $fx = Import-EnvironmentFixture -Name 'duplicate-and-missing-path' -TempRoot $script:tmpDir
+            $env:PATH = $fx.ProcessPath
+            Install-EnvironmentMocks $fx
+
+            $result = Invoke-EnvironmentHealthAsObject
+            $result.severity | Should -Be 'INFO'
+            $result.detail.missing_path_dirs | Should -HaveCount 1
+            $result.detail.missing_path_dirs[0].scope | Should -Be 'user'
+            $result.detail.duplicate_path_entries | Should -HaveCount 1
+            $result.detail.duplicate_path_entries[0].count | Should -Be 2
+        }
+    }
+
+    Context 'shadowed executables' {
+        It 'reports INFO when User wins over Machine for the same name' {
+            $fx = Import-EnvironmentFixture -Name 'shadowed-exe' -TempRoot $script:tmpDir
+            $env:PATH = $fx.ProcessPath
+            Install-EnvironmentMocks $fx
+
+            $result = Invoke-EnvironmentHealthAsObject
+            $result.severity | Should -Be 'INFO'
+            $result.detail.shadowed_executables | Should -HaveCount 1
+            $result.detail.shadowed_executables[0].name | Should -Be 'git.exe'
+            $result.detail.shadowed_executables[0].winner_scope | Should -Be 'user'
+            $result.detail.shadowed_executables[0].warn | Should -BeFalse
+        }
+
+        It 'warns when the winner is Machine while a User copy also exists' {
+            $fx = Import-EnvironmentFixture -Name 'shadow-machine-wins' -TempRoot $script:tmpDir
+            $env:PATH = $fx.ProcessPath
+            Install-EnvironmentMocks $fx
+
+            $result = Invoke-EnvironmentHealthAsObject
+            $result.severity | Should -Be 'WARN'
+            $result.detail.shadowed_executables | Should -HaveCount 1
+            $result.detail.shadowed_executables[0].winner_scope | Should -Be 'machine'
+            $result.detail.shadowed_executables[0].warn | Should -BeTrue
+        }
+    }
+
+    Context 'User Path value kind and length' {
+        It 'warns when HKCU Path is REG_SZ' {
+            $fx = Import-EnvironmentFixture -Name 'path-reg-sz' -TempRoot $script:tmpDir
+            $env:PATH = $fx.ProcessPath
+            Install-EnvironmentMocks $fx
+
+            $result = Invoke-EnvironmentHealthAsObject
+            $result.severity | Should -Be 'WARN'
+            $result.detail.user_path_kind | Should -Be 'String'
+            $result.detail.user_path_is_expand_sz | Should -BeFalse
+            $result.summary | Should -Match 'REG_SZ'
+        }
+
+        It 'warns when User Path length is at least 1800' {
+            $fx = Import-EnvironmentFixture -Name 'path-length-warn' -TempRoot $script:tmpDir
+            $env:PATH = $fx.ProcessPath
+            Install-EnvironmentMocks $fx
+
+            $result = Invoke-EnvironmentHealthAsObject
+            $result.severity | Should -Be 'WARN'
+            $result.detail.user_path_length | Should -Be 1800
+        }
+
+        It 'is CRIT when User Path length reaches 2047' {
+            $fx = Import-EnvironmentFixture -Name 'path-length-crit' -TempRoot $script:tmpDir
+            $env:PATH = $fx.ProcessPath
+            Install-EnvironmentMocks $fx
+
+            $result = Invoke-EnvironmentHealthAsObject
+            $result.severity | Should -Be 'CRIT'
+            $result.detail.user_path_length | Should -Be 2047
+        }
+    }
+
+    Context 'credential-named variables' {
+        It 'reports names and scopes and never reads or emits values' {
+            $fx = Import-EnvironmentFixture -Name 'credential-names' -TempRoot $script:tmpDir
+            $env:PATH = $fx.ProcessPath
+            Install-EnvironmentMocks $fx
+
+            $raw = Invoke-EnvironmentHealthRaw
+            $raw | Should -Not -Match 'super-secret-gh-token-2866-must-never-appear'
+            $raw | Should -Not -Match 'sk-planted-api-key-value-do-not-log'
+            $raw | Should -Not -Match 'planted-secret-value-do-not-log'
+            $raw | Should -Not -Match 'planted-password-value-do-not-log'
+
+            $result = $raw | ConvertFrom-Json
+            { Assert-CheckResult $result } | Should -Not -Throw
+            $result.severity | Should -Be 'WARN'
+            $names = @($result.detail.credential_named_vars | ForEach-Object { $_.name }) | Sort-Object
+            $names | Should -Be @('ACME_SECRET', 'DB_PASSWORD', 'GITHUB_TOKEN', 'MY_API_KEY')
+            foreach ($row in $result.detail.credential_named_vars) {
+                $row.PSObject.Properties.Name | Should -Not -Contain 'value'
+                $row.scope | Should -Be 'user'
+            }
+
+            $fx.UserKey.GetValueCalls | Should -Not -Contain 'GITHUB_TOKEN'
+            $fx.UserKey.GetValueCalls | Should -Not -Contain 'MY_API_KEY'
+            $fx.UserKey.GetValueCalls | Should -Not -Contain 'ACME_SECRET'
+            $fx.UserKey.GetValueCalls | Should -Not -Contain 'DB_PASSWORD'
+            $fx.UserKey.GetValueCalls | Should -Contain 'Path'
+
+            $human = (& $script:ScriptPath -Human | Out-String)
+            $human | Should -Not -Match 'super-secret-gh-token-2866-must-never-appear'
+        }
+    }
+
+    Context 'degraded machine scope' {
+        It 'continues with User-scope findings when HKLM Environment is unreadable' {
+            $fx = Import-EnvironmentFixture -Name 'disable-autoupdater' -TempRoot $script:tmpDir
+            $env:PATH = $fx.ProcessPath
+            $script:UserKey = $fx.UserKey
+            $userKey = $fx.UserKey
+            Mock Get-Item -ParameterFilter { $LiteralPath -eq 'HKCU:\Environment' } -MockWith (
+                { $userKey }.GetNewClosure()
+            )
+            Mock Get-Item -ParameterFilter { $LiteralPath -eq 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment' } -MockWith {
+                throw 'Access is denied.'
+            }
+
+            $result = Invoke-EnvironmentHealthAsObject
+            $result.ran_successfully | Should -BeTrue
+            $result.detail.machine_scope_readable | Should -BeFalse
+            $result.detail.disable_autoupdater | Should -HaveCount 1
+            $result.notes | Should -Match 'Machine Environment unreadable'
+        }
+    }
+
+    Context 'must never write' {
+        It 'does not call registry or environment mutators' {
+            $fx = Import-EnvironmentFixture -Name 'healthy' -TempRoot $script:tmpDir
+            $env:PATH = $fx.ProcessPath
+            Install-EnvironmentMocks $fx
+            Mock Set-ItemProperty { throw 'mutation forbidden: Set-ItemProperty' }
+            Mock Set-Item { throw 'mutation forbidden: Set-Item' }
+            Mock Clear-ItemProperty { throw 'mutation forbidden: Clear-ItemProperty' }
+            Mock Remove-ItemProperty { throw 'mutation forbidden: Remove-ItemProperty' }
+
+            $result = Invoke-EnvironmentHealthAsObject
+            $result.ran_successfully | Should -BeTrue
+            $result.severity | Should -Be 'OK'
+        }
+    }
+
+    Context 'registry read failure' {
+        It 'returns UNKNOWN when HKCU Environment cannot be read' {
+            Mock Get-Item -ParameterFilter { $LiteralPath -eq 'HKCU:\Environment' } -MockWith {
+                throw 'HKCU Environment missing'
+            }
+            Mock Get-Item -ParameterFilter { $LiteralPath -eq 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment' } -MockWith {
+                New-MockEnvironmentKey -Entries @{}
+            }
+
+            $result = Invoke-EnvironmentHealthAsObject
+            $result.severity | Should -Be 'UNKNOWN'
+            $result.ran_successfully | Should -BeFalse
+            $result.error | Should -Match 'HKCU Environment missing'
+        }
+    }
+}

--- a/plugins/machine-health/skills/audit/tests/windows/lib/Invoke-TrendAnalysis.Tests.ps1
+++ b/plugins/machine-health/skills/audit/tests/windows/lib/Invoke-TrendAnalysis.Tests.ps1
@@ -157,6 +157,26 @@ Describe 'Invoke-TrendAnalysis' -Tag 'lib' {
         $result[0].trend.adjusted_from | Should -Be 'WARN'
     }
 
+    It 'maps environment-health to user_path_length without a generic upward upgrade' {
+        Get-TrendRelevantKey -CheckId 'environment-health' | Should -Be 'user_path_length'
+        Test-WorseningTrend -CheckId 'environment-health' -CurrentValue 420 -PriorValue 400 |
+            Should -BeFalse -Because 'composite WARN causes must not escalate on PATH growth'
+
+        $history = @(
+            New-HistoryEntry `
+                -SeverityByCategory @{ config = [pscustomobject]@{ WARN = 1 } } `
+                -TopMetrics @{ 'environment-health.user_path_length' = 400 } `
+                -ChecksRan @('environment-health')
+        )
+        $checks = @(New-CheckStub -Id 'environment-health' -Category 'config' `
+                -Severity 'WARN' -Detail @{ user_path_length = 420 })
+        $result = Invoke-TrendAnalysis -CheckResults $checks -HistoryTail $history
+        $result[0].trend.delta | Should -Match 'user_path_length'
+        $result[0].trend.delta | Should -Match '\+20'
+        $result[0].severity | Should -Be 'WARN'
+        $result[0].trend.adjusted_from | Should -BeNullOrEmpty
+    }
+
     It 'treats battery downward drop as worsening (fullCapacityPct going down)' {
         $history = @(
             New-HistoryEntry `


### PR DESCRIPTION
## Summary

Adds `environment-health` as the eighteenth shipped Windows catalog check (`config` category). It is detect-only: it reads persisted User (`HKCU:\Environment`) and Machine environment values and never writes the registry or PATH.

Findings, matching the #2866 shapes:

- `DISABLE_AUTOUPDATER` set (WARN when truthy)
- PATH entries pointing at missing directories (INFO)
- Duplicate PATH entries (INFO)
- Shadowed executables (INFO; WARN when the live PATH winner is a lower-precedence scope than User)
- User Path stored as `REG_SZ` rather than `REG_EXPAND_SZ` (WARN)
- User Path length against the 2047-character legacy-editor ceiling (WARN at 1800, CRIT at 2047)
- Credential-pattern variable **names** (`*_TOKEN`, `*_API_KEY`, `*_SECRET`, `*_PASSWORD`) — name and scope only

Credential values are never read (`GetValue` is not called for those names). There is no remediation entry; registry cleanup remains unauthorized.

Shipped via the Windows check registration pattern (script + `catalog/checks.jsonc` + `check-catalog.md` § 18 + plugin 0.11.0), not as a machine-local overlay. Overlay remains the consumer seam for host-specific disable/demote of this check.

## Fix

New check script `Test-EnvironmentHealth.ps1`, catalog entry `environment-health`, rubric § 18, Pester fixtures/tests, trend key `user_path_length`, and plugin version 0.11.0. The check reads `HKCU:\Environment` and the machine Session Manager Environment key, classifies PATH/search-order shapes, and emits a single CheckResult. It never calls `Set-Item`, `Set-ItemProperty`, or `SetEnvironmentVariable`.

A follow-up commit rewords the fixture README so `HKLM:\SYSTEM` is not scanned as a GNU `\S` token by `shell-portability-lint`.

## Verification

- Pester `Test-EnvironmentHealth.Tests.ps1`: 13 passed (healthy, `DISABLE_AUTOUPDATER`, missing/duplicate PATH, shadowing, REG_SZ, length WARN/CRIT, credential non-leak including `GetValue` call log, machine-scope degrade, no-write, HKCU failure → UNKNOWN)
- Catalog integration + trend analysis suites: 35 passed (new catalog entry schema-valid; `user_path_length` trend key)
- `scripts/check-changelog-parity.sh --check`, `--check-order`, `--check-bump origin/main`: pass
- `scripts/check-shell-portability.sh --paths` on the fixture README: pass after the `\S` reword

## Test plan

- [x] Pester environment-health + catalog/trend suites as above
- [x] Changelog parity and local portability lint
- [ ] CI green on this PR

## Related

Closes #2866