### PR TITLE
docs(claude-config): de-slop instruction surfaces (0.38.10)

### DIFF
--- a/plugins/claude-config/.claude-plugin/plugin.json
+++ b/plugins/claude-config/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "claude-config",
-  "version": "0.39.1",
+  "version": "0.39.2",
   "description": "Nine configuration-health skills (plus setup) for a repo's Claude Code configuration: audit (settings.json / .mcp.json / hooks / plugins / permissions drift), audit-automation-gaps (evidence-gated verdicts on automation gaps), audit-permission-grants (allow-rule / allowed-tools grants for auto-mode durability and portability), audit-permission-state (the permission rules actually in effect — every settings scope merged with per-rule provenance, what auto mode drops on entry, config written where nothing reads it, and which managed intents are enforced versus loosenable), draft-auto-mode-rules (interview and draft a paste-ready autoMode classifier block; prints only, never writes), audit-instructions (locally-owned instruction surfaces vs current model capability — proposes removals/rewrites of instructions the model no longer needs, and detects cross-surface instruction conflicts), audit-prompting-postures (the additive lane — posture guidance the prompting guide says a component's purpose needs but the component does not carry), audit-pass (one coordinated, ordered, resumable pass over a named target — three-scope inventory, run-time-derived exclusion set, stable finding identity, suppression memory, resume, one human gate — delegating every check to the plugin that owns it), and unhobble (the empirical bare-baseline experiment: reversibly strip a repo's standing instructions, log real stumbles against the current model, re-add only what evidence earns).",
   "author": {
     "name": "Melodic Software",

--- a/plugins/claude-config/CHANGELOG.md
+++ b/plugins/claude-config/CHANGELOG.md
@@ -3,6 +3,24 @@
 All notable changes to the `claude-config` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.39.2]
+
+### Changed
+
+- **De-slop the instruction surfaces (#2891).** Fifth shard of the em-dash purge, after
+  `session-flow` (#3106), `planning` (#3105), `work-items` (#3107) and `source-control` (#3108).
+  Rewrote `README.md` and all ten `SKILL.md` files under `/ai-slop:audit fix` semantics: em dashes
+  become periods, commas, a colon before a list, or a restructured sentence, never parentheses, en
+  dashes, or a spaced hyphen, since each of those is the same interruption wearing a different mark.
+  482 `rule-em-dash` findings cleared to zero, verified with the rule force-enabled (this repo's
+  `.claude/ai-slop.json` disables it corpus-wide, so the check runs against an isolated config).
+  Frontmatter `description` and `argument-hint` values are rewritten too; no quoted auto-invocation
+  trigger phrase contained an em dash, so no trigger changed. Wording only, with no change to any
+  check, phase, gate, lane, or contract. Rebased across 0.39.0 and 0.39.1: the `--persist-findings`
+  flag, the `context/report-keying.md` and `context/persist-findings.md` spokes, and 0.39.1's
+  canonical SSOT wording are all retained, with the em dashes in that newer prose purged in the
+  same style rather than reverted.
+
 ## [0.39.1]
 
 ### Changed

--- a/plugins/claude-config/README.md
+++ b/plugins/claude-config/README.md
@@ -7,12 +7,12 @@ different question about the same surface:
 | Skill | Question it answers |
 |---|---|
 | `/claude-config:audit` | Are the configuration FILES (`settings.json`, `settings.local.json`, `.mcp.json`, hooks, plugins, permissions) correct against upstream truth? |
-| `/claude-config:audit-automation-gaps` | Is the configured automation SET the right set — are there genuine gaps, judged against the enforcement hierarchy? |
-| `/claude-config:audit-permission-grants` | Are the permission GRANTS (`allowed-tools`, `permissions.allow`) portable and durable — do they survive auto mode, work across machines, and live where they can take effect? |
-| `/claude-config:audit-permission-state` | Which permission rules are actually IN EFFECT, and where does each one come from — across managed policy, user-global, project, local, and the pre-v2.1.211 start-directory copy? |
+| `/claude-config:audit-automation-gaps` | Is the configured automation SET the right set? Are there genuine gaps, judged against the enforcement hierarchy? |
+| `/claude-config:audit-permission-grants` | Are the permission GRANTS (`allowed-tools`, `permissions.allow`) portable and durable? Do they survive auto mode, work across machines, and live where they can take effect? |
+| `/claude-config:audit-permission-state` | Which permission rules are actually IN EFFECT, and where does each one come from, across managed policy, user-global, project, local, and the pre-v2.1.211 start-directory copy? |
 | `/claude-config:audit-instructions` | Are the INSTRUCTIONS you wrote (CLAUDE.md, rules, skill bodies, agents, hooks, output styles) still earning their context cost against current model capability, or is prior-model scar tissue holding the model back? |
-| `/claude-config:audit-pass` | Can all of that run as ONE ordered, resumable pass over a named target — every scope inventoried before any check, one reconciled findings artifact, one human gate — instead of several separate runs whose results nobody reconciles? |
-| `/claude-config:unhobble` | What does the CURRENT MODEL actually still need — measured, not reasoned: reversibly strip the project's standing instructions to a bare baseline, log real stumbles, and re-add only what the evidence earns back? |
+| `/claude-config:audit-pass` | Can all of that run as ONE ordered, resumable pass over a named target, with every scope inventoried before any check, one reconciled findings artifact, and one human gate, instead of several separate runs whose results nobody reconciles? |
+| `/claude-config:unhobble` | What does the CURRENT MODEL actually still need, measured rather than reasoned: reversibly strip the project's standing instructions to a bare baseline, log real stumbles, and re-add only what the evidence earns back? |
 
 The instruction/memory-layer *hygiene* question (is `CLAUDE.md` too long, well-placed, free of
 inferable content) is owned by the `audit` skill in the separate `claude-memory` plugin;
@@ -33,7 +33,7 @@ recheck against live official docs and known upstream
 issues, report severity-rated findings, and optionally fix. Includes live plugin-drift detection
 against each registered marketplace's upstream `marketplace.json` (ORPHAN / NEW / RENAME modes) with an
 asymmetric auto-fix policy that never removes a plugin the user explicitly enabled. `settings.local.json`
-is inspected structurally (key counts) only — never read or echoed.
+is inspected structurally (key counts) only, never read or echoed.
 
 ```shell
 /claude-config:audit              # full report-only audit
@@ -46,7 +46,7 @@ is inspected structurally (key counts) only — never read or echoed.
 Discovers automation-gap candidates (hooks, MCP servers, skills, subagents, scheduled tasks), then
 deep-dives each against eight quality gates (already enforced, too slow, not scriptable, zero
 incidents, already exists, YAGNI, platform mismatch, premature) with required evidence. Default
-verdict is REJECT — a clean bill of health is a valid outcome.
+verdict is REJECT. A clean bill of health is a valid outcome.
 
 ```shell
 /claude-config:audit-automation-gaps               # evaluate, recommend-only
@@ -56,14 +56,14 @@ verdict is REJECT — a clean bill of health is a valid outcome.
 
 ### audit-permission-grants
 
-Audits permission GRANTS (not file correctness — that is `audit`) for the failure modes that
+Audits permission GRANTS (not file correctness, which is `audit`) for the failure modes that
 make a grant silently do nothing: interpreter-wildcard / blanket rules that Claude Code drops on
 entering auto mode, hardcoded absolute machine/user paths (Bash rules match literally, no expansion),
 and inert plugin self-grants. A deterministic detector scans skill/command/agent frontmatter
 `allowed-tools` and the project, local, and user-global `permissions.allow` arrays, and recommends the
 bare-command-on-PATH pattern. The user-global file
 (`${CLAUDE_CONFIG_DIR:-$HOME/.claude}/settings.json`) is where Claude Code's own "Always allow" path
-writes, so on a long-lived machine expect it to carry most of the findings — and their remediation is
+writes, so on a long-lived machine expect it to carry most of the findings. Their remediation is
 the operator's, since no skill can write that file. The principle and citations live in the marketplace
 [permission-rule-hygiene convention](../../docs/conventions/permission-rule-hygiene/README.md).
 Report-only.
@@ -79,14 +79,14 @@ Report-only.
 Reports the permission state actually in effect. Claude Code exposes no `claude permissions`
 subcommand and no machine-readable export, so "where is this rule coming from" has meant reading five
 files in five places and hoping you knew all five. A deterministic reader discovers every settings
-scope — managed policy, user-global, project, local, and any pre-v2.1.211 copy left in the session's
-start directory — and inventories each one's `allow` / `ask` / `deny` rules with its source named.
+scope, covering managed policy, user-global, project, local, and any pre-v2.1.211 copy left in the
+session's start directory, then inventories each one's `allow` / `ask` / `deny` rules with its source named.
 
 The status vocabulary is the point: `absent` means looked and found nothing, `skipped` means could not
 look. The managed scope is four surfaces per OS, not one file; the Windows policy registry keys and
 the macOS managed-preferences domain are optional platform integrations that degrade visibly while the
 portable core (the JSON file and its `managed-settings.d/` drop-ins) still reads. Server-managed
-settings have no local path and are disclosed as invisible rather than assumed empty. Report-only —
+settings have no local path and are disclosed as invisible rather than assumed empty. Report-only:
 it writes nothing in any scope, and managed policy is read-only by construction.
 
 ```shell
@@ -96,19 +96,19 @@ it writes nothing in any scope, and managed policy is read-only by construction.
 
 ### audit-instructions
 
-Audits instruction *content* against current model capability — a different question from the
+Audits instruction *content* against current model capability, a different question from the
 sibling audits (config-file correctness) and from `skill-quality:check` (structural lint) or
 `docs-hygiene:compress` (token brevity). It sweeps the locally-owned surfaces (user + project
 `CLAUDE.md`, `.claude/rules`, skill bodies, agent definitions, hook instruction text, output styles)
 against a sixteen-check catalog cited to current official prompting and harness doctrine, running
 a fresh read-only subagent per surface, then a fresh-context verify pass that re-judges every removal
 proposal before it is surfaced. Findings are tiered mechanical vs behavioral and delivered as a
-report plus proposed diffs — report-only, never auto-applied. On memory-layer surfaces it runs only
+report plus proposed diffs, report-only and never auto-applied. On memory-layer surfaces it runs only
 the model-era checks and routes hygiene findings to the `claude-memory` plugin's `audit` skill (with
 a documented fallback when it is not installed); upstream-owned plugin-cache and managed-file
 findings route to the owning repository rather than being edited in place.
 
-**Check I15 asks a different question with a different unit of judgment** — do two surfaces
+**Check I15 asks a different question with a different unit of judgment.** Do two surfaces
 contradict each other? A per-surface lane sees only one half of a pair, so it is answered by its own
 pass over the pair set, against `reference/conflict-criteria.md`. The `conflicts` scope runs that
 pass alone, so a scheduled hygiene routine can compose it on its own token budget.
@@ -124,19 +124,19 @@ pass alone, so a scheduled hygiene routine can compose it on its own token budge
 
 Coordinates one pass rather than adding checks: every check is delegated to the plugin that owns it
 through a presence-gated invocation with a documented fallback. It supplies the run semantics that
-invoking those skills by hand does not — a three-scope inventory taken before any check runs (managed
+invoking those skills by hand does not: a three-scope inventory taken before any check runs (managed
 policy read-only, user scope routed as recommendations, project scope), an exclusion set derived at
 run time from the target's own shared-source registry, the `vendor/` rule, `git worktree list`, and
 the pass's own artifacts; content-derived finding identity that survives an unrelated edit above it;
 a `finding_id`-keyed suppression record with staleness reporting; per-lane persistence with resume;
-and one human gate per run. Findings report in three tiers — derived (exact equality across runs),
+and one human gate per run. Findings report in three tiers: derived (exact equality across runs),
 judged (a stability tolerance whose violation fails the run's self-check), delegated. `/doctor` is an
 operator handoff, never a dispatch, because it is interactive.
 
 **The target must be a git repository**, and one that resolves to the active project root. Both halves
 are refused non-zero rather than reinterpreted. The git requirement is not incidental: the state key,
 the scan baseline, the worktree exclusion, and the top read-only assertion are all defined over git,
-and suppression is enacted only by the *tracked* layer — so on a non-git target no suppression would
+and suppression is enacted only by the *tracked* layer, so on a non-git target no suppression would
 ever persist. Audit such a directory by opening it as a repository, or through the delegated skills
 directly.
 
@@ -157,12 +157,12 @@ as the project.
 The empirical counterpart to `audit-instructions`: instead of judging instruction *text* against
 doctrine, it measures the *model* against the repo with the instructions gone. Four resumable
 phases: **snapshot** (inventory the live project surfaces on a dedicated experiment branch, classify
-hooks policy-vs-behavioral), **bare** (reversibly strip the behavioral tier — tracked files via git,
+hooks policy-vs-behavioral), **bare** (reversibly strip the behavioral tier: tracked files via git,
 settings entries via manifest-recorded backups; policy gates and managed settings are never
 touched), **observe** (work normally in fresh sessions, logging real stumbles to a ledger), and
 **readd** (restore only instructions with at least two same-cause ledger rows, each restore citing
 its evidence; everything else stays deleted, with git history as the archive). The canonical trigger
-is a frontier model release — instructions written for the previous generation are the experiment's
+is a frontier model release. Instructions written for the previous generation are the experiment's
 subject. Human-gated at every mutation; state persists under `${CLAUDE_PLUGIN_DATA}` for resume.
 
 ```shell
@@ -197,12 +197,12 @@ valid state.
 
 The marketplace's `renames` map still carries a historical `claude-config-audit` →
 `claude-config` entry, so settings that name the old plugin id resolve to this one at your next
-session — no action needed for `audit`, `audit-automation-gaps`, and `audit-permission-grants`.
+session. No action is needed for `audit`, `audit-automation-gaps`, and `audit-permission-grants`.
 That entry is a migration aid for consumers who predate the rename, not the marketplace's
 go-forward mechanism: the map is frozen-historical and later renames ship as clean breaking
 changes (see the [migration playbook](../../docs/MIGRATION-PLAYBOOK.md#version-pinning-and-update-delivery)).
 
-The `memory-health` skill did **not** move to `claude-config` — it was extracted into the new,
+The `memory-health` skill did **not** move to `claude-config`. It was extracted into the new,
 separate `claude-memory` plugin (now its `audit` skill). The rename only rewrites the `claude-config-audit`
 plugin key; it does not enable additional plugins, so `claude-memory` is not installed for you
 automatically. If you used `/claude-config-audit:memory-health`, install it explicitly:
@@ -213,9 +213,9 @@ automatically. If you used `/claude-config-audit:memory-health`, install it expl
 
 ## Configuration
 
-No `userConfig`. One tracked consumer-project file — `audit-pass`'s suppression record, above.
+No `userConfig`. One tracked consumer-project file, `audit-pass`'s suppression record, above.
 Persistent plugin state: `audit-pass` writes its run reports and manifests under
-`${CLAUDE_PLUGIN_DATA}`, which resolves under `~` — outside a target below the home directory, and
+`${CLAUDE_PLUGIN_DATA}`, which resolves under `~`, outside a target below the home directory and
 inside one at or above it. A run never *scans* what it wrote: where the resolved report path is
 contained in the target, the run excludes that path before writing and says so.
 Network: `audit` fetches official docs pages and each registered marketplace's `marketplace.json`
@@ -226,12 +226,12 @@ from `raw.githubusercontent.com` (read-only; a failed fetch degrades to SKIP).
 The bundled scripts run in `bash` (Claude Code's Bash-tool shell on every platform;
 [Git Bash](https://code.claude.com/docs/en/setup#set-up-on-windows) on native Windows). The
 JSON-parsing scripts require `jq`; the plugin-drift check additionally requires `curl`; and `awk`
-and `sort` are required across three skills, not one — `audit`'s plugin-drift check (both) and its
+and `sort` are required across three skills, not one: `audit`'s plugin-drift check (both) and its
 fix (`sort`), `audit-permission-grants`' rule check (both), and `audit-instructions`' conflict pass
 (both). Only the conflict pass probes for them and `exit 2`s naming the one that is missing; the
 others call them unguarded, so an absent `awk` or `sort` surfaces there as a bare `command not
 found` partway through a run. Both ship with every POSIX userland, so a missing one means a minimal
-shell environment (Git Bash, a `busybox` shim) rather than an absent package — install a full
+shell environment (Git Bash, a `busybox` shim) rather than an absent package. Install a full
 userland (Git for Windows; `gawk`/`mawk` plus `coreutils` on Linux; `brew install gawk coreutils`
 on macOS). Run `/claude-config:setup` (`check` by default) to verify these prerequisites; `apply`
 gives platform install guidance and re-verifies.

--- a/plugins/claude-config/skills/audit-automation-gaps/SKILL.md
+++ b/plugins/claude-config/skills/audit-automation-gaps/SKILL.md
@@ -1,6 +1,6 @@
 ---
-description: "Audit a repo's Claude Code automation landscape (hooks, MCP servers, skills, subagents, scheduled tasks) against the enforcement hierarchy, producing PASS/REJECT/CONDITIONAL verdicts backed by evidence — the default verdict is REJECT because most gaps are already covered by compiler/analyzer/build-time checks. Use when: 'audit automations', 'what automations should we add', 'are we missing any hooks', 'hook gap analysis', 'should I add an MCP server for X'; pass --implement to apply approved items, or filter by category (hooks|mcp|skills|subagents|scheduled)."
-argument-hint: "[--recommend-only] [--implement] [category] — category: hooks|mcp|skills|subagents|scheduled|all (default: all)"
+description: "Audit a repo's Claude Code automation landscape, covering hooks, MCP servers, skills, subagents and scheduled tasks, against the enforcement hierarchy, producing PASS/REJECT/CONDITIONAL verdicts backed by evidence. The default verdict is REJECT because most gaps are already covered by compiler/analyzer/build-time checks. Use when: 'audit automations', 'what automations should we add', 'are we missing any hooks', 'hook gap analysis', 'should I add an MCP server for X'; pass --implement to apply approved items, or filter by category (hooks|mcp|skills|subagents|scheduled)."
+argument-hint: "[--recommend-only] [--implement] [category]: hooks|mcp|skills|subagents|scheduled|all (default: all)"
 user-invocable: true
 disable-model-invocation: false
 shell: bash
@@ -15,23 +15,23 @@ Automation inventory: !`bash "${CLAUDE_PLUGIN_ROOT}/skills/audit-automation-gaps
 
 ## Purpose
 
-Audit the repo's automation landscape and identify genuine gaps — not surface-level "you don't have X"
+Audit the repo's automation landscape and identify genuine gaps, not surface-level "you don't have X"
 observations, but evidence-backed gaps where no mechanism in the enforcement hierarchy covers the
 concern.
 
 **Design principle**: most "missing automation" gaps are already covered by higher enforcement levels
 (compiler, analyzers, build-time checks, architecture tests, behavioral rules). This skill's job is to
-prove a gap exists before recommending a solution — the default verdict is REJECT, not PASS.
+prove a gap exists before recommending a solution. The default verdict is REJECT, not PASS.
 
 **The enforcement hierarchy** (strongest first): compiler settings → static analyzers/linters →
 architecture tests → unit/integration tests → git hooks → Claude Code hooks → code review →
 documentation/behavioral rules. A consuming repo that documents its own hierarchy in `CLAUDE.md` or
-rules files overrides this default ordering — read and use theirs.
+rules files overrides this default ordering, so read and use theirs.
 
 ## Adapting to your environment (graceful degrade)
 
-This skill is self-contained. Where a phase names an adjacent capability — a research skill, an
-implementation-planning skill, a work-item tracker, an outcome verifier — treat it as optional: if
+This skill is self-contained. Where a phase names an adjacent capability, such as a research skill, an
+implementation-planning skill, a work-item tracker, or an outcome verifier, treat it as optional: if
 your setup provides an equivalent, use it; otherwise follow the inline guidance, which stands on its
 own. Adjacent skills cover neighboring questions: the sibling `audit` skill (are the config FILES
 correct?) and the `audit` skill in the `claude-memory` plugin (is the instruction layer healthy?).
@@ -40,20 +40,20 @@ correct?) and the `audit` skill in the `claude-memory` plugin (is the instructio
 
 Parse `$ARGUMENTS` for:
 
-- **`--recommend-only`**: Run evaluation phases only — skip implementation. Default behavior
+- **`--recommend-only`**: Run evaluation phases only, skipping implementation. Default behavior
 - **`--implement`**: After presenting validated recommendations, implement user-chosen items sequentially
 - **Category filter** (`hooks`, `mcp`, `skills`, `subagents`, `scheduled`): Limit to a specific automation type. Default: `all`
 
 ## Track progress
 
 For any deep-dive run (Phases 1-4), keep a phase checklist and tick each phase + every anti-noise
-doctrine check as it completes — either in-response or by copying
+doctrine check as it completes, either in-response or by copying
 `${CLAUDE_PLUGIN_ROOT}/skills/audit-automation-gaps/templates/checklist.md` into wherever the consuming
 repo keeps working task notes. Phase 4 is SKIPPED in default `--recommend-only` mode.
 
 ## Phase 1: Discover Candidates (Self-Generated)
 
-Analyze the current automation landscape directly — no external recommender dependency.
+Analyze the current automation landscape directly, with no external recommender dependency.
 
 ### 1.1 Inventory Current State
 
@@ -64,14 +64,14 @@ Run `bash "${CLAUDE_PLUGIN_ROOT}/skills/audit-automation-gaps/scripts/inventory.
 | Hooks | Every hook location: user + project + local `settings.json` → `hooks`, managed policy settings when readable, each enabled plugin's `hooks/hooks.json`, and skill or agent frontmatter `hooks:` |
 | MCP servers | `.mcp.json` + `settings.json` → `disabledMcpjsonServers` |
 | Permissions | `settings.json` → `permissions` (deny/ask/allow) |
-| Enforcement | Ecosystem-specific build config (`<root-build-config>` — e.g. `Directory.Build.props` for .NET, `pyproject.toml` for Python, `package.json` for TS/JS), `.editorconfig` (top 20 lines), any enforcement-hierarchy section in the repo's own instruction files |
+| Enforcement | Ecosystem-specific build config (`<root-build-config>`, e.g. `Directory.Build.props` for .NET, `pyproject.toml` for Python, `package.json` for TS/JS), `.editorconfig` (top 20 lines), any enforcement-hierarchy section in the repo's own instruction files |
 | Codebase shape | File counts per language: `find . -name "*.cs" \| wc -l`, same for `.py`, `.ts`, `.sh`, `.ps1` |
 | Incident history | `git log --oneline \| wc -l` for baseline, `git log --oneline -50` for recent activity |
 
 ### 1.2 Gap Analysis
 
 For each automation category, systematically check for gaps using the category-specific checklists in
-[context/gap-analysis.md](context/gap-analysis.md) — Hooks (formatter exists? fast enough? higher
+[context/gap-analysis.md](context/gap-analysis.md): Hooks (formatter exists? fast enough? higher
 enforcement already covers?), MCP Servers (configured? CLI equivalent? service in use yet?), Skills
 (skill exists? frequency? simpler mechanism?), Subagents (value over hook/skill? isolation help?
 plugin exists?), Scheduled (tracked in the repo's work-item tracker? Dependabot/CI covers? right
@@ -79,8 +79,8 @@ durability model?).
 
 ### 1.3 Generate Candidate List
 
-Produce a numbered list of candidates with category and one-line rationale. Target **5-10 candidates**
-— cast a wide net, the quality gates will filter. Include borderline items; it's better to evaluate
+Produce a numbered list of candidates with category and one-line rationale. Target **5-10 candidates**.
+Cast a wide net, the quality gates will filter. Include borderline items; it's better to evaluate
 and reject with evidence than to silently exclude.
 
 ## Phase 2: Deep-Dive Each Candidate
@@ -92,10 +92,10 @@ once), then evaluate candidates sequentially.
 
 For each candidate:
 
-- **Read the relevant config/code** — the specific files that would be affected
-- **Check the enforcement hierarchy** — walk up from the weakest level (docs) to the strongest (compiler). Stop when you find coverage. Document which level covers it
-- **Check incident history** — `git log --grep` for related problems. Count incidents vs total commits for frequency
-- **Measure performance** — if the candidate involves a CLI tool as a hook, time it:
+- **Read the relevant config/code**: the specific files that would be affected
+- **Check the enforcement hierarchy**: walk up from the weakest level (docs) to the strongest (compiler). Stop when you find coverage. Document which level covers it
+- **Check incident history**: `git log --grep` for related problems. Count incidents vs total commits for frequency
+- **Measure performance**: if the candidate involves a CLI tool as a hook, time it:
 
 ```bash
 time <tool-command> 2>&1 | tail -5
@@ -132,7 +132,7 @@ A candidate **fails** if ANY gate triggers:
 | Gate | Condition | Evidence Required |
 |------|-----------|-------------------|
 | **Already enforced** | A higher enforcement hierarchy level covers it | Name the level and mechanism |
-| **Too slow** | Tool exceeds 30s AND the hook must block — a non-blocking command hook can set `async: true` instead | Timing measurement + whether a decision is returned |
+| **Too slow** | Tool exceeds 30s AND the hook must block, where a non-blocking command hook can set `async: true` instead | Timing measurement + whether a decision is returned |
 | **Not scriptable** | The mechanism can't be automated with available tools | Specific limitation cited |
 | **Zero incidents** | Git history shows the problem has never occurred | Incident count + total commit count |
 | **Already exists** | A skill, behavioral rule, or convention already handles it | File path and line |
@@ -140,16 +140,16 @@ A candidate **fails** if ANY gate triggers:
 | **Platform mismatch** | Requires infrastructure the user doesn't have | Platform requirement cited |
 | **Premature** | Depends on unfinished work (planned database, future CI) | What's missing cited |
 
-These gates answer *should* we mechanize. Whether a candidate *can* be — and how far up the hierarchy
-it climbs — is a separate enforceability question: the **Not scriptable** gate maps to concerns no
+These gates answer *should* we mechanize. Whether a candidate *can* be, and how far up the hierarchy
+it climbs, is a separate enforceability question: the **Not scriptable** gate maps to concerns no
 hook type reaches, **Already enforced** to a deterministic finding already escalated. `prompt` and
 `agent` hooks do evaluate reasoning-only concerns, `agent` experimentally.
 
 Produce a verdict per candidate:
 
-- **PASS** — clears all gates, provides genuine value
-- **CONDITIONAL PASS** — value exists but only under specific conditions (document the condition)
-- **REJECT** — fails one or more gates (cite which gates and evidence)
+- **PASS**: clears all gates, provides genuine value
+- **CONDITIONAL PASS**: value exists but only under specific conditions (document the condition)
+- **REJECT**: fails one or more gates (cite which gates and evidence)
 
 ## Phase 3: Present Results
 
@@ -170,7 +170,7 @@ For each candidate, provide:
 - **Evidence** (timing data, git history counts, enforcement mechanisms found)
 - **For PASS/CONDITIONAL PASS**: implementation plan (files to change, effort estimate, test strategy)
 
-**Order by value/impact** — highest value first. Value = frequency × severity × ease of implementation.
+**Order by value/impact**, highest value first. Value = frequency × severity × ease of implementation.
 
 ### Maturity Assessment
 
@@ -180,19 +180,19 @@ project stage.
 
 If items pass: "Which items would you like to implement? I'll work through them sequentially."
 
-If no items pass: State that clearly — a clean bill of health is a valid outcome.
+If no items pass: State that clearly. A clean bill of health is a valid outcome.
 
 ## Phase 4: Implement (if `--implement` or user requests)
 
 For each user-selected item:
 
-1. **Explore** — re-read current state (may have changed since evaluation)
-2. **Research + Validate** — verify the implementation approach against current docs
-3. **Plan** — detailed implementation steps
-4. **Implement** — execute with incremental validation and commit checkpoints
-5. **Test** — verify the automation works (run hooks, test skills, etc.)
-6. **Review** — self-review for consistency with existing patterns
-7. **Verify** — build/test the repo if code changed, confirm no regressions
+1. **Explore**: re-read current state (may have changed since evaluation)
+2. **Research + Validate**: verify the implementation approach against current docs
+3. **Plan**: detailed implementation steps
+4. **Implement**: execute with incremental validation and commit checkpoints
+5. **Test**: verify the automation works (run hooks, test skills, etc.)
+6. **Review**: self-review for consistency with existing patterns
+7. **Verify**: build/test the repo if code changed, confirm no regressions
 
 Route steps 2-7 through the consuming environment's own workflow skills when it has them; the inline
 steps stand on their own otherwise.
@@ -204,7 +204,7 @@ Lessons from evaluation sessions:
 1. **The enforcement hierarchy is your first check.** Most "gaps" are covered by the compiler-through-git-hooks levels
 2. **Measure, don't assume.** Time every tool before recommending it as a hook. A formatter looks perfect until you measure 15+ seconds per file
 3. **Check incident history.** Zero incidents across 100+ commits is strong evidence the problem doesn't exist in practice
-4. **Behavioral rules are valid enforcement.** A rule in CLAUDE.md is legitimate coverage — not everything needs a hook or script
+4. **Behavioral rules are valid enforcement.** A rule in CLAUDE.md is legitimate coverage; not everything needs a hook or script
 5. **YAGNI is a quality gate, not laziness.** Automation for a task at 4% frequency is premature
 6. **Premature is worse than missing.** Adding a database MCP before a database exists, or scheduling before CI exists, creates maintenance burden for zero value
-7. **A clean bill of health is a valid outcome.** Not finding gaps means the automation is mature — don't manufacture recommendations to justify the audit
+7. **A clean bill of health is a valid outcome.** Not finding gaps means the automation is mature; don't manufacture recommendations to justify the audit

--- a/plugins/claude-config/skills/audit-instructions/SKILL.md
+++ b/plugins/claude-config/skills/audit-instructions/SKILL.md
@@ -1,6 +1,6 @@
 ---
-description: "Audit locally-owned Claude Code instruction surfaces — CLAUDE.md, .claude/rules, skill bodies, agent definitions, hook instruction text, output styles — for instructions current models no longer need (prior-model workarounds, over-prescriptive scaffolding, stale examples), instructions that misstate Claude Code's own behavior or cite files in forms that never load, and cross-surface conflicts where two surfaces contradict each other. Report-only: proposed diffs gated to the human, never auto-applied. Use when: 'after a model upgrade', 'are my instructions holding the model back', 'instructions the model no longer needs', 'too prescriptive', 'audit instructions', 'instruction audit', 'stale Claude Code behavior', 'outdated harness claim', 'my @path import is not loading', 'instruction re-reads CLAUDE.md', 'conflicting instructions', 'contradictory instructions', 'which instruction wins'. Not a brevity pass and not memory-layer hygiene."
-argument-hint: "[scope] [--target-model <version>] [--opinion] [--no-stopping-condition] [--persist-findings] — scope: claude-md|rules|skills|agents|hooks|output-styles|conflicts|all (default: all)"
+description: "Audit locally-owned Claude Code instruction surfaces, including CLAUDE.md, .claude/rules, skill bodies, agent definitions, hook instruction text and output styles, for instructions current models no longer need (prior-model workarounds, over-prescriptive scaffolding, stale examples), instructions that misstate Claude Code's own behavior or cite files in forms that never load, and cross-surface conflicts where two surfaces contradict each other. Report-only: proposed diffs gated to the human, never auto-applied. Use when: 'after a model upgrade', 'are my instructions holding the model back', 'instructions the model no longer needs', 'too prescriptive', 'audit instructions', 'instruction audit', 'stale Claude Code behavior', 'outdated harness claim', 'my @path import is not loading', 'instruction re-reads CLAUDE.md', 'conflicting instructions', 'contradictory instructions', 'which instruction wins'. Not a brevity pass and not memory-layer hygiene."
+argument-hint: "[scope] [--target-model <version>] [--opinion] [--no-stopping-condition] [--persist-findings]; scope: claude-md|rules|skills|agents|hooks|output-styles|conflicts|all (default: all)"
 disallowed-tools: Edit, NotebookEdit
 user-invocable: true
 disable-model-invocation: false
@@ -17,24 +17,24 @@ workarounds for mistakes the model no longer makes, prescriptive step lists that
 than they help, bare prohibitions, and show-your-thinking directives. This skill sweeps the
 locally-owned instruction surfaces, cites each finding to current official prompting doctrine, tiers
 it by how confident the evidence can be, and packages proposed removals or rewrites as a human-gated
-diff — so instruction surfaces shrink as models get better instead of only ever growing.
+diff, so instruction surfaces shrink as models get better instead of only ever growing.
 
-The check catalog — the checks I1–I28, their evidence tier, authority tag, severity, per-surface
-applicability, and the `OPINION`-tier enablement policy — lives in
+The check catalog, covering the checks I1–I28, their evidence tier, authority tag, severity,
+per-surface applicability, and the `OPINION`-tier enablement policy, lives in
 [reference/criteria.md](reference/criteria.md); the deterministic pre-scan is
 `${CLAUDE_PLUGIN_ROOT}/skills/audit-instructions/scripts/instruction-scan.sh`.
-One check has a different unit of judgment — do two surfaces contradict each other? — and Phase B2
+One check has a different unit of judgment, do two surfaces contradict each other, and Phase B2
 answers it against [reference/conflict-criteria.md](reference/conflict-criteria.md).
 
 ## Read-only contract
 
-This skill is report-only. There is no `--fix`: instruction files are the operator's voice —
+This skill is report-only. There is no `--fix`: instruction files are the operator's voice, so
 every change is applied by the human (or explicitly delegated afterward), never by this skill.
 Diffs are proposed artifacts. A clean audit is a valid outcome.
 
 `disallowed-tools: Edit, NotebookEdit` narrows the surface; it does **not** make the contract
 mechanical. `Write` stays for the Phase D persist and `Bash` for the pre-scans, and either can mutate
-a file this skill has already read — so this is an instruction-held contract with a narrowed accident
+a file this skill has already read, so this is an instruction-held contract with a narrowed accident
 surface, not an enforced one. Never describe it to an operator as a guarantee. The restriction clears
 on their next message (<https://code.claude.com/docs/en/skills>, frontmatter reference, fetched
 2026-08-12), so whoever accepts a diff can apply it. `audit-prompting-postures` carries the identical
@@ -44,10 +44,10 @@ the shape of defect this pair keeps producing.
 ## Scope boundary (route out)
 
 This skill owns instruction **content vs current model capability**. It does not own the adjacent
-concerns its siblings already cover — route rather than re-answer:
+concerns its siblings already cover, so route rather than re-answer:
 
 - Posture guidance that is **absent and needed** is `claude-config:audit-prompting-postures` (same
-  plugin) — the additive lane to this one. This skill judges instruction text that is present and
+  plugin), the additive lane to this one. This skill judges instruction text that is present and
   wrong; that one proposes text the official prompting guide says a component's purpose needs and
   the component does not carry. Neither finds the other's defects, so a sweep that wants both runs
   both, and a request phrased as "what guardrails is this skill missing" belongs there, not here.
@@ -55,21 +55,21 @@ concerns its siblings already cover — route rather than re-answer:
 - Token brevity for its own sake is `docs-hygiene:compress`.
 - Config-file mechanics (settings.json, .mcp.json, hooks wiring) is `claude-config:audit`; grant
   portability is `claude-config:audit-permission-grants`.
-- The empirical bare-baseline experiment — strip the surfaces, observe the bare model, re-add on
-  repeated stumble evidence — is `unhobble` (same plugin): this skill judges instruction *text*
-  against doctrine; unhobble measures the *model*.
+- The empirical bare-baseline experiment, stripping the surfaces, observing the bare model, and
+  re-adding on repeated stumble evidence, is `unhobble` (same plugin): this skill judges instruction
+  *text* against doctrine; unhobble measures the *model*.
 
 On **memory-layer surfaces** (CLAUDE.md, CLAUDE.local.md, `.claude/rules/`, and `rules/` under the
 user root Phase A resolves),
 this skill runs only the model-era checks I6–I28. It never runs or reports the hygiene checks
-I1–I5 (line-necessity, length, placement, inferable content, rule-to-hook) on these surfaces —
+I1–I5 (line-necessity, length, placement, inferable content, rule-to-hook) on these surfaces;
 that instruction-memory hygiene layer belongs to the `claude-memory` plugin. When that plugin is
 installed, route memory-layer hygiene to its `audit` skill; when it is not installed, emit a single
 one-line pointer to the official CLAUDE.md include/exclude guidance (recorded with I1–I5 in
-[reference/criteria.md](reference/criteria.md)) so the operator knows where that audit lives — this
+[reference/criteria.md](reference/criteria.md)) so the operator knows where that audit lives, though this
 skill still does not perform it. Either way, no I1–I5 hygiene finding is ever produced here. On
 **non-memory surfaces** (skill bodies, agent definitions, hook instruction text, output styles) the
-catalog applies — no incumbent auditor covers instruction content there — **bounded by each row's
+catalog applies, since no incumbent auditor covers instruction content there, **bounded by each row's
 own surface declaration**, which is narrower than the partition for some checks. I13 and I14 name
 their own surface sets and are not run outside them; this partition never widens a row.
 
@@ -86,19 +86,19 @@ repository's tracker, never in-place edits; absent such a declaration, no exclus
 
 ## Arguments
 
-Parse `$ARGUMENTS` for an optional scope filter. It narrows which surfaces may **produce** findings —
+Parse `$ARGUMENTS` for an optional scope filter. It narrows which surfaces may **produce** findings,
 never which surfaces are read. Phase A always inventories the full comparison set, because I15 is a
 relation between two surfaces and a scoped run still needs the counterpart:
 
-- `claude-md` — findings on user + project CLAUDE.md and CLAUDE.local.md
-- `rules` — findings on `.claude/rules/` and `rules/` under the user root Phase A resolves
-- `skills` — findings on skill bodies and their context/reference files
-- `agents` — findings on agent definition markdown
-- `hooks` — findings on hook instruction text: prompt-type hook text, and handler output injected
+- `claude-md`: findings on user + project CLAUDE.md and CLAUDE.local.md
+- `rules`: findings on `.claude/rules/` and `rules/` under the user root Phase A resolves
+- `skills`: findings on skill bodies and their context/reference files
+- `agents`: findings on agent definition markdown
+- `hooks`: findings on hook instruction text: prompt-type hook text, and handler output injected
   into the session's context
-- `output-styles` — findings on output-style markdown
-- `conflicts` — Phase A plus Phase B2 only, so a scheduled routine can compose it on its own budget
-- `all` — findings on every locally-owned surface, and the conflict pass (default)
+- `output-styles`: findings on output-style markdown
+- `conflicts`: Phase A plus Phase B2 only, so a scheduled routine can compose it on its own budget
+- `all`: findings on every locally-owned surface, and the conflict pass (default)
 
 A finding still names both sides of a conflict even when one side is out of scope; the filter decides
 which side the run is auditing.
@@ -108,23 +108,23 @@ checks and rows (its "Model scoping" section) fire only when this resolved targe
 scope; non-matching ones are inert and the report lists them as `skipped-for-target`.
 
 - **Default resolution ladder:** (1) an explicit `--target-model` always wins; (2) otherwise use
-  the session's EFFECTIVE model — what this session actually runs, which a `--model` launch
-  override may have set, not the bare settings pin — and normalize it alias → model VERSION
+  the session's EFFECTIVE model, what this session actually runs, which a `--model` launch
+  override may have set rather than the bare settings pin, and normalize it alias → model VERSION
   against the live model-config docs at run time; (3) anything that cannot be normalized to a
-  single version fails loud (below). The normalized token is the catalog's local grammar —
+  single version fails loud (below). The normalized token is the catalog's local grammar,
   lowercase family and version joined by hyphens (`opus-5`, `sonnet-5`, `fable-5`), derived from
   the documented model the alias or full model name resolves to, not a string upstream publishes.
-  Matching against catalog scopes is exact equality of the normalized version token — the
+  Matching against catalog scopes is exact equality of the normalized version token, and the
   catalog's "Model scoping" section owns that predicate.
-- **Fail loud on ambiguity:** a value may carry no version at all — a family alias like `opus`
+- **Fail loud on ambiguity:** a value may carry no version at all, such as a family alias like `opus`
   (with or without a context-window suffix such as `[1m]`), an absent `model` setting in an
   out-of-session run, or a custom/gateway deployment ID that matches no documented pattern.
   Normalization MUST stop in that case by ABORTING the run with an error that names the exact
-  argument to pass (`--target-model <version>`) — a non-interactive abort, never a mid-run prompt,
+  argument to pass (`--target-model <version>`), a non-interactive abort, never a mid-run prompt,
   and never a silent guess that a family alias means its newest version, which would misfire the
   exact model-scoped distinctions the catalog draws. When the ambiguous value is a documented
   family alias, the abort message ALSO names the normalized token of the version that alias
-  currently resolves to per the live model-config docs — as a suggested `--target-model` value the
+  currently resolves to per the live model-config docs, as a suggested `--target-model` value the
   user confirms, never a value the run proceeds on (e.g. "`opus` currently resolves to `opus-5`;
   re-run with `--target-model opus-5` to confirm"). Suggesting is not guessing: the user's
   confirmation is what turns the resolution into a target. The resolved target (and how it was
@@ -132,69 +132,69 @@ scope; non-matching ones are inert and the report lists them as `skipped-for-tar
 
 Two flags govern the `OPINION` tier, whose enablement policy the catalog defines:
 
-- `--opinion` — also run the `OPINION`-tier checks that emit findings. Off by default; their
+- `--opinion`: also run the `OPINION`-tier checks that emit findings. Off by default; their
   findings are capped at `info` and are never applied. **Which rows those are is read from the
   catalog at run time and deliberately not restated here**: the catalog owns the enablement policy,
   so a second copy of the set in this file is one more thing to keep in sync on every new
   `OPINION` row, and a stale copy silently narrows the flag. The run's tier-transparency line
   reports how many it found.
-- `--no-stopping-condition` — disable the `OPINION`-tier stopping condition that bounds I6 and I8.
+- `--no-stopping-condition`: disable the `OPINION`-tier stopping condition that bounds I6 and I8.
   It is on by default because it withholds findings rather than emitting them, so turning it off
   makes both trimming checks more aggressive, not the audit more conservative.
 
 `--persist-findings` also writes the run's I28 findings as a `type: review-findings` file for
 `review:fanout`'s `fix` action (off by default; only I28 is eligible, body-scoped; a proposal for a
-human-gated relay, not an applied edit — [context/persist-findings.md](context/persist-findings.md)).
+human-gated relay, not an applied edit; see [context/persist-findings.md](context/persist-findings.md)).
 
-## Phase A — Inventory
+## Phase A: Inventory
 
 Enumerate the locally-owned instruction surfaces in scope. All paths below are current per the
 official memory and `.claude`-directory docs (cited in the report's Sources line):
 
-- User — resolve the root as `${CLAUDE_CONFIG_DIR:-~/.claude}` (setting `CLAUDE_CONFIG_DIR`
+- User: resolve the root as `${CLAUDE_CONFIG_DIR:-~/.claude}` (setting `CLAUDE_CONFIG_DIR`
   relocates the whole `~/.claude` tree, so never hardcode `~/.claude`), then: `CLAUDE.md`,
   `rules/`, `skills/`, `agents/`, `output-styles/` under that root.
 - Project: `./CLAUDE.md` or `./.claude/CLAUDE.md`, `./CLAUDE.local.md`, and every nested
   `CLAUDE.md` / `CLAUDE.local.md` in subdirectories of the project tree (Claude loads these on
-  demand when it reads files in those directories, so walk the tree — do not stop at the root);
+  demand when it reads files in those directories, so walk the tree and do not stop at the root);
   `.claude/rules/`, `.claude/skills/`, `.claude/agents/`, `.claude/output-styles/`.
 - **Hook instruction text** configured in the project or user `settings.json`, **and in
-  `.claude/settings.local.json`** — local settings are a supported hook-configuration scope, so a
-  hook configured there gates the session as much as one configured anywhere else — **and declared
+  `.claude/settings.local.json`**, since local settings are a supported hook-configuration scope and a
+  hook configured there gates the session as much as one configured anywhere else, **and declared
   in the `hooks:` frontmatter of the user- and project-scope skills and agents listed above**.
   Frontmatter is a supported hook location, live "while the component is active", so a hook in a
   locally owned `.claude/skills/**/SKILL.md` or `.claude/agents/*.md` is exactly as editable as the
-  body it rides on and belongs in this set, not the read-only tier below — that tier's counterpart
-  item covers the plugin cache, whose components no proposal may touch. Anchor a frontmatter hook at
+  body it rides on and belongs in this set, not the read-only tier below, whose counterpart
+  item covers the plugin cache and whose components no proposal may touch. Anchor a frontmatter hook at
   its own component file and frontmatter line rather than at a settings file. A subagent's
   frontmatter `Stop` hook is registered as `SubagentStop`, so resolve the effective event before
   pairing. Two kinds, and the discriminator is **whether the handler's output reaches this session's
   context, never the handler's `type`**
   ([reference/conflict-criteria.md](reference/conflict-criteria.md) owns the distinction and its
   citations):
-  - **Prompt-type hook text** — extract the prompt text. **What is compared is the gate, not the
+  - **Prompt-type hook text**: extract the prompt text. **What is compared is the gate, not the
     prose:** it goes to a separate evaluator model, never into this session's context, so it enters
     the comparison set as the act it blocks under its event and `matcher`. An `agent` handler is
     treated the same way.
-  - **Context-injecting handler output** — a handler that prints to stdout on `SessionStart`,
+  - **Context-injecting handler output**: a handler that prints to stdout on `SessionStart`,
     `UserPromptSubmit`, or `UserPromptExpansion`, or returns `hookSpecificOutput.additionalContext`
     on a main-session event that accepts it, puts that text in this session's context window. It is
-    live instruction text and enters the comparison set as text. `command` is not an exclusion —
+    live instruction text and enters the comparison set as text. `command` is not an exclusion:
     `mcp_tool` shares the stdout channel and `http` the JSON one. Two bounds the criteria file
     states and cites: `SubagentStart` / `SubagentStop` `additionalContext` lands in **that
     subagent's** context, not this session's; and type decides registrability, so resolve the
     event×type pair before admitting a surface (`SessionStart` takes only `command` and `mcp_tool`).
-    Where the output is not literal in the config — a handler that runs a script — record the
+    Where the output is not literal in the config, as with a handler that runs a script, record the
     surface with the emitting handler's event and `matcher` and mark the text `text-unresolved`
     rather than inventing it; a run inside the session it describes can read what was injected.
 
   Never carry a command line, token, or other secret-bearing value out of a settings file or a
-  component's frontmatter into the report — extract only the injected text, under the same
+  component's frontmatter into the report. Extract only the injected text, under the same
   no-secrets handling for both kinds and both locations.
 
 **The tree does not decide what is live.** Before the inventory is handed to any lane, resolve the
-session's effective liveness controls — the launch directory, the merged `claudeMdExcludes`,
-`--setting-sources`, the additional-directory inputs, **and effective hook enablement** — then drop
+session's effective liveness controls: the launch directory, the merged `claudeMdExcludes`,
+`--setting-sources`, the additional-directory inputs, **and effective hook enablement**. Then drop
 what they exclude and add the memory files they contribute. A walk of the project tree alone both
 invents surfaces that are dead in this session and misses live ones that are not in the tree at all.
 The controls, their official sources, and the `liveness-unresolved` marking for values an
@@ -204,15 +204,15 @@ resolved controls in the report's tier-transparency line.
 
 **Hook enablement is a liveness control, and configuration alone does not establish it.**
 `disableAllHooks` turns off hooks without removing them, so an enabled plugin's handler, or one wired
-in project settings, sits on disk unable to run — and a gate that cannot run this session constrains
+in project settings, sits on disk unable to run, and a gate that cannot run this session constrains
 nothing to compare against. Its reach is all hooks with exactly one carve-out, and that carve-out is
 what makes this a per-scope resolution rather than a per-file one: set in user, project, or local
 settings it cannot disable **managed** hooks, so managed hook text stays live against it and must not
 be dropped with the rest; only a managed-level `disableAllHooks` reaches those too. The mirror
 control, `allowManagedHooksOnly`, cuts the other way and blocks user, project, and plugin hooks,
-exempting plugins force-enabled in managed `enabledPlugins`. Omit every hook surface they disable —
+exempting plugins force-enabled in managed `enabledPlugins`. Omit every hook surface they disable,
 both kinds, prompt-type and context-injecting alike, since neither reaches this session when the
-handler never fires — and report both resolved values with the other controls.
+handler never fires, and report both resolved values with the other controls.
 
 Exclude from the **editable** set, and hold for the routing subsection: auto-memory
 (`projects/<project>/memory/` under the resolved user root, owned by `claude-memory`), installed
@@ -225,28 +225,28 @@ to compare against them even though no proposed edit may ever touch them. Read-o
 nothing about ownership: these surfaces still produce no proposal of their own, and a finding
 involving one still carries the no-change representation and its routing recommendation.
 
-- **Auto memory, when it is on** — the `MEMORY.md` entrypoint at the effective auto-memory location
+- **Auto memory, when it is on**: the `MEMORY.md` entrypoint at the effective auto-memory location
   (the highest-precedence scope that sets `autoMemoryDirectory`, otherwise
   `projects/<project>/memory/` under the **resolved** user root above, never a hardcoded
-  `~/.claude` — `CLAUDE_CONFIG_DIR` moves `projects/` with the rest of the tree, so a hardcoded
+  `~/.claude`, since `CLAUDE_CONFIG_DIR` moves `projects/` with the rest of the tree and a hardcoded
   default misses the live `MEMORY.md` and compares against a store the session no longer
   writes). **Resolve the effective enabled state first, by
-  precedence — not by any single scope's value.** `CLAUDE_CODE_DISABLE_AUTO_MEMORY` is authoritative
+  precedence rather than by any single scope's value.** `CLAUDE_CODE_DISABLE_AUTO_MEMORY` is authoritative
   wherever it is set (`=1` off, `=0` on, even against `autoMemoryEnabled: false`); with the variable
   unset, apply settings precedence (managed > local > project > user) to `autoMemoryEnabled`, which
   defaults to on. Reading a lower-scope `false` as decisive would drop a `MEMORY.md` a
   higher-precedence scope re-enabled, and inventorying unconditionally would pair live instructions
-  against a file left on disk after auto memory was turned off — the same defect as reading a
+  against a file left on disk after auto memory was turned off, the same defect as reading a
   disabled plugin's cache. `/claude-memory:stateless` owns this resolver; its `status` action reports
   the effective state, including a disagreement between the variable and the setting. When auto
   memory is on it loads into every session, and
   [reference/conflict-criteria.md](reference/conflict-criteria.md) assigns every pair involving it to
-  I15 precisely because `claude-memory`'s C6 does not read it — so excluding it outright would leave
+  I15 precisely because `claude-memory`'s C6 does not read it, so excluding it outright would leave
   a `MEMORY.md`-versus-`CLAUDE.md` contradiction audited by neither skill. Only the content that
   actually loads is compared (the first 200 lines or 25KB); topic files beside it are read on demand
   and are not resident. Ownership is unchanged: `claude-memory` still owns auto memory, and a finding
   here routes there rather than editing it.
-- **Each enabled agent's own memory, under that same gate** — an agent definition carrying a
+- **Each enabled agent's own memory, under that same gate**: an agent definition carrying a
   `memory` field gets its **own** memory directory, separate from the main conversation's and named
   per agent, and that subagent reads and writes its own `MEMORY.md` there. The field's value is the
   scope, and each scope has its own location: `user` → `agent-memory/<name-of-agent>/` under the
@@ -259,17 +259,17 @@ involving one still carries the no-change representation and its routing recomme
   definition enables the field, under the same loaded-portion bound. The gate is the effective state
   resolved just above: subagent memory is part of auto memory, so with auto memory off the `memory`
   field has no effect and the subagent launches without the memory instructions or the memory tool
-  access — an agent memory left on disk after the switch flipped is not inventoried.
+  access; an agent memory left on disk after the switch flipped is not inventoried.
   Read-only and `claude-memory`-owned exactly as the main entrypoint is.
-- **Org-managed policy** — the managed-policy `CLAUDE.md`, any `claudeMd` value in managed settings,
+- **Org-managed policy**: the managed-policy `CLAUDE.md`, any `claudeMd` value in managed settings,
   and hook instruction text configured in managed settings, of **both** kinds above. All three are
   live instruction text, and a managed hook contradicting a project skill is exactly the conflict I15
   explicitly owns; that comparison is impossible if the text is never read. Extract managed hook text
   under the same two-kind, no-secrets handling as the other settings scopes.
-- **Upstream-owned instruction text that is nonetheless live** — skill bodies and agent definitions
+- **Upstream-owned instruction text that is nonetheless live**: skill bodies and agent definitions
   from the cache of an **enabled** plugin, hook instruction text of both kinds in an enabled
   plugin's `hooks/hooks.json` (a plugin is a supported hook location, so that text is as live as a
-  settings-configured hook — and a plugin `SessionStart` handler injecting a standing behavioral
+  settings-configured hook, and a plugin `SessionStart` handler injecting a standing behavioral
   block is the case that motivated the two-kind split), hooks declared in the frontmatter of an
   active skill or agent **from that cache** (a supported location, live "while the component is
   active"; the user- and project-scope counterparts are locally owned and are inventoried in the
@@ -280,14 +280,14 @@ involving one still carries the no-change representation and its routing recomme
   `output-styles/` directory, and a plugin style with `force-for-plugin` applies "automatically
   whenever the plugin is enabled, without requiring users to select it", overriding the user's
   `outputStyle` setting ([output-styles](https://code.claude.com/docs/en/output-styles)). Resolve
-  which style is actually active — a `force-for-plugin` style from the enabled set first, else the
-  `outputStyle` value, which may itself name a plugin-supplied style — and inventory that one. Only
+  which style is actually active, a `force-for-plugin` style from the enabled set first, else the
+  `outputStyle` value, which may itself name a plugin-supplied style, and inventory that one. Only
   the active style is resident, so the others stay out of the corpus. Enablement is
   the same gate for every plugin-sourced surface here: a disabled plugin's cache stays on disk while
-  none of its components load — including a `force-for-plugin` style, which applies only while its
-  plugin is enabled — so resolve effective `enabledPlugins` across settings scopes first and
+  none of its components load, including a `force-for-plugin` style, which applies only while its
+  plugin is enabled, so resolve effective `enabledPlugins` across settings scopes first and
   inventory only the
-  plugins that resolve enabled — a cached body from a disabled plugin would put text Claude cannot
+  plugins that resolve enabled. A cached body from a disabled plugin would put text Claude cannot
   load into the comparison corpus. Enablement alone is not enough to pick a directory: the cache can
   hold several versions of one plugin, and a plugin may be installed at more than one scope, so
   resolve the install record that is actually selected for this project and read **only** that
@@ -304,7 +304,7 @@ involving one still carries the no-change representation and its routing recomme
   comparison counterparts. Findings still name both sides; the filter decides which side the run is
   auditing, never that the counterpart goes unread.
 
-## Phase B — Per-surface lanes
+## Phase B: Per-surface lanes
 
 Run one **fresh read-only subagent per surface**, each sharing
 [reference/criteria.md](reference/criteria.md) and applying the per-surface check partition from
@@ -317,18 +317,18 @@ bash "${CLAUDE_PLUGIN_ROOT}/skills/audit-instructions/scripts/instruction-scan.s
 ```
 
 It emits `file:line:check-id` candidate rows for I6 (bare prohibitions lacking a rationale
-marker), I10 (reasoning-echo directives), the I8 families under per-family ids — `I8-a`
+marker), I10 (reasoning-echo directives), the I8 families under per-family ids: `I8-a`
 instructed self-check, `I8-b` conservative-reporting, `I8-c` don't-think / don't-reason (I8-c's
 tag-naming sub-detect is lane-only, not seeded, as are I8's base row and `I8-d` short-turn
 assumptions, whose phrasings are too varied for a pattern that would earn its false-positive rate;
-`I8-e` forced interim-status cadence is likewise unseeded, but on a narrower ground — its skeleton is
+`I8-e` forced interim-status cadence is likewise unseeded, but on a narrower ground: its skeleton is
 patternable, and it waits only on an attested instance to calibrate the interval forms against), I23
-(self-estimated context-budget phrasing — the budget clause alone, never the stop/summarize/hand-off
+(self-estimated context-budget phrasing, the budget clause alone, never the stop/summarize/hand-off
 verb it licenses, which routinely sits in a different sentence), I25 (retired sampling parameters),
 I27 (effort-for-brevity: an effort-lowering directive paired with a brevity token on one line), and
 the I28 families (`I28-a` forced-compliance emphasis, case-sensitive; `I28-b` blanket tool
 defaults); `--count` prints the row count.
-Advisory — a grep cannot judge whether a rationale is genuinely present, whether a restraint clause
+Advisory: a grep cannot judge whether a rationale is genuinely present, whether a restraint clause
 is a reporting gate, whether a budget mention is a directive or the counter-steer against one, or
 which model a row targets, so the lane refines every candidate against the catalog's fences and the
 run's resolved target model.
@@ -336,13 +336,13 @@ run's resolved target model.
 Bound concurrency to 3–5 lanes at a time; the skills surface fans out one lane per skill. Before the
 total dispatch count (lanes plus Phase C verifiers) would exceed ~20, confirm with the user.
 
-## Phase B2 — Cross-surface conflict pass
+## Phase B2: Cross-surface conflict pass
 
 Phase B judges each surface alone, so a contradiction spanning two surfaces is invisible to it. This
 pass supplies the missing unit: a **pair** of surfaces that both claim authority over one behavior and
 disagree. Every criterion, table and worked example lives in
 [reference/conflict-criteria.md](reference/conflict-criteria.md). **A scope filters findings, never
-reads** — B2 enumerates every surface `all` would collect and reports a pair when at least one anchor
+reads.** B2 enumerates every surface `all` would collect and reports a pair when at least one anchor
 is in scope; the criteria file states why.
 
 Seed it with the deterministic pre-scan over the inventoried files:
@@ -355,23 +355,24 @@ It emits `fileA:lineA|fileB:lineB|entity|flags` candidate pairs; `--count` print
 Advisory and always exit 0, so every row is refined against the criteria file's must-not-flag set.
 
 **The scan is a priority ordering, not the work list.** It only reaches directives naming a
-tool-shaped entity, so an ordinary pair — "Always run tests before committing" against "Never run
-tests" — emits nothing. Work the rows first, then read the surfaces for pairs it cannot shape-match.
+tool-shaped entity, so an ordinary pair such as "Always run tests before committing" against "Never run
+tests" emits nothing. Work the rows first, then read the surfaces for pairs it cannot shape-match.
 **A pass that reports only what the scanner emitted has not run this check.**
 
 **Detect the disagreement; do not adjudicate it:** name a winner only where the criteria file's
 precedence table cites a documented order, otherwise report `unresolved`. Its routing table governs
 what belongs to `claude-memory:audit`'s C6 instead.
 
-## Phase C — Verify pass
+## Phase C: Verify pass
 
 Every removal or rewrite proposal is re-judged before it reaches the report. Dispatch **fresh-context,
-non-fork** subagents — this is a self-grade of the audit's own proposals, so a fork that inherits the
-producing context would not be independent — prompted to refute: "would removing this instruction
+non-fork** subagents, since this is a self-grade of the audit's own proposals and a fork that inherits the
+producing context would not be independent, prompted to refute: "would removing this instruction
 cause Claude to make mistakes? Argue that it is still load-bearing." Where the removal call is
-high-stakes and correlated blind spots are the risk, prefer a cross-vendor advisor **when one is installed and set up** —
-e.g. the OpenAI Codex plugin, when its documented surface can take this artifact, invoked per its own docs — with
-the fresh-context same-vendor subagent as the stated fallback, never a route to a command that may not resolve
+high-stakes and correlated blind spots are the risk, prefer a cross-vendor advisor **when one is
+installed and set up**, e.g. the OpenAI Codex plugin, when its documented surface can take this
+artifact, invoked per its own docs, with the fresh-context same-vendor subagent as the stated
+fallback, never a route to a command that may not resolve
 (per `docs/PLUGIN-PHILOSOPHY.md` "Fresh-eyes checkpoints" in the marketplace repository).
 Batch one verifier per surface
 (not one per finding), counted under the same ~20-dispatch gate. A proposal the verifier defends is
@@ -379,7 +380,7 @@ demoted to `info` or dropped, never surfaced as a confident removal.
 
 **A conflict pair takes a different refutation**, because the removal prompt cannot falsify it: both
 sides are usually load-bearing, so "argue it is still needed" defends both and demotes the finding
-untested. Refute a pair on its own gates — *same observable, or two sharing a keyword? does any
+untested. Refute a pair on its own gates: *same observable, or two sharing a keyword? does any
 resident text already arbitrate? is there a prompt that fires both?* A defended pair is one where a
 gate fails, dropped for that named reason.
 
@@ -389,7 +390,7 @@ Phases B and C **require** fresh-context, non-fork subagent dispatch. When the A
 blocked, unavailable, or the session cannot spawn subagents:
 
 1. **Disclose in the report header** which phases ran inline, which were skipped, and why dispatch
-   was unavailable — a run that skipped verification MUST be structurally distinguishable from a
+   was unavailable. A run that skipped verification MUST be structurally distinguishable from a
    fully verified one.
 2. **Mark unverified proposals.** Every removal or rewrite that did not receive an independent
    verifier MUST carry an `(unverified)` marker in the findings table and MUST NOT be surfaced as a
@@ -397,7 +398,7 @@ blocked, unavailable, or the session cannot spawn subagents:
 3. **Extend the cost line.** The Phase D cost line MUST list phases that did not run and name the
    verification mode per surface (`verified` | `inline` | `skipped`).
 
-## Phase D — Report
+## Phase D: Report
 
 Persist the report to `${CLAUDE_PLUGIN_DATA}/audit-instructions/<state-key>/last-audit.md`, deriving
 `<state-key>` by running `bash "${CLAUDE_PLUGIN_ROOT}/lib/state-key.sh"` and using its output.
@@ -407,9 +408,9 @@ the two absent-prior cases.
 
 Then summarize in chat. The report header carries a **cost line**: how many checks ran per surface
 (naming any added by a catalog version bump), the model-scoped rows skipped for the resolved target,
-and the estimated per-surface token delta versus the previous catalog version **for this project** —
+and the estimated per-surface token delta versus the previous catalog version **for this project**,
 and it confirms the run added zero new interactive gates (report-only contract unchanged; the
-target-model fail-loud stop is an invocation-time validation abort, not an interactive gate — it
+target-model fail-loud stop is an invocation-time validation abort, not an interactive gate, since it
 prompts nobody and blocks nothing mid-run). Present findings as a table:
 
 | # | Check | Surface:Line | Severity | Tier | Authority | Finding | Proposed change |
@@ -419,19 +420,19 @@ Phase B2's findings carry two anchors, so they get their own **Cross-surface con
 
 For each finding, give the proposed removal or rewrite as a fenced diff block. Tier is `mechanical`
 (pattern-detectable) or `behavioral` (its ground truth is observed behavior); authority is the
-check's tag from the catalog. An I15 conflict finding names **both** participating locations — it is
+check's tag from the catalog. An I15 conflict finding names **both** participating locations, since it is
 a relation between two instructions, not a property of one line.
 
-**No-change findings are exempt from the diff contract.** Where a check forbids proposing an edit —
-the I15 managed-policy case, and any finding routed to an owning repository rather than applied —
+**No-change findings are exempt from the diff contract.** Where a check forbids proposing an edit,
+covering the I15 managed-policy case and any finding routed to an owning repository rather than applied,
 write `no change proposed` in the Proposed change column and, in place of the fenced diff, a one-line
 statement of who owns the resolution. Never manufacture a diff to satisfy the table; a check that
 forbids an edit and a report that demands one would otherwise contradict each other.
 
 Three sections the catalog's `OPINION` policy requires: the shadowed-definition `info` section (the
-live definition and the inert one, for shadowed skills and subagents — MCP servers are outside this
+live definition and the inert one, for shadowed skills and subagents, since MCP servers are outside this
 report's contract, per I15); a **Withheld** subsection naming every I6/I8 proposal the stopping
-condition suppressed and on what ground; and a one-line `OPINION` discovery note — how many
+condition suppressed and on what ground; and a one-line `OPINION` discovery note stating how many
 `OPINION`-tier checks were available, how many did not run, and the argument that enables them.
 
 End with a **Routing** subsection listing every excluded upstream-owned
@@ -439,14 +440,14 @@ or memory-layer surface and where its findings should go, and a **Recommended fo
 subsection: apply an accepted change, then observe whether Claude's behavior actually shifts;
 re-add on the next mistake as the compounding safety net; for example blocks, A/B against the
 no-example default. The full delete-and-watch loop is operationalized by `/claude-config:unhobble`
-(same plugin) — route there when the operator wants the experiment run rather than described.
+(same plugin); route there when the operator wants the experiment run rather than described.
 
 Open the Sources line with the two official pages the paths and doctrine derive from
 (code.claude.com memory + `.claude`-directory docs; the prompting pages cited per check in the
 catalog).
 
 **With `--persist-findings`**, also emit the run's I28 findings for the apply relay per
-[context/persist-findings.md](context/persist-findings.md) — it owns every mechanic and the
+[context/persist-findings.md](context/persist-findings.md), which owns every mechanic and the
 carve-out drop preceding the write. Report the path and the emitted/declined counts, and say
 plainly that nothing has been applied.
 
@@ -459,7 +460,7 @@ plainly that nothing has been applied.
   instead of what not to do"; adding a rationale is the fallback where a genuine hard "never"
   survives. Do not mechanically delete every prohibition the pre-scan flags.
 - **Behavioral findings ship as proposals, not confident cuts.** A narrow eval can miss a small
-  regression from an over-aggressive trim — that is why the verify pass and the delete-and-watch
+  regression from an over-aggressive trim, which is why the verify pass and the delete-and-watch
   loop exist. Never present a behavioral removal as certain.
 - **Windows shell.** The pre-scans are bash; on native Windows run them through Git Bash.
 - **A conflict pair needs two files.** Feeding `conflict-scan.sh` one surface at a time reproduces
@@ -467,16 +468,16 @@ plainly that nothing has been applied.
 
 ## What this skill does NOT do
 
-- Never edits an instruction file and never auto-files a tracker item — output is a report plus
+- Never edits an instruction file and never auto-files a tracker item; output is a report plus
   proposed diffs the human applies.
 - Not a token-brevity pass (`docs-hygiene:compress`) and not structural skill lint
   (`skill-quality:check`).
-- Not memory-layer hygiene — checks I1–I5 on CLAUDE.md/rules route to `claude-memory`'s `audit`
+- Not memory-layer hygiene: checks I1–I5 on CLAUDE.md/rules route to `claude-memory`'s `audit`
   skill when installed, and upstream-owned plugin-cache or managed materializations route to the
   owning repository rather than being edited here.
 - Does not grade a contradiction whose two halves both sit in the
-  **discover-instruction-surfaces** population — root-level project **or user** `CLAUDE.md` /
-  `CLAUDE.local.md` / rules, including **user↔project** pairs — that is `claude-memory:audit`'s C6.
+  **discover-instruction-surfaces** population, namely root-level project **or user** `CLAUDE.md` /
+  `CLAUDE.local.md` / rules, including **user↔project** pairs. That is `claude-memory:audit`'s C6.
   A **nested** `CLAUDE.md` / `CLAUDE.local.md` side, an auto-memory side, or any surface outside that
   population keeps the pair here;
   [reference/conflict-criteria.md](reference/conflict-criteria.md) owns the routing table and its

--- a/plugins/claude-config/skills/audit-pass/SKILL.md
+++ b/plugins/claude-config/skills/audit-pass/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: "Run ONE coordinated, ordered, resumable pass over a named target repository: a three-scope inventory first (managed policy read-only, user scope routed as recommendations, project scope), then delegated checks lane by lane, findings persisted per lane so an interrupted run resumes instead of restarting, and one human gate for the whole pass instead of one per skill. Adds run semantics, not checks — every check belongs to the plugin that owns it and is invoked presence-gated. Read-only on bare invocation; edits only behind an explicit --fix override, and never to managed policy or user-scope files. Use when: 'audit pass', 'run one pass over this repo', 'coordinate the audit skills', 'audit this repo end to end', 'resume the audit', 'one reconciled findings report', 'sweep all three scopes', or before a release that needs a single diffable findings artifact."
+description: "Run ONE coordinated, ordered, resumable pass over a named target repository: a three-scope inventory first (managed policy read-only, user scope routed as recommendations, project scope), then delegated checks lane by lane, findings persisted per lane so an interrupted run resumes instead of restarting, and one human gate for the whole pass instead of one per skill. Adds run semantics, not checks: every check belongs to the plugin that owns it and is invoked presence-gated. Read-only on bare invocation; edits only behind an explicit --fix override, and never to managed policy or user-scope files. Use when: 'audit pass', 'run one pass over this repo', 'coordinate the audit skills', 'audit this repo end to end', 'resume the audit', 'one reconciled findings report', 'sweep all three scopes', or before a release that needs a single diffable findings artifact."
 argument-hint: "[target] [--fix] [--opinion] [--resume] [--report-to <path>]"
 user-invocable: true
 disable-model-invocation: false
@@ -12,7 +12,7 @@ metadata:
 ## Purpose
 
 One bounded, ordered pass over a target repository's Claude Code **instruction** surface, coordinated
-across three scopes and resumable mid-run. It **adds no criteria of its own** — every check is
+across three scopes and resumable mid-run. It **adds no criteria of its own**: every check is
 delegated to the plugin that owns it. What it contributes is what invoking those skills by hand
 yields none of: a three-scope inventory before any check runs, a run-time-derived exclusion set,
 stable finding identity, suppression memory, incremental persistence and resume, and one human gate
@@ -24,16 +24,16 @@ Bare invocation reads and reports. `--fix` is the only mutation path, and it is 
 
 | Scope | Posture under `--fix` |
 |---|---|
-| Managed policy | **Never remediated.** Read-only in every mode. A finding here reports "conflicts with org policy at `<path>`" and proposes no edit to either side — seeking a policy exception is an organizational decision, not a linting one. |
+| Managed policy | **Never remediated.** Read-only in every mode. A finding here reports "conflicts with org policy at `<path>`" and proposes no edit to either side; seeking a policy exception is an organizational decision, not a linting one. |
 | User | **Routed as a recommendation, never edited in place.** A user-scope tree is commonly managed by a dotfiles manager, so an in-place edit is drift the operator's own sync path will fight. |
 | Project | The only editable scope, per-finding confirmed. |
 
 The frontmatter carries it mechanically too: `disallowed-tools: Edit, NotebookEdit` removes both
 editing tools from the pool while this skill is active, so the report-only contract is a property of
-the tool set, not of model obedience. `Write` is kept — run state and the report persist under
+the tool set, not of model obedience. `Write` is kept, since run state and the report persist under
 `${CLAUDE_PLUGIN_DATA}`.
 
-**`scripts/run-state.sh` writes under that same plugin data directory and nowhere else** — never
+**`scripts/run-state.sh` writes under that same plugin data directory and nowhere else**, never
 inside a target repository. It takes the data directory as an argument rather than discovering one,
 and validates both path segments it contributes: `lib/state-key.sh` refuses a remote URL that would
 become traversing directory components, and a `--run-id` outside `[A-Za-z0-9][A-Za-z0-9_.-]*` is
@@ -53,14 +53,14 @@ them.
 
 Parse `$ARGUMENTS`:
 
-- **`target`** — the git repository to audit. Default: the project root Claude Code resolved for this
+- **`target`**: the git repository to audit. Default: the project root Claude Code resolved for this
   session; where no such root is available, `git rev-parse --show-toplevel`. Never the working
-  directory — a run launched from a subdirectory must key and scan identically to one launched from
+  directory, since a run launched from a subdirectory must key and scan identically to one launched from
   the root.
 
   **Do not express this as a condition over `${CLAUDE_PROJECT_DIR}` "when set".** That placeholder is
   substituted inline in skill content before this file reaches you, so the literal token is never
-  visible and the test is not yours to make — you would be deciding "is it set?" about a value that
+  visible and the test is not yours to make. You would be deciding "is it set?" about a value that
   has already been resolved. Work from what you can observe: the resolved path, or a command you run.
   The sibling `audit-prompting-postures` states this same rule where it derives its report path, and
   the two skills contradicted each other on it until this was fixed.
@@ -69,25 +69,25 @@ Parse `$ARGUMENTS`:
   delegated interfaces accept no target: `audit-instructions` takes a surface scope and inventories
   the active project, and `claude-memory:audit` takes an action verb. This pass dispatches skills and
   never reads inside one, so there is no channel through which it could tell a delegate to look
-  elsewhere — a run given `../other-repo` would key, lock, and report against that path while every
+  elsewhere. A run given `../other-repo` would key, lock, and report against that path while every
   delegated finding came from the active project. Findings attributed to the wrong repository are
   worse than a refusal, because nothing downstream can detect the mismatch.
 
   So the argument is validated rather than silently reinterpreted: a `target` that does not resolve
   to the active project root exits non-zero, naming both paths and the reason. Auditing another
   repository means opening it as the project. Lifting the restriction is a change to the
-  **delegated** interfaces — each would have to accept and honor a target root — and belongs to
+  **delegated** interfaces, each of which would have to accept and honor a target root, and belongs to
   those skills rather than this one. The argument itself survives because the state key, the lock,
   and the report are already keyed on the resolved root.
 
   **The gate enforces both halves of that first sentence: the active project root, *and* a git
-  repository.** A `target` that is not inside a git repository is refused the same way — non-zero,
+  repository.** A `target` that is not inside a git repository is refused the same way: non-zero,
   before Phase 0 does any work, naming the path and the reason, writing nothing.
 
   **Name the directory, not an empty string.** In the case this refusal is *for*, the default
   resolution above produces nothing: with no explicit `target` and no session-resolved project root,
   `git rev-parse --show-toplevel` fails outside a repository and there is no resolved root to report.
-  So for the diagnostic only, fall back to the current directory and name **that** — a refusal that
+  So for the diagnostic only, fall back to the current directory and name **that**. A refusal that
   cannot say which path it refused is barely better than a silent one. The fallback is for the message;
   it never becomes a target.
   Requiring only "the active project root" let a non-git directory through into a contract with no
@@ -99,20 +99,20 @@ Parse `$ARGUMENTS`:
     fallback;
   - assertion 2.1 is stated over `git status --porcelain`, so the top read-only assertion is
     unevaluable;
-  - and — the one that is a permanent capability loss rather than a missing derivation — **only the
+  - and, the one that is a permanent capability loss rather than a missing derivation, **only the
     team layer enacts a suppression**, and the team layer is the *tracked* layer. With nothing
     tracked, no suppression is ever enactable on such a target, so an operator could accept a finding
     and have the acceptance silently fail to persist, forever.
 
   **The refusal says that cost out loud** rather than reading as an arbitrary restriction, and it names
   the suppression consequence in particular. Refusing closes a target class deliberately; it is not a
-  side effect. The alternative — specifying all four branches — was considered and rejected, because
+  side effect. The alternative, specifying all four branches, was considered and rejected, because
   the last of them obliges the contract to promise a capability it can never deliver on that class.
   A non-git directory is audited by opening it as a repository, or by the delegated skills directly.
-- **`--fix`** — the explicit mutation override. Absent, the pass writes nothing into the target.
-- **`--opinion`** — run the `OPINION`-tier checks the delegated catalogs declare default-off.
-- **`--resume`** — resume the most recent incomplete run for this target's state key.
-- **`--report-to <path>`** — redirect the report into the target tree. The destination is accepted only
+- **`--fix`**: the explicit mutation override. Absent, the pass writes nothing into the target.
+- **`--opinion`**: run the `OPINION`-tier checks the delegated catalogs declare default-off.
+- **`--resume`**: resume the most recent incomplete run for this target's state key.
+- **`--report-to <path>`**: redirect the report into the target tree. The destination is accepted only
   if it is an `audit-pass`-owned report or a new path that is **not a recognized instruction surface**;
   anything else is refused non-zero, naming the file. Refused on name rather than on existence,
   because `--report-to CLAUDE.md` against a repo that has none would *create* a live instruction
@@ -120,16 +120,16 @@ Parse `$ARGUMENTS`:
 
   **The self-exclusion obligation is not this flag's.** It belongs to the predicate
   `report_path ⊆ target_root`: **any** run whose resolved report path is contained in the target adds
-  that path to its own exclusion set before writing — not only for later runs, or the two runs' derived
-  sets could not be equal — and says so in its output. `--report-to` is one way containment arises. The
+  that path to its own exclusion set before writing, not only for later runs, since otherwise the two
+  runs' derived sets could not be equal, and says so in its output. `--report-to` is one way containment arises. The
   **default** path is another, because `${CLAUDE_PLUGIN_DATA}` resolves under `~` and is inside any
   target at or above it. Full statement in
   [reference/report-location-and-schema.md](reference/report-location-and-schema.md) §2 and
   [reference/exclusion-set.md](reference/exclusion-set.md) Class 4.
 
-## Phase 0 — Resolve, key, lock
+## Phase 0: Resolve, key, lock
 
-Resolve the target root, compute the state key, and take the lock posture for the mode — read-only
+Resolve the target root, compute the state key, and take the lock posture for the mode. Read-only
 runs take no lock and run concurrently; an applying run takes an exclusive advisory lock and refuses
 rather than queues. All specified in
 [reference/run-state-and-resumability.md](reference/run-state-and-resumability.md). With `--resume`,
@@ -146,19 +146,19 @@ bash "$S" paths --plugin-data "$D" --run-id "<run-id>"
 bash "$S" lease acquire --run-dir "<run-dir>" --run-id "<run-id>" --plugin-data "$D"
 ```
 
-`paths` derives `<plugin-data>/runs/<state-key>/<run-id>` through the plugin's own `lib/state-key.sh`
-— the library whose header records the keying scheme as *this skill's*, and which until now three
+`paths` derives `<plugin-data>/runs/<state-key>/<run-id>` through the plugin's own `lib/state-key.sh`,
+the library whose header records the keying scheme as *this skill's*, and which until now three
 other skills called and this one did not. Pass `--plugin-data` explicitly: `${CLAUDE_PLUGIN_DATA}`
 substitutes in this text but is **not** exported to the Bash tool's environment, so a shell cannot
 expand it. `acquire` takes it too, and refuses a `--run-dir` that is not under
-`<plugin-data>/runs/` — it is the only command that *creates* a directory, so it is where the write
+`<plugin-data>/runs/`. It is the only command that *creates* a directory, so it is where the write
 tree is pinned; a wrong or invented run dir would otherwise be created and written into.
 
 **`--resume` never attaches to a run that is still going.** Concurrent read-only runs are safe
 because each owns its own partial artifact; resume is the one operation that reaches into *another*
 run's artifact, so the no-lock policy that makes concurrency safe is exactly what leaves resume
 unable to tell a live run from an interrupted one. Both would then append lane attempts and
-terminating records to one file, and highest-terminated-attempt assembly becomes race-dependent —
+terminating records to one file, and highest-terminated-attempt assembly becomes race-dependent,
 the interruption-tolerance mechanism producing a report neither run performed.
 
 So every active run, read-only included, maintains a **lease**, and `--resume` reads it before it
@@ -166,31 +166,31 @@ reads the partial. `run-state.sh lease classify --run-dir <run-dir>` prints the 
 a **live** lease means the run is still going, and resume exits non-zero naming the run id rather
 than attaching; a **stale** lease means the run was interrupted and its artifact is resumable; a
 `released` tombstone is resumable immediately; `missing` means there is nothing to attach to. The
-lease is not a lock — it excludes nothing, blocks no concurrent read-only run, and grants no
+lease is not a lock: it excludes nothing, blocks no concurrent read-only run, and grants no
 exclusivity; it answers the one question resume has to ask and previously could not.
 
 Refresh it at every lane's persistence point (`lease heartbeat`) and write the tombstone on a clean
-exit (`lease release`). The full specification — path, contents, the two-sided liveness window, and an
-explicit statement of **which clauses the script enforces and which remain the run's own discipline**
-— is in [reference/run-state-and-resumability.md](reference/run-state-and-resumability.md) §3. Read
+exit (`lease release`). The full specification, covering path, contents, the two-sided liveness window, and an
+explicit statement of **which clauses the script enforces and which remain the run's own discipline**,
+is in [reference/run-state-and-resumability.md](reference/run-state-and-resumability.md) §3. Read
 that split before relying on any of it: the section specified a refresh interval and a staleness
 threshold against no writer at all, which is the same shape as "on the same heartbeat the applying
-lock uses" — a mechanism named rather than provided.
+lock uses", a mechanism named rather than provided.
 
 **The scan baseline is captured after the inventory is frozen and before any lane reads.** The
 digest spans every inventoried scope, so it cannot be computed before Phase 1 has produced that
-inventory — taking it at the top of Phase 0 would either omit the user and managed surfaces, which
+inventory. Taking it at the top of Phase 0 would either omit the user and managed surfaces, which
 are exactly the mid-run external edits the gate exists to detect, or force an unspecified second
-inventory. So Phase 0 resolves, keys, and locks; Phase 1 freezes the inventory; the **scan baseline**
-— the target's HEAD commit and the run's state digest — is taken at that boundary, and the matching
+inventory. So Phase 0 resolves, keys, and locks; Phase 1 freezes the inventory; the **scan baseline**,
+the target's HEAD commit and the run's state digest, is taken at that boundary, and the matching
 **audit endpoint** capture is taken when the last lane completes, before any Phase 5 mutation.
 
 Baseline to endpoint is therefore exactly the window in which lanes read, which is what the
-determinism gate is a claim about — a run that never measures it cannot claim it held. The digest
+determinism gate is a claim about: a run that never measures it cannot claim it held. The digest
 pairs each path with a hash of its current content, because a *count* holds still while a dirty
 file's contents change underneath the run.
 
-## Phase 1 — Three-scope inventory, before any check
+## Phase 1: Three-scope inventory, before any check
 
 **Nothing is checked until all three scopes are inventoried.** A project-only inventory cannot see a
 project-versus-user conflict, so a fix from one would be applied against half the picture.
@@ -198,27 +198,27 @@ Native-first: the filesystem walk produces a **candidate** set, never the answer
 
 **Liveness has two ground-truth sources, and neither alone covers the surface set.**
 `InstructionsLoaded` payloads name exactly which instruction files loaded and through which parent,
-but only for the memory layer (`CLAUDE.md`, `.claude/rules/*.md`); `/context` covers what that misses
-— Skills, Custom Agents, MCP Tools — and is where launch-directory dependence becomes visible. Take
+but only for the memory layer (`CLAUDE.md`, `.claude/rules/*.md`); `/context` covers what that misses,
+namely Skills, Custom Agents and MCP Tools, and is where launch-directory dependence becomes visible. Take
 **both** and report a disagreement rather than picking a winner; a single-source design under-covers
 silently, and under-coverage reads as a clean report. **Neither observes `managed-settings.json`'s
-`claudeMd` key** — a limitation of these two sources, not a claim about the harness: probe for it and
+`claudeMd` key**, a limitation of these two sources rather than a claim about the harness: probe for it and
 name it in `skipped`. Then `/memory`, `/skills`, `/hooks`, `/mcp`, `/permissions`, `/status`, and
 `claude --safe-mode` with a relocated `CLAUDE_CONFIG_DIR` for a clean-room comparison.
 
 **`InstructionsLoaded` is normally UNAVAILABLE, and the run says so rather than requiring it.** This
 plugin wires no `InstructionsLoaded` hook, the only producer in this marketplace
 (`claude-ops/hooks/instructions-loaded-audit.sh`) is optional, is a no-op without a telemetry sink,
-and drops `session_start` events by default — and the startup events this skill would need have
+and drops `session_start` events by default, and the startup events this skill would need have
 already fired before it is invoked, so there is nothing to subscribe to at dispatch time even where a
 producer exists. Requiring data the plugin never records would make the memory-layer liveness
 inventory unbuildable in the ordinary installation, which is the one every first operator has.
 
 So the source is **probed, not assumed**, and its absence is a reported state rather than a failure:
 
-- **Present** — a recorded payload set for this session exists and is fresh — take it as ground truth
+- **Present**, meaning a recorded payload set for this session exists and is fresh: take it as ground truth
   for the memory layer, as specified above.
-- **Absent** — the ordinary case — report `InstructionsLoaded: unavailable` in `skipped`, naming the
+- **Absent**, the ordinary case: report `InstructionsLoaded: unavailable` in `skipped`, naming the
   capture prerequisite that would supply it. `/context` alone then carries the memory layer, and
   every memory-layer liveness claim in the report is marked **single-sourced**, because the whole
   reason for two sources is that neither covers the set alone.
@@ -235,28 +235,28 @@ fails the determinism property rather than looking like an improvement.
 **Output styles are the case a walk alone cannot get right.** They modify the system prompt directly,
 a custom one drops the built-in software-engineering instructions unless
 `keep-coding-instructions: true`, and a
-plugin's `force-for-plugin` "overrides the user's `outputStyle` setting" — so a walk plus settings
+plugin's `force-for-plugin` "overrides the user's `outputStyle` setting", so a walk plus settings
 reports a selection as live when it is not ([output styles](https://code.claude.com/docs/en/output-styles),
 verified 2026-08-04). Report the resolved live style and what resolved it.
 
 **Shadowed definitions fall out of this inventory, not out of a catalog.** Skills, subagents, and MCP
 servers override *by name*: where two share a name across scopes, exactly one is live. That is name
-comparison across a fixed precedence order — deterministic, model-free, derived tier — reported at
+comparison across a fixed precedence order, deterministic, model-free and derived tier, reported at
 `info` in its own section naming the live definition and the shadowed one. It is not a conflict
 finding and is never merged into one.
 
-## Phase 2 — Derive the exclusion set
+## Phase 2: Derive the exclusion set
 
 **Derived at run time from the target's own state. Never transcribed, and no count of any class is
-ever carried in this skill** — a count written down is wrong on the next commit and wrong in every
+ever carried in this skill.** A count written down is wrong on the next commit and wrong in every
 other repository. Four classes: registered byte-identical cluster copies, vendored upstream
 materializations, worktrees, and the pass's own artifacts. Each class's derivation, its fallback on a
 failed read, and the hard error when a suppression targets an excluded path are in
 [reference/exclusion-set.md](reference/exclusion-set.md).
 
-## Phase 3 — Lanes and dispatch
+## Phase 3: Lanes and dispatch
 
-**A lane is one delegated invocation at the finest filter that skill's own interface accepts** — the
+**A lane is one delegated invocation at the finest filter that skill's own interface accepts**, the
 granularity the pass can actually dispatch, since it invokes skills and never reaches inside one. A
 finer lane is unbuildable, not merely inconvenient: per-lane persistence, input digests, and
 selective resume all key on something the pass can re-invoke on its own.
@@ -264,37 +264,37 @@ selective resume all key on something the pass can re-invoke on its own.
 So the split falls out of the delegated interfaces rather than being asserted over them: a skill
 taking a **surface-class filter** yields one lane per filter value it is given, and a skill taking
 only an action verb yields **one lane** covering everything it audits. Where a skill runs its whole
-catalog per invocation, the lane carries that whole catalog — the pass never splits a catalog it
+catalog per invocation, the lane carries that whole catalog; the pass never splits a catalog it
 cannot address. Extending a delegated interface to accept a finer filter is a change to that skill,
 and until it lands the lane stays at the coarser grain.
 
-Dispatch, in inventory order — every skill below is invoked via the Skill tool — each invocation
+Dispatch, in inventory order, with every skill below invoked via the Skill tool, each invocation
 presence-gated with its fallback stated:
 
-- **`/claude-config:audit-instructions`** — sibling in this plugin, always available. Carries the
+- **`/claude-config:audit-instructions`**: sibling in this plugin, always available. Carries the
   model-capability catalog over every non-memory surface, and the cross-surface conflict check. It
   takes a **surface-class scope**, so the per-class values yield **one lane per scope value
   dispatched**, each running that skill's per-surface catalog over that class. Its conflicts come
-  back as **one finding carrying two sites**, never two linked findings — a contradiction is retired
+  back as **one finding carrying two sites**, never two linked findings, since a contradiction is retired
   by fixing either side, so the sides are not independently correctable.
 
   **The conflict pass is dispatched exactly once, as its own lane, via that skill's `conflicts`
-  scope — never once per surface class.** Its unit is a *pair*, and its Phase B2 reports a pair
+  scope, never once per surface class.** Its unit is a *pair*, and its Phase B2 reports a pair
   whenever **at least one** anchor falls in the requested scope, so a conflict spanning a skill body
   and an agent definition would be returned by the `skills` lane *and* the `agents` lane. Both would
   carry the same identity, and the partial-log contract assembles per lane with no cross-lane
   ownership rule, so the finding would land in the report twice. Its own scope makes every pair
-  belong to exactly one lane by construction rather than needing a deduplication rule downstream —
+  belong to exactly one lane by construction rather than needing a deduplication rule downstream,
   and the per-class lanes drop the pair check, since dispatching it there is what created the
   overlap.
-- **`/claude-config:audit-permission-state`** — sibling in this plugin, always available. It owns the
+- **`/claude-config:audit-permission-state`**: sibling in this plugin, always available. It owns the
   permission plane as it is *in effect*: the merged allow/ask/deny set with per-rule provenance,
   what auto mode drops on entry, configuration written where nothing reads it, and which managed
   intents are enforced versus loosenable. It takes an **action flag and no target**, so it is
   **exactly one lane** covering all of that.
 
   **Its managed-scope reads belong to the pass's read-only managed inventory, not to a project lane.**
-  It reads managed policy on every OS and never writes anywhere, in any scope, under any flag — so it
+  It reads managed policy on every OS and never writes anywhere, in any scope, under any flag, so it
   is safe to dispatch under the pass's bare invocation. Its `--oracle` path spawns a real session and
   is **never dispatched here**: the pass has no way to price that for the operator mid-run, and the
   flag exists to make the cost an explicit choice.
@@ -302,71 +302,71 @@ presence-gated with its fallback stated:
   **Its optional lanes degrade rather than fail.** The `autoMode` block lane needs `python3` and
   `claude` on PATH; absent either, that lane self-reports as skipped and the rest of the skill still
   runs. Carry that skip into the report as **unchecked with its reason**, exactly as an absent plugin
-  would be — the distinction between "clean" and "not read" is this skill's whole contract and the
+  would be. The distinction between "clean" and "not read" is this skill's whole contract and the
   pass must not collapse it.
-- **`/claude-memory:audit`** — invoke when the `claude-memory` plugin is installed; it owns
+- **`/claude-memory:audit`**: invoke when the `claude-memory` plugin is installed; it owns
   memory-layer hygiene and the within-memory-layer consistency check. It takes an **action verb and
   no surface filter**, so it is **exactly one lane** covering the whole memory layer. Not installed:
   the pass reports both as **unchecked**, names that skill as their owner, and emits the one-line
-  pointer to the official memory guidance — never a silent skip, never a re-implementation here.
+  pointer to the official memory guidance, never a silent skip and never a re-implementation here.
 
 Structural skill lint is deliberately **not** dispatched: it answers shape rather than content, and
 its fan-out over a large corpus would consume the dispatch budget reserved for instruction-content
 lanes. Route it out (`skill-quality:check` when installed).
 
 Persist each lane's findings to the partial artifact **as that lane completes**, never buffered to
-the end — a lane is complete when its terminating record is in the partial, and every record carries
+the end. A lane is complete when its terminating record is in the partial, and every record carries
 its attempt id so an abandoned re-attempt is discardable rather than merely older. The write is one
-call per record — `bash "$S" partial append --run-dir "<run-dir>" --record '<json-line>' --epoch
-"<held>"` — and the lease is refreshed at the same boundary. A lease must exist, so a record resume
+call per record, `bash "$S" partial append --run-dir "<run-dir>" --record '<json-line>' --epoch
+"<held>"`, and the lease is refreshed at the same boundary. A lease must exist, so a record resume
 could not attribute to a live-or-abandoned run is never written. **Pass the epoch you hold**: the
 filename is the writer's epoch, not whatever the lease now carries, which keeps a fenced writer's rows
 out of its adopter's file. The record is validated as well-formed single-line JSON rather than sniffed
-by its first character — a malformed row here is permanent, and resume is its only reader.
+by its first character, because a malformed row here is permanent and resume is its only reader.
 
 **Exit 3 means FENCED: stop this run.** The record was written safely to your own epoch file, but the
 lease has moved on and another run has adopted the artifact, so continuing dispatches lanes whose
 output nothing will assemble. Stop and report the run as superseded. Never retry the append, and never
 read that exit as transient.
 
-**The lane count is bounded by the delegated interfaces, not chosen here** — one per scope value the
-instruction catalog accepts, plus one for the memory layer — so it is a handful, and a per-run
+**The lane count is bounded by the delegated interfaces, not chosen here**, at one per scope value the
+instruction catalog accepts plus one for the memory layer, so it is a handful, and a per-run
 dispatch ceiling would never bind. What is *not* bounded here is the fan-out inside a lane: the
 delegated catalogs spawn their own subagents, and this pass cannot reach inside one to cap it. So cap
-concurrency at 3–5 lanes and let incremental persistence carry the rest — it is what degrades a blown
+concurrency at 3–5 lanes and let incremental persistence carry the rest. It is what degrades a blown
 session ceiling into a resumed run.
 
 **That mitigation now names something that exists.** "Let incremental persistence carry the rest" was
 the load-bearing answer to the *one* cost dimension this passage declines to bound, and until
-`run-state.sh` shipped the persistence it named was prose — so an intra-lane overrun, the failure
+`run-state.sh` shipped the persistence it named was prose, so an intra-lane overrun, the failure
 mode this paragraph is explicitly about, degraded into nothing resumable. The `partial append` call
 above **bounds nothing**, and the disclaimer stands unchanged; what it buys is that an overrun costs
 the lanes still running rather than the whole pass.
 
-## Phase 4 — The `/doctor` handoff
+## Phase 4: The `/doctor` handoff
 
 `/doctor` owns the `CLAUDE.md` trim-and-migrate half, for which this pass deliberately builds no
-replacement. **It is interactive, so it is never dispatched** — it proposes fixes only after the
+replacement. **It is interactive, so it is never dispatched**: it proposes fixes only after the
 operator confirms. Its version floor, what its presence check verifies versus what it must probe
 rather than assume, and its optional-capability absence classification are in
 [reference/doctor-handoff.md](reference/doctor-handoff.md). When absent, name it as the missing
 capability and state what goes unchecked.
 
 **Phase 4 records the handoff; it does not stop the pass.** Emitting the instruction and halting here
-meant a `--fix` run never reached Phase 5 and *no* run reached the Phase 6 report — so the presence
+meant a `--fix` run never reached Phase 5 and *no* run reached the Phase 6 report, so the presence
 of an optional collaborator cancelled the coordinated pass that is this skill's entire purpose,
 leaving the operator worse off than if `/doctor` had been absent. It also contradicted
 `reference/doctor-handoff.md`, which says to finish the pass's own phases first.
 
 So Phase 4 opens the `delegated` lane, records the instruction in the report, and continues. Phases 5
 and 6 run normally, and the assembled report carries the handoff as an outstanding item with its lane
-marked `open` — routed and not yet returned. The operator runs `/doctor` when they choose; a later
+marked `open`, routed and not yet returned. The operator runs `/doctor` when they choose; a later
 `--resume` closes that lane by re-prompt rather than re-scan, because nothing about it needs the
 sweep to run again.
 
 **`open` is an assembly terminator, not a completion.** The two are distinct and conflating them
 would have made the promised resume impossible: §7 needs a terminating record to assemble a report at
-all, while §5 skips any lane whose state is complete and whose digest is unchanged — so a lane that
+all, while §5 skips any lane whose state is complete and whose digest is unchanged, so a lane that
 was both terminated *and* complete would be carried forward untouched on every resume, and the
 outstanding handoff would never close. So the record terminates the attempt for assembly and marks
 the lane's state **incomplete**. `--resume` therefore re-runs it, which for a delegated lane means
@@ -376,16 +376,16 @@ not.
 **That instruction to the operator is only true if the terminating record is actually written.**
 `--resume` reads the partial, not the report, so a report telling the operator to come back with
 `--resume` against a partial nothing wrote is a false instruction in the one artifact they act on. So
-the `open` terminator goes through `partial append` at the moment Phase 4 records the handoff — never
+the `open` terminator goes through `partial append` at the moment Phase 4 records the handoff, never
 deferred to Phase 6 assembly, which is exactly where a run that does not reach Phase 6 loses it.
 
-## Phase 5 — Apply, only under `--fix`
+## Phase 5: Apply, only under `--fix`
 
 Per-finding confirmation, project scope only, bounded by the table above. Refuse and name the
 canonical source if a fix or a suppression would write into a derived-exclusion path.
 
 The apply-verify step judges work this same run produced, so it is delegated: hand the applied diff
-and the finding it claims to resolve — the artifact, not this run's reasoning — to a cross-vendor
+and the finding it claims to resolve, the artifact rather than this run's reasoning, to a cross-vendor
 advisor when one is installed and set up (the OpenAI Codex plugin, say, invoked per its own docs),
 with a **fresh-context (non-fork) subagent** as the stated fallback.
 
@@ -401,43 +401,43 @@ When the Agent tool is blocked, unavailable, or the session cannot spawn subagen
 3. **Do not silently complete.** The `skipped` section and report header MUST name dispatch
    unavailability when it prevented a mandated verification phase.
 
-## Phase 6 — Report
+## Phase 6: Report
 
 Two artifacts, because incremental persistence and a sectioned report want different shapes: an
 append-only `findings.partial.<owner_epoch>.jsonl` during the run, assembled into `findings.json` at
-the end — epoch-scoped so a fenced writer cannot interleave into its adopter's file, with assembly
+the end, epoch-scoped so a fenced writer cannot interleave into its adopter's file, with assembly
 reading only the highest epoch present. Both schemas, the identity-versus-presentation field split,
 and the sections are in
 [reference/report-location-and-schema.md](reference/report-location-and-schema.md); the tier
 memberships are in [reference/determinism-tiers.md](reference/determinism-tiers.md). Tiers stay in
 separate sections because their guarantees differ. Every run also emits, in **one line**, how many `OPINION`-tier checks were
-available, how many were not run, and the argument that enables them (`--opinion`) — without it the
+available, how many were not run, and the argument that enables them (`--opinion`). Without it the
 tier ships unreachable.
 
 ## The suppression record
 
 A deliberately-kept finding is recorded at `.claude/audit-pass.md` in the target repository, layered
-per the config-cascade convention. **It is the only suppression mechanism — there is no inline
+per the config-cascade convention. **It is the only suppression mechanism, and there is no inline
 marker**, at any target: a marker would have to carry the same constituents, could not express a
 two-site finding at all, and would write into a tree the pass must leave clean. An entry stores the
-finding's **constituents** — `check`, `claim`, every `(surface, anchor)` site — under the
+finding's **constituents**, meaning `check`, `claim`, and every `(surface, anchor)` site, under the
 `finding_id` derived from them, never a bare id: an id is a one-way hash, so a record built on one
 cannot compute a tiered match. Keys, layer merge, precedence inversion, and the four entry
 dispositions are in [reference/suppression.md](reference/suppression.md); the cross-consumer key
 contract is this marketplace's separately published **finding-suppression** convention.
 
 **Only the team layer enacts a suppression.** A personal entry for an id the team layer does not
-carry is reported as `personal-only, not applied` rather than applied — absence from the team layer
+carry is reported as `personal-only, not applied` rather than applied, since absence from the team layer
 is the team's *unsuppressed* state, so honoring a personal-only entry would hide a finding the team
 never accepted. A suppression is a decision about the repository, so it belongs in the layer the
 repository tracks; a personal layer drafts one for promotion.
 
 Two report obligations. Every entry names its reason, its date, and **which cascade layer supplied
-it**. And **only an exact match is silent** — a one-sided anchor change carries forward as
+it**. And **only an exact match is silent**: a one-sided anchor change carries forward as
 `needs-reconfirmation`, a deeper change closes the old entry and opens the new finding, and a
 vanished finding must be accounted for as a fix, a successor, a **retirement with its check** when
 the check that raised it is absent or renamed in this run's detection configuration, or an
-**unexplained disappearance that fails the self-check** — the only detector the convergence property
+**unexplained disappearance that fails the self-check**, the only detector the convergence property
 has. Retirement is a reported disposition, not an exemption: it names the retiring check and the
 version transition, because letting findings vanish silently on a catalog edit is the exact shape
 this accounting exists to detect.
@@ -446,12 +446,12 @@ this accounting exists to detect.
 
 <!-- fresh-eyes-exempt: deterministic-gate -- the tolerance comparison is set arithmetic over two runs' identity sets; its pass/fail IS the verdict and no judgment enters it -->
 **Establish the precondition first.** If HEAD or the state digest moved between the **scan-baseline**
-and **audit-endpoint** captures — or if two lanes recorded different content for a path they share — the
+and **audit-endpoint** captures, or if two lanes recorded different content for a path they share, the
 tree did not hold still and the gate reports **`indeterminate`**, never `passed`. A shared checkout
 is the normal case, and an unfalsifiable pass manufactures confidence out of a basis nobody measured.
 
 **The audit endpoint is taken before Phase 5, not after it.** Under `--fix`, Phase 5 edits project
-files *by design*, so an endpoint captured after it necessarily differs from Phase 0 — which would
+files *by design*, so an endpoint captured after it necessarily differs from Phase 0, which would
 mark **every successful mutating run** `indeterminate` and skip P1–P3, the gate firing hardest on
 runs that did exactly what was asked. What the precondition is about is whether the tree held still
 *while the lanes were reading it*, and that window closes when the last lane completes. So the
@@ -466,7 +466,7 @@ the determinism one.
 
 When it held, any derived-tier inequality is a defect, and judged-tier growth beyond the tolerance in
 [reference/determinism-tiers.md](reference/determinism-tiers.md) **fails the self-check as an
-instability finding against this skill**, naming the checks that moved — never absorbed by
+instability finding against this skill**, naming the checks that moved, never absorbed by
 recalibration.
 
 ## Gotchas
@@ -476,7 +476,7 @@ recalibration.
   claims to hold belongs to the canonical source. Refuse; name that source.
 - **A whole-surface (`s:`) suppression survives every edit to the file and dies on a rename.** Not a
   bug: a finding about a file *as a whole* must not be retired by editing a line inside it.
-- **A judged finding does not contribute to the determinism gate — the norm, not a weakness.** Every
+- **A judged finding does not contribute to the determinism gate, which is the norm rather than a weakness.** Every
   delegated check passes through model refinement first; the gate belongs to the derived tier.
 - **Never propose an `@path` import as a context saving.** Splitting into imports "helps organization
   but doesn't reduce context, since imported files load at launch"
@@ -489,7 +489,7 @@ recalibration.
   defect this skill's whole shape exists to avoid.
 - Never reads another plugin's files. Cross-plugin cooperation is invocation only.
 - Never edits managed policy or a user-scope file, in any mode.
-- Never scans what it wrote. Where its resolved report path is contained in the target — by
-  `--report-to`, or by `${CLAUDE_PLUGIN_DATA}` resolving under `~` for a target at or above it — the
+- Never scans what it wrote. Where its resolved report path is contained in the target, by
+  `--report-to` or by `${CLAUDE_PLUGIN_DATA}` resolving under `~` for a target at or above it, the
   path is excluded before the write and the containment is disclosed. Never silently.
 - Never audits a target that is not a git repository. It refuses, and says what the refusal costs.

--- a/plugins/claude-config/skills/audit-permission-grants/SKILL.md
+++ b/plugins/claude-config/skills/audit-permission-grants/SKILL.md
@@ -1,6 +1,6 @@
 ---
-description: "Audit Claude Code permission GRANTS for portability and auto-mode durability — scans skill/command/agent frontmatter allowed-tools and settings.json/settings.local.json/user-global permissions.allow for interpreter-wildcard rules dropped in auto mode, hardcoded machine/user paths, and inert plugin self-grants. Use when: 'check permission rules', 'why was my allowed-tools grant ignored', 'audit allow rules', 'is this permission portable', after authoring a code-execution grant, or when a guarded helper is denied despite an allow rule. Report-only."
-argument-hint: "[scope] — scope: frontmatter|settings|plugins|all (default: all)"
+description: "Audit Claude Code permission GRANTS for portability and auto-mode durability. Scans skill/command/agent frontmatter allowed-tools and settings.json/settings.local.json/user-global permissions.allow for interpreter-wildcard rules dropped in auto mode, hardcoded machine/user paths, and inert plugin self-grants. Use when: 'check permission rules', 'why was my allowed-tools grant ignored', 'audit allow rules', 'is this permission portable', after authoring a code-execution grant, or when a guarded helper is denied despite an allow rule. Report-only."
+argument-hint: "[scope]: frontmatter|settings|plugins|all (default: all)"
 user-invocable: true
 disable-model-invocation: false
 metadata:
@@ -12,7 +12,7 @@ metadata:
 
 Audit whether a repo's permission **grants** actually take effect. Answers a question the sibling
 `audit` skill does not: "Are our allow-rules and `allowed-tools` grants portable across
-machines and durable when the session enters auto mode — and is the operative rule in a place that can
+machines and durable when the session enters auto mode, and is the operative rule in a place that can
 work?"
 
 The principle, the three anti-patterns, and the correct pattern (with official-doc citations) live in
@@ -20,12 +20,12 @@ the marketplace's **permission-rule-hygiene** convention, published at
 <https://raw.githubusercontent.com/melodic-software/claude-code-plugins/main/docs/conventions/permission-rule-hygiene/README.md>.
 The mechanical check definitions (P1/P2/P3, severities, detector invocation) are in
 [reference/criteria.md](reference/criteria.md), which carries every recommendation this skill needs at
-run time — the convention is the doctrine's owner, not a runtime dependency.
+run time. The convention is the doctrine's owner, not a runtime dependency.
 
 ## Scope boundary (route out)
 
 This skill owns grant portability + auto-mode durability + who adds the operative rule. It does **not**
-own config-file correctness — baseline deny/ask presence, overly broad patterns, or live plugin
+own config-file correctness. Baseline deny/ask presence, overly broad patterns, and live plugin
 drift belong to the sibling `audit` skill. When a request is about
 those, route it there rather than answering here. The `audit` skill in the `claude-memory` plugin
 owns the instruction layer (CLAUDE.md / rules / auto-memory).
@@ -33,17 +33,17 @@ owns the instruction layer (CLAUDE.md / rules / auto-memory).
 ## Arguments
 
 Parse `$ARGUMENTS` for an optional scope filter. **It narrows which checks may produce findings,
-never what the detector scans** — one full detector run happens either way, and the filter is
+never what the detector scans.** One full detector run happens either way, and the filter is
 applied to its output:
 
-- `frontmatter` — skill/command/agent `allowed-tools` only
-- `settings` — project, local, and user-global `permissions.allow` only
-- `plugins` — plugin `settings.json` self-grant (P3) only
-- `all` — everything (default)
+- `frontmatter`: skill/command/agent `allowed-tools` only
+- `settings`: project, local, and user-global `permissions.allow` only
+- `plugins`: plugin `settings.json` self-grant (P3) only
+- `all`: everything (default)
 
 Saying so is the fix, not a workaround. The filter reads like a scan-scope, and the cost argument
 for making it one no longer holds: since #2249 the root is a git toplevel, `$CLAUDE_PROJECT_DIR`, or
-an explicitly named directory — never an unbounded sweep — and over this repository the two `find`
+an explicitly named directory, never an unbounded sweep, and over this repository the two `find`
 walks measure **0.49 s** and **0.41 s** (2026-08-12). Detector flags to skip half a second of walk
 would buy nothing and add a second place for scope to be defined. The coverage block still reports
 the whole denominator on a filtered run, so a narrowed report never implies a narrowed scan.
@@ -63,34 +63,34 @@ bash "${CLAUDE_PLUGIN_ROOT}/skills/audit-permission-grants/scripts/permission-ru
 It scans frontmatter `allowed-tools` and settings `permissions.allow` across the consuming repo and
 the user-global settings file (`${CLAUDE_CONFIG_DIR:-$HOME/.claude}/settings.json`), and prints one
 finding per fragile grant (`<severity> [<check>] <source>: <detail>`). `--count` prints the count.
-**Exit 2 is the environment-gap channel — report the gap rather than a clean bill.** Three things
+**Exit 2 is the environment-gap channel: report the gap rather than a clean bill.** Three things
 raise it: a missing `jq`, a scan root that resolves to neither a git toplevel nor
 `$CLAUDE_PROJECT_DIR`, and an unresolvable user scope when the user-global scan cannot locate
 `${CLAUDE_CONFIG_DIR:-$HOME/.claude}`. On an unresolvable project root, say the scan did not run and
-give the fix — run from inside the repository you mean to scan, or set
+give the fix: run from inside the repository you mean to scan, or set
 `$PERMISSION_HYGIENE_SCAN_ROOT` explicitly. That variable is a supported operator lever, not a
 test-only seam; `$PERMISSION_HYGIENE_FIXTURE_DIR` still works as a back-compatible alias and the new
 name wins when both are set. Never report "no fragile permission grants found" on an exit 2.
-`settings.local.json` is parsed for its `permissions.allow` array only — never echoed wholesale.
+`settings.local.json` is parsed for its `permissions.allow` array only, never echoed wholesale.
 
 ### Report the denominator, always
 
-Every run ends with a **coverage block**, and it is not optional garnish — it is what makes a clean
+Every run ends with a **coverage block**, and it is not optional garnish. It is what makes a clean
 result readable. Carry its numbers into the report:
 
 - **A clean bill needs a non-zero denominator.** `No fragile permission grants found.` is printed
   only when the run actually parsed at least one `allowed-tools` block or allow rule. When it parsed
-  none the detector prints `NOTHING TO AUDIT` instead — **relay that as the outcome; never soften it
+  none the detector prints `NOTHING TO AUDIT` instead. **Relay that as the outcome; never soften it
   into a clean bill.** A scan of nothing is not evidence about grants.
 - **Say what was not read.** The block counts paths the walk could not open, settings files present
   but not valid JSON (whose rules were skipped entirely), and files an exclusion rule removed. Each
   of those is a hole in the denominator, and each belongs in the report next to the finding count.
-- **Name the scopes this detector never opens** — managed-policy and enterprise settings, a
+- **Name the scopes this detector never opens**: managed-policy and enterprise settings, a
   `--settings` flag file, the pre-v2.1.211 start-directory copy. `audit-permission-state` owns the
   question of which scopes exist; this skill's silence about them is a boundary, not a result.
 
 A user-global finding is reported the same as any other, but its remediation is the operator's: a
-skill cannot write that file. Expect this scope to carry the most findings on a long-lived machine —
+skill cannot write that file. Expect this scope to carry the most findings on a long-lived machine.
 "Always allow" writes there, and nothing prunes it.
 
 If a scope filter was given, run the full detector and present only the matching checks (P1/P2 map to
@@ -102,8 +102,8 @@ Present findings as the severity-rated table in
 [reference/criteria.md](reference/criteria.md) "Output format". For each finding, give the concrete
 recommendation from its check. For P1, match the platform reality the convention records: where
 plugin `bin/` is not reliably on the Bash tool's PATH (see the convention's **Known gap** section),
-prescribe the bundled-path grant that works today and an operator-setup note for the bare-name rule —
-do not unconditionally tell the operator to expose a bare command on PATH when that end state is not
+prescribe the bundled-path grant that works today and an operator-setup note for the bare-name rule.
+Do not unconditionally tell the operator to expose a bare command on PATH when that end state is not
 yet reachable on the measured platform. Add an **Operator setup** note wherever a user-global
 `~/.claude/settings.json` rule is required.
 
@@ -114,7 +114,7 @@ yet reachable on the measured platform. Add an **Operator setup** note wherever 
 | error | Non-portable grant that leaks a username / breaks on other machines (P2) |
 | warning | Interpreter/runner-led grant whose broad forms auto mode drops, or an inert self-grant (P1, P3) |
 
-A clean scan ("No fragile permission grants found.") is a valid outcome — report it as such, with
+A clean scan ("No fragile permission grants found.") is a valid outcome. Report it as such, with
 the denominator beside it. `NOTHING TO AUDIT` is **not** that outcome; see "Report the denominator".
 
 ## Consumer conventions
@@ -124,9 +124,9 @@ or path shapes it treats as fragile, or a documented exemption (e.g. a deliberat
 a PreToolUse hook). Read those when present; this skill does not assume them.
 
 **Three constraints on those declarations, because the repo being audited is the repo that writes
-them.** The docs name this threat model directly — "Review project skills before trusting a
+them.** The docs name this threat model directly, in "Review project skills before trusting a
 repository, since a skill can grant itself broad tool access"
-(<https://code.claude.com/docs/en/skills>, fetched 2026-08-12) — and an exemption read out of the
+(<https://code.claude.com/docs/en/skills>, fetched 2026-08-12), and an exemption read out of the
 audited tree is input from the subject of the audit:
 
 1. **Disclosure.** Every declaration the run read is named in the report, with the file it came from
@@ -137,6 +137,6 @@ audited tree is input from the subject of the audit:
    annotates it `exempt — <declaration source>: <stated reason>`; the row stays in the table and
    stays in the counts.
 3. **A suppressed report must not read like a clean one.** If every finding in a run is exempted,
-   the report says so explicitly — "N finding(s), all exempted by consumer declaration" — and does
+   the report says so explicitly, "N finding(s), all exempted by consumer declaration", and does
    not print a clean bill. Combined with the denominator, that closes the two ways this report could
    claim health it never established: an empty scan, and a silenced one.

--- a/plugins/claude-config/skills/audit-permission-state/SKILL.md
+++ b/plugins/claude-config/skills/audit-permission-state/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: "Report the Claude Code permission state actually in effect — discovers every settings scope (managed policy, user-global, project, local, and the pre-v2.1.211 start-directory copy), merges them into the effective allow/ask/deny set with each rule's source and precedence mechanic named, and classifies which allow rules auto mode drops on entry. Use when: 'what permissions are actually in effect', 'which settings file is my rule coming from', 'why is my allow rule ignored', 'show me my effective permissions', 'what does auto mode drop', 'which of my rules survive auto mode', 'is my managed policy being read', 'what scopes did you check', or before changing a permission rule you cannot locate. Report-only — never writes any settings file."
+description: "Report the Claude Code permission state actually in effect. Discovers every settings scope (managed policy, user-global, project, local, and the pre-v2.1.211 start-directory copy), merges them into the effective allow/ask/deny set with each rule's source and precedence mechanic named, and classifies which allow rules auto mode drops on entry. Use when: 'what permissions are actually in effect', 'which settings file is my rule coming from', 'why is my allow rule ignored', 'show me my effective permissions', 'what does auto mode drop', 'which of my rules survive auto mode', 'is my managed policy being read', 'what scopes did you check', or before changing a permission rule you cannot locate. Report-only, never writes any settings file."
 argument-hint: "[--scopes] surfaces only | [--entry-diff] what auto mode drops"
 user-invocable: true
 disable-model-invocation: false
@@ -11,7 +11,7 @@ metadata:
 ## Purpose
 
 `/permissions` lists your rules and the settings file each one came from, and for "where is this rule
-written" that is the answer — use it. What it does not do is resolve the outcome: it will show you an
+written" that is the answer, so use it. What it does not do is resolve the outcome: it will show you an
 allow and a deny for the same tool without saying which wins, it cannot tell a scope that was empty
 from one it could not read, there is no `claude permissions` subcommand or machine-readable export,
 and none of it exists outside a live session. This skill computes that locally, in a form another
@@ -19,7 +19,7 @@ tool can consume.
 
 It answers a question the siblings do not. `audit-permission-grants` asks whether the grants you
 **wrote** are durable and portable; `audit` asks whether your config files are **correct**. This
-skill asks what is **in effect** — which scopes exist on this machine, which of them this reader
+skill asks what is **in effect**: which scopes exist on this machine, which of them this reader
 could actually open, and what each one holds.
 
 ## Scope boundary (route out)
@@ -30,25 +30,25 @@ could actually open, and what each one holds.
 
 ## Report-only, permanently
 
-**This skill writes no settings file, in any scope, under any flag** — that is the contract, and it
+**This skill writes no settings file, in any scope, under any flag.** That is the contract, and it
 holds including under `--oracle`. It is not the same as writing nothing at all: `--oracle` spawns a
 real `claude -p` session, and a session rewrites `~/.claude.json` and adds project, session-env,
 security, subagent and backup state under your config directory. The flag prints that before it
 spawns anything. Every other action writes nothing anywhere. Managed policy is read-only by
-construction — those are admin-write OS locations or a claude.ai Owner role, so a plugin could not
+construction: those are admin-write OS locations or a claude.ai Owner role, so a plugin could not
 author them even if it wanted to.
 
 ## Arguments
 
 Parse `$ARGUMENTS`:
 
-- `--scopes` — surface records only, no rule inventory. Use when the question is "which scopes exist
+- `--scopes`: surface records only, no rule inventory. Use when the question is "which scopes exist
   and which could you read", not "what is in them".
-- `--entry-diff` — run the full pipeline through to the auto-mode entry diff (Phase 3 below).
-- `--oracle` — with `--entry-diff`, cross-check the prediction against the harness's own drop
+- `--entry-diff`: run the full pipeline through to the auto-mode entry diff (Phase 3 below).
+- `--oracle`: with `--entry-diff`, cross-check the prediction against the harness's own drop
   narration. **Spawns a real `claude -p` session**; never fires without this flag. See its cost
   notice, which the run prints before anything is spawned.
-- (no argument) — surfaces plus one record per allow/ask/deny rule, then the merge.
+- (no argument): surfaces plus one record per allow/ask/deny rule, then the merge.
 
 ## Phase 1: Discover and inventory
 
@@ -94,14 +94,14 @@ inert <kind> scopes=<a,b> outranked_by=<kind> <rule>           one per beaten en
 Two mechanics decide those records, and conflating them produces confident wrong answers:
 
 - **Rules merge across scopes rather than override**, so the same rule in the same list at two scopes
-  has no winner — both are live, and `scopes=` names every contributor. Never report one of them as
+  has no winner. Both are live, and `scopes=` names every contributor. Never report one of them as
   having overridden the other.
-- **Kind is decided by evaluation order — deny, then ask, then allow — from any scope, in both
+- **Kind is decided by evaluation order, deny then ask then allow, from any scope, in both
   directions.** A user-level deny blocks a project-level allow just as a project-level deny blocks a
   user-level allow. Scope rank does not enter into it. This is what answers "why is my allow rule
   ignored": the `inert` record names the rule that beat it.
 - **A rule that is a bare tool name reaches every call of that tool.** A whole-tool deny removes the
-  tool from context entirely, so every other rule naming it is inert — other denies included;
+  tool from context entirely, so every other rule naming it is inert, other denies included;
   `EndConversation` is the documented exception. A whole-tool ask prompts for every call, so no scoped
   allow for that tool applies. Both print a `NOTE:` naming the tool.
 
@@ -128,9 +128,9 @@ entry-diff summary allow_before=<n> dropped=<n> suspended=<n> kept=<n>
 ```
 
 - **Only allow rules change on entry.** Deny and ask are evaluated before the classifier in every
-  mode, so they are not part of this diff — do not report them as "surviving".
+  mode, so they are not part of this diff. Do not report them as "surviving".
 - **`class` names the documented reason**: `blanket`, `interpreter-wildcard`, `package-manager-run`,
-  or `agent`, from `lib/permission-patterns.sh` — the vocabulary `audit-permission-grants` check P1
+  or `agent`, from `lib/permission-patterns.sh`, the vocabulary `audit-permission-grants` check P1
   also scans with.
 - **`autoMode.classifyAllShell` inverts the answer wholesale.** When true it suspends *every* Bash and
   PowerShell allow rule, so narrow rules do **not** carry over. It is resolved only from the scopes
@@ -160,36 +160,36 @@ Nine checks: three `C2-*` dead-config gates, `C5-disableType`, and five `C6-*` r
 the checks are written NOT to flag.
 
 - **`C5-disableType` is the one to read first.** `disableAutoMode` must be the **string** `"disable"`;
-  a boolean is valid JSON, is accepted, and does nothing — so the operator believes auto mode is
+  a boolean is valid JSON, is accepted, and does nothing, so the operator believes auto mode is
   locked out when it is not.
 - **The three `C2` gates stay separate findings.** Different scope sets, different version histories:
   an operator who fixed one and saw the count drop would reasonably believe they had fixed all three.
 - **Several of these also produce a startup warning.** The added value here is reading every scope at
-  once, before a session, and naming the file — not that the harness is silent.
+  once, before a session, and naming the file, not that the harness is silent.
 - **Advisory: the lint always exits 0 when it ran.** Exit 2 means it could not run at all, never
   "nothing found".
 
 ## Phase 5: The `autoMode` classifier block
 
 A different surface from everything above: four natural-language sections an LLM classifier reads,
-not permission rules the harness matches. Independent of the pipeline — it reads the CLI, not stdin:
+not permission rules the harness matches. Independent of the pipeline, it reads the CLI, not stdin:
 
 ```shell
 bash "${CLAUDE_PLUGIN_ROOT}/skills/audit-permission-state/scripts/automode-block-lint.sh" [--critique]
 ```
 
-- **`C4-defaults`** — a customized section that omits `"$defaults"`. Customizing **replaces** the
+- **`C4-defaults`**: a customized section that omits `"$defaults"`. Customizing **replaces** the
   built-in list rather than adding to it, so the finding names how many built-in entries are gone.
-- **`C2b-contradiction`** — the same subject in `allow` and in a deny section.
-- **`C3-shadowed`** — an entry an earlier `hard_deny` already forecloses, so it can never fire.
-- **`--critique` surfaces `claude auto-mode critique`, wrapped — never replaced.** It owns the
+- **`C2b-contradiction`**: the same subject in `allow` and in a deny section.
+- **`C3-shadowed`**: an entry an earlier `hard_deny` already forecloses, so it can never fire.
+- **`--critique` surfaces `claude auto-mode critique`, wrapped and never replaced.** It owns the
   semantic judgment. What this adds is honesty about it: measured across three consecutive runs on one
   unchanged config, output was truncated mid-sentence twice and empty once, **exiting 0 every time**.
   A mid-sentence cut is reported as truncated; an empty result says "critique returned nothing; run it
   yourself" rather than implying your rules are clean.
 
 **This lane is optional, and its prerequisite is nobody else's problem.** It needs `python3` because
-`claude auto-mode config` emits raw control characters inside string values — `jq` rejects the output
+`claude auto-mode config` emits raw control characters inside string values. `jq` rejects the output
 outright, and no line-oriented POSIX filter can repair it, since the offending byte is a raw line feed
 inside a string. Absent `python3` or `claude`, the lane prints a visible skip notice and exits 0; every
 other stage still runs.
@@ -208,17 +208,17 @@ bash "${CLAUDE_PLUGIN_ROOT}/skills/audit-permission-state/scripts/permission-sta
   bash "${CLAUDE_PLUGIN_ROOT}/skills/audit-permission-state/scripts/managed-conformance.sh"
 ```
 
-- **`managed enforced deny <rule>`** — the strongest thing an administrator can write. No level,
+- **`managed enforced deny <rule>`**: the strongest thing an administrator can write. No level,
   command line included, can override a managed permission rule, and a tool denied at any level
   cannot be allowed at another.
-- **`managed loosenable rule …`** — the interaction that surprises people. "Managed is highest" and
+- **`managed loosenable rule …`**: the interaction that surprises people. "Managed is highest" and
   "deny before ask before allow, **from any scope**" are both true: a lower-scope deny beats a managed
   allow without ever overriding it.
-- **`managed loosenable autoMode`** — a managed `autoMode` section is **additive, not a policy
+- **`managed loosenable autoMode`**: a managed `autoMode` section is **additive, not a policy
   boundary**. A developer cannot remove entries it provides, but a developer-added `allow` can
   override an organization `soft_deny`. Permissions, hooks, MCP, sandbox-filesystem and
   sandbox-network each got an exclusivity lock; auto mode did not.
-- **`managed loosenable lockout`** — `disableAutoMode` set to anything but the string `"disable"`.
+- **`managed loosenable lockout`**: `disableAutoMode` set to anything but the string `"disable"`.
 
 **This report never prescribes.** It says what the consumer's own policy does and does not achieve;
 every rule string it prints came from a file it read. It ships no security floor of its own.
@@ -237,7 +237,7 @@ anything this skill produced. The status vocabulary carries the whole point of t
 collapse it in the report:
 
 - **`absent` means looked and found nothing.** **`skipped` means could not look.** Never present a
-  `skipped` surface as "no policy" — say the surface was not read and why. The script emits a `NOTE:`
+  `skipped` surface as "no policy". Say the surface was not read and why. The script emits a `NOTE:`
   naming the reason every time.
 - **Every scope and every managed surface emits a record on every OS**, including the ones that do
   not apply here (`not-applicable`). A surface missing from the output is a defect in this reader,
@@ -247,31 +247,31 @@ collapse it in the report:
   into the report rather than implying completeness.
 - **An `ask` finding carries an open upstream discrepancy.** The permissions page says content-scoped
   `ask` rules always prompt, "even in auto mode"; issues #83766 and #42797 report them auto-approved
-  under `defaultMode: "auto"`. This plugin follows the documented behavior — it is the only source
-  with a stated contract — but say so when reporting an `ask` result, and point at `permissions.deny`
+  under `defaultMode: "auto"`. This plugin follows the documented behavior, the only source
+  with a stated contract, but say so when reporting an `ask` result, and point at `permissions.deny`
   where the outcome must hold regardless. See `reference/criteria.md`.
 - **`invalid-json` is not `absent`.** A malformed settings file contributes no rules to the
-  inventory, but its rules may still be a live problem for the operator — report it as a finding, not
+  inventory, but its rules may still be a live problem for the operator. Report it as a finding, not
   as an empty scope.
 
 ## Scopes
 
 Five, and the two easy to get wrong: `local` resolves **through worktrees to the main checkout**, so
 a reader anchored on the worktree root looks where the file is not; `startdir-local` is a
-pre-v2.1.211 copy that is **not** a fallback — permission rules from both files stay in effect.
+pre-v2.1.211 copy that is **not** a fallback, since permission rules from both files stay in effect.
 `managed` is four surfaces per OS, not one file. `reference/criteria.md` §Scopes has the full table.
 
 ## Prerequisites
 
-- **`jq` — required for correctness.** Absent, the script stops at the entry point with
+- **`jq`, required for correctness.** Absent, the script stops at the entry point with
   `ERROR: jq required` and exit 2. Report the environment gap; do not report a clean bill.
-- **`reg` (Windows) and `defaults` (macOS) — required for an optional feature.** Absent, that one
+- **`reg` (Windows) and `defaults` (macOS), required for an optional feature.** Absent, that one
   managed surface is `skipped` with a visible notice and everything else still runs.
 
 ## Verification status
 
 The Windows registry surface was verified end to end against a real registry key. The macOS
-preferences domain and the Linux managed paths are **not** verified on real hardware — they are an
+preferences domain and the Linux managed paths are **not** verified on real hardware. They are an
 honest manual-verification gap, not a claim. Treat a macOS `plist` record as reporting the surface,
 not its contents: the reader names the domain and does not yet inventory its rules.
 
@@ -287,11 +287,11 @@ Observed failures, each of which produced a confidently wrong answer before it w
   wrong answer by hand.
 - **A missing shared library used to look like a clean machine.** If the plugin's
   `lib/managed-scope.sh` could not be sourced, every managed surface reported `absent`. It is now a
-  hard `exit 2` — a reader that cannot load its own location list must not answer the question.
+  hard `exit 2`. A reader that cannot load its own location list must not answer the question.
 - **The local file is not under the worktree you are standing in.** `settings.local.json` resolves
   through worktrees to the main checkout, so a reader anchored on `git rev-parse --show-toplevel`
   looks where the file is not and reports `absent`. Three documented exceptions keep it in the start
-  directory — outside a git repository, when the repository root is the home directory, and in Agent
+  directory: outside a git repository, when the repository root is the home directory, and in Agent
   SDK sessions. The reader detects the first two and states that it cannot detect the third.
 - **An empty merge is not an empty machine.** Piping a reader that died into the merge would have
   produced a clean "nothing in effect" on a machine full of rules. The merge now exits 2 when the

--- a/plugins/claude-config/skills/audit-prompting-postures/SKILL.md
+++ b/plugins/claude-config/skills/audit-prompting-postures/SKILL.md
@@ -1,6 +1,6 @@
 ---
-description: "Audit locally-owned instruction components — skill bodies, agent definitions, hook instruction text, output styles, CLAUDE.md, rules — for MISSING posture guidance the official prompting guide says their purpose needs: delegation criteria/caps in orchestration components, minimal-scope and anti-test-gaming guardrails in code-changing components, investigate-before-answering grounding, progress-claim grounding on long runs, autonomy vs checkpoint posture, destructive-action confirmation, context-budget reassurance, multi-window state guidance, parallel-tool-call steering. The additive complement to audit-instructions (which finds text that is present and wrong; this finds text that is absent and needed). Report-only: emits proposed additions sourced from a live fetch of the guide, gated to the human, never auto-applied. Use when: 'posture audit', 'audit prompting postures', 'is my skill missing guardrails', 'missing delegation criteria', 'should this component confirm destructive actions', 'align my components with the prompting guide', after authoring a new skill or agent, or as the additive lane of a prompting-guide alignment pass. Not for removing or rewriting existing instructions (audit-instructions), structural skill lint (skill-quality:check), or brevity (docs-hygiene:compress)."
-argument-hint: "[scope] — scope: skills|agents|hooks|output-styles|claude-md|rules|all (default: all)"
+description: "Audit locally-owned instruction components, including skill bodies, agent definitions, hook instruction text, output styles, CLAUDE.md and rules, for MISSING posture guidance the official prompting guide says their purpose needs: delegation criteria/caps in orchestration components, minimal-scope and anti-test-gaming guardrails in code-changing components, investigate-before-answering grounding, progress-claim grounding on long runs, autonomy vs checkpoint posture, destructive-action confirmation, context-budget reassurance, multi-window state guidance, parallel-tool-call steering. The additive complement to audit-instructions (which finds text that is present and wrong; this finds text that is absent and needed). Report-only: emits proposed additions sourced from a live fetch of the guide, gated to the human, never auto-applied. Use when: 'posture audit', 'audit prompting postures', 'is my skill missing guardrails', 'missing delegation criteria', 'should this component confirm destructive actions', 'align my components with the prompting guide', after authoring a new skill or agent, or as the additive lane of a prompting-guide alignment pass. Not for removing or rewriting existing instructions (audit-instructions), structural skill lint (skill-quality:check), or brevity (docs-hygiene:compress)."
+argument-hint: "[scope]: skills|agents|hooks|output-styles|claude-md|rules|all (default: all)"
 disallowed-tools: Edit, NotebookEdit
 user-invocable: true
 disable-model-invocation: false
@@ -11,38 +11,38 @@ metadata:
 
 ## Purpose
 
-The official prompting guide prescribes posture guidance that agentic components should CARRY —
+The official prompting guide prescribes posture guidance that agentic components should CARRY:
 delegation criteria, scope guardrails, grounding instructions, autonomy postures, confirmation
 gates. `audit-instructions` detects instruction text that is present and wrong; nothing detects
 text that is absent and needed. This skill is that additive lane: it classifies each component by
 purpose, checks the postures that purpose calls for, and proposes additions with wording taken
-from a live fetch of the guide — never from this file.
+from a live fetch of the guide, never from this file.
 
 ## Read-only contract
 
 Report-only. No `--fix`: every proposed addition is applied by the human (or explicitly delegated
 afterward). A clean audit is a valid outcome, and with well-authored components it is the expected
-one — the default verdict per posture is NOT-APPLICABLE, not MISSING.
+one. The default verdict per posture is NOT-APPLICABLE, not MISSING.
 
-**Instruction-held, not tool-enforced — never tell an operator this skill *cannot* edit their files.**
+**Instruction-held, not tool-enforced. Never tell an operator this skill *cannot* edit their files.**
 `disallowed-tools: Edit, NotebookEdit` narrows the surface, nothing more: `Write` stays for Phase D's
 persist and Phase B has already read every audited component, so it can overwrite one; `Bash` stays
 for the state key, and a shell mutates files too. That closes the likeliest accidental path, not the
-capability — and a skill auditing assurance must not overstate its own.
+capability, and a skill auditing assurance must not overstate its own.
 (<https://code.claude.com/docs/en/skills>, fetched 2026-08-12; the restriction clears on the human's
 next message, so whoever accepts a proposal can apply it.)
 
 ## Scope boundary (route out)
 
-- Text that is present and wrong — over-prescription, stale claims, emphasis language, retired
-  parameters — is `audit-instructions`. When one sweep wants both lanes, run both skills; a
+- Text that is present and wrong, covering over-prescription, stale claims, emphasis language and
+  retired parameters, is `audit-instructions`. When one sweep wants both lanes, run both skills; a
   coordinated pass (`audit-pass`, when installed) composes them.
 - Structural skill lint is `skill-quality:check`; token brevity is `docs-hygiene:compress`.
 - Upstream-owned surfaces (installed plugin cache, managed materializations) produce routing
-  recommendations to the owning repository, never in-place proposals — same exclusion
+  recommendations to the owning repository, never in-place proposals, the same exclusion
   `audit-instructions` applies.
 
-## Phase A — Fetch the guide
+## Phase A: Fetch the guide
 
 The posture catalog in [reference/postures.md](reference/postures.md) carries, per posture, an
 applicability predicate and a POINTER to the guide section that states the recommended wording.
@@ -50,66 +50,66 @@ It deliberately carries no copied sample text, so no proposal is written before 
 in hand. It names two kinds of page; they are fetched at different times and fail differently.
 
 **The best-practices page: fetched here, every run, before any judging.** It is this skill's one
-non-negotiable input — every posture points at it, so losing it degrades all ten at once. If it
+non-negotiable input: every posture points at it, so losing it degrades all ten at once. If it
 cannot be fetched, **ABORT the run**, naming the URL and the failure; continuing would emit ten
 `wording-unverified` postures, a report shaped like an audit that audited nothing. Same posture the
 sibling takes on its own single input (`audit-instructions/SKILL.md`, "Fail loud on ambiguity").
 
-**Model-specific subpages: fetched lazily, in Phase C, per applicable row** — when a posture whose
+**Model-specific subpages: fetched lazily, in Phase C, per applicable row**, when a posture whose
 predicate actually matched points at one, not once per catalog row, since a row names its subpage
 statically whether or not anything in scope matches. A failed subpage fetch degrades only the
 postures citing it: mark those `wording-unverified`, carry the pointer instead of wording, never
 invent text. One page is fatal; the rest are local, and "before judging anything" is not a
 requirement to hold every page at once.
 
-## Phase B — Inventory and classify
+## Phase B: Inventory and classify
 
 Parse `$ARGUMENTS` for an optional scope filter (`skills`, `agents`, `hooks`, `output-styles`,
 `claude-md`, `rules`, or `all`, the default). It narrows which surfaces may produce findings, never
 which pages Phase A fetches.
 
 Enumerate locally-owned instruction components in scope. **This skill names its own surface set**;
-what it shares with `audit-instructions` Phase A is the *resolution* procedure, not the list — resolve
+what it shares with `audit-instructions` Phase A is the *resolution* procedure, not the list. Resolve
 `${CLAUDE_CONFIG_DIR:-~/.claude}` and project `.claude/`, and apply the same liveness and
 upstream-ownership exclusions. The set, one entry per scope token above: skill bodies (and the
 context/reference files a skill instructs the model to read), agent definition markdown, hook
 instruction text of both kinds, output-style markdown, CLAUDE.md / CLAUDE.local.md, `.claude/rules/`.
 Inheriting it by reference from a sibling that versions independently is how `output-styles` came to
 be inventoried here and unnameable by this skill's own filter. **The inventory bounds what may produce
-a finding, not what counts as evidence** — Phase C's mechanical-gate rule reads outside it to establish
+a finding, not what counts as evidence.** Phase C's mechanical-gate rule reads outside it to establish
 PRESENCE, which can only turn a MISSING into a PRESENT, never add a finding on an excluded surface.
 
-For each component, classify its purpose from its own description and body — the classification
+For each component, classify its purpose from its own description and body. The classification
 vocabulary and its tie to each posture's predicate live in the catalog. A component can match several
 purposes or none; none is the common case, and unclassified components go in the coverage line rather
 than being force-fitted.
 
-## Phase C — Judge postures
+## Phase C: Judge postures
 
 For each component × applicable posture: does the component (or a file it instructs the model to
-read) already carry the posture, in any wording? Judge substance, not phrasing — a numeric
+read) already carry the posture, in any wording? Judge substance, not phrasing. A numeric
 concurrency cap satisfies the delegation-criteria posture without quoting the guide. Only a genuine
 absence on a component whose purpose clearly needs it becomes a finding. Three standing fences:
 
 - **Do not manufacture.** The predicate must match the component's actual purpose, not a
   conceivable use. When in doubt, NOT-APPLICABLE.
-- **Mechanical gates are presence evidence and do not live in the inventory.** P7 — and only P7 —
+- **Mechanical gates are presence evidence and do not live in the inventory.** P7, and only P7,
   blesses a deny-by-default hook **or script** gate "without any prose", while Phase B inventories
   instruction *text*, so those gates sit outside that set by construction. Before judging a
   `destructive-capable` component MISSING on P7, look in all three: settings scopes Phase B resolved
   (`permissions.deny` / `ask`), hook config registering a PreToolUse matcher over the action, and
-  **the script the component delegates the action to** — follow the invocation and read it, since a
+  **the script the component delegates the action to**, following the invocation and reading it, since a
   component whose destructive step runs through a script that performs the approval check is gated.
   Any one of the three is PRESENT, cited by file and rule, or by script and line.
 - **Repo conventions win on wording.** The proposal adapts the guide's substance to the
   component's own voice and the repo's terseness conventions; it never pastes a guide block
   verbatim into a proposal without trimming to what the component needs.
 
-## Phase D — Verify and report
+## Phase D: Verify and report
 
 Dispatch one fresh-context, non-fork verifier per surface batch, prompted to refute each proposed
 addition: "argue this component's purpose does not need this posture, or that it already carries
-it." A refuted finding is **demoted to `info` and kept, never dropped** — it stays a row carrying its
+it." A refuted finding is **demoted to `info` and kept, never dropped**. It stays a row carrying its
 refutation, because deleting it erases the evidence that Phase D ran and disagreed.
 
 ### When dispatch is unavailable
@@ -120,8 +120,8 @@ unavailable, or the session cannot spawn subagents:
 1. **Disclose in the report header** that Phase D did not run and why.
 2. **Mark unverified proposals.** Every proposed addition that did not receive an independent
    verifier MUST carry an `(unverified)` marker and MUST NOT be presented as a confident finding.
-3. **Add a verifier attestation line** to the report tail — components verified, verified inline,
-   or skipped — alongside the existing coverage and Sources lines.
+3. **Add a verifier attestation line** to the report tail, naming components verified, verified
+   inline, or skipped, alongside the existing coverage and Sources lines.
 
 Persist the report to `${CLAUDE_PLUGIN_DATA}/audit-prompting-postures/<state-key>/last-audit.md`.
 
@@ -132,12 +132,12 @@ bash "${CLAUDE_PLUGIN_ROOT}/lib/state-key.sh"
 ```
 
 `${CLAUDE_PLUGIN_DATA}` is machine-global, not per-project, so a fixed `last-audit.md` is silently
-overwritten by the next run from any other root — this skill's only durable deliverable, destroyed by
+overwritten by the next run from any other root, this skill's only durable deliverable, destroyed by
 ordinary use of it. The scheme is `<repo-identity>/<worktree-discriminator>`, defined by the
 marketplace's `plugin-data-report-keying` convention and reused rather than reinvented, and it
-lives in one executable rather than being restated per skill —
+lives in one executable rather than being restated per skill,
 [`lib/state-key.sh`](../../lib/state-key.sh), with `lib/state-key.test.sh` beside it. Pass `--explain`
-when the report should say which rung produced the key. **The key stops overwrites, not reaping** —
+when the report should say which rung produced the key. **The key stops overwrites, not reaping.**
 "By default, uninstalling from the last remaining scope also deletes the plugin's
 `${CLAUDE_PLUGIN_DATA}` directory. Use `--keep-data` to preserve it."
 (<https://code.claude.com/docs/en/plugins-reference>, `plugin uninstall`, fetched 2026-08-12), so when
@@ -148,7 +148,7 @@ remote and its scp-style ssh equivalent normalize to the same `github.com/<owner
 only remote is `upstream` keys by that remote rather than dropping to the local rung; a repo with no
 remote gives `local/<12>`; a non-repo root gives `nonrepo/<12>`; and relative (`../central.git`),
 absolute-local, and Windows-path remotes all key by hash, with no `..` and no backslash surviving into
-a path segment — the identity becomes directory components, so that is a security property, not a
+a path segment, since the identity becomes directory components, so that is a security property, not a
 cosmetic one. Two worktrees of one repository differ in the discriminator, which is what it exists for.
 
 Run it and use the result. Do **not** express the path as a condition over `${CLAUDE_PROJECT_DIR}`
@@ -169,33 +169,33 @@ Then summarize in chat:
 | # | Posture | Component | Verdict | Proposed addition or pointer |
 |---|---------|-----------|---------|------------------------------|
 
-Verdicts — the closed set, four tokens: `MISSING` (finding, with proposed addition as a fenced diff),
+Verdicts are a closed set of four tokens: `MISSING` (finding, with proposed addition as a fenced diff),
 `PRESENT` (where it is), `NOT-APPLICABLE` (with the failed predicate), `info` (a Phase D verifier
-refuted it — always kept as a row, never dropped, never a proposal to apply). Two markers are
+refuted it, always kept as a row, never dropped, never a proposal to apply). Two markers are
 orthogonal and ride **alongside** a verdict, never in place of one: `wording-unverified` (a subpage
-fetch failed in Phase C — the fifth column then carries the guide POINTER, which is what that column
+fetch failed in Phase C, so the fifth column then carries the guide POINTER, which is what that column
 is named for, and a pointer is never dressed up as guide wording) and `(unverified)` (Phase D could
-not verify this proposal — see "When dispatch is unavailable"). End with a coverage line — components
-inventoried, classified, unclassified — and a Sources line citing the pages fetched this run with
-dates. When Phase D ran, end with a verifier attestation line — surface batches verified, verified
+not verify this proposal; see "When dispatch is unavailable"). End with a coverage line naming components
+inventoried, classified and unclassified, and a Sources line citing the pages fetched this run with
+dates. When Phase D ran, end with a verifier attestation line naming surface batches verified, verified
 inline, or skipped.
 
 ## Gotchas
 
 - **Presence can live one file away.** A SKILL.md that routes to a context file the model must
-  read counts as carrying whatever that file carries — follow the component's own read
+  read counts as carrying whatever that file carries. Follow the component's own read
   instructions before judging absence.
 - **Human-gated designs are not missing autonomy postures.** A report-only skill that ends at a
   human gate needs no autonomous-pipeline branch; the autonomy posture applies to components that
   claim unattended operation.
 - **Model-conditional postures stay conditional.** Where the guide ties a posture to specific
-  models, the proposal must be model-neutral or carry the same condition — components here run on
+  models, the proposal must be model-neutral or carry the same condition, since components here run on
   any consumer model.
 
 ## What this skill does NOT do
 
-- Never edits a component and never auto-applies a proposal — held by instruction, since
+- Never edits a component and never auto-applies a proposal. This is held by instruction, since
   `disallowed-tools` narrows the surface but `Write` and `Bash` remain and both can mutate a file.
-- Never copies guide text into its own catalog — wording comes from the run's live fetch.
+- Never copies guide text into its own catalog; wording comes from the run's live fetch.
 - Does not judge existing text (that is `audit-instructions`), lint structure
   (`skill-quality:check`), or compress prose (`docs-hygiene:compress`).

--- a/plugins/claude-config/skills/audit/SKILL.md
+++ b/plugins/claude-config/skills/audit/SKILL.md
@@ -1,6 +1,6 @@
 ---
-description: "Audit Claude Code configuration files — settings.json, settings.local.json, .mcp.json, hooks, plugins, permissions, environment variables — for correctness, security, and drift against current official docs. Use when: 'audit settings', 'check config', 'check for config drift', after a Claude Code update, or when permissions, hooks, plugins, or MCP servers may be misconfigured; pass --fix to apply auto-correctable findings with confirmation."
-argument-hint: "[--fix] [scope] — scope: permissions|mcp|hooks|plugins|issues|all (default: all)"
+description: "Audit Claude Code configuration files, including settings.json, settings.local.json, .mcp.json, hooks, plugins, permissions and environment variables, for correctness, security, and drift against current official docs. Use when: 'audit settings', 'check config', 'check for config drift', after a Claude Code update, or when permissions, hooks, plugins, or MCP servers may be misconfigured; pass --fix to apply auto-correctable findings with confirmation."
+argument-hint: "[--fix] [scope]: permissions|mcp|hooks|plugins|issues|all (default: all)"
 user-invocable: true
 disable-model-invocation: false
 shell: bash
@@ -21,12 +21,12 @@ date?"
 
 ## Adapting to your environment (graceful degrade)
 
-This skill is self-contained. Where a phase names an adjacent capability — a Claude Code issue-tracking
-skill, an environment-bootstrap checker — treat it as optional: if your setup provides an equivalent
+This skill is self-contained. Where a phase names an adjacent capability, such as a Claude Code
+issue-tracking skill or an environment-bootstrap checker, treat it as optional: if your setup provides an equivalent
 skill or tool, use it; otherwise follow the inline guidance here, which stands on its own.
 Project-specific conventions (required permission patterns beyond the baseline, documented reasons for
 disabled servers, launcher-script wrappers) come from the consuming repo's own `CLAUDE.md` and
-`.claude/rules/` — read them when present; this skill does not assume them.
+`.claude/rules/`. Read them when present; this skill does not assume them.
 
 Two adjacent skills cover neighboring questions: the sibling `audit-automation-gaps` skill asks whether the
 configured automation SET is the right set (landscape gaps); the `audit` skill in the `claude-memory`
@@ -39,12 +39,12 @@ Parse `$ARGUMENTS` for:
 
 - **`--fix`**: Apply corrections automatically (with user confirmation per fix). Without this flag, report-only mode
 - **Scope filter**: Limit audit to a single category. If omitted, run all categories
-  - `permissions` — deny/ask/allow rules, security gaps
-  - `mcp` — MCP server definitions, commands, env vars, connectivity
-  - `hooks` — hook scripts exist, timeouts, matchers
-  - `plugins` — enabled/disabled status, marketplace availability
-  - `issues` — recheck known GitHub issues only
-  - `all` — run everything (default)
+  - `permissions`: deny/ask/allow rules, security gaps
+  - `mcp`: MCP server definitions, commands, env vars, connectivity
+  - `hooks`: hook scripts exist, timeouts, matchers
+  - `plugins`: enabled/disabled status, marketplace availability
+  - `issues`: recheck known GitHub issues only
+  - `all`: run everything (default)
 
 ## Config Files
 
@@ -53,9 +53,9 @@ Parse `$ARGUMENTS` for:
 | `.claude/settings.json` | Read tool or `jq` | Project-level, checked in |
 | `.claude/settings.local.json` | `jq` via Bash only | Commonly deny-listed for the Read tool because it holds tokens. Parse structure/key counts only. **Never echo secret values** |
 | `.mcp.json` | Read tool or `jq` | Project-level MCP server definitions |
-| `~/.claude/settings.json` | Read tool | User-level defaults (optional — check if exists) |
+| `~/.claude/settings.json` | Read tool | User-level defaults (optional; check if exists) |
 | start-directory `.claude/settings.local.json` | `check-structure.sh` (structure only) | Only when the session's start directory is not the repository root AND a copy is there. A pre-v2.1.211 Claude Code wrote the file to the start directory and the current one still reads what it left; the repository-root copy wins on a shared key, but **permission rules from both files stay in effect** |
-| `managed-settings.json` + `managed-settings.d/` | `check-structure.sh` (structure only) | Machine-scope managed policy, the highest-precedence layer. OS-specific path resolved by the script (macOS `/Library/Application Support/ClaudeCode/`, Linux/WSL `/etc/claude-code/`, Windows `%ProgramFiles%\ClaudeCode\`). Findings on it are report-only routing — managed policy is the administrator's, never edited by `--fix` |
+| `managed-settings.json` + `managed-settings.d/` | `check-structure.sh` (structure only) | Machine-scope managed policy, the highest-precedence layer. OS-specific path resolved by the script (macOS `/Library/Application Support/ClaudeCode/`, Linux/WSL `/etc/claude-code/`, Windows `%ProgramFiles%\ClaudeCode\`). Findings on it are report-only routing; managed policy is the administrator's, never edited by `--fix` |
 | managed policy outside the filesystem | not read | The Windows `HKLM`/`HKCU\SOFTWARE\Policies\ClaudeCode` policy keys and the macOS `com.anthropic.claudecode` managed-preferences domain. `check-structure.sh` names them so an absent `managed-settings.json` is never read as "no managed policy deployed", but it does not read them |
 
 ### Reading settings.local.json safely
@@ -65,8 +65,8 @@ Even when no deny rule blocks it, treat `settings.local.json` as secret-bearing:
 validity, never dump its contents. Supplemental jq recipes: [context/procedures.md](context/procedures.md)
 "Reading settings.local.json safely".
 
-The counts are not guaranteed. Where the project's configuration blocks the read — a sandbox
-`denyRead` merged from the baseline `Read` deny, or filesystem permissions — the script reports
+The counts are not guaranteed. Where the project's configuration blocks the read, whether a sandbox
+`denyRead` merged from the baseline `Read` deny or filesystem permissions, the script reports
 `Readable: no` and a `not inspectable` note instead of failing. Record the file as not inspectable,
 carry that into the report, and do not reach for another reader to get the counts anyway.
 
@@ -74,7 +74,7 @@ carry that into the report, and do not reach for another reader to get the count
 
 ## Track progress
 
-For any full audit run (Phases 1-5), keep a phase checklist and tick each phase as it completes —
+For any full audit run (Phases 1-5), keep a phase checklist and tick each phase as it completes,
 either in-response or by copying `${CLAUDE_PLUGIN_ROOT}/skills/audit/templates/checklist.md`
 into wherever the consuming repo keeps working task notes. Phase 5 is SKIPPED in default report-only
 mode.
@@ -85,7 +85,7 @@ mode.
 
 Read all config files and validate basic structure.
 
-Record the installed Claude Code version (`claude --version`) — Phase 3.2 compares issue-fix versions
+Record the installed Claude Code version (`claude --version`). Phase 3.2 compares issue-fix versions
 against it. Then run `bash "${CLAUDE_PLUGIN_ROOT}/skills/audit/scripts/check-structure.sh"`
 before the table below.
 
@@ -93,8 +93,8 @@ before the table below.
 
 Run `bash "${CLAUDE_PLUGIN_ROOT}/skills/audit/scripts/check-hook-coverage.sh"` and keep its output for
 the rest of the run. It enumerates settings-declared hooks **and** the hooks shipped by every enabled
-plugin — resolved through the installed-plugin registry, so no version-directory guessing is
-involved — plus the levers (`disableAllHooks`, `allowManagedHooksOnly`,
+plugin, resolved through the installed-plugin registry so no version-directory guessing is
+involved, plus the levers (`disableAllHooks`, `allowManagedHooksOnly`,
 `strictPluginOnlyCustomization`) that switch hooks off wholesale.
 
 Two categories depend on it and neither could take this inventory before:
@@ -105,13 +105,13 @@ Two categories depend on it and neither could take this inventory before:
   hook already blocks the family. That narrowing is only takeable against a real inventory.
 
 **Read the exit code, not just the table.** `0` means the inventory is complete. `1` means it is
-**partial** — some enabled plugin did not resolve, or a hook config did not parse — and the "Not
+**partial**, because some enabled plugin did not resolve or a hook config did not parse, and the "Not
 enumerated" block names which. For anything a partial inventory could not see, keep the conditional
 posture in [required-permissions.md](reference/required-permissions.md) "Fail open where the inventory
 is incomplete". `2` is fatal (no readable settings scope, or `jq` missing); treat it as no inventory at
 all rather than as an empty one.
 
-The script never runs a hook and never decides whether a hook *covers* a family — that judgment stays
+The script never runs a hook and never decides whether a hook *covers* a family. That judgment stays
 with Category B, against the three preconditions in "Narrowing the baseline".
 
 ### 1.1 JSON validity
@@ -142,18 +142,18 @@ Load the audit checklist: [audit-checklist.md](reference/audit-checklist.md)
 
 Run each category's checks. Record findings with severity ratings.
 
-Nine categories — names + the question each answers below; **full per-check criteria in
+Nine categories, with names plus the question each answers below; **full per-check criteria in
 [context/validation-categories.md](context/validation-categories.md)** (read it when running Phase 2).
 
-- **A — Schema & Structure**: `$schema` present, no unknown keys, `mcpServers` not in `settings.local.json`
-- **B — Permissions**: baseline deny/ask patterns present (list in [reference/required-permissions.md](reference/required-permissions.md), plus any additional patterns the consuming repo's own rules declare as required), deny-rules-in-`settings.json`-only (bug #8961)
-- **C — MCP Servers**: commands resolve, `${VAR}` syntax, `disabledMcpjsonServers` match, documented disable reasons
-- **D — Hooks**: paths resolve + readable, `timeout` in seconds and sane, valid matchers, quoted path placeholders in shell form, exec-form `command` resolvable on Windows, no duplicates, valid events
-- **E — Plugins**: static checks (marketplace membership) + live upstream drift detection (`scripts/check-plugin-drift.sh` — ORPHAN/NEW/RENAME modes, auto-fix policy table in the context file)
-- **F — Environment Variables**: documented/justified vars, secrets in `settings.local.json` only, forward-slash paths
-- **G — Skill-listing budget**: overflow check by a route this run can actually take (`/doctor` interactively, `--debug` headless), the budget constant it was measured against, and trim levers scoped to the roster's composition (`skillOverrides` reaches project and user skills; plugin skills are managed through `/plugin`)
-- **H — Model and effort settings**: `effortLevel`, `fallbackModel`, `availableModels`, `enforceAvailableModels` — values the harness accepts into the file but does not apply as written
-- **I — Deep-link registration**: `disableDeepLinkRegistration` — the one documented value that takes effect, and a visible attempt at an enforcement requirement lodged in a scope that cannot enforce it
+- **A, Schema & Structure**: `$schema` present, no unknown keys, `mcpServers` not in `settings.local.json`
+- **B, Permissions**: baseline deny/ask patterns present (list in [reference/required-permissions.md](reference/required-permissions.md), plus any additional patterns the consuming repo's own rules declare as required), deny-rules-in-`settings.json`-only (bug #8961)
+- **C, MCP Servers**: commands resolve, `${VAR}` syntax, `disabledMcpjsonServers` match, documented disable reasons
+- **D, Hooks**: paths resolve + readable, `timeout` in seconds and sane, valid matchers, quoted path placeholders in shell form, exec-form `command` resolvable on Windows, no duplicates, valid events
+- **E, Plugins**: static checks (marketplace membership) + live upstream drift detection (`scripts/check-plugin-drift.sh`, covering ORPHAN/NEW/RENAME modes, auto-fix policy table in the context file)
+- **F, Environment Variables**: documented/justified vars, secrets in `settings.local.json` only, forward-slash paths
+- **G, Skill-listing budget**: overflow check by a route this run can actually take (`/doctor` interactively, `--debug` headless), the budget constant it was measured against, and trim levers scoped to the roster's composition (`skillOverrides` reaches project and user skills; plugin skills are managed through `/plugin`)
+- **H, Model and effort settings**: `effortLevel`, `fallbackModel`, `availableModels`, `enforceAvailableModels`, values the harness accepts into the file but does not apply as written
+- **I, Deep-link registration**: `disableDeepLinkRegistration`, the one documented value that takes effect, and a visible attempt at an enforcement requirement lodged in a scope that cannot enforce it
 
 ---
 
@@ -161,13 +161,13 @@ Nine categories — names + the question each answers below; **full per-check cr
 
 External verification against current documentation.
 
-**Read every page in this phase verbatim, not through a summarizer.** These pages are long — `settings`
-and `env-vars` are hundreds of KB — and a summarizing fetch truncates, then reports the rows past the
+**Read every page in this phase verbatim, not through a summarizer.** These pages are long, with `settings`
+and `env-vars` running to hundreds of KB, and a summarizing fetch truncates, then reports the rows past the
 cutoff as *absent*. That false negative has already been observed on the `settings` page: three keys
 reported NOT FOUND that raw `curl` + `grep` found. So for each fetch below,
 `curl https://code.claude.com/docs/en/<page>.md` to a file and grep the file, per the
 [fetch route](https://github.com/melodic-software/claude-code-plugins/blob/main/docs/conventions/upstream-drift/README.md#reading-the-basis--the-fetch-route).
-**A truncated read supports NO finding** — say so and move on, in either direction: neither "the key is
+**A truncated read supports NO finding.** Say so and move on, in either direction: neither "the key is
 gone" nor "the key is unchanged" is reportable from a read that may have been cut.
 
 ### 3.1 Official docs check
@@ -181,7 +181,7 @@ Fetch [code.claude.com/docs/en/settings](https://code.claude.com/docs/en/setting
 ### 3.2 GitHub issue recheck
 
 For each issue in [known-issues.md](reference/known-issues.md), check live status
-(`gh issue view <number> -R anthropics/claude-code --json state,title` — or the consuming repo's own
+(`gh issue view <number> -R anthropics/claude-code --json state,title`, or the consuming repo's own
 Claude Code issue-tracking skill if it has one). For any issue whose upstream fix has shipped at or
 below the installed Claude Code version, confirm the settings-specific workaround is still needed and
 recommend retiring it if not.
@@ -191,7 +191,7 @@ recommend retiring it if not.
 **MANDATORY** for any category H finding: fetch
 [code.claude.com/docs/en/model-config](https://code.claude.com/docs/en/model-config) and confirm the
 behavior the finding rests on. Do NOT report a category H finding from this checklist's wording
-alone — the accepted `effortLevel` values, the fallback-chain cap, and the allowlist wildcard rule
+alone: the accepted `effortLevel` values, the fallback-chain cap, and the allowlist wildcard rule
 are all upstream-owned and move with the harness.
 
 ### 3.4 Permission syntax verification
@@ -210,7 +210,7 @@ Present all findings as a severity-rated GFM table:
 
 | # | Category | Severity | Finding | Current | Recommended |
 | --- | --- | --- | --- | --- | --- |
-| 1 | B — Permissions | error | Deny rule placed in `settings.local.json`, where bug #8961 leaves it inert | `settings.local.json` → `permissions.deny: ["Bash(rm -rf:*)"]` | Move the rule into `settings.json`; keep `settings.local.json` deny empty |
+| 1 | B, Permissions | error | Deny rule placed in `settings.local.json`, where bug #8961 leaves it inert | `settings.local.json` → `permissions.deny: ["Bash(rm -rf:*)"]` | Move the rule into `settings.json`; keep `settings.local.json` deny empty |
 
 ### Severity guide
 
@@ -248,7 +248,7 @@ After all fixes:
 Auto-fixable (add `$schema`, **move** deny rules from local to project, plugin orphan-removal +
 new-as-`false` via `scripts/fix-plugin-drift.sh --yes`) vs judgment-required (**adding** a baseline deny
 rule, new settings from docs, permission restructure, MCP config, orphan-`true` removal, heuristic
-rename) — full matrix in [context/procedures.md](context/procedures.md) "Phase 5 — fixes the skill can
+rename), with the full matrix in [context/procedures.md](context/procedures.md) "Phase 5, fixes the skill can
 apply". Adding and moving a deny rule are graded apart on purpose: moving one is #8961 placement, while
 adding one has to be checked against hook coverage that may already hold and against an ask-gate the
 addition would suppress.
@@ -260,14 +260,14 @@ addition would suppress.
 Category B (Phase 2) checks that the project's `.claude/settings.json` contains a security baseline of
 deny/ask patterns: secret-file Read denies, destructive-git Bash denies, and a `git push` ask-gate. The
 concrete list is in [reference/required-permissions.md](reference/required-permissions.md). Projects
-with a stricter posture declare their additional required patterns in their own rules files — when the
+with a stricter posture declare their additional required patterns in their own rules files. When the
 consuming repo documents such a list, include it in the Category B check.
 
 Report the secret-file Read denies with their scope, not as protection: a `Read(...)` deny covers the
 built-in file tools and the Bash file commands Claude Code recognizes, but not a subprocess that opens
 the path itself. "Scope of a Read deny" in
 [reference/required-permissions.md](reference/required-permissions.md) carries the covered /
-not-covered split, the ranked remedies, and the platform limit — carry it into the finding rather than
+not-covered split, the ranked remedies, and the platform limit. Carry it into the finding rather than
 implying the file is unreachable.
 
 CC settings schema, MCP server shape, hook event names, and permission glob syntax are upstream
@@ -279,7 +279,7 @@ as fixed patterns here.
 ### Consumer workaround inventory
 
 When a settings-affecting upstream issue drives a project-specific workaround (or one becomes
-obsolete), record that in the consuming repo's own conventions/rules files — the plugin's bundled
+obsolete), record that in the consuming repo's own conventions/rules files. The plugin's bundled
 [known-issues.md](reference/known-issues.md) tracks only broadly-applicable upstream issues and is
 refreshed via plugin updates, not per-consumer edits.
 

--- a/plugins/claude-config/skills/draft-auto-mode-rules/SKILL.md
+++ b/plugins/claude-config/skills/draft-auto-mode-rules/SKILL.md
@@ -1,6 +1,6 @@
 ---
-description: "Draft an `autoMode` classifier block for Claude Code by interviewing you about what should and should not be auto-approved, then printing a paste-ready JSON block to stdout. Entries follow the shape the classifier actually reads well — a label, bulleted COVERED / NOT COVERED, one line of rationale — and every section keeps `\"$defaults\"` so customizing does not discard the built-in rules. Use when: 'help me write auto mode rules', 'draft an autoMode block', 'set up auto mode', 'add an auto-mode rule for X', 'my auto mode rules are too vague', 'rewrite this classifier entry', or after an audit shows rules being dropped or ignored. Prints only — never writes any settings file."
-argument-hint: "[section] — environment | allow | soft_deny | hard_deny to focus the interview"
+description: "Draft an `autoMode` classifier block for Claude Code by interviewing you about what should and should not be auto-approved, then printing a paste-ready JSON block to stdout. Entries follow the shape the classifier actually reads well: a label, bulleted COVERED / NOT COVERED, one line of rationale. Every section keeps `\"$defaults\"` so customizing does not discard the built-in rules. Use when: 'help me write auto mode rules', 'draft an autoMode block', 'set up auto mode', 'add an auto-mode rule for X', 'my auto mode rules are too vague', 'rewrite this classifier entry', or after an audit shows rules being dropped or ignored. Prints only, never writes any settings file."
+argument-hint: "[section]: environment | allow | soft_deny | hard_deny to focus the interview"
 user-invocable: true
 disable-model-invocation: false
 metadata:
@@ -11,7 +11,7 @@ metadata:
 ## Purpose
 
 The `autoMode` block is a natural-language prompt for a classifier, not a rule list the harness
-matches — so it fails in ways a config file does not. `claude auto-mode critique`, run against a real
+matches, so it fails in ways a config file does not. `claude auto-mode critique`, run against a real
 66 KB hand-authored block, found the pattern: the classifier is "an LLM doing a single pass under a
 'default is ALLOW' instruction", so "buried conditions in paragraph position 40 will be missed at a
 materially higher rate than conditions in a bullet list."
@@ -27,7 +27,7 @@ thing this plugin exists not to do.
 ## Scope boundary (route out)
 
 - What is in effect now, what auto mode drops, what a section discards →
-  `claude-config:audit-permission-state`. **Run it first** — drafting against rules you have not read
+  `claude-config:audit-permission-state`. **Run it first.** Drafting against rules you have not read
   is how a block ends up contradicting itself.
 - Grant portability and auto-mode durability → `claude-config:audit-permission-grants`.
 - Whether an existing block is any good → `claude auto-mode critique`, surfaced by
@@ -66,17 +66,17 @@ Three things there change what you should ask:
 Ask about one entry at a time. For each, you need four things, and the fourth is where drafts fail:
 
 1. **Which section.** `allow` (auto-approve), `soft_deny` (block, overridable), `hard_deny` (never),
-   `environment` (facts the classifier needs — organization, repositories, trusted domains).
-2. **A short label** — the subject, two or three words. It is what a reader scans for.
+   `environment` (facts the classifier needs: organization, repositories, trusted domains).
+2. **A short label**: the subject, two or three words. It is what a reader scans for.
 3. **What is covered, and what is explicitly not.** Both. An entry with no stated exclusions is one
    the classifier will over-apply.
 4. **A condition visible in the transcript.** This is the one that matters. The critique's finding was
-   that "uncheckable conditions are the biggest weakness" — entries state preconditions the classifier
+   that "uncheckable conditions are the biggest weakness". Entries state preconditions the classifier
    cannot evaluate from the command text, so it either allows blindly (the condition is decorative) or
    blocks (the grant is inoperable), with no stated disposition.
 
-   When an answer names something the classifier cannot see — a person's intent, a fact about the
-   build server, whether a change was reviewed — **say so and ask for the observable form instead**.
+   Some answers name something the classifier cannot see: a person's intent, a fact about the
+   build server, whether a change was reviewed. **Say so and ask for the observable form instead.**
    "Only when the deploy is approved" is not checkable; "only when the command names the staging
    endpoint" is.
 
@@ -99,15 +99,15 @@ bash "${CLAUDE_PLUGIN_ROOT}/skills/draft-auto-mode-rules/scripts/draft-automode-
 ```
 
 It prints a JSON object carrying only the sections that got entries. **An unknown section name
-is a hard failure** — exit 2, nothing on stdout — rather than a warning beside partial output,
+is a hard failure**, exiting 2 with nothing on stdout rather than warning beside partial output,
 because a caller capturing both streams together would otherwise get unparsable JSON. **Every section opens with
-`"$defaults"`** — customizing a section replaces the built-in list rather than adding to it, so
+`"$defaults"`.** Customizing a section replaces the built-in list rather than adding to it, so
 omitting the token silently discards every shipped rule in that section.
 
 ## Phase 4: Hand it over
 
-Print the block, say exactly where it goes — the `autoMode` key of
-`${CLAUDE_CONFIG_DIR:-$HOME/.claude}/settings.json` — and stop.
+Print the block. Say exactly where it goes: the `autoMode` key of
+`${CLAUDE_CONFIG_DIR:-$HOME/.claude}/settings.json`. Then stop.
 
 Two things to say while handing it over, because both are load-bearing:
 

--- a/plugins/claude-config/skills/setup/SKILL.md
+++ b/plugins/claude-config/skills/setup/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: "Verify claude-config's readiness for this repository — the external CLI prerequisites its audit scripts need, jq (the JSON-parsing audit scripts) and curl (the plugin-drift check), and the tracked suppression record audit-pass reads at .claude/audit-pass.md — so the audit skills run instead of failing. Use when: 'set up claude-config', 'configure claude-config', 'is claude-config working', 'set up audit-pass suppressions', or an audit skill reported a missing prerequisite. Actions: check (read-only verification, default) | apply (resolve what check found). Re-runnable and safe."
+description: "Verify claude-config's readiness for this repository: the external CLI prerequisites its audit scripts need, jq (the JSON-parsing audit scripts) and curl (the plugin-drift check), and the tracked suppression record audit-pass reads at .claude/audit-pass.md, so the audit skills run instead of failing. Use when: 'set up claude-config', 'configure claude-config', 'is claude-config working', 'set up audit-pass suppressions', or an audit skill reported a missing prerequisite. Actions: check (read-only verification, default) | apply (resolve what check found). Re-runnable and safe."
 argument-hint: "check | apply"
 user-invocable: true
 disable-model-invocation: true
@@ -11,106 +11,106 @@ Setup per the uniform setup contract (`docs/PLUGIN-PHILOSOPHY.md` "Setup is expl
 the marketplace repository): `check` inspects and reports, `apply` resolves. This plugin declares no
 `userConfig`, and has two setup concerns:
 
-- the external command-line tools its bundled scripts require — here `apply` is guidance-and-verify
+- the external command-line tools its bundled scripts require, where `apply` is guidance-and-verify
   with no write path: it points at platform install instructions and never installs a system package;
 - the **tracked consumer-project configuration** `audit-pass` reads, the suppression record at
-  `.claude/audit-pass.md` — the one surface `apply` may write.
+  `.claude/audit-pass.md`, the one surface `apply` may write.
 
 Action routing: no argument or `check` runs the check; `apply` runs the check first, then remediation.
-Both are non-interactive — never prompt when the action is given.
+Both are non-interactive, so never prompt when the action is given.
 
 ## `check` (read-only)
 
 The bundled scripts are the single source of truth for what this plugin requires.
 
-**Read it first** — probe what it actually does, don't recite this file. Then run each probe via
-Bash and report a PASS/FAIL/INFO table with one remediation line per FAIL. Do not modify anything.
+**Read it first**, probing what it actually does rather than reciting this file. Then run each probe
+via Bash and report a PASS/FAIL/INFO table with one remediation line per FAIL. Do not modify anything.
 
 The runtime scripts and their tools:
 
-- `${CLAUDE_PLUGIN_ROOT}/skills/audit/scripts/check-plugin-drift.sh` — jq **and** curl, plus awk and sort
-- `${CLAUDE_PLUGIN_ROOT}/skills/audit/scripts/check-structure.sh` — jq; `fix-plugin-drift.sh` — jq plus sort
-- `${CLAUDE_PLUGIN_ROOT}/skills/audit-automation-gaps/scripts/inventory.sh` — jq
-- `${CLAUDE_PLUGIN_ROOT}/skills/audit-permission-grants/scripts/permission-rule-check.sh` — jq plus awk and sort
-- `${CLAUDE_PLUGIN_ROOT}/skills/audit-instructions/scripts/instruction-scan.sh` — grep only (POSIX; no jq)
-- `${CLAUDE_PLUGIN_ROOT}/skills/audit-instructions/scripts/conflict-scan.sh` — awk **and** sort (no jq)
+- `${CLAUDE_PLUGIN_ROOT}/skills/audit/scripts/check-plugin-drift.sh`: jq **and** curl, plus awk and sort
+- `${CLAUDE_PLUGIN_ROOT}/skills/audit/scripts/check-structure.sh`: jq; `fix-plugin-drift.sh`: jq plus sort
+- `${CLAUDE_PLUGIN_ROOT}/skills/audit-automation-gaps/scripts/inventory.sh`: jq
+- `${CLAUDE_PLUGIN_ROOT}/skills/audit-permission-grants/scripts/permission-rule-check.sh`: jq plus awk and sort
+- `${CLAUDE_PLUGIN_ROOT}/skills/audit-instructions/scripts/instruction-scan.sh`: grep only (POSIX; no jq)
+- `${CLAUDE_PLUGIN_ROOT}/skills/audit-instructions/scripts/conflict-scan.sh`: awk **and** sort (no jq)
 
 Only `conflict-scan.sh` probes for awk and sort; the three above it call them with no guard, so read
 each script's actual calls rather than trusting a single script's prerequisite block to speak for the
 plugin.
 
-1. **`jq`** — `command -v jq`. FAIL if absent: the JSON-parsing scripts need it (`inventory.sh` degrades
+1. **`jq`**, via `command -v jq`. FAIL if absent: the JSON-parsing scripts need it (`inventory.sh` degrades
    to an empty inventory; the others `exit 2` with an install remediation). Missing `jq` blocks the three
    JSON-parsing audit skills (`audit`, `audit-automation-gaps`, `audit-permission-grants`);
    `audit-instructions` scans markdown and is unaffected.
-2. **`curl`** — `command -v curl`. FAIL if absent, but scoped: only the plugin-drift check
+2. **`curl`**, via `command -v curl`. FAIL if absent, but scoped: only the plugin-drift check
    (`check-plugin-drift.sh`) uses it and `exit 2`s without it. The rest of `audit` and the other three
-   skills still run — say so in the remediation line.
-3. **`awk` and `sort`** — `command -v awk`, `command -v sort`. FAIL if either is absent, and **not**
+   skills still run; say so in the remediation line.
+3. **`awk` and `sort`**, via `command -v awk` and `command -v sort`. FAIL if either is absent, and **not**
    scoped to one skill: `conflict-scan.sh` executes both and `exit 2`s naming the missing one, while
    `check-plugin-drift.sh` (both), `permission-rule-check.sh` (both), and `fix-plugin-drift.sh`
-   (`sort`) reach them with no prerequisite check at all — so `audit` and `audit-permission-grants`
+   (`sort`) reach them with no prerequisite check at all, so `audit` and `audit-permission-grants`
    fail mid-run on a bare `command not found` rather than on a named prerequisite. Say in the
    remediation line that this FAIL reaches three skills, not just `audit-instructions`. Report `awk`
    and `sort` by name rather than as one row, since a minimal shell can carry one and not the other.
-4. **Bash shell** — INFO: the scripts are bash (arrays, `[[ ]]`, process substitution, `BASH_SOURCE`),
-   run through Claude Code's Bash tool — the bash shell on every platform, Git Bash on native Windows.
+4. **Bash shell**, INFO: the scripts are bash (arrays, `[[ ]]`, process substitution, `BASH_SOURCE`),
+   run through Claude Code's Bash tool, which is the bash shell on every platform and Git Bash on native Windows.
    Report the resolved interpreter; FAIL only if no bash is resolvable.
-5. **Network reachability** — INFO only: `audit`'s drift/freshness fetches read
+5. **Network reachability**, INFO only: `audit`'s drift/freshness fetches read
    `raw.githubusercontent.com`, and a failed fetch degrades to SKIP rather than a setup failure. Do not
-   fetch here — `check` performs no network call.
+   fetch here; `check` performs no network call.
 
 ### The `audit-pass` suppression record
 
 `audit-pass` reads a tracked suppression record layered per the marketplace's config-cascade
 convention. Read the operative shape from
-`${CLAUDE_PLUGIN_ROOT}/skills/audit-pass/reference/suppression.md` rather than inferring it — that
+`${CLAUDE_PLUGIN_ROOT}/skills/audit-pass/reference/suppression.md` rather than inferring it. That
 reference ships inside this plugin, so it resolves in an installed cache where a path out to the
 marketplace's own docs does not. The cross-consumer key contract is the marketplace's published
 **finding-suppression** convention, which is not a runtime dependency of this plugin. All layers
 absent is a valid state (no suppressions), so report INFO, never FAIL, when none exists.
 
-Anchor at the repo root (`${CLAUDE_PROJECT_DIR}`, else `git rev-parse --show-toplevel`) — never a
+Anchor at the repo root (`${CLAUDE_PROJECT_DIR}`, else `git rev-parse --show-toplevel`), never a
 CWD-relative read, which resolves a different (or missing) file depending on the subdirectory or
-nested worktree the skill was invoked from — then report one row per layer. The same
+nested worktree the skill was invoked from, then report one row per layer. The same
 tracked/ignored question has opposite correct answers per layer, so verify each on its own terms:
 
-- **user-global** `~/.claude/audit-pass.md` — outside the worktree; no git command applies. INFO only.
-- **team** `.claude/audit-pass.md` — must be tracked. Untracked while present is a hard STOP:
+- **user-global** `~/.claude/audit-pass.md`: outside the worktree; no git command applies. INFO only.
+- **team** `.claude/audit-pass.md`: must be tracked. Untracked while present is a hard STOP:
   teammates never receive the shared suppressions.
-- **local overlay** `.claude/audit-pass.local.md` — must be gitignored and never staged. Staged or
+- **local overlay** `.claude/audit-pass.local.md`: must be gitignored and never staged. Staged or
   tracked is a FAIL: a personal deviation can reach team history.
 
-Parse each present layer and report any entry missing **any** of its five required keys — `check`,
-`claim`, `sites`, `reason`, `date` — as malformed. Checking only `reason` and `date` would pass an
+Parse each present layer and report as malformed any entry missing **any** of its five required
+keys: `check`, `claim`, `sites`, `reason`, `date`. Checking only `reason` and `date` would pass an
 entry that `audit-pass` itself rejects, so readiness would report green on configuration that cannot
 suppress anything. Report as malformed too an entry whose stored constituents do not hash to its own
 key: the constituents are authoritative and the key is derived from them. A malformed entry does not
 suppress, and a silent partial parse would turn a formatting slip into a lost check.
 
 Report a **user-global or overlay entry for an id the team layer does not carry** as INFO
-`personal-only, not applied`, naming promotion to the team layer as what makes it take effect — the
+`personal-only, not applied`, naming promotion to the team layer as what makes it take effect. The
 team layer is the only one that enacts a suppression, so a personal-only entry that looks live is a
 finding the operator believes is accepted and is not.
 
 ## `apply` (idempotent)
 
-Run `check`, then for each FAIL give the platform install instructions from the README Requirements —
-this skill never installs system packages:
+Run `check`, then for each FAIL give the platform install instructions from the README Requirements.
+This skill never installs system packages:
 
 - **missing `jq`:** the platform's jq install (for example `winget install jqlang.jq`, `brew install
   jq`, or `apt-get install jq`); rerun `check` after.
-- **missing `curl`:** the platform's curl install — modern Windows and Git Bash already ship `curl`.
+- **missing `curl`:** the platform's curl install. Modern Windows and Git Bash already ship `curl`.
   Only the plugin-drift check needs it, so the rest of the plugin works meanwhile.
 - **missing `awk` or `sort`:** both ship with every POSIX userland, so absence means the shell
-  environment is minimal rather than that one package is missing — Git Bash and Windows `busybox`
+  environment is minimal rather than that one package is missing. Git Bash and Windows `busybox`
   shims are where this shows up. Remediate by installing a full userland rather than the single tool:
   Git for Windows, which bundles both; the distribution's `gawk`/`mawk` and `coreutils` on Linux;
   `brew install gawk coreutils` on macOS. Report the two separately, since a minimal shell can carry
-  one and not the other. Three skills depend on them — `audit`, `audit-permission-grants`, and
-  `audit-instructions` — and only the last `exit 2`s cleanly, so do not offer the other two as still
+  one and not the other. Three skills depend on them, `audit`, `audit-permission-grants`, and
+  `audit-instructions`, and only the last `exit 2`s cleanly, so do not offer the other two as still
   working meanwhile.
-- **no resolvable bash:** also not remediable by one package — the scripts use arrays, `[[ ]]`,
+- **no resolvable bash:** also not remediable by one package. The scripts use arrays, `[[ ]]`,
   process substitution, and `BASH_SOURCE`, so they need a real bash on `PATH`: Git for Windows on
   native Windows, the distribution's `bash` elsewhere. Nothing bundled runs until it resolves, so
   say that this FAIL blocks the plugin rather than offering a partial workaround.
@@ -118,19 +118,19 @@ this skill never installs system packages:
 The network row stays INFO and has no `apply` entry on purpose: a failed fetch degrades to SKIP by
 design, so there is nothing to remediate.
 
-After any install, re-run the relevant `check` probe and report its actual result — never claim resolved
+After any install, re-run the relevant `check` probe and report its actual result. Never claim resolved
 on the install command's exit code alone. Re-running `apply` once every probe passes changes nothing and
 reports "already configured".
 
 Then converge the one surface this plugin owns, conservatively:
 
-- **No suppression record anywhere** — leave it that way and say so. Absent is valid; an empty
+- **No suppression record anywhere**: leave it that way and say so. Absent is valid; an empty
   scaffold is noise. Scaffold the team layer with the documented shape only on an explicit request.
-- **Team layer present but untracked** — report the STOP and the exact `git add` the operator should
+- **Team layer present but untracked**: report the STOP and the exact `git add` the operator should
   run. Never stage on their behalf.
-- **Overlay present but not ignored** — recommend the recursive `.claude/**/*.local.*` line and leave
+- **Overlay present but not ignored**: recommend the recursive `.claude/**/*.local.*` line and leave
   the `.gitignore` edit to the consumer.
-- **Malformed or unrecognized entries** — report them and stop. Never rewrite, reorder, or drop an
+- **Malformed or unrecognized entries**: report them and stop. Never rewrite, reorder, or drop an
   operator's suppression: an entry this skill cannot reconcile is a question for the operator, and a
   silent rewrite would hide the very finding the entry was suppressing.
 
@@ -139,23 +139,23 @@ Every write names the file and the exact change before making it, and preserves 
 ## Gotchas
 
 - **Never run a git command against the user-global layer.** `~/.claude/audit-pass.md` is outside the
-  worktree, so `git check-ignore` and `git status` return a meaningless verdict there — or a
+  worktree, so `git check-ignore` and `git status` return a meaningless verdict there, or a
   confidently wrong one when the home directory is itself a git repository.
 - **Missing config is not a failure.** All three suppression layers absent means no suppressions,
   which is the normal state for a repo that has never suppressed a finding. INFO, never FAIL.
 - **Recommend the recursive gitignore line, and leave the edit to the consumer.** `.claude/**/*.local.*`
   covers flat, folder-form, and profiled overlays alike; the narrower `.claude/*.local.*` silently
-  misses any nested overlay. The consumer's ignore file is their artifact — this skill never writes it.
+  misses any nested overlay. The consumer's ignore file is their artifact; this skill never writes it.
 - **An install command's exit code is not verification.** After any install, re-run the probe and
   report its actual result.
 
 ## What this skill does NOT do
 
-- Run an audit — that is `/claude-config:audit`, `/claude-config:audit-automation-gaps`,
+- Run an audit; that is `/claude-config:audit`, `/claude-config:audit-automation-gaps`,
   `/claude-config:audit-permission-grants`, `/claude-config:audit-instructions`, and
   `/claude-config:audit-pass`.
 - Write the plugin cache, Claude Code user settings, or `pluginConfigs`.
 - Install system packages.
 - Write the consumer's `.gitignore`, stage anything, or edit an operator's suppression entries.
-- Download anything — `check` makes no network call; the audit skills' own doc/marketplace fetches are
+- Download anything. `check` makes no network call; the audit skills' own doc/marketplace fetches are
   theirs, not setup's.

--- a/plugins/claude-config/skills/unhobble/SKILL.md
+++ b/plugins/claude-config/skills/unhobble/SKILL.md
@@ -1,6 +1,6 @@
 ---
 description: "Empirical bare-baseline experiment on a repo's standing instructions: reversibly strip project CLAUDE.md/rules/behavioral hooks/skills on a dedicated branch, work normally against the bare model logging observed stumbles to a ledger, then re-add ONLY instructions with repeated same-cause evidence, each restore citing its ledger rows. Measures the model where sibling audit-instructions judges the text. Use when: 'unhobble', 'run the bare experiment', 'delete my CLAUDE.md and see', 'does the model still need these instructions', 'new model dropped, re-baseline', 'instruction ablation experiment'. Human-gated mutations; resumable state."
-argument-hint: "[phase] — snapshot|bare|observe|readd|status (default: guided full flow)"
+argument-hint: "[phase]: snapshot|bare|observe|readd|status (default: guided full flow)"
 user-invocable: true
 disable-model-invocation: false
 metadata:
@@ -14,21 +14,21 @@ As models improve, instruction surfaces written for older models become the ceil
 every standing line every session, and lines that correct mistakes it no longer makes cost context
 and constrain behavior. Official doctrine says cut any line whose removal would not cause mistakes
 ([best-practices](https://code.claude.com/docs/en/best-practices)); the strongest form of that test
-is empirical — delete, run, watch. This skill operationalizes the experiment its sibling
+is empirical: delete, run, watch. This skill operationalizes the experiment its sibling
 `audit-instructions` can only reason about: instead of judging instruction *text* against doctrine,
-it measures the *model* against the repo with the instructions gone, and lets observed stumbles —
-not guesses — decide what returns.
+it measures the *model* against the repo with the instructions gone, and lets observed stumbles,
+not guesses, decide what returns.
 
 Rebuild rule (the whole contract in one line): **an instruction returns only after the bare model
 repeatedly stumbles on the same thing, and the re-added line cites the evidence.**
 
 ## When to run
 
-- A frontier model generation ships (the canonical trigger — instructions written for the previous
-  generation are now suspect).
+- A frontier model generation ships (the canonical trigger, since instructions written for the
+  previous generation are now suspect).
 - The repo's instruction surface has grown past the point anyone can say which lines still earn
   their cost.
-- On a cadence the operator chooses (see Cadence wiring below) — the talk-circuit heuristic is
+- On a cadence the operator chooses (see Cadence wiring below). The talk-circuit heuristic is
   "every six months", but the model release is the real event.
 
 ## Scope and safety rails
@@ -36,7 +36,7 @@ repeatedly stumbles on the same thing, and the re-added line cites the evidence.
 - **Project scope by default.** The experiment strips the *project's* surfaces: project CLAUDE.md /
   CLAUDE.local.md, `.claude/rules/`, `.claude/skills/`, `.claude/agents/`, project-settings hooks,
   and project-enabled plugins. User-global surfaces (`~/.claude/**`) are included only when the
-  operator explicitly opts in per phase-1 prompt — never by default.
+  operator explicitly opts in per phase-1 prompt, never by default.
 - **Managed settings are never touched.** Org-managed policy is not the operator's to ablate.
 - **Reversible by construction.** Tracked-file changes happen on a dedicated experiment branch;
   untracked/settings changes are backed up to plugin state before modification and restored from
@@ -44,7 +44,7 @@ repeatedly stumbles on the same thing, and the re-added line cites the evidence.
 - **Human-gated.** Every mutating step (strip, restore, re-add) presents its exact change set and
   waits for operator confirmation. Bare invocation of a phase never mutates silently.
 - **Security posture is out of scope.** Hooks that enforce policy (secrets gates, PR-body contracts,
-  permission guards) are classified `policy` at snapshot time and are NOT stripped by default —
+  permission guards) are classified `policy` at snapshot time and are NOT stripped by default:
   the experiment measures model capability, and policy gates are not model-era workarounds. The
   operator may force-include one explicitly; the manifest records that choice.
 
@@ -55,63 +55,63 @@ repeatedly stumbles on the same thing, and the re-added line cites the evidence.
 The basename is a convenience label, not the identity: `${CLAUDE_PLUGIN_DATA}` is machine-global,
 so two checkouts sharing a basename (a fork, a same-named worktree) running the same model on the
 same day would otherwise resolve to one directory and cross-restore each other's settings. The
-manifest therefore records the canonical checkout identity — the resolved absolute worktree path
-and, when a remote exists, the origin URL — and every later phase verifies it matches the current
+manifest therefore records the canonical checkout identity, the resolved absolute worktree path
+and, when a remote exists, the origin URL, and every later phase verifies it matches the current
 checkout before acting; a mismatch aborts with the conflicting path named. `snapshot` never reuses
 an existing experiment directory: a fresh run mints a fresh id, and resuming an open experiment
 means passing its phase commands from inside the same checkout its manifest names.
 
-- `manifest.json` — every surface found, its classification (`behavioral` | `policy` | `hybrid` | `convention`),
+- `manifest.json`: every surface found, its classification (`behavioral` | `policy` | `hybrid` | `convention`),
   what was stripped, how to restore it (path, restore mechanism, backup location), branch name,
   target model, phase timestamps.
-- `stumbles.md` — the observation ledger (one row per observed failure: date, task, what the model
+- `stumbles.md`: the observation ledger (one row per observed failure: date, task, what the model
   did, what was expected, suspected missing instruction, severity).
-- `backups/` — pre-strip copies of any non-git-tracked file modified (e.g. settings hook entries).
+- `backups/`: pre-strip copies of any non-git-tracked file modified (e.g. settings hook entries).
 
 `status` prints the manifest summary: phase, days elapsed, ledger row count, re-add candidates.
 
-## Phase 1 — snapshot
+## Phase 1: snapshot
 
 1. Verify a clean working tree; refuse to start on a dirty tree or on the default branch. Create or
    confirm a dedicated branch (suggest `experiment/unhobble-<model-version>`).
 2. Inventory the live project instruction surfaces (the same liveness discipline as
    `audit-instructions` Phase A, lighter: what actually loads in a session here, not what is merely
    on disk). Record line counts per surface.
-3. Classify **every surface the strip plan will touch** — hooks, rules, instruction files
+3. Classify **every surface the strip plan will touch**: hooks, rules, instruction files
    (CLAUDE.md / CLAUDE.local.md, `.claude/skills/`, `.claude/agents/`), and project-enabled
-   plugins alike: `policy` (enforces team/safety policy regardless of model — kept), `behavioral`
-   (corrects or scaffolds model behavior — stripped), `hybrid` (one unit carrying both, with the
-   split named — trimmed, never removed whole), or `convention` (team conventions in git —
+   plugins alike: `policy` (enforces team/safety policy regardless of model, so kept), `behavioral`
+   (corrects or scaffolds model behavior, so stripped), `hybrid` (one unit carrying both, with the
+   split named, trimmed and never removed whole), or `convention` (team conventions in git, the
    operator's call, default kept per the official carve-out). For hook entries specifically, the
-   classification rubric — mechanism vs class, the hybrid trim-not-delete rule, and the
+   classification rubric, covering mechanism vs class, the hybrid trim-not-delete rule, and the
    ground-truth-oracle carve-out (behavioral purpose with a non-derivable machine oracle is a
-   keep) — is owned by the marketplace's PLUGIN-PHILOSOPHY "Classifying a hook" section; this
+   keep), is owned by the marketplace's PLUGIN-PHILOSOPHY "Classifying a hook" section; this
    phase applies it to hooks, never re-derives it. Non-hook surfaces (rules, instruction files,
    skills, agents, plugins) classify by the class definitions above; `hybrid` applies to any unit
    whose behavioral and policy surfaces can be split in place. Classification is per unit that
    Phase 2 acts on: a hook entry, a rule file, a skill, an agent, a plugin. A **mixed** instruction
-   file — a CLAUDE.md carrying both convention sections and behavioral lines is the common case —
+   file, where a CLAUDE.md carrying both convention sections and behavioral lines is the common case,
    is not classified whole: split it in the strip plan, naming which sections are stripped and
    which are preserved (extracted to a retained file or left in place), so the convention
    carve-out holds at section granularity rather than being deleted wholesale with the file. A
    **hybrid hook entry** gets the same treatment at its own granularity: the strip plan names the
    behavioral surface (an injected prose payload, a coaching string) and the policy residue (the
-   gate, the finding relay), and strips only the former — via the hook's own kill switch or
+   gate, the finding relay), and strips only the former, via the hook's own kill switch or
    config where one exists, otherwise recorded as `unstripped-hybrid-hook` with the confound
    noted for the observe phase. Never remove a hybrid entry's wiring whole; that takes the policy
    residue down with the behavioral surface.
 4. Write `manifest.json`; present the strip plan (what goes, what stays and why) and stop for
    confirmation.
 
-## Phase 2 — bare
+## Phase 2: bare
 
 Apply the confirmed strip plan:
 
 - Tracked instruction files: per the plan's per-file (and, for mixed files, per-section)
-  classification — `git rm` / `git mv` a file classified behavioral whole; for a mixed file,
+  classification, `git rm` / `git mv` a file classified behavioral whole; for a mixed file,
   remove the behavioral sections and keep the convention sections in place or in an extracted
-  retained file. A file classified `hybrid` operationalizes exactly like a mixed file — strip the
-  behavioral sections, keep the policy residue in place or extracted — the classes differ in what
+  retained file. A file classified `hybrid` operationalizes exactly like a mixed file, stripping the
+  behavioral sections and keeping the policy residue in place or extracted. The classes differ in what
   the residue is (policy vs convention), not in the mechanics. One commit, message
   `experiment: strip instruction surfaces for unhobble baseline`.
 - Project-settings hook entries classified `behavioral`: back up the settings file to `backups/`,
@@ -121,7 +121,7 @@ Apply the confirmed strip plan:
   phase notes the confound), per the plan's named split.
 - Project-enabled plugins: record the current enabled set in the manifest, then disable the ones
   classified `behavioral` for this project (leave policy/tooling plugins the operator marked keep).
-  Plugins toggle whole — project settings offer no partial disable — so a plugin classified
+  Plugins toggle whole, since project settings offer no partial disable, so a plugin classified
   **`hybrid`** (any `policy`-classified surface alongside behavioral components, e.g. a policy
   hook next to behavioral convenience skills; older strip plans say "mixed" for the same class)
   is **kept whole**, with its behavioral components recorded in the manifest as
@@ -131,38 +131,38 @@ Apply the confirmed strip plan:
   behavioral or hybrid HOOK may still be individually stripped when the plugin exposes a per-hook
   kill switch (a `<hook>_enabled`-style userConfig option): record the option flipped and its
   prior value in the manifest as a partial strip, restoring by flipping it back. No per-hook
-  switch → the hook stays loaded, recorded by its own class — `unstripped-behavioral-hook` for a
+  switch → the hook stays loaded, recorded by its own class: `unstripped-behavioral-hook` for a
   plain behavioral hook (nothing of it is legitimately loaded; the whole hook is the confound),
   `unstripped-hybrid-hook` for a hybrid (its policy residue is legitimately loaded; only the
-  behavioral surface is the confound) — alongside the plugin's confound note.
+  behavioral surface is the confound), alongside the plugin's confound note.
 - Print the "you are bare" summary: what a fresh session will now load (ideally: nothing but the
   code) and how to restore everything (`readd` phase reads the manifest; `git` holds the files).
 
-Start a **fresh session** after stripping — the current session already carries the old
+Start a **fresh session** after stripping. The current session already carries the old
 instructions in context, so it cannot measure their absence.
 
-## Phase 3 — observe
+## Phase 3: observe
 
 Work normally on real tasks for a meaningful window (days of real work, not one toy prompt). When
-the model stumbles — does something an instruction used to prevent, misses a convention, breaks a
-workflow — append a row to `stumbles.md`:
+the model stumbles, doing something an instruction used to prevent, missing a convention, or breaking a
+workflow, append a row to `stumbles.md`:
 
 | Date | Task | What happened | Expected | Suspected missing instruction | Severity |
 
-Log honestly, including surprises in the other direction (things the bare model now does *better* —
-mark those `improvement`; they are the deletions proving themselves). The ledger is the experiment's
+Log honestly, including surprises in the other direction (things the bare model now does *better*;
+mark those `improvement`, since they are the deletions proving themselves). The ledger is the experiment's
 entire evidentiary output: an unlogged stumble cannot earn an instruction back, and a ledger with no
 rows after real work is a licensed permanent deletion.
 
-## Phase 4 — readd
+## Phase 4: readd
 
 1. Group ledger rows by suspected missing instruction. The gate: **at least two rows, same
-   underlying cause.** One-off failures do not reopen a standing line — retry the task first.
-2. For each group that clears the gate, restore the narrowest instruction that addresses the cause —
-   a single line or rule file, not the whole pre-experiment surface — and cite the ledger rows in
+   underlying cause.** One-off failures do not reopen a standing line; retry the task first.
+2. For each group that clears the gate, restore the narrowest instruction that addresses the cause,
+   a single line or rule file rather than the whole pre-experiment surface, and cite the ledger rows in
    the restoring commit or an adjacent comment.
 3. For instructions being rewritten rather than restored verbatim, route the text-level judgment to
-   `audit-instructions` (same plugin) — it owns instruction-content-vs-doctrine analysis.
+   `audit-instructions` (same plugin), which owns instruction-content-vs-doctrine analysis.
 4. Everything the ledger did not defend stays deleted. Close the experiment: final manifest update
    (`phase: closed`, surfaces restored vs retired counts), and merge or fold the experiment branch
    per the repo's normal PR flow.
@@ -172,7 +172,7 @@ rows after real work is a licensed permanent deletion.
 The re-run trigger is the next frontier model release. To make that standing rather than
 remembered: if the `work-items` plugin is installed, add a recurring item ("re-run
 `/claude-config:unhobble` against the new model") rechecked on model upgrades; otherwise a note in
-the repo's own conventions or a calendar reminder serves. This skill never wires a schedule itself —
+the repo's own conventions or a calendar reminder serves. This skill never wires a schedule itself:
 scheduling surfaces vary per consumer and are the operator's choice.
 
 ## Gotchas
@@ -187,7 +187,7 @@ scheduling surfaces vary per consumer and are the operator's choice.
   2026-08-17): simple mode (`CLAUDE_CODE_SIMPLE=1`, CLI flag `--bare`) disables fetches, keychain
   reads, and `CLAUDE.md` auto-discovery, while `CLAUDE_CODE_SIMPLE_SYSTEM_PROMPT=1` swaps in the
   lean built-in system prompt. Both ablate *Claude Code's own* surfaces, so this skill neither sets
-  nor depends on either — the experiment here ablates *your* instructions, which is the part you
+  nor depends on either: the experiment here ablates *your* instructions, which is the part you
   own. (Measuring what those product-side switches buy belongs to a context-budget audit, not to
   this experiment.)
 - **Windows:** restore paths in `manifest.json` are stored with forward slashes; git handles both.
@@ -197,5 +197,5 @@ scheduling surfaces vary per consumer and are the operator's choice.
 - Never strips managed settings, user-global surfaces (without explicit opt-in), or policy-classified
   hooks by default.
 - Never mutates without presenting the change set and getting confirmation.
-- Does not judge instruction text against doctrine — that is `audit-instructions`.
+- Does not judge instruction text against doctrine; that is `audit-instructions`.
 - Does not schedule its own re-runs; cadence wiring is the operator's, per above.


### PR DESCRIPTION
No linked issue

## Summary

Fifth #2891 de-slop shard: purge em dashes from the `claude-config` plugin instruction surfaces, the
next-worst cluster after `session-flow` (#3106), `planning` (#3105), `work-items` (#3107) and
`source-control` (#3108). #2891 stays open; ranked by em-dash lines over non-vendor instruction
surfaces, the next unclaimed cluster after this one is `discipline` (468), then `claude-ops` (336).

## Fix

Rewrote `README.md` and all ten `SKILL.md` files under `/ai-slop:audit fix` semantics: em dashes
become periods, commas, a colon before a list, or a restructured sentence. Never parentheses, en
dashes, or a spaced hyphen, since each of those is the same interruption wearing a different mark.

A self-review against that guardrail caught seven places where a paired em dash had become
parentheses in this very diff — four frontmatter `description` values (`audit`, `audit-instructions`,
`audit-automation-gaps`, `audit-prompting-postures`) and three inline spots (`setup`'s required-keys
list, `audit-instructions`' I8-family list and its discover-instruction-surfaces population,
`audit-pass`' exclusion-set aside). All seven were restructured to commas, a colon, or a sentence
break; the net parenthesis delta across the diff is -1.

Frontmatter `description` and `argument-hint` values are rewritten too. No quoted auto-invocation
trigger phrase contained an em dash, so no trigger changed. `claude-config` 0.38.10.

Wording only: no check, phase, gate, lane, contract, or script changed.

## Verification

This repo's `.claude/ai-slop.json` disables `rule-em-dash` corpus-wide (a deliberate house-style
decision, #3031), so every detector run below pins `HOME` and `CLAUDE_PROJECT_DIR` to empty
directories to lift that config and force the rule on — the same isolation the detector's own test
suite uses.

- `detect.sh` over the 11 shard files: **482 `rule-em-dash` findings to 0**, with every other rule
  also reporting 0.
- No en dash or spaced hyphen introduced; net parenthesis delta -1.
- `scripts/check-changelog-parity.sh --check` and `--check-bump origin/main`: pass.
- `CHECK_SKILL_SKIP_MARKDOWNLINT=1 bash scripts/check-changed-skills.sh origin/main`: 10 skills,
  0 errors. It confirms every base-ref trigger phrase is preserved on all ten. One soft warning
  (`unhobble` at 201 lines against a 200-line target) is pre-existing.
- `markdownlint-cli2` over the 12 changed files: 0 issues.
- `node scripts/generate-cheatsheet.mjs`: already in sync — no `metadata.summary` value changed, so
  unlike the `work-items` shard this one needs no cheat-sheet refresh.
- `python3 scripts/sync-plugin-options-docs.py --check`, `typos`, `editorconfig-checker`: pass.
- `origin/main` merged into the branch before this PR; no conflicts, and the two new main commits
  (#3115, #3116) touch no `claude-config` file.

**Pre-existing failure, not from this diff.** Three `audit-permission-state` script suites fail in
this environment: `permission-merge` 19/51, `automode-entry-diff` 3/63, `managed-conformance` 1/37.
They fail with identical counts on a clean `origin/main` worktree, and this shard touches no script.
Flagging rather than fixing, since diagnosing them is out of scope here.

## Related

- Refs #2891 — the de-slop campaign this shard advances; stays open for the remaining clusters.
- Refs #3105, #3106, #3107, #3108 — the sibling instruction-surface shards.
- Refs #3031 — the measurement and decision that disabled `rule-em-dash` corpus-wide, which is why
  the verification runs force the rule back on rather than trusting a default run.

**Deferred finding, deliberately not fixed here: manifest `description` fields are outside the
campaign's scope definition.** Review flagged that `plugins/claude-config/.claude-plugin/plugin.json`
still carries 5 em dashes in its marketplace-facing `description`. That is correct, and it is a gap
in #2891's own scoping rather than in this shard: the issue defines the target set as "every
`SKILL.md`, plugin READMEs, `AGENTS.md`, root `README`", which does not include `plugin.json`. The
merged `work-items` shard (#3107) touched its manifest for the version bump only, so every shipped
shard carries the same gap.

Measured across the marketplace: **47 plugins** have em dashes in their manifest `description`, led
by `discipline` (14), `claude-ops` (12) and `session-flow` (11). Fixing only `claude-config` here
would leave the shard series internally inconsistent while resolving 5 of ~120 occurrences, so this
belongs to a campaign-level decision on #2891 about whether manifest descriptions join the target
set, not to this PR. Recorded here so it is not lost.
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tu5t8rYWv2kDzRcdmLE2ro

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tu5t8rYWv2kDzRcdmLE2ro)_


---
_Generated by [Claude Code](https://claude.ai/code)_