### PR TITLE
fix(testing): make the date guard discriminating, and correct two records it exposed

### DIFF
--- a/plugins/ai-slop/.claude-plugin/plugin.json
+++ b/plugins/ai-slop/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "ai-slop",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Detects and removes AI-writing tells (slop) in checked-in markdown prose: em dashes, emoji formatting, AI vocabulary, negative parallelisms, chatbot phrases, filler, stacked hedging, citation artifacts, and the rest of a catalog distilled from Wikipedia's Signs of AI writing. Read-only audit by default with a deterministic detector plus a judgment rubric; an explicit fix action rewrites findings behind a semantic-diff guard. Findings conform to the detector-findings convention so the review fanout fix relay can consume them.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/ai-slop/CHANGELOG.md
+++ b/plugins/ai-slop/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.3.4]
+
+- **The README now points back at the upstream ledger.** `docs/upstream/cursor-pstack.md` names
+  this plugin's catalog and rewrite guide as where the Cursor `unslop` skill landed, but nothing
+  under `plugins/ai-slop/` pointed the other way — the only derived plugin in the marketplace with
+  no citation of that file, so a reader who arrived at the catalog through the README had no route
+  to what the port took, deduplicated, or rejected, nor to the row that decides the next drift
+  recheck. The README's existing sentence naming Cursor's skill now carries that link. The pointer
+  belongs here rather than appended to the earlier entry that recorded the port, because a published
+  changelog entry is history and is not edited. Documentation only.
+
 ## [0.3.3]
 
 Three corrections found by re-reading what 0.3.1 and the 2.4.0 contract release actually shipped.

--- a/plugins/ai-slop/README.md
+++ b/plugins/ai-slop/README.md
@@ -26,8 +26,11 @@ distilled from Wikipedia's
 ["Signs of AI writing"](https://en.wikipedia.org/wiki/Wikipedia:Signs_of_AI_writing)
 (revision-pinned, tracked under the upstream-drift convention), plus a set of additions inspired by
 [Cursor's `unslop` skill](https://github.com/cursor/plugins/blob/main/pstack/skills/unslop/SKILL.md)
-and deduplicated against it in the catalog's overlap map. Fix-time rewrite guidance (plain speech,
-substitution guardrails, adding voice) lives in
+and deduplicated against it in the catalog's overlap map. What that port took, deduplicated, and
+rejected is recorded in the marketplace's upstream ledger,
+[`docs/upstream/cursor-pstack.md`](../../docs/upstream/cursor-pstack.md) (the `unslop` row), which
+is also where the next drift recheck against upstream is decided. Fix-time rewrite guidance (plain
+speech, substitution guardrails, adding voice) lives in
 [`skills/audit/reference/rewrite-guide.md`](skills/audit/reference/rewrite-guide.md), which the
 `fix` action applies.
 

--- a/plugins/overengineering/.claude-plugin/plugin.json
+++ b/plugins/overengineering/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "overengineering",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Evidence-earned-keep audit of an existing enforcement surface — agent hooks and standing instructions, repository and version-control hooks, CI lanes and gate scripts, branch protections, forge apps, declared external integrations — treating every incumbent mechanism as a retirement candidate until empirical evidence earns its keep, arguing every verdict in cost of carry, capping retirement-direction verdicts on security-class artifacts at FLAG-FOR-HUMAN, and realigning to the simplest adequate solution behind an explicit per-item human gate. The audit is read-only and emits a diffable findings artifact; realignment is a separate, explicitly invoked skill; and a third read-only lane re-runs the audit on whatever cadence the consumer wires and reports only what moved since the last run, above a configurable noise budget.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/overengineering/CHANGELOG.md
+++ b/plugins/overengineering/CHANGELOG.md
@@ -3,6 +3,23 @@
 All notable changes to the `overengineering` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.2.1]
+
+### Fixed
+
+- **The findings artifact's `date:` field was justified by a property it cannot have.**
+  `context/findings-artifact.md` argued the field as "Colon-free UTC, **Windows-safe**, lexically
+  sortable". Windows-safety is a *filename* property — a colon is illegal in a Windows path
+  component — and is meaningless for a field written *inside* a file; this contract fixes one
+  stable filename per home (`findings.md`) and deliberately rejects a timestamped one, so there is
+  no filename here for the claim to attach to either. The row now argues the format on what is
+  actually true of it: compact, unambiguous about its zone, and lexically sortable, so string order
+  is chronological order. **The format is unchanged.** ISO-basic `YYYYMMDDTHHMMSSZ` is valid
+  ISO-8601 and this artifact is not a detector-findings adopter — its only consumer is
+  `/overengineering:realign` — so nothing obliges it to match any neighbor's extended form, and a
+  wrong rationale is not grounds to move a contract that works. Documentation only; no consumer
+  reads the rationale cell.
+
 ## [0.2.0]
 
 ### Added

--- a/plugins/overengineering/context/findings-artifact.md
+++ b/plugins/overengineering/context/findings-artifact.md
@@ -73,7 +73,7 @@ branch: <branch at audit time>
 |---|---|---|
 | `type` | yes | Exactly `overengineering-findings`. The selector realign matches on. |
 | `schema` | yes | Integer contract version, currently `1`. A consumer reading an unrecognized value **stops with a visible message** rather than guessing at the shape. |
-| `date` | yes | Colon-free UTC, Windows-safe, lexically sortable. The only record of when the audit actually ran. |
+| `date` | yes | ISO-basic UTC (`YYYYMMDDTHHMMSSZ`): compact, unambiguous about its zone, and lexically sortable — string order is chronological order. The only record of when the audit actually ran. (Colon-freedom buys nothing *inside* a file; it is a **filename** property, and this contract fixes one stable filename per home rather than a timestamped one.) |
 | `scope` | yes | The layers walked, from the layer vocabulary below. A layer-scoped pass says so here; **a layer absent from `scope` was not walked, and is not the same as a layer walked and found empty.** The merge rules depend on this distinction. |
 | `branch` | yes | The branch at audit time. Realign refuses an artifact whose `branch:` does not match the current branch, naming the mismatch. |
 

--- a/plugins/testing/.claude-plugin/plugin.json
+++ b/plugins/testing/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "testing",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "Test-stage discipline across all ecosystems: coverage-gap analysis and test planning (`/testing:plan`), TDD test authoring and placement (`/testing:write`), live E2E plus non-UI smoke verification (`/testing:run-e2e`), failing-test root-cause diagnosis with the reproduce → isolate → fix → retest loop (`/testing:diagnose`), and a deterministic can't-fail test audit with a fail-closed gate mode and opt-in findings persistence (`/testing:audit`).",
   "author": {
     "name": "Melodic Software",

--- a/plugins/testing/CHANGELOG.md
+++ b/plugins/testing/CHANGELOG.md
@@ -3,6 +3,32 @@
 All notable changes to the `testing` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.7.4]
+
+### Fixed
+
+- **`audit`'s own unit suite carried a can't-fail assertion for the `date:` frontmatter
+  field.** `cant-fail-scan.test.sh` asserted `date: 20` under the name "date frontmatter is
+  present" — a truncated prefix of a structured value, so it passed for the emitter's real
+  `2026-08-23T04:37:40Z` and equally for `2026-08-21T13-36-00Z`, a hyphenated time that is
+  ISO-8601 in neither the extended nor the basic profile. That is the same assertion shape
+  that pinned `ai-slop`'s emitter bug rather than catching it (#3097), sitting inside the
+  skill whose whole purpose is finding tests that cannot fail. The assertion now anchors the
+  full extended form with an explicit `Z`
+  (`^date: [0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$`), and was confirmed
+  discriminating: it FAILS against both malformed shapes above and PASSES against
+  `cant-fail-scan.sh --findings` output. Test-only — the emitter already stamped the correct
+  format, so no scanner behavior changes.
+
+### Added
+
+- **`assert_matches <name> <haystack> <ERE>` in `cant-fail-scan.test.sh`.** An assertion about
+  the *shape* of a field's value now has somewhere to go other than a substring test on part
+  of that value, which is what produced the guard above. The file's sibling assertions were
+  re-read at the same time: every other one pins an exact literal that a malformed value would
+  not contain, so that was the only non-discriminating guard present and nothing else was
+  rewritten.
+
 ## [0.7.3]
 
 ### Changed

--- a/plugins/testing/skills/audit/scripts/cant-fail-scan.test.sh
+++ b/plugins/testing/skills/audit/scripts/cant-fail-scan.test.sh
@@ -40,6 +40,17 @@ assert_not_contains() {
     *) pass "$1" ;;
   esac
 }
+assert_matches() {
+  # assert_matches <name> <haystack> <ERE>. Use this wherever the assertion is
+  # about the SHAPE of a field's value: a substring check on a prefix of that
+  # value passes for every malformed value sharing the prefix, which is the
+  # can't-fail shape this scanner exists to find.
+  if printf '%s\n' "$2" | LC_ALL=C grep -qE "$3"; then
+    pass "$1"
+  else
+    fail "$1" "expected output to match ERE: $3"
+  fi
+}
 count_lines() { printf '%s\n' "$1" | grep -c "$2"; }
 
 TMP_ROOT="$(mktemp -d)"
@@ -144,7 +155,14 @@ out="$(CANT_FAIL_SCAN_ROOT="$REPO" bash "$SCAN" --findings 2>/dev/null)" || rc=$
 assert_exit "--findings completes in a git repo" 0 "$rc"
 assert_contains "frontmatter declares the findings type" "$out" "type: review-findings"
 assert_contains "branch frontmatter is the checked-out branch, verbatim" "$out" "branch: findings-branch"
-assert_contains "date frontmatter is present" "$out" "date: 20"
+# The `date:` value is a contract SHAPE, not a presence flag. `date: 20` also
+# matches `date: 2026-08-21T13-36-00Z` — a hyphenated time that is ISO-8601 in
+# neither the extended nor the basic profile — so it is the same assertion that
+# pinned ai-slop's emitter bug instead of catching it (#3097). Anchoring the
+# full extended form with an explicit `Z` makes a format-string regression in
+# the emitter fail here.
+assert_matches "date frontmatter is ISO-8601 extended UTC (YYYY-MM-DDThh:mm:ssZ)" "$out" \
+  '^date: [0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$'
 assert_not_contains "tier: is omitted (no lifecycle-tier analogue)" "$out" "tier:"
 assert_contains "table header matches the consumed shape" "$out" "| Rank | Tier | Confidence | Location | Surface(s) | Finding | Action |"
 assert_contains "row carries tier and confidence" "$out" "| IMPORTANT | high |"


### PR DESCRIPTION
No linked issue.

## Summary

Three items surfaced by adversarial verification passes on #3097 and #3094, each re-confirmed against `origin/main` before this branch was cut. One is a test that cannot fail, inside the skill built to find tests that cannot fail. The other two are records that misstate something, in documents whose job is to be accurate.

Nothing behavioral changes. All three plugins take patch bumps.

## Fix

**1 — a non-discriminating guard in `testing:audit`'s own suite.** `cant-fail-scan.test.sh` asserted:

```
assert_contains "date frontmatter is present" "$out" "date: 20"
```

That needle is a truncated prefix of a structured value, so it accepts anything beginning `date: 20` — including the malformed `date: 2026-08-21T13-36-00Z` that #3097 just removed from `ai-slop`'s emitter, where an identically-shaped guard had been holding the bug in place while passing green. `testing:audit` exists to detect exactly this, which is why it is worth fixing on principle as well as on merit.

Replaced with an anchored shape assertion, via a new `assert_matches <name> <haystack> <ERE>` helper added beside the file's three existing asserts so shape checks have somewhere to live other than a prefix match:

```
assert_matches "date frontmatter is ISO-8601 extended UTC (YYYY-MM-DDThh:mm:ssZ)" "$out" \
  '^date: [0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$'
```

**Proven to discriminate, not asserted.** Both assertion bodies run against three inputs, the last produced by actually invoking `cant-fail-scan.sh --findings`:

| Input | Old assertion | New assertion |
|---|---|---|
| `date: 2026-08-21T13-36-00Z` (hyphenated time) | PASS | **FAIL** |
| `date: 2026-08-21` (no time, no `Z`) | PASS | **FAIL** |
| `date: 2026-08-23T04:37:40Z` (real emitter output) | PASS | PASS |

**Sibling assertions were audited and deliberately left alone.** `date: 20` was the only needle in the file that is a truncated prefix of a structured value; every other one pins a whole-token literal a malformed value would not contain (`type: review-findings`, the full table header, `| IMPORTANT | high |`, `left\|\|right`, the refusal strings). No test-suite rewrite.

**2 — a justification that does not hold, in `overengineering`'s findings-artifact contract.** Its frontmatter `date` field was justified as "Colon-free UTC, **Windows-safe**, lexically sortable". Windows-safety is a *filename* property — a colon is illegal in a Windows path component and irrelevant to a field inside a file.

**The format is not changed and was never wrong.** ISO-basic `YYYYMMDDTHHMMSSZ` is valid ISO-8601 and lexically sortable; this artifact has its own consumer (`/overengineering:realign`) and is explicitly not a detector-findings producer, so nothing obliges it to match `ai-slop`'s extended form. The format specification at all three sites is byte-identical to `main`; only the rationale cell changed.

The claim is dropped rather than re-sited, because there is no filename to attach it to: this contract fixes "one stable filename per home, rewritten in place" and rejects a timestamped filename by name. The cell now records *why* colon-freedom does not apply here, so the claim does not quietly return.

**3 — the one derived plugin with no reverse pointer to the upstream record.** Measured: `plugins/ai-slop/CHANGELOG.md` cited `docs/upstream/cursor-pstack.md` zero times, against at least one citation in each of the eleven other derived plugins.

The natural home — ai-slop's #3031 entry — is published history this repo does not edit, so the pointer went to the plugin README instead, onto the sentence that already named Cursor's `unslop` skill and the overlap map. **Flagged as a new placement:** no plugin README cites `docs/upstream/` today; all eleven existing citations are in changelogs. Defensible, but new, and easy to relocate if you would rather it went elsewhere.

## Verification

| Gate | Result |
|---|---|
| Discrimination proof (item 1) | old assertion accepts both malformed inputs; new one rejects both, accepts real emitter output |
| `cant-fail-scan.test.sh` | All 69 checks passed |
| `ai-slop detect.test.sh` (regression) | All 92 cases passed |
| `check-changelog-parity.sh` `--check` / `--check-bump` / `--check-order` / `--check-preserved` | PASS — 83 changelogs; 3 changed, 36 headings preserved |
| `check-changed-skills.sh origin/main` | PASS — 0 errors, 0 warnings |
| `check-stale-base-overlap.sh --check origin/main` | up to date |
| `shellcheck` | clean |
| `markdownlint-cli2` on 5 changed files | 0 issues |
| Published changelog entries | all three files `+N -0` — additive only |

Versions verified against `main` before bumping rather than assumed: `testing` 0.7.3 → 0.7.4, `ai-slop` 0.3.3 → 0.3.4, `overengineering` 0.2.0 → 0.2.1. All patch — every change is test-only or documentation-only.

## Related

- #3097 — removed the same guard shape from `ai-slop`'s emitter test, where it had been pinning a real bug.
- #3094 / #3103 — the attribution-table work whose verification surfaced item 3.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AqwX2njhiLMWGrMg3QNt4g)_