### PR TITLE
docs(cloud-fleet): supersede Custom allowlist with All network access

### DIFF
--- a/docs/CLOUD-FLEET-SETUP.md
+++ b/docs/CLOUD-FLEET-SETUP.md
@@ -84,14 +84,22 @@ Edit **Default** in place — the paste-once rollout settles on one account-wide
 than a separate named environment (see
 [One environment per account?](../prompts/cloud-bootstrap-rollout.md#one-environment-per-account)):
 
-- **Network access**: **Custom**, with **Also include default list of common package managers**
-  checked, plus these hosts: `dot.net`, `aka.ms`, `builds.dotnet.microsoft.com`,
-  `download.visualstudio.microsoft.com`. This is a hard requirement, not a fallback: the 2026-08-14
-  verification run ([#2654](https://github.com/melodic-software/claude-code-plugins/issues/2654),
-  Blocker 1) reproduced the .NET installer's redirect chain being `403`-blocked under Trusted
-  (session-side probes on 2026-08-13 had suggested the documented allowlist was conservative; the
-  setup-script build proved otherwise). Trusted works only if the fleet ever drops .NET from the
-  environment.
+- **Network access**: **All** — operator decision 2026-08-22, superseding this doc's earlier
+  Custom allowlist (`dot.net`, `aka.ms`, `builds.dotnet.microsoft.com`,
+  `download.visualstudio.microsoft.com`). The access level is an exfiltration control whose Custom
+  default already opens publish-capable package registries; the GitHub proxy, MCP connector
+  traffic and the Anthropic API bypass the level at every setting; and a blocked host mid-session
+  kills the session until an environment edit plus a cache rebuild. **All** removes that failure
+  class outright, the .NET case included: the 2026-08-14 verification run
+  ([#2654](https://github.com/melodic-software/claude-code-plugins/issues/2654), Blocker 1)
+  reproduced the .NET installer's redirect chain being `403`-blocked under *Trusted*, and that
+  blocker is moot under All — no host list to keep current, and no narrower level left to choose
+  between. The host list above is superseded history, not a recipe. The one exception that still
+  needs a recipe: an account handling sensitive material drops back to **Custom** — and only a
+  complete Custom is safe. That means **Also include default list of common package managers**
+  checked, plus `dot.net`, `aka.ms`, `builds.dotnet.microsoft.com`, and
+  `download.visualstudio.microsoft.com`; a Custom missing any of it leaves the .NET installer's
+  redirect chain exposed to the same `403` block Blocker 1 demonstrated under Trusted.
 - **Environment variables**: none. There is no secrets store — anything here is readable by every
   session in the environment. `gh`/git auth comes from the GitHub proxy automatically.
 - **Setup script**: paste only the three-line bootstrap below. The real script is the
@@ -227,12 +235,14 @@ session on this repo in the new environment and ask Claude to verify:
    `/plugin` is not available in cloud sessions, and a Bash-side
    `claude plugin list` proves only disk state, not that the session loaded anything (see the
    same-session limit in [CLOUD-SESSIONS.md](CLOUD-SESSIONS.md)).
-5. If the .NET setup-script step failed (`dotnet` missing), confirm the environment actually has
-   the Custom allowlist from [Step 1](#step-1--the-shared-environment-claudeai-ui-one-time) —
-   under Trusted this step *always* fails (#2654 Blocker 1) — then rebuild and re-verify.
+5. If the .NET setup-script step failed (`dotnet` missing), confirm the environment's network
+   access is **All** per [Step 1](#step-1--the-shared-environment-claudeai-ui-one-time) — a
+   narrower level can `403`-block the installer's redirect chain (#2654 Blocker 1), which All
+   moots — then rebuild and re-verify. If it is already All, the cause is not network access:
+   read `/var/log/melodic-env-setup.log` for what the .NET track actually hit.
 6. Python: in a claude-code-proxy or medley session, `uv python install 3.14` — if the download
-   is `403`-blocked (release assets ride the GitHub proxy's repository scope), fall back to the
-   VM's system Python for tooling or add the astral-sh host to a Custom allowlist. This repo's
+   is `403`-blocked (release assets ride the GitHub proxy's repository scope, which applies at
+   every network access level), fall back to the VM's system Python for tooling. This repo's
    cloud bootstrap installs from `.github/requirements-ci.txt` with `--require-hashes`; that
    pin list includes cp311 wheels so the cloud VM's system Python 3.11 can satisfy `pyyaml`
    (CI itself uses 3.14).
@@ -252,9 +262,10 @@ session on this repo in the new environment and ask Claude to verify:
   but are never loaded by the session that ran them (the registry is read before the hook), so
   plugins go live at turn one only when the cache build runs the bootstrap pre-launch, which the
   standards `cloud-environment` component does. Remaining #2654 actions are environment-side,
-  not repo-side: switch the environment to the Custom allowlist
-  ([Step 1](#step-1--the-shared-environment-claudeai-ui-one-time)) and rebuild the interrupted
-  cache, then re-run the [checklist](#verification-checklist).
+  not repo-side: set the environment's network access to **All**
+  ([Step 1](#step-1--the-shared-environment-claudeai-ui-one-time)), which moots Blocker 1 rather
+  than working around it, and rebuild the interrupted cache, then re-run the
+  [checklist](#verification-checklist).
 - **`dotfiles` cannot deliver user config to the cloud.** By platform design nothing from
   `~/.claude` reaches cloud sessions; the repo remains editable in the cloud, but any behavior it
   installs locally must be re-homed (repo `.claude/`, plugins, or the environment) to exist

--- a/docs/CLOUD-SESSIONS.md
+++ b/docs/CLOUD-SESSIONS.md
@@ -53,7 +53,8 @@ more, and keep it repo-agnostic, since it serves all repos:
 - [Create or edit environments](https://code.claude.com/docs/en/cloud-environments#configure-your-environment)
   from the selector at claude.ai/code; pick a
   [network access level](https://code.claude.com/docs/en/cloud-environments#access-levels) if
-  Trusted isn't right.
+  Trusted isn't right — this fleet's accounts all run **All** (see
+  [One environment or several?](#one-environment-or-several)).
 - [Environment variables](https://code.claude.com/docs/en/cloud-environments#set-environment-variables)
   are readable by anyone who uses the environment and there is no secrets store — no credentials.
 - A [setup script](https://code.claude.com/docs/en/cloud-environments#setup-scripts) is only for
@@ -127,18 +128,23 @@ plus the cost model of
 ### One environment or several?
 
 Start with one Default. Environments are account-scoped and repo-agnostic, so a single
-Trusted-network environment serves every repository. Add a second, named environment only when a
-class of work needs something incompatible or heavy enough to isolate — a big SDK whose cache
-churn you want contained, or a
+environment serves every repository — this fleet runs its Default at **All** network access
+(operator decision 2026-08-22; rationale in
+[CLOUD-FLEET-SETUP.md](CLOUD-FLEET-SETUP.md#step-1--the-shared-environment-claudeai-ui-one-time)).
+Add a second, named environment only when a class of work needs something incompatible or heavy
+enough to isolate — a big SDK whose cache churn you want contained, or an account that handles
+sensitive material and therefore has to run narrower than All, on a
 [custom domain allowlist](https://code.claude.com/docs/en/cloud-environments#allow-specific-domains).
 A repo needing an uninstalled toolchain (the docs' example is the .NET SDK) means adding its
 install to a setup script — extend Default, or create a dedicated environment and select it when
-starting sessions on that repo; NuGet and dotnet.microsoft.com are already on the default
-allowlist.
+starting sessions on that repo. Reaching NuGet and dotnet.microsoft.com is not what settles .NET:
+both are on the default allowlist, yet under Trusted the installer's redirect chain still came
+back `403` (#2654 Blocker 1). That is why the toolchain question and the network-access question
+are separate — and why the fleet answers the second with All.
 
 ## How this repository is set up
 
-The environment side stays generic (Default environment, Trusted network, no variables, the
+The environment side stays generic (Default environment, **All** network access, no variables, the
 `gh` setup-script one-liner and the guarded pre-launch bootstrap call from above). The repo side:
 
 - [`.claude/cloud-bootstrap.sh`](../.claude/cloud-bootstrap.sh) is the bootstrap, with two

--- a/prompts/cloud-bootstrap-rollout.md
+++ b/prompts/cloud-bootstrap-rollout.md
@@ -71,11 +71,18 @@ Report the diff summary and anything you could not verify from this session.
 For each claude.ai account, at [claude.ai/code](https://claude.ai/code) → environment selector →
 edit **Default** (one environment per account; see the rationale at the end):
 
-1. **Network access**: **Custom**, with **Also include default list of common package managers**
-   checked, plus these hosts: `dot.net`, `aka.ms`, `builds.dotnet.microsoft.com`,
-   `download.visualstudio.microsoft.com`. Not optional if the fleet keeps .NET in the
-   environment: under Trusted the .NET install *always* fails
-   ([#2654](https://github.com/melodic-software/claude-code-plugins/issues/2654) Blocker 1).
+1. **Network access**: **All** (operator decision 2026-08-22, superseding the Custom +
+   four-.NET-host recipe). The access level is an exfiltration control whose Custom default
+   already opens publish-capable package registries; the GitHub proxy, MCP connector traffic and
+   the Anthropic API bypass the level at every setting; and a blocked host mid-session kills that
+   session until an environment edit plus a cache rebuild. **All** removes that failure class,
+   including the `dot.net` special case —
+   [#2654](https://github.com/melodic-software/claude-code-plugins/issues/2654) Blocker 1 is moot
+   under All. The one exception is an account that handles sensitive material: drop that account
+   back to **Custom** — and configure it in full, or the .NET SDK install is back in the failure
+   mode Blocker 1 found. In full means **Also include default list of common package managers**
+   checked, plus `dot.net`, `aka.ms`, `builds.dotnet.microsoft.com`,
+   `download.visualstudio.microsoft.com`.
 2. **Environment variables**: none (values are readable by every session; there is no secrets
    store).
 3. **Setup script**: paste the canonical stub below (same as
@@ -161,8 +168,9 @@ fix, and the verification results.
 Yes. Environments are account-scoped and repo-agnostic, the stub is generic (all real work is
 delegated to the standards component and the checked-out repo's own script), and with 10–20
 accounts every extra environment multiplies manual UI work. Edit **Default** in place — with the
-Custom network allowlist from Part 2, which every account needs anyway — rather than adding a
-named environment; add a second environment later only when a class of work needs isolation (a
-different domain allowlist, or an SDK heavy enough that its cache churn should be contained).
+network access from Part 2, which every account needs anyway — rather than adding a named
+environment; add a second environment later only when a class of work needs isolation (an account
+handling sensitive material that has to run narrower than All, or an SDK heavy enough that its
+cache churn should be contained).
 This supersedes the "add a *Melodic* environment so Default stays pristine" option in
 [docs/CLOUD-FLEET-SETUP.md](../docs/CLOUD-FLEET-SETUP.md) for the paste-once fleet play.


### PR DESCRIPTION
No linked issue

## Summary

Two rollout documents still prescribed the superseded **Custom + four-.NET-host** network-access
recipe for cloud environments, four days after the 2026-08-22 operator decision moved the fleet to
**All**. One of them is the document operators are pointed at while executing the rollout, so the
drift would have misdirected the sweep it exists to guide.

## Fix

`prompts/cloud-bootstrap-rollout.md`

- Part 2 step 1: Custom + the four .NET hosts → **All**, carrying the decision's rationale (the
  access level is an exfiltration control whose Custom default already opens publish-capable
  package registries; the GitHub proxy, MCP connector traffic and the Anthropic API bypass the
  level at every setting; a blocked host mid-session kills that session until an environment edit
  plus a cache rebuild), the note that #2654 Blocker 1 is moot under All, and the carve-out that
  an account handling sensitive material drops back to Custom.
- "One environment per account?": the second-environment trigger "a different domain allowlist"
  → "an account handling sensitive material that has to run narrower than All", the only remaining
  reason a second environment would differ on network.

`docs/CLOUD-FLEET-SETUP.md`

- Step 1 "Network access": dropped the "hard requirement, not a fallback" escalation; now **All**
  with the same rationale. The 2026-08-14 finding is preserved but re-scoped — the .NET redirect
  chain was `403`-blocked under *Trusted*, and that blocker is moot under All — so no reader is
  left thinking Trusted-vs-Custom is still the live choice.
- Verification checklist step 5: `dotnet`-missing triage now checks for All, and says what to read
  when it is already All.
- Verification checklist step 6: dropped the "add the astral-sh host to a Custom allowlist" half.
  Its stated cause (release assets ride the GitHub proxy's repository scope) is level-independent,
  so that half was never a real fix.
- Findings bullet: remaining #2654 action is now "set network access to **All**, which moots
  Blocker 1 rather than working around it".

The canonical three-line setup-script stub is deliberately untouched in both files — verified
byte-identical to what the rollout prescribes (`0` `setup.sh` lines in the diff).

## Verification

Run against the changed files, all clean:

```
markdownlint-cli2 --config .markdownlint-cli2.jsonc <both files>   → 0 issues in 0 files (exit 0)
typos --config _typos.toml <both files>                            → no output (exit 0)
editorconfig-checker <both files>                                  → no output (exit 0)
```

Diff reviewed in full before opening (this touches operator-facing security guidance, so it got a
read rather than a skim). Every remaining `Custom` / `allowlist` / `Trusted` / `2654` hit in the two
files was checked and left only where still correct under All — the cache-rebuild mechanic, the
platform's *default* host list for `raw.githubusercontent.com`, and #2654 Blocker 2 (interrupted
cache build), none of which depend on the access level. No link text or target changed anywhere in
the diff, so the `link-check` lane sees no new surface.

Scope: docs only, no plugin manifest touched, so no version bump or CHANGELOG entry applies. Note
that `docs/` and `prompts/` are *not* in `scripts/docs-only-paths.txt` (which lists only
`docs/topics/`), so the full hygiene suite runs on this PR by design.

## Related

Refs #3053 — the operator-closeout issue whose Step 3 points at
`prompts/cloud-bootstrap-rollout.md` Part 2 and mandates All. That issue is `needs-human` and stays
open; this PR deliberately carries no closing keyword for it.

Refs #2654 — Blocker 1 (the .NET redirect chain under Trusted) is the finding this change records
as moot under All rather than worked around.


---
_Generated by [Claude Code](https://claude.ai/code/session_01SCqMjtVmrE9Y8xPGp8cz3U)_