### PR TITLE
fix(docs-hygiene): correct audit-noise's stated negation limitation (0.21.2)

### DIFF
--- a/plugins/docs-hygiene/.claude-plugin/plugin.json
+++ b/plugins/docs-hygiene/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "docs-hygiene",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "description": "Documentation-hygiene toolkit: compress (flavor-trim markdown with a semantic-diff safety net), audit-noise (classify markdown noise), extract-ssot (deduplicate repeated content into a single source of truth), audit-encapsulation (detect citations into skill-private surfaces), rename-references (sweep stale references after renames), audit-derivability (classify whether a whole document earns its existence — could a fresh agent re-derive it from the code?), audit-progressive-disclosure (grade instruction files against a load-tier model for split opportunities and hub/spoke disclosure defects), write-for-agents (authoring-time doctrine that fires while agent-consumed markdown is being written), and write-for-humans (the same moment for the other reader — end-user READMEs, RFCs, release notes and guides — resolving the consuming project's own style guide first).",
   "author": {
     "name": "Melodic Software",

--- a/plugins/docs-hygiene/CHANGELOG.md
+++ b/plugins/docs-hygiene/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog — docs-hygiene plugin
 
+## [0.21.2]
+
+### Fixed
+
+- **`audit-noise`'s stated `negation` limitation described behavior the skill no longer has, in the
+  wrong direction (#3195).** 0.21.1's "the line must close its own sentence" gate silently changed
+  what happens to a soft-wrapped prohibition, and the "known limitation" bullet in `SKILL.md` was
+  left describing 0.21.0. It claimed `Do not use markdown;` / `compose prose instead.` across two
+  lines **is reported**; measured on the shipped detector it is not — `;` never terminates a
+  sentence, so the line reaches no verdict. It also claimed the error direction "is a false
+  positive, never a silent withhold". That is now inverted: a hard-wrapped prohibition with no
+  positive alternative anywhere in its sentence is missed entirely.
+
+  The correction matters beyond wording. A silent withhold is the one failure mode the
+  detector-findings admission test asks this rule set to avoid, and in a hard-wrapped repo it takes
+  every prohibition long enough to wrap — so the bullet now names it as the shape's one departure
+  from fail-safe-toward-emitting rather than reassuring a reader that coverage is safe. The
+  deferral pointer is unchanged; #3195 carries the revised acceptance criteria.
+
+  Documentation only — no detector, emitter or test behavior changes.
+
 ## [0.21.1]
 
 ### Fixed

--- a/plugins/docs-hygiene/skills/audit-noise/SKILL.md
+++ b/plugins/docs-hygiene/skills/audit-noise/SKILL.md
@@ -136,12 +136,17 @@ Shared clean-tree / no-scope shape: [`../../context/clean-tree-fallback.md`](../
   pairing rule is per sentence, so a continuation line cannot be shown to lack a positive sitting on
   the next line; the same test excludes a table row. The cost is stated rather than hidden: a
   subject-led instruction ("The agent must not emit a bare summary") is not selected.
-- **`negation` is scoped to one physical line (known limitation).** `detect.sh` classifies line by
-  line, so a sentence markdown soft-wraps is judged in pieces: `Do not use markdown;` on one line
-  with `compose prose instead.` on the next is reported even though the positive is paired in the
-  same sentence. The error direction is a false positive, never a silent withhold, so it costs
-  reviewer attention rather than coverage. Accumulating sentence state across soft line breaks is
-  deferred, not assumed away.
+- **`negation` is scoped to one physical line, and WITHHOLDS on a soft-wrapped sentence (known
+  limitation).** `detect.sh` classifies line by line, and the scope gate requires a line to close
+  its own sentence, so a prohibition that markdown soft-wraps reaches no verdict at all: `Do not
+  use markdown` on one line with `in the summary body.` on the next is not reported, even though
+  no positive is paired anywhere in that sentence. Unlike every other gap here the error direction
+  is a **silent withhold, not a false positive** — it costs coverage rather than reviewer
+  attention, and in a hard-wrapped repo it takes every prohibition long enough to wrap. This is the
+  one place the shape does not satisfy the fail-safe-toward-emitting property that the
+  detector-findings admission test asks for, and it is stated rather than assumed away.
+  Accumulating sentence state across soft line breaks is deferred to
+  [#3195](https://github.com/melodic-software/claude-code-plugins/issues/3195).
 - **Opt-out markers respected.** A well-formed HTML comment line `<!-- markdown-discipline-ignore -->` (covers the next paragraph, through the next blank line or heading) and `<!-- markdown-discipline-ignore-line -->` (exactly the next physical line — a blank line consumes it, so place the marker directly above the content line) skip the wrapped content. A prose mention of the marker name is not a live marker.
 - **Convention-path exemptions apply per matched path, never per line.** An angle-bracket slot variable (`.work/<slug>/…`, `docs/topics/<slug>/…`) is a schema placeholder, not a literal path; the reserved concern-scoped roots (`.work/handoffs/`, `.work/reviews/`, `.work/running-retros/`, `.work/overengineering/` — roster SSOT: topic-docs Memory, concern-scoped tier) are citable only bare or with a placeholder child — a concrete child under them flags. A convention token on a line never exempts a concrete ghost ref sharing that line; the tracked concern file (`.claude/topic-docs.yaml`) matches no ghost-ref pattern and needs no exemption. Exception: the retired `.claude/notes/` location flags even in placeholder form.
 - **Output deterministic.** Filenames sort lexically; per-file tier rows sort by line number; no timestamps in output.


### PR DESCRIPTION
No linked issue

Deliberately not `Closes #3195`. This corrects what the skill body *says*; #3195 remains open for the paragraph-accumulation fix that changes what the detector *does*.

## Summary

0.21.1 (#3202) added a gate requiring a `negation` candidate's line to **close its own sentence**. That silently changed what happens to a soft-wrapped prohibition, and the "known limitation" bullet in `SKILL.md` was left describing 0.21.0 — so `main` currently ships a skill body making two false claims about its own detector.

Measured against the shipped detector at `7dea5a84`:

```markdown
Do not use markdown;
compose flowing prose instead.

Do not use markdown
in the summary body.

Never emit a bare summary.
```

| Line | `SKILL.md` claims | Actual |
|---|---|---|
| `Do not use markdown;` (positive paired on next line) | **"is reported"** | **not reported** — `;` never terminates a sentence, so the line reaches no verdict |
| `Do not use markdown` (no positive anywhere) | — | **not reported** |
| `Never emit a bare summary.` | flags | flags |

1. **"is reported" is false.** The false positive the bullet documents no longer occurs.
2. **"The error direction is a false positive, never a silent withhold" is inverted.** A hard-wrapped prohibition with no positive alternative anywhere in its sentence is now missed entirely.

## Fix

Rewrite the "known limitation" bullet in `plugins/docs-hygiene/skills/audit-noise/SKILL.md` to describe the behavior that actually ships, and bump to 0.21.2 with a CHANGELOG entry. Documentation only — no detector, emitter, or test behavior changes.

The rewritten bullet does three things the old one did not:

- **States the real mechanism.** The gate requires a line to close its own sentence, so a soft-wrapped prohibition reaches no verdict at all — rather than the old claim that it is reported in pieces.
- **Names the error direction correctly, as a silent withhold.** This is the load-bearing half. A silent withhold is the one failure mode admission test 2 in `docs/conventions/detector-findings/README.md` asks this rule set to fail *away* from, and in a repo that hard-wraps its prose — this one — it takes every prohibition long enough to wrap. The old text told a reader the opposite: that the gap cost reviewer attention rather than coverage, which is exactly the reassurance that would stop someone from prioritizing it.
- **Marks it as the shape's one departure from fail-safe-toward-emitting**, and points at #3195, which now carries the revised acceptance criteria.

### A second correction, recorded rather than silently fixed

While re-measuring I found the merged #3202's body table says the narrowing took the negation count **1053 → 31**. That is wrong: **31** was the intermediate line-gate build, superseded when the per-sentence gate landed. The shipped figure is **69**, which is what `CHANGELOG.md` 0.21.1 and the corpus re-measure both say.

Re-run on the identical 85-file corpus (`plugins/docs-hygiene` + `plugins/source-control` tracked markdown, minus `evals/fixtures` and `CHANGELOG.md`) at `7dea5a84`:

| Shape | Count |
|---|---|
| `negation` | **69** |
| `ghost-ref` | 3 |
| `ticket-pr-residue` | 2 |
| `citation` | 2 |
| `scope-meta` | 1 |
| `plan-reference` | 1 |
| `enum-list` | 1 |

The other shapes are byte-identical to the claim (3/2/2/1/1/1), so the narrowing itself behaved as described — only the headline number in that PR body was stale. Issue #3201's body carries the same `31`. Both are merged/closed records; the correction is noted here and on #3195 rather than by rewriting them.

## Verification

| Gate | Result |
|---|---|
| `detect.test.sh` | All 133 checks passed |
| `emit-findings.test.sh` | All 35 checks passed |
| `check-skill.sh` (source checkout) | PASS — 0 errors; all 8 base-ref trigger phrases preserved |
| `check-changelog-parity.sh` `--check` / `--check-bump origin/main` / `--check-order` | PASS |
| `check-detector-findings-crosswalk.sh` | PASS |
| markdownlint | 0 issues |
| typos | clean |
| corpus re-measure, 85 files | negation 69; other shapes 3/2/2/1/1/1 |

The reproduction above was run against the merged detector, not a local build, so the "Actual" column reflects what `main` ships today.

## Related

- #3202 — shipped the 0.21.1 gate whose side effect this documents; its body's `1053 → 31` is corrected above.
- #3195 — the deferred paragraph-accumulation fix; its acceptance criteria and error direction were revised in light of this measurement.
- #3201 — closed by #3202; its body carries the same superseded `31`.
- #3194 — introduced the shape and the original limitation text.