### PR TITLE
fix(docs): correct setup-contract drift in docs and tracked PR config

### DIFF
--- a/.claude/source-control.md
+++ b/.claude/source-control.md
@@ -5,14 +5,26 @@ Commit-subject / PR-title convention for the source-control plugin, resolved by
 CLAUDE.md/rules/commit-msg hook or fall back to the bundled Conventional Commits default.
 Re-run `/source-control:setup` to change these values.
 
-Only `pr_body_required_sections` is set here — every other key falls through to
-`/source-control:setup`'s inference (this repo's commit history is already Conventional-Commits-shaped)
-per config-resolution.md's per-key fallthrough, so this file deliberately does not restate them.
+Of the convention keys, only `pr_body_required_sections` is set here — every other one falls through
+to `/source-control:setup`'s inference (this repo's commit history is already
+Conventional-Commits-shaped) per config-resolution.md's per-key fallthrough, so this file
+deliberately does not restate them. The `babysit_loop_*` keys below are the other key family this
+file carries, and they are set explicitly.
+
+The `pr_body_required_sections` values below are the sections this repo's merge gate actually
+requires, each non-empty, alongside a native closing keyword: `pr-issue-linkage`, defined in
+`melodic-software/ci-workflows/.github/workflows/pr-issue-linkage.yml` and called by this repo's
+`.github/workflows/pr-issue-linkage.yml` — which exempts `dependabot[bot]`, and no other author. The
+gate is the authority; this key restates it so `/source-control:pull-request` drafts a body that
+passes. Read the reusable at the SHA the caller pins, not at its default branch, since that pin is
+what actually runs. Re-read it before changing either — an author or agent trusting a stale list
+writes a PR body that fails CI.
 
 ## pr_body_required_sections
 
 - Summary
-- Test plan
+- Fix
+- Verification
 - Related
 
 ## babysit_loop_stop_mode

--- a/docs/MIGRATION-PLAYBOOK.md
+++ b/docs/MIGRATION-PLAYBOOK.md
@@ -306,8 +306,10 @@ a skill ships them only when they earn their keep.
 **Warrant rule.** A skill **warrants** evals when it carries a judgment-bearing behavioral contract
 that could silently regress — how it triggers, how it routes an ambiguous request, when it refuses,
 or the shape of what it emits. A skill is an explicit **skip** when it is pure-reference (answers
-from a knowledge corpus with no decision contract — `playbooks:fable-5`, `tdd`, …) or lives in a **hook** plugin
-(deterministic, silent-always-on, guarded by `.test.sh`, no model-invoked skill). A `setup`
+from a knowledge corpus with no decision contract — `playbooks:fable-5`, `tdd`, …). A **hook** plugin
+is a skip only in the case its rationale actually describes — deterministic, silent-always-on,
+guarded by `.test.sh`, **no model-facing skill at all**. A hook plugin that ships a `setup` skill has
+a skill with a judgment-bearing contract, and the plugin's shape does not exempt it: a `setup`
 skill *is* warrantable — it makes interview and write-config decisions (the
 `codebase-health/setup` eval is the model). Gray-zone skills (thin mechanical wrappers, reference-ish
 routers) are **author-confirm**: re-check the warrant against the live `SKILL.md` at authoring time
@@ -315,6 +317,19 @@ and record an explicit skip verdict if it dissolves — a satisfied "looks cover
 This section is the policy; current coverage is verified on demand — a live glob of
 `plugins/*/skills/*/evals/evals.json` against the tree, read against the warrant rule above — never a
 checked-in snapshot that decays the moment a skill lands.
+
+**The gate is operative, and it is broader than this policy.** `scripts/check-changed-skills.sh`
+passes `--require-evals` for every skill whose `SKILL.md` is new or modified, and
+`plugins/skill-quality/scripts/check-skill.sh` then hard-FAILs on a missing `evals/evals.json` for
+any skill shape — with no allowlist, frontmatter opt-out, or plugin-type awareness in either, and no
+way for the one CI caller to override it. So a "skip" verdict recorded here holds only until someone
+touches that `SKILL.md`, at which point CI requires evals and gets them. Read this policy as
+governing what a skill ships *absent a touch*, and expect the gate to decide otherwise the moment
+the file changes. That is a real disagreement rather than a nuance, and the pure-reference skip is
+where it still bites: the standing resolution — either the gate learns a recorded-skip mechanism
+(the repo's idiom is an exemptions file carrying the verdict, as
+`scripts/skill-count-claim-exemptions.txt` does) or this policy drops "skip" and evals become
+mandatory — is tracked in issue #3135 and is not settled here.
 
 **Rich form.** Each case carries `id`, a kebab-case `name`, a `prompt`, an `expected_output`
 description, optional `files` fixtures, and an `expectations` array of objectively-verifiable checks
@@ -1342,7 +1357,9 @@ Reintegration (below) covers a repo that already ran an in-repo copy and now swi
    scope; a sensitive value still routes to secure credential storage (smoke-tests A and C).
    Re-running that command later against an already-installed plugin prints `already installed`
    **and still writes the value** (smoke-test C), so a headless reconfiguration is another `--config`
-   install rather than an uninstall/reinstall. Interactively, `/plugin configure` owns personal
+   install rather than an uninstall/reinstall — verified for a **non-sensitive option at `user`
+   scope** on Claude Code 2.1.240 and **not** at the `--scope project` this step uses, so read the
+   stored value back there rather than assuming the write landed. Interactively, `/plugin configure` owns personal
    `userConfig`; an explicit setup skill owns any separate tracked project configuration declared by
    the plugin.
 4. **Headless prompting caveat.** Install never prompts non-interactively — a required `userConfig`
@@ -1392,7 +1409,12 @@ surface to a published plugin for a single consumer's low-value nicety.
    project --config KEY=VALUE …`, seeding every
    non-default `userConfig` toggle on that install command — re-running it later against an
    already-installed plugin prints `already installed` **and still writes the value** (smoke-test C),
-   so a headless reconfiguration is another `--config` install, not an uninstall/reinstall.
+   so a headless reconfiguration is another `--config` install, not an uninstall/reinstall. That was
+   verified for a **non-sensitive option at `user` scope** on Claude Code 2.1.240 and is **untested at
+   the `project` scope this step uses**, so read the stored value back before reporting a
+   project-scope reconfiguration as applied — from the **user** `settings.json` `pluginConfigs`, where
+   step 3 above records non-sensitive options landing irrespective of enable scope (itself observed
+   only at `--scope local`, smoke-test A), not from the project settings this command names.
    **Exception:** a `directory`/`file` relative-path entry in checked-in project settings resolves
    against the repo checkout (cloud sessions included) — see
    [`docs/CLOUD-SESSIONS.md`](CLOUD-SESSIONS.md). Otherwise the marketplace is known but the plugin is absent, and step 3's

--- a/docs/PLUGIN-PHILOSOPHY.md
+++ b/docs/PLUGIN-PHILOSOPHY.md
@@ -16,6 +16,30 @@ consumer tiers, explicit adoption — is owned by `melodic-software/standards`
 `conventions/engineering/shareable-artifact-design.md`; this document specializes it for Claude Code
 plugins and adds only what is plugin-specific.
 
+**Org-agnosticism** names the publisher half of that boundary, and it governs *tokens in shipped
+content*, not only runtime behavior: the publishing organization's name, its marketplace id, its own
+repository names, and publisher-prefixed configuration keys do not appear in a plugin's skill, agent,
+or schema content. One use is sanctioned — a citation that *names a source rather than a target the
+plugin acts on*: a documentation URL, or a cross-plugin reference to this marketplace's own published
+files, cited for a reader to consult. The line is what the content does with it, not where it points:
+prose citing such a URL is conforming, while a skill instructed to fetch, poll, or write to it has
+made the publisher a runtime dependency and is not. (`plugin.json` publisher metadata sits outside
+this rule entirely, being neither skill, agent, nor schema content — identifying the source is what
+the manifest is for.)
+
+Like the setup contract below, **this is a normative target, not a description of the fleet**, and
+enforcement reaches a strict subset of it. `scripts/validate-plugin-contracts.mjs` gates the
+marketplace id, `melodic-software/github-iac`, and `MELODIC_*` keys across every plugin's skill
+content, and holds the `autonomy` plugin to a stricter token set;
+`plugins/github/github.test.sh` runs a wider sweep over its own plugin's prose as its "agnostic
+conformance" check — a sibling of that file's D4 zero-vendored-knowledge checks, not one of them. The
+bare organization name in skill prose is gated nowhere *fleet-wide* — only inside `autonomy` and
+`github`, each by its own narrower sweep — and agent content is gated nowhere at all, so shipped
+skills predating this statement are nonconforming until brought into conformance rather than absolved
+by a green build. A fleet-wide edit answers to two independent mechanisms, both steps of the same
+`plugin-gate` CI job and neither aware of the other; consolidating them behind this statement, and
+settling that conformance gap deliberately, is tracked in issue #3136.
+
 Keep plugins horizontally decoupled:
 
 - A plugin owns its skills, hooks, agents, scripts, dependencies, and state.
@@ -367,8 +391,32 @@ is closed. Setup must be:
 - idempotent and safe to rerun;
 - transparent about what it inferred, changed, skipped, or could not verify;
 - limited to configuration the plugin owns;
-- safe for existing files, preserving unrelated user content; and
+- safe for existing files, preserving unrelated user content;
+- evidence-bearing: after making or routing a change, it reports the effective value it *observed*,
+  and says plainly where it could not observe one — never an unobserved change; and
 - non-interactive when complete arguments are supplied, so automation and headless use remain possible.
+
+The readback is a property of the `setup` skill, not of the `apply` verb: it belongs to whichever
+action made or routed the change, so a check-only skill (below) carries it in `check`. Where the
+change was routed to a surface setup may not write — Claude Code's native configuration flow, an
+edit left to the operator — the rule is unchanged.
+
+**Keep two claims apart:** that the write was issued and stored, and how the *running* session
+behaves. They can legitimately disagree, so a naive readback reports false failures — and reporting
+one as a failed write is the specific error this clause exists to prevent. Verify the effective value
+by re-checking in a **fresh session**, and never claim an unobserved change. A same-session `check`
+therefore satisfies the bullet above by reporting what it observed *and* naming it as possibly stale,
+not by pretending the running session already reflects the write.
+
+Two mechanisms are offered across the fleet as the reason the two diverge: that a `${user_config.*}`
+value is substituted into skill content at load, and that a hook's `CLAUDE_PLUGIN_OPTION_*` mirror
+comes from an environment fixed at session start. Both timings are **untested here**.
+[Smoke-test D](extensibility-contract-smoke-tests.md) records the rendered *result* in skill content
+on Claude Code 2.1.212, not when substitution happens; smoke-test B records only a negative on
+2.1.207, that a skill-spawned Bash subprocess receives no mirror at all, and sources the
+agent-content half of that seam to upstream spec rather than to an observation. The rule does not
+rest on either: a fresh-session re-check is correct whichever way they resolve, which is why it is
+the prescription and they are only the explanation.
 
 Setup is one **plugin-level** `setup` skill, never a per-skill setup action. Setup granularity
 follows install granularity: a plugin installs and is configured as a unit, and its configuration


### PR DESCRIPTION
Closes #3127

## Summary

Parts **2–6** of #3127. Part 1 — the unstamped `--config` claim across three docs — shipped separately in #3173 while this branch was open, and #3173 deliberately did not close the issue. This PR was rebuilt on top of it: every part-1 rewrite here was **dropped** in favour of what shipped, `docs/extensibility-contract-smoke-tests.md` is no longer touched at all, and three files remain.

One part-1 delta survives, because #3173's text has a gap this branch's reviewers had already found six times — see the first item under Fix.

## Fix

**The surviving part-1 delta — scope qualifier at two `--scope project` steps.** Both `MIGRATION-PLAYBOOK.md` reintegration/onboarding steps pair a `--scope project` install example with the rerun-writes claim, citing smoke-test C without stating its conditions. The 2.1.240 verification was `-s user` with a non-sensitive option; `project` and `local` were never run. Both sites now state the scope inline, name the shown `--scope project` as untested, and route the reader to a readback — at the location step 3 records, **attributed rather than asserted**, since that record itself generalises from `--scope local` runs alone (smoke-test A). No project-scope install was run to make the sentences true; the qualifier is the fix.

**Part 2 — the setup contract's read-back clause** (`docs/PLUGIN-PHILOSOPHY.md` § Setup is explicit and repeatable). #3115 converged its setup skills on identical wording with no contract to derive it from. The clause is stated as a property of the **setup skill**, not of the `apply` verb — five plugins ship a setup skill with no `apply`, so an `apply`-scoped clause would be false on arrival, which is the defect #3115's own fourth commit existed to fix.

It carries the false-failure hazard the merged skills already describe: the write can succeed while the running session still reports the old value, and reporting *that* as a failed write is the error the clause prevents. Both timing mechanisms are marked **untested**, with what smoke-tests B and D actually recorded stated rather than implied.

Part 2's *coverage* half is already on `main` via #3115 ("Stated as fleet coverage") and is **not** re-landed here — one rule, one place.

**Part 3 — `.claude/source-control.md`.** `pr_body_required_sections` set to Summary / Fix / Verification / Related, read from the enforced gate's own `requiredSections` array at the SHA the caller pins. "Test plan" appears nowhere in the gate. The file records that the gate is the authority, that the caller exempts `dependabot[bot]` and no other author, and to read the reusable at the pin. Two adjacent corrections: the intro claimed only one key was set here while five are, and the new prose sits above the first `## <key>` H2 so the list-valued key's grammar stays intact.

**Part 4 — evals doctrine vs the evals gate + #3135.** The hook-plugin eval **skip** rested on a rationale — "no model-invoked skill" — false for a hook plugin shipping a `setup` skill, which the same paragraph calls warrantable. Narrowed to the case its rationale describes. The gate is then recorded as operative rather than left to win silently: `check-changed-skills.sh` requires evals for any touched `SKILL.md`, `check-skill.sh` hard-FAILs for any shape, and the one CI caller cannot override it. The pure-reference skip remains a live contradiction; #3135 carries the two exits.

**Part 5 — org-agnosticism + #3136.** The rule had no named home. It now has one, declared a **normative target whose enforcement reaches a strict subset** — naming what is ungated (the bare org name fleet-wide, agent content entirely) rather than implying coverage, exactly as the setup contract below already models. The sanctioned use is a citation that *names a source rather than a target the plugin acts on*, with the boundary drawn explicitly: prose citing a URL is conforming, a skill instructed to fetch or write to it is not.

**Part 6 — no doc change owed.** `apply` is not unconditionally mandatory: the **check-only carve-out** already names *Native `userConfig`* as a qualifying surface, and `dometrain`/`miro` own no writable artifact, so both conform. The residual gap is validator-side — `validate-plugin-contracts.mjs` passes any skill whose body contains the substring `check-only` without checking the precondition. Filed as #3137.

## Verification

Three files changed; nothing under `plugins/**` or `scripts/**`.

- `markdownlint-cli2@0.23.2` with the repo config over all three — **0 issues**
- `lychee --offline --config lychee.toml` over all three — **0 errors**
- `check-contract-clause-coverage.py` — **PASS**; `node scripts/validate-plugin-contracts.mjs` — **PASS** (50 setup skills, 2817 files); `check-changelog-parity.sh --check` — **PASS**; `check-skill-count-claims.sh --check` — **PASS**
- The section list came from `gh api` on the reusable at the caller's pinned SHA, read out of its `requiredSections` array. This body is the test: it carries exactly those four headings.

**On verification itself — the honest record.** This branch shipped **eight** instances of the defect it exists to correct: a claim outrunning its evidence. Six were caught by human review (one finding, raised across six rounds — an unqualified "verified" beside an untested scope). Two were caught by an *unbounded* verification criterion instructing the verifier to hunt for what no named criterion covers. **None was caught by self-review.**

The transferable lesson is not "the verifier was weak". Five bounded passes returned PASS while the scope defect was live, because scope was not among the criteria they were handed: **a verifier is bounded by its criteria, so a defect nobody thought to name survives an arbitrary number of green passes.** Re-verification now carries the scope criterion explicitly *and* an open-ended hunt — which is what caught instances seven and eight.

## Related

- #3173 — shipped part 1 into the same three docs while this branch was open; this PR is rebuilt on it and drops every overlapping rewrite. Its playbook text lacks the scope qualifier, which is the one part-1 delta retained here.
- #3115 — corrected the claim across the setup skills and landed the coverage rule this PR therefore does not re-land; its `visualization` setup skill was removed under the trivial test. Part 2's read-back clause is the contract its skills had no home to derive from.
- #3135 — evals gate vs warrant policy (part 4's code half).
- #3136 — org-agnosticism enforcement consolidation and the conformance gap (part 5's code half).
- #3137 — the check-only carve-out validated as a keyword rather than a surface (part 6's code half).
- #3112, #3113 — own `plugins/claude-ops/` and `plugins/source-control/`; no file overlap with this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
