### PR TITLE
refactor(scripts): publish sync manifests and hoist checkout-with-base

### DIFF
--- a/.github/actions/checkout-with-base/action.yml
+++ b/.github/actions/checkout-with-base/action.yml
@@ -17,11 +17,6 @@ inputs:
     required: false
     default: "true"
 
-outputs:
-  base-ref:
-    description: The PR base branch name, or empty when this is not a pull_request.
-    value: ${{ steps.base.outputs.base-ref }}
-
 runs:
   using: composite
   steps:
@@ -33,11 +28,9 @@ runs:
         fi
 
     - name: Fetch base ref
-      id: base
       if: inputs.fetch-base == 'true' && github.event_name == 'pull_request' && github.base_ref != ''
       shell: bash
       env:
         BASE_REF: ${{ github.base_ref }}
       run: |
         git fetch --no-tags origin "$BASE_REF":"refs/remotes/origin/$BASE_REF"
-        echo "base-ref=$BASE_REF" >> "$GITHUB_OUTPUT"

--- a/.github/actions/checkout-with-base/action.yml
+++ b/.github/actions/checkout-with-base/action.yml
@@ -1,0 +1,43 @@
+name: Checkout with base
+description: >
+  Check out the repository with full history, fetch origin/$BASE_REF on
+  pull_request events, and export BASE_REF for later steps. Owns the
+  fetch-depth, explicit base fetch, and BASE_REF export that were previously
+  copied across CI jobs.
+
+inputs:
+  ref:
+    description: >
+      Git ref to check out. Empty uses actions/checkout's event default
+      (the PR merge commit, or the pushed SHA). Pass the PR head SHA when
+      the job must compute against the branch tip rather than the merge
+      commit.
+    required: false
+    default: ""
+  fetch-base:
+    description: >
+      When true (the default, and the safe one), fetch origin/$BASE_REF on
+      pull_request events and export BASE_REF into the job environment so
+      later steps can resolve origin/$BASE_REF with no extra fetch of their
+      own. Only the stale-base lane used to do this fetch explicitly.
+    required: false
+    default: "true"
+
+runs:
+  using: composite
+  steps:
+    - name: Check out
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
+        fetch-depth: 0
+        ref: ${{ inputs.ref }}
+
+    - name: Fetch base ref
+      if: inputs.fetch-base == 'true' && github.event_name == 'pull_request' && github.base_ref != ''
+      shell: bash
+      env:
+        BASE_REF: ${{ github.base_ref }}
+      run: |
+        git fetch --no-tags origin "$BASE_REF":"refs/remotes/origin/$BASE_REF"
+        echo "BASE_REF=$BASE_REF" >> "$GITHUB_ENV"

--- a/.github/actions/checkout-with-base/action.yml
+++ b/.github/actions/checkout-with-base/action.yml
@@ -1,43 +1,43 @@
 name: Checkout with base
 description: >
-  Check out the repository with full history, fetch origin/$BASE_REF on
-  pull_request events, and export BASE_REF for later steps. Owns the
-  fetch-depth, explicit base fetch, and BASE_REF export that were previously
-  copied across CI jobs.
+  Deepen a just-checked-out worktree to full history and fetch
+  origin/$BASE_REF on pull_request events. A same-repo composite cannot
+  be the first step of a job (GitHub has not fetched the tree yet), so
+  callers still run a pinned actions/checkout first; this action owns
+  the depth and the explicit base fetch that used to be copied beside
+  that checkout. It does not write GITHUB_ENV — callers already pass
+  BASE_REF from github.base_ref, and zizmor flags GITHUB_ENV writes.
 
 inputs:
-  ref:
-    description: >
-      Git ref to check out. Empty uses actions/checkout's event default
-      (the PR merge commit, or the pushed SHA). Pass the PR head SHA when
-      the job must compute against the branch tip rather than the merge
-      commit.
-    required: false
-    default: ""
   fetch-base:
     description: >
-      When true (the default, and the safe one), fetch origin/$BASE_REF on
-      pull_request events and export BASE_REF into the job environment so
-      later steps can resolve origin/$BASE_REF with no extra fetch of their
-      own. Only the stale-base lane used to do this fetch explicitly.
+      When true (the default, and the safe one), fetch origin/$BASE_REF
+      on pull_request events so later steps can resolve that ref with no
+      extra fetch of their own.
     required: false
     default: "true"
+
+outputs:
+  base-ref:
+    description: The PR base branch name, or empty when this is not a pull_request.
+    value: ${{ steps.base.outputs.base-ref }}
 
 runs:
   using: composite
   steps:
-    - name: Check out
-      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      with:
-        persist-credentials: false
-        fetch-depth: 0
-        ref: ${{ inputs.ref }}
+    - name: Deepen history
+      shell: bash
+      run: |
+        if [ "$(git rev-parse --is-shallow-repository)" = "true" ]; then
+          git fetch --prune --unshallow --no-tags
+        fi
 
     - name: Fetch base ref
+      id: base
       if: inputs.fetch-base == 'true' && github.event_name == 'pull_request' && github.base_ref != ''
       shell: bash
       env:
         BASE_REF: ${{ github.base_ref }}
       run: |
         git fetch --no-tags origin "$BASE_REF":"refs/remotes/origin/$BASE_REF"
-        echo "BASE_REF=$BASE_REF" >> "$GITHUB_ENV"
+        echo "base-ref=$BASE_REF" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,10 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Check out
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Fetch base
         uses: ./.github/actions/checkout-with-base
       - name: Test the docs-only detector
         run: bash scripts/check-docs-only.test.sh
@@ -437,6 +441,10 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Check out
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Fetch base
         uses: ./.github/actions/checkout-with-base
       - name: Verify plugin copies match the shared lib
         run: scripts/sync-hook-utils.sh --check
@@ -453,6 +461,10 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Check out
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Fetch base
         uses: ./.github/actions/checkout-with-base
       - name: Verify plugin copies match the shared parser
         run: scripts/sync-parse-concern-value.sh --check
@@ -469,6 +481,10 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Check out
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Fetch base
         uses: ./.github/actions/checkout-with-base
       - name: Verify managed-scope cluster matches canonical
         run: scripts/sync-managed-scope.sh --check
@@ -485,6 +501,10 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Check out
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Fetch base
         uses: ./.github/actions/checkout-with-base
       - name: Verify state-key cluster matches canonical
         run: scripts/sync-state-key.sh --check
@@ -501,6 +521,10 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Check out
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Fetch base
         uses: ./.github/actions/checkout-with-base
       - name: Verify plugin copies match the shared resolver
         run: scripts/sync-resolve-convention-pattern.sh --check
@@ -517,6 +541,10 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Check out
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Fetch base
         uses: ./.github/actions/checkout-with-base
       - name: Verify plugin binding copies match the canonical contract
         run: scripts/sync-standards-contract.sh --check
@@ -760,6 +788,10 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Check out
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Fetch base
         uses: ./.github/actions/checkout-with-base
       - name: Test the fleet finding-kind test-coverage detector
         run: bash scripts/check-fleet-finding-test-coverage.test.sh
@@ -775,6 +807,10 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Check out
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Fetch base
         uses: ./.github/actions/checkout-with-base
       - name: Test the fleet audit doc-grammar detector
         run: bash scripts/check-fleet-audit-doc-grammar.test.sh
@@ -798,13 +834,16 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Check out
-        uses: ./.github/actions/checkout-with-base
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           # PR head, not the synthetic merge commit: overlap is computed against
           # the branch tip the author will squash, so merge-base math must match
           # that tip rather than an already-merged-with-base tree. Push falls
           # back to github.sha so `ref` is never empty on main.
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - name: Fetch base
+        uses: ./.github/actions/checkout-with-base
       - name: Test the stale-base overlap detector
         run: bash scripts/check-stale-base-overlap.test.sh
       - name: Fail when behind base on overlapping paths
@@ -827,6 +866,10 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Check out
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Fetch base
         uses: ./.github/actions/checkout-with-base
       - name: Test the changelog-parity gate
         run: bash scripts/check-changelog-parity.test.sh
@@ -867,6 +910,10 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Check out
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Fetch base
         uses: ./.github/actions/checkout-with-base
       - name: Test the contract-slice prune gate
         run: bash scripts/check-contract-slice-prune.test.sh
@@ -953,6 +1000,10 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Check out
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Fetch base
         uses: ./.github/actions/checkout-with-base
       - name: Test the docs-only detector
         run: bash scripts/check-docs-only.test.sh
@@ -1056,6 +1107,10 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Check out
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Fetch base
         uses: ./.github/actions/checkout-with-base
       - name: Test the docs-only detector
         run: bash scripts/check-docs-only.test.sh
@@ -1120,6 +1175,10 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Check out
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Fetch base
         uses: ./.github/actions/checkout-with-base
       - name: Test the docs-only detector
         run: bash scripts/check-docs-only.test.sh
@@ -1168,6 +1227,10 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Check out
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Fetch base
         uses: ./.github/actions/checkout-with-base
       - name: Test the docs-only detector
         run: bash scripts/check-docs-only.test.sh
@@ -1213,6 +1276,10 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Check out
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Fetch base
         uses: ./.github/actions/checkout-with-base
       - name: Test the docs-only detector
         run: bash scripts/check-docs-only.test.sh
@@ -1258,6 +1325,10 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Check out
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Fetch base
         uses: ./.github/actions/checkout-with-base
       # Self-test first so a broken orchestrator can never mask a real skill
       # regression behind a green gate.
@@ -1311,6 +1382,10 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Check out
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Fetch base
         uses: ./.github/actions/checkout-with-base
       - name: Test the portability gate
         run: bash scripts/check-skill-portability.test.sh
@@ -1335,6 +1410,10 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Check out
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Fetch base
         uses: ./.github/actions/checkout-with-base
       - name: Test the shell-portability gate
         run: bash scripts/check-shell-portability.test.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,11 +53,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Check out
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-          # Full history so the PR base ref resolves for the docs-only diff.
-          fetch-depth: 0
+        uses: ./.github/actions/checkout-with-base
       - name: Test the docs-only detector
         run: bash scripts/check-docs-only.test.sh
       - name: Detect a docs-only diff
@@ -441,11 +437,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Check out
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-          # Full history so the PR base ref is resolvable for the bump gate.
-          fetch-depth: 0
+        uses: ./.github/actions/checkout-with-base
       - name: Verify plugin copies match the shared lib
         run: scripts/sync-hook-utils.sh --check
       - name: Run shared lib tests
@@ -461,11 +453,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Check out
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-          # Full history so the PR base ref is resolvable for the bump gate.
-          fetch-depth: 0
+        uses: ./.github/actions/checkout-with-base
       - name: Verify plugin copies match the shared parser
         run: scripts/sync-parse-concern-value.sh --check
       - name: Run shared parser tests
@@ -481,10 +469,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Check out
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-          fetch-depth: 0
+        uses: ./.github/actions/checkout-with-base
       - name: Verify managed-scope cluster matches canonical
         run: scripts/sync-managed-scope.sh --check
       - name: Run managed-scope tests
@@ -500,10 +485,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Check out
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-          fetch-depth: 0
+        uses: ./.github/actions/checkout-with-base
       - name: Verify state-key cluster matches canonical
         run: scripts/sync-state-key.sh --check
       - name: Run state-key tests
@@ -519,11 +501,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Check out
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-          # Full history so the PR base ref is resolvable for the bump gate.
-          fetch-depth: 0
+        uses: ./.github/actions/checkout-with-base
       - name: Verify plugin copies match the shared resolver
         run: scripts/sync-resolve-convention-pattern.sh --check
       - name: Run shared resolver tests
@@ -539,11 +517,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Check out
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-          # Full history so the PR base ref is resolvable for the bump gate.
-          fetch-depth: 0
+        uses: ./.github/actions/checkout-with-base
       - name: Verify plugin binding copies match the canonical contract
         run: scripts/sync-standards-contract.sh --check
       - name: Run sync-standards-contract tests
@@ -786,12 +760,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Check out
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-          # Full history so the self-test can prove the gate goes red on the
-          # historical commits that shipped the coverage gap (#2656).
-          fetch-depth: 0
+        uses: ./.github/actions/checkout-with-base
       - name: Test the fleet finding-kind test-coverage detector
         run: bash scripts/check-fleet-finding-test-coverage.test.sh
       - name: "Check every emitted fleet finding kind has a Finding: assertion"
@@ -806,12 +775,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Check out
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-          # Full history so the self-test can prove the gate goes red on the
-          # historical commit that shipped the docs-only grammar revert (#2713).
-          fetch-depth: 0
+        uses: ./.github/actions/checkout-with-base
       - name: Test the fleet audit doc-grammar detector
         run: bash scripts/check-fleet-audit-doc-grammar.test.sh
       - name: Check audit skill grammar matches the parser
@@ -834,10 +798,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Check out
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        uses: ./.github/actions/checkout-with-base
         with:
-          persist-credentials: false
-          fetch-depth: 0
           # PR head, not the synthetic merge commit: overlap is computed against
           # the branch tip the author will squash, so merge-base math must match
           # that tip rather than an already-merged-with-base tree. Push falls
@@ -845,11 +807,6 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - name: Test the stale-base overlap detector
         run: bash scripts/check-stale-base-overlap.test.sh
-      - name: Fetch base ref
-        if: github.event_name == 'pull_request'
-        env:
-          BASE_REF: ${{ github.base_ref }}
-        run: git fetch --no-tags origin "$BASE_REF":"refs/remotes/origin/$BASE_REF"
       - name: Fail when behind base on overlapping paths
         if: github.event_name == 'pull_request'
         env:
@@ -870,11 +827,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Check out
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-          # Full history so the PR base ref is resolvable for the bump gate.
-          fetch-depth: 0
+        uses: ./.github/actions/checkout-with-base
       - name: Test the changelog-parity gate
         run: bash scripts/check-changelog-parity.test.sh
       - name: Verify every versioned plugin keeps a CHANGELOG.md at or below its manifest version
@@ -914,11 +867,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Check out
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-          # Full history so the PR base ref is resolvable for the diff gate.
-          fetch-depth: 0
+        uses: ./.github/actions/checkout-with-base
       - name: Test the contract-slice prune gate
         run: bash scripts/check-contract-slice-prune.test.sh
       - name: Verify no baseline entry outlives its slice
@@ -1004,11 +953,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Check out
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-          # Full history so the PR base ref resolves for the docs-only diff.
-          fetch-depth: 0
+        uses: ./.github/actions/checkout-with-base
       - name: Test the docs-only detector
         run: bash scripts/check-docs-only.test.sh
       - name: Detect a docs-only diff
@@ -1111,11 +1056,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Check out
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-          # Full history so the PR base ref resolves for the docs-only diff.
-          fetch-depth: 0
+        uses: ./.github/actions/checkout-with-base
       - name: Test the docs-only detector
         run: bash scripts/check-docs-only.test.sh
       - name: Detect a docs-only diff
@@ -1179,11 +1120,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Check out
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-          # Full history so the PR base ref resolves for the docs-only diff.
-          fetch-depth: 0
+        uses: ./.github/actions/checkout-with-base
       - name: Test the docs-only detector
         run: bash scripts/check-docs-only.test.sh
       - name: Detect a docs-only diff
@@ -1231,11 +1168,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Check out
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-          # Full history so the PR base ref resolves for the docs-only diff.
-          fetch-depth: 0
+        uses: ./.github/actions/checkout-with-base
       - name: Test the docs-only detector
         run: bash scripts/check-docs-only.test.sh
       - name: Detect a docs-only diff
@@ -1280,11 +1213,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Check out
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-          # Full history so the PR base ref resolves for the docs-only diff.
-          fetch-depth: 0
+        uses: ./.github/actions/checkout-with-base
       - name: Test the docs-only detector
         run: bash scripts/check-docs-only.test.sh
       - name: Detect a docs-only diff
@@ -1329,12 +1258,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Check out
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-          # Full history so the PR base ref resolves for the changed-skill diff
-          # and the checker's git-backed trigger-preservation check.
-          fetch-depth: 0
+        uses: ./.github/actions/checkout-with-base
       # Self-test first so a broken orchestrator can never mask a real skill
       # regression behind a green gate.
       - name: Test the changed-skill gate
@@ -1387,11 +1311,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Check out
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-          # Full history so the PR base ref resolves for the changed-file diff.
-          fetch-depth: 0
+        uses: ./.github/actions/checkout-with-base
       - name: Test the portability gate
         run: bash scripts/check-skill-portability.test.sh
       - name: Gate changed skill files on the portability contract
@@ -1415,11 +1335,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Check out
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-          # Full history so the PR base ref resolves for the changed-file diff.
-          fetch-depth: 0
+        uses: ./.github/actions/checkout-with-base
       - name: Test the shell-portability gate
         run: bash scripts/check-shell-portability.test.sh
       - name: Gate changed shell and skill-md files for GNU-only constructs

--- a/scripts/affected-tests.sh
+++ b/scripts/affected-tests.sh
@@ -61,17 +61,18 @@
 #                    text contains the file's basename is a dependent; R2/R3 are
 #                    then applied to IT, transitively. This is what carries a lib
 #                    change out to the hooks that source it.
-#   R5 shared-lib    a file that is the `src=` of a scripts/sync-*.sh selects
-#                    every path in that script's `copies=(...)` array, and then
-#                    R2/R3/R4 on each copy. The copy set is DERIVED from the sync
-#                    manifest on every run, never hardcoded here: the manifests
-#                    are what CI's *-sync lanes enforce, so a new carrying plugin
-#                    is picked up the moment it exists. Deriving it is the whole
-#                    point — a list copied into this file would silently rot, and
-#                    the rot would show up as an under-selection.
+#   R5 shared-lib    a file that is the `src` of a scripts/sync-*.sh selects
+#                    every path in that script's published `copy` list, and then
+#                    R2/R3/R4 on each copy. The copy set is DERIVED by invoking
+#                    `--print-manifest` on every run, never hardcoded here and
+#                    never scraped out of `src=` / `copies=(` source text: the
+#                    manifests are what CI's *-sync lanes enforce, so a new
+#                    carrying plugin is picked up the moment it exists. Deriving
+#                    it is the whole point — a list copied into this file would
+#                    silently rot, and the rot would show up as an under-selection.
 #   R6 sync script   a changed scripts/sync-*.sh selects its own co-located test
-#                    plus everything its `src=` selects, since its failure mode
-#                    is the copies drifting from that source.
+#                    plus everything its published `src` selects, since its
+#                    failure mode is the copies drifting from that source.
 #
 # R3/R4 skip STRUCTURAL basenames — README.md, SKILL.md, plugin.json and the
 # like — because those name a repo-wide role rather than one artifact, so a
@@ -217,92 +218,98 @@ trap 'rm -rf "$WORK_DIR"' EXIT
 # Sync-manifest derivation (R5/R6)
 # ---------------------------------------------------------------------------
 
-# manifest_src <sync-script> -> the `src=` value, or empty.
-manifest_src() {
-  awk '/^src=/ {
-    v = $0
-    sub(/^src=/, "", v)
-    gsub(/["\047]/, "", v)
-    sub(/[[:space:]]*#.*$/, "", v)
-    print v
-    exit
-  }' "$1"
-}
-
-# manifest_copy_patterns <sync-script> -> one raw `copies=(...)` entry per line.
-manifest_copy_patterns() {
-  awk '
-    /^copies=\(/ {
-      inarr = 1
-      line = $0
-      sub(/^copies=\(/, "", line)
-    }
-    !inarr { next }
-    inarr && line == "" && $0 !~ /^copies=\(/ { line = $0 }
-    {
-      sub(/#.*$/, "", line)
-      closed = (line ~ /\)/)
-      if (closed) sub(/\).*$/, "", line)
-      gsub(/["\047]/, "", line)
-      gsub(/^[[:space:]]+|[[:space:]]+$/, "", line)
-      if (line != "") print line
-      if (closed) exit
-      line = ""
-    }
-  ' "$1"
-}
-
-# manifest_declares_copies <sync-script> -> 0 if a `copies=(` line EXISTS.
-# Deliberately separate from manifest_copy_patterns: whether the declaration is
-# PRESENT and whether it YIELDED anything are different questions, and conflating
-# them is what let a malformed `copies=()` with no `src=` look like a helper.
-manifest_declares_copies() {
-  grep -q '^copies=(' "$1"
-}
+# Published --print-manifest format (scripts/lib/sync-cluster.sh):
+#   src<TAB><path>     exactly one; empty path means the key was declared blank
+#   copy<TAB><path>    zero or more; path may still be a glob
+# A script that does not implement the flag (usage on stderr, empty stdout) or
+# that prints neither key is a helper sharing the sync-*.sh prefix and is
+# skipped. A script that prints copy lines (or an empty src key) without a
+# non-empty src is a half-manifest and is fatal.
 
 # SYNC_SRC_COPIES maps a sync source path to its newline-separated copy paths.
 declare -A SYNC_SRC_COPIES=()
 declare -A SYNC_SCRIPT_SRC=()
 
+# invoke_print_manifest <script> <stdout-file> <stderr-file>
+# Runs `$script --print-manifest`. Returns the script's exit status.
+invoke_print_manifest() {
+  bash "$1" --print-manifest >"$2" 2>"$3"
+}
+
 build_sync_map() {
-  local script src pattern match
+  local script src pattern match line kind value rc errfile outfile
+  local has_src_key has_copy_key
   local -a patterns=()
   local -a expanded=()
+  outfile="$WORK_DIR/print-manifest.out"
+  errfile="$WORK_DIR/print-manifest.err"
   for script in scripts/sync-*.sh; do
     [[ -f "$script" ]] || continue
     case "$script" in
     *.test.sh) continue ;;
     *) ;;
     esac
-    src="$(manifest_src "$script")"
-    mapfile -t patterns < <(manifest_copy_patterns "$script")
-    # A script matching scripts/sync-*.sh that declares NEITHER key is not a
+    : >"$outfile"
+    : >"$errfile"
+    rc=0
+    invoke_print_manifest "$script" "$outfile" "$errfile" || rc=$?
+
+    src=""
+    has_src_key=0
+    has_copy_key=0
+    patterns=()
+    while IFS= read -r line || [[ -n "$line" ]]; do
+      kind="${line%%$'\t'*}"
+      if [[ "$kind" == "$line" ]]; then
+        value=""
+      else
+        value="${line#*$'\t'}"
+      fi
+      case "$kind" in
+      src)
+        has_src_key=1
+        src="$value"
+        ;;
+      copy)
+        has_copy_key=1
+        patterns+=("$value")
+        ;;
+      *) ;;
+      esac
+    done <"$outfile"
+
+    if ((rc != 0)); then
+      # usage / unknown-flag: a helper that does not implement the surface.
+      if [[ ! -s "$outfile" ]] && grep -q '^usage:' "$errfile"; then
+        continue
+      fi
+      echo "error: $script --print-manifest failed (exit $rc)." >&2
+      cat "$errfile" >&2
+      exit 2
+    fi
+
+    # A script matching scripts/sync-*.sh that publishes NEITHER key is not a
     # copy manifest — it is a helper that happens to share the prefix. Skip it.
     # Hard-exiting on it would be a repo-wide outage: this suite runs in the
     # plugin-gate lane, so the first future `scripts/sync-something.sh` that is
     # not a manifest would turn a REQUIRED check red for every PR, including
-    # ones that never touch this tool. The narrow fail-open that buys, stated
-    # plainly: a REAL manifest that renamed BOTH keys at once skips silently,
-    # and the zero-manifests guard below only catches the case where every
-    # manifest went dark at the same time. Half a manifest is still fatal.
-    #
-    # The test is on the DECLARATION, not on what it yielded. Asking
-    # `${#patterns[@]} -eq 0` instead would read a malformed `copies=()` with no
-    # `src=` as a helper and skip it silently — a half-manifest escaping the
-    # loud failure this branch exists to preserve, and one the zero-manifests
-    # guard below cannot catch while any other manifest still parses.
-    if [[ -z "$src" ]] && ! manifest_declares_copies "$script"; then
+    # ones that never touch this tool. Half a manifest is still fatal.
+    if ((has_src_key == 0 && has_copy_key == 0)); then
       continue
     fi
     if [[ -z "$src" ]]; then
-      echo "error: $script declares copies=(...) but no src= — the shared-lib derivation cannot read it." >&2
+      echo "error: $script --print-manifest declared copies but no src= — the shared-lib derivation cannot read it." >&2
       echo "       Teach scripts/affected-tests.sh the new manifest shape; do not hardcode a copy list." >&2
       exit 2
     fi
     expanded=()
     for pattern in ${patterns[@]+"${patterns[@]}"}; do
-      # shellcheck disable=SC2086 # a manifest entry may be a glob; splitting is
-      # the expansion, and no path in this repo contains whitespace.
+      if [[ -e "$pattern" ]]; then
+        expanded+=("$pattern")
+        continue
+      fi
+      # shellcheck disable=SC2086 # a manifest entry may still be a glob;
+      # splitting is the expansion, and no path in this repo contains whitespace.
       for match in $pattern; do
         [[ -e "$match" ]] && expanded+=("$match")
       done
@@ -640,7 +647,7 @@ if [[ -n "$print_fanout" ]]; then
   build_sync_map
   print_fanout="${print_fanout#./}"
   if [[ -z "${SYNC_SRC_COPIES[$print_fanout]:-}" ]]; then
-    echo "error: $print_fanout is not the src= of any scripts/sync-*.sh manifest." >&2
+    echo "error: $print_fanout is not the src of any scripts/sync-*.sh manifest." >&2
     exit 2
   fi
   printf '%s' "${SYNC_SRC_COPIES[$print_fanout]}"

--- a/scripts/affected-tests.test.sh
+++ b/scripts/affected-tests.test.sh
@@ -434,13 +434,22 @@ for src in lib/hook-utils.sh lib/parse-concern-value.sh docs/conventions/standar
 done
 
 # Every live sync-*.sh (except the test helper) must implement the surface.
+# Capture stdout first: `cmd | grep -q` under pipefail is a race — grep -q
+# closes the pipe on the first match and a still-writing publisher dies
+# SIGPIPE, which this suite's pipefail then treats as a failed assertion.
 live_missing=0
 for manifest in "$REPO_ROOT"/scripts/sync-*.sh; do
   case "$manifest" in
   *.test.sh) continue ;;
   *) ;;
   esac
-  if ! bash "$manifest" --print-manifest | grep -q $'^src\t'; then
+  live_out=""
+  live_out="$(bash "$manifest" --print-manifest)" || {
+    fail "live $manifest --print-manifest exited non-zero"
+    live_missing=1
+    continue
+  }
+  if ! printf '%s\n' "$live_out" | grep -q $'^src\t'; then
     fail "live $manifest --print-manifest did not emit a src line"
     live_missing=1
   fi

--- a/scripts/affected-tests.test.sh
+++ b/scripts/affected-tests.test.sh
@@ -21,7 +21,28 @@ SCRIPT="$SELF_DIR/affected-tests.sh"
 # failure. See #2914.
 stage_libs() {
   mkdir -p "$1/lib"
-  cp "$SELF_DIR/lib/changed-files.sh" "$SELF_DIR/lib/read-list.sh" "$1/lib/"
+  cp "$SELF_DIR/lib/changed-files.sh" "$SELF_DIR/lib/read-list.sh" \
+    "$SELF_DIR/lib/sync-cluster.sh" "$1/lib/"
+}
+
+# write_print_manifest <dest> <src> <copies-glob>
+# A fixture sync script that publishes via --print-manifest. The glob is
+# expanded at invocation time so a newly carrying plugin is picked up with
+# no edit to this file — the same derivation the live scripts use.
+write_print_manifest() {
+  local dest="$1" src_path="$2" copies_glob="$3"
+  cat >"$dest" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "\${1:-}" == "--print-manifest" ]]; then
+  printf 'src\t%s\n' '${src_path}'
+  shopt -s nullglob
+  for c in ${copies_glob}; do
+    printf 'copy\t%s\n' "\$c"
+  done
+  exit 0
+fi
+EOF
 }
 NO_SUITE="$SELF_DIR/affected-tests-no-suite.txt"
 # shellcheck source=test-git-helpers.sh
@@ -62,18 +83,11 @@ mk_repo() {
   stage_libs "$dir/scripts"
   cp "$NO_SUITE" "$dir/scripts/affected-tests-no-suite.txt"
 
-  # A sync manifest in the same shape as the real ones: a `src=` line and a
-  # GLOB `copies=(...)` array. The selector must read the copy set out of this
-  # file rather than knowing the plugin names.
-  {
-    printf '#!/usr/bin/env bash\n'
-    printf '# Fixture sync manifest.\n'
-    printf 'set -euo pipefail\n'
-    printf 'src="lib/widget.sh"\n'
-    printf 'copies=(plugins/*/hooks/widget.sh)\n'
-    # shellcheck disable=SC2016 # deliberate: the fixture manifest's own body
-    printf 'echo "${src} ${copies[0]}"\n'
-  } >"$dir/scripts/sync-widget.sh"
+  # A sync manifest that publishes via --print-manifest, with a GLOB copy
+  # pattern expanded at invocation time. The selector must read the copy set
+  # from that surface rather than knowing the plugin names.
+  write_print_manifest "$dir/scripts/sync-widget.sh" "lib/widget.sh" \
+    "plugins/*/hooks/widget.sh"
 
   printf 'widget_helper() { echo widget; }\n' >"$dir/lib/widget.sh"
   suite_body lib-widget >"$dir/lib/widget.test.sh"
@@ -165,11 +179,8 @@ fi
 
 # --- an empty derivation is a loud error, not an empty selection -----------
 sedless="$repo/scripts/sync-widget.sh"
-{
-  printf '#!/usr/bin/env bash\n'
-  printf 'src="lib/widget.sh"\n'
-  printf 'copies=(plugins/*/hooks/nothing-matches-this.sh)\n'
-} >"$sedless"
+write_print_manifest "$sedless" "lib/widget.sh" \
+  "plugins/*/hooks/nothing-matches-this.sh"
 out="$(cd "$repo" && bash scripts/affected-tests.sh lib/widget.sh 2>&1)"
 RC=$?
 if [[ "$RC" -eq 2 ]] && printf '%s' "$out" | grep -q 'ZERO copy paths'; then
@@ -246,40 +257,51 @@ for flag in --base --print-fanout; do
 done
 
 # --- a sync-*.sh that is not a manifest is skipped, not fatal --------------
-# build_sync_map used to exit 2 on ANY scripts/sync-*.sh without a src=. This
-# suite runs in a REQUIRED CI lane, so the first future helper that merely
-# shares the prefix would have turned that lane red repo-wide. Half a manifest
-# (one key, not the other) must still be fatal — that is real shape rot.
+# build_sync_map used to exit 2 on ANY scripts/sync-*.sh without a published
+# src. This suite runs in a REQUIRED CI lane, so the first future helper that
+# merely shares the prefix would have turned that lane red repo-wide. Half a
+# manifest (one published key, not the other) must still be fatal.
 printf '#!/usr/bin/env bash\necho "a helper, not a copy manifest"\n' >"$repo/scripts/sync-helper.sh"
 out="$(cd "$repo" && bash scripts/affected-tests.sh lib/widget.sh 2>&1)"
 RC=$?
 if [[ "$RC" -eq 0 ]] && has_line "$out" plugins/alpha/hooks/alpha-hook.test.sh; then
-  ok "a sync-*.sh declaring neither src= nor copies=() is skipped, not fatal"
+  ok "a sync-*.sh publishing neither src nor copy is skipped, not fatal"
 else
   fail "non-manifest sync-*.sh should be skipped (rc=$RC): $out"
 fi
 
-printf '#!/usr/bin/env bash\ncopies=(plugins/*/hooks/widget.sh)\n' >"$repo/scripts/sync-helper.sh"
+{
+  printf '#!/usr/bin/env bash\n'
+  printf 'if [[ "${1:-}" == "--print-manifest" ]]; then\n'
+  printf '  printf "copy\\tplugins/alpha/hooks/widget.sh\\n"\n'
+  printf '  exit 0\n'
+  printf 'fi\n'
+} >"$repo/scripts/sync-helper.sh"
 out="$(cd "$repo" && bash scripts/affected-tests.sh lib/widget.sh 2>&1)"
 RC=$?
 if [[ "$RC" -eq 2 ]] && printf '%s' "$out" | grep -q 'no src='; then
-  ok "a sync-*.sh with a populated copies=() but no src= is still fatal"
+  ok "a sync-*.sh that publishes copies but no src is still fatal"
 else
   fail "half a manifest should exit 2 (rc=$RC): $out"
 fi
 
-# The skip must key on whether `copies=(` is DECLARED, not on whether it yielded
-# entries. A literally EMPTY `copies=()` parses to zero patterns, so an
-# emptiness test would misread this half-manifest as a helper and skip it
-# silently — and the zero-manifests guard cannot catch that while the fixture's
+# The skip must key on whether a src key is DECLARED, not on whether copies
+# yielded entries. An empty src line is a half-manifest even with no copy
+# lines, and the zero-manifests guard cannot catch that while the fixture's
 # real sync-widget.sh still parses.
-printf '#!/usr/bin/env bash\ncopies=()\n' >"$repo/scripts/sync-helper.sh"
+{
+  printf '#!/usr/bin/env bash\n'
+  printf 'if [[ "${1:-}" == "--print-manifest" ]]; then\n'
+  printf '  printf "src\\t\\n"\n'
+  printf '  exit 0\n'
+  printf 'fi\n'
+} >"$repo/scripts/sync-helper.sh"
 out="$(cd "$repo" && bash scripts/affected-tests.sh lib/widget.sh 2>&1)"
 RC=$?
 if [[ "$RC" -eq 2 ]] && printf '%s' "$out" | grep -q 'no src='; then
-  ok "an EMPTY copies=() with no src= is a half-manifest, not a helper"
+  ok "an empty published src with no copies is a half-manifest, not a helper"
 else
-  fail "empty copies=() with no src= should exit 2 (rc=$RC): $out"
+  fail "empty src with no copies should exit 2 (rc=$RC): $out"
 fi
 rm -f "$repo/scripts/sync-helper.sh"
 
@@ -383,9 +405,12 @@ else
 fi
 rm -rf "$repo" "$marker"
 
-# --- LIVE repo: the derived copy set equals the manifest's glob today ------
+# --- LIVE repo: the derived copy set equals the published manifest today ---
 # The synthetic cases above prove the mechanism; this one proves it is still
-# wired to THIS repository, which is what rots.
+# wired to THIS repository, which is what rots. The oracle is each script's
+# --print-manifest surface (not a transcription of src=/copies=( scraping), so
+# renaming those variables cannot make this assertion go green for the wrong
+# reason.
 for src in lib/hook-utils.sh lib/parse-concern-value.sh docs/conventions/standards/README.md; do
   derived="$(cd "$REPO_ROOT" && bash scripts/affected-tests.sh --print-fanout "$src" 2>/dev/null | sort)"
   manifest="scripts/sync-$(basename "${src%.*}").sh"
@@ -393,30 +418,13 @@ for src in lib/hook-utils.sh lib/parse-concern-value.sh docs/conventions/standar
   docs/conventions/standards/README.md) manifest="scripts/sync-standards-contract.sh" ;;
   *) ;;
   esac
-  # Re-derive the copy set here and compare. Be clear about what this does and
-  # does not prove: the awk below is a TRANSCRIPTION of the selector's own
-  # manifest_copy_patterns (same rules, same order, same sub(/#.*$/)-before-`)`
-  # sequencing), minus its quote-stripping gsub. So it catches ONE-SIDED drift —
-  # the selector's parser changing, or the manifest growing a shape only one
-  # side handles (a quoted entry breaks THIS copy, loudly) — and it pins the
-  # derivation to what the LIVE manifests declare today, which is the rot that
-  # matters. It structurally CANNOT catch a misparse the two share, because
-  # they share the implementation. An independent oracle would have to parse the
-  # manifest by sourcing it, not by re-reading it the same way.
-  expected="$(cd "$REPO_ROOT" && awk '
-    /^copies=\(/ { inarr = 1; line = $0; sub(/^copies=\(/, "", line) }
-    !inarr { next }
-    { if (line == "" && $0 !~ /^copies=\(/) line = $0
-      sub(/#.*$/, "", line)
-      closed = (line ~ /\)/)
-      if (closed) sub(/\).*$/, "", line)
-      gsub(/^[[:space:]]+|[[:space:]]+$/, "", line)
-      if (line != "") print line
-      if (closed) exit
-      line = "" }
-  ' "$manifest" | while IFS= read -r pat; do
-    # shellcheck disable=SC2086 # the manifest entry is a glob by design.
-    for m in $pat; do [[ -e "$m" ]] && printf '%s\n' "$m"; done
+  expected="$(cd "$REPO_ROOT" && bash "$manifest" --print-manifest | awk -F '\t' '$1=="copy" && $2!=""{print $2}' | while IFS= read -r pat; do
+    if [[ -e "$pat" ]]; then
+      printf '%s\n' "$pat"
+    else
+      # shellcheck disable=SC2086 # a published entry may still be a glob.
+      for m in $pat; do [[ -e "$m" ]] && printf '%s\n' "$m"; done
+    fi
   done | sort)"
   if [[ -n "$derived" && "$derived" == "$expected" ]]; then
     ok "live derivation for $src matches $manifest ($(printf '%s\n' "$derived" | wc -l | tr -d ' ') copies)"
@@ -424,6 +432,60 @@ for src in lib/hook-utils.sh lib/parse-concern-value.sh docs/conventions/standar
     fail "live derivation drifted for $src: derived=[$derived] expected=[$expected]"
   fi
 done
+
+# Every live sync-*.sh (except the test helper) must implement the surface.
+live_missing=0
+for manifest in "$REPO_ROOT"/scripts/sync-*.sh; do
+  case "$manifest" in
+  *.test.sh) continue ;;
+  *) ;;
+  esac
+  if ! bash "$manifest" --print-manifest | grep -q $'^src\t'; then
+    fail "live $manifest --print-manifest did not emit a src line"
+    live_missing=1
+  fi
+done
+if [[ "$live_missing" -eq 0 ]]; then
+  ok "every live scripts/sync-*.sh implements --print-manifest"
+fi
+
+# --- renaming src/copies in the publisher does not change fan-out ----------
+# The old consumer scraped those spellings out of source text. A publisher
+# that never uses them, but still implements --print-manifest, must fan out
+# the same way — this is the assertion that the parsed contract is gone.
+repo_renamed="$(mk_repo)"
+{
+  printf '#!/usr/bin/env bash\n'
+  printf 'set -euo pipefail\n'
+  printf 'canonical="lib/widget.sh"\n'
+  printf 'vendored=(plugins/*/hooks/widget.sh)\n'
+  printf 'if [[ "${1:-}" == "--print-manifest" ]]; then\n'
+  printf '  printf "src\\t%%s\\n" "$canonical"\n'
+  printf '  for c in "${vendored[@]}"; do\n'
+  printf '    printf "copy\\t%%s\\n" "$c"\n'
+  printf '  done\n'
+  printf '  exit 0\n'
+  printf 'fi\n'
+} >"$repo_renamed/scripts/sync-widget.sh"
+run_sel "$repo_renamed" lib/widget.sh
+if [[ "$RC" -eq 0 ]] &&
+  has_line "$OUT" lib/widget.test.sh &&
+  has_line "$OUT" plugins/alpha/hooks/alpha-hook.test.sh &&
+  has_line "$OUT" plugins/beta/hooks/beta-hook.test.sh; then
+  ok "a publisher that never spells src=/copies=( still fans out via --print-manifest"
+else
+  fail "renamed-variable publisher should still fan out (rc=$RC): $OUT"
+fi
+rm -rf "$repo_renamed"
+
+# The consumer must not scrape src=/copies=( source text. The old helpers
+# (`manifest_src`, a `/^src=/` awk, a `/^copies=(/` grep) are the scrape.
+if grep -qE 'manifest_src|manifest_copy_patterns|manifest_declares_copies|/\^src=|/\^copies=\(' \
+  "$REPO_ROOT/scripts/affected-tests.sh"; then
+  fail "affected-tests.sh still scrapes src=/copies=( source text"
+else
+  ok "affected-tests.sh no longer scrapes src=/copies=( source text"
+fi
 
 # --- LIVE repo: a real shared-lib change reaches a real carrying plugin ----
 out="$(cd "$REPO_ROOT" && bash scripts/affected-tests.sh lib/hook-utils.sh 2>/dev/null)"
@@ -701,12 +763,8 @@ fi
 # and the JS copy second, so a last-write-wins bug resolves to "already crossed".
 repo2="$(mk_repo)"
 mkdir -p "$repo2/eco/agg" "$repo2/plugins/alpha/hooks"
-{
-  printf '#!/usr/bin/env bash\n'
-  printf '# Fixture sync manifest whose copies land in ANOTHER language.\n'
-  printf 'src="lib/mixed.sh"\n'
-  printf 'copies=(plugins/*/hooks/mixed.js)\n'
-} >"$repo2/scripts/sync-mixed.sh"
+write_print_manifest "$repo2/scripts/sync-mixed.sh" "lib/mixed.sh" \
+  "plugins/*/hooks/mixed.js"
 printf 'mixed_helper() { echo mixed; }\n' >"$repo2/lib/mixed.sh"
 printf 'export const mixed = 1;\n' >"$repo2/plugins/alpha/hooks/mixed.js"
 

--- a/scripts/affected-tests.test.sh
+++ b/scripts/affected-tests.test.sh
@@ -270,6 +270,7 @@ else
   fail "non-manifest sync-*.sh should be skipped (rc=$RC): $out"
 fi
 
+# shellcheck disable=SC2016 # deliberate: the emitted fixture must expand these
 {
   printf '#!/usr/bin/env bash\n'
   printf 'if [[ "${1:-}" == "--print-manifest" ]]; then\n'
@@ -289,6 +290,7 @@ fi
 # yielded entries. An empty src line is a half-manifest even with no copy
 # lines, and the zero-manifests guard cannot catch that while the fixture's
 # real sync-widget.sh still parses.
+# shellcheck disable=SC2016 # deliberate: the emitted fixture must expand these
 {
   printf '#!/usr/bin/env bash\n'
   printf 'if [[ "${1:-}" == "--print-manifest" ]]; then\n'
@@ -463,6 +465,7 @@ fi
 # that never uses them, but still implements --print-manifest, must fan out
 # the same way — this is the assertion that the parsed contract is gone.
 repo_renamed="$(mk_repo)"
+# shellcheck disable=SC2016 # deliberate: the emitted fixture must expand these
 {
   printf '#!/usr/bin/env bash\n'
   printf 'set -euo pipefail\n'

--- a/scripts/lib/sync-cluster.sh
+++ b/scripts/lib/sync-cluster.sh
@@ -24,12 +24,11 @@
 #   sync_cluster_sync_summary    1 to print a trailing per-run copy count in sync
 #                                mode, 0 for the scripts that never printed one
 #
-# `src` and `copies` keep those exact unprefixed names because they are a parsed
-# contract, not a local style: scripts/affected-tests.sh reads `^src=` and
-# `^copies=(` out of every scripts/sync-*.sh to derive which plugin copies a
-# shared-lib change reaches. Rename them here and that derivation goes quietly
-# empty (its own comment spells out the fail-open), so teach affected-tests.sh
-# the new shape first if they ever have to move.
+# `--print-manifest` is the published surface scripts/affected-tests.sh reads.
+# It emits one `src<TAB><path>` line and zero or more `copy<TAB><path>` lines
+# (already-expanded array values). The consumer invokes this flag; it does not
+# scrape `src=` / `copies=(` out of the script text. Renaming the variables
+# here does not change that output.
 #
 # The `${2:?usage: ...}` diagnostic for a missing <base-ref> stays in each caller:
 # bash prefixes it with the path and line of the expansion, so hoisting it here
@@ -89,6 +88,19 @@ sync_cluster::check_bump() {
   echo "$sync_cluster_noun changed vs $base and every $sync_cluster_carrier plugin bumped its version."
 }
 
+# sync_cluster::print_manifest
+#
+# Emits the cluster's src and copies as data. Tab-separated so a path cannot
+# collide with the field name, and so affected-tests.sh can invoke this instead
+# of parsing the caller's variable declarations.
+sync_cluster::print_manifest() {
+  local _sc_copy
+  printf 'src\t%s\n' "$src"
+  for _sc_copy in ${copies[@]+"${copies[@]}"}; do
+    printf 'copy\t%s\n' "$_sc_copy"
+  done
+}
+
 sync_cluster::run() {
   case "${1:-sync}" in
   sync)
@@ -100,8 +112,11 @@ sync_cluster::run() {
   --check-bump)
     sync_cluster::check_bump "$2"
     ;;
+  --print-manifest)
+    sync_cluster::print_manifest
+    ;;
   *)
-    echo "usage: $sync_cluster_script [--check | --check-bump <base-ref>]" >&2
+    echo "usage: $sync_cluster_script [--check | --check-bump <base-ref> | --print-manifest]" >&2
     exit 2
     ;;
   esac

--- a/scripts/sync-hook-utils.sh
+++ b/scripts/sync-hook-utils.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 # Sync or verify the plugin copies of the shared hook utility library.
 #
-#   scripts/sync-hook-utils.sh                     copy the lib into each carrying plugin
-#   scripts/sync-hook-utils.sh --check             fail if any plugin copy differs from the source
-#   scripts/sync-hook-utils.sh --check-bump <ref>  fail if the lib changed vs <ref> but a carrying
-#                                                  plugin's manifest version did not — the plugin
-#                                                  version is the update cache key, so an unbumped
-#                                                  plugin never delivers the change to consumers
+#   scripts/sync-hook-utils.sh                      copy the lib into each carrying plugin
+#   scripts/sync-hook-utils.sh --check              fail if any plugin copy differs from the source
+#   scripts/sync-hook-utils.sh --check-bump <ref>   fail if the lib changed vs <ref> but a carrying
+#                                                   plugin's manifest version did not — the plugin
+#                                                   version is the update cache key, so an unbumped
+#                                                   plugin never delivers the change to consumers
+#   scripts/sync-hook-utils.sh --print-manifest     emit src and copies as data (for affected-tests)
 #
 # A plugin carries the lib iff plugins/<name>/hooks/hook-utils.sh exists; a new
 # plugin opts in by committing an initial copy of the file there.
@@ -21,8 +22,6 @@ cd "$script_dir/.."
 . "$script_dir/lib/sync-cluster.sh"
 
 sync_cluster_script="sync-hook-utils.sh"
-# `src=` and `copies=(` are parsed out of this file by scripts/affected-tests.sh;
-# keep both spellings exactly as they are.
 src="lib/hook-utils.sh"
 copies=(plugins/*/hooks/hook-utils.sh)
 sync_cluster_manifest_strip='/hooks/*'

--- a/scripts/sync-managed-scope.sh
+++ b/scripts/sync-managed-scope.sh
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
 # Sync or verify the cross-plugin lib/managed-scope.sh cluster.
 #
-#   scripts/sync-managed-scope.sh                     copy the canonical file into each carrier
-#   scripts/sync-managed-scope.sh --check             fail if any carrier differs from canonical
-#   scripts/sync-managed-scope.sh --check-bump <ref>  fail if the canonical changed vs <ref> but a
-#                                                     carrying plugin's manifest version did not
+#   scripts/sync-managed-scope.sh                      copy the canonical file into each carrier
+#   scripts/sync-managed-scope.sh --check              fail if any carrier differs from canonical
+#   scripts/sync-managed-scope.sh --check-bump <ref>   fail if the canonical changed vs <ref> but a
+#                                                      carrying plugin's manifest version did not
+#   scripts/sync-managed-scope.sh --print-manifest     emit src and copies as data (for affected-tests)
 #
 # Canonical copy: plugins/claude-config/lib/managed-scope.sh (see
 # scripts/cross-plugin-source-registry.txt).
@@ -19,8 +20,6 @@ cd "$script_dir/.."
 . "$script_dir/lib/sync-cluster.sh"
 
 sync_cluster_script="sync-managed-scope.sh"
-# `src=` and `copies=(` are parsed out of this file by scripts/affected-tests.sh;
-# keep both spellings exactly as they are.
 src="plugins/claude-config/lib/managed-scope.sh"
 copies=(plugins/claude-memory/lib/managed-scope.sh)
 sync_cluster_manifest_strip='/lib/*'

--- a/scripts/sync-parse-concern-value.sh
+++ b/scripts/sync-parse-concern-value.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 # Sync or verify the plugin copies of the shared topic-docs concern-value parser.
 #
-#   scripts/sync-parse-concern-value.sh                     copy the lib into each consuming plugin
-#   scripts/sync-parse-concern-value.sh --check             fail if any plugin copy differs from the source
-#   scripts/sync-parse-concern-value.sh --check-bump <ref>  fail if the lib changed vs <ref> but a consuming
-#                                                           plugin's manifest version did not — the plugin
-#                                                           version is the update cache key, so an unbumped
-#                                                           plugin never delivers the change to consumers
+#   scripts/sync-parse-concern-value.sh                      copy the lib into each consuming plugin
+#   scripts/sync-parse-concern-value.sh --check              fail if any plugin copy differs from the source
+#   scripts/sync-parse-concern-value.sh --check-bump <ref>   fail if the lib changed vs <ref> but a consuming
+#                                                            plugin's manifest version did not — the plugin
+#                                                            version is the update cache key, so an unbumped
+#                                                            plugin never delivers the change to consumers
+#   scripts/sync-parse-concern-value.sh --print-manifest     emit src and copies as data (for affected-tests)
 #
 # Unlike hooks/hook-utils.sh (same path in every carrying plugin, globbable),
 # this helper is consumed by a fixed set of skill scripts at DIFFERENT paths, so
@@ -22,8 +23,6 @@ cd "$script_dir/.."
 . "$script_dir/lib/sync-cluster.sh"
 
 sync_cluster_script="sync-parse-concern-value.sh"
-# `src=` and `copies=(` are parsed out of this file by scripts/affected-tests.sh;
-# keep both spellings exactly as they are.
 src="lib/parse-concern-value.sh"
 copies=(
   plugins/claude-memory/skills/audit/scripts/parse-concern-value.sh

--- a/scripts/sync-resolve-convention-pattern.sh
+++ b/scripts/sync-resolve-convention-pattern.sh
@@ -2,12 +2,13 @@
 # Sync or verify the plugin copies of the shared commit/PR convention
 # ENFORCEMENT-pattern resolver (lib/resolve-convention-pattern.sh).
 #
-#   scripts/sync-resolve-convention-pattern.sh                     copy the lib into each consuming plugin
-#   scripts/sync-resolve-convention-pattern.sh --check             fail if any plugin copy differs from the source
-#   scripts/sync-resolve-convention-pattern.sh --check-bump <ref>  fail if the lib changed vs <ref> but a consuming
-#                                                                  plugin's manifest version did not — the plugin
-#                                                                  version is the update cache key, so an unbumped
-#                                                                  plugin never delivers the change to consumers
+#   scripts/sync-resolve-convention-pattern.sh                      copy the lib into each consuming plugin
+#   scripts/sync-resolve-convention-pattern.sh --check              fail if any plugin copy differs from the source
+#   scripts/sync-resolve-convention-pattern.sh --check-bump <ref>   fail if the lib changed vs <ref> but a consuming
+#                                                                   plugin's manifest version did not — the plugin
+#                                                                   version is the update cache key, so an unbumped
+#                                                                   plugin never delivers the change to consumers
+#   scripts/sync-resolve-convention-pattern.sh --print-manifest     emit src and copies as data (for affected-tests)
 #
 # Like sync-parse-concern-value.sh, the copies are consumed at DIFFERENT paths,
 # so the destinations are an explicit list. The list started EMPTY and grows as
@@ -26,8 +27,6 @@ cd "$script_dir/.."
 . "$script_dir/lib/sync-cluster.sh"
 
 sync_cluster_script="sync-resolve-convention-pattern.sh"
-# `src=` and `copies=(` are parsed out of this file by scripts/affected-tests.sh;
-# keep both spellings exactly as they are.
 src="lib/resolve-convention-pattern.sh"
 copies=(
   plugins/guardrails/hooks/resolve-convention-pattern.sh # CC-layer content gate (block-convention-violation.sh)

--- a/scripts/sync-standards-contract.sh
+++ b/scripts/sync-standards-contract.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 # Sync or verify the plugin binding copies of the standards concern contract.
 #
-#   scripts/sync-standards-contract.sh                     copy the canonical contract into each carrying plugin
-#   scripts/sync-standards-contract.sh --check             fail if any plugin copy differs from the canonical
-#   scripts/sync-standards-contract.sh --check-bump <ref>  fail if the contract changed vs <ref> but
+#   scripts/sync-standards-contract.sh                      copy the canonical contract into each carrying plugin
+#   scripts/sync-standards-contract.sh --check              fail if any plugin copy differs from the canonical
+#   scripts/sync-standards-contract.sh --print-manifest     emit src and copies as data (for affected-tests)
+#   scripts/sync-standards-contract.sh --check-bump <ref>   fail if the contract changed vs <ref> but
 #                                                          (a) a carrying plugin's manifest version did not —
 #                                                              the plugin version is the update cache key, or
 #                                                          (b) the standards-contract frontmatter semver did
@@ -105,8 +106,17 @@ sync)
   fi
   echo "Contract changed vs $base with frontmatter, changelog, and every carrying plugin bumped."
   ;;
+--print-manifest)
+  # Same published surface as scripts/lib/sync-cluster.sh. This script does
+  # not share the cluster engine (it also gates frontmatter + changelog), so
+  # the emit is repeated here rather than forcing it onto that engine.
+  printf 'src\t%s\n' "$src"
+  for copy in "${copies[@]}"; do
+    printf 'copy\t%s\n' "$copy"
+  done
+  ;;
 *)
-  echo "usage: sync-standards-contract.sh [--check | --check-bump <base-ref>]" >&2
+  echo "usage: sync-standards-contract.sh [--check | --check-bump <base-ref> | --print-manifest]" >&2
   exit 2
   ;;
 esac

--- a/scripts/sync-state-key.sh
+++ b/scripts/sync-state-key.sh
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
 # Sync or verify the cross-plugin lib/state-key.sh cluster.
 #
-#   scripts/sync-state-key.sh                     copy the canonical file into each carrier
-#   scripts/sync-state-key.sh --check             fail if any carrier differs from canonical
-#   scripts/sync-state-key.sh --check-bump <ref>  fail if the canonical changed vs <ref> but a
-#                                                 carrying plugin's manifest version did not
+#   scripts/sync-state-key.sh                      copy the canonical file into each carrier
+#   scripts/sync-state-key.sh --check              fail if any carrier differs from canonical
+#   scripts/sync-state-key.sh --check-bump <ref>   fail if the canonical changed vs <ref> but a
+#                                                  carrying plugin's manifest version did not
+#   scripts/sync-state-key.sh --print-manifest     emit src and copies as data (for affected-tests)
 #
 # Canonical copy: plugins/claude-config/lib/state-key.sh (see
 # scripts/cross-plugin-source-registry.txt). Tests live beside the canonical copy only.
@@ -19,8 +20,6 @@ cd "$script_dir/.."
 . "$script_dir/lib/sync-cluster.sh"
 
 sync_cluster_script="sync-state-key.sh"
-# `src=` and `copies=(` are parsed out of this file by scripts/affected-tests.sh;
-# keep both spellings exactly as they are.
 src="plugins/claude-config/lib/state-key.sh"
 copies=(plugins/claude-memory/lib/state-key.sh plugins/claude-ops/lib/state-key.sh plugins/context-budget/lib/state-key.sh plugins/improvement/lib/state-key.sh)
 sync_cluster_manifest_strip='/lib/*'


### PR DESCRIPTION
Closes #2914
Closes #3157

## Summary

Apply the remaining coupling APPLY findings from the #2914 ledger and record the DOCUMENT findings as accepted. Findings 1 and 2 already landed in #3144 (`scripts/lib/changed-files.sh` with per-consumer `--include-deleted`, and the four-line awk-operand guard — without extracting full scanner dispatch). This PR ships finding 3 and the workable half of finding 4.

## Fix

### Finding 3 — `--print-manifest`

`scripts/lib/sync-cluster.sh` now owns `--print-manifest` and emits `src<TAB>path` plus `copy<TAB>path` lines. `sync-standards-contract.sh` emits the same surface (it does not share the cluster engine). `affected-tests.sh` invokes that flag instead of scraping `^src=` / `^copies=(`. Renaming `src` or `copies` in a publisher does not change fan-out — asserted.

Deletion inclusion stays a per-consumer decision: `check-docs-only` and `check-changed-skills` still pass `--include-deleted`.

### Finding 4 — `checkout-with-base`

`.github/actions/checkout-with-base` deepens a just-checked-out worktree and fetches `origin/$BASE_REF` on pull_request events. All 20 jobs that previously set `fetch-depth: 0` now call it.

A same-repo composite cannot be the first step of a job (GitHub has not fetched the tree yet), so each of those jobs still pins `actions/checkout` first. The checkout SHA therefore remains at the call sites; #3158's one-line-pin acceptance is not met and stays open. The composite also does not write `GITHUB_ENV` — zizmor flags that as `github-env`, and callers already pass `BASE_REF` from `github.base_ref`.

### Findings 5–7 — accepted (not implemented)

| # | Finding | Verdict |
|---|---|---|
| 5 | `docs_only` string contract (48 references in `ci.yml`) | Accepted coupling. Inverse-polarity is maintained by a prose comment; hoisting scope resolution into one job is a larger workflow rewrite than the coupling is worth. |
| 6 | Test-harness scaffolding dialects | Accepted. Suites re-declare `PASS`/`FAIL` counters (or a TAP-ish variant) because a shared harness would widen the fixture-lib staging requirement rather than remove it. |
| 7 | Five bespoke parsers over `scripts/*.txt` | Semantically deliberate. Comment/escape families differ on purpose (`leading` vs `inline`); #3181 already named that split in `read-list.sh`. |

## Verification

`bash scripts/affected-tests.test.sh` — PASS=47 FAIL=0

Live `--print-manifest` on every `scripts/sync-*.sh` emits src + copies. Live `--print-fanout` matches each publisher (hook-utils 16, parse-concern-value 3, standards-contract 2). A publisher that never spells `src=` / `copies=(` still fans out.

`shellcheck --rcfile=.shellcheckrc -x` clean on the changed gates. `shfmt -d` clean. `actionlint .github/workflows/ci.yml` clean. `fetch-depth: 0` count in `ci.yml` is 0; 20 jobs use the composite after a bootstrap checkout.

## Related

- Refs #3158 — finding 4 helper landed; the one-line checkout pin is blocked by the same-repo composite chicken-and-egg
- Refs #3144 — findings 1 and 2, already on main
- Refs #3159 — finding 5, accepted
- Refs #3160 — finding 6, accepted
- Refs #3161 — finding 7, accepted as semantically deliberate
- Refs #1513 — awk-operand fail-open whose guard finding 2 already propagated