### PR TITLE
fix(ci): correct the pr-issue-linkage header's claims about the pinned reusable

### DIFF
--- a/.github/workflows/pr-issue-linkage.yml
+++ b/.github/workflows/pr-issue-linkage.yml
@@ -6,8 +6,9 @@ name: pr-issue-linkage
 # issue", not a literal string) and four non-empty contract sections —
 # `## Summary`, `## Fix`, `## Verification`, `## Related` — via the shared
 # pr-issue-linkage reusable from ci-workflows. Both body scans run with fenced
-# and indented code blocks blanked, inline code spans masked, and HTML-commented
-# text discarded, so a marker inside a code block or comment does not count.
+# code blocks and any 4-space- or tab-indented line blanked, inline code spans
+# masked, and HTML-commented text discarded, so a marker inside a fence, an
+# indented line, or a comment does not count.
 # `pull_request_target` runs the base-branch definition, so a head-branch edit
 # cannot bypass the gate — safe here because no head-branch code ever executes:
 # the pinned reusable checks out nothing, holds read-only pull-request/actions
@@ -20,8 +21,9 @@ name: pr-issue-linkage
 # design. `edited` re-validates on a body edit. `merge_group` reports the check
 # green in the queue (the body was validated at PR time; inert without a queue).
 # The emitted required-check context is `pr-issue-linkage / pr-issue-linkage`.
-# Public repo: the `with:` block pins `runner: ubuntu-24.04` explicitly, which
-# coincides with the reusable's default.
+# Public repo: GitHub-hosted runners are free here, and the `with:` block pins
+# `runner: ubuntu-24.04` explicitly, which coincides with the reusable's
+# default.
 on:
   # zizmor: ignore[dangerous-triggers] metadata-only gate; rationale in the header comment
   pull_request_target:

--- a/.github/workflows/pr-issue-linkage.yml
+++ b/.github/workflows/pr-issue-linkage.yml
@@ -1,17 +1,27 @@
 name: pr-issue-linkage
 
 # Validates the PR body carries a native closing keyword (Closes/Fixes/Resolves
-# #N, including owner/repo#N, or a no-issue marker when the PR closes
-# nothing) and four non-empty contract sections — `## Summary`, `## Fix`,
-# `## Verification`, `## Related` — via the shared
-# pr-issue-linkage reusable from ci-workflows. `pull_request_target` runs the
-# base-branch definition, so a head-branch edit cannot bypass the gate — safe
-# here because the reusable reads PR body metadata from the event payload only
-# and runs no head code. `edited` re-validates on a body edit. `merge_group`
-# reports the check green in the queue (the body was validated at PR time; inert
-# without a queue). The emitted required-check context is
-# `pr-issue-linkage / pr-issue-linkage`. Public repo: runs on the reusable's
-# hosted default runner.
+# #N, including owner/repo#N, or a no-issue marker when the PR closes nothing —
+# a case-insensitive regex matching the phrase "no linked issue" or "no related
+# issue", not a literal string) and four non-empty contract sections —
+# `## Summary`, `## Fix`, `## Verification`, `## Related` — via the shared
+# pr-issue-linkage reusable from ci-workflows. Both body scans run with fenced
+# and indented code blocks blanked, inline code spans masked, and HTML-commented
+# text discarded, so a marker inside a code block or comment does not count.
+# `pull_request_target` runs the base-branch definition, so a head-branch edit
+# cannot bypass the gate — safe here because no head-branch code ever executes:
+# the pinned reusable checks out nothing, holds read-only pull-request/actions
+# permissions only, and passes the body into its script step through
+# env/GITHUB_ENV rather than splicing it into script text. The reusable reads
+# the body via a live `gh api` re-fetch, falling back to the event payload if
+# that call fails; at the pinned SHA no token reaches that step, so the re-fetch
+# fails auth every time and the payload fallback is the path that actually runs
+# — payload-only in effect as a side effect of the failed re-fetch, not by
+# design. `edited` re-validates on a body edit. `merge_group` reports the check
+# green in the queue (the body was validated at PR time; inert without a queue).
+# The emitted required-check context is `pr-issue-linkage / pr-issue-linkage`.
+# Public repo: the `with:` block pins `runner: ubuntu-24.04` explicitly, which
+# coincides with the reusable's default.
 on:
   # zizmor: ignore[dangerous-triggers] metadata-only gate; rationale in the header comment
   pull_request_target:


### PR DESCRIPTION
Closes #3184

## Summary

The header comment in `.github/workflows/pr-issue-linkage.yml` justified its `pull_request_target` trigger — and the `zizmor: ignore[dangerous-triggers]` suppression that points at it — with a sentence that does not describe the pinned reusable: "the reusable reads PR body metadata from the event payload only and runs no head code." Only the second half is true. The same block also misattributed the runner to "the reusable's hosted default" and described the no-issue opt-out as a literal string. This PR rewrites the header so every claim matches the reusable's actual code at the pinned SHA (`7107b34`, v0.14.2).

## Fix

Comment text only; no functional YAML changes. Three corrections:

- **Body-read mechanism.** The reusable's `Load current PR body` step live-refetches the body via `gh api` and uses the event payload only as a fallback when that call fails. Re-verified at the pinned SHA: no `GH_TOKEN`/`GITHUB_TOKEN` reaches that step (its `env:` carries only `PR_NUMBER` and `FALLBACK_BODY`, and neither the job nor the workflow wires a token), so the re-fetch fails auth every time and the payload fallback is the path that actually runs. The header now states this — payload-only in effect, as a side effect of the failed re-fetch, not by design — and rests the `pull_request_target` safety rationale on what actually makes the trigger safe: no head-branch code ever executes (the reusable checks out nothing, holds `pull-requests: read` / `actions: read` only, and passes the body through `env:`/`GITHUB_ENV` rather than splicing it into script text).
- **Runner.** "Runs on the reusable's hosted default runner" replaced with the truth: the `with:` block pins `runner: ubuntu-24.04` explicitly, which coincides with the reusable's default.
- **No-issue marker.** Described as what it is: a case-insensitive regex matching the phrase "no linked issue" or "no related issue" (`/\bno (?:linked|related) issue\b/i`), not a literal string, with both body scans running against a body whose fenced code blocks and 4-space/tab-indented lines are blanked, inline code spans masked, and HTML-commented text discarded.

Per the issue's scope note, wiring a token into the reusable so the re-fetch succeeds is out of scope — that lives in `melodic-software/ci-workflows` and would be a behavior change, not a comment fix.

## Verification

- Every claim in the new header was verified directly against the reusable's source fetched at the exact pinned SHA `7107b34832a7b6db5d08d3b132621c599fbe5e50`: the `gh api` re-fetch with `FALLBACK_BODY` fallback, the absence of any token in the step/job/workflow environment, the absence of any checkout step, the read-only `permissions:` block, the `env:`/`GITHUB_ENV` body path with random heredoc delimiter, the `runner` input default, the `NO_ISSUE_MARKER` regex, and the code/comment masking in `stripRenderedHtmlComments` (including the `/^(?: {4}|\t)/` indented-code branch).
- `actionlint` passes on the edited file; `zizmor` passes with the `dangerous-triggers` suppression still honored (`No findings to report. (1 ignored, 1 suppressed)`).
- `git diff -U0` filtered to non-comment lines is empty: `on:`, `permissions:`, the `uses:` pin, and the `with:` values are byte-identical to `main`.
- An independent fresh-context reviewer re-verified each header claim against the pinned reusable source with the author rationale withheld: PASS on every criterion, plus two advisory phrasing findings (the "indented code blocks" wording and a dangling "Public repo:" lead-in), both applied in the second commit with linters re-run green.
- This change is comment-only; no test can meaningfully cover it, so no test is claimed.

## Related

- #3183 — corrected the gate-description half of this comment block; this PR corrects the half it deliberately left alone.
- #3182 — parent issue that first flagged the block.
- This PR does not touch `.github/workflows/ci.yml`; it cannot collide with the concurrent `docs_only` scope-resolution work there (#3159).
