### PR TITLE
docs(docs-hygiene): de-slop instruction surfaces (0.21.8)

### DIFF
--- a/plugins/docs-hygiene/.claude-plugin/plugin.json
+++ b/plugins/docs-hygiene/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "docs-hygiene",
-  "version": "0.21.7",
+  "version": "0.21.8",
   "description": "Documentation-hygiene toolkit: compress (flavor-trim markdown with a semantic-diff safety net), audit-noise (classify markdown noise), extract-ssot (deduplicate repeated content into a single source of truth), audit-encapsulation (detect citations into skill-private surfaces), rename-references (sweep stale references after renames), audit-derivability (classify whether a whole document earns its existence — could a fresh agent re-derive it from the code?), audit-progressive-disclosure (grade instruction files against a load-tier model for split opportunities and hub/spoke disclosure defects), write-for-agents (authoring-time doctrine that fires while agent-consumed markdown is being written), and write-for-humans (the same moment for the other reader — end-user READMEs, RFCs, release notes and guides — resolving the consuming project's own style guide first).",
   "author": {
     "name": "Melodic Software",

--- a/plugins/docs-hygiene/CHANGELOG.md
+++ b/plugins/docs-hygiene/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog — docs-hygiene plugin
 
+## [0.21.8]
+
+### Changed
+
+- **Instruction-surface de-slop (#2891, shard 6).** Rewrote this plugin's `README.md` and every
+  `SKILL.md` to drop em dashes under the repo's zero-tolerance house policy, using
+  `/ai-slop:audit fix` semantics: periods or commas, or a restructured sentence, never
+  parentheses, en dashes, or a spaced hyphen as a stand-in. Meaning stays; only the mark
+  and the sentence break change. Fenced report and protocol templates keep their original
+  punctuation. `audit-noise`'s shape table keeps the 0.21.7 wording that landed after this
+  shard was cut, so that file's remaining em dashes are a follow-up rather than a revert of
+  the soft-wrap / document-locator / porcelain fixes.
+
 ## [0.21.7]
 
 ### Fixed

--- a/plugins/docs-hygiene/README.md
+++ b/plugins/docs-hygiene/README.md
@@ -1,6 +1,6 @@
 # docs-hygiene
 
-A Claude Code plugin bundling documentation-hygiene skills — one cohesive
+A Claude Code plugin bundling documentation-hygiene skills. One cohesive
 capability: keeping a repository's tracked markdown lean, deduplicated, and
 free of decayed references. Each skill is invocable on its own; together they
 cover the flavor, noise, duplication, boundary, rename, worth, loading,
@@ -12,26 +12,26 @@ and authoring axes of doc upkeep.
 |---|---|
 | `/docs-hygiene:compress` | Tightens markdown by dropping flavor (filler, hedging, articles) while preserving all content, behind a mandatory fresh-context semantic-diff audit that reverts any semantic loss. Supports an optional `caveman` plugin backend (`/caveman:compress`) with a built-in in-session fallback. |
 | `/docs-hygiene:audit-noise` | Read-only classifier for nine markdown noise shapes (historical citations, ghost refs to ephemeral working directories, "why this file exists" preambles, hard-coupled consumer lists, scope/loading meta-commentary, plan/changeset references, conversational antecedents, tracker/PR back-references, prohibitions with no positive alternative) with tiered findings and per-shape treatment guidance. `--persist-findings` routes the negation findings to the `review:fanout` fix relay. |
-| `/docs-hygiene:extract-ssot` | Deduplicates repeated content into a single named source of truth and migrates call sites to cite it by heading. Reports duplication at every multiplicity in three labelled buckets — a lone recap of an existing SSOT, a drifting pair with no declared owner, and clusters that meet the Rule of Three — while refuse-fast verification gates (Rule of Three, Tier-0 evidence) keep *creating* a new artifact reserved for 3+ instances; below that, only non-abstracting remedies are offered. |
+| `/docs-hygiene:extract-ssot` | Deduplicates repeated content into a single named source of truth and migrates call sites to cite it by heading. Reports duplication at every multiplicity in three labelled buckets, a lone recap of an existing SSOT, a drifting pair with no declared owner, and clusters that meet the Rule of Three, while refuse-fast verification gates (Rule of Three, Tier-0 evidence) keep *creating* a new artifact reserved for 3+ instances; below that, only non-abstracting remedies are offered. |
 | `/docs-hygiene:audit-encapsulation` | Detects external citations reaching into skill-private surfaces inside `.claude/skills/<name>/` (private subdirectories, heading anchors, schema files) and routes each violation to a remediation path. Ships its own public-surface contract reference. |
-| `/docs-hygiene:rename-references` | Sweeps stale references after renames — the forms plain token grep misses: slash-command tokens, relative paths from moved files, frontmatter chains and globs — via a 12-form pattern library with audit, half-rename detection, and apply modes. |
+| `/docs-hygiene:rename-references` | Sweeps stale references after renames, the forms plain token grep misses: slash-command tokens, relative paths from moved files, frontmatter chains and globs, via a 12-form pattern library with audit, half-rename detection, and apply modes. |
 | `/docs-hygiene:audit-derivability` | Read-only, document-level worth classifier: could a fresh agent re-derive this whole document from the code, config, and structure? Weighs derivability, re-derivation cost, drift risk, and fact ownership into a verdict (delete, convert-to-pointer, keep-as-derivation-cache, keep-owns-facts), splits it by audience, and confirms load-bearing deletions with a fresh-context spot-test. Where the other five trim *inside* a doc, this decides whether the doc should exist. |
-| `/docs-hygiene:audit-progressive-disclosure` | Read-only progressive-disclosure classifier: grades agent-facing instruction markdown against a three-tier load-cost model (always-loaded / invocation-loaded / on-demand) and emits seven finding shapes in two lanes — split opportunities (oversize, mixed-concerns, tier-mismatch) and hub/spoke structure defects (blind-pointer, orphan-spoke, deep-nesting, missing-toc) — with tiered treatment guidance. Thresholds are advisory and Anthropic-prescribed; a deterministic `detect.sh` emits the facts, the judgment layer adjudicates. |
-| `/docs-hygiene:write-for-agents` | The write-side complement to the audit skills: authoring-time doctrine that fires while agent-consumed markdown is being written (CLAUDE.md/AGENTS.md content, rules files, agent-loaded reference docs, pointer lines, doc-plus-pointer extractions) — two-loads budgeting, branch-covering pointers, steps-vs-reference separation, observable completion criteria, split-by-sequence, positive-form prompting — with a verified auto-read surface reference and a trigger-reliability eval suite. |
-| `/docs-hygiene:write-for-humans` | The other half of the write-side pair: authoring-time doctrine for prose a **person** reads — end-user READMEs, RFCs, design docs, release notes, tutorials, how-to guides, reference pages, explanations. Resolves the consuming project's own declared style guide first and reaches for a bundled default set only as the fallback (Diátaxis document modes, Google developer style, ASD-STE100 instruction rules, Global English disambiguation), so the plugin never silently imposes a house style. Ships the mode picker, a rhythm section against machine-cadence prose, one sentence-rules spoke, drift-stamped source records, and a seven-item self-check. |
+| `/docs-hygiene:audit-progressive-disclosure` | Read-only progressive-disclosure classifier: grades agent-facing instruction markdown against a three-tier load-cost model (always-loaded / invocation-loaded / on-demand) and emits seven finding shapes in two lanes. Split opportunities (oversize, mixed-concerns, tier-mismatch) and hub/spoke structure defects (blind-pointer, orphan-spoke, deep-nesting, missing-toc), with tiered treatment guidance. Thresholds are advisory and Anthropic-prescribed; a deterministic `detect.sh` emits the facts, the judgment layer adjudicates. |
+| `/docs-hygiene:write-for-agents` | The write-side complement to the audit skills: authoring-time doctrine that fires while agent-consumed markdown is being written (CLAUDE.md/AGENTS.md content, rules files, agent-loaded reference docs, pointer lines, doc-plus-pointer extractions). Two-loads budgeting, branch-covering pointers, steps-vs-reference separation, observable completion criteria, split-by-sequence, positive-form prompting, with a verified auto-read surface reference and a trigger-reliability eval suite. |
+| `/docs-hygiene:write-for-humans` | The other half of the write-side pair: authoring-time doctrine for prose a **person** reads. End-user READMEs, RFCs, design docs, release notes, tutorials, how-to guides, reference pages, explanations. Resolves the consuming project's own declared style guide first and reaches for a bundled default set only as the fallback (Diátaxis document modes, Google developer style, ASD-STE100 instruction rules, Global English disambiguation), so the plugin never silently imposes a house style. Ships the mode picker, a rhythm section against machine-cadence prose, one sentence-rules spoke, drift-stamped source records, and a seven-item self-check. |
 
 ## Requirements
 
-- **Bash + git + jq** — ambient skill mechanics (Git Bash on native Windows;
+- **Bash + git + jq**. Ambient skill mechanics (Git Bash on native Windows;
   the skills' scripts strip CRLF and avoid Windows-hostile constructs).
-- **`markdownlint-cli2`** — **required by `/docs-hygiene:compress`**, whose
+- **`markdownlint-cli2`**. **required by `/docs-hygiene:compress`**, whose
   post-edit lint pass is the mandatory ship gate. It must be on `PATH` or
   installed in the consuming repo (`node_modules/.bin/markdownlint-cli2`);
   when absent, `compress` stops at the entry point with that remediation
   instead of shipping unverified output. `compress` is the only skill that gates
   its entry point on it; `extract-ssot` names it as one option for its ship-gate
   lint step, and no other skill calls it.
-- **`caveman` plugin** (optional) — a compression backend for `compress`;
+- **`caveman` plugin** (optional), a compression backend for `compress`;
   absent, an in-session fallback applies and every verification gate still
   runs.
 
@@ -55,7 +55,7 @@ they are invoked in, output destinations default to conventional locations
 detection follows the marketplace topic-docs convention (memory slices under
 `.work/<slug>/`, branch-pruned contract slices under `docs/topics/<slug>/`,
 retired `.claude/notes/`). Refine any of these through
-your own repository's `CLAUDE.md` / `.claude/rules` — the skills read the
+your own repository's `CLAUDE.md` / `.claude/rules`, the skills read the
 consuming project's context; nothing requires editing the plugin.
 
 ## Configuration

--- a/plugins/docs-hygiene/skills/audit-derivability/SKILL.md
+++ b/plugins/docs-hygiene/skills/audit-derivability/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: "Audit whether a documentation file earns its existence — could a fresh agent re-derive its conclusions by exploring the code, config, and structure itself? Read-only classifier: weighs derivability x re-derivation cost x drift risk x fact ownership into a verdict — delete, convert-to-pointer, keep-as-derivation-cache, or keep-owns-facts. Audience-aware: agent-facing surfaces get the full axe; human-facing docs clear a higher deletion bar. Use when: 'is this doc worth keeping', 'audit doc value', 'derivability', 'could an agent figure this out itself', 'should this doc exist', 'this doc just restates the code', 'prune redundant docs', 'does this doc earn its maintenance', or before deleting a doc — not line-level noise (/docs-hygiene:audit-noise), cross-file duplication (/docs-hygiene:extract-ssot), prose flavor (/docs-hygiene:compress), or code-mismatch staleness."
+description: "Audit whether a documentation file earns its existence. Could a fresh agent re-derive its conclusions by exploring the code, config, and structure itself? Read-only classifier: weighs derivability x re-derivation cost x drift risk x fact ownership into a verdict. Delete, convert-to-pointer, keep-as-derivation-cache, or keep-owns-facts. Audience-aware: agent-facing surfaces get the full axe; human-facing docs clear a higher deletion bar. Use when: 'is this doc worth keeping', 'audit doc value', 'derivability', 'could an agent figure this out itself', 'should this doc exist', 'this doc just restates the code', 'prune redundant docs', 'does this doc earn its maintenance', or before deleting a doc, not line-level noise (/docs-hygiene:audit-noise), cross-file duplication (/docs-hygiene:extract-ssot), prose flavor (/docs-hygiene:compress), or code-mismatch staleness."
 argument-hint: "[audit] [target] | sweep <dir>"
 user-invocable: true
 disable-model-invocation: false
@@ -16,22 +16,22 @@ Uncommitted .md files (first 20; empty = none): !`s=$(git status --porcelain 2>/
 
 ## Purpose
 
-Docs carry a standing tax: every tracked document must be kept true as the code it describes moves, and every low-signal document a reader (human or agent) wades through costs attention. A document earns that tax only when it holds something a reader could NOT cheaply reconstruct for themselves. This skill audits one axis the siblings do not: **document-level worth** — should this whole document exist at all?
+Docs carry a standing tax: every tracked document must be kept true as the code it describes moves, and every low-signal document a reader (human or agent) wades through costs attention. A document earns that tax only when it holds something a reader could NOT cheaply reconstruct for themselves. This skill audits one axis the siblings do not: **document-level worth**. Should this whole document exist at all?
 
-The test is **derivability**: could a fresh agent reach this document's conclusions by natively exploring the repository — reading the code, config, metadata, and structure — without being handed the document? A document that only restates what the code already says is a derivation cache at best and dead weight at worst; a document that records *why* a decision was made, a constraint that is not visible in any single file, or a fact that lives outside the repo owns something exploration can never recover.
+The test is **derivability**: could a fresh agent reach this document's conclusions by natively exploring the repository, reading the code, config, metadata, and structure, without being handed the document? A document that only restates what the code already says is a derivation cache at best and dead weight at worst; a document that records *why* a decision was made, a constraint that is not visible in any single file, or a fact that lives outside the repo owns something exploration can never recover.
 
-Read-only classifier: it surfaces a verdict per document with the reasoning; the author owns every deletion and rewrite. Deletion is the highest-stakes doc edit, so — like the sibling `/docs-hygiene:audit-noise` — this skill never applies it.
+Read-only classifier: it surfaces a verdict per document with the reasoning; the author owns every deletion and rewrite. Deletion is the highest-stakes doc edit, so, like the sibling `/docs-hygiene:audit-noise`, this skill never applies it.
 
-## The rubric — four factors, never derivability alone
+## The rubric. Four factors, never derivability alone
 
 A verdict is never "derivable, therefore delete." Derivability is one factor of four; weigh all four together. `context/rubric.md` holds the scoring detail this file only summarizes: factor definitions, the Diataxis fact-ownership mapping, the audience cost model, the spot-test protocol, and worked examples. Load it when a verdict is close.
 
 | Factor | Question | Pushes toward |
 |---|---|---|
 | **Derivable?** | Could a fresh agent reconstruct these conclusions from native exploration alone? | derivable → delete/pointer; not derivable → keep |
-| **Re-derivation cost** | If deleted, how expensive is it for the next reader to rebuild — a 2-second grep, or a multi-file investigation? | cheap → delete; expensive → keep-as-cache |
+| **Re-derivation cost** | If deleted, how expensive is it for the next reader to rebuild, a 2-second grep, or a multi-file investigation? | cheap → delete; expensive → keep-as-cache |
 | **Drift risk** | How fast does the source move underneath this document, and how silently does the doc rot when it does? | high drift → delete/pointer; low drift → cache is safer |
-| **Fact ownership** | Does the document OWN non-derivable facts — rationale, decisions, constraints, external facts, cross-cutting invariants no single file states? | owns facts → keep, regardless of derivability of the rest |
+| **Fact ownership** | Does the document OWN non-derivable facts. Rationale, decisions, constraints, external facts, cross-cutting invariants no single file states? | owns facts → keep, regardless of derivability of the rest |
 
 Fact ownership is the trump card: a document that owns even one non-derivable fact is kept (verdict `keep-owns-facts`), and the derivable remainder is routed to trimming (`/docs-hygiene:audit-noise`, `/docs-hygiene:extract-ssot`), not deletion.
 
@@ -40,26 +40,26 @@ Fact ownership is the trump card: a document that owns even one non-derivable fa
 | Verdict | Meaning | Condition |
 |---|---|---|
 | `delete` | The document is derivable, cheap to re-derive, and owns no non-derivable fact. It is dead weight. | All of: derivable, low re-derivation cost, no owned facts. Load-bearing or contested candidates require the empirical spot-test below before a confident `delete`. |
-| `convert-to-pointer` | The document exists to route readers to a truth that lives elsewhere (code, another doc, an external source). Replace the body with a one-line pointer to the source of truth. | Derivable OR duplicative, but the routing/orientation value is real. Point, don't copy. The verdict MUST name its pointer target as a repo path verified to exist (or an external URL) — the verification is part of the rationale; a pointer at a nonexistent anchor is worse than the doc it replaces. |
-| `keep-as-derivation-cache` | The content is derivable but re-derivation is expensive enough that a cached rendering earns its keep — IF the cache cannot silently rot. | Derivable + high re-derivation cost + **a drift-control condition is present**: a regeneration/verification path, or a recorded recheck trigger. Absent that condition, this verdict **demotes** to `convert-to-pointer` or `delete`. |
+| `convert-to-pointer` | The document exists to route readers to a truth that lives elsewhere (code, another doc, an external source). Replace the body with a one-line pointer to the source of truth. | Derivable OR duplicative, but the routing/orientation value is real. Point, don't copy. The verdict MUST name its pointer target as a repo path verified to exist (or an external URL), the verification is part of the rationale; a pointer at a nonexistent anchor is worse than the doc it replaces. |
+| `keep-as-derivation-cache` | The content is derivable but re-derivation is expensive enough that a cached rendering earns its keep, IF the cache cannot silently rot. | Derivable + high re-derivation cost + **a drift-control condition is present**: a regeneration/verification path, or a recorded recheck trigger. Absent that condition, this verdict **demotes** to `convert-to-pointer` or `delete`. |
 | `keep-owns-facts` | The document owns at least one non-derivable fact (rationale, decision, constraint, external fact, cross-cutting invariant). | Any owned non-derivable fact. Route the derivable remainder to the trimming siblings. |
 
-A cache verdict with no regeneration path and no recheck trigger is an unmaintained copy that drifts silently from its source — demote it (the standing rule below; the why is in `context/rubric.md`).
+A cache verdict with no regeneration path and no recheck trigger is an unmaintained copy that drifts silently from its source. Demote it (the standing rule below; the why is in `context/rubric.md`).
 
-### Out of scope — functional artifacts
+### Out of scope. Functional artifacts
 
-A file a component CONSUMES or copies at runtime — a checklist template a skill instructs agents to copy and tick, an eval fixture, a scaffold — is machinery, not documentation, and receives NO verdict here. The one-line test: is this file an INPUT a tool or skill consumes, rather than prose a reader learns from? If yes, record it as `out-of-scope: functional artifact` in the ledger and move on — the four factors presuppose a document read for its claims, and a scaffold has none to derive.
+A file a component CONSUMES or copies at runtime, a checklist template a skill instructs agents to copy and tick, an eval fixture, a scaffold, is machinery, not documentation, and receives NO verdict here. The one-line test: is this file an INPUT a tool or skill consumes, rather than prose a reader learns from? If yes, record it as `out-of-scope: functional artifact` in the ledger and move on, the four factors presuppose a document read for its claims, and a scaffold has none to derive.
 
 ## Audience-awareness
 
-Re-derivation cost is paid by the reader, and agent-facing and human-facing readers pay differently — the same content can score differently by audience. Classify each document's primary audience and name it in the verdict; a document serving both is classified for each, taking the more conservative (keep-leaning) verdict. Agent-facing surfaces (`CLAUDE.md`, `AGENTS.md`, `.claude/rules/`, skill and agent bodies) get the full axe — exploration is cheap and redundant context is a standing token tax. Human-facing docs (onboarding, READMEs, tutorials, architecture explainers) clear a higher bar — human re-derivation cost is real. Cost model and examples: `context/rubric.md`.
+Re-derivation cost is paid by the reader, and agent-facing and human-facing readers pay differently, the same content can score differently by audience. Classify each document's primary audience and name it in the verdict; a document serving both is classified for each, taking the more conservative (keep-leaning) verdict. Agent-facing surfaces (`CLAUDE.md`, `AGENTS.md`, `.claude/rules/`, skill and agent bodies) get the full axe. Exploration is cheap and redundant context is a standing token tax. Human-facing docs (onboarding, READMEs, tutorials, architecture explainers) clear a higher bar. Human re-derivation cost is real. Cost model and examples: `context/rubric.md`.
 
 ## Establishing derivability
 
 Do NOT guess derivability from a skim. Two passes, escalating only where the stakes justify it:
 
-1. **Heuristic claim-source classification (every document).** Classify each load-bearing claim by where its truth lives — *code/config/structure* (derivable), *another tracked doc* (duplication → `/docs-hygiene:extract-ssot`), or *nowhere else* (owned, non-derivable) — and let the mix drive a provisional verdict. Before an actionable verdict on an empty or near-empty file, check `git log` for evidence the state is deliberate: a deliberately emptied or reset file is a recorded decision (Factor 4) → `keep-owns-facts`.
-2. **Empirical spot-test (load-bearing or contested deletions only).** Once this context has read the document it knows the answers and will overestimate how derivable they were — a self-grade. Confirm a `delete`/`convert-to-pointer` by delegating to a **fresh-context, non-fork subagent** (e.g. `Explore`) that has NOT seen the document: it reproduces the document's conclusions from native exploration only, then compare. Prefer a cross-vendor advisor for that spot-test **when one is installed and set up** — e.g. the OpenAI Codex plugin, when its documented surface can take this artifact, invoked per its own docs — with the fresh-context same-vendor subagent as the stated fallback, never a route to a command that may not resolve (per `docs/PLUGIN-PHILOSOPHY.md` "Fresh-eyes checkpoints" in the marketplace repository). Convergence confirms derivable; divergence means the document owns something exploration could not recover — keep it. Never the Agent tool's `fork` subagent type for spot-tests that must stay uncontaminated — official docs contrast it (inherits the parent conversation) with a skill's own `context: fork` frontmatter (starts blank); an internal melodic-software tracker issue (#1258 there) contests whether the Agent-tool fork actually inherits at runtime, so treat the contrast as documented guidance for routing spot-tests, not as a settled probe result. Full protocol: `context/rubric.md`.
+1. **Heuristic claim-source classification (every document).** Classify each load-bearing claim by where its truth lives. *code/config/structure* (derivable), *another tracked doc* (duplication → `/docs-hygiene:extract-ssot`), or *nowhere else* (owned, non-derivable), and let the mix drive a provisional verdict. Before an actionable verdict on an empty or near-empty file, check `git log` for evidence the state is deliberate: a deliberately emptied or reset file is a recorded decision (Factor 4) → `keep-owns-facts`.
+2. **Empirical spot-test (load-bearing or contested deletions only).** Once this context has read the document it knows the answers and will overestimate how derivable they were, a self-grade. Confirm a `delete`/`convert-to-pointer` by delegating to a **fresh-context, non-fork subagent** (e.g. `Explore`) that has NOT seen the document: it reproduces the document's conclusions from native exploration only, then compare. Prefer a cross-vendor advisor for that spot-test **when one is installed and set up**, e.g. the OpenAI Codex plugin, when its documented surface can take this artifact, invoked per its own docs, with the fresh-context same-vendor subagent as the stated fallback, never a route to a command that may not resolve (per `docs/PLUGIN-PHILOSOPHY.md` "Fresh-eyes checkpoints" in the marketplace repository). Convergence confirms derivable; divergence means the document owns something exploration could not recover. Keep it. Never the Agent tool's `fork` subagent type for spot-tests that must stay uncontaminated. Official docs contrast it (inherits the parent conversation) with a skill's own `context: fork` frontmatter (starts blank); an internal melodic-software tracker issue (#1258 there) contests whether the Agent-tool fork actually inherits at runtime, so treat the contrast as documented guidance for routing spot-tests, not as a settled probe result. Full protocol: `context/rubric.md`.
 
 Gate the spot-test by stakes: skip it for an obviously trivial derivable file (an auto-generated index, a verbatim config restatement); run it whenever being wrong about the deletion costs a reader something real.
 
@@ -69,29 +69,29 @@ Gate the spot-test by stakes: skip it for an obviously trivial derivable file (a
 |---|---|---|
 | `<target>` (default, no action keyword) | empty → uncommitted `.md` files; file path → single doc; dir path → each `.md` directly in it | Run the rubric per document: heuristic pass, spot-test where gated, emit the verdict ledger |
 | `audit [target]` | same target rules | Explicit form of the default; identical behavior |
-| `sweep <dir>` | a directory to walk recursively | Corpus audit of the directory's tracked markdown (enumerate via `git ls-files -- '<dir>/*.md'` — one combined pathspec; two pathspecs (`'*.md' -- <dir>`) OR together and silently escalate the sweep to the whole repo. Gitignored and untracked files are out of scope, and so are `/docs-hygiene:extract-ssot`'s codified survey exclusions (vendored trees, eval fixtures, test data, run logs — `${CLAUDE_PLUGIN_ROOT}/skills/extract-ssot/actions/identify.md` owns that list; read it there, don't paraphrase it). Report the scope root and enumerated file count before fan-out. Throttled fan-out of fresh read-only subagents at a low concurrency ceiling (at most 3-4 at a time — rate-limit headroom beats wall-clock; the runtime may cap lower, which is fine). Small corpus: one document per subagent. Large corpus: batch ~15-25 documents per subagent, grouped by directory affinity so siblings share one exploration context — and route same-basename or near-identical files into ONE batch; where they still split, reconcile divergent verdicts on near-identical documents before the aggregate. Each subagent writes its per-document verdict blocks to a batch ledger file (session scratchpad or similar) and returns compact verdicts and counts; the reply carries the aggregate, the actionable subset, and pointers to the batch ledgers — corpus-scale per-document detail never streams through one context or one reply. Spot-test a small sample of keep verdicts too, so false-keeps are bounded, not only false-deletes. |
+| `sweep <dir>` | a directory to walk recursively | Corpus audit of the directory's tracked markdown (enumerate via `git ls-files -- '<dir>/*.md'`. One combined pathspec; two pathspecs (`'*.md' -- <dir>`) OR together and silently escalate the sweep to the whole repo. Gitignored and untracked files are out of scope, and so are `/docs-hygiene:extract-ssot`'s codified survey exclusions (vendored trees, eval fixtures, test data, run logs. `${CLAUDE_PLUGIN_ROOT}/skills/extract-ssot/actions/identify.md` owns that list; read it there, don't paraphrase it). Report the scope root and enumerated file count before fan-out. Throttled fan-out of fresh read-only subagents at a low concurrency ceiling (at most 3-4 at a time. Rate-limit headroom beats wall-clock; the runtime may cap lower, which is fine). Small corpus: one document per subagent. Large corpus: batch ~15-25 documents per subagent, grouped by directory affinity so siblings share one exploration context, and route same-basename or near-identical files into ONE batch; where they still split, reconcile divergent verdicts on near-identical documents before the aggregate. Each subagent writes its per-document verdict blocks to a batch ledger file (session scratchpad or similar) and returns compact verdicts and counts; the reply carries the aggregate, the actionable subset, and pointers to the batch ledgers. Corpus-scale per-document detail never streams through one context or one reply. Spot-test a small sample of keep verdicts too, so false-keeps are bounded, not only false-deletes. |
 
-One action per response; actions do not chain implicitly. `sweep` is the only recursive mode — the bare/`audit` default never walks subdirectories, so a large tree is never audited by accident.
+One action per response; actions do not chain implicitly. `sweep` is the only recursive mode, the bare/`audit` default never walks subdirectories, so a large tree is never audited by accident.
 
 ## Auto-detect default
 
 Shared clean-tree / no-scope shape: [`../../context/clean-tree-fallback.md`](../../context/clean-tree-fallback.md).
 
-1. Empty arg AND clean tree → no default target exists. Report that, then OFFER escalation to a repo-wide corpus sweep — never start it unprompted. Confirm with the user first (via `AskUserQuestion` where available, a plain prose question otherwise), presenting the prescribed defaults below pre-filled so a bare "yes" suffices; the interview may adjust any knob. Declining, or no answer, ends as the friendly no-op exit 0 ("No uncommitted .md files. Pass a file/dir target, or `sweep <dir>` for a corpus.")
+1. Empty arg AND clean tree → no default target exists. Report that, then OFFER escalation to a repo-wide corpus sweep, never start it unprompted. Confirm with the user first (via `AskUserQuestion` where available, a plain prose question otherwise), presenting the prescribed defaults below pre-filled so a bare "yes" suffices; the interview may adjust any knob. Declining, or no answer, ends as the friendly no-op exit 0 ("No uncommitted .md files. Pass a file/dir target, or `sweep <dir>` for a corpus.")
 2. Empty arg AND uncommitted `.md` files → audit those files
 3. Single file path → single-document audit
 4. Directory path (bare/`audit`) → audit each `.md` directly in the directory (non-recursive; filenames sorted lexically)
 5. First positional == `sweep` → recursive throttled corpus audit on the rest
 
-### Repo-wide escalation — prescribed defaults
+### Repo-wide escalation. Prescribed defaults
 
 The interview knobs for the confirmation in rule 1, each with its default. A confirmed escalation runs as a `sweep` over the resolved scope; every hard rule (read-only above all) still applies.
 
-- **Scope** — all tracked `.md` files (`git ls-files '*.md'`); the user may narrow to a directory.
-- **Execution** — the `sweep` contract: fresh read-only subagents, batched for a large corpus.
-- **Concurrency** — a low ceiling (at most 3-4 concurrent): rate-limit headroom over wall-clock; the runtime may cap lower, which is fine. Raise only if the user asks.
-- **Subagent model tier** — the session's model unless the user pins a tier.
-- **Spot-tests** — run for load-bearing `delete`/`convert-to-pointer` verdicts up to a stated cap per pass. A flagged verdict past the cap is emitted as **provisional**: pending its spot-test, excluded from the actionable-routing offer, never presented as a confirmed delete. The cap *defers* the hard rule's spot-test to a follow-up pass; it never waives it.
+- **Scope**. All tracked `.md` files (`git ls-files '*.md'`); the user may narrow to a directory.
+- **Execution**, the `sweep` contract: fresh read-only subagents, batched for a large corpus.
+- **Concurrency**, a low ceiling (at most 3-4 concurrent): rate-limit headroom over wall-clock; the runtime may cap lower, which is fine. Raise only if the user asks.
+- **Subagent model tier**, the session's model unless the user pins a tier.
+- **Spot-tests**. Run for load-bearing `delete`/`convert-to-pointer` verdicts up to a stated cap per pass. A flagged verdict past the cap is emitted as **provisional**: pending its spot-test, excluded from the actionable-routing offer, never presented as a confirmed delete. The cap *defers* the hard rule's spot-test to a follow-up pass; it never waives it.
 
 ## Output schema
 
@@ -119,18 +119,18 @@ Batch / sweep aggregate at the end:
 Audited <N> document(s): <d> delete, <p> convert-to-pointer, <c> keep-as-cache, <k> keep-owns-facts, <f> out-of-scope functional artifacts; <r> of the verdicts also carry a route-to-sibling annotation.
 ```
 
-Route-to-sibling is an ANNOTATION on a verdict, never a fifth verdict class: a document whose verdict stands (usually a keep) but whose rationale routes material to a sibling — doc-to-doc duplication to `/docs-hygiene:extract-ssot`, line-level noise to `/docs-hygiene:audit-noise` — records that route in its rationale, and `<r>` counts the documents carrying one, so routed work is visible in the aggregate instead of vanishing into the keep bucket. In-tree follow-up status for the 2026-08-15 repo-wide routed set: [`../../context/derivability-route-followups.md`](../../context/derivability-route-followups.md).
+Route-to-sibling is an ANNOTATION on a verdict, never a fifth verdict class: a document whose verdict stands (usually a keep) but whose rationale routes material to a sibling. Doc-to-doc duplication to `/docs-hygiene:extract-ssot`, line-level noise to `/docs-hygiene:audit-noise`. Records that route in its rationale, and `<r>` counts the documents carrying one, so routed work is visible in the aggregate instead of vanishing into the keep bucket. In-tree follow-up status for the 2026-08-15 repo-wide routed set: [`../../context/derivability-route-followups.md`](../../context/derivability-route-followups.md).
 
-Corpus-scale sweeps (more documents than one reply can carry): the per-document blocks live in the batch ledger files; the reply carries the aggregate line, the confirmed-actionable (`delete` / `convert-to-pointer`) subset, the provisional (cap-deferred) verdicts reported separately for visibility — never as part of the actionable subset — and the ledger file locations.
+Corpus-scale sweeps (more documents than one reply can carry): the per-document blocks live in the batch ledger files; the reply carries the aggregate line, the confirmed-actionable (`delete` / `convert-to-pointer`) subset, the provisional (cap-deferred) verdicts reported separately for visibility, never as part of the actionable subset, and the ledger file locations.
 
-After the ledger, OFFER to route actionable verdicts (delete / convert-to-pointer) to the consumer's work-item tracker — one item per document — and stop. Never auto-file, never auto-edit.
+After the ledger, OFFER to route actionable verdicts (delete / convert-to-pointer) to the consumer's work-item tracker, one item per document, and stop. Never auto-file, never auto-edit.
 
 ## Hard rules
 
 - **Read-only with respect to the repository.** No `Edit` or `Write` inside the repo, no `Bash` that mutates it; session-scratchpad ledgers and artifacts are the one sanctioned write surface. The author applies every deletion and rewrite. Deletion is the highest-stakes doc edit; the classifier only recommends.
 - **Never derivability alone.** A `delete` verdict requires all of: derivable, low re-derivation cost, no owned facts. Any owned non-derivable fact forces `keep-owns-facts`.
 - **Cache verdicts carry a drift-control condition or they demote.** No regeneration path and no recheck trigger → not a cache, demote to pointer/delete.
-- **Load-bearing or contested deletions are spot-tested by a fresh, non-fork subagent** — never confirmed from this (contaminated) context, never by the Agent tool's `fork` subagent type (official docs contrast it with a skill's `context: fork`, which starts blank; an internal melodic-software tracker issue contests the Agent-tool half at runtime — documented guidance for routing, not a settled probe result). A verdict whose spot-test is deferred (e.g. past a sweep's cap) stays provisional and is never routed as actionable.
+- **Load-bearing or contested deletions are spot-tested by a fresh, non-fork subagent**, never confirmed from this (contaminated) context, never by the Agent tool's `fork` subagent type (official docs contrast it with a skill's `context: fork`, which starts blank; an internal melodic-software tracker issue contests the Agent-tool half at runtime: documented guidance for routing, not a settled probe result). A verdict whose spot-test is deferred (e.g. past a sweep's cap) stays provisional and is never routed as actionable.
 - **Audience named in every verdict.** Agent-facing and human-facing docs clear different deletion bars.
 - **The empty-target escalation is offer-only.** A repo-wide sweep from the no-op path runs only after explicit user confirmation; decline or silence ends as the no-op.
 - **Owned facts are salvaged before anything is deleted.** When a doc is mostly derivable but owns a fact, the verdict is keep + route-the-remainder, never delete-and-lose.
@@ -138,8 +138,8 @@ After the ledger, OFFER to route actionable verdicts (delete / convert-to-pointe
 
 ## Gotchas
 
-- **Derivable is not a verdict.** "An agent could re-derive this" alone never justifies `delete` — check re-derivation cost, drift risk, and fact ownership first. The most common misfire is deleting a mostly-derivable doc that owned one buried rationale line.
-- **The self-grade trap.** After reading a doc you know its answers, so it always *looks* re-derivable. Never confirm a load-bearing deletion from this context — delegate to a fresh, non-fork subagent that has not seen the doc, never the Agent tool's `fork` subagent type.
+- **Derivable is not a verdict.** "An agent could re-derive this" alone never justifies `delete`. Check re-derivation cost, drift risk, and fact ownership first. The most common misfire is deleting a mostly-derivable doc that owned one buried rationale line.
+- **The self-grade trap.** After reading a doc you know its answers, so it always *looks* re-derivable. Never confirm a load-bearing deletion from this context. Delegate to a fresh, non-fork subagent that has not seen the doc, never the Agent tool's `fork` subagent type.
 - **Cache without drift control is not a cache.** `keep-as-derivation-cache` with no regeneration path and no recheck trigger is an unmaintained copy; demote it.
 - **Code-derivable ≠ duplicates-another-doc.** A doc restating *another doc* is `/docs-hygiene:extract-ssot`, not a `delete` here. Derivability is re-derivation from code/config/structure.
 - **Audience changes the verdict.** The same restatement can be dead weight on an agent surface and worth keeping for humans. Do not carry one surface's verdict to the other.
@@ -149,12 +149,12 @@ After the ledger, OFFER to route actionable verdicts (delete / convert-to-pointe
 - **Not `/docs-hygiene:audit-noise`.** That classifies line-level noise *inside* a document worth keeping. This decides whether the whole document is worth keeping. A doc can pass audit-derivability (`keep-owns-facts`) and still have noise lines for audit-noise to trim.
 - **Not `/docs-hygiene:extract-ssot`.** That deduplicates a unit repeated across files into one home, at any multiplicity (a new home is created only at 3+). Derivability is re-derivation from CODE/config/structure, not from another markdown file. A doc that duplicates *another doc* is extract-ssot's; a doc that restates *the code* is this skill's.
 - **Not `/docs-hygiene:compress`.** That trims prose flavor within a doc that stays. This deletes or repoints whole docs.
-- **Not a doc-drift / staleness detector.** Those ask "does this doc still match the code?" This asks "should this doc exist even when it is perfectly accurate?" — a currently-correct doc can still be dead weight because it is trivially re-derivable and carries drift risk.
+- **Not a doc-drift / staleness detector.** Those ask "does this doc still match the code?" This asks "should this doc exist even when it is perfectly accurate?", a currently-correct doc can still be dead weight because it is trivially re-derivable and carries drift risk.
 - **Not a doc generator or an Edit operation.** It recommends; the author acts.
 
 ## Sources
 
-- [Diátaxis](https://diataxis.fr) — the four documentation modes; the fact-ownership factor leans on its separation of derivable reference material from explanation, which owns the non-derivable *why*.
+- [Diátaxis](https://diataxis.fr), the four documentation modes; the fact-ownership factor leans on its separation of derivable reference material from explanation, which owns the non-derivable *why*.
 
 ## Recheck triggers
 

--- a/plugins/docs-hygiene/skills/audit-encapsulation/SKILL.md
+++ b/plugins/docs-hygiene/skills/audit-encapsulation/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: "Audit and remediate skill-encapsulation violations — external citations reaching into private surfaces inside `.claude/skills/<X>/` or `plugins/<plugin>/skills/<X>/` (marketplace monorepos) beyond the slash invocation. Use when: 'audit encapsulation', 'find skill leaks', 'skill boundary violation', 'who is reaching into <skill>', 'check skill boundaries', 'public API drift', or before refactoring a skill."
+description: "Audit and remediate skill-encapsulation violations. External citations reaching into private surfaces inside `.claude/skills/<X>/` or `plugins/<plugin>/skills/<X>/` (marketplace monorepos) beyond the slash invocation. Use when: 'audit encapsulation', 'find skill leaks', 'skill boundary violation', 'who is reaching into <skill>', 'check skill boundaries', 'public API drift', or before refactoring a skill."
 argument-hint: "[detect|sweep|fix <file>:<line>|file-issues]"
 user-invocable: true
 disable-model-invocation: false
@@ -10,78 +10,78 @@ metadata:
 
 ## Why this skill exists
 
-Skills have a public API and a private body — the contract is `context/public-surface-contract.md` (bundled with this skill). External consumers — rules, agents, other skills, prose docs — must cite the public surface only. Editing the private body must not break external consumers because no external consumer is allowed to depend on it.
+Skills have a public API and a private body, the contract is `context/public-surface-contract.md` (bundled with this skill). External consumers, rules, agents, other skills, prose docs, must cite the public surface only. Editing the private body must not break external consumers because no external consumer is allowed to depend on it.
 
-Without enforcement, private bodies leak. A rule file cites a path inside `<skill>/<some-subdir>/` because the content is convenient. The skill author refactors that subdir and the citation breaks silently — nothing fails the build, nothing greps red. The skill cannot evolve without coordinating with every leaker.
+Without enforcement, private bodies leak. A rule file cites a path inside `<skill>/<some-subdir>/` because the content is convenient. The skill author refactors that subdir and the citation breaks silently. Nothing fails the build, nothing greps red. The skill cannot evolve without coordinating with every leaker.
 
-This skill provides the detection + classification + remediation discipline that closes that gap. Distinct concern from `/docs-hygiene:extract-ssot` (which detects content duplication via Rule of Three). Encapsulation violations are **single-violation matters** — Rule of Three does not gate them.
+This skill provides the detection + classification + remediation discipline that closes that gap. Distinct concern from `/docs-hygiene:extract-ssot` (which detects content duplication via Rule of Three). Encapsulation violations are **single-violation matters**. Rule of Three does not gate them.
 
 ## Public surface matrix
 
-The **Skill** surface — public = frontmatter + documented actions + args/flags + `/skill-name` slash invocation + the `scripts/` entry surface; private = everything else inside `.claude/skills/<X>/` or `plugins/<plugin>/skills/<X>/` (any OTHER subdirectory, all `*.schema.json` at any depth, all heading anchors) — is defined by `context/public-surface-contract.md`, including the data-file and scripts/ entry-surface carve-outs and the rip-and-paste-portability rationale. This skill audits cites against two more authoring surfaces the contract file does not enumerate:
+The **Skill** surface, Public = frontmatter + documented actions + args/flags + `/skill-name` slash invocation + the `scripts/` entry surface; private = everything else inside `.claude/skills/<X>/` or `plugins/<plugin>/skills/<X>/` (any OTHER subdirectory, all `*.schema.json` at any depth, all heading anchors), is defined by `context/public-surface-contract.md`, including the data-file and scripts/ entry-surface carve-outs and the rip-and-paste-portability rationale. This skill audits cites against two more authoring surfaces the contract file does not enumerate:
 
 | Surface | Public (cite externally) | Private |
 |---------|--------------------------|---------|
 | **Rule file** (`.claude/rules/*.md`) | All H2/H3 headings (entire file is shared vocabulary) | n/a |
 | **Scheduled-automation prompt** (e.g. `.claude/routines/*.md`, if the consumer repo keeps them) | Top-of-file orchestration prompt | Internal exclusion lists, escape conditions |
 
-### CI / git-hook sharing — pick a technique, not an exception
+### CI / git-hook sharing. Pick a technique, not an exception
 
-Workflows and git hooks needing logic that ALSO lives in a skill must not reach into skill internals. Pick a sharing technique by logic size — scripts/ facade (the skill exposes a public `scripts/<name>.sh` entry delegating to a private backend; hooks/CI invoke it), intentional duplication, plugin packaging, or headless `claude -p '/skill <action>'` invocation — per `context/public-surface-contract.md` "CI / git-hook consumption — entry surface, not internals".
+Workflows and git hooks needing logic that ALSO lives in a skill must not reach into skill internals. Pick a sharing technique by logic size. Scripts/ facade (the skill exposes a public `scripts/<name>.sh` entry delegating to a private backend; hooks/CI invoke it), intentional duplication, plugin packaging, or headless `claude -p '/skill <action>'` invocation, per `context/public-surface-contract.md` "CI / git-hook consumption. Entry surface, not internals".
 
-The choice is per-cite. The bundled `detect.sh` is a **candidate enumerator**: it lists path shapes that *may* be private-surface cites. Exit 1 means candidates exist after mechanical filters — not that those hits are adjudicated violations. Classification (filter taxonomy below) is required before treating a hit as illegal. Do not hard-gate CI or pre-commit on `detect.sh`'s exit code alone.
+The choice is per-cite. The bundled `detect.sh` is a **candidate enumerator**: it lists path shapes that *may* be private-surface cites. Exit 1 means candidates exist after mechanical filters, not that those hits are adjudicated violations. Classification (filter taxonomy below) is required before treating a hit as illegal. Do not hard-gate CI or pre-commit on `detect.sh`'s exit code alone.
 
 ## Action router
 
 | Argument | Action | Purpose |
 |----------|--------|---------|
-| *(empty)* / `detect` | Default | Run detection grep, classify legal vs illegal, output violation table — behind the no-scope confirmation below when nothing narrows the scope |
-| `sweep` | Explicit repo-wide detect | Default detect minus the no-scope confirmation — for when the user already said "whole repo" |
+| *(empty)* / `detect` | Default | Run detection grep, classify legal vs illegal, output violation table. Behind the no-scope confirmation below when nothing narrows the scope |
+| `sweep` | Explicit repo-wide detect | Default detect minus the no-scope confirmation. For when the user already said "whole repo" |
 | `fix <file>:<line>` | Targeted remediation | Interactive Path A (promote-out) vs Path B (route-via-`/<skill>`) for one hit |
 | `file-issues` | Batch | File one tracking work item per illegal hit in the consumer's tracker (e.g. `gh issue create`); emit a checklist if no tracker is available |
 
 One action per response.
 
-### No inherited scope — confirm before a repo-wide run
+### No inherited scope. Confirm before a repo-wide run
 
 Shared clean-tree / no-scope shape: [`../../context/clean-tree-fallback.md`](../../context/clean-tree-fallback.md).
-This skill's trigger is "no inherited scope" (not only "clean tree") — a dirty tree with unrelated
+This skill's trigger is "no inherited scope" (not only "clean tree"), a dirty tree with unrelated
 edits still needs the confirm when nothing names the detect surface.
 
 The default action's domain is the whole repo, but a bare invocation does not prove the user meant
-that. When the invocation arrives with NO inherited working set — no diff in flight, no prior audit
-notes, nothing in the conversation narrowing the scope — ask ONE confirmation before running the
+that. When the invocation arrives with NO inherited working set. No diff in flight, no prior audit
+notes, nothing in the conversation narrowing the scope. Ask ONE confirmation before running the
 detection, presenting these prescribed defaults for adjustment:
 
 | Default | Value |
 |---------|-------|
 | Scope | entire tracked repo (the detect script's scan domain) |
 | Mode | detect + classify only; remediation stays a separate, user-approved step |
-| Worker fan-out | off — classify in-session. When the user opts into subagent classification or remediation, run 2–3 concurrent workers, no more, while rate-limit telemetry is absent; when the `rate-limit-guard` plugin's snapshot is readable, resolve pacing from its reader contract instead (that contract owns the snapshot path, staleness rule, and thresholds — read them there) |
+| Worker fan-out | off. Classify in-session. When the user opts into subagent classification or remediation, run 2–3 concurrent workers, no more, while rate-limit telemetry is absent; when the `rate-limit-guard` plugin's snapshot is readable, resolve pacing from its reader contract instead (that contract owns the snapshot path, staleness rule, and thresholds. Read them there) |
 
-An inherited scope — or a scope the user already stated in the invocation ("across the repo",
-"audit this directory") — suppresses the question; audit that surface directly. `sweep` is the
+An inherited scope, or a scope the user already stated in the invocation ("across the repo",
+"audit this directory"). Suppresses the question; audit that surface directly. `sweep` is the
 explicit opt-in that skips the confirmation and runs the repo-wide detect immediately.
 
 ## Detection
 
 `bash "${CLAUDE_SKILL_DIR}/scripts/detect.sh"` (`--apply-filters` optional)
 
-`detect.sh` enumerates **candidates**, not adjudicated violations. With `--apply-filters`, stderr summary keys are `raw` / `mech-filtered` / `candidates`. Exit 1 = candidates remain; exit 0 = no candidates (not a clean bill of health — see limitations below).
+`detect.sh` enumerates **candidates**, not adjudicated violations. With `--apply-filters`, stderr summary keys are `raw` / `mech-filtered` / `candidates`. Exit 1 = candidates remain; exit 0 = no candidates (not a clean bill of health. See limitations below).
 
 Matched shapes:
 
-- Any path into a subdirectory under a skill (`<X>/<any-subdir>/...` — regardless of subdir name, including uppercase / single-char / digit-leading / underscore-leading segments) **except `scripts/`** (entry-surface carve-out, see below)
+- Any path into a subdirectory under a skill (`<X>/<any-subdir>/...`. Regardless of subdir name, including uppercase / single-char / digit-leading / underscore-leading segments) **except `scripts/`** (entry-surface carve-out, see below)
 - Heading-anchor cites into `SKILL.md` body structure (`<X>/SKILL.md#<anchor>`)
 - Any `*.schema.json` file at any depth (`<X>/<file>.schema.json`)
 
-Matched path prefixes: `.claude/skills/<X>/...`, `plugins/<plugin>/skills/<X>/...`, and relative forms (`skills/<X>/...` plugin-README short cites, plus `../`-prefixed cites whose lexical resolution lands on a private skill surface — including sibling-skill links that never spell `skills/` in the cite text).
+Matched path prefixes: `.claude/skills/<X>/...`, `plugins/<plugin>/skills/<X>/...`, and relative forms (`skills/<X>/...` plugin-README short cites, plus `../`-prefixed cites whose lexical resolution lands on a private skill surface, including sibling-skill links that never spell `skills/` in the cite text).
 
-Legal external cites: bare `<X>/SKILL.md` path (discouraged but legal — natural-language + slash invocation is canonical), `<X>/<file>.json` data files at skill root (data-file carve-out), and `<X>/scripts/<entry>` entry scripts (entry-surface carve-out below).
+Legal external cites: bare `<X>/SKILL.md` path (discouraged but legal. Natural-language + slash invocation is canonical), `<X>/<file>.json` data files at skill root (data-file carve-out), and `<X>/scripts/<entry>` entry scripts (entry-surface carve-out below).
 
-**scripts/ entry-surface carve-out:** a skill's `scripts/` is its declared ENTRY surface per `context/public-surface-contract.md`. Harness / CI / hooks / workflow registries MAY path-cite a skill's entry scripts directly, so this inbound audit treats `<X>/scripts/...` cites as legal (like data files and bare `SKILL.md`) and never flags them. The skill-to-skill half of the asymmetry — a sibling SKILL.md citing another skill's `scripts/` stays slash-only — is out of this inbound audit's scope; a consuming repo that wants it enforced wires its own outbound gate.
+**scripts/ entry-surface carve-out:** a skill's `scripts/` is its declared ENTRY surface per `context/public-surface-contract.md`. Harness / CI / hooks / workflow registries MAY path-cite a skill's entry scripts directly, so this inbound audit treats `<X>/scripts/...` cites as legal (like data files and bare `SKILL.md`) and never flags them. The skill-to-skill half of the asymmetry, a sibling SKILL.md citing another skill's `scripts/` stays slash-only, is out of this inbound audit's scope; a consuming repo that wants it enforced wires its own outbound gate.
 
-The script scans the consumer repo it runs in: every `.claude/` child directory except `skills/` (self-citation domain; opt in via `--include-skills` for skill-maintenance review) and `worktrees/`, plus `.github/`, `docs/`, `.lefthook/`, `plugins/`, root instruction/config files (`AGENTS.md`, `CLAUDE.md`, `README.md`, `CONTRIBUTING.md`, `lefthook.yml`), and `.claude/` top-level files — each filtered to what exists.
+The script scans the consumer repo it runs in: every `.claude/` child directory except `skills/` (self-citation domain; opt in via `--include-skills` for skill-maintenance review) and `worktrees/`, plus `.github/`, `docs/`, `.lefthook/`, `plugins/`, root instruction/config files (`AGENTS.md`, `CLAUDE.md`, `README.md`, `CONTRIBUTING.md`, `lefthook.yml`), and `.claude/` top-level files. Each filtered to what exists.
 
 Or invoke the skill (the agent applies the filter taxonomy below):
 
@@ -89,26 +89,26 @@ Or invoke the skill (the agent applies the filter taxonomy below):
 /docs-hygiene:audit-encapsulation detect
 ```
 
-## Filter taxonomy — legal hits
+## Filter taxonomy. Legal hits
 
-`detect.sh` output is broad without `--apply-filters`. Use the filter taxonomy below for KIND-1/2/3; `--apply-filters` drops only the mechanically-decidable subset (self-citation and worktree paths). Remaining rows are **candidates** — apply KIND-1/2/3, mirror-automation, glob-config, and plugin-cache judgment in-session before calling anything a violation.
+`detect.sh` output is broad without `--apply-filters`. Use the filter taxonomy below for KIND-1/2/3; `--apply-filters` drops only the mechanically-decidable subset (self-citation and worktree paths). Remaining rows are **candidates**. Apply KIND-1/2/3, mirror-automation, glob-config, and plugin-cache judgment in-session before calling anything a violation.
 
 | Filter | Hit shape | Why legal |
 |--------|-----------|-----------|
-| **Self-citation** | A skill cites its own internals — absolute (`.claude/skills/<X>/...` / `plugins/.../skills/<X>/...`), bare `skills/<X>/...`, or a `../` cite that resolves into the same skill | Intra-skill progressive disclosure (per `context/public-surface-contract.md`) |
+| **Self-citation** | A skill cites its own internals. Absolute (`.claude/skills/<X>/...` / `plugins/.../skills/<X>/...`), bare `skills/<X>/...`, or a `../` cite that resolves into the same skill | Intra-skill progressive disclosure (per `context/public-surface-contract.md`) |
 | **KIND-1 meta-prose** | A rule or doc describing the encapsulation contract itself, OR documenting skill internals as a worked example / historical narrative / empirically-verified quirk | Self-referential explanatory prose, not citation |
 | **KIND-2 forced-cite** | Another tool's semantics structurally require a verbatim path (a path-scoped rule trigger, a watch-glob, a drift-gate comparing against a vendored copy) | Citation IS the structural contract |
 | **KIND-3 self-test** | This skill's / a hook's own regression fixtures embed literal violation strings | Exercise the filter; not real citations |
 | **Mirror-automation** | A scheduled-automation prompt (e.g. `.claude/routines/<name>.md`) cites `.claude/skills/<name>/<private-path>` when its basename matches the skill name | Such prompts are cron arms of slash skills; mirror cites are part of the skill contract per the Public surface matrix |
-| **Glob-config** | Skill-internal path used as a glob/filter in an exclusion list, hooks allowlist, or `.gitignore` — not a content `Read` cite | Path is structural filter syntax, not progressive-disclosure content (overlaps KIND-2; named separately for grading) |
-| **Plugin cache** | `~/.claude/plugins/cache/<plugin>/...` | Upstream territory; foreign contract. These paths never match the detector PATTERN (not under a skill root), so `--apply-filters` has no cache branch — classify as legal if they appear in a manual/agent sweep |
-| **Worktree path** | `<worktree-root>/<n>/.claude/skills/<X>/...` (per the repo's worktree convention — e.g. `.worktrees/`, `.claude/worktrees/`, `.git/worktrees/`) | Worktrees share the tracked tree; same rules apply at the root path |
+| **Glob-config** | Skill-internal path used as a glob/filter in an exclusion list, hooks allowlist, or `.gitignore`, not a content `Read` cite | Path is structural filter syntax, not progressive-disclosure content (overlaps KIND-2; named separately for grading) |
+| **Plugin cache** | `~/.claude/plugins/cache/<plugin>/...` | Upstream territory; foreign contract. These paths never match the detector PATTERN (not under a skill root), so `--apply-filters` has no cache branch. Classify as legal if they appear in a manual/agent sweep |
+| **Worktree path** | `<worktree-root>/<n>/.claude/skills/<X>/...` (per the repo's worktree convention, e.g. `.worktrees/`, `.claude/worktrees/`, `.git/worktrees/`) | Worktrees share the tracked tree; same rules apply at the root path |
 
 Hits that survive ALL filters = illegal. Report.
 
 ## Remediation paths
 
-### Path A — Promote content out (caller wants the data)
+### Path A. Promote content out (caller wants the data)
 
 Use when: the caller needs data the private file contains, and the data is genuinely shared vocabulary or constraint.
 
@@ -118,7 +118,7 @@ Use when: the caller needs data the private file contains, and the data is genui
 4. Delete or shrink the private file
 5. Invoke `/docs-hygiene:rename-references` via the Skill tool to sweep all syntactic forms
 
-### Path B — Route via `/skill-name` invocation (caller wants the behavior)
+### Path B. Route via `/skill-name` invocation (caller wants the behavior)
 
 Use when: the caller wants the skill's behavior, not the data. A reference into the private body is a workaround because the skill has no public action covering the use case.
 
@@ -139,8 +139,8 @@ When invoked from another skill's execute pass (e.g. `/docs-hygiene:extract-ssot
 | 1 | Run the detection grep against the caller list (or repo-wide) |
 | 2 | Classify each match via the filter taxonomy: legal hit vs violation |
 | 3 | For each violation, choose Path A (promote) or Path B (route via `/name`) |
-| 4 | DO NOT preserve a violation because "it works today" — broken-window pattern |
-| 5 | If Path B is needed but the action is missing, file a tracking work item and STOP — don't ship a partial fix |
+| 4 | DO NOT preserve a violation because "it works today". Broken-window pattern |
+| 5 | If Path B is needed but the action is missing, file a tracking work item and STOP. Don't ship a partial fix |
 | 6 | Invoke `/docs-hygiene:rename-references` via the Skill tool to sweep after edits |
 
 A surfaced violation is never silently ignored: fix it, capture it as a side note to the user, or file a tracking work item.
@@ -174,10 +174,10 @@ A surfaced violation is never silently ignored: fix it, capture it as a side not
 
 ## Anti-patterns guarded
 
-- **Single-violation tolerance** — "it's only one place, no big deal." Encapsulation rot accumulates one violation at a time. Each is a binary contract break, not a Rule of Three threshold.
-- **Silent workaround** — the caller inlines the data instead of routing through the skill, hiding the violation from future audits. Mitigated by the `# TODO(audit-encapsulation)` marker requirement.
-- **Filter laziness** — flagging every grep hit without applying the filter taxonomy. False positives erode trust in the audit; users stop running it.
-- **Wrong-direction Path A** — promoting skill-internal content to a shared doc when the caller actually wanted skill behavior. Mitigated by the "data vs behavior" classification step in Path A vs Path B selection.
+- **Single-violation tolerance**. "it's only one place, no big deal." Encapsulation rot accumulates one violation at a time. Each is a binary contract break, not a Rule of Three threshold.
+- **Silent workaround**, the caller inlines the data instead of routing through the skill, hiding the violation from future audits. Mitigated by the `# TODO(audit-encapsulation)` marker requirement.
+- **Filter laziness**. Flagging every grep hit without applying the filter taxonomy. False positives erode trust in the audit; users stop running it.
+- **Wrong-direction Path A**. Promoting skill-internal content to a shared doc when the caller actually wanted skill behavior. Mitigated by the "data vs behavior" classification step in Path A vs Path B selection.
 
 ## Sanity checks
 
@@ -194,16 +194,16 @@ A surfaced violation is never silently ignored: fix it, capture it as a side not
 - Detect content duplication / Rule of Three clusters → `/docs-hygiene:extract-ssot`
 - Enforce code-side public/private (TypeScript `export`, .NET `internal`, Python `_prefix`) → language-level tooling (compiler, lint)
 - Refactor skill bodies that ARE legitimately self-contained (no external violations) → general refactoring, out of scope
-- File work items without classification — Path A vs Path B must be picked first
-- Auto-fix without user review — each Path B route changes call-site invocation; the user inspects the diff
+- File work items without classification. Path A vs Path B must be picked first
+- Auto-fix without user review. Each Path B route changes call-site invocation; the user inspects the diff
 
 ## Cross-references
 
-- `context/public-surface-contract.md` — canonical definition of what's public vs private, both carve-outs, the violation-shape table, and the CI / git-hook consumption techniques
-- `/docs-hygiene:extract-ssot verify` — 6-gate refuse-fast check for Path A "promote out" decisions
-- `/docs-hygiene:extract-ssot execute` — writes the SSOT and sweeps citations after a Path A migration
-- `/docs-hygiene:extract-ssot` — duplication-skill counterpart; an encapsulation violation is one of its failure modes (cross-cite)
-- `/docs-hygiene:rename-references` — load-bearing multi-pattern sweep after any heading change
+- `context/public-surface-contract.md`. Canonical definition of what's public vs private, both carve-outs, the violation-shape table, and the CI / git-hook consumption techniques
+- `/docs-hygiene:extract-ssot verify`. 6-gate refuse-fast check for Path A "promote out" decisions
+- `/docs-hygiene:extract-ssot execute`. Writes the SSOT and sweeps citations after a Path A migration
+- `/docs-hygiene:extract-ssot`. Duplication-skill counterpart; an encapsulation violation is one of its failure modes (cross-cite)
+- `/docs-hygiene:rename-references`. Load-bearing multi-pattern sweep after any heading change
 
 ## Recheck triggers
 
@@ -211,6 +211,6 @@ A surfaced violation is never silently ignored: fix it, capture it as a side not
 |-----------|--------|
 | `context/public-surface-contract.md` changes | Re-sync the Public surface matrix here and the pattern comments in `scripts/detect.sh` |
 | Scan scope changes in `scripts/detect.sh` (dirs, file globs, include flags) | Update the Detection scan-scope sentence here so docs and script cannot drift |
-| A new CI workflow or git hook needs skill logic | Pick a technique from `context/public-surface-contract.md` "CI / git-hook consumption — entry surface, not internals"; prefer a skill `scripts/` facade the hook invokes — no vendored copy |
+| A new CI workflow or git hook needs skill logic | Pick a technique from `context/public-surface-contract.md` "CI / git-hook consumption. Entry surface, not internals"; prefer a skill `scripts/` facade the hook invokes. No vendored copy |
 | Violations recur across audits | Promote the `detect` action to a scheduled cadence in the consumer repo (e.g. `/loop` or `/schedule`) |
 | Anthropic ships a native skill-boundary linter | Demote this skill to advisory or sunset it |

--- a/plugins/docs-hygiene/skills/audit-progressive-disclosure/SKILL.md
+++ b/plugins/docs-hygiene/skills/audit-progressive-disclosure/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: "Read-only progressive-disclosure audit for agent-facing instruction markdown — grades every target against a three-tier load-cost model (always-loaded / invocation-loaded / on-demand) and classifies seven finding shapes in two lanes: split opportunities (oversize vs tier-calibrated Anthropic-prescribed caps, mixed-concerns, tier-mismatch — procedures, path-local, or sometimes-only content sitting in an always-loaded file) and disclosure-structure defects (blind-pointer lacking a when-to-read clause or read-vs-run intent, orphan-spoke, deep-nesting past one level, missing-toc on long references). Emits Tier 1/2/3 findings with per-shape treatment guidance; read-only, no edits applied. Use when: 'progressive disclosure', 'split this file', 'this file is too long', 'too much context', 'mixed concerns', 'hub and spoke', 'is my CLAUDE.md too big', 'audit context loading', 'what should always be loaded', or before splitting any instruction file — not for prose flavor (/docs-hygiene:compress), in-page noise (/docs-hygiene:audit-noise), whole-doc existence (/docs-hygiene:audit-derivability), or skill frontmatter QA (/skill-quality:check)."
+description: "Read-only progressive-disclosure audit for agent-facing instruction markdown. Grades every target against a three-tier load-cost model (always-loaded / invocation-loaded / on-demand) and classifies seven finding shapes in two lanes: split opportunities (oversize vs tier-calibrated Anthropic-prescribed caps, mixed-concerns, tier-mismatch. Procedures, path-local, or sometimes-only content sitting in an always-loaded file) and disclosure-structure defects (blind-pointer lacking a when-to-read clause or read-vs-run intent, orphan-spoke, deep-nesting past one level, missing-toc on long references). Emits Tier 1/2/3 findings with per-shape treatment guidance; read-only, no edits applied. Use when: 'progressive disclosure', 'split this file', 'this file is too long', 'too much context', 'mixed concerns', 'hub and spoke', 'is my CLAUDE.md too big', 'audit context loading', 'what should always be loaded', or before splitting any instruction file, not for prose flavor (/docs-hygiene:compress), in-page noise (/docs-hygiene:audit-noise), whole-doc existence (/docs-hygiene:audit-derivability), or skill frontmatter QA (/skill-quality:check)."
 argument-hint: "[audit] [target]"
 user-invocable: true
 disable-model-invocation: false
@@ -17,8 +17,8 @@ Uncommitted .md files (sample, first 10): !`git status --porcelain 2>/dev/null |
 
 ## Purpose
 
-Agent-facing instruction markdown — `CLAUDE.md`/`AGENTS.md`, `.claude/rules/`, skill/agent/command
-bodies, their bundled spokes — has a load cost set by its **tier**: always-loaded content is paid
+Agent-facing instruction markdown, `CLAUDE.md`/`AGENTS.md`, `.claude/rules/`, skill/agent/command
+bodies, their bundled spokes, has a load cost set by its **tier**: always-loaded content is paid
 every session, invocation-loaded content recurs for the rest of the session once triggered, and
 on-demand content is free until read. This skill audits both directions of that economy: content
 that should move DOWN a tier (split opportunities), and existing hub/spoke structures whose
@@ -33,12 +33,12 @@ threshold, routing rule, or citation posture (Anthropic-prescribed vs corroborat
 
 | Lane | Shape | What it looks like | Default tier | Treatment |
 |---|---|---|---|---|
-| split | `oversize` | File at/approaching its tier's size guidance (SKILL.md approaching 500 lines; CLAUDE.md above ~200; references per the TOC bands). Ceilings, not targets — size alone below the cap is no finding | 2 | Add a hierarchy layer: name the sections to push into spokes, each behind a conditioned pointer |
-| split | `mixed-concerns` | Mutually-exclusive contexts co-resident (content that never co-executes), category straddle, multi-topic rules file, cross-file contradiction | 2 | Split by concern — one topic per file; name the proposed split seams |
+| split | `oversize` | File at/approaching its tier's size guidance (SKILL.md approaching 500 lines; CLAUDE.md above ~200; references per the TOC bands). Ceilings, not targets. Size alone below the cap is no finding | 2 | Add a hierarchy layer: name the sections to push into spokes, each behind a conditioned pointer |
+| split | `mixed-concerns` | Mutually-exclusive contexts co-resident (content that never co-executes), category straddle, multi-topic rules file, cross-file contradiction | 2 | Split by concern. One topic per file; name the proposed split seams |
 | split | `tier-mismatch` | Content at the wrong tier: a procedure grown inside CLAUDE.md (→ skill), path-local rules in a global file (→ scoped rule), reference detail inline in a hub (→ spoke), always-loaded content not needed every session (→ demote behind a pointer) | 1 when an official routing rule decides it; else 2 | Route down-tier per the rule; the finding names source section and destination surface |
 | structure | `blind-pointer` | Pointer with no when-to-read clause, unmarked execute-vs-read intent, or a vague target name (`doc2.md`, `utils`) | 2 | Attach the condition and intent; rename the target descriptively. On skill descriptions, a missing when-NOT-to-use clause is advisory color (community-sourced), never a violation |
-| structure | `orphan-spoke` | Bundled spoke no hub references — unreachable by pointer | 2 | 3-way: add the missing pointer, merge the content up, or delete the spoke |
-| structure | `deep-nesting` | Spoke-to-spoke chain — required reading more than one level from the hub (documented partial-read failure) | 2; 1 when the chain is the only path to required content | Re-link the deep target directly from the hub, or flatten |
+| structure | `orphan-spoke` | Bundled spoke no hub references. Unreachable by pointer | 2 | 3-way: add the missing pointer, merge the content up, or delete the spoke |
+| structure | `deep-nesting` | Spoke-to-spoke chain, required reading more than one level from the hub (documented partial-read failure) | 2; 1 when the chain is the only path to required content | Re-link the deep target directly from the hub, or flatten |
 | structure | `missing-toc` | Reference file >300 lines with no TOC = definite; 100–300 lines with none = awareness only, citing the official 100-vs-300 conflict | 1 (>300) / 3 (100–300) | Add a TOC at top (or a grep recipe for lookup-shaped content) |
 
 Thresholds are advisory and tier-calibrated, never hard gates; consuming repos refine them via
@@ -52,15 +52,14 @@ is a scaling tool, and a small single-file skill is never flagged for lacking sp
 | `<target>` (default) | empty → uncommitted `.md` files from git; file path → single file; dir path → recursive batch | run `${CLAUDE_SKILL_DIR}/scripts/detect.sh` on the targets; map its facts onto the shapes table via the judgment rules below |
 | `audit [target]` | same target rules | explicit form of the default; same behavior |
 
-Single action v1; a `split` action (applying the splits) is deferred until real demand surfaces —
-author hand-edits driven by audit output cover the workflow.
+Single action v1; a `split` action (applying the splits) is deferred until real demand surfaces. Author hand-edits driven by audit output cover the workflow.
 
 **Facts vs judgment.** `detect.sh` is a fact emitter, not an adjudicator: it emits per-file size
 and heading facts, load-tier classification (path + frontmatter heuristic; `unknown` is yours to
 classify), a pointer inventory with source-line context, orphan-spoke records, and spoke-to-spoke
 `chain` records. The judgment layer owns: concern-mixing (from the heading census + content),
 whole-conversation relevance of always-loaded sections, when-clause quality (a `pointer` record's
-`ctx` shows the surrounding line — judge whether it carries a condition and intent), and whether a
+`ctx` shows the surrounding line. Judge whether it carries a condition and intent), and whether a
 `chain` is a required reading path (finding) or a legitimate cross-reference (not one). In a repo
 with no Claude Code configuration the tier model degrades gracefully: most files classify
 on-demand/unknown and the split lane still applies.
@@ -74,7 +73,7 @@ Shared clean-tree / no-scope shape: [`../../context/clean-tree-fallback.md`](../
    `.claude/rules/`, skill/agent/command trees) minus `**/evals/fixtures/**`, `**/vendor/**`, and
    `CHANGELOG.md`; scan via one `detect.sh` pass per top-level root; report-first. Unattended,
    surface the offer as blocked and stop.
-2. Empty arg AND uncommitted `.md` files → batch audit over ALL of them — re-derive the full
+2. Empty arg AND uncommitted `.md` files → batch audit over ALL of them. Re-derive the full
    list in-session (`git status --porcelain`); the pre-computed sample above caps at 10 and is
    orientation, never the corpus.
 3. Single file path → single-file audit.
@@ -94,7 +93,7 @@ Shared clean-tree / no-scope shape: [`../../context/clean-tree-fallback.md`](../
 - **Skip surfaces.** `CHANGELOG.md`, `evals/fixtures/`, `vendor/` trees, YAML frontmatter, and
   fenced code blocks are never findings surfaces.
 - **Output deterministic.** Files sort lexically; per-file rows sort by line; no timestamps.
-- **Default action is the audit action** — `/docs-hygiene:audit-progressive-disclosure <file>` ==
+- **Default action is the audit action**. `/docs-hygiene:audit-progressive-disclosure <file>` ==
   `… audit <file>`.
 
 ## Output schema
@@ -124,9 +123,9 @@ Total: <N> file(s) audited — T1=<n>, T2=<n>, T3=<n>. Facts: files=<n> pointers
   the cap, and the internal-practice hub figure (~30 lines) is far below it. Size alone under the
   cap never fires `oversize`.
 - Invocation-loaded is **cheap to have, not cheap to use**: once a skill body loads, every line
-  recurs for the session — so mutually-exclusive content inside one body defeats the tier and
+  recurs for the session, so mutually-exclusive content inside one body defeats the tier and
   fires `mixed-concerns` even when the file is "small enough".
-- A `chain` record is a candidate, not a verdict — sibling cross-references between spokes that
+- A `chain` record is a candidate, not a verdict. Sibling cross-references between spokes that
   are alternates (not required reading) are legitimate.
 - An unresolved pointer (`resolved=no`) is upstream breakage worth surfacing, but rename sweeps
   belong to `/docs-hygiene:rename-references`, not here.
@@ -135,23 +134,23 @@ Total: <N> file(s) audited — T1=<n>, T2=<n>, T3=<n>. Facts: files=<n> pointers
 
 ## What this skill is NOT
 
-- **Not `/docs-hygiene:compress`** — flavor/wordiness inside a file is compression, not disclosure.
-- **Not `/docs-hygiene:audit-noise`** — in-page noise shapes (citations, ghost-refs, preambles).
-- **Not `/docs-hygiene:audit-derivability`** — whether a whole doc should exist at all.
-- **Not `/docs-hygiene:extract-ssot`** — content repeated across files is deduplication territory.
-- **Not `/skill-quality:check`** — frontmatter validation, listing budgets, and description QA are
+- **Not `/docs-hygiene:compress`**. Flavor/wordiness inside a file is compression, not disclosure.
+- **Not `/docs-hygiene:audit-noise`**. In-page noise shapes (citations, ghost-refs, preambles).
+- **Not `/docs-hygiene:audit-derivability`**. Whether a whole doc should exist at all.
+- **Not `/docs-hygiene:extract-ssot`**. Content repeated across files is deduplication territory.
+- **Not `/skill-quality:check`**. Frontmatter validation, listing budgets, and description QA are
   its static gates; this skill audits loading structure, and cross-references rather than
   duplicates those checks.
 
 ## Sources
 
-- [Claude Code skills docs](https://code.claude.com/docs/en/skills) — loading levels, listing cap, compaction budgets, split triggers
-- [Claude Code memory docs](https://code.claude.com/docs/en/memory) — CLAUDE.md/rules loading, 200-line target, fact-vs-procedure routing
-- [Claude Code large-codebases docs](https://code.claude.com/docs/en/large-codebases) — root-orients / per-directory layering, escalation ladder
-- [Agent Skills best practices](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices) — hub-and-spoke patterns, pointer rules, observed-navigation diagnostics, >100-line TOC guidance
-- [Agent Skills spec](https://agentskills.io/specification) — frontmatter limits, one-level-deep rule, ~100-token metadata
-- [Anthropic engineering: Agent Skills](https://www.anthropic.com/engineering/equipping-agents-for-the-real-world-with-agent-skills) — mutual-exclusivity split rule
-- [Anthropic engineering: context engineering](https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents) — just-in-time retrieval, pointer doctrine
-- [skill-creator](https://github.com/anthropics/skills/tree/main/skills/skill-creator) — approaching-the-limit split trigger, >300-line TOC guidance
-- [UC Davis disclosure study (arXiv 2607.17598)](https://arxiv.org/abs/2607.17598) — scale boundary, depth>1 harm (academic corroboration)
-- [happyskills: listing eviction](https://happyskills.ai) — community source for eviction scoring and the when-NOT-to-use description clause (advisory color only)
+- [Claude Code skills docs](https://code.claude.com/docs/en/skills). Loading levels, listing cap, compaction budgets, split triggers
+- [Claude Code memory docs](https://code.claude.com/docs/en/memory). CLAUDE.md/rules loading, 200-line target, fact-vs-procedure routing
+- [Claude Code large-codebases docs](https://code.claude.com/docs/en/large-codebases). Root-orients / per-directory layering, escalation ladder
+- [Agent Skills best practices](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices). Hub-and-spoke patterns, pointer rules, observed-navigation diagnostics, >100-line TOC guidance
+- [Agent Skills spec](https://agentskills.io/specification). Frontmatter limits, one-level-deep rule, ~100-token metadata
+- [Anthropic engineering: Agent Skills](https://www.anthropic.com/engineering/equipping-agents-for-the-real-world-with-agent-skills). Mutual-exclusivity split rule
+- [Anthropic engineering: context engineering](https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents). Just-in-time retrieval, pointer doctrine
+- [skill-creator](https://github.com/anthropics/skills/tree/main/skills/skill-creator). Approaching-the-limit split trigger, >300-line TOC guidance
+- [UC Davis disclosure study (arXiv 2607.17598)](https://arxiv.org/abs/2607.17598). Scale boundary, depth>1 harm (academic corroboration)
+- [happyskills: listing eviction](https://happyskills.ai). Community source for eviction scoring and the when-NOT-to-use description clause (advisory color only)

--- a/plugins/docs-hygiene/skills/compress/SKILL.md
+++ b/plugins/docs-hygiene/skills/compress/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: "Compress (tighten, shorten, trim) markdown files by dropping flavor — filler, hedging, articles — while preserving all content (directives, qualifiers, thresholds, examples), with a mandatory semantic-diff subagent that reverts any SEMANTIC LOSS or AMBIGUITY. Use when: 'compress this doc', 'tighten markdown', 'cut prose', 'shorten without losing meaning', 'trim onboarding doc', or verbose prose in docs/, READMEs, rule bodies, skill bodies, or third-party pasted text — actions: default (snapshot → backend → semantic-diff subagent → revert-pass → markdownlint) and audit (read-only dry-run classifying SKIP/COMPRESS/UNCERTAIN per file); empty target + clean tree in an interactive session offers a confirmation-gated repo-wide run (audit-first interview with prescribed defaults) instead of the no-op; flags: --force (bypass <3% revert rule), --keep-snapshot; not for: session compaction (/compact), markdown noise classification (/audit-noise), code-comment trimming, or content relocation/SSOT consolidation (/extract-ssot)."
+description: "Compress (tighten, shorten, trim) markdown files by dropping flavor, filler, hedging, articles, while preserving all content (directives, qualifiers, thresholds, examples), with a mandatory semantic-diff subagent that reverts any SEMANTIC LOSS or AMBIGUITY. Use when: 'compress this doc', 'tighten markdown', 'cut prose', 'shorten without losing meaning', 'trim onboarding doc', or verbose prose in docs/, READMEs, rule bodies, skill bodies, or third-party pasted text. Actions: default (snapshot → backend → semantic-diff subagent → revert-pass → markdownlint) and audit (read-only dry-run classifying SKIP/COMPRESS/UNCERTAIN per file); empty target + clean tree in an interactive session offers a confirmation-gated repo-wide run (audit-first interview with prescribed defaults) instead of the no-op; flags: --force (bypass <3% revert rule), --keep-snapshot; not for: session compaction (/compact), markdown noise classification (/audit-noise), code-comment trimming, or content relocation/SSOT consolidation (/extract-ssot)."
 argument-hint: "[audit] [target] [--force] [--keep-snapshot]"
 user-invocable: true
 disable-model-invocation: false
@@ -16,24 +16,24 @@ Uncommitted .md files: !`{ git status --porcelain 2>/dev/null | grep '\.md$' || 
 
 ## Purpose
 
-Markdown in `docs/`, README files, onboarding docs, third-party pasted prose, and drifted skill bodies accumulates FLAVOR — filler ("just", "really", "basically"), hedging ("perhaps", "might"), articles, pleasantries. `context/flavor-vs-content-matrix.md` defines FLAVOR (safe to cut) vs CONTENT (never cut). The **batch fan-out path** (Phase A LATITUDE) is a word-level trimmer: mechanical drops + passive→active + nominalization only — no sentence-level restatement deletion. The **single-file in-session Edit fallback** may apply the full matrix taxonomy (including redundant restatement of bold rule names) behind the same semantic-diff net. Always-loaded instruction files (`.claude/rules/**`, `AGENTS.md`, `CLAUDE.md`, `**/SKILL.md`) bound empirically at 2-3% yield (see ## Sources). Likely 5-15% yield on author-time-undisciplined content when the Edit fallback's broader latitude applies; batch fan-out yields are correspondingly smaller.
+Markdown in `docs/`, README files, onboarding docs, third-party pasted prose, and drifted skill bodies accumulates FLAVOR. Filler ("just", "really", "basically"), hedging ("perhaps", "might"), articles, pleasantries. `context/flavor-vs-content-matrix.md` defines FLAVOR (safe to cut) vs CONTENT (never cut). The **batch fan-out path** (Phase A LATITUDE) is a word-level trimmer: mechanical drops + passive→active + nominalization only. No sentence-level restatement deletion. The **single-file in-session Edit fallback** may apply the full matrix taxonomy (including redundant restatement of bold rule names) behind the same semantic-diff net. Always-loaded instruction files (`.claude/rules/**`, `AGENTS.md`, `CLAUDE.md`, `**/SKILL.md`) bound empirically at 2-3% yield (see ## Sources). Likely 5-15% yield on author-time-undisciplined content when the Edit fallback's broader latitude applies; batch fan-out yields are correspondingly smaller.
 
 Methodology: snapshot original → backend mechanical compression (the `caveman` plugin via `/caveman:compress`, OR in-session Edit fallback) → spawn semantic-diff subagent comparing original vs condensed (output: SEMANTIC LOSS / AMBIGUITY / FALSE POSITIVE per finding with verbatim citations) → revert every SEMANTIC LOSS + AMBIGUITY → run `markdownlint-cli2` → ship or revert.
 
 ## Backend selection
 
-Default-action Step B picks the mechanical-compression backend: the `caveman` plugin (marketplace `caveman`, invoked as `/caveman:compress` via the Skill tool) when present, otherwise the in-session Edit-based fallback. Caveman performs the mechanical flavor cuts (articles, fillers, hedging, verbose-verb collapses) as the compression backend — it is NOT the verification gate. Fallback policy is graceful: the in-session Edit-based path substitutes whenever caveman is absent or unwanted. Subsequent steps (semantic-diff dispatch, revert pass, markdownlint) wrap the output regardless of backend choice.
+Default-action Step B picks the mechanical-compression backend: the `caveman` plugin (marketplace `caveman`, invoked as `/caveman:compress` via the Skill tool) when present, otherwise the in-session Edit-based fallback. Caveman performs the mechanical flavor cuts (articles, fillers, hedging, verbose-verb collapses) as the compression backend. It is NOT the verification gate. Fallback policy is graceful: the in-session Edit-based path substitutes whenever caveman is absent or unwanted. Subsequent steps (semantic-diff dispatch, revert pass, markdownlint) wrap the output regardless of backend choice.
 
  `disable-model-invocation: false` is deliberate: compress is model-invocable with interview confirmation gates and permission-governed Edit/Bash; not an oversight relative to D1 guidance that mutating skills often set the flag true.
 
-Note the distinction inside that plugin: `/caveman:compress` is a function-call skill (this skill's backend); `/caveman:caveman` is a session-wide response formatter — unrelated to this skill.
+Note the distinction inside that plugin: `/caveman:compress` is a function-call skill (this skill's backend); `/caveman:caveman` is a session-wide response formatter. Unrelated to this skill.
 
-**Step A — detect caveman plugin:** `bash "${CLAUDE_SKILL_DIR}/scripts/detect-caveman.sh"`
-Tri-state: `available` → prefer caveman; `absent` OR `unknown` → treat as absent and use the Edit fallback (`unknown` means `claude`/`jq` missing from PATH — fail open to Edit, not a hard error).
+**Step A. Detect caveman plugin:** `bash "${CLAUDE_SKILL_DIR}/scripts/detect-caveman.sh"`
+Tri-state: `available` → prefer caveman; `absent` OR `unknown` → treat as absent and use the Edit fallback (`unknown` means `claude`/`jq` missing from PATH: fail open to Edit, not a hard error).
 
-**Step B — caveman backend (preferred when available):** cross-tool-call steps (Bash state does not persist across tool calls — no `trap … EXIT`, no relying on `$tempdir` in a later call):
+**Step B, caveman backend (preferred when available):** cross-tool-call steps (Bash state does not persist across tool calls, no `trap … EXIT`, no relying on `$tempdir` in a later call):
 
-1. **Bash call 1** — create a temp copy and echo its absolute path (no EXIT trap):
+1. **Bash call 1**. Create a temp copy and echo its absolute path (no EXIT trap):
 
    ```bash
    tempdir=$(mktemp -d)
@@ -41,8 +41,8 @@ Tri-state: `available` → prefer caveman; `absent` OR `unknown` → treat as ab
    printf '%s\n' "$tempdir/$(basename "$target")"
    ```
 
-2. **Skill call** — `Skill(caveman:compress, args="<absolute-path-from-step-1>")` on that temp copy. Caveman may write `<file>.original.md` beside the copy inside the tempdir.
-3. **Bash call 2** — on caveman success, copy the compressed file back and remove the tempdir explicitly:
+2. **Skill call**. `Skill(caveman:compress, args="<absolute-path-from-step-1>")` on that temp copy. Caveman may write `<file>.original.md` beside the copy inside the tempdir.
+3. **Bash call 2**. On caveman success, copy the compressed file back and remove the tempdir explicitly:
 
    ```bash
    cp "<absolute-path-from-step-1>" "$target"
@@ -53,7 +53,7 @@ Tri-state: `available` → prefer caveman; `absent` OR `unknown` → treat as ab
 
 Tempdir wrapper contains caveman's hardcoded `<file>.original.md` backup write. Real-path file replaced only on success. Consumers may add a defensive `**/*.original.md` entry to their `.gitignore` as belt-and-suspenders against cleanup races or future caveman backup-path-convention changes.
 
-**Step B fallback — in-session Edit (caveman absent, unknown, or unwanted):**
+**Step B fallback. In-session Edit (caveman absent, unknown, or unwanted):**
 
 Agent applies Edit ops directly on `$target` per the `context/flavor-vs-content-matrix.md` taxonomy (full matrix, including restatement deletion). Same flavor-vs-content rules; no backend indirection.
 
@@ -68,8 +68,8 @@ Agent applies Edit ops directly on `$target` per the `context/flavor-vs-content-
 
 Flags (apply to both actions):
 
-- `--force` — proceed even when the default `<3% AND 0 semantic-loss → REVERT` rule would trip. User owns the sub-3% diff
-- `--keep-snapshot` — persist the original to `${CLAUDE_PLUGIN_DATA}/snapshots/<ISO-basic>Z-<basename>.orig.md` (the plugin data directory survives plugin updates)
+- `--force`. Proceed even when the default `<3% AND 0 semantic-loss → REVERT` rule would trip. User owns the sub-3% diff
+- `--keep-snapshot`. Persist the original to `${CLAUDE_PLUGIN_DATA}/snapshots/<ISO-basic>Z-<basename>.orig.md` (the plugin data directory survives plugin updates)
 
 ## Auto-detect default
 
@@ -79,31 +79,31 @@ Shared clean-tree / no-scope shape: [`../../context/clean-tree-fallback.md`](../
 2. Empty arg AND uncommitted `.md` files → batch default action over those files
 3. Single file path → single-file default action
 4. Directory path → batch default action (filenames sorted lexically for deterministic output)
-5. First positional == `audit` → audit action on rest (same clean-tree offer as rule 1 when the rest is empty — report-only corpus audit, no Edit)
+5. First positional == `audit` → audit action on rest (same clean-tree offer as rule 1 when the rest is empty. Report-only corpus audit, no Edit)
 
 ## Repo-wide interview fallback (empty arg, clean tree, interactive)
 
-Instead of dead-ending, offer a repo-wide run — confirmation-gated at every step; declining at any step exits with the friendly no-op message. Bare `/docs-hygiene:compress audit` on a clean tree uses steps 1–2 only (free audit + report; no compression interview).
+Instead of dead-ending, offer a repo-wide run, confirmation-gated at every step; declining at any step exits with the friendly no-op message. Bare `/docs-hygiene:compress audit` on a clean tree uses steps 1–2 only (free audit + report; no compression interview).
 
 1. **Offer** (AskUserQuestion): run against all tracked eligible `.md` files? Decline → no-op exit.
-2. **Audit first** (free — mechanical scan, no subagents): run the audit action over every tracked eligible `.md`. Present INLINE only aggregate counts per class, a dispatch-cost estimate (2 subagent requests per compressed file), and a top-20 excerpt of COMPRESS rows selected deterministically: expected-yield band descending, then word count descending, then lexical path (band strings tie; the two tie-breaks keep the excerpt stable run-to-run). Write the full per-file table to a file — destination `${CLAUDE_PLUGIN_DATA}/audit/<branch-or-scope>-audit.md` when that dir is writable, otherwise a temp path echoed to the user — lexically sorted per the "Summary output deterministic" hard rule — and point at it. Never render every row inline — on a large repo the full table can run to hundreds of KB and truncate the confirmation prompt it feeds. **Stop here when the invocation was the audit action** (report-only).
-3. **Interview with prescribed defaults** (AskUserQuestion, recommended option listed first) — default (mutating) action only:
-   - **Scope** — default: **top-10** COMPRESS-classified files, highest expected yield first (report-only / decline remains available); alternates: top-N (user picks N), all COMPRESS, include UNCERTAIN, stop after audit (report only). Downgraded from "all COMPRESS" after the 2026-08-15 calibration run (87 consecutive auto-reverts) — see `context/fan-out-orchestration.md` circuit breaker.
-   - **Concurrency** — default: 2 concurrent subagents per wave (rate-limit-conservative); alternates: 1 (sequential), 3-5 (`context/fan-out-orchestration.md` default).
-   - **Always-loaded files** — default: excluded (SKIP per the 2-3% empirical baseline); including them requires the same explicit opt-in as `--force`.
-4. **Confirm and run**: batch default action over the confirmed set, waves per `context/fan-out-orchestration.md`. Every per-file hard rule — semantic-diff dispatch, revert pass, markdownlint, `<3% AND 0 semantic-loss → REVERT` — applies unchanged.
+2. **Audit first** (free, mechanical scan, no subagents): run the audit action over every tracked eligible `.md`. Present INLINE only aggregate counts per class, a dispatch-cost estimate (2 subagent requests per compressed file), and a top-20 excerpt of COMPRESS rows selected deterministically: expected-yield band descending, then word count descending, then lexical path (band strings tie; the two tie-breaks keep the excerpt stable run-to-run). Write the full per-file table to a file: destination `${CLAUDE_PLUGIN_DATA}/audit/<branch-or-scope>-audit.md` when that dir is writable, otherwise a temp path echoed to the user, lexically sorted per the "Summary output deterministic" hard rule, and point at it. Never render every row inline. On a large repo the full table can run to hundreds of KB and truncate the confirmation prompt it feeds. **Stop here when the invocation was the audit action** (report-only).
+3. **Interview with prescribed defaults** (AskUserQuestion, recommended option listed first), default (mutating) action only:
+   - **Scope**. Default: **top-10** COMPRESS-classified files, highest expected yield first (report-only / decline remains available); alternates: top-N (user picks N), all COMPRESS, include UNCERTAIN, stop after audit (report only). Downgraded from "all COMPRESS" after the 2026-08-15 calibration run (87 consecutive auto-reverts). See `context/fan-out-orchestration.md` circuit breaker.
+   - **Concurrency**. Default: 2 concurrent subagents per wave (rate-limit-conservative); alternates: 1 (sequential), 3-5 (`context/fan-out-orchestration.md` default).
+   - **Always-loaded files**. Default: excluded (SKIP per the 2-3% empirical baseline); including them requires the same explicit opt-in as `--force`.
+4. **Confirm and run**: batch default action over the confirmed set, waves per `context/fan-out-orchestration.md`. Every per-file hard rule, semantic-diff dispatch, revert pass, markdownlint, `<3% AND 0 semantic-loss → REVERT`, applies unchanged.
 
-Non-interactive contexts never interview; they take the no-op branch. The fallback adds an entry path only — it changes no compression, verification, or revert semantics.
+Non-interactive contexts never interview; they take the no-op branch. The fallback adds an entry path only. It changes no compression, verification, or revert semantics.
 
 ## Hard rules
 
-- **Semantic-diff dispatch is mandatory for default action.** Audit is read-only — no dispatch.
-- **Post-edit `markdownlint-cli2` MUST pass** (using the consuming repository's markdownlint config when present). Non-zero exit blocks ship; revert and surface failures. `markdownlint-cli2` is **required for correctness** (it is the ship gate): if the binary is absent (neither on `PATH` nor as the repo's `node_modules/.bin/markdownlint-cli2`), STOP at the entry point before compressing anything and surface the remediation — install it explicitly (`npm install --save-dev markdownlint-cli2` or a global install); never treat absence as a lint failure and never ship unverified output.
+- **Semantic-diff dispatch is mandatory for default action.** Audit is read-only. No dispatch.
+- **Post-edit `markdownlint-cli2` MUST pass** (using the consuming repository's markdownlint config when present). Non-zero exit blocks ship; revert and surface failures. `markdownlint-cli2` is **required for correctness** (it is the ship gate): if the binary is absent (neither on `PATH` nor as the repo's `node_modules/.bin/markdownlint-cli2`), STOP at the entry point before compressing anything and surface the remediation. Install it explicitly (`npm install --save-dev markdownlint-cli2` or a global install); never treat absence as a lint failure and never ship unverified output.
 - **Default `<3% AND 0 semantic-loss → REVERT`.** Proven safe in the authoring repo's empirical baseline (always-loaded instruction files: 3/3 attempts reverted). `--force` bypasses.
 - **Summary output deterministic.** No timestamps; filenames sort lexically.
 - **Snapshot default = ephemeral** (`mktemp -d`, deleted post-dispatch). `--keep-snapshot` persists to `${CLAUDE_PLUGIN_DATA}/snapshots/` instead.
-- **Always-loaded instruction-file policy: SOFT-BLOCK.** Default reverts <3%/0SL on ANY file including `.claude/rules/**` / `AGENTS.md` / `CLAUDE.md` / `**/SKILL.md`. `--force` bypasses on ANY file — user owns the result. `audit` heuristic emits informational SKIP recommendation on always-loaded paths citing the 2-3% empirical baseline; not a structural gate.
-- **Subagent dispatch follows `context/semantic-diff-prompt.md` template.** Findings must carry verifiable citations; training-recall citation tokens are forbidden — `[known]` / `[from memory]` / `[context]` / `[obvious]` / `[standard]` / `[usual]`.
+- **Always-loaded instruction-file policy: SOFT-BLOCK.** Default reverts <3%/0SL on ANY file including `.claude/rules/**` / `AGENTS.md` / `CLAUDE.md` / `**/SKILL.md`. `--force` bypasses on ANY file. User owns the result. `audit` heuristic emits informational SKIP recommendation on always-loaded paths citing the 2-3% empirical baseline; not a structural gate.
+- **Subagent dispatch follows `context/semantic-diff-prompt.md` template.** Findings must carry verifiable citations; training-recall citation tokens are forbidden. `[known]` / `[from memory]` / `[context]` / `[obvious]` / `[standard]` / `[usual]`.
 - **Backend choice does NOT bypass semantic-diff dispatch.** When the caveman backend is absent or unwanted, `/docs-hygiene:compress` falls back to in-session Edit-based compression. Backend selection determines only the mechanical-compression path; semantic-diff + revert pass + markdownlint hard rules apply regardless. LLM-compression fabrication risk (caveman backend OR in-session Edit) caught structurally by the revert pass.
 
 ## Output schema (default action, per target)
@@ -118,19 +118,19 @@ Audit action output: table with `target`, `expected_yield_pct`, `classify` (SKIP
 
 ## Gotchas
 
-Observed failure points — each traces to a real incident; grown iteratively.
+Observed failure points. Each traces to a real incident; grown iteratively.
 
-- **Self-audit drifts toward EXPANSION.** The semantic-diff dispatch must run as a SEPARATE fresh-context audit, never a self-audit by the model that produced the edits — self-audit re-adds words just removed ("preserve clarity"; an observed failure — see ## Sources). Prefer a cross-vendor advisor for that audit **when one is installed and set up** — e.g. the OpenAI Codex plugin, when its documented surface can take this artifact, invoked per its own docs — with the fresh-context same-vendor subagent as the stated fallback, never a route to a command that may not resolve (per `docs/PLUGIN-PHILOSOPHY.md` "Fresh-eyes checkpoints" in the marketplace repository). Subagents cannot reliably spawn the verifier themselves (nested subagent support is version-dependent, and a fresh-context verifier beats self-critique regardless), so for batch fan-out follow `context/fan-out-orchestration.md`: the main session dispatches separate compress + audit subagents, reconciling per finding.
-- **Sub-3% diffs auto-revert unless `--force`.** Default `<3% AND 0 semantic-loss → REVERT`; always-loaded instruction files bound at 2-3% yield (see ## Sources). Pass `--force` only when a targeted sub-3% diff is intentional — the user owns the result.
+- **Self-audit drifts toward EXPANSION.** The semantic-diff dispatch must run as a SEPARATE fresh-context audit, never a self-audit by the model that produced the edits. Self-audit re-adds words just removed ("preserve clarity"; an observed failure, see ## Sources). Prefer a cross-vendor advisor for that audit **when one is installed and set up**, e.g. the OpenAI Codex plugin, when its documented surface can take this artifact, invoked per its own docs, with the fresh-context same-vendor subagent as the stated fallback, never a route to a command that may not resolve (per `docs/PLUGIN-PHILOSOPHY.md` "Fresh-eyes checkpoints" in the marketplace repository). Subagents cannot reliably spawn the verifier themselves (nested subagent support is version-dependent, and a fresh-context verifier beats self-critique regardless), so for batch fan-out follow `context/fan-out-orchestration.md`: the main session dispatches separate compress + audit subagents, reconciling per finding.
+- **Sub-3% diffs auto-revert unless `--force`.** Default `<3% AND 0 semantic-loss → REVERT`; always-loaded instruction files bound at 2-3% yield (see ## Sources). Pass `--force` only when a targeted sub-3% diff is intentional, the user owns the result.
 - **Caveman writes a `<file>.original.md` backup beside the target.** The caveman backend hardcodes this backup path; running it against the real file litters the repo. Backend Step B wraps caveman in a `mktemp -d` tempdir so the backup lands there and the `trap` cleans it; a gitignore entry for `**/*.original.md` in the consuming repo is optional belt-and-suspenders.
 
 ## When NOT to use
 
-- Code files (`.cs`, `.py`, `.ts`, `.sh`, etc.) — methodology is markdown-specific. Code-comment compression is out of scope
+- Code files (`.cs`, `.py`, `.ts`, `.sh`, etc.). Methodology is markdown-specific. Code-comment compression is out of scope
 - Binary files
-- Author-time-disciplined instruction files (`.claude/rules/**`, `AGENTS.md`, `CLAUDE.md`, `**/SKILL.md`) — `audit` will SKIP-recommend; sub-3% revert default applies (Gotchas "Sub-3% diffs auto-revert unless `--force`")
-- Conversation summarization or session compaction — that's the built-in `/compact`, different semantic
-- **Subagent context invoking `/docs-hygiene:compress` for batch fan-out** — see Gotchas "Self-audit drifts toward EXPANSION"; follow `context/fan-out-orchestration.md`
+- Author-time-disciplined instruction files (`.claude/rules/**`, `AGENTS.md`, `CLAUDE.md`, `**/SKILL.md`). `audit` will SKIP-recommend; sub-3% revert default applies (Gotchas "Sub-3% diffs auto-revert unless `--force`")
+- Conversation summarization or session compaction. That's the built-in `/compact`, different semantic
+- **Subagent context invoking `/docs-hygiene:compress` for batch fan-out**. See Gotchas "Self-audit drifts toward EXPANSION"; follow `context/fan-out-orchestration.md`
 
 ## What this skill is NOT
 
@@ -139,17 +139,17 @@ Observed failure points — each traces to a real incident; grown iteratively.
 - **Not a code-comment compressor.** Out of scope
 - **Not a `/code-review` / `/simplify` shadow.** The bundled `/code-review` and `/simplify` skills review code changes; `/docs-hygiene:compress` rewrites markdown prose. Different concerns
 - **Not `/docs-hygiene:audit-noise`.** `/docs-hygiene:compress` owns FLAVOR (filler, hedging, articles, redundant restatement). `/docs-hygiene:audit-noise` owns NOISE classification (historical citations, ghost refs, "Why this file exists" preambles, hard-coupled enumerated consumer lists) per its own taxonomy. Different concerns; both may apply to the same target iteratively
-- **Not a content-relocation / cite-don't-recap tool.** When an inline passage recaps detail that already lives in a cited single source of truth (another doc or rule), condensing it is content RELOCATION, not flavor removal — the mandatory semantic-diff net sees the words gone from THIS file and reverts them as SEMANTIC LOSS, blind to the SSOT. Apply "reference, don't duplicate" as a MANUAL editorial pass (verify the cited SSOT actually holds the detail first — an unread pointer is an unverified claim); route the duplicated cluster to `/docs-hygiene:extract-ssot` at any multiplicity (it rosters rule-of-one / -two / -three buckets; only extraction into a NEW artifact waits for 3+ files)
+- **Not a content-relocation / cite-don't-recap tool.** When an inline passage recaps detail that already lives in a cited single source of truth (another doc or rule), condensing it is content RELOCATION, not flavor removal, the mandatory semantic-diff net sees the words gone from THIS file and reverts them as SEMANTIC LOSS, blind to the SSOT. Apply "reference, don't duplicate" as a MANUAL editorial pass (verify the cited SSOT actually holds the detail first, an unread pointer is an unverified claim); route the duplicated cluster to `/docs-hygiene:extract-ssot` at any multiplicity (it rosters rule-of-one / -two / -three buckets; only extraction into a NEW artifact waits for 3+ files)
 
 ## Sources
 
 - Always-loaded instruction-file yield bound (2-3%): authoring-repo baseline, 3/3 compression attempts reverted, all flavor-only, 0 semantic loss
-- Self-audit expansion drift: authoring-repo batch compression wave, 2026-05-23 — 4/4 reverse-direction edits from self-audit (`context/fan-out-orchestration.md` ## History)
+- Self-audit expansion drift: authoring-repo batch compression wave, 2026-05-23. 4/4 reverse-direction edits from self-audit (`context/fan-out-orchestration.md` ## History)
 
 ## Cross-references
 
-- `context/semantic-diff-prompt.md` — subagent dispatch template (Agent tool prompt + return-format contract)
-- `context/flavor-vs-content-matrix.md` — canonical FLAVOR / CONTENT taxonomy + per-content-type variants
-- `context/target-types.md` — per-action argument shapes + author-time-signal heuristic
-- `context/fan-out-orchestration.md` — multi-phase batch fan-out recipe; read when compressing N files via parallel subagents (keeps the semantic-diff in a separate fresh-context auditor)
-- `context/integration.md` — composition contract with sibling skills and consumer workflows
+- `context/semantic-diff-prompt.md`. Subagent dispatch template (Agent tool prompt + return-format contract)
+- `context/flavor-vs-content-matrix.md`. Canonical FLAVOR / CONTENT taxonomy + per-content-type variants
+- `context/target-types.md`. Per-action argument shapes + author-time-signal heuristic
+- `context/fan-out-orchestration.md`. Multi-phase batch fan-out recipe; read when compressing N files via parallel subagents (keeps the semantic-diff in a separate fresh-context auditor)
+- `context/integration.md`. Composition contract with sibling skills and consumer workflows

--- a/plugins/docs-hygiene/skills/extract-ssot/SKILL.md
+++ b/plugins/docs-hygiene/skills/extract-ssot/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: "Deduplicate repeated markdown content — rule files, skill bodies, ADRs, docs — into a single named source of truth and migrate every call site to cite it by exact heading. Use when the same prose, literal, or concept appears (or is reworded) across files: 'DRY this prose', 'extract a shared rule', 'single source of truth for X', a value-bump diff touching several files. Reports duplication at every multiplicity in rule-of-one / rule-of-two / rule-of-three buckets, offering only non-abstracting remedies below three — creating a NEW SSOT artifact still refuses below the Rule of Three."
+description: "Deduplicate repeated markdown content, rule files, skill bodies, ADRs, docs, into a single named source of truth and migrate every call site to cite it by exact heading. Use when the same prose, literal, or concept appears (or is reworded) across files: 'DRY this prose', 'extract a shared rule', 'single source of truth for X', a value-bump diff touching several files. Reports duplication at every multiplicity in rule-of-one / rule-of-two / rule-of-three buckets, offering only non-abstracting remedies below three. Creating a NEW SSOT artifact still refuses below the Rule of Three."
 argument-hint: "[identify|verify|plan|execute|batch|unwind] [<cluster-name>] [--min-instances=<N>] [--buckets=<list>] [--fix] [--dry-run] [--yes]"
 user-invocable: true
 disable-model-invocation: false
@@ -12,40 +12,40 @@ metadata:
 
 ## Why this skill exists
 
-Codifies the markdown-SSOT-extraction pattern as a repeatable workflow. Each invocation targets ONE cluster of repeated markdown content and resolves it to a single named source of truth — consolidating into an existing SSOT home when one already owns the concept, otherwise creating a new artifact (e.g. a rule file or a new skill) — plus migration of all call sites to cite by exact heading.
+Codifies the markdown-SSOT-extraction pattern as a repeatable workflow. Each invocation targets ONE cluster of repeated markdown content and resolves it to a single named source of truth, consolidating into an existing SSOT home when one already owns the concept, otherwise creating a new artifact (e.g. a rule file or a new skill), plus migration of all call sites to cite by exact heading.
 
-The principle is the coding Rule of Three / DRY, applied to markdown text. If the same unit of prose appears 3+ times, changes together, and has an identity that can be named, collapse to one definition and reference by name. Below 3 instances, minting a new SSOT artifact is premature abstraction — the dominant failure mode — and the skill refuses it.
+The principle is the coding Rule of Three / DRY, applied to markdown text. If the same unit of prose appears 3+ times, changes together, and has an identity that can be named, collapse to one definition and reference by name. Below 3 instances, minting a new SSOT artifact is premature abstraction, the dominant failure mode, and the skill refuses it.
 
 Refusing to *create* is not refusing to *report*. A lone consumer that recaps an SSOT it should be citing, and a pair of files asserting the same contract with no declared owner, are real defects that drift. Both are rostered in their own multiplicity bucket and remedied in place, with no new artifact.
 
 Typical markdown extraction shapes the workflow handles:
 
-- A vocabulary of CLI/API verbs that many prompts, skills, and rules invoke inline — collapsed into one rule file with stable headings the call sites cite
-- A constraint or guardrail repeated across multiple skills (e.g. "always run X before Y") — promoted to a single always-loaded rule
-- A workflow primitive appearing across several skills — extracted to a shared primitive doc that skills cite by name
+- A vocabulary of CLI/API verbs that many prompts, skills, and rules invoke inline. Collapsed into one rule file with stable headings the call sites cite
+- A constraint or guardrail repeated across multiple skills (e.g. "always run X before Y"). Promoted to a single always-loaded rule
+- A workflow primitive appearing across several skills. Extracted to a shared primitive doc that skills cite by name
 
 Extraction is dangerous: ~19% failure rate even on curated skills (SkillsBench, n=84 tasks), ~50% on practitioner-authored skills (40-skill failure analysis). This skill encodes the guardrails (Rule of Three, categorical-shape test, ≤500-line bound, one-level-deep mandate, Metz unwind procedure) so each invocation is reversible and reviewable.
 
-**Code / config escape-hatch.** Repeated string literals, magic constants, helper functions in source code, or repeated CI / settings / MCP stanzas in config files are also extractable in principle (Rule of Three applies). This skill flags such clusters during `identify` but does NOT ship a citation contract for them — the caller uses the language-idiomatic form (`import` / `using` / `source`, YAML anchor, JSON `$ref`, build-tool include) and language-aware refactoring tools (IDE rename, Roslyn / ts-morph). Markdown is the only file class with no language-level rename safety net — that is where the contract here adds value.
+**Code / config escape-hatch.** Repeated string literals, magic constants, helper functions in source code, or repeated CI / settings / MCP stanzas in config files are also extractable in principle (Rule of Three applies). This skill flags such clusters during `identify` but does NOT ship a citation contract for them, the caller uses the language-idiomatic form (`import` / `using` / `source`, YAML anchor, JSON `$ref`, build-tool include) and language-aware refactoring tools (IDE rename, Roslyn / ts-morph). Markdown is the only file class with no language-level rename safety net. That is where the contract here adds value.
 
 ## Evidence discipline
 
-Every extraction decision must be grounded in **direct evidence captured this session** — grep output or file reads you performed yourself. This skill calls such evidence **Tier 0**. Recall ("I remember seeing this repeated"), a subagent's survey summary, or any other synthesized claim is NOT Tier 0 — promote it via your own grep before it drives a plan or an edit. A subagent roster is a lead list, never proof.
+Every extraction decision must be grounded in **direct evidence captured this session**. Grep output or file reads you performed yourself. This skill calls such evidence **Tier 0**. Recall ("I remember seeing this repeated"), a subagent's survey summary, or any other synthesized claim is NOT Tier 0. Promote it via your own grep before it drives a plan or an edit. A subagent roster is a lead list, never proof.
 
 ## Scope: markdown SSOT
 
-**In-scope:** repeated content across the consuming repository's tracked markdown — instruction files (`CLAUDE.md`, `AGENTS.md`, `README.md`), rule files (`.claude/rules/`), skill bodies (`.claude/skills/`), agent definitions (`.claude/agents/`), automation/routine prompts, ADRs, and docs. Markdown is the file class with no compiler or IDE refactor to catch a broken reference — the citation contract here is what closes that gap.
+**In-scope:** repeated content across the consuming repository's tracked markdown. Instruction files (`CLAUDE.md`, `AGENTS.md`, `README.md`), rule files (`.claude/rules/`), skill bodies (`.claude/skills/`), agent definitions (`.claude/agents/`), automation/routine prompts, ADRs, and docs. Markdown is the file class with no compiler or IDE refactor to catch a broken reference, the citation contract here is what closes that gap.
 
 | Citation target | Form |
 |-----------------|------|
 | Rule-file H3 heading | `` per `<file>.md` "<exact heading>" `` |
-| New skill | `/<skill-name>` invocation (skill internals NOT cited externally — see `/docs-hygiene:audit-encapsulation`) |
+| New skill | `/<skill-name>` invocation (skill internals NOT cited externally. See `/docs-hygiene:audit-encapsulation`) |
 
 **Out-of-scope, but flagged during `identify`:**
 
-- **Code clusters** (`.cs`, `.ts`, `.py`, `.sh`, `.ps1`, …) — repeated literal, magic constant, regex, helper function. Use language-idiomatic extraction (constants file, shared module, IDE rename refactor / Roslyn / ts-morph). Compiler + lint catch missed call sites — citation rot is structurally prevented.
-- **Config clusters** (`.yml`, `.json`, `.toml`, `.editorconfig`) — repeated CI step, MCP entry, settings stanza. Use the tooling's native include / anchor / `$ref` mechanism. Schema validation catches mismatches.
-- **Mixed clusters** spanning markdown + code + config — pick the canonical owner (usually code/schema where runtime authority lives), then each file class cites in its native form. This skill handles the markdown half; the code/config half follows that file class's own conventions.
+- **Code clusters** (`.cs`, `.ts`, `.py`, `.sh`, `.ps1`, …). Repeated literal, magic constant, regex, helper function. Use language-idiomatic extraction (constants file, shared module, IDE rename refactor / Roslyn / ts-morph). Compiler + lint catch missed call sites. Citation rot is structurally prevented.
+- **Config clusters** (`.yml`, `.json`, `.toml`, `.editorconfig`). Repeated CI step, MCP entry, settings stanza. Use the tooling's native include / anchor / `$ref` mechanism. Schema validation catches mismatches.
+- **Mixed clusters** spanning markdown + code + config. Pick the canonical owner (usually code/schema where runtime authority lives), then each file class cites in its native form. This skill handles the markdown half; the code/config half follows that file class's own conventions.
 
 The 6-test extraction gate (Rule of Three, namable, stable, self-contained, bounded, one level deep) generalizes to all file classes, and `context/decision-framework.md` annotates each test with code/config equivalents. The HOW (citation contract, rename sweep, encapsulation rule) is markdown-specific.
 
@@ -53,15 +53,15 @@ Boundary with single-file refactoring: a rename, inline, or extract confined to 
 
 ## When to use vs not use
 
-**Use** when: the same unit appears more than once across files (3+ instances is the bar for *creating* a new SSOT artifact; 1 and 2 route to the non-abstracting buckets); the instances change together (correlated edits); the unit has a stable identity that can be named; the unit is self-contained (extracts cleanly without dragging unrelated context). **Normal-work entry point** — when a cleanup pass, audit, value-bump diff, or review surfaces ANY of the three duplication smells — (a) same literal repeated across tracked files, (b) value-bump diff touches multiple unrelated files, (c) same concept reworded across files or contradicting nuance between files — route detection here. The skill accepts both literal and semantic clusters; the 6-test gate's "namable + categorical-shape + stable identity" tests admit semantic clusters provided the unit can be named and instances change together.
+**Use** when: the same unit appears more than once across files (3+ instances is the bar for *creating* a new SSOT artifact; 1 and 2 route to the non-abstracting buckets); the instances change together (correlated edits); the unit has a stable identity that can be named; the unit is self-contained (extracts cleanly without dragging unrelated context). **Normal-work entry point**, when a cleanup pass, audit, value-bump diff, or review surfaces ANY of the three duplication smells, (a) same literal repeated across tracked files, (b) value-bump diff touches multiple unrelated files, (c) same concept reworded across files or contradicting nuance between files. Route detection here. The skill accepts both literal and semantic clusters; the 6-test gate's "namable + categorical-shape + stable identity" tests admit semantic clusters provided the unit can be named and instances change together.
 
 **Classify each file's role before flagging it as a duplicate:**
 
-- **DESCRIBE** — the file IS the SSOT and owns the value or concept; keep the body.
-- **USE** — the file consumes the concept as a load-bearing reference (rules, agent prompts, skill bodies invoking the rule); it MUST cite the SSOT by exact heading or path + key rather than restate body content.
-- **EXPOSE** — the file surfaces the concept to humans for onboarding clarity (README install commands, error messages, public-facing docs); it MAY restate when onboarding clarity outweighs maintenance cost AND adjacent prose cross-references the SSOT.
+- **DESCRIBE**, the file IS the SSOT and owns the value or concept; keep the body.
+- **USE**, the file consumes the concept as a load-bearing reference (rules, agent prompts, skill bodies invoking the rule); it MUST cite the SSOT by exact heading or path + key rather than restate body content.
+- **EXPOSE**, the file surfaces the concept to humans for onboarding clarity (README install commands, error messages, public-facing docs); it MAY restate when onboarding clarity outweighs maintenance cost AND adjacent prose cross-references the SSOT.
 
-Contract identifiers the SSOT defines (tier names, label slugs, action verbs, command names) stay inline in consumers — naming them is not duplication; those tokens ARE the contract surface. Content (definitions, criteria, mapping tables, thresholds, exception clauses) must cite, never recap.
+Contract identifiers the SSOT defines (tier names, label slugs, action verbs, command names) stay inline in consumers. Naming them is not duplication; those tokens ARE the contract surface. Content (definitions, criteria, mapping tables, thresholds, exception clauses) must cite, never recap.
 
 **Don't use** for: single-file refactoring inside one diff; recent-diff simplification of a single skill or feature; filing a tracking issue (route to the repo's issue tracker); writing a new skill from scratch without an underlying repetition trigger (use a skill-authoring workflow such as the skill-creator plugin); cross-language type sharing where the answer is codegen, not text dedup.
 
@@ -71,9 +71,9 @@ Full decision matrix: `context/decision-framework.md` (6+5 checklist with worked
 
 | Argument | Action | Purpose |
 |----------|--------|---------|
-| *(empty)* | Smart default | Auto-detect: working notes from a prior run hold an active candidate roster → resume the current phase; the invocation or conversation already names a scope → `identify`; otherwise → confirm scope with the user first (see "Bare invocation — confirm scope first") |
+| *(empty)* | Smart default | Auto-detect: working notes from a prior run hold an active candidate roster → resume the current phase; the invocation or conversation already names a scope → `identify`; otherwise → confirm scope with the user first (see "Bare invocation. Confirm scope first") |
 | `identify [<cluster-name>]` | Find candidates (default = exhaustive subagent survey) | Dispatches a read-only exploration subagent over 30+ duplication heuristics (full body in `actions/identify.md`); ranks by ROI; emits batch-sequencing matrix + recommended `/docs-hygiene:extract-ssot batch` invocation. Rosters every surviving candidate in a labelled multiplicity bucket (N=1 / N=2 / N≥3) with its instance count; artifact-creating outputs stay reserved for N≥3. Single-cluster mode (`identify <name>`) skips the subagent for a targeted Tier 0 grep |
-| `verify <cluster-name>` | Refuse-fast pre-extraction gate | 6-gate cheap check (bucket assignment + Tier 0 grep, citation state, primary-source URL gate, bifurcation check, off-by-one heuristic, LOW-ROI threshold). Output: `PROCEED \| REFUSE-{reason} \| WARN` plus the assigned `bucket:`. OPTIONAL — does not gate `plan`/`execute`. See `actions/verify.md` |
+| `verify <cluster-name>` | Refuse-fast pre-extraction gate | 6-gate cheap check (bucket assignment + Tier 0 grep, citation state, primary-source URL gate, bifurcation check, off-by-one heuristic, LOW-ROI threshold). Output: `PROCEED \| REFUSE-{reason} \| WARN` plus the assigned `bucket:`. OPTIONAL. Does not gate `plan`/`execute`. See `actions/verify.md` |
 | `plan <cluster-name>` | Architect | Pre-step (Tier 0 grep): does an existing rule/doc already own the concept? If yes → consolidate-into-existing branch (extend the home + de-recap consumers, no new artifact). Else choose creation output type (rule vs skill); draft or extend SSOT body; sketch migration plan |
 | `execute <cluster-name>` | Migrate | Write or extend the SSOT (skip writing when an existing home already documents the concept); rewrite call sites to cite + de-recap inline reproductions; sweep references by invoking `/docs-hygiene:rename-references` via the Skill tool if a heading/identifier changed; verify |
 | `batch <cluster-list>` | Multi-candidate orchestration | Auto-`verify` filter, file-overlap matrix, sequential-by-default dispatch, lesson injection between subagents. See `actions/batch.md` |
@@ -87,7 +87,7 @@ Accepted by `identify` and `batch` (the roster-producing surfaces); `batch` pass
 
 | Flag | Default | Behavior |
 |------|---------|----------|
-| `--min-instances=<N>` | `1` | Lowest bucket to roster. `--min-instances=3` is the regression guard — it reproduces the pre-bucket behavior where sub-three clusters never reach the user |
+| `--min-instances=<N>` | `1` | Lowest bucket to roster. `--min-instances=3` is the regression guard. It reproduces the pre-bucket behavior where sub-three clusters never reach the user |
 | `--buckets=<list>` | all | Filter the roster to the named buckets, e.g. `--buckets=1,2` for the non-abstracting work only |
 | `--fix` | off | Apply ONLY the non-abstracting remedies (`trim-to-citation`, `normalize-wording`). Never writes a new artifact; still honors the per-bucket review gate unless `--yes` |
 | `--dry-run` | off | Print the diff `--fix` would apply; write nothing |
@@ -95,7 +95,7 @@ Accepted by `identify` and `batch` (the roster-producing surfaces); `batch` pass
 
 Bare invocation (no flags) stays read-only: it reports the buckets and stops, matching `/docs-hygiene:audit-noise` and `/docs-hygiene:audit-derivability`. Full flag semantics: `actions/identify.md`.
 
-## Bare invocation — confirm scope first
+## Bare invocation. Confirm scope first
 
 Shared clean-tree / no-scope shape: [`../../context/clean-tree-fallback.md`](../../context/clean-tree-fallback.md).
 
@@ -103,18 +103,18 @@ A bare `/docs-hygiene:extract-ssot` with no working notes to resume, no
 argument, and no scope implied by the conversation does **not**
 auto-dispatch the exhaustive survey. Exhaustive `identify` sweeps every
 tracked markdown file and, at whole-repo scale, feeds a multi-agent
-verify/execute batch — a spend the user opts into, never a default.
+verify/execute batch, a spend the user opts into, never a default.
 Ask one question with prescribed defaults, recommended option first:
 
 1. **Whole-repo exhaustive survey** (recommended for maintenance
-   sweeps) — runs under `context/orchestrated-mode.md` defaults; in the
+   sweeps). It runs under `context/orchestrated-mode.md` defaults; in the
    same ask, confirm depth (roster only / verified roster / full
    pipeline with wave commits).
-2. **Path- or glob-scoped exhaustive survey** — the user names one or
+2. **Path- or glob-scoped exhaustive survey**, the user names one or
    more directories / globs (e.g. `plugins/docs-hygiene/`, `docs/**/*.md`);
    routes to exhaustive `identify` restricted to tracked markdown under
    that pathspec (still a survey, not a single-cluster grep).
-3. **Targeted cluster** — the user names a semantic cluster; routes to
+3. **Targeted cluster**, the user names a semantic cluster; routes to
    `identify <cluster-name>` (Tier 0 grep on that cluster only).
 4. **Not now.**
 
@@ -127,13 +127,13 @@ whole-repo intent.
 
 Before recommending a NEW SSOT artifact, run the 6-test gate (all must pass) + 5-test inline gate (any one keeps inline). Full checklist with evidence and worked examples in `context/decision-framework.md`.
 
-Headline gate: **Rule of Three** (Don Roberts / Fowler) — refuse *creation of a new SSOT artifact* at <3 instances. Premature abstraction is the dominant failure mode. Rule of Three gates artifact creation, NOT reporting: every candidate is rostered at its own multiplicity, and the bucket decides which remedies are on the table.
+Headline gate: **Rule of Three** (Don Roberts / Fowler). Refuse *creation of a new SSOT artifact* at <3 instances. Premature abstraction is the dominant failure mode. Rule of Three gates artifact creation, NOT reporting: every candidate is rostered at its own multiplicity, and the bucket decides which remedies are on the table.
 
 | Bucket | Rostered? | Permitted remedies | Creates a new artifact? |
 |---|---|---|---|
-| N=1 — inline recap of an existing SSOT | always | `trim-to-citation`, `normalize-wording` | never |
-| N=2 — two consumers recap an existing home, or two files assert one contract with no declared owner (bifurcation risk) | always | `trim-to-citation`, `edit-existing-rule`, `name-an-owner`, `normalize-wording` | never |
-| N≥3 — Rule of Three met | always | all of the above, plus `rule-file` / `new-skill` / `new-action` | only behind the 6-test gate |
+| N=1. Inline recap of an existing SSOT | always | `trim-to-citation`, `normalize-wording` | never |
+| N=2. Two consumers recap an existing home, or two files assert one contract with no declared owner (bifurcation risk) | always | `trim-to-citation`, `edit-existing-rule`, `name-an-owner`, `normalize-wording` | never |
+| N≥3. Rule of Three met | always | all of the above, plus `rule-file` / `new-skill` / `new-action` | only behind the 6-test gate |
 
 Lowering the reporting threshold does not lower the abstraction threshold: the sub-three buckets offer only remedies that edit files already present. Full rationale: `context/decision-framework.md` "Reporting gate vs abstraction gate".
 
@@ -144,11 +144,11 @@ Markdown branch (primary):
 | Shape | Target | Trigger |
 |-------|--------|---------|
 | Concept already has an SSOT home | Consolidate into the existing file (extend it only where a consumer carries nuance the home lacks) + de-recap the inline reproductions; create no new artifact | An existing rule/skill/doc already owns the concept and consumers recap it inline instead of citing it. Positive output-type form of `verify` Gate 2 + anti-pattern Shape C; `identify` flags it as `edit-existing-rule` / `trim-to-citation` |
-| Divergent phrasings of one agreed truth | `normalize-wording` — align every site onto the canonical/agreed wording in place; **no new artifact** | Instances say the same thing differently and the drift itself is the defect. Available in every bucket, including N=1 and N=2 |
-| Two files assert the same contract, neither declared canonical | `name-an-owner` — declare one existing file the owner; the other cites it | Accidental source-of-truth bifurcation (anti-pattern #11, accidental branch); the N=2 bucket's default remedy. **No new artifact** |
-| Vocabulary, IF-THEN rules, hard constraints, ≤500 lines | Rule file wherever the consuming repository's own conventions place shared rules — default `.claude/rules/<topic>.md` (always-loaded) or a path-scoped rule file | Categorical markdown content; consumers cite by H3 heading. **Artifact-creating — N≥3 only, behind the 6-test gate** |
-| Workflow, multi-action, has its own actions/anti-patterns | New skill at `.claude/skills/<name>/SKILL.md`, authored via the consumer's skill-authoring workflow (e.g. the skill-creator plugin) | Process content; consumers invoke `/<name>`. **Artifact-creating — N≥3 only, behind the 6-test gate** |
-| New action on existing skill | Action row added to the skill's action router | The workflow maps cleanly onto an existing skill's concern — same domain, same triggers, same output surface — rather than warranting a new top-level skill. **Artifact-creating — N≥3 only, behind the 6-test gate** |
+| Divergent phrasings of one agreed truth | `normalize-wording`. Align every site onto the canonical/agreed wording in place; **no new artifact** | Instances say the same thing differently and the drift itself is the defect. Available in every bucket, including N=1 and N=2 |
+| Two files assert the same contract, neither declared canonical | `name-an-owner`. Declare one existing file the owner; the other cites it | Accidental source-of-truth bifurcation (anti-pattern #11, accidental branch); the N=2 bucket's default remedy. **No new artifact** |
+| Vocabulary, IF-THEN rules, hard constraints, ≤500 lines | Rule file wherever the consuming repository's own conventions place shared rules, default `.claude/rules/<topic>.md` (always-loaded) or a path-scoped rule file | Categorical markdown content; consumers cite by H3 heading. **Artifact-creating. N≥3 only, behind the 6-test gate** |
+| Workflow, multi-action, has its own actions/anti-patterns | New skill at `.claude/skills/<name>/SKILL.md`, authored via the consumer's skill-authoring workflow (e.g. the skill-creator plugin) | Process content; consumers invoke `/<name>`. **Artifact-creating. N≥3 only, behind the 6-test gate** |
+| New action on existing skill | Action row added to the skill's action router | The workflow maps cleanly onto an existing skill's concern, same domain, same triggers, same output surface, rather than warranting a new top-level skill. **Artifact-creating. N≥3 only, behind the 6-test gate** |
 
 Skill-vs-rule heuristic: if the SSOT body is mostly nouns (named units the caller cites), it's a rule file. If the SSOT body is mostly verbs (steps the caller invokes), it's a skill.
 
@@ -165,13 +165,13 @@ For markdown call sites, cite by exact H3 heading text + 1-line inline summary. 
 
 For code call sites, use the language's native import syntax. For config call sites, use the tooling's native include / anchor / `$ref` mechanism.
 
-One level deep — never chain `A.md` → `B.md` → `C.md`. A heading rename triggers a sweep: invoke `/docs-hygiene:rename-references` via the Skill tool across all 10 syntactic forms.
+One level deep, never chain `A.md` → `B.md` → `C.md`. A heading rename triggers a sweep: invoke `/docs-hygiene:rename-references` via the Skill tool across all 10 syntactic forms.
 
 Full contract incl. line-wrap edge case: `context/citation-form.md`.
 
 ## Encapsulation rule
 
-Encapsulation enforcement (detection grep, public/private surface matrix, remediation paths) lives in its own skill — `/docs-hygiene:audit-encapsulation`. Different concern from duplication: violations are single-instance matters (Rule of Three does not gate them).
+Encapsulation enforcement (detection grep, public/private surface matrix, remediation paths) lives in its own skill. `/docs-hygiene:audit-encapsulation`. Different concern from duplication: violations are single-instance matters (Rule of Three does not gate them).
 
 `/docs-hygiene:extract-ssot execute` invokes `/docs-hygiene:audit-encapsulation detect` via the Skill tool during the refactor pass to catch any encapsulation violations introduced or exposed by the migration. See `/docs-hygiene:audit-encapsulation` for the public surface matrix, filter taxonomy, and remediation paths.
 
@@ -211,23 +211,23 @@ Per-phase checklist: `context/execution-checklist.md`.
 - Decide for the user whether to migrate a specific cluster (advisory; user picks)
 - Modify files outside the repository it runs in
 - Skip per-phase user diff review
-- Single-file micro-refactoring (rename, inline, extract confined to one file) — ordinary editing
-- Workitem filing — route to the repo's issue tracker
-- Author a brand-new skill from scratch without a repetition trigger — use a skill-authoring workflow (e.g. the skill-creator plugin)
+- Single-file micro-refactoring (rename, inline, extract confined to one file). Ordinary editing
+- Workitem filing. Route to the repo's issue tracker
+- Author a brand-new skill from scratch without a repetition trigger. Use a skill-authoring workflow (e.g. the skill-creator plugin)
 - Cross-language type sharing where the answer is codegen, not text dedup
-- **Replace a workspace-wide verification pass** — the `verify` action here is a per-cluster refuse-fast pre-extraction gate, not a build+test+lint run; run the consuming repository's own verification after `execute`
+- **Replace a workspace-wide verification pass**, the `verify` action here is a per-cluster refuse-fast pre-extraction gate, not a build+test+lint run; run the consuming repository's own verification after `execute`
 
 ## Cross-references
 
-- `context/decision-framework.md` — 6+5 gate, Pre-extraction Tier 0 checklist, output-type table, worked examples
-- `context/citation-form.md` — full citation contract for markdown call sites
-- `context/anti-patterns.md` — 13-pattern taxonomy with mitigations
-- `context/execution-checklist.md` — per-phase checks for the `execute` action
-- `context/lessons.md` — append-only empirical lessons from batch executions; consumed by the `verify` action and `context/decision-framework.md`
-- `context/orchestrated-mode.md` — whole-repo batch defaults: worker tiering, static concurrency cap, rate-limit-guard consumption, wave-committed cadence
-- `actions/identify.md`, `actions/verify.md`, `actions/batch.md` — action bodies (private surface)
-- `/docs-hygiene:rename-references` — load-bearing 10-pattern sweep after any heading change (owns the syntactic-form set)
-- `/docs-hygiene:audit-encapsulation` — encapsulation detection + remediation (separate concern)
+- `context/decision-framework.md`. 6+5 gate, Pre-extraction Tier 0 checklist, output-type table, worked examples
+- `context/citation-form.md`. Full citation contract for markdown call sites
+- `context/anti-patterns.md`. 13-pattern taxonomy with mitigations
+- `context/execution-checklist.md`. Per-phase checks for the `execute` action
+- `context/lessons.md`. Append-only empirical lessons from batch executions; consumed by the `verify` action and `context/decision-framework.md`
+- `context/orchestrated-mode.md`. Whole-repo batch defaults: worker tiering, static concurrency cap, rate-limit-guard consumption, wave-committed cadence
+- `actions/identify.md`, `actions/verify.md`, `actions/batch.md`. Action bodies (private surface)
+- `/docs-hygiene:rename-references`. Load-bearing 10-pattern sweep after any heading change (owns the syntactic-form set)
+- `/docs-hygiene:audit-encapsulation`. Encapsulation detection + remediation (separate concern)
 
 ## Recheck triggers
 
@@ -236,4 +236,4 @@ Per-phase checklist: `context/execution-checklist.md`.
 | External tool/CLI/API documented inside an SSOT rule ships a major version bump | Re-verify the Tier 0 flag/verb set in the affected rule file; cited entries may have moved or renamed |
 | `/docs-hygiene:rename-references` adds a new syntactic form to its 10-pattern sweep | Update the sweep step in `context/execution-checklist.md` |
 | Anthropic ships a first-class native rule/skill linker (heading-rename auto-sweep) | Demote the `/docs-hygiene:rename-references` step to advisory; reduce sweep scope |
-| Practitioner-authored skill failure rate drops below 20% (SkillsBench refresh) | Reduce gate strictness; consider relaxing the artifact-creation gate from Rule of Three to Two for low-risk vocabulary (the reporting buckets are unaffected — they already roster at one) |
+| Practitioner-authored skill failure rate drops below 20% (SkillsBench refresh) | Reduce gate strictness; consider relaxing the artifact-creation gate from Rule of Three to Two for low-risk vocabulary (the reporting buckets are unaffected. They already roster at one) |

--- a/plugins/docs-hygiene/skills/extract-ssot/SKILL.md
+++ b/plugins/docs-hygiene/skills/extract-ssot/SKILL.md
@@ -71,7 +71,7 @@ Full decision matrix: `context/decision-framework.md` (6+5 checklist with worked
 
 | Argument | Action | Purpose |
 |----------|--------|---------|
-| *(empty)* | Smart default | Auto-detect: working notes from a prior run hold an active candidate roster → resume the current phase; the invocation or conversation already names a scope → `identify`; otherwise → confirm scope with the user first (see "Bare invocation. Confirm scope first") |
+| *(empty)* | Smart default | Auto-detect: working notes from a prior run hold an active candidate roster → resume the current phase; the invocation or conversation already names a scope → `identify`; otherwise → confirm scope with the user first (see "Bare invocation — confirm scope first") |
 | `identify [<cluster-name>]` | Find candidates (default = exhaustive subagent survey) | Dispatches a read-only exploration subagent over 30+ duplication heuristics (full body in `actions/identify.md`); ranks by ROI; emits batch-sequencing matrix + recommended `/docs-hygiene:extract-ssot batch` invocation. Rosters every surviving candidate in a labelled multiplicity bucket (N=1 / N=2 / N≥3) with its instance count; artifact-creating outputs stay reserved for N≥3. Single-cluster mode (`identify <name>`) skips the subagent for a targeted Tier 0 grep |
 | `verify <cluster-name>` | Refuse-fast pre-extraction gate | 6-gate cheap check (bucket assignment + Tier 0 grep, citation state, primary-source URL gate, bifurcation check, off-by-one heuristic, LOW-ROI threshold). Output: `PROCEED \| REFUSE-{reason} \| WARN` plus the assigned `bucket:`. OPTIONAL. Does not gate `plan`/`execute`. See `actions/verify.md` |
 | `plan <cluster-name>` | Architect | Pre-step (Tier 0 grep): does an existing rule/doc already own the concept? If yes → consolidate-into-existing branch (extend the home + de-recap consumers, no new artifact). Else choose creation output type (rule vs skill); draft or extend SSOT body; sketch migration plan |
@@ -95,7 +95,7 @@ Accepted by `identify` and `batch` (the roster-producing surfaces); `batch` pass
 
 Bare invocation (no flags) stays read-only: it reports the buckets and stops, matching `/docs-hygiene:audit-noise` and `/docs-hygiene:audit-derivability`. Full flag semantics: `actions/identify.md`.
 
-## Bare invocation. Confirm scope first
+## Bare invocation — confirm scope first
 
 Shared clean-tree / no-scope shape: [`../../context/clean-tree-fallback.md`](../../context/clean-tree-fallback.md).
 

--- a/plugins/docs-hygiene/skills/rename-references/SKILL.md
+++ b/plugins/docs-hygiene/skills/rename-references/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: "Sweep stale references after renames — the syntactic forms token-only grep misses (slash-tokens, paths, chain prose, numbered table rows, frontmatter chains and globs). Use when: 'rename X to Y', 'I renamed X', 'audit rename', 'find stale refs', 'check for stragglers', 'after git mv', 'sweep references', 'rename impact preview', 'find half-renamed state', 'broken refs after rename', 'pre-PR rename check' — actions: audit, audit blast, audit half-rename, audit orphans, apply, preview, blocklist; not for framework migrations or repo-wide dead-reference audits."
+description: "Sweep stale references after renames, the syntactic forms token-only grep misses (slash-tokens, paths, chain prose, numbered table rows, frontmatter chains and globs). Use when: 'rename X to Y', 'I renamed X', 'audit rename', 'find stale refs', 'check for stragglers', 'after git mv', 'sweep references', 'rename impact preview', 'find half-renamed state', 'broken refs after rename', 'pre-PR rename check'. Actions: audit, audit blast, audit half-rename, audit orphans, apply, preview, blocklist; not for framework migrations or repo-wide dead-reference audits."
 argument-hint: "[action] [<old> [to <new>]] [--include-historical|--include-memory|--include-plan-docs|--include-bare-token|--container|--identifier] (e.g., /rename-references audit, /rename-references audit blast /verify to /verify-changes, /rename-references audit half-rename /a to /b, /rename-references audit orphans /a to /b, /rename-references blocklist)"
 user-invocable: true
 disable-model-invocation: false
@@ -19,11 +19,11 @@ Current branch: !`git branch --show-current 2>/dev/null || echo "unknown"`
 
 Renames are deceptively hard. After renaming a skill, file, or identifier, references survive in 7+ syntactic forms beyond the obvious token. Token-only grep (`/old`) catches 50–70%; the rest hide in chain prose (`→ old →`), comma-lists (`Test, Old, Retro`), numbered table rows (`| 7. Old |`), frontmatter chain strings (`description: "...→ old → retro process."`), frontmatter globs (`{a,b,old,c}`), cross-skill mode references, and content-file paths (context/old.md style).
 
-This skill makes "find every reference" one invocation instead of 4 manual sweep passes. Runs the full pattern library, triages matches into 3 buckets, surfaces ambiguity (English-verb collisions like `confirm`/`test`/`review`) for user confirmation rather than auto-applying blindly.
+This skill makes "find every reference" one invocation instead of 4 manual sweep passes. It runs the full pattern library, triages matches into 3 buckets, and surfaces ambiguity (English-verb collisions like `confirm`/`test`/`review`) for user confirmation rather than auto-applying blindly.
 
 ## Adapting to your environment
 
-This skill is self-contained — the pattern library, triage classifier, and audit modes below need only git and the Grep tool. Where prose names an adjacent capability (a verification workflow, an issue tracker, a codebase-audit routine), treat it as optional: if your environment provides it, invoke it; otherwise proceed without. Consumer-specific conventions (work-notes locations, commit policy, naming rules) come from the consuming repository's own CLAUDE.md and rules — read them; this skill does not assume them.
+This skill is self-contained, the pattern library, triage classifier, and audit modes below need only git and the Grep tool. Where prose names an adjacent capability (a verification workflow, an issue tracker, a codebase-audit routine), treat it as optional: if your environment provides it, invoke it; otherwise proceed without. Consumer-specific conventions (work-notes locations, commit policy, naming rules) come from the consuming repository's own CLAUDE.md and rules. Read them; this skill does not assume them.
 
 ## Action router
 
@@ -31,18 +31,18 @@ Parse `$ARGUMENTS` first token to determine action. Subsequent tokens are the re
 
 | Argument shape | Action | Read |
 |---|---|---|
-| *(empty)* | **Smart default** | inline below — detect rename pair from conversation/git/staged |
-| `audit` | **Audit** (read-only sweep — alias for `audit blast`) | [context/audit.md](context/audit.md) + [audit-modes.md](context/audit-modes.md) |
+| *(empty)* | **Smart default** | inline below. Detect rename pair from conversation/git/staged |
+| `audit` | **Audit** (read-only sweep. Alias for `audit blast`) | [context/audit.md](context/audit.md) + [audit-modes.md](context/audit-modes.md) |
 | `audit <old>` or `audit <old> to <new>` | **Audit** with explicit pair | [context/audit.md](context/audit.md) |
-| `audit blast [<old> [to <new>]]` | **Audit Blast** — pre-rename impact (counts + per-file + bucket distribution; inline-only) | [audit-modes.md](context/audit-modes.md) |
-| `audit half-rename <old> to <new>` | **Audit Half-Rename** — files mentioning BOTH old AND new (incomplete-rename hygiene) | [audit-modes.md](context/audit-modes.md) |
-| `audit orphans <old> to <new>` | **Audit Orphans** — refs at old name OR vanished path AFTER rename (REQUIRES pair) | [audit-modes.md](context/audit-modes.md) |
+| `audit blast [<old> [to <new>]]` | **Audit Blast**. Pre-rename impact (counts + per-file + bucket distribution; inline-only) | [audit-modes.md](context/audit-modes.md) |
+| `audit half-rename <old> to <new>` | **Audit Half-Rename**. Files mentioning BOTH old AND new (incomplete-rename hygiene) | [audit-modes.md](context/audit-modes.md) |
+| `audit orphans <old> to <new>` | **Audit Orphans**. Refs at old name OR vanished path AFTER rename (REQUIRES pair) | [audit-modes.md](context/audit-modes.md) |
 | `<old> to <new>` | **Apply** full rename | [context/apply.md](context/apply.md) |
 | `preview <old> to <new>` | **Preview** dry-run | [context/apply.md](context/apply.md) (skip Edit phase) |
-| `<old>` (single token, no separator) | **Reverse** — find refs, ask what to replace with | [context/audit.md](context/audit.md) |
+| `<old>` (single token, no separator) | **Reverse**. Find refs, ask what to replace with | [context/audit.md](context/audit.md) |
 | `blocklist` | **Print English-verb blocklist** (read-only introspection of triage-bucket safety mechanism) | inline below |
 
-**Pattern library is the load-bearing component** — the full form registry lives in [context/patterns.md](context/patterns.md); execute sweeps with the Grep tool. Read it before any sweep. Triage logic is in [context/triage.md](context/triage.md). Audit sub-mode detail (Blast / Half-rename / Orphans) is in [context/audit-modes.md](context/audit-modes.md).
+**Pattern library is the load-bearing component**, the full form registry lives in [context/patterns.md](context/patterns.md); execute sweeps with the Grep tool. Read it before any sweep. Triage logic is in [context/triage.md](context/triage.md). Audit sub-mode detail (Blast / Half-rename / Orphans) is in [context/audit-modes.md](context/audit-modes.md).
 
 ## Override flags (audit modes)
 
@@ -52,7 +52,7 @@ Six flags. Four widen the sweep; two override the rename-mode resolution. Defaul
 |---|---|---|
 | `--include-historical` | Sweep archived/completed work notes and frozen records of past work | OK |
 | `--include-memory` | Sweep Claude Code auto-memory files (`~/.claude/projects/*/memory/*.md`) and `MEMORY.md` indices | OK |
-| `--include-plan-docs` | Sweep the active plan/work-notes documents that document THIS rename | **AUDIT-MODE ONLY** — apply mode rejects with explicit error (footgun prevention; the plan doc documents the rename — both names appear by design) |
+| `--include-plan-docs` | Sweep the active plan/work-notes documents that document THIS rename | **AUDIT-MODE ONLY**, apply mode rejects with explicit error (footgun prevention; the plan doc documents the rename, both names appear by design) |
 | `--include-bare-token` | Surface the bare-token residue that container-rename mode suppresses ([patterns.md](context/patterns.md) "Phase 0b"). Always **Ambiguous**, never Certain. Not applicable to `audit orphans`, which sweeps no bare-token form | **AUDIT-MODE ONLY** |
 | `--container` | Force container-rename mode, skipping the evidence ladder ([patterns.md](context/patterns.md) "Phase 0b") | OK |
 | `--identifier` | Force identifier-rename mode | OK |
@@ -61,18 +61,18 @@ Multiple flags compose. Unknown flags raise an error. Detail in [audit-modes.md]
 
 ## Blocklist action
 
-`/docs-hygiene:rename-references blocklist` prints the English-verb blocklist literal from [context/triage.md](context/triage.md). Read-only — no edits, no sweeps. Use to inspect which tokens force the ambiguous-bucket safety path. To extend, edit `triage.md` directly.
+`/docs-hygiene:rename-references blocklist` prints the English-verb blocklist literal from [context/triage.md](context/triage.md). Read-only. No edits, no sweeps. Use to inspect which tokens force the ambiguous-bucket safety path. To extend, edit `triage.md` directly.
 
 ## Smart default (no arguments)
 
 Detect rename pairs in this priority order:
 
-1. **Explicit args** (highest precedence — never overridden)
-2. **Recent conversation** — scan last 20 turns for prose like "I renamed X to Y", "rename X → Y", "git mv X Y", or assistant edits replacing identifier X with Y across multiple files
-3. **Git rename detection** — `git diff --name-status -M HEAD` and `git diff --cached --name-status -M`; `R<score>` lines map old path → new path
-4. **Paired `D <path>` + `?? <similar-path>`** in `git status --porcelain` (heuristic — Levenshtein-similar basenames within same dir)
+1. **Explicit args** (highest precedence, never overridden)
+2. **Recent conversation**. Scan last 20 turns for prose like "I renamed X to Y", "rename X → Y", "git mv X Y", or assistant edits replacing identifier X with Y across multiple files
+3. **Git rename detection**. `git diff --name-status -M HEAD` and `git diff --cached --name-status -M`; `R<score>` lines map old path → new path
+4. **Paired `D <path>` + `?? <similar-path>`** in `git status --porcelain` (heuristic. Levenshtein-similar basenames within same dir)
 
-If multiple candidates surface, present via `AskUserQuestion` — user picks which pair to audit.
+If multiple candidates surface, present via `AskUserQuestion`. User picks which pair to audit.
 
 If zero candidates: report "No rename detected in conversation or git state. Provide `/docs-hygiene:rename-references <old> to <new>` or `/docs-hygiene:rename-references audit <old>` to invoke explicitly."
 
@@ -87,34 +87,34 @@ The argument string after the action keyword can be:
 | `<old> → <new>` | `test live → test e2e` | old=`test live`, new=`test e2e` |
 | `<old> -> <new>` | `foo -> bar` | old=`foo`, new=`bar` |
 | `<old> into <new>` | `legacy into modern` | old=`legacy`, new=`modern` |
-| `<path/old.md> to <path/new.md>` | `confirm/SKILL.md to verify/SKILL.md` | path rename — skill applies extra path-form patterns |
+| `<path/old.md> to <path/new.md>` | `confirm/SKILL.md to verify/SKILL.md` | path rename. Skill applies extra path-form patterns |
 
-Multi-word old/new is fine — separator is the only delimiter. Quote characters (`"foo bar"`) optional. Old/new taken verbatim — leading slashes preserved (`/confirm` stays `/confirm`, not `confirm`).
+Multi-word old/new is fine. Separator is the only delimiter. Quote characters (`"foo bar"`) optional. Old/new taken verbatim. Leading slashes preserved (`/confirm` stays `/confirm`, not `confirm`).
 
 ## Workflow phases (apply mode)
 
-1. **Detect** — gather rename pair (args / conversation / git per Smart default)
-2. **Survey** — run all patterns from `context/patterns.md` in parallel against tracked text files; aggregate per-file hit counts. For a skill/identifier rename, FIRST enumerate coupled-sibling renames (dot-form behavior point-IDs, internal mode names, content-file basenames that changed in lockstep) and queue EACH as its own rename pair — they carry no primary token, so the primary sweep never reaches them (see Gotchas "coupled-rename")
-3. **Triage** — classify each match into 3 buckets per `context/triage.md`:
-   - **Certain** — slash-token, path, frontmatter glob (high precision, auto-apply candidate)
-   - **Chain-context** — preceded/followed by other known skill names; numbered table rows; chain prose with multiple skill tokens
-   - **Ambiguous** — bare-token matches where token is in English-verb blocklist (`confirm`/`test`/`review`/`fix`/`clean`/`build`/`lint`/`verify`/`plan`/etc.)
-4. **Confirm** — present buckets via `AskUserQuestion`:
-   - Certain → "auto-apply N matches?" — yes/no
-   - Chain-context → "review N matches one-by-one?" — yes/skip-bucket/auto-apply-all
+1. **Detect**. Gather rename pair (args / conversation / git per Smart default)
+2. **Survey**. Run all patterns from `context/patterns.md` in parallel against tracked text files; aggregate per-file hit counts. For a skill/identifier rename, FIRST enumerate coupled-sibling renames (dot-form behavior point-IDs, internal mode names, content-file basenames that changed in lockstep) and queue EACH as its own rename pair. They carry no primary token, so the primary sweep never reaches them (see Gotchas "coupled-rename")
+3. **Triage**. Classify each match into 3 buckets per `context/triage.md`:
+   - **Certain**. Slash-token, path, frontmatter glob (high precision, auto-apply candidate)
+   - **Chain-context**. Preceded/followed by other known skill names; numbered table rows; chain prose with multiple skill tokens
+   - **Ambiguous**. Bare-token matches where token is in English-verb blocklist (`confirm`/`test`/`review`/`fix`/`clean`/`build`/`lint`/`verify`/`plan`/etc.)
+4. **Confirm**. Present buckets via `AskUserQuestion`:
+   - Certain → "auto-apply N matches?". Yes/no
+   - Chain-context → "review N matches one-by-one?". Yes/skip-bucket/auto-apply-all
    - Ambiguous → per-match yes/no with surrounding context
-5. **Apply** — Edit each accepted match. Idempotent — running twice is safe.
-6. **Re-sweep** — re-run Phase 2; exit when the ACTIONABLE count is 0 (the survey after `context/patterns.md` "Phase 0" span-precedence and "Phase 0b" container-rename mode, MINUS the matches the user confirmed skipping in Phase 4 — neither the mode's residue nor a deliberate skip ever counts, or the loop cannot terminate). If non-zero, NEW form not in pattern library — report to user, add to `context/patterns.md`, re-iterate.
-7. **Hand off** — suggest running the consuming repository's verification workflow (build + test + lint) to confirm no semantic regression in the rename target.
+5. **Apply**, Edit each accepted match. Idempotent, running twice is safe.
+6. **Re-sweep**. Re-run Phase 2; exit when the ACTIONABLE count is 0 (the survey after `context/patterns.md` "Phase 0" span-precedence and "Phase 0b" container-rename mode, MINUS the matches the user confirmed skipping in Phase 4: neither the mode's residue nor a deliberate skip ever counts, or the loop cannot terminate). If non-zero, NEW form not in pattern library. Report to user, add to `context/patterns.md`, re-iterate.
+7. **Hand off**. Suggest running the consuming repository's verification workflow (build + test + lint) to confirm no semantic regression in the rename target.
 
-Audit mode runs phases 1-3 only and reports — no Edit calls. Preview mode runs 1-4 and reports planned edits — no Edit.
+Audit mode runs phases 1-3 only and reports, no Edit calls. Preview mode runs 1-4 and reports planned edits, no Edit.
 
 ## Auto-exclusions
 
 Paths skipped from sweeps automatically:
 
-- **Rename-documenting plan/work-notes documents** — an active plan file, migration notes, or changelog entry drafted for THIS rename references the rename pair as part of documenting the migration; both names appear by design. Identify these from conversation context and the consuming repository's work-notes conventions (its CLAUDE.md / rules). Skipping prevents self-reference loops.
-- **Archived/historical work notes** — completed plan documents and frozen records of past work are deliberately preserved as-is; past renames documented there are historical record, not stale references.
+- **Rename-documenting plan/work-notes documents**, an active plan file, migration notes, or changelog entry drafted for THIS rename references the rename pair as part of documenting the migration; both names appear by design. Identify these from conversation context and the consuming repository's work-notes conventions (its CLAUDE.md / rules). Skipping prevents self-reference loops.
+- **Archived/historical work notes**. Completed plan documents and frozen records of past work are deliberately preserved as-is; past renames documented there are historical record, not stale references.
 - `.git/`, `node_modules/`, `bin/`, `obj/`, `.venv/`, `dist/`, `build/`
 - Claude Code auto-memory files in `~/.claude/projects/*/memory/` describing past renames
 
@@ -129,37 +129,37 @@ Paths skipped from sweeps automatically:
 
 ## Edge cases
 
-- **English-verb collision** — tokens like `confirm`, `test`, `review`, `clean`, `fix`, `build`, `lint`, `plan`, `run`, `view`, `start`, `stop`, `merge`, `split`, `sort`, `filter`, `group`, `head`, `body`, `link`, `list`, `work`, `log`, `watch`, `monitor`. Triage forces these into ambiguous bucket regardless of regex hit position. User confirms each.
-- **Self-reference in plan docs** — the active plan/work-notes document mentions the rename pair as part of *documenting* the migration. Auto-excluded; never modify.
-- **Concurrent sessions** — Edit tool's read-before-write guard catches racing edits. If guard fails, report to user and abort.
-- **Word-boundary trap** — `confirm` inside `confirmation` MUST NOT match. All bare-token patterns use `\b`.
-- **Slash-token specificity** — `/confirm` should match but not `/confirmation`, `/confirm-changes`, or `path/confirm`. Use `\B/<old>([^\w-]|$)` (non-word-boundary before the slash; a CONSUMED terminator after that excludes a hyphen). A trailing `\b` is not enough: it treats a hyphen as a boundary, so it matches inside kebab-case sibling commands — and Form 1 is Certain, so that auto-applies. The consumed character is not part of the reference.
-- **Frontmatter trailing newline** — YAML frontmatter description strings can span lines. Patterns must handle multi-line. Use `multiline: true` on the Grep tool.
-- **Renames with overlap** — `test` → `test e2e` is a substring expansion. Apply most-specific match first, mark already-edited regions to prevent double-edit.
-- **Pattern false negative** — if Phase 6 re-sweep reveals a NEW syntactic form, that's a feature gap. Add the pattern to `context/patterns.md`, re-iterate. Do NOT silently apply.
+- **English-verb collision**. Tokens like `confirm`, `test`, `review`, `clean`, `fix`, `build`, `lint`, `plan`, `run`, `view`, `start`, `stop`, `merge`, `split`, `sort`, `filter`, `group`, `head`, `body`, `link`, `list`, `work`, `log`, `watch`, `monitor`. Triage forces these into ambiguous bucket regardless of regex hit position. User confirms each.
+- **Self-reference in plan docs**, the active plan/work-notes document mentions the rename pair as part of *documenting* the migration. Auto-excluded; never modify.
+- **Concurrent sessions**. Edit tool's read-before-write guard catches racing edits. If guard fails, report to user and abort.
+- **Word-boundary trap**. `confirm` inside `confirmation` MUST NOT match. All bare-token patterns use `\b`.
+- **Slash-token specificity**. `/confirm` should match but not `/confirmation`, `/confirm-changes`, or `path/confirm`. Use `\B/<old>([^\w-]|$)` (non-word-boundary before the slash; a CONSUMED terminator after that excludes a hyphen). A trailing `\b` is not enough: it treats a hyphen as a boundary, so it matches inside kebab-case sibling commands, and Form 1 is Certain, so that auto-applies. The consumed character is not part of the reference.
+- **Frontmatter trailing newline**. YAML frontmatter description strings can span lines. Patterns must handle multi-line. Use `multiline: true` on the Grep tool.
+- **Renames with overlap**. `test` → `test e2e` is a substring expansion. Apply most-specific match first, mark already-edited regions to prevent double-edit.
+- **Pattern false negative**, if Phase 6 re-sweep reveals a NEW syntactic form, that's a feature gap. Add the pattern to `context/patterns.md`, re-iterate. Do NOT silently apply.
 
 ## What this skill does NOT do
 
-- **Does not perform AST-level renames** — Python class names, C# type names, JS function refactors. Use IDE refactor tools or language-aware refactoring tooling. This skill handles documentation, configuration, and identifier-string renames in text files.
-- **Does not rename git branches** — use `git branch -m`. Operates on file content, not git refs.
-- **Does not handle framework version migrations** — use dedicated migration tooling. Different concern: behavioral upgrade, not text rename.
-- **Does not auto-fix conversation history or memory entries** — past mentions of the old name in conversation/memory are deliberately preserved as historical record. Future renames are the user's responsibility to invoke this skill for.
-- **Does not run builds or tests** — hand off to the consuming repository's build/test/verification workflow after the rename completes.
-- **Does not perform general dead-reference scanning** — `audit orphans` is STRICTLY pair-driven (post-rename hygiene only). For repo-wide dead-link / dead-reference checks unrelated to a specific rename, use a codebase-audit workflow or documentation link checker if your environment provides one. Charter boundary preserves single responsibility.
+- **Does not perform AST-level renames**. Python class names, C# type names, JS function refactors. Use IDE refactor tools or language-aware refactoring tooling. This skill handles documentation, configuration, and identifier-string renames in text files.
+- **Does not rename git branches**. Use `git branch -m`. Operates on file content, not git refs.
+- **Does not handle framework version migrations**. Use dedicated migration tooling. Different concern: behavioral upgrade, not text rename.
+- **Does not auto-fix conversation history or memory entries**. Past mentions of the old name in conversation/memory are deliberately preserved as historical record. Future renames are the user's responsibility to invoke this skill for.
+- **Does not run builds or tests**. Hand off to the consuming repository's build/test/verification workflow after the rename completes.
+- **Does not perform general dead-reference scanning**. `audit orphans` is STRICTLY pair-driven (post-rename hygiene only). For repo-wide dead-link / dead-reference checks unrelated to a specific rename, use a codebase-audit workflow or documentation link checker if your environment provides one. Charter boundary preserves single responsibility.
 
 ## Gotchas
 
 - **NEVER trust a single-pattern grep as "clean."** That was the bug this skill exists to prevent. In the skill-rename incident that motivated the pattern library, token-only grep returned 0 matches across 4 sweep passes; chain prose, comma-lists, numbered rows, and frontmatter forms surfaced one round at a time. Run all patterns or invoke `/docs-hygiene:rename-references audit`.
 - **Ambiguous bucket is mandatory triage, not optional.** English-verb collisions are the highest false-positive vector. If a token is in the blocklist, force into ambiguous regardless of position. Cost of one extra confirmation prompt is far lower than silently mangling prose.
-- **Re-sweep until the ACTIONABLE count is 0.** Don't trust Phase 5 ended cleanly without verification. Phase 6 is the gate. "Actionable" is load-bearing, and it excludes TWO categories the sweep leaves matching forever: the bare-token residue container-rename mode deliberately leaves unrenamed, and any match the user confirmed skipping in Phase 4. Gating on the RAW count means the loop never terminates; gating on residue alone means it never terminates whenever the user declines a match, which container mode makes routine by demoting Forms 4–12 to per-match prompts. Skips are keyed by occurrence span, REMAPPED as Phase 5's edits shift later columns on the same line (a pre-edit span does not survive an edit when `<old>` and `<new>` differ in length), and reported separately from residue in the hand-off — one was declined, the other was never proposed.
+- **Re-sweep until the ACTIONABLE count is 0.** Don't trust Phase 5 ended cleanly without verification. Phase 6 is the gate. "Actionable" is load-bearing, and it excludes TWO categories the sweep leaves matching forever: the bare-token residue container-rename mode deliberately leaves unrenamed, and any match the user confirmed skipping in Phase 4. Gating on the RAW count means the loop never terminates; gating on residue alone means it never terminates whenever the user declines a match, which container mode makes routine by demoting Forms 4–12 to per-match prompts. Skips are keyed by occurrence span, REMAPPED as Phase 5's edits shift later columns on the same line (a pre-edit span does not survive an edit when `<old>` and `<new>` differ in length), and reported separately from residue in the hand-off. One was declined, the other was never proposed.
 - **Plan-doc exclusion is mandatory.** The active plan/work-notes document *documents the rename* and contains both old and new names by design. Editing it would break the documentation narrative.
 - **Pattern library evolves.** When Phase 6 finds a NEW form, treat as a learning event: extend `context/patterns.md`, add an eval case. Future renames benefit immediately.
-- **A file MOVE breaks the moved files' own relative paths — sweep INSIDE the moved set, not just refs TO it.** When `git mv` changes directory depth, relative refs *inside* the moved files (`source ../../lib.sh`, `# shellcheck source=../../../../tests/...`, relative markdown links) silently break — they carry no renamed token, so every token-keyed pattern returns clean while the moved file itself is broken. After any depth-changing move: `grep -nE '\.\./' <moved-files>` + re-run the moved code from its new location (tests, `--help`). Real example: a directory promotion left a `# shellcheck source=` directive pointing four levels up when the new home was two.
-- **A rename couples sibling renames — sweep each as its own pair.** Renaming a skill or identifier usually drags coupled siblings that do NOT contain the primary token: dot-form action/mode IDs (`verify.runtime-affecting-paths` — Form 12), internal mode names (`quality` mode), content-file basenames (context/quality.md style paths). A phase-scoped, skill-only grep on the primary token (`/verify`) leaves these EXTERNAL refs — in skill bodies, config files, and other skills' dispatch tables — unverified. A slash-anchored token sweep can return "clean" while `<old>.id` / `<old-mode>` / `<old>.md`-path refs survive elsewhere. Before declaring a rename complete: enumerate the coupled identifiers (Survey phase) and run a sweep per pair.
+- **A file MOVE breaks the moved files' own relative paths. Sweep INSIDE the moved set, not just refs TO it.** When `git mv` changes directory depth, relative refs *inside* the moved files (`source ../../lib.sh`, `# shellcheck source=../../../../tests/...`, relative markdown links) silently break. They carry no renamed token, so every token-keyed pattern returns clean while the moved file itself is broken. After any depth-changing move: `grep -nE '\.\./' <moved-files>` + re-run the moved code from its new location (tests, `--help`). Real example: a directory promotion left a `# shellcheck source=` directive pointing four levels up when the new home was two.
+- **A rename couples sibling renames. Sweep each as its own pair.** Renaming a skill or identifier usually drags coupled siblings that do NOT contain the primary token: dot-form action/mode IDs (`verify.runtime-affecting-paths`, Form 12), internal mode names (`quality` mode), content-file basenames (context/quality.md style paths). A phase-scoped, skill-only grep on the primary token (`/verify`) leaves these EXTERNAL refs, in skill bodies, config files, and other skills' dispatch tables, unverified. A slash-anchored token sweep can return "clean" while `<old>.id` / `<old-mode>` / `<old>.md`-path refs survive elsewhere. Before declaring a rename complete: enumerate the coupled identifiers (Survey phase) and run a sweep per pair.
 
 ## Integration with workflow
 
-`/docs-hygiene:rename-references` is invocable mid-workflow whenever a rename happens — typically during implementation (when the work includes a rename) or as a precursor to final verification, to confirm no stragglers before declaring done.
+`/docs-hygiene:rename-references` is invocable mid-workflow whenever a rename happens. Typically during implementation (when the work includes a rename) or as a precursor to final verification, to confirm no stragglers before declaring done.
 
 **Skill chaining:**
 

--- a/plugins/docs-hygiene/skills/write-for-agents/SKILL.md
+++ b/plugins/docs-hygiene/skills/write-for-agents/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: "Write agent-consumed markdown well at the moment of writing — CLAUDE.md or AGENTS.md content, .claude/rules files, agent-loaded reference/context docs, navigation-pointer lines, and doc-plus-pointer extractions. Use when: 'add this to CLAUDE.md', 'write a rule for X', 'write this up for the agent', 'add a pointer to the docs', 'move this section into its own doc', 'draft an AGENTS.md section', or any drafting or editing of a markdown file an agent will load. NOT for: creating or editing a SKILL.md (playbooks:skill-authoring and skill-quality:check own that), auditing existing docs (the docs-hygiene audit skills own that), or human-facing docs such as end-user READMEs, RFCs, release notes and changelogs — those route to docs-hygiene:write-for-humans, the sibling that fires at the same moment for the other reader."
+description: "Write agent-consumed markdown well at the moment of writing. CLAUDE.md or AGENTS.md content, .claude/rules files, agent-loaded reference/context docs, navigation-pointer lines, and doc-plus-pointer extractions. Use when: 'add this to CLAUDE.md', 'write a rule for X', 'write this up for the agent', 'add a pointer to the docs', 'move this section into its own doc', 'draft an AGENTS.md section', or any drafting or editing of a markdown file an agent will load. NOT for: creating or editing a SKILL.md (playbooks:skill-authoring and skill-quality:check own that), auditing existing docs (the docs-hygiene audit skills own that), or human-facing docs such as end-user READMEs, RFCs, release notes and changelogs. Those route to docs-hygiene:write-for-humans, the sibling that fires at the same moment for the other reader."
 argument-hint: "[<file or section being written>]"
 user-invocable: true
 disable-model-invocation: false
@@ -13,22 +13,22 @@ metadata:
 ## Why this skill exists
 
 The docs-hygiene siblings are audit-shaped: they find problems in docs that already exist. This
-skill is the write-side complement — it fires while the doc is being written, so the problems the
+skill is the write-side complement. It fires while the doc is being written, so the problems the
 audits catch are not created in the first place. Its scope is any markdown an agent will consume;
 the auto-read surfaces (CLAUDE.md scopes, `.claude/rules`, auto-memory, and their kin) are the
 high-value core because their cost recurs every session. Read
 [`reference/agent-doc-surfaces.md`](reference/agent-doc-surfaces.md) when you need to know
-whether, when, and how much of a target file the harness actually loads — write differently for
+whether, when, and how much of a target file the harness actually loads. Write differently for
 an always-loaded surface than for an on-demand one.
 
 ## Budget both loads
 
 Every line you write spends two budgets, and cutting one can overspend the other:
 
-- **Context load** — tokens the agent pays, every session for always-loaded surfaces. Governed
+- **Context load**. Tokens the agent pays, every session for always-loaded surfaces. Governed
   marketplace-wide by PLUGIN-PHILOSOPHY's Instruction economy: an instruction earns its place
   with observed-stumble evidence, or it goes.
-- **Cognitive load** — attention the human maintainer pays. The human is the index of the doc
+- **Cognitive load**. Attention the human maintainer pays. The human is the index of the doc
   set: they must be able to hold where things live. Ten tiny fragment files can be cheaper for
   the agent and ruinous for the human; one 500-line file the reverse. When the two budgets
   conflict, say which one you spent and why.
@@ -44,18 +44,18 @@ text alone, without opening the target.
   output specifically, read X"), so both the follow and the skip are informed decisions.
 - A pointer that exists only because changes must be mirrored across distant folders can mask a
   cohesion problem. Before adding it, consider restructuring so the things that change together
-  live together — a pointer papering over low cohesion outlives the reorganization that would
+  live together, a pointer papering over low cohesion outlives the reorganization that would
   have removed it. (Audit-side remediation home: `claude-memory:audit`'s C5 fix guidance, if
   that plugin is installed.)
 
-The full pointer-quality criteria are owned by the sibling audit skill — invoke
+The full pointer-quality criteria are owned by the sibling audit skill. Invoke
 `/docs-hygiene:audit-progressive-disclosure` via the Skill tool to grade a draft against them,
 rather than failing them at audit time.
 
 ## Separate steps from reference, and co-locate what runs together
 
 Steps are read in order and executed; reference is jumped into and queried. Mixing them makes
-both worse — a procedure interrupted by lookup tables loses its thread, and reference buried in
+both worse, a procedure interrupted by lookup tables loses its thread, and reference buried in
 a procedure is unfindable.
 
 - Put the procedure in one contiguous block; move lookup material below it or into a spoke file
@@ -67,7 +67,7 @@ a procedure is unfindable.
 
 ## Give every step a completion criterion
 
-A step is done when its criterion says so — not when text resembling the step has been produced.
+A step is done when its criterion says so, not when text resembling the step has been produced.
 
 - **Clarity and demand.** State what "done" observably is, and demand it: "run X; the step is
   complete when Y appears" beats "run X".
@@ -75,13 +75,13 @@ A step is done when its criterion says so — not when text resembling the step 
   goal-state is reached will be marked complete at first plausible output. Make the criterion
   the goal-state, never the attempt.
 - **Post-completion steps.** When finishing creates an obligation (regenerate, notify, clean
-  up), state it in the step — an obligation after "done" is otherwise dropped.
+  up), state it in the step, an obligation after "done" is otherwise dropped.
 - **The agent does the legwork.** Write steps that resolve their own facts from the environment;
   a step that sends the human to look something up the agent could read is a defect.
 
 ## Split by sequence; choose invocation by the rubric
 
-When one doc serves two moments in time, split it at the moment boundary — the reader at step
+When one doc serves two moments in time, split it at the moment boundary, the reader at step
 one should not scroll past material for step nine. Splitting an instruction surface into skills
 with different invocation modes is a different axis with its own decision rubric: follow the
 [invocation-mode rubric](https://github.com/melodic-software/claude-code-plugins/blob/main/docs/conventions/invocation-mode/README.md)
@@ -91,28 +91,28 @@ with different invocation modes is a different axis with its own decision rubric
 
 Write what to do, not what to avoid: a prohibition drags the banned behavior into context, and
 pretrained leading words are the compact anchors that steer ("Prefer X" over "Never do Y unless").
-Keep a negation only when the positive form genuinely loses the constraint — then pair it with
+Keep a negation only when the positive form genuinely loses the constraint, then pair it with
 the positive alternative in the same sentence.
 
 ## After writing
 
-- Repeated the same prose in another file — even a second occurrence, or a recap of an SSOT that
+- Repeated the same prose in another file. Even a second occurrence, or a recap of an SSOT that
   already exists? Invoke `/docs-hygiene:extract-ssot` via the Skill tool. Creating a new shared home
   still waits for the third occurrence; below that it remedies the repetition in place.
 - Resolved or coined a domain term? Invoke `/domain-driven-design:curate-language` via the
-  Skill tool (if that plugin is installed) — never hand-write a glossary entry.
+  Skill tool (if that plugin is installed), never hand-write a glossary entry.
 - Editing exposed pre-existing problems in the surrounding doc? Invoke the fitting audit
   sibling via the Skill tool (`/docs-hygiene:audit-noise`, `/docs-hygiene:audit-derivability`,
   `/docs-hygiene:audit-progressive-disclosure`) rather than expanding this write into an audit.
 
 ## What this skill does NOT do
 
-- **Does not author skills** — a SKILL.md is `playbooks:skill-authoring` + `skill-quality:check`
+- **Does not author skills**, a SKILL.md is `playbooks:skill-authoring` + `skill-quality:check`
   territory; this skill's doctrine reaches skill authors through those surfaces.
-- **Does not audit existing docs** — the audit siblings own read-only findings; this skill fires
+- **Does not audit existing docs**, the audit siblings own read-only findings; this skill fires
   at the writing moment only.
-- **Does not write human-facing docs** — end-user READMEs, changelogs, and marketing prose have
+- **Does not write human-facing docs**. End-user READMEs, changelogs, and marketing prose have
   a different reader and different rules. Those are the sibling `docs-hygiene:write-for-humans`,
   which fires at this same moment and resolves the consuming project's own style guide first.
-- **Does not enforce via hooks** — trigger reliability is carried by this skill's description
+- **Does not enforce via hooks**. Trigger reliability is carried by this skill's description
   and its eval suite, deliberately not by a forcing hook.

--- a/plugins/docs-hygiene/skills/write-for-humans/SKILL.md
+++ b/plugins/docs-hygiene/skills/write-for-humans/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: "Write human-facing prose well at the moment of writing — end-user READMEs, RFCs, design docs, release notes, changelog entries, tutorials, how-to guides, reference pages, and explanations. Resolves the consuming project's own style guide first and applies a named default set only as the fallback (Diátaxis document modes, Google developer style, ASD-STE100 instruction rules, Global English disambiguation). Use when: 'write the README', 'draft an RFC', 'write the release notes', 'write a how-to for X', 'document this for users', 'write this up for humans', 'what kind of doc is this', 'is this the right kind of doc', 'make this doc readable', 'this doc reads like a machine wrote it'. NOT for: markdown an agent will load — CLAUDE.md or AGENTS.md content, rules files, agent-loaded reference docs — which is docs-hygiene:write-for-agents; auditing prose that already exists (the docs-hygiene audit skills own structure and derivability, ai-slop:audit owns AI-writing tells); commit-message or PR-body shape, owned by source-control; or product UI strings, which follow your product's own copy guidelines."
+description: "Write human-facing prose well at the moment of writing. End-user READMEs, RFCs, design docs, release notes, changelog entries, tutorials, how-to guides, reference pages, and explanations. Resolves the consuming project's own style guide first and applies a named default set only as the fallback (Diátaxis document modes, Google developer style, ASD-STE100 instruction rules, Global English disambiguation). Use when: 'write the README', 'draft an RFC', 'write the release notes', 'write a how-to for X', 'document this for users', 'write this up for humans', 'what kind of doc is this', 'is this the right kind of doc', 'make this doc readable', 'this doc reads like a machine wrote it'. NOT for: markdown an agent will load, CLAUDE.md or AGENTS.md content, rules files, agent-loaded reference docs, which is docs-hygiene:write-for-agents; auditing prose that already exists (the docs-hygiene audit skills own structure and derivability, ai-slop:audit owns AI-writing tells); commit-message or PR-body shape, owned by source-control; or product UI strings, which follow your product's own copy guidelines."
 argument-hint: "[<doc or section being written>]"
 user-invocable: true
 disable-model-invocation: false
@@ -24,7 +24,7 @@ sentence carry, and can any sentence be read two ways.
 
 ## Resolve the standard before you apply one
 
-**The project's own style guide wins. Always.** Before writing, look for one — a `STYLE.md`, a
+**The project's own style guide wins. Always.** Before writing, look for one, a `STYLE.md`, a
 documentation contributing guide, a house standard named in the contributor docs, or a linter config
 encoding prose rules. When the project declares a standard, it is authoritative and everything below
 is a fallback you do not reach for. Say which one you resolved, in one line, before you write.
@@ -38,7 +38,7 @@ The layers below are a **named default set**, not this plugin's house rules:
 | Load | How much does each sentence carry? | ASD-STE100 Simplified Technical English |
 | Ambiguity | Can this be read two ways? | Global English |
 
-A project that adopted a different guide — Microsoft's, Chicago, an in-house one — gets that guide,
+A project that adopted a different guide, Microsoft's, Chicago, an in-house one, gets that guide,
 not these. A project with none gets these, and you say so, so the choice stays visible and the
 project can overrule it later. Never silently impose one.
 
@@ -49,7 +49,7 @@ the reader; a sentence that obeys every rule and sounds machine-written has fail
 
 These are the only part of this skill that outlives a project's own guide: they are about doing the
 work, not picking a style, and no standard asks you to keep dead words or rename the thing you are
-documenting. Apply them whichever standard you resolved — and if a project's guide somehow
+documenting. Apply them whichever standard you resolved, and if a project's guide somehow
 contradicts one, the guide still wins.
 
 - **Cut every word that does no work.** If the sentence survives without a word, the word goes.
@@ -58,7 +58,7 @@ contradicts one, the guide still wins.
   to buy its length with precision.
 - **Write the real name, and the real number.** The thing being documented supplies the vocabulary:
   the actual symbol, file, flag, or command name, never a synonym or a description of it. Do not
-  invent jargon — use the words a developer would say out loud ("move", "delete", "a budget that
+  invent jargon. Use the words a developer would say out loud ("move", "delete", "a budget that
   only decreases", not "evacuate", "ratchet", "endgame"); a named pattern is fine when the doc says
   what it means the first time. Counts, file trees, and inventories are claims too: each must be
   true at the commit that lands it, and the doc should carry the command that regenerates it.
@@ -76,21 +76,21 @@ One document, one mode. Two questions pick it: does the content serve **doing** 
 Use the compass on a whole document or on a single sentence. Reach for it whenever you feel unsure
 what you are writing; gut feel is often wrong here.
 
-**Tutorial — learning by doing.** You are the teacher and the learner's success is your job. Open
+**Tutorial. Learning by doing.** You are the teacher and the learner's success is your job. Open
 by saying what they will build, not what they will "learn". Every step produces a visible result,
 and you tell them what they should see: the expected output, the prompt change, the log line. Cut
-explanation to one clause and a link — teaching pauses break the lesson. Write as "we", in commands.
+explanation to one clause and a link. Teaching pauses break the lesson. Write as "we", in commands.
 
-**How-to — steps to a goal.** Solve a problem a person has, not an operation the machine can
+**How-to. Steps to a goal.** Solve a problem a person has, not an operation the machine can
 perform. Assume competence, skip teaching, allow forks ("if you want x, do y"). Name the guide by
 the task ("How to calibrate the radar array", not "Radar array calibration").
 
-**Reference — facts for lookup.** Describe, and only describe. No instruction, no persuasion, no
+**Reference. Facts for lookup.** Describe, and only describe. No instruction, no persuasion, no
 opinion, no hedging: state facts, options, limits, and errors. Mirror the structure of the thing
 described so code and docs navigate together, and generate from source where you can so it stays
 true.
 
-**Explanation — understanding and why.** One bounded topic, readable away from the product. Each
+**Explanation. Understanding and why.** One bounded topic, readable away from the product. Each
 title should tolerate an implicit "About…" in front. Give design decisions, history, constraints,
 and alternatives. Opinion is allowed here and nowhere else.
 
@@ -113,7 +113,7 @@ view anywhere, nothing specific.
 
 ## Write the sentences
 
-The three sentence-level layers — address, load, ambiguity — apply to every sentence at once, so
+The three sentence-level layers, address, load, ambiguity, apply to every sentence at once, so
 they live together in one place rather than three:
 [`reference/sentence-rules.md`](reference/sentence-rules.md). Read it while drafting, not after.
 
@@ -143,9 +143,9 @@ ambiguity). "If exceeded" gets a subject: the request (ambiguity).
 ## After writing
 
 - **Check for AI-writing tells.** Invoke `/ai-slop:audit` via the Skill tool when it is available in
-  the session; when it is not, re-read for the obvious tells yourself — filler, stacked hedging,
-  negative parallelism, promotional tone — and say that you did the lighter pass.
-- **Repeated the same prose in another file — even a second occurrence, or a recap of an SSOT that
+  the session; when it is not, re-read for the obvious tells yourself. Filler, stacked hedging,
+  negative parallelism, promotional tone, and say that you did the lighter pass.
+- **Repeated the same prose in another file. Even a second occurrence, or a recap of an SSOT that
   already exists?** Invoke `/docs-hygiene:extract-ssot` via the Skill tool. Creating a new shared
   home still waits for the third occurrence; below that it remedies the repetition in place.
 - **The draft is over-long rather than misshapen?** Invoke `/docs-hygiene:compress` via the Skill
@@ -157,7 +157,7 @@ ambiguity). "If exceeded" gets a subject: the request (ambiguity).
 **Check the draft against the standard you resolved.** Questions 4, 6 and 7 restate the three rules
 above, so they apply whichever standard that was. The other four come from the bundled layers: when
 the project declared its own guide, that guide supplies their equivalents and these four do not
-apply — reaching for them would impose the bundled set on a project that already chose. Answer
+apply. Reaching for them would impose the bundled set on a project that already chose. Answer
 whichever apply against the text you just wrote, not from memory of writing it.
 
 1. Is each document one mode, with links where modes meet? Confirm it by naming the mode.
@@ -178,14 +178,14 @@ The draft is done when every answer is yes. A "no" is a rewrite now, not a note 
   is a fallback, and which one was applied is stated in the output.
 - **Does not audit existing prose.** Structure and derivability belong to the `docs-hygiene` audit
   siblings; AI-writing tells belong to `ai-slop:audit`. This skill fires at the writing moment only.
-- **Does not write agent-consumed markdown** — CLAUDE.md or AGENTS.md content, rules files, and
+- **Does not write agent-consumed markdown**. CLAUDE.md or AGENTS.md content, rules files, and
   agent-loaded reference docs are `docs-hygiene:write-for-agents`.
 - **Does not touch commit messages or PR bodies.** Their shape is owned by `source-control:commit`'s
   subject-convention ladder and the marketplace's PR-body-sections convention, and the
   markdown-prose regime already excludes them.
 - **Does not cover product UI strings.** Button labels, empty states, and error toasts are product
   copy, not documentation; they follow your product's own copy guidelines.
-- **Does not author skills** — a SKILL.md is `playbooks:skill-authoring` and `skill-quality:check`
+- **Does not author skills**, a SKILL.md is `playbooks:skill-authoring` and `skill-quality:check`
   territory.
 - **Does not claim to be the standards it names.** Each layer is a paraphrase of a published
   standard; see the source records below.
@@ -194,7 +194,7 @@ The draft is done when every answer is yes. A "no" is a rewrite now, not a note 
 
 - **Falling back because no `STYLE.md` sat in the root.** Style rules also live in contributor
   guides, docs READMEs, and prose-linter configs. Look in all of them before reaching for the
-  bundled set — an unnoticed house guide is the failure this skill's first step exists to prevent.
+  bundled set, an unnoticed house guide is the failure this skill's first step exists to prevent.
 - **Rewording a passage the edit did not touch.** It costs a reviewer a diff they must read for
   nothing, and it teaches the codebase two names for one thing. Change what the edit is about.
 - **Flattening explanation into reference.** Explanation is the one mode that permits a view, and
@@ -206,6 +206,6 @@ The draft is done when every answer is yes. A "no" is a rewrite now, not a note 
 ## Source records
 
 The four bundled layers are distilled paraphrases of published standards, each with a four-part
-drift stamp — claim, basis, as-of date, recheck trigger — in
+drift stamp, claim, basis, as-of date, recheck trigger, in
 [`reference/sources.md`](reference/sources.md). Read it before citing a layer as the standard: the
 STE layer is a principles subset, and a document written to it is not thereby STE-conformant.

--- a/plugins/docs-hygiene/skills/write-for-humans/SKILL.md
+++ b/plugins/docs-hygiene/skills/write-for-humans/SKILL.md
@@ -143,8 +143,8 @@ ambiguity). "If exceeded" gets a subject: the request (ambiguity).
 ## After writing
 
 - **Check for AI-writing tells.** Invoke `/ai-slop:audit` via the Skill tool when it is available in
-  the session; when it is not, re-read for the obvious tells yourself. Filler, stacked hedging,
-  negative parallelism, promotional tone, and say that you did the lighter pass.
+  the session; when it is not, re-read for the obvious tells yourself: filler, stacked hedging,
+  negative parallelism, and promotional tone. Then say that you did the lighter pass.
 - **Repeated the same prose in another file. Even a second occurrence, or a recap of an SSOT that
   already exists?** Invoke `/docs-hygiene:extract-ssot` via the Skill tool. Creating a new shared
   home still waits for the third occurrence; below that it remedies the repetition in place.


### PR DESCRIPTION
No linked issue

## Summary

Shard 6 of the #2891 instruction-surface de-slop campaign: purge em dashes from the `docs-hygiene` plugin README and every SKILL.md.

## Fix

Rewrote `plugins/docs-hygiene/README.md` and every `plugins/docs-hygiene/**/SKILL.md` under `/ai-slop:audit fix` semantics (periods, commas, or a restructured sentence; never parentheses, en dashes, or a spaced hyphen as a stand-in). Meaning-preserving self-audit reconnected subjectless fragments the first pass split. Fenced report and protocol templates keep their original punctuation. Quoted auto-invocation triggers stay byte-identical. `docs-hygiene` 0.21.3.

## Verification

- `CHECK_SKILL_SKIP_MARKDOWNLINT=1 bash scripts/check-changed-skills.sh origin/main` 9 skill(s) checked, 0 failed
- Quoted trigger extractor vs `origin/main`: all preserved
- `python3 scripts/sync-plugin-options-docs.py --check` up to date
- `scripts/check-changelog-parity.sh --check-bump origin/main` passes

## Related

Refs #2891