### PR TITLE
fix(code-tidying): backtick audit-comment-residue shape examples (0.14.3)

### DIFF
--- a/plugins/code-tidying/.claude-plugin/plugin.json
+++ b/plugins/code-tidying/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "code-tidying",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "description": "Code tidying and comment hygiene: /code-tidying:tidy proactively hunts a rotated, glob-scoped lane for Beck-style tidyings under a research-backed scope budget and ships one tight PR; /code-tidying:batch-simplify sweeps a time window, a branch, or an entire repository through grouped, dependency-ordered simplification waves with a never-drop deferred-items contract; /code-tidying:dissolve-comments enforces self-describing expressive code over a diff or target, widening to the branch diff and then the whole repository when the tree is clean — deletes zero-information comments, dissolves code-expressible ones into names and structure behind a tests gate (safe mode restricts applied edits to removals), and keeps only terse load-bearing comments code cannot express; /code-tidying:audit-comment-residue is a read-only classifier that flags history, plan, conversational, and ticket/PR residue in code comments for author-applied deletion. Project-specific tidy lanes are scaffolded into a tracked .claude/tidy-lanes/ config folder by a re-runnable setup skill.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/code-tidying/CHANGELOG.md
+++ b/plugins/code-tidying/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to the `code-tidying` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.14.3]
+
+### Fixed
+
+- **`audit-comment-residue` shape-definition examples no longer self-match
+  `audit-noise` (#3191).** Three rows of the residue-shape table wrote their
+  illustrative phrases in plain double quotes (`"Task 2 replaces the old…"`,
+  `"per your request"`, `"see PR #45"`). `audit-noise` strips inline-code spans
+  before matching, so the sibling skill's backticked examples stay invisible
+  while these three rows flagged against their own definitions. The quoted
+  phrases are now wrapped in backticks. Detector behavior is unchanged.
+
 ## [0.14.2]
 
 ### Fixed

--- a/plugins/code-tidying/skills/audit-comment-residue/SKILL.md
+++ b/plugins/code-tidying/skills/audit-comment-residue/SKILL.md
@@ -35,9 +35,9 @@ is left to the author; the shapes below are the comments that fail it.
 | Shape | What it looks like | Default tier | Treatment |
 |---|---|---|---|
 | `history-narration` | The comment narrates the code's past: "used to…", "no longer…", "previously", "renamed from X", "we switched from…", "now returns…" | 1 | Delete — version control owns history. Keep only if the *reason* for the change is a load-bearing constraint, rewritten as present-tense rationale ("must stay ordered because…") |
-| `plan-reference` | References a work plan, session, or changeset rather than the code: "Task 2 replaces the old…", "as planned", "in this PR/commit/refactor" | 1 | Delete — the plan is not part of the code's meaning. Fold any surviving intent into a present-tense why-comment |
-| `conversational-antecedent` | Addresses the requester or the producing conversation: "per your request", "as you asked", "like you said", "per our discussion" | 1 | Delete — the conversation is invisible to every future reader |
-| `ticket-pr-residue` | Back-reference to a tracker/PR/branch a reader can't follow: "see PR #45", "from the feature branch", "JIRA-123" | 2 | Review — delete a bare provenance reference; a `TODO(#issue)` tracking real outstanding work is the sanctioned exception and is NOT flagged |
+| `plan-reference` | References a work plan, session, or changeset rather than the code: `"Task 2 replaces the old…"`, `"as planned"`, `"in this PR/commit/refactor"` | 1 | Delete — the plan is not part of the code's meaning. Fold any surviving intent into a present-tense why-comment |
+| `conversational-antecedent` | Addresses the requester or the producing conversation: `"per your request"`, `"as you asked"`, `"like you said"`, `"per our discussion"` | 1 | Delete — the conversation is invisible to every future reader |
+| `ticket-pr-residue` | Back-reference to a tracker/PR/branch a reader can't follow: `"see PR #45"`, `"from the feature branch"`, `"JIRA-123"` | 2 | Review — delete a bare provenance reference; a `TODO(#issue)` tracking real outstanding work is the sanctioned exception and is NOT flagged |
 
 Consumers with their own comment conventions can refine these defaults in their repo's `CLAUDE.md` /
 rules; the classifier's shapes and tiers above are the skill's built-in baseline.


### PR DESCRIPTION
Closes #3191

## Summary

Three rows of `audit-comment-residue`'s shape-definition table wrote their example phrases in plain double quotes. `audit-noise` strips inline-code spans before matching, so those rows flagged against their own definitions on every sweep. The sibling skill already writes the same examples in backticks and does not self-match.

## Fix

Wrapped the quoted example phrases in the `plan-reference`, `conversational-antecedent`, and `ticket-pr-residue` rows in backticks. No detector behavior change. Plugin version `0.14.2` → `0.14.3` with a changelog entry.

## Verification

- `audit-noise` `detect.sh` against `origin/main`'s copy of the skill: T1=2 T2=1 (the three named rows: `plan-reference` L38, `conversational-antecedent` L39, `ticket-pr-residue` L40).
- Same detector against this branch's file: `Summary total: files=1 T1=0 T2=0 T3=0`.
- `scripts/check-changelog-parity.sh` `--check` / `--check-bump origin/main` / `--check-order` / `--check-preserved origin/main`: PASS.
- `scripts/check-changed-skills.sh origin/main`: PASS (0 errors, 1 pre-existing Gotchas warning).
- `scripts/check-skill-count-claims.sh --check`: PASS.
- `scripts/check-skill-leaf-names.sh --check`: PASS.
- `scripts/check-cross-plugin-source-drift.sh --check`: PASS.
- `markdownlint-cli2` on both changed markdown files: 0 issues.
- `claude plugin validate plugins/code-tidying`: Validation passed.

## Related

- Refs #3162 — where the self-matches were found and adjudicated; that PR was fenced to `plugins/docs-hygiene/`.
- `plugins/docs-hygiene/skills/audit-noise/SKILL.md` — the backticked sibling rows this matches.