### PR TITLE
fix(docs): correct the unstamped --config reconfiguration claim (#3127)

### DIFF
--- a/docs/MIGRATION-PLAYBOOK.md
+++ b/docs/MIGRATION-PLAYBOOK.md
@@ -1336,13 +1336,15 @@ Reintegration (below) covers a repo that already ran an in-repo copy and now swi
    cutover, which pairs both fields in the project settings.
 2. **Enable at project scope** so every clone inherits it — declare `enabledPlugins` in the same
    checked-in `.claude/settings.json` (choose user scope instead for machine-wide, not per-repo).
-3. **Install and seed config on one fresh install.** `--config` is accepted only on a fresh install
-   (smoke-test C), so pass every option on the install command, never a later call: `claude plugin
+3. **Install and seed config.** Pass every option on the install command: `claude plugin
    install <plugin>@<marketplace> --scope project --config KEY=VALUE …` (repeatable, schema-validated).
    Non-sensitive options land in the **user** `settings.json` `pluginConfigs` regardless of the enable
    scope; a sensitive value still routes to secure credential storage (smoke-tests A and C).
-   Interactively, `/plugin configure` owns personal `userConfig`; an explicit setup skill owns any
-   separate tracked project configuration declared by the plugin.
+   Re-running that command later against an already-installed plugin prints `already installed`
+   **and still writes the value** (smoke-test C), so a headless reconfiguration is another `--config`
+   install rather than an uninstall/reinstall. Interactively, `/plugin configure` owns personal
+   `userConfig`; an explicit setup skill owns any separate tracked project configuration declared by
+   the plugin.
 4. **Headless prompting caveat.** Install never prompts non-interactively — a required `userConfig`
    option left unset does **not** block the install; it stays advisory until set (smoke-test C). Seed
    every required option on the install command so the plugin does not run unconfigured.
@@ -1388,10 +1390,11 @@ surface to a published plugin for a single consumer's low-value nicety.
    marketplace does not install its plugins, so do both explicitly at project scope: `claude plugin
    marketplace add <repo> --scope project` then `claude plugin install <plugin>@<marketplace> --scope
    project --config KEY=VALUE …`, seeding every
-   non-default `userConfig` toggle on that install command — `--config` applies only on a fresh install and
-   is ignored once the plugin is already installed (smoke-test C), so a headless reconfiguration later
-   means uninstall/reinstall. **Exception:** a `directory`/`file` relative-path entry in checked-in
-   project settings resolves against the repo checkout (cloud sessions included) — see
+   non-default `userConfig` toggle on that install command — re-running it later against an
+   already-installed plugin prints `already installed` **and still writes the value** (smoke-test C),
+   so a headless reconfiguration is another `--config` install, not an uninstall/reinstall.
+   **Exception:** a `directory`/`file` relative-path entry in checked-in project settings resolves
+   against the repo checkout (cloud sessions included) — see
    [`docs/CLOUD-SESSIONS.md`](CLOUD-SESSIONS.md). Otherwise the marketplace is known but the plugin is absent, and step 3's
    verify edit would run with no plugin hook.
 2. Interactively, `/plugin configure` adjusts `userConfig` toggles at any time; keep the

--- a/docs/PLUGIN-PHILOSOPHY.md
+++ b/docs/PLUGIN-PHILOSOPHY.md
@@ -259,8 +259,11 @@ hand-edit — migrates to `userConfig` with the schema used honestly:
   lands in `~/.claude/.credentials.json`, so verify storage on the target platform before migrating
   a secret; and
 - `claude plugin install --config` documented in the plugin's setup skill for headless use — note
-  in that same documentation that this flag only seeds a value on a fresh install; re-running it
-  against an already-installed plugin does not update the stored value (empirically verified); and
+  in that same documentation that re-running it against an already-installed plugin prints
+  `already installed` **and still writes the value**: the short-circuit is about the install, not the
+  config write. **Empirically verified on Claude Code 2.1.240** (a non-sensitive option at `user`
+  scope: a non-default value written to an installed plugin, then restored) — a `sensitive` option
+  and `project`/`local` scope were not covered, so re-verify before relying on it there; and
 - for any `sensitive: true` option, the plugin's README documents `/plugin configure
   <plugin>@<marketplace>` as the rotation/clear path (see
   [`docs/extensibility-contract-smoke-tests.md`](extensibility-contract-smoke-tests.md) Test E —

--- a/docs/extensibility-contract-smoke-tests.md
+++ b/docs/extensibility-contract-smoke-tests.md
@@ -18,8 +18,8 @@ relative path resolved against?
 
 **Commands.**
 
-`--config` is applied only on a fresh install (Test C), so uninstall before each run and read the
-stored `pluginConfigs` after each:
+Each run uninstalls first so every observation starts from a clean install, then reads the stored
+`pluginConfigs`:
 
 ```shell
 # 1) existing relative paths
@@ -107,10 +107,14 @@ claude plugin install smoketest@<marketplace> --scope local </dev/null
   configure smoketest@<marketplace> in Claude Code, or pass --config KEY=VALUE.`
 - **The non-interactive configuration path is `--config KEY=VALUE`** on `claude plugin install`
   (repeatable, schema-validated, "stored via the same path as the interactive `/plugin configure`
-  flow"). It applies **only on a fresh install** — `--config` is ignored once the plugin is already
-  installed (the command short-circuits "already installed"). `claude plugin` has no `configure`
-  subcommand (verified against `claude plugin --help` on 2.1.207; `/plugin configure` is an interactive
-  slash command only), so reconfiguring headless requires uninstall then reinstall.
+  flow"). Against an already-installed plugin the command short-circuits and prints
+  `already installed` — the observation recorded here on 2.1.207 — but it **still writes the value**:
+  the short-circuit is about the install, not the config write. **Re-verified on Claude Code 2.1.240**
+  (a non-sensitive option at `user` scope: a non-default value written to an installed plugin, then
+  restored); a `sensitive` option and `project`/`local` scope were not covered. `claude plugin` has no
+  `configure` subcommand (verified against `claude plugin --help` on 2.1.207; `/plugin configure` is an
+  interactive slash command only), so headless reconfiguration is another `--config` install — not
+  uninstall then reinstall.
 - **CI implication.** Seed every required option with `--config` at install time. A bare headless
   install leaves required options unset without failing, so the plugin would run unconfigured.
 

--- a/docs/extensibility-contract-smoke-tests.md
+++ b/docs/extensibility-contract-smoke-tests.md
@@ -28,7 +28,7 @@ claude plugin install smoketest@<marketplace> --scope local \
   --config req_key=hello --config some_dir=./realdir --config some_file=./realfile.txt
 # then read ~/.claude/settings.json → pluginConfigs[smoketest@<marketplace>].options
 
-# 2) non-existent relative paths (uninstall first, or --config short-circuits as a no-op)
+# 2) non-existent relative paths (uninstall first so this run starts from a clean install)
 claude plugin uninstall smoketest@<marketplace> --scope local
 claude plugin install smoketest@<marketplace> --scope local \
   --config req_key=hello --config some_dir=./does_not_exist_dir --config some_file=./does_not_exist.txt


### PR DESCRIPTION
No linked issue

## Summary

#3111 / #3115 corrected the "`--config` only applies on a fresh install" claim across 25 setup
skills and the options-doc generator, and version-stamped the replacement. The claim survived one
layer up, in `docs/`, at five sites across three files. This corrects and stamps each of them.

This is **part 1 of #3127 only**. That issue carries six parts; the other five stay open, so this PR
deliberately does not close it.

## Fix

Five sites, matching the wording #3115 established rather than inventing new phrasing — against an
already-installed plugin the command prints `already installed` **and still writes the value**; the
short-circuit is about the install, not the config write.

| File | Site | Change |
|---|---|---|
| `docs/PLUGIN-PHILOSOPHY.md` | `userConfig` contract bullet | Corrected + stamped to 2.1.240 |
| `docs/MIGRATION-PLAYBOOK.md` | Fresh-consumer onboarding, step 3 | Corrected; heading no longer says "on one fresh install" |
| `docs/MIGRATION-PLAYBOOK.md` | Reintegration, step 1 | Corrected; drops the uninstall/reinstall prescription |
| `docs/extensibility-contract-smoke-tests.md` | Test A, methodology preamble | Justification restated; the uninstall-per-run methodology is preserved as actually run |
| `docs/extensibility-contract-smoke-tests.md` | Test C, result bullet | Observation kept as recorded on 2.1.207; only the inference drawn from it is replaced |

Each stamped site carries the coverage limits alongside the claim rather than dropping them: verified
for a non-sensitive option at `user` scope, with a `sensitive` option and `project`/`local` scope
explicitly not covered.

Per #3127's own caution, this does not claim the old text was *always* wrong — the claim landed
2026-07-18 (`fe28ffa70`, #360) unstamped, and CC 2.1.221 changed install-activation behaviour, so
"always false" and "true when written, fixed since" are not distinguishable from here. The stamps
say what was observed and when, and nothing more.

## Verification

- `grep` sweep for the stale assertion across every tracked `*.md` — **no residual instances**
  repo-wide (`only on a fresh install`, `only seeds a value`, `does not update the stored value`,
  `ignored once the plugin is already`, `accepted only on a fresh`).
- `markdownlint-cli2` on all three files — `0 issues in 0 files`.
- `typos` over `docs/` — exit 0.
- `editorconfig-checker` on all three files — exit 0.
- No plugin files touched (`git diff --name-only` is three `docs/` paths), so no per-plugin version
  bump or CHANGELOG entry applies, and `check-changed-skills.sh` has no changed skill to gate.

## Related

Refs #3127 — part 1 of 6. Parts 2-6 remain open: the setup contract having no SSOT, the
`.claude/source-control.md` PR-section drift, the evals/playbook contradiction, org-agnosticism
having no single home, and the contract accepting non-conforming plugins.

Refs #3115, #3111 — the setup-skill layer this PR follows one level up.

Corroboration for #3127 part 3, found while populating this PR body: `.github/pull_request_template.md`
requires **Summary / Fix / Verification / Related**, matching the issue's claim. The tracked
`.claude/source-control.md` declares `Summary / Test plan / Related`, and "Test plan" appears in
neither the template nor the gate — so that part of #3127 is confirmed against a local authoritative
artifact, without needing the pinned `ci-workflows` reusable.

---
_Generated by [Claude Code](https://claude.ai/code/session_0131ka1K2ZwqXwNvmNiNVsZ5)_