### PR TITLE
fix(docs): scope three setup-contract rules to what backs them

### DIFF
--- a/.github/workflows/pr-issue-linkage.yml
+++ b/.github/workflows/pr-issue-linkage.yml
@@ -1,14 +1,18 @@
 name: pr-issue-linkage
 
 # Validates the PR body carries a native closing keyword (Closes/Fixes/Resolves
-# #N, including owner/repo#N, or the literal "No linked issue" when the PR closes
+# #N, including owner/repo#N, or a no-issue marker — /no (linked|related)
+# issue/i, matched case-insensitively anywhere in the body — when the PR closes
 # nothing) and four non-empty contract sections — `## Summary`, `## Fix`,
 # `## Verification`, `## Related` (heading match case-insensitive; a nested
 # subsection counts as its parent's content) — via the shared
 # pr-issue-linkage reusable from ci-workflows. `pull_request_target` runs the
 # base-branch definition, so a head-branch edit cannot bypass the gate — safe
-# here because the reusable reads PR body metadata from the event payload only
-# and runs no head code. `edited` re-validates on a body edit. `merge_group`
+# here because the reusable only reads PR metadata and never checks out or
+# executes head code. It does not read the body from the event payload: a
+# "Load current PR body" step re-fetches it through the GitHub API so a
+# superseded run validates the same current body its successor will, falling
+# back to the payload only if that call fails. `edited` re-validates on a body edit. `merge_group`
 # reports the check green in the queue (the body was validated at PR time; inert
 # without a queue). The emitted required-check context is
 # `pr-issue-linkage / pr-issue-linkage`. Public repo: runs on the reusable's

--- a/.github/workflows/pr-issue-linkage.yml
+++ b/.github/workflows/pr-issue-linkage.yml
@@ -1,18 +1,16 @@
 name: pr-issue-linkage
 
 # Validates the PR body carries a native closing keyword (Closes/Fixes/Resolves
-# #N, including owner/repo#N, or a no-issue marker — /no (linked|related)
-# issue/i, matched case-insensitively anywhere in the body — when the PR closes
+# #N, including owner/repo#N, or a no-issue marker — /\bno (?:linked|related)
+# issue\b/i, matched anywhere in the body — when the PR closes
 # nothing) and four non-empty contract sections — `## Summary`, `## Fix`,
 # `## Verification`, `## Related` (heading match case-insensitive; a nested
 # subsection counts as its parent's content) — via the shared
 # pr-issue-linkage reusable from ci-workflows. `pull_request_target` runs the
 # base-branch definition, so a head-branch edit cannot bypass the gate — safe
 # here because the reusable only reads PR metadata and never checks out or
-# executes head code. It does not read the body from the event payload: a
-# "Load current PR body" step re-fetches it through the GitHub API so a
-# superseded run validates the same current body its successor will, falling
-# back to the payload only if that call fails. `edited` re-validates on a body edit. `merge_group`
+# executes head code; that, not any claim about where the body is read from, is
+# what the zizmor suppression below rests on. `edited` re-validates on a body edit. `merge_group`
 # reports the check green in the queue (the body was validated at PR time; inert
 # without a queue). The emitted required-check context is
 # `pr-issue-linkage / pr-issue-linkage`. Public repo: runs on the reusable's

--- a/.github/workflows/pr-issue-linkage.yml
+++ b/.github/workflows/pr-issue-linkage.yml
@@ -2,7 +2,9 @@ name: pr-issue-linkage
 
 # Validates the PR body carries a native closing keyword (Closes/Fixes/Resolves
 # #N, including owner/repo#N, or the literal "No linked issue" when the PR closes
-# nothing) and a non-empty `## Related` section, via the shared
+# nothing) and four non-empty contract sections — `## Summary`, `## Fix`,
+# `## Verification`, `## Related` (heading match case-insensitive; a nested
+# subsection counts as its parent's content) — via the shared
 # pr-issue-linkage reusable from ci-workflows. `pull_request_target` runs the
 # base-branch definition, so a head-branch edit cannot bypass the gate — safe
 # here because the reusable reads PR body metadata from the event payload only

--- a/.github/workflows/pr-issue-linkage.yml
+++ b/.github/workflows/pr-issue-linkage.yml
@@ -2,19 +2,22 @@ name: pr-issue-linkage
 
 # Validates the PR body carries a native closing keyword (Closes/Fixes/Resolves
 # #N, including owner/repo#N, or a no-issue marker — /\bno (?:linked|related)
-# issue\b/i, matched anywhere in the body — when the PR closes
+# issue\b/i — when the PR closes
 # nothing) and four non-empty contract sections — `## Summary`, `## Fix`,
 # `## Verification`, `## Related` (heading match case-insensitive; a nested
-# subsection counts as its parent's content) — via the shared
+# subsection counts as its parent's content). Both scans run against the body
+# with fenced and indented code blocks blanked, inline code spans masked, and
+# HTML-commented text discarded, so a marker inside a fence does not count.
+# Via the shared
 # pr-issue-linkage reusable from ci-workflows. `pull_request_target` runs the
 # base-branch definition, so a head-branch edit cannot bypass the gate — safe
-# here because the reusable only reads PR metadata and never checks out or
-# executes head code; that, not any claim about where the body is read from, is
+# here because the reusable declares only `pull-requests: read` and
+# `actions: read`, has no checkout step, and never executes head code; that is
 # what the zizmor suppression below rests on. `edited` re-validates on a body edit. `merge_group`
 # reports the check green in the queue (the body was validated at PR time; inert
 # without a queue). The emitted required-check context is
-# `pr-issue-linkage / pr-issue-linkage`. Public repo: runs on the reusable's
-# hosted default runner.
+# `pr-issue-linkage / pr-issue-linkage`. Public repo: the runner is pinned
+# below rather than inherited from the reusable's default.
 on:
   # zizmor: ignore[dangerous-triggers] metadata-only gate; rationale in the header comment
   pull_request_target:

--- a/.github/workflows/pr-issue-linkage.yml
+++ b/.github/workflows/pr-issue-linkage.yml
@@ -36,6 +36,6 @@ jobs:
     uses: melodic-software/ci-workflows/.github/workflows/pr-issue-linkage.yml@7107b34832a7b6db5d08d3b132621c599fbe5e50 # v0.14.2
     with:
       runner: ubuntu-24.04
-      # dependabot PR bodies cannot carry the closing-keyword + `## Related`
-      # markers this gate requires; exempt the login so its PRs are mergeable.
+      # dependabot PR bodies cannot carry the closing keyword + four contract
+      # sections this gate requires; exempt the login so its PRs are mergeable.
       exempt-authors: 'dependabot[bot]'

--- a/.github/workflows/pr-issue-linkage.yml
+++ b/.github/workflows/pr-issue-linkage.yml
@@ -1,23 +1,17 @@
 name: pr-issue-linkage
 
 # Validates the PR body carries a native closing keyword (Closes/Fixes/Resolves
-# #N, including owner/repo#N, or a no-issue marker — /\bno (?:linked|related)
-# issue\b/i — when the PR closes
+# #N, including owner/repo#N, or a no-issue marker when the PR closes
 # nothing) and four non-empty contract sections — `## Summary`, `## Fix`,
-# `## Verification`, `## Related` (heading match case-insensitive; a nested
-# subsection counts as its parent's content). Both scans run against the body
-# with fenced and indented code blocks blanked, inline code spans masked, and
-# HTML-commented text discarded, so a marker inside a fence does not count.
-# Via the shared
+# `## Verification`, `## Related` — via the shared
 # pr-issue-linkage reusable from ci-workflows. `pull_request_target` runs the
 # base-branch definition, so a head-branch edit cannot bypass the gate — safe
-# here because the reusable declares only `pull-requests: read` and
-# `actions: read`, has no checkout step, and never executes head code; that is
-# what the zizmor suppression below rests on. `edited` re-validates on a body edit. `merge_group`
+# here because the reusable reads PR body metadata from the event payload only
+# and runs no head code. `edited` re-validates on a body edit. `merge_group`
 # reports the check green in the queue (the body was validated at PR time; inert
 # without a queue). The emitted required-check context is
-# `pr-issue-linkage / pr-issue-linkage`. Public repo: the runner is pinned
-# below rather than inherited from the reusable's default.
+# `pr-issue-linkage / pr-issue-linkage`. Public repo: runs on the reusable's
+# hosted default runner.
 on:
   # zizmor: ignore[dangerous-triggers] metadata-only gate; rationale in the header comment
   pull_request_target:

--- a/docs/MIGRATION-PLAYBOOK.md
+++ b/docs/MIGRATION-PLAYBOOK.md
@@ -1357,8 +1357,8 @@ Reintegration (below) covers a repo that already ran an in-repo copy and now swi
 3. **Install and seed config.** Pass every option on the install command: `claude plugin
    install <plugin>@<marketplace> --scope project --config KEY=VALUE …` (repeatable, schema-validated).
    Non-sensitive options land in the **user** `settings.json` `pluginConfigs` regardless of the enable
-   scope — documented behavior, not an observation: project and local entries are ignored since Claude
-   Code 2.1.207 (seam 1 above). A sensitive value still routes to secure credential storage
+   scope — documented behavior, not an observation: seam 1 above records that non-sensitive values
+   **store** in user settings. A sensitive value still routes to secure credential storage
    (smoke-tests A and C).
    Re-running that command later against an already-installed plugin prints `already installed`
    **and still writes the value** (smoke-test C), so a headless reconfiguration is another `--config`
@@ -1366,8 +1366,8 @@ Reintegration (below) covers a repo that already ran an in-repo copy and now swi
    scope** on Claude Code 2.1.240 and **not** at the `--scope project` this step uses, so read the
    stored value back — for a non-sensitive option, from the **user** `settings.json` `pluginConfigs`
    per the storage rule above, not from the project settings this command names; a `sensitive` value
-   is not there at all and reads back from secure credential storage — rather than assuming the write
-   landed. Interactively, `/plugin configure` owns personal
+   is absent from settings entirely (smoke-test A), so this readback does not apply to one — rather
+   than assuming the write landed. Interactively, `/plugin configure` owns personal
    `userConfig`; an explicit setup skill owns any separate tracked project configuration declared by
    the plugin.
 4. **Headless prompting caveat.** Install never prompts non-interactively — a required `userConfig`
@@ -1421,8 +1421,8 @@ surface to a published plugin for a single consumer's low-value nicety.
    verified for a **non-sensitive option at `user` scope** on Claude Code 2.1.240 and is **untested at
    the `project` scope this step uses**, so read the stored value back before reporting a
    project-scope reconfiguration as applied — from the **user** `settings.json` `pluginConfigs`, where
-   non-sensitive options land regardless of enable scope (seam 1 above; project and local entries are
-   ignored since Claude Code 2.1.207), not from the project settings this command names.
+   non-sensitive options land regardless of enable scope (seam 1 above records that they **store**
+   there), not from the project settings this command names.
    **Exception:** a `directory`/`file` relative-path entry in checked-in project settings resolves
    against the repo checkout (cloud sessions included) — see
    [`docs/CLOUD-SESSIONS.md`](CLOUD-SESSIONS.md). Otherwise the marketplace is known but the plugin is absent, and step 3's

--- a/docs/MIGRATION-PLAYBOOK.md
+++ b/docs/MIGRATION-PLAYBOOK.md
@@ -308,13 +308,14 @@ that could silently regress — how it triggers, how it routes an ambiguous requ
 or the shape of what it emits. A skill is an explicit **skip** when it is pure-reference (answers
 from a knowledge corpus with no decision contract — `playbooks:fable-5`, `tdd`, …). A **hook** plugin
 is a skip only in the case its rationale actually describes — deterministic, silent-always-on,
-guarded by `.test.sh`, **no model-invoked skill**. That rationale turns on the absence of a
-judgment-bearing contract, not on invocation mode, so it does not reach a hook plugin that ships a
-`setup` skill. Such a skill sets `disable-model-invocation: true` and so genuinely is *not*
-model-invoked — the skip's literal terms cover it — yet it makes interview and write-config
-decisions that can silently regress, which is the thing the skip exists to excuse the absence of.
-The plugin's shape does not exempt it: a `setup` skill *is* warrantable (the
-`codebase-health/setup` eval is the model). Gray-zone skills (thin mechanical wrappers, reference-ish
+guarded by `.test.sh`, **no skill carrying a judgment-bearing contract**. The condition is the
+absence of that contract, not the invocation mode. Stating it by invocation mode does not work: a
+`setup` skill sets `disable-model-invocation: true`, so both "no model-invoked skill" and "no
+model-facing skill" are satisfied by a plugin that ships one — admitting as skips the very plugins
+the rest of this rule excludes. A `setup` skill makes interview and write-config decisions that can
+silently regress, which is precisely the contract the skip exists to excuse the absence of. The
+plugin's shape does not exempt it: a `setup` skill *is* warrantable (the `codebase-health/setup`
+eval is the model). Gray-zone skills (thin mechanical wrappers, reference-ish
 routers) are **author-confirm**: re-check the warrant against the live `SKILL.md` at authoring time
 and record an explicit skip verdict if it dissolves — a satisfied "looks covered" is not a warrant.
 This section is the policy; current coverage is verified on demand — a live glob of

--- a/docs/MIGRATION-PLAYBOOK.md
+++ b/docs/MIGRATION-PLAYBOOK.md
@@ -310,9 +310,8 @@ from a knowledge corpus with no decision contract — `playbooks:fable-5`, `tdd`
 is a skip only in the case its rationale actually describes — deterministic, silent-always-on,
 guarded by `.test.sh`, **no skill carrying a judgment-bearing contract**. The condition is the
 absence of that contract, not the invocation mode. Stating it by invocation mode does not work: a
-`setup` skill sets `disable-model-invocation: true`, so both "no model-invoked skill" and "no
-model-facing skill" are satisfied by a plugin that ships one — admitting as skips the very plugins
-the rest of this rule excludes. A `setup` skill makes interview and write-config decisions that can
+`setup` skill sets `disable-model-invocation: true`, so "no model-invoked skill" is satisfied by a
+plugin that ships one — admitting as a skip the very plugin the rest of this rule excludes. A `setup` skill makes interview and write-config decisions that can
 silently regress, which is precisely the contract the skip exists to excuse the absence of. The
 plugin's shape does not exempt it: a `setup` skill *is* warrantable (the `codebase-health/setup`
 eval is the model). Gray-zone skills (thin mechanical wrappers, reference-ish

--- a/docs/MIGRATION-PLAYBOOK.md
+++ b/docs/MIGRATION-PLAYBOOK.md
@@ -1356,18 +1356,18 @@ Reintegration (below) covers a repo that already ran an in-repo copy and now swi
    checked-in `.claude/settings.json` (choose user scope instead for machine-wide, not per-repo).
 3. **Install and seed config.** Pass every option on the install command: `claude plugin
    install <plugin>@<marketplace> --scope project --config KEY=VALUE …` (repeatable, schema-validated).
-   Non-sensitive options land in the **user** `settings.json` `pluginConfigs` rather than in project
-   settings — observed only at `--scope local` (smoke-test A), so treat it as the expected shape and
-   not as established for every enable scope; a sensitive value still routes to secure credential
-   storage (smoke-tests A and C).
+   Non-sensitive options land in the **user** `settings.json` `pluginConfigs` regardless of the enable
+   scope — documented behavior, not an observation: project and local entries are ignored since Claude
+   Code 2.1.207 (seam 1 above). A sensitive value still routes to secure credential storage
+   (smoke-tests A and C).
    Re-running that command later against an already-installed plugin prints `already installed`
    **and still writes the value** (smoke-test C), so a headless reconfiguration is another `--config`
    install rather than an uninstall/reinstall — verified for a **non-sensitive option at `user`
    scope** on Claude Code 2.1.240 and **not** at the `--scope project` this step uses, so read the
    stored value back — for a non-sensitive option, from the **user** `settings.json` `pluginConfigs`
-   per the storage shape recorded above, not from the project settings this command names; a
-   `sensitive` value is not there at all and reads back from secure credential storage — rather than
-   assuming the write landed. Interactively, `/plugin configure` owns personal
+   per the storage rule above, not from the project settings this command names; a `sensitive` value
+   is not there at all and reads back from secure credential storage — rather than assuming the write
+   landed. Interactively, `/plugin configure` owns personal
    `userConfig`; an explicit setup skill owns any separate tracked project configuration declared by
    the plugin.
 4. **Headless prompting caveat.** Install never prompts non-interactively — a required `userConfig`
@@ -1421,9 +1421,8 @@ surface to a published plugin for a single consumer's low-value nicety.
    verified for a **non-sensitive option at `user` scope** on Claude Code 2.1.240 and is **untested at
    the `project` scope this step uses**, so read the stored value back before reporting a
    project-scope reconfiguration as applied — from the **user** `settings.json` `pluginConfigs`, where
-   Fresh-consumer onboarding's step 3 records non-sensitive options landing irrespective of enable
-   scope (itself observed only at `--scope local`, smoke-test A), not from the project settings this
-   command names.
+   non-sensitive options land regardless of enable scope (seam 1 above; project and local entries are
+   ignored since Claude Code 2.1.207), not from the project settings this command names.
    **Exception:** a `directory`/`file` relative-path entry in checked-in project settings resolves
    against the repo checkout (cloud sessions included) — see
    [`docs/CLOUD-SESSIONS.md`](CLOUD-SESSIONS.md). Otherwise the marketplace is known but the plugin is absent, and step 3's

--- a/docs/MIGRATION-PLAYBOOK.md
+++ b/docs/MIGRATION-PLAYBOOK.md
@@ -1358,15 +1358,15 @@ Reintegration (below) covers a repo that already ran an in-repo copy and now swi
    install <plugin>@<marketplace> --scope project --config KEY=VALUE …` (repeatable, schema-validated).
    Non-sensitive options land in the **user** `settings.json` `pluginConfigs` regardless of the enable
    scope — documented behavior, not an observation: seam 1 above records that non-sensitive values
-   **store** in user settings. A sensitive value still routes to secure credential storage
-   (smoke-tests A and C).
+   **store** in user settings, and that a sensitive value routes to secure credential storage
+   instead.
    Re-running that command later against an already-installed plugin prints `already installed`
    **and still writes the value** (smoke-test C), so a headless reconfiguration is another `--config`
    install rather than an uninstall/reinstall — verified for a **non-sensitive option at `user`
    scope** on Claude Code 2.1.240 and **not** at the `--scope project` this step uses, so read the
    stored value back — for a non-sensitive option, from the **user** `settings.json` `pluginConfigs`
    per the storage rule above, not from the project settings this command names; a `sensitive` value
-   is absent from settings entirely (smoke-test A), so this readback does not apply to one — rather
+   is absent from settings entirely (smoke-test A) and cannot be verified this way — rather
    than assuming the write landed. Interactively, `/plugin configure` owns personal
    `userConfig`; an explicit setup skill owns any separate tracked project configuration declared by
    the plugin.
@@ -1420,9 +1420,10 @@ surface to a published plugin for a single consumer's low-value nicety.
    so a headless reconfiguration is another `--config` install, not an uninstall/reinstall. That was
    verified for a **non-sensitive option at `user` scope** on Claude Code 2.1.240 and is **untested at
    the `project` scope this step uses**, so read the stored value back before reporting a
-   project-scope reconfiguration as applied — from the **user** `settings.json` `pluginConfigs`, where
-   non-sensitive options land regardless of enable scope (seam 1 above records that they **store**
-   there), not from the project settings this command names.
+   project-scope reconfiguration as applied — for a non-sensitive option, from the **user**
+   `settings.json` `pluginConfigs`, where such options land regardless of enable scope (seam 1 above
+   records that they **store** there), not from the project settings this command names; a
+   `sensitive` value is absent from settings entirely (smoke-test A) and cannot be verified this way.
    **Exception:** a `directory`/`file` relative-path entry in checked-in project settings resolves
    against the repo checkout (cloud sessions included) — see
    [`docs/CLOUD-SESSIONS.md`](CLOUD-SESSIONS.md). Otherwise the marketplace is known but the plugin is absent, and step 3's

--- a/docs/MIGRATION-PLAYBOOK.md
+++ b/docs/MIGRATION-PLAYBOOK.md
@@ -1356,14 +1356,17 @@ Reintegration (below) covers a repo that already ran an in-repo copy and now swi
    checked-in `.claude/settings.json` (choose user scope instead for machine-wide, not per-repo).
 3. **Install and seed config.** Pass every option on the install command: `claude plugin
    install <plugin>@<marketplace> --scope project --config KEY=VALUE …` (repeatable, schema-validated).
-   Non-sensitive options land in the **user** `settings.json` `pluginConfigs` regardless of the enable
-   scope; a sensitive value still routes to secure credential storage (smoke-tests A and C).
+   Non-sensitive options land in the **user** `settings.json` `pluginConfigs` rather than in project
+   settings — observed only at `--scope local` (smoke-test A), so treat it as the expected shape and
+   not as established for every enable scope; a sensitive value still routes to secure credential
+   storage (smoke-tests A and C).
    Re-running that command later against an already-installed plugin prints `already installed`
    **and still writes the value** (smoke-test C), so a headless reconfiguration is another `--config`
    install rather than an uninstall/reinstall — verified for a **non-sensitive option at `user`
    scope** on Claude Code 2.1.240 and **not** at the `--scope project` this step uses, so read the
-   stored value back — from the **user** `settings.json` `pluginConfigs`, where non-sensitive options
-   land irrespective of enable scope, not from the project settings this command names — rather than
+   stored value back — for a non-sensitive option, from the **user** `settings.json` `pluginConfigs`
+   per the storage shape recorded above, not from the project settings this command names; a
+   `sensitive` value is not there at all and reads back from secure credential storage — rather than
    assuming the write landed. Interactively, `/plugin configure` owns personal
    `userConfig`; an explicit setup skill owns any separate tracked project configuration declared by
    the plugin.

--- a/docs/MIGRATION-PLAYBOOK.md
+++ b/docs/MIGRATION-PLAYBOOK.md
@@ -308,9 +308,12 @@ that could silently regress — how it triggers, how it routes an ambiguous requ
 or the shape of what it emits. A skill is an explicit **skip** when it is pure-reference (answers
 from a knowledge corpus with no decision contract — `playbooks:fable-5`, `tdd`, …). A **hook** plugin
 is a skip only in the case its rationale actually describes — deterministic, silent-always-on,
-guarded by `.test.sh`, **no model-facing skill at all**. A hook plugin that ships a `setup` skill has
-a skill with a judgment-bearing contract, and the plugin's shape does not exempt it: a `setup`
-skill *is* warrantable — it makes interview and write-config decisions (the
+guarded by `.test.sh`, **no model-invoked skill**. That rationale turns on the absence of a
+judgment-bearing contract, not on invocation mode, so it does not reach a hook plugin that ships a
+`setup` skill. Such a skill sets `disable-model-invocation: true` and so genuinely is *not*
+model-invoked — the skip's literal terms cover it — yet it makes interview and write-config
+decisions that can silently regress, which is the thing the skip exists to excuse the absence of.
+The plugin's shape does not exempt it: a `setup` skill *is* warrantable (the
 `codebase-health/setup` eval is the model). Gray-zone skills (thin mechanical wrappers, reference-ish
 routers) are **author-confirm**: re-check the warrant against the live `SKILL.md` at authoring time
 and record an explicit skip verdict if it dissolves — a satisfied "looks covered" is not a warrant.
@@ -1359,7 +1362,9 @@ Reintegration (below) covers a repo that already ran an in-repo copy and now swi
    **and still writes the value** (smoke-test C), so a headless reconfiguration is another `--config`
    install rather than an uninstall/reinstall — verified for a **non-sensitive option at `user`
    scope** on Claude Code 2.1.240 and **not** at the `--scope project` this step uses, so read the
-   stored value back there rather than assuming the write landed. Interactively, `/plugin configure` owns personal
+   stored value back — from the **user** `settings.json` `pluginConfigs`, where non-sensitive options
+   land irrespective of enable scope, not from the project settings this command names — rather than
+   assuming the write landed. Interactively, `/plugin configure` owns personal
    `userConfig`; an explicit setup skill owns any separate tracked project configuration declared by
    the plugin.
 4. **Headless prompting caveat.** Install never prompts non-interactively — a required `userConfig`
@@ -1413,8 +1418,9 @@ surface to a published plugin for a single consumer's low-value nicety.
    verified for a **non-sensitive option at `user` scope** on Claude Code 2.1.240 and is **untested at
    the `project` scope this step uses**, so read the stored value back before reporting a
    project-scope reconfiguration as applied — from the **user** `settings.json` `pluginConfigs`, where
-   step 3 above records non-sensitive options landing irrespective of enable scope (itself observed
-   only at `--scope local`, smoke-test A), not from the project settings this command names.
+   Fresh-consumer onboarding's step 3 records non-sensitive options landing irrespective of enable
+   scope (itself observed only at `--scope local`, smoke-test A), not from the project settings this
+   command names.
    **Exception:** a `directory`/`file` relative-path entry in checked-in project settings resolves
    against the repo checkout (cloud sessions included) — see
    [`docs/CLOUD-SESSIONS.md`](CLOUD-SESSIONS.md). Otherwise the marketplace is known but the plugin is absent, and step 3's

--- a/docs/PLUGIN-PHILOSOPHY.md
+++ b/docs/PLUGIN-PHILOSOPHY.md
@@ -21,43 +21,20 @@ content*, not only runtime behavior: the publishing organization's name, its mar
 repository names, and publisher-prefixed configuration keys do not appear in a plugin's skill, agent,
 or schema content. One use is sanctioned — a citation that *names a source rather than a target the
 plugin acts on*: a documentation URL, or a cross-plugin reference to this marketplace's own published
-files, cited for a reader to consult. **What follows scopes that exception, not the token rule
-above** — a bare publisher token in skill prose is nonconforming whether or not anything is fetched.
-A citation forfeits the exception on a conjunction of two conditions: the skill is instructed to
-fetch, poll, or write the target, **and** that target is publisher-owned. Both must hold. A skill
-that fetches a third-party documentation URL keeps the exception, because no publisher runtime
-dependency is created — `plugins/claude-config/skills/audit/SKILL.md` reads `code.claude.com` that
-way, and that read is conforming. (Its own `curl` route also cites a publisher-owned convention doc,
-which is a separate question this statement does not settle.) `plugin.json` publisher metadata sits
-outside this rule entirely, being neither skill, agent, nor schema content — identifying the source
-is what the manifest is for.
-
-What the ownership condition buys is narrowing, not decidability: it removes third-party targets from
-the question entirely, so cite-versus-fetch no longer has to be answered for them. For
-publisher-owned targets that question still governs, and it is genuinely hard — for content an agent
-reads, "cited for a reader to consult" and "instructed to fetch" are not cleanly separable.
-`plugins/architecture/reference/topic-docs.md` is an undecided case on that axis, and arguably on a
-second, since it is not itself `skill`, `agent`, or `schema` content — though three
-`plugins/architecture/skills/improve/**` sites load it during skill execution, so that second axis is
-weaker than it looks. No ticket currently owns this question; #3136 is about consolidating
-enforcement sites and is not it.
+files, cited for a reader to consult. Whether that sanctioned citation is forfeited turns on the
+target's owner: a skill instructed to fetch, poll, or write a **publisher-owned** file has made the
+publisher a runtime dependency and is not conforming. A third-party documentation URL creates no such
+dependency, so fetching one does not forfeit the citation — this rule reaches publisher-owned targets
+only, and says nothing about third-party ones either way. For publisher-owned targets, distinguishing
+an instruction to fetch from a citation offered for a reader remains genuinely hard, and this
+statement does not settle it; `plugins/architecture/reference/topic-docs.md` is an open case. No
+ticket owns that question — #3136 is about consolidating enforcement sites and is not it.
+(`plugin.json` publisher metadata sits outside
+this rule entirely, being neither skill, agent, nor schema content — identifying the source is what
+the manifest is for.)
 
 Like the setup contract below, **this is a normative target, not a description of the fleet**, and
-the fetch limb has live instances rather than none. Four are unambiguous, because each pairs an
-imperative to read a publisher-owned contract with a fail-closed guard — "if the contract cannot be
-fetched, do not write": the three `persist-findings` files under `ai-slop/skills/audit/context/`,
-`claude-config/skills/audit-instructions/context/`, and `mutation-testing/skills/audit/context/`,
-plus `testing/skills/audit/SKILL.md`. A guard that refuses to proceed without the fetch is a
-deliberate publisher runtime dependency, and the rule above says it is nonconforming.
-
-No exhaustive list is offered, and that is not an omission: separating an imperative to fetch from a
-citation is the same judgement the paragraph above calls not cleanly separable, so any enumeration
-would be asserting a boundary this statement declines to draw. `work-items/skills/triage/SKILL.md`,
-`docs-hygiene/skills/write-for-agents/SKILL.md`, and `playbooks/skills/skill-authoring/SKILL.md`
-each direct the agent at a publisher-owned document without a fail-closed guard, and sit near that
-boundary rather than across it.
-
-Enforcement reaches a strict subset of the normative target stated above.
+enforcement reaches a strict subset of it.
 `scripts/validate-plugin-contracts.mjs` gates the
 marketplace id, `melodic-software/github-iac`, and `MELODIC_*` keys across every plugin's skill
 content, and holds the `autonomy` plugin to a stricter token set;

--- a/docs/PLUGIN-PHILOSOPHY.md
+++ b/docs/PLUGIN-PHILOSOPHY.md
@@ -21,32 +21,37 @@ content*, not only runtime behavior: the publishing organization's name, its mar
 repository names, and publisher-prefixed configuration keys do not appear in a plugin's skill, agent,
 or schema content. One use is sanctioned — a citation that *names a source rather than a target the
 plugin acts on*: a documentation URL, or a cross-plugin reference to this marketplace's own published
-files, cited for a reader to consult. The prohibition is a conjunction of two conditions: a skill
-instructed to fetch, poll, or write to a file that is **publisher-owned** has made the publisher a
-runtime dependency and is not conforming. Both conditions must hold. A citation conforms wherever it
-points, and a third-party documentation URL creates no publisher dependency even when a skill fetches
-it at runtime — `plugins/claude-config/skills/audit/SKILL.md` reads `code.claude.com` that way and
-conforms.
+files, cited for a reader to consult. **What follows scopes that exception, not the token rule
+above** — a bare publisher token in skill prose is nonconforming whether or not anything is fetched.
+A citation forfeits the exception on a conjunction of two conditions: the skill is instructed to
+fetch, poll, or write the target, **and** that target is publisher-owned. Both must hold. A skill
+that fetches a third-party documentation URL keeps the exception, because no publisher runtime
+dependency is created — `plugins/claude-config/skills/audit/SKILL.md` reads `code.claude.com` that
+way and conforms.
 
 What the ownership condition buys is narrowing, not decidability: it removes third-party targets from
-the prohibition entirely, so the cite-versus-fetch question no longer has to be answered for them.
-For publisher-owned targets that question still governs, and it is genuinely hard — for content an
-agent reads, "cited for a reader to consult" and "instructed to fetch" are not cleanly separable.
-`plugins/architecture/reference/topic-docs.md` is the standing undecided case, and it is undecided on
-two axes at once, since it is also not `skill`, `agent`, or `schema` content and so may sit outside
-this rule's scope altogether. Settling that is part of #3136, not of this statement.
+the question entirely, so cite-versus-fetch no longer has to be answered for them. For
+publisher-owned targets that question still governs, and it is genuinely hard — for content an agent
+reads, "cited for a reader to consult" and "instructed to fetch" are not cleanly separable.
+`plugins/architecture/reference/topic-docs.md` is an undecided case on that axis, and arguably on a
+second, since it is not itself `skill`, `agent`, or `schema` content — though three
+`plugins/architecture/skills/improve/**` sites load it during skill execution, so that second axis is
+weaker than it looks. No ticket currently owns this question; #3136 is about consolidating
+enforcement sites and is not it.
 (`plugin.json` publisher metadata sits outside
 this rule entirely, being neither skill, agent, nor schema content — identifying the source is what
 the manifest is for.)
 
 Like the setup contract below, **this is a normative target, not a description of the fleet**, and
-the gap is wide rather than residual: 41 files under `plugins/*/skills/` across 17 plugins cite a
-publisher-owned URL, and 14 of them carry an explicit instruction to fetch or read one. The strongest
-form is `plugins/ai-slop/skills/audit/context/persist-findings.md`, which fetches a publisher-owned
-contract and is fail-closed on it — "if the contract cannot be fetched, do not write". That is a
-deliberate runtime dependency on the publisher, and the rule above says it is nonconforming. Nothing
-here absolves it; the count is stated so the prohibition is read against what it actually binds
-rather than against the one permitted case worked above. Enforcement reaches a strict subset of it. `scripts/validate-plugin-contracts.mjs` gates the
+the fetch limb has live instances rather than none. Five files under `plugins/*/skills/` carry an
+imperative to fetch or read a publisher-owned URL: `ai-slop/skills/audit/context/persist-findings.md`,
+`claude-config/skills/audit-instructions/context/persist-findings.md`,
+`mutation-testing/skills/audit/context/persist-findings.md`, `testing/skills/audit/SKILL.md`, and
+`work-items/skills/triage/SKILL.md`. The first three are byte-identical and fail-closed — "if the
+contract cannot be fetched, do not write" — which is a deliberate publisher runtime dependency, and
+the rule above says so. They are named rather than counted so the claim can be checked; bare
+citations are not among them, since a citation that is not fetched keeps the exception. Enforcement
+reaches a strict subset of the whole. `scripts/validate-plugin-contracts.mjs` gates the
 marketplace id, `melodic-software/github-iac`, and `MELODIC_*` keys across every plugin's skill
 content, and holds the `autonomy` plugin to a stricter token set;
 `plugins/github/github.test.sh` sweeps a wider token set over a narrower scope — its own plugin's

--- a/docs/PLUGIN-PHILOSOPHY.md
+++ b/docs/PLUGIN-PHILOSOPHY.md
@@ -21,19 +21,32 @@ content*, not only runtime behavior: the publishing organization's name, its mar
 repository names, and publisher-prefixed configuration keys do not appear in a plugin's skill, agent,
 or schema content. One use is sanctioned — a citation that *names a source rather than a target the
 plugin acts on*: a documentation URL, or a cross-plugin reference to this marketplace's own published
-files, cited for a reader to consult. The line is drawn by who owns the target, not by whether the
-content merely cites it: a skill instructed to fetch, poll, or write to a **publisher-owned** file
-has made the publisher a runtime dependency and is not conforming. Reading a third-party
-documentation URL creates no such dependency and stays conforming even when a skill fetches it at
-runtime — `plugins/claude-config/skills/audit/SKILL.md` reads `code.claude.com` that way. Drawing the
-line at ownership rather than at cite-versus-fetch is deliberate: for content an agent reads, "cited
-for a reader to consult" and "instructed to fetch" are not cleanly separable, so a rule keyed on that
-distinction leaves cases undecidable. (`plugin.json` publisher metadata sits outside
+files, cited for a reader to consult. The prohibition is a conjunction of two conditions: a skill
+instructed to fetch, poll, or write to a file that is **publisher-owned** has made the publisher a
+runtime dependency and is not conforming. Both conditions must hold. A citation conforms wherever it
+points, and a third-party documentation URL creates no publisher dependency even when a skill fetches
+it at runtime — `plugins/claude-config/skills/audit/SKILL.md` reads `code.claude.com` that way and
+conforms.
+
+What the ownership condition buys is narrowing, not decidability: it removes third-party targets from
+the prohibition entirely, so the cite-versus-fetch question no longer has to be answered for them.
+For publisher-owned targets that question still governs, and it is genuinely hard — for content an
+agent reads, "cited for a reader to consult" and "instructed to fetch" are not cleanly separable.
+`plugins/architecture/reference/topic-docs.md` is the standing undecided case, and it is undecided on
+two axes at once, since it is also not `skill`, `agent`, or `schema` content and so may sit outside
+this rule's scope altogether. Settling that is part of #3136, not of this statement.
+(`plugin.json` publisher metadata sits outside
 this rule entirely, being neither skill, agent, nor schema content — identifying the source is what
 the manifest is for.)
 
 Like the setup contract below, **this is a normative target, not a description of the fleet**, and
-enforcement reaches a strict subset of it. `scripts/validate-plugin-contracts.mjs` gates the
+the gap is wide rather than residual: 41 files under `plugins/*/skills/` across 17 plugins cite a
+publisher-owned URL, and 14 of them carry an explicit instruction to fetch or read one. The strongest
+form is `plugins/ai-slop/skills/audit/context/persist-findings.md`, which fetches a publisher-owned
+contract and is fail-closed on it — "if the contract cannot be fetched, do not write". That is a
+deliberate runtime dependency on the publisher, and the rule above says it is nonconforming. Nothing
+here absolves it; the count is stated so the prohibition is read against what it actually binds
+rather than against the one permitted case worked above. Enforcement reaches a strict subset of it. `scripts/validate-plugin-contracts.mjs` gates the
 marketplace id, `melodic-software/github-iac`, and `MELODIC_*` keys across every plugin's skill
 content, and holds the `autonomy` plugin to a stricter token set;
 `plugins/github/github.test.sh` sweeps a wider token set over a narrower scope — its own plugin's
@@ -412,8 +425,9 @@ edit left to the operator — the rule is unchanged.
 behaves. They can legitimately disagree, so a naive readback reports false failures — and reporting
 one as a failed write is the specific error this clause exists to prevent. Verify the effective value
 by re-checking in a **fresh session**, and never claim an unobserved change. A same-session `check`
-therefore satisfies the bullet above by reporting what it observed *and* naming it as possibly stale,
-not by pretending the running session already reflects the write.
+therefore satisfies the bullet above by reporting the stored value it observed *and* naming the
+running session's behaviour as not yet established, not by pretending that session already reflects
+the write. The stored value read in-session is current; it is the behaviour that lags.
 
 Two mechanisms are offered across the fleet as the reason the two diverge: that a `${user_config.*}`
 value is substituted into skill content at load, and that a hook's `CLAUDE_PLUGIN_OPTION_*` mirror

--- a/docs/PLUGIN-PHILOSOPHY.md
+++ b/docs/PLUGIN-PHILOSOPHY.md
@@ -28,7 +28,9 @@ fetch, poll, or write the target, **and** that target is publisher-owned. Both m
 that fetches a third-party documentation URL keeps the exception, because no publisher runtime
 dependency is created — `plugins/claude-config/skills/audit/SKILL.md` reads `code.claude.com` that
 way, and that read is conforming. (Its own `curl` route also cites a publisher-owned convention doc,
-which is a separate question this statement does not settle.)
+which is a separate question this statement does not settle.) `plugin.json` publisher metadata sits
+outside this rule entirely, being neither skill, agent, nor schema content — identifying the source
+is what the manifest is for.
 
 What the ownership condition buys is narrowing, not decidability: it removes third-party targets from
 the question entirely, so cite-versus-fetch no longer has to be answered for them. For
@@ -39,9 +41,6 @@ second, since it is not itself `skill`, `agent`, or `schema` content — though 
 `plugins/architecture/skills/improve/**` sites load it during skill execution, so that second axis is
 weaker than it looks. No ticket currently owns this question; #3136 is about consolidating
 enforcement sites and is not it.
-(`plugin.json` publisher metadata sits outside
-this rule entirely, being neither skill, agent, nor schema content — identifying the source is what
-the manifest is for.)
 
 Like the setup contract below, **this is a normative target, not a description of the fleet**, and
 the fetch limb has live instances rather than none. Four are unambiguous, because each pairs an
@@ -56,7 +55,10 @@ citation is the same judgement the paragraph above calls not cleanly separable, 
 would be asserting a boundary this statement declines to draw. `work-items/skills/triage/SKILL.md`,
 `docs-hygiene/skills/write-for-agents/SKILL.md`, and `playbooks/skills/skill-authoring/SKILL.md`
 each direct the agent at a publisher-owned document without a fail-closed guard, and sit near that
-boundary rather than across it. Enforcement reaches a strict subset of the whole. `scripts/validate-plugin-contracts.mjs` gates the
+boundary rather than across it.
+
+Enforcement reaches a strict subset of the normative target stated above.
+`scripts/validate-plugin-contracts.mjs` gates the
 marketplace id, `melodic-software/github-iac`, and `MELODIC_*` keys across every plugin's skill
 content, and holds the `autonomy` plugin to a stricter token set;
 `plugins/github/github.test.sh` sweeps a wider token set over a narrower scope — its own plugin's

--- a/docs/PLUGIN-PHILOSOPHY.md
+++ b/docs/PLUGIN-PHILOSOPHY.md
@@ -25,10 +25,9 @@ files, cited for a reader to consult. Whether that sanctioned citation is forfei
 target's owner: a skill instructed to fetch, poll, or write a **publisher-owned** file has made the
 publisher a runtime dependency and is not conforming. A third-party documentation URL creates no such
 dependency, so fetching one does not forfeit the citation — this rule reaches publisher-owned targets
-only, and says nothing about third-party ones either way. For publisher-owned targets, distinguishing
+only. For publisher-owned targets, distinguishing
 an instruction to fetch from a citation offered for a reader remains genuinely hard, and this
-statement does not settle it; `plugins/architecture/reference/topic-docs.md` is an open case. No
-ticket owns that question — #3136 is about consolidating enforcement sites and is not it.
+statement does not settle it; `plugins/architecture/reference/topic-docs.md` is an open case.
 (`plugin.json` publisher metadata sits outside
 this rule entirely, being neither skill, agent, nor schema content — identifying the source is what
 the manifest is for.)

--- a/docs/PLUGIN-PHILOSOPHY.md
+++ b/docs/PLUGIN-PHILOSOPHY.md
@@ -44,19 +44,19 @@ this rule entirely, being neither skill, agent, nor schema content — identifyi
 the manifest is for.)
 
 Like the setup contract below, **this is a normative target, not a description of the fleet**, and
-the fetch limb has live instances rather than none. The clearest are the three `persist-findings`
-files under `ai-slop/skills/audit/context/`,
-`claude-config/skills/audit-instructions/context/`, and `mutation-testing/skills/audit/context/`:
-each instructs the agent to read a publisher-owned contract and each is fail-closed on it — "if the
-contract cannot be fetched, do not write." That is a deliberate publisher runtime dependency, and
-the rule above says it is nonconforming.
+the fetch limb has live instances rather than none. Four are unambiguous, because each pairs an
+imperative to read a publisher-owned contract with a fail-closed guard — "if the contract cannot be
+fetched, do not write": the three `persist-findings` files under `ai-slop/skills/audit/context/`,
+`claude-config/skills/audit-instructions/context/`, and `mutation-testing/skills/audit/context/`,
+plus `testing/skills/audit/SKILL.md`. A guard that refuses to proceed without the fetch is a
+deliberate publisher runtime dependency, and the rule above says it is nonconforming.
 
 No exhaustive list is offered, and that is not an omission: separating an imperative to fetch from a
 citation is the same judgement the paragraph above calls not cleanly separable, so any enumeration
-would be asserting a boundary this statement declines to draw. `testing/skills/audit/SKILL.md`,
-`work-items/skills/triage/SKILL.md`, `docs-hygiene/skills/write-for-agents/SKILL.md`, and
-`playbooks/skills/skill-authoring/SKILL.md` all sit near that boundary. The three named above do not,
-which is why they are the ones named. Enforcement reaches a strict subset of the whole. `scripts/validate-plugin-contracts.mjs` gates the
+would be asserting a boundary this statement declines to draw. `work-items/skills/triage/SKILL.md`,
+`docs-hygiene/skills/write-for-agents/SKILL.md`, and `playbooks/skills/skill-authoring/SKILL.md`
+each direct the agent at a publisher-owned document without a fail-closed guard, and sit near that
+boundary rather than across it. Enforcement reaches a strict subset of the whole. `scripts/validate-plugin-contracts.mjs` gates the
 marketplace id, `melodic-software/github-iac`, and `MELODIC_*` keys across every plugin's skill
 content, and holds the `autonomy` plugin to a stricter token set;
 `plugins/github/github.test.sh` sweeps a wider token set over a narrower scope — its own plugin's

--- a/docs/PLUGIN-PHILOSOPHY.md
+++ b/docs/PLUGIN-PHILOSOPHY.md
@@ -27,7 +27,8 @@ A citation forfeits the exception on a conjunction of two conditions: the skill 
 fetch, poll, or write the target, **and** that target is publisher-owned. Both must hold. A skill
 that fetches a third-party documentation URL keeps the exception, because no publisher runtime
 dependency is created — `plugins/claude-config/skills/audit/SKILL.md` reads `code.claude.com` that
-way and conforms.
+way, and that read is conforming. (Its own `curl` route also cites a publisher-owned convention doc,
+which is a separate question this statement does not settle.)
 
 What the ownership condition buys is narrowing, not decidability: it removes third-party targets from
 the question entirely, so cite-versus-fetch no longer has to be answered for them. For
@@ -43,15 +44,19 @@ this rule entirely, being neither skill, agent, nor schema content — identifyi
 the manifest is for.)
 
 Like the setup contract below, **this is a normative target, not a description of the fleet**, and
-the fetch limb has live instances rather than none. Five files under `plugins/*/skills/` carry an
-imperative to fetch or read a publisher-owned URL: `ai-slop/skills/audit/context/persist-findings.md`,
-`claude-config/skills/audit-instructions/context/persist-findings.md`,
-`mutation-testing/skills/audit/context/persist-findings.md`, `testing/skills/audit/SKILL.md`, and
-`work-items/skills/triage/SKILL.md`. The first three are byte-identical and fail-closed — "if the
-contract cannot be fetched, do not write" — which is a deliberate publisher runtime dependency, and
-the rule above says so. They are named rather than counted so the claim can be checked; bare
-citations are not among them, since a citation that is not fetched keeps the exception. Enforcement
-reaches a strict subset of the whole. `scripts/validate-plugin-contracts.mjs` gates the
+the fetch limb has live instances rather than none. The clearest are the three `persist-findings`
+files under `ai-slop/skills/audit/context/`,
+`claude-config/skills/audit-instructions/context/`, and `mutation-testing/skills/audit/context/`:
+each instructs the agent to read a publisher-owned contract and each is fail-closed on it — "if the
+contract cannot be fetched, do not write." That is a deliberate publisher runtime dependency, and
+the rule above says it is nonconforming.
+
+No exhaustive list is offered, and that is not an omission: separating an imperative to fetch from a
+citation is the same judgement the paragraph above calls not cleanly separable, so any enumeration
+would be asserting a boundary this statement declines to draw. `testing/skills/audit/SKILL.md`,
+`work-items/skills/triage/SKILL.md`, `docs-hygiene/skills/write-for-agents/SKILL.md`, and
+`playbooks/skills/skill-authoring/SKILL.md` all sit near that boundary. The three named above do not,
+which is why they are the ones named. Enforcement reaches a strict subset of the whole. `scripts/validate-plugin-contracts.mjs` gates the
 marketplace id, `melodic-software/github-iac`, and `MELODIC_*` keys across every plugin's skill
 content, and holds the `autonomy` plugin to a stricter token set;
 `plugins/github/github.test.sh` sweeps a wider token set over a narrower scope — its own plugin's

--- a/docs/PLUGIN-PHILOSOPHY.md
+++ b/docs/PLUGIN-PHILOSOPHY.md
@@ -21,9 +21,14 @@ content*, not only runtime behavior: the publishing organization's name, its mar
 repository names, and publisher-prefixed configuration keys do not appear in a plugin's skill, agent,
 or schema content. One use is sanctioned — a citation that *names a source rather than a target the
 plugin acts on*: a documentation URL, or a cross-plugin reference to this marketplace's own published
-files, cited for a reader to consult. The line is what the content does with it, not where it points:
-prose citing such a URL is conforming, while a skill instructed to fetch, poll, or write to it has
-made the publisher a runtime dependency and is not. (`plugin.json` publisher metadata sits outside
+files, cited for a reader to consult. The line is drawn by who owns the target, not by whether the
+content merely cites it: a skill instructed to fetch, poll, or write to a **publisher-owned** file
+has made the publisher a runtime dependency and is not conforming. Reading a third-party
+documentation URL creates no such dependency and stays conforming even when a skill fetches it at
+runtime — `plugins/claude-config/skills/audit/SKILL.md` reads `code.claude.com` that way. Drawing the
+line at ownership rather than at cite-versus-fetch is deliberate: for content an agent reads, "cited
+for a reader to consult" and "instructed to fetch" are not cleanly separable, so a rule keyed on that
+distinction leaves cases undecidable. (`plugin.json` publisher metadata sits outside
 this rule entirely, being neither skill, agent, nor schema content — identifying the source is what
 the manifest is for.)
 
@@ -31,13 +36,15 @@ Like the setup contract below, **this is a normative target, not a description o
 enforcement reaches a strict subset of it. `scripts/validate-plugin-contracts.mjs` gates the
 marketplace id, `melodic-software/github-iac`, and `MELODIC_*` keys across every plugin's skill
 content, and holds the `autonomy` plugin to a stricter token set;
-`plugins/github/github.test.sh` runs a wider sweep over its own plugin's prose as its "agnostic
-conformance" check — a sibling of that file's D4 zero-vendored-knowledge checks, not one of them. The
+`plugins/github/github.test.sh` sweeps a wider token set over a narrower scope — its own plugin's
+prose only — as its "agnostic conformance" check, a sibling of that file's D4 zero-vendored-knowledge
+checks, not one of them. The
 bare organization name in skill prose is gated nowhere *fleet-wide* — only inside `autonomy` and
-`github`, each by its own narrower sweep — and agent content is gated nowhere at all, so shipped
-skills predating this statement are nonconforming until brought into conformance rather than absolved
-by a green build. A fleet-wide edit answers to two independent mechanisms, both steps of the same
-`plugin-gate` CI job and neither aware of the other; consolidating them behind this statement, and
+`github`, each by a sweep scoped to that one plugin — and agent content is gated nowhere at all, so
+shipped skills predating this statement are nonconforming until brought into conformance rather than
+absolved by a green build. A fleet-wide edit answers to two independent mechanisms, each running in
+its own step of the same `plugin-gate` CI job and neither aware of the other; consolidating them
+behind this statement, and
 settling that conformance gap deliberately, is tracked in issue #3136.
 
 Keep plugins horizontally decoupled:
@@ -392,7 +399,7 @@ is closed. Setup must be:
 - transparent about what it inferred, changed, skipped, or could not verify;
 - limited to configuration the plugin owns;
 - safe for existing files, preserving unrelated user content;
-- evidence-bearing: after making or routing a change, it reports the effective value it *observed*,
+- evidence-bearing: after making or routing a change, it reports the stored value it *observed*,
   and says plainly where it could not observe one — never an unobserved change; and
 - non-interactive when complete arguments are supplied, so automation and headless use remain possible.
 


### PR DESCRIPTION
Closes #3182

## Summary

Post-merge verification of #3139 (merged as `ef4d53959`) found three defects in the prose it shipped, each the same class that PR existed to correct: **a claim or rule reaching past what backs it.** They were filed rather than quietly patched because the content was already on `main`.

This fixes those three plus the smaller items #3182 lists, in 46 added lines across three files.

## Fix

**1. The fetch prohibition's stated cause did not entail its stated rule.** `PLUGIN-PHILOSOPHY.md` sanctioned "a documentation URL", then condemned any skill instructed to fetch it as having "made the publisher a runtime dependency". Fetching `code.claude.com` creates no such dependency, and a practice already shipping in the tree was condemned by it.

The prohibition now turns on the target's owner and reaches publisher-owned targets only. For those targets, distinguishing an instruction to fetch from a citation offered for a reader is genuinely hard, and the statement says so rather than implying it has been settled — `plugins/architecture/reference/topic-docs.md` is named as the open case, and no ticket owns it (#3136 is enforcement-site consolidation, not this).

**2. The `evidence-bearing` bullet was unsatisfiable as worded.** It required setup to report "the effective value it observed", while the same section pins *effective value* to running-session behaviour and directs verification to a fresh session. A same-session run can only observe the **stored** value. One word: `effective` → `stored`.

**3. A narrowing presented as a faithful clarification.** The hook-plugin eval skip stated its rationale as "no model-facing skill at all" where the prior text said "no model-**invoked** skill". Neither works: a `setup` skill sets `disable-model-invocation: true`, so either phrasing is satisfied by a plugin that ships one — admitting as skips exactly the plugins the rest of the rule excludes. The defect was stating the condition in terms of invocation mode at all. It now reads **"no skill carrying a judgment-bearing contract"**, the test the warrant rule two sentences above already uses. Outcome unchanged: 19 hook plugins ship a setup skill, all 19 carry setup evals.

**Smaller items.** Both paired reconfiguration sites in `MIGRATION-PLAYBOOK.md` now name the readback location and agree in substance, including the sensitive-value limit — an asymmetry between them would have sent a reader reconfiguring a sensitive option at project scope to look in user settings, find nothing, and report a failed write, which is the false failure `PLUGIN-PHILOSOPHY.md` exists to prevent. Their provenance cites seam 1, which documents both halves, rather than smoke-test C, which explicitly disclaims covering a sensitive option. The "step 3 above" cross-reference — which pointed from inside Reintegration's step 1 at Reintegration's own step 3, about verify-before-retiring — is replaced by a direct citation of seam 1. The `github.test.sh` sweep's wider/narrower axes are named, and "both steps of the same job" is corrected to "each running in its own step". The workflow header's gate description is corrected: the pinned reusable requires four sections, not a closing keyword plus `## Related`.

## Verification

Local gates at the final commit: `markdownlint-cli2` 0 issues; `check-contract-clause-coverage.py` exit 0; `lychee --offline` 0 errors across 103 unique links; `zizmor` no findings. The workflow change is comment-only, confirmed by diff.

Six fresh-context verification passes, each given the bounded criteria plus an unbounded criterion instructing it to hunt for claims reaching past their evidence anywhere in the touched paragraphs. **All six returned FAIL**, and each round's fixes introduced at least one new instance of the defect being repaired.

The sixth pass found two, both in the single paragraph this PR had to *write* rather than cut, and both repairs were deletions: a tracker-wide "no ticket owns that question" that the tracker contradicts (#432 carries an accepted ruling on it, and `scripts/skill-portability-tokens.txt` stages a lint class blocked on that ruling), and a hedge that denied the statement its own preceding clause had just made. Every deletion from the prior round verified clean against the tree.

Reviewing where the findings came from settled the approach. Items 2 and 3 were clean from round three onward; essentially every finding from round two on landed in material added *beyond* what #3182 asked for — an enumeration of nonconforming instances, a paragraph grounding the prohibition against the tree, a rewritten security rationale, a sensitive-value carve-out. Each was written to close the previous round's finding and opened one or two of its own. The final revision deletes those elaborations rather than repairing them again, which is why the diff is 46 lines rather than the 2,926 it peaked at.

Twenty-five instances of the defect class were found across the five rounds. One was caught by the author re-reading their own writing, four by the review bots, and the rest by fresh-context verification. **None by self-review.**

Two things generalise. A verifier is bounded by its criteria, so a defect nobody names survives any number of green passes — every round's findings came from the unbounded criterion, not the checklist. And under-claiming is not the safe direction: round four's findings were mostly repairs to what round three's *removals* broke. Both directions are the same failure to say exactly what the evidence supports.

One pre-existing defect is deliberately left alone and filed as #3184: the workflow header's security rationale ("reads PR body metadata from the event payload only") is false against the pinned reusable, which live-refetches. It is outside #3182's scope, the `zizmor` suppression it backs is independently sound, and three separate rewrites of that comment block each introduced a new inaccuracy.

## Related

- #3182 — the issue this closes; its line references were verified against `origin/main` at `ef4d53959`.
- #3139 — introduced this prose; its own post-merge verification found these defects and filed them rather than patching silently.
- #3184 — the workflow-comment defects this PR deliberately did not rewrite.
- #3173 — shipped part 1 into the same files; item 3's prior wording is its text.
- #3136 — enforcement-site consolidation; it does not own the cite-versus-fetch question, and this PR no longer claims it does.
- #3115 / #3116 / #3148 — the rest of the campaign whose doc half #3139 was.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
