### PR TITLE
fix(code-tidying): read porcelain -z so escaped paths reach the audit

### DIFF
--- a/plugins/code-tidying/.claude-plugin/plugin.json
+++ b/plugins/code-tidying/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "code-tidying",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "Code tidying and comment hygiene: /code-tidying:tidy proactively hunts a rotated, glob-scoped lane for Beck-style tidyings under a research-backed scope budget and ships one tight PR; /code-tidying:batch-simplify sweeps a time window, a branch, or an entire repository through grouped, dependency-ordered simplification waves with a never-drop deferred-items contract; /code-tidying:dissolve-comments enforces self-describing expressive code over a diff or target, widening to the branch diff and then the whole repository when the tree is clean — deletes zero-information comments, dissolves code-expressible ones into names and structure behind a tests gate (safe mode restricts applied edits to removals), and keeps only terse load-bearing comments code cannot express; /code-tidying:audit-comment-residue is a read-only classifier that flags history, plan, conversational, and ticket/PR residue in code comments for author-applied deletion. Project-specific tidy lanes are scaffolded into a tracked .claude/tidy-lanes/ config folder by a re-runnable setup skill.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/code-tidying/CHANGELOG.md
+++ b/plugins/code-tidying/CHANGELOG.md
@@ -3,6 +3,31 @@
 All notable changes to the `code-tidying` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.14.2]
+
+### Fixed
+
+- **`audit-comment-residue` decodes the paths v1 porcelain escapes (#3126).** `0.13.3` fixed the
+  spaced-path false negative by slicing the v1 record, and recorded at the parse site that git's
+  octal escapes for control and non-ASCII bytes were still not decoded, so such a path continued
+  to miss. `detect.sh` now reads the NUL-delimited `--porcelain -z` form instead, which git
+  documents as performing no quoting or backslash-escaping, so there is nothing left to decode:
+  `café.py`, a name holding a tab or a backslash, and a name literally containing `" -> "` all
+  reach the audit. Under `-z` a rename emits the new path first and the original as a following
+  record — the reverse of v1's display order — and that second record is consumed and dropped, so
+  the intent-to-add rename `0.13.3` gated on the worktree status letter resolves structurally
+  rather than by string-matching an arrow.
+
+  The skill's `Uncommitted code files` pre-computed context moves to `-z` with it. `0.13.3` brought
+  that line to parity with the v1 slice and added a test that extracts and runs it, so leaving it
+  behind would have reopened the divergence that test exists to prevent — the audit would find
+  `café.py` while the preview shown to the model still listed nothing. That test now reads the
+  porcelain invocation out of `SKILL.md` as well as the awk program, rather than hardcoding a
+  form: feeding `-z` input to a v1 program makes the v1 program look correct, because `-z` output
+  carries no quoting for it to fail at decoding, so a hardcoded harness would have masked exactly
+  the mismatch it was checking for. Its fixture set gains a non-ASCII name, the only one of the
+  cases that both parses do not already agree on.
+
 ## [0.14.1]
 
 ### Changed

--- a/plugins/code-tidying/skills/audit-comment-residue/SKILL.md
+++ b/plugins/code-tidying/skills/audit-comment-residue/SKILL.md
@@ -13,7 +13,7 @@ metadata:
 ## Pre-computed context
 
 Current branch: !`git branch --show-current 2>/dev/null || echo "unknown"`
-Uncommitted code files: !`git status --porcelain 2>/dev/null | awk '{ p = substr($0, 4); if (substr($0, 1, 2) ~ /[RC]/) sub(/^.* -> /, "", p); if (p ~ /^".*"$/) { p = substr(p, 2, length(p) - 2); gsub(/\\"/, "\"", p); gsub(/\\\\/, "\\", p) } print p }' | grep -Ei '\.(cs|ts|tsx|js|jsx|py|sh|ps1|go|rs|java|rb|lua|sql|c|h|cpp|hpp|yaml|yml|toml)$' | head -10 || echo "none"`
+Uncommitted code files: !`git status --porcelain -z 2>/dev/null | awk 'BEGIN { RS = "\0" } skip { skip = 0; next } { if (substr($0, 1, 2) ~ /[RC]/) skip = 1; print substr($0, 4) }' | grep -Ei '\.(cs|ts|tsx|js|jsx|py|sh|ps1|go|rs|java|rb|lua|sql|c|h|cpp|hpp|yaml|yml|toml)$' | head -10 || echo "none"`
 Residue findings (sample): !`${CLAUDE_SKILL_DIR}/scripts/detect.sh 2>/dev/null | grep -E '^(Summary total:|Finding shape:)' | head -20 || echo "none"`
 
 ## Purpose

--- a/plugins/code-tidying/skills/audit-comment-residue/scripts/detect.sh
+++ b/plugins/code-tidying/skills/audit-comment-residue/scripts/detect.sh
@@ -97,34 +97,24 @@ if [[ ${#TARGETS[@]} -eq 0 ]]; then
       TARGETS+=("$(cr_anchor_path "$line")")
     done <"$PATHS_FILE"
   elif [[ -n "$repo_root" ]]; then
-    # Uncommitted files: modified/added/renamed/untracked, per git status. Parse porcelain
-    # by slicing, not by splitting on whitespace, so paths containing spaces survive (#3126);
-    # $NF dropped everything before the last space and kept git's closing quote, so a spaced
-    # path resolved to a nonexistent file and vanished from the audit with no signal.
-    while IFS= read -r line; do
-      line="${line//$'\r'/}"
-      [[ -z "$line" ]] && continue
-      # XY + space + path.
-      status_path="${line:3}"
-      # Rename/copy entries read "old -> new" — audit the new path. Gated on the status
-      # letters so an ordinary path that happens to contain " -> " is left intact. BOTH
-      # columns matter: X is the index status and Y the worktree status, and a rename
-      # staged only as intent-to-add lands in Y (`mv old new && git add -N new` emits
-      # " R old -> new"). Checking X alone left that record unsplit and unresolvable.
-      if [[ "${line:0:1}" == [RC] || "${line:1:1}" == [RC] ]]; then
-        status_path="${status_path##* -> }"
-      fi
-      # Paths with spaces or other special characters arrive C-quoted: "my helper.sh".
-      # Unwrap and unescape. Backslash-escaped quotes and backslashes are handled; git's
-      # octal escapes for control and non-ASCII bytes are not, so such a path still misses.
-      if [[ "$status_path" == \"*\" ]]; then
-        status_path="${status_path#\"}"
-        status_path="${status_path%\"}"
-        status_path="${status_path//\\\"/\"}"
-        status_path="${status_path//\\\\/\\}"
-      fi
-      TARGETS+=("$status_path")
-    done < <(git status --porcelain 2>/dev/null)
+    # Uncommitted files: modified/added/renamed/untracked, per git status. Read the NUL-delimited
+    # -z form, which git documents as performing no quoting or backslash-escaping: the default v1
+    # output wraps any path holding a space, a non-ASCII byte, or a control character in quotes and
+    # C-style-escapes it (an é becomes \303\251), and splitting that back apart cannot be done reliably.
+    # Porcelain paths are repo-relative and the cd to repo_root above already ran, so they need no
+    # anchoring.
+    while IFS= read -r -d '' record; do
+      [[ -z "$record" ]] && continue
+      # Each record is XY + space + path. A rename/copy emits the NEW path here and the ORIGINAL
+      # as the next record (the reverse of v1's "old -> new" display order), so consume that
+      # second record and drop it rather than auditing a path that no longer exists.
+      case "${record:0:2}" in
+      [RC]? | ?[RC]) IFS= read -r -d '' _ || true ;;
+      *) ;;
+      esac
+      local_path="${record:3}"
+      [[ -n "$local_path" ]] && TARGETS+=("$local_path")
+    done < <(git status --porcelain -z 2>/dev/null)
   fi
 fi
 

--- a/plugins/code-tidying/skills/audit-comment-residue/scripts/detect.test.sh
+++ b/plugins/code-tidying/skills/audit-comment-residue/scripts/detect.test.sh
@@ -268,14 +268,31 @@ else
     : >"$REPO13/quote\".py"
     : >"$REPO13/back\\-slash.py"
     : >"$REPO13/plain space.py"
+    # A non-ASCII name is the case the v1 parse could not decode: the é arrives octal-escaped as
+    # \303\251, which a quote-strip alone leaves naming no file. The ASCII fixtures above
+    # all pass either parse, so without this one the parity check stays green while the two
+    # parsers diverge on exactly the path detect.sh was moved to -z to reach.
+    : >"$REPO13/café.py"
     cp "$ALL_SHAPES" "$REPO13/renamed-src.py"
     git -C "$REPO13" add renamed-src.py
     git -C "$REPO13" -c user.email=t@example.com -c user.name=t commit -qm init
     mv "$REPO13/renamed-src.py" "$REPO13/renamed-dst.py"
     git -C "$REPO13" add -N renamed-dst.py
 
-    skill_out="$(cd "$REPO13" && git status --porcelain | awk "$skill_awk")"
+    # Extract the porcelain invocation too, not just the awk program. Hardcoding either form here
+    # would let the harness mask a mismatch: feeding -z to a v1 program makes the v1 program look
+    # correct, because -z output carries no quoting for it to fail at decoding. Reading both ends
+    # from SKILL.md means the fixtures below test the line as it actually runs.
+    skill_porcelain="$(sed -n 's/^Uncommitted code files: !`\(git status --porcelain[^|]*\)|.*/\1/p' "$SKILL_MD")"
+    if [[ -z "$skill_porcelain" ]]; then
+      fail "SKILL.md porcelain invocation extracted" "non-empty command" "no match — line shape changed"
+    else
+      pass "SKILL.md porcelain invocation extracted"
+    fi
+    skill_out="$(cd "$REPO13" && eval "$skill_porcelain" | awk "$skill_awk")"
 
+    assert_contains "SKILL.md parser reads a non-ASCII path undecoded" "$skill_out" 'café.py'
+    assert_not_contains "SKILL.md parser leaks no octal escape" "$skill_out" '\303'
     assert_contains "SKILL.md parser unescapes an embedded quote" "$skill_out" 'quote".py'
     assert_contains "SKILL.md parser unescapes an embedded backslash" "$skill_out" 'back\-slash.py'
     assert_contains "SKILL.md parser unwraps a spaced path" "$skill_out" 'plain space.py'
@@ -304,6 +321,24 @@ else
     fi
   fi
 fi
+
+# --- 11. Paths v1 porcelain escapes or renders ambiguously (#3126) ---------------------
+# The v1 record cannot be parsed back reliably: git wraps and C-style-escapes any path holding a
+# non-ASCII byte, a tab, or a backslash, and its "old -> new" rename rendering is byte-identical
+# to an ordinary file literally named "left -> right.py". Reading -z instead removes the encoding
+# entirely. Kept in its own repo so REPO13's parity fixture stays as 0.13.3 wrote it.
+REPO14="$TEST_TMPDIR/repo14"
+mkdir -p "$REPO14"
+git -C "$REPO14" init -q
+cp "$ALL_SHAPES" "$REPO14/left -> right.py"
+cp "$ALL_SHAPES" "$REPO14/café.py"
+cp "$ALL_SHAPES" "$REPO14/$(printf 'tab\there.py')"
+escaped_out="$(cd "$REPO14" && bash "$DETECT")"
+assert_contains "arrow-in-filename audited, not split as a rename" "$escaped_out" "left -> right.py"
+assert_contains "non-ASCII path audited without escape mangling" "$escaped_out" "café.py"
+assert_contains "tab-bearing path audited" "$escaped_out" "$(printf 'tab\there.py')"
+assert_not_contains "escaped paths are not reported as files=0" "$escaped_out" "files=0"
+assert_not_contains "no C-style octal escape leaks into a target path" "$escaped_out" '\303'
 
 # --- Final report --------------------------------------------------------------------
 


### PR DESCRIPTION
No related issue: follow-on to the limitation #3140 recorded at its own parse site. #3126 is already closed by that PR, and no issue tracks the residual escape-decode gap.

## Summary

#3140 fixed the #3126 false negative by slicing the v1 porcelain record, and recorded the remaining limitation at the parse site:

> Git's octal escapes for control and non-ASCII bytes are still not decoded by either, so such a path continues to miss.

This PR closes that gap, in both parsers that carry it. **It is a follow-on to #3140, not a competing fix.**

| Path | v1 renders as | v1 slice yields |
|---|---|---|
| `café.py` | `?? "caf\303\251.py"` | literal escape sequence — names nothing |
| `tab<TAB>here.py` | `?? "tab\there.py"` | literal `\t` — names nothing |

Both confirmed against git 2.55. The file is silently dropped, so the run reports a clean tree — the same false-negative class #3126 described.

## Fix

Both porcelain parsers in this skill move to the NUL-delimited `--porcelain -z` form, which git documents as performing no quoting or backslash-escaping, so there is nothing left to decode.

- **`detect.sh`** — the audit's target router.
- **`SKILL.md`'s `Uncommitted code files:` preview** — the pre-computed context the model reads. #3140 deliberately brought this to parity and added a test that extracts and runs it, so leaving it behind would have reopened the divergence that test exists to prevent: the audit would find `café.py` while the preview listed nothing.

Under `-z` a rename emits the **new** path first and the original as a following record — the reverse of v1's display order — and that second record is consumed and dropped. Rename handling is therefore structural, with no arrow matching, which also resolves the intent-to-add rename #3140 gated on the worktree status letter (` R dst\0src\0` → `dst`, verified against git 2.55).

## Verification

- **53/53 pass**, including every one of #3140's checks.
- Nothing vacuous, checked by reverting each piece:
  - `main`'s `detect.sh` → fails 2 of case 11's 5 assertions (`non-ASCII`, `tab-bearing`). The arrow assertion passes on `main` — #3140's `[RC]` gating already handles it, **not** claimed here.
  - `main`'s `SKILL.md` → fails 3 assertions, including #3140's own `SKILL.md preview covers every file detect.sh audits`.
- The parity harness was itself masking the defect and is fixed here. It extracted only the awk program and hardcoded the porcelain invocation; feeding `-z` to a v1 program makes the v1 program look correct, because `-z` output carries no quoting for it to fail at decoding. It now reads the invocation from `SKILL.md` too, and `REPO13` gains a non-ASCII fixture.
- `mawk 1.3.4` (the runner's default `awk`) confirmed to support `RS = "\0"` before relying on it.
- Local gates green: typos, shell-portability (scripts and `SKILL.md`), skill-portability, skill-precompute-compose, changed-skills, leaf-names, count-claims, fixture-git-isolation, orphaned-fixtures, manifest-duplicate-keys, `bash -n`, changelog-parity in all three modes.
- `ci-status` (the required aggregate check) reported **success** on head `65a7b2c`; head `d7b2b67` adds only a `main` merge plus the version rebase.

## Current state — read this before continuing

Head is **`d7b2b67`**, version **`0.14.2`**. `main` published its own `0.14.0` (#3156) and `0.14.1` mid-review, so the version was rebased twice; the changelog keeps each published entry intact with this PR's entry above them.

**One blocker remains, and it is not about the code.** The branch's commits are signed with a key that is not registered on the committing GitHub account, so they report `verified=false, reason=unknown_key`. That trips two ruleset rules:

- `required_signatures`
- `require_extra_approval_for_unattributed_changes`

Everything else is satisfied: all four required checks green, all review threads resolved, no merge conflicts, and `required_approving_review_count` is **0** — so once the signature question is settled this PR needs no human approval.

Two ways to settle it:

1. **Register the signing key** on the account (Settings → SSH and GPG keys → New SSH key, type *Signing Key*). No push needed; the existing commits become verified, and the commit history is preserved.
2. **Rebuild the branch through the GitHub API.** Commits created via the API are signed by GitHub and verify automatically — that is why every commit on `main` shows `committer=noreply@github.com, verified=true`. Since the repo is squash-merge only, collapsing this branch's commits loses nothing that would survive the merge anyway.

## Related

- Refs #3140 — landed the v1 slice this builds on; its `0.13.3` entry and full test suite are preserved here.
- Refs #3156 — bumped `code-tidying` to `0.14.0` mid-review.
- Refs #3126 — the original bug, closed by #3140. Not reopened here.
- Refs #3164 — `audit-noise` carries the same defect class. #3171 fixed its rename-split half; the octal-escape half is still open and tracked there. **Not fixed here** — separate plugin, separate version bump.