### PR TITLE
fix(typos-format): check notebook edits and cap disclosure under the channel limit (0.6.26)

### DIFF
--- a/plugins/typos-format/.claude-plugin/plugin.json
+++ b/plugins/typos-format/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "typos-format",
-  "version": "0.6.24",
+  "version": "0.6.25",
   "description": "Spell-check on edit via typos-cli, unconditionally — report-only by default, honoring the consuming repo's own typos configuration when one is present.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/typos-format/.claude-plugin/plugin.json
+++ b/plugins/typos-format/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "typos-format",
-  "version": "0.6.25",
+  "version": "0.6.26",
   "description": "Spell-check on edit via typos-cli, unconditionally — report-only by default, honoring the consuming repo's own typos configuration when one is present.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/typos-format/CHANGELOG.md
+++ b/plugins/typos-format/CHANGELOG.md
@@ -12,7 +12,9 @@ All notable changes to the `typos-format` plugin are documented here. Format fol
   PATH, which the plugin-gate job does not install, so that case kept
   skipping on every PR. The stub suite now records argv and asserts the hook
   injects `-c <plugin>/config/default-typos.toml` whenever `CLAUDE_PLUGIN_ROOT`
-  is set — and does not inject it when the variable is unset
+  is set — and does not inject it when the variable is unset. The stub helper
+  unsets `CLAUDE_PLUGIN_ROOT` so an ambient host value cannot flip the
+  negative case
   ([#3133](https://github.com/melodic-software/claude-code-plugins/issues/3133)).
 
 ## [0.6.25]

--- a/plugins/typos-format/CHANGELOG.md
+++ b/plugins/typos-format/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to the `typos-format` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.6.26]
+
+### Fixed
+
+- **tests:** the bundled `-c` merge pin now runs in CI. The real-binary case
+  that proves repo `extend-ignore-re` survives `-c` still needs `typos` on
+  PATH, which the plugin-gate job does not install, so that case kept
+  skipping on every PR. The stub suite now records argv and asserts the hook
+  injects `-c <plugin>/config/default-typos.toml` whenever `CLAUDE_PLUGIN_ROOT`
+  is set — and does not inject it when the variable is unset
+  ([#3133](https://github.com/melodic-software/claude-code-plugins/issues/3133)).
+
 ## [0.6.25]
 
 ### Fixed

--- a/plugins/typos-format/CHANGELOG.md
+++ b/plugins/typos-format/CHANGELOG.md
@@ -3,6 +3,29 @@
 All notable changes to the `typos-format` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.6.25]
+
+### Fixed
+
+- **hook:** notebook edits are spell-checked. The `PostToolUse` matcher listed only
+  `Write|Edit`, which the harness reads as exact-string alternation rather than a regex, so a
+  `NotebookEdit` never reached the hook and notebook content went unchecked
+  ([#3133](https://github.com/melodic-software/claude-code-plugins/issues/3133)). Registering
+  the tool alone would not have been enough: `NotebookEdit` carries its target as
+  `tool_input.notebook_path`, not `file_path`, so the hook would have fired and found no path
+  to check. The hook now accepts either key — an explicit `file_path` still wins — and normalizes
+  before the shared reader, which keeps that reader's project-membership and temp-tree scoping
+  the single gate a path passes through. `.ipynb` is not on the write allowlist, so a notebook
+  is scanned and disclosed, never rewritten in place.
+- **hook:** the agent-channel disclosure ceiling is 8,000 characters, down from 12,000. The
+  hooks reference caps hook output strings — `additionalContext` included — at 10,000, and
+  saves anything past that to a file, replacing it with a preview and a path. The old ceiling
+  sat 2,000 characters above that cap, so the hook's own truncation — which keeps the finding
+  counts and says that it truncated — could never fire first: a disclosure in that band was
+  demoted to a file pointer *after* write mode had already rewritten the file, which is the
+  outcome the ceiling exists to prevent
+  ([#3133](https://github.com/melodic-software/claude-code-plugins/issues/3133)).
+
 ## [0.6.24]
 
 ### Changed

--- a/plugins/typos-format/README.md
+++ b/plugins/typos-format/README.md
@@ -1,7 +1,8 @@
 # typos-format
 
 A Claude Code plugin that spell-checks the moment you edit any file. On every
-`Write` or `Edit` it runs [typos](https://github.com/crate-ci/typos) and
+`Write`, `Edit`, or `NotebookEdit` it runs
+[typos](https://github.com/crate-ci/typos) and
 surfaces findings back to Claude as advisory context — including remediation
 guidance for allowlisting a false positive. It is **report-only by default**;
 with the `typos_format_write_changes` opt-in it applies typos' safe

--- a/plugins/typos-format/README.md
+++ b/plugins/typos-format/README.md
@@ -8,11 +8,14 @@ guidance for allowlisting a false positive. It is **report-only by default**;
 with the `typos_format_write_changes` opt-in it applies typos' safe
 corrections in place and reports every correction it applied.
 
-It ships no rules of its own and runs unconditionally, using typos' built-in
-spelling dictionary. If your repository has its own typos configuration
-(`typos.toml`, `_typos.toml`, `.typos.toml`, `Cargo.toml` with
+It ships one fleet-wide protection of its own — a bundled
+`config/default-typos.toml` injected via `typos -c` so write mode cannot
+silently corrupt git SHAs — and otherwise runs unconditionally on typos'
+built-in spelling dictionary. If your repository has its own typos
+configuration (`typos.toml`, `_typos.toml`, `.typos.toml`, `Cargo.toml` with
 `[workspace.metadata.typos]`/`[package.metadata.typos]`, or `pyproject.toml`
-with `[tool.typos]`), typos discovers and honors it automatically — no
+with `[tool.typos]`), typos discovers it from the target path and merges
+`extend-*` keys with the bundled file rather than replacing them — no
 opt-in required.
 
 ## Behavior

--- a/plugins/typos-format/hooks/hooks.json
+++ b/plugins/typos-format/hooks/hooks.json
@@ -2,7 +2,7 @@
   "hooks": {
     "PostToolUse": [
       {
-        "matcher": "Write|Edit",
+        "matcher": "Write|Edit|NotebookEdit",
         "hooks": [
           {
             "type": "command",

--- a/plugins/typos-format/hooks/typos-format.sh
+++ b/plugins/typos-format/hooks/typos-format.sh
@@ -1,11 +1,13 @@
 #!/usr/bin/env bash
 # PostToolUse hook: spell-check via typos-cli (crate-ci/typos), REPORT-ONLY by
-# default. Triggered on Write|Edit of ANY file for the read-only scan — typos
-# is language-agnostic, unlike the sibling ruff-format/markdown-format hooks,
-# which are extension-scoped. Write mode (`typos_format_write_changes`) is a
-# different story: --write-changes is gated on an explicit extension allowlist
-# (#2650), so an unknown/fixture/binary-adjacent extension stays report-only
-# even when the opt-in is set.
+# default. Triggered on Write|Edit|NotebookEdit of ANY file for the read-only
+# scan — typos is language-agnostic, unlike the sibling
+# ruff-format/markdown-format hooks, which are extension-scoped. Write mode
+# (`typos_format_write_changes`) is a different story: --write-changes is gated
+# on an explicit extension allowlist (#2650), so an unknown/fixture/
+# binary-adjacent extension stays report-only even when the opt-in is set —
+# `.ipynb` is not on that allowlist, so a notebook is scanned and reported on,
+# never rewritten.
 #
 # ADVISORY: always exits 0. Findings surface via additionalContext but never
 # block the edit. A commit hook or CI is the hard gate.
@@ -96,15 +98,44 @@ emit_tel() {
 
 INPUT=$(hook::buffer_stdin) || exit 0
 
+# NotebookEdit carries its target as tool_input.notebook_path, NOT file_path
+# (verified against the tool's own input schema), so every path-reading step
+# below — the jq-free pre-filter and hook::read_file_path alike — sees nothing
+# for a notebook edit and the hook silently no-ops. Adding NotebookEdit to the
+# matcher alone would therefore fire the hook and change nothing.
+#
+# The key is normalized HERE rather than in hook::read_file_path because
+# hooks/hook-utils.sh is a registered byte-identical cross-plugin cluster
+# (scripts/cross-plugin-source-registry.txt, CI job hook-utils-sync): teaching
+# the shared reader about notebooks is a nine-plugin change and belongs in its
+# own pass. Normalizing the payload keeps the shared reader — and its
+# project-membership and temp-tree scoping, which is the load-bearing part —
+# the single place a path is admitted.
+
 # jq-free applicability pre-filter: never emit the jq notice when there is no
-# file_path at all (e.g. a tool_input shape this hook cannot act on regardless).
+# target path at all (e.g. a tool_input shape this hook cannot act on
+# regardless). Mirrors hook::raw_file_path's escaped-string match for the
+# notebook key, so a NotebookEdit payload reaches the jq gate like any other.
+raw_notebook_path() {
+  [[ "$1" =~ \"notebook_path\"[[:space:]]*:[[:space:]]*\"(([^\"\\]|\\.)*)\" ]] || return 1
+  [[ -n "${BASH_REMATCH[1]}" ]] || return 1
+  printf '%s' "${BASH_REMATCH[1]}"
+}
 # shellcheck disable=SC2034  # existence-only check; scan has no extension filter
 # (typos is language-agnostic). Write mode applies its own allowlist later (#2650).
-RAW_FILE=$(hook::raw_file_path "$INPUT") || exit 0
+RAW_FILE=$(hook::raw_file_path "$INPUT") || RAW_FILE=$(raw_notebook_path "$INPUT") || exit 0
 
 # jq is load-bearing for input parsing; absent → visible once-per-session skip
 # notice instead of a silent no-op (dim-9 doctrine).
 hook::require_jq PostToolUse typos-format "$INPUT"
+
+# Copy notebook_path onto file_path when only the former is present. An
+# explicit file_path always wins, so a payload carrying both is untouched; a
+# jq failure leaves $INPUT exactly as it arrived rather than emptying it.
+NORMALIZED_INPUT=$(printf '%s' "$INPUT" | jq -c '
+  if ((.tool_input.file_path // "") == "") and ((.tool_input.notebook_path // "") != "")
+  then .tool_input.file_path = .tool_input.notebook_path
+  else . end' 2>/dev/null) && [[ -n "$NORMALIZED_INPUT" ]] && INPUT="$NORMALIZED_INPUT"
 
 FILE=$(printf '%s' "$INPUT" | hook::read_file_path) || exit 0
 
@@ -606,20 +637,29 @@ fi
 # Trim the trailing newline the same way hook::ctx_flush does.
 CTX="${CTX%"${CTX##*[![:space:]]}"}"
 
-# Hard character ceiling, belt to the per-entry elision's braces. systemMessage
-# is documented at a 10,000-character cap
-# (docs/conventions/hook-observability/README.md, from the hooks reference), and
-# a disclosure that overruns it can be truncated or rejected by the channel
-# AFTER the file has already been rewritten — the one outcome this whole path
-# exists to prevent. The budget leaves headroom for JSON escaping, which can
-# expand a string well past its character count.
+# Hard character ceiling, belt to the per-entry elision's braces. The hooks
+# reference caps hook output strings — additionalContext, systemMessage and
+# plain stdout alike — at 10,000 characters, and saves anything past that to a
+# file, replacing it with a preview and a path. The disclosure is not lost, but
+# it stops being the inline account this hook just promised — and in write mode
+# the file has ALREADY been rewritten by then, which is the outcome this whole
+# path exists to prevent. Both budgets sit UNDER that documented cap, so THIS
+# hook's own truncation — which keeps the counts and says that it truncated —
+# is the one that fires, with headroom left for JSON escaping, which can expand
+# a string well past its character count: 4,000 for systemMessage (the
+# person-facing summary, deliberately the tighter of the two) and 8,000 for
+# additionalContext — a 20% margin under the cap, the agent channel carrying
+# the fuller finding list. The agent budget was previously 12,000 — 2,000
+# characters ABOVE the very cap this ceiling exists to respect, so it could
+# never fire first.
 #
 # DEFENCE IN DEPTH, not the working bound: at MAX_REPORT=10 entries × 60-char
 # elided tokens the message tops out near 1,100 characters, so this ceiling does
 # not fire today and its branch is exercised only if one of those numbers moves.
 # It is kept because both of them are tunable and the documented channel cap is
 # not — raise MAX_REPORT or the elision width far enough and this is the only
-# thing standing between a rewrite and a rejected disclosure. Cutting on bytes
+# thing standing between a rewrite and a disclosure the channel offloads to a
+# file the agent has to go and read. Cutting on bytes
 # rather than characters is deliberate: it can split a multi-byte sequence, and
 # a mangled tail character is a strictly better failure than an over-long
 # message the channel drops whole.
@@ -632,7 +672,7 @@ truncate_to() {
   fi
 }
 SYSMSG=$(truncate_to "$SYSMSG" 4000)
-CTX=$(truncate_to "$CTX" 12000)
+CTX=$(truncate_to "$CTX" 8000)
 
 hook::emit_channels PostToolUse "$CTX" "$SYSMSG"
 

--- a/plugins/typos-format/hooks/typos-format.test.sh
+++ b/plugins/typos-format/hooks/typos-format.test.sh
@@ -905,6 +905,111 @@ else
   ok "stub/long: long tokens are elided in the rendered report"
 fi
 
+# --- The agent-channel ceiling must sit under the documented channel cap -----
+# Asserted on the CONSTANT, not on a rendered message: per-entry elision caps
+# the rendered report near 1,100 characters, so any "the emitted disclosure is
+# under N" assertion passes for every N above that and would stay green with
+# the ceiling put back over the cap. The hooks reference caps hook output
+# strings — additionalContext included — at 10,000 characters; a ceiling above
+# that is the channel truncating or dropping a disclosure the hook believed it
+# had delivered. Read the same way this suite already reads MAX_REPORT.
+# shellcheck disable=SC2016  # the sed script matches the hook's literal source text
+CTX_CEIL="$(sed -n 's/^CTX=$(truncate_to "\$CTX" \([0-9][0-9]*\)).*/\1/p' "$HOOK" | head -1)"
+# shellcheck disable=SC2016  # ditto
+SYS_CEIL="$(sed -n 's/^SYSMSG=$(truncate_to "\$SYSMSG" \([0-9][0-9]*\)).*/\1/p' "$HOOK" | head -1)"
+if [[ -z "$CTX_CEIL" || -z "$SYS_CEIL" ]]; then
+  fail "stub/ceiling: could not read the truncate_to ceilings from the hook (ctx='$CTX_CEIL' sys='$SYS_CEIL')"
+else
+  if ((CTX_CEIL <= 10000)); then
+    ok "stub/ceiling: the agent-channel ceiling ($CTX_CEIL) is at or under the documented 10,000-character cap"
+  else
+    fail "stub/ceiling: the agent-channel ceiling is $CTX_CEIL — above the documented 10,000-character cap"
+  fi
+  if ((SYS_CEIL <= 10000)); then
+    ok "stub/ceiling: the user-channel ceiling ($SYS_CEIL) is at or under the documented 10,000-character cap"
+  else
+    fail "stub/ceiling: the user-channel ceiling is $SYS_CEIL — above the documented 10,000-character cap"
+  fi
+fi
+
+# --- NotebookEdit reaches the hook, and reaches it with a usable path --------
+# NotebookEdit carries its target as tool_input.notebook_path; every other
+# tool this hook matches carries file_path. Registering NotebookEdit in the
+# matcher without teaching the hook that key fires the hook and produces
+# nothing, so both halves are pinned here: the registration (read out of
+# hooks.json, which no behavioral case can see) and the payload handling.
+HOOKS_JSON="$HOOK_DIR/hooks.json"
+if jq -e '[.hooks.PostToolUse[].matcher] | any(. == "Write|Edit|NotebookEdit")' "$HOOKS_JSON" >/dev/null 2>&1; then
+  ok "notebook/matcher: hooks.json registers NotebookEdit alongside Write and Edit"
+else
+  fail "notebook/matcher: NotebookEdit is not in the PostToolUse matcher: $(jq -c '[.hooks.PostToolUse[].matcher]' "$HOOKS_JSON" 2>&1)"
+fi
+
+# Same stub, same file, two payload shapes: a NotebookEdit carrying only
+# notebook_path must produce the byte-identical disclosure a Write carrying
+# file_path does.
+run_stub_notebook() {
+  local notebook_path="$1"
+  shift
+  (
+    cd "$UNRELATED" || return 1
+    printf '{"session_id":"stub-1","tool_input":{"notebook_path":"%s","new_source":"x"},"tool_name":"NotebookEdit"}' "$notebook_path" |
+      env -u CLAUDE_PROJECT_DIR PATH="$STUB_BIN:$PATH" \
+        CLAUDE_PLUGIN_OPTION_TYPOS_FORMAT_ENABLED=true \
+        CLAUDE_PLUGIN_OPTION_TYPOS_FORMAT_WRITE_CHANGES=true "$@" bash "$HOOK"
+  )
+}
+
+NB="$STUB_REPO/notebook.ipynb"
+printf '{"cells":[{"source":["this has teh typo"]}]}\n' >"$NB" # spellchecker:disable-line
+NB_BEFORE="$(cat "$NB")"
+OUT_NB=$(run_stub_notebook "$NB")
+RC_NB=$?
+CTX_NB=$(printf '%s' "$OUT_NB" | jq -r '.hookSpecificOutput.additionalContext // empty' 2>/dev/null)
+OUT_NBW=$(run_stub "$NB")
+CTX_NBW=$(printf '%s' "$OUT_NBW" | jq -r '.hookSpecificOutput.additionalContext // empty' 2>/dev/null)
+if [[ $RC_NB -eq 0 ]]; then
+  ok "notebook/payload: exit 0 (advisory)"
+else
+  fail "notebook/payload: exit $RC_NB"
+fi
+if [[ -n "$CTX_NB" ]] && printf '%s' "$CTX_NB" | grep -qF 'teh'; then # spellchecker:disable-line
+  ok "notebook/payload: a notebook_path-only payload produces the finding disclosure"
+else
+  fail "notebook/payload: no disclosure for a notebook_path-only payload (the hook saw no path): '$CTX_NB'"
+fi
+if [[ "$CTX_NB" == "$CTX_NBW" ]]; then
+  ok "notebook/payload: the notebook_path disclosure matches the file_path disclosure for the same file"
+else
+  fail "notebook/payload: notebook_path and file_path disagree:\n  notebook: $CTX_NB\n  file:     $CTX_NBW"
+fi
+# .ipynb is not on the write allowlist, so write mode degrades to report-only
+# for it: a notebook is scanned and disclosed, never rewritten in place (a
+# whole-file dictionary rewrite of notebook JSON would reach cell ids and
+# encoded outputs, not only prose).
+if [[ "$(cat "$NB")" == "$NB_BEFORE" ]]; then
+  ok "notebook/payload: write mode leaves the notebook byte-identical (extension not write-allowlisted)"
+else
+  fail "notebook/payload: the notebook was rewritten: $(cat "$NB")"
+fi
+
+# An explicit file_path always wins; a payload carrying both is not rerouted.
+printf 'this has teh typo\n' >"$STUB_REPO/both.txt" # spellchecker:disable-line
+OUT_BOTH=$(
+  cd "$UNRELATED" || exit 1
+  printf '{"session_id":"stub-1","tool_input":{"file_path":"%s","notebook_path":"%s"},"tool_name":"NotebookEdit"}' \
+    "$STUB_REPO/both.txt" "$NB" |
+    env -u CLAUDE_PROJECT_DIR PATH="$STUB_BIN:$PATH" \
+      CLAUDE_PLUGIN_OPTION_TYPOS_FORMAT_ENABLED=true \
+      CLAUDE_PLUGIN_OPTION_TYPOS_FORMAT_WRITE_CHANGES=true bash "$HOOK"
+)
+CTX_BOTH=$(printf '%s' "$OUT_BOTH" | jq -r '.hookSpecificOutput.additionalContext // empty' 2>/dev/null)
+if printf '%s' "$CTX_BOTH" | grep -qF 'both.txt' && ! printf '%s' "$CTX_BOTH" | grep -qF 'notebook.ipynb'; then
+  ok "notebook/precedence: an explicit file_path wins over notebook_path"
+else
+  fail "notebook/precedence: expected both.txt in the disclosure, got: $CTX_BOTH"
+fi
+
 # --- A broken write pass must not be read as "everything was applied" --------
 printf 'this has teh typo and wnat too\n' >"$STUB_REPO/break.txt" # spellchecker:disable-line
 OUT_BR=$(run_stub "$STUB_REPO/break.txt" STUB_BREAK=1)

--- a/plugins/typos-format/hooks/typos-format.test.sh
+++ b/plugins/typos-format/hooks/typos-format.test.sh
@@ -1356,6 +1356,32 @@ else
   fail "config precedence wrong: $(cat "$REPO_PREC/p.txt")"
 fi
 
+# --- bundled -c merges with repo _typos.toml (extend-ignore-re) -------------
+# The hook injects `-c <plugin>/config/default-typos.toml` whenever
+# CLAUDE_PLUGIN_ROOT is set. That file's header claims a merge; if `-c`
+# replaced the discovered config, a repo `spellchecker:disable-line` pragma
+# would be lost and write mode would "fix" the protected line (#3133 F1).
+PLUGIN_ROOT="$(cd "$HOOK_DIR/.." && pwd)"
+REPO_CMERGE="$WORK/c-merge"
+new_typos_repo "$REPO_CMERGE" NO_CONFIG
+printf '[default]\nextend-ignore-re = [".*spellchecker:disable-line.*"]\n' >"$REPO_CMERGE/_typos.toml"
+# spellchecker:off
+printf 'recieve  # spellchecker:disable-line\n' >"$REPO_CMERGE/protected.txt"
+# spellchecker:on
+BEFORE=$(cat "$REPO_CMERGE/protected.txt")
+run_hook_env "$REPO_CMERGE/protected.txt" \
+  -u CLAUDE_PROJECT_DIR \
+  CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" \
+  CLAUDE_PLUGIN_OPTION_TYPOS_FORMAT_ENABLED=true \
+  CLAUDE_PLUGIN_OPTION_TYPOS_FORMAT_WRITE_CHANGES=true \
+  PATH="$(dirname "$REAL_TYPOS"):$PATH" >/dev/null
+AFTER=$(cat "$REPO_CMERGE/protected.txt")
+if [[ "$AFTER" == "$BEFORE" ]]; then
+  ok "bundled -c merges repo extend-ignore-re (pragma-protected line not rewritten)"
+else
+  fail "bundled -c overrode repo _typos.toml: $AFTER"
+fi
+
 # --- Case 3: config present + clean file -> exit 0, empty stdout ------------
 REPO="$WORK/consumer"
 new_typos_repo "$REPO"

--- a/plugins/typos-format/hooks/typos-format.test.sh
+++ b/plugins/typos-format/hooks/typos-format.test.sh
@@ -136,9 +136,13 @@ run_hook_env() {
 # Exit codes mirror typos-cli 1.44.0 as verified against the real binary:
 # 0 = nothing left to report, 2 = findings remain. jsonlines on stdout.
 STUB_BIN="$(mktemp -d "$WORK/stubbin.XXXXXX")"
+PLUGIN_ROOT="$(cd "$HOOK_DIR/.." && pwd)"
 cat >"$STUB_BIN/typos" <<'STUB'
 #!/usr/bin/env bash
 set -uo pipefail
+if [[ -n "${STUB_LOG_ARGV:-}" ]]; then
+  printf '%s\n' "$*" >>"$STUB_LOG_ARGV"
+fi
 write=0
 target=""
 skip_next=0
@@ -359,6 +363,29 @@ if [[ -z "$(printf '%s' "$OUT_DEF" | jq -r '.systemMessage // empty' 2>/dev/null
   ok "stub/default: no user-channel message (nothing was mutated)"
 else
   fail "stub/default: emitted a systemMessage without mutating anything"
+fi
+
+# --- Bundled -c is passed whenever CLAUDE_PLUGIN_ROOT is set -----------------
+# The real-binary merge pin below needs `typos` on PATH, which CI's plugin-gate
+# job does not install. This stub records argv, so the same `-c <bundled toml>`
+# injection is asserted on every run — including stock ubuntu-24.04 CI.
+printf 'plain line\n' >"$STUB_REPO/cmerge-argv.txt"
+: >"$WORK/stub-argv.log"
+run_stub_default "$STUB_REPO/cmerge-argv.txt" \
+  CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" \
+  STUB_LOG_ARGV="$WORK/stub-argv.log" >/dev/null
+if grep -q -- '-c ' "$WORK/stub-argv.log" && grep -q 'default-typos.toml' "$WORK/stub-argv.log"; then
+  ok "stub/bundled-c: -c default-typos.toml is passed when CLAUDE_PLUGIN_ROOT is set"
+else
+  fail "stub/bundled-c: expected -c bundled config on argv: $(cat "$WORK/stub-argv.log")"
+fi
+: >"$WORK/stub-argv.log"
+run_stub_default "$STUB_REPO/cmerge-argv.txt" \
+  STUB_LOG_ARGV="$WORK/stub-argv.log" >/dev/null
+if grep -q -- '-c ' "$WORK/stub-argv.log"; then
+  fail "stub/bundled-c: -c leaked onto argv without CLAUDE_PLUGIN_ROOT: $(cat "$WORK/stub-argv.log")"
+else
+  ok "stub/bundled-c: no -c when CLAUDE_PLUGIN_ROOT is unset"
 fi
 
 # --- Report-only can also be pinned explicitly (option set to false) ---------
@@ -1361,7 +1388,6 @@ fi
 # CLAUDE_PLUGIN_ROOT is set. That file's header claims a merge; if `-c`
 # replaced the discovered config, a repo `spellchecker:disable-line` pragma
 # would be lost and write mode would "fix" the protected line (#3133 F1).
-PLUGIN_ROOT="$(cd "$HOOK_DIR/.." && pwd)"
 REPO_CMERGE="$WORK/c-merge"
 new_typos_repo "$REPO_CMERGE" NO_CONFIG
 printf '[default]\nextend-ignore-re = [".*spellchecker:disable-line.*"]\n' >"$REPO_CMERGE/_typos.toml"

--- a/plugins/typos-format/hooks/typos-format.test.sh
+++ b/plugins/typos-format/hooks/typos-format.test.sh
@@ -293,6 +293,7 @@ run_stub_default() {
     cd "$UNRELATED" || return 1
     printf '{"session_id":"stub-1","tool_input":{"file_path":"%s"},"tool_name":"Write"}' "$file_path" |
       env -u CLAUDE_PROJECT_DIR -u CLAUDE_PLUGIN_OPTION_TYPOS_FORMAT_WRITE_CHANGES \
+        -u CLAUDE_PLUGIN_ROOT \
         PATH="$STUB_BIN:$PATH" \
         CLAUDE_PLUGIN_OPTION_TYPOS_FORMAT_ENABLED=true "$@" bash "$HOOK"
   )

--- a/plugins/typos-format/skills/setup/SKILL.md
+++ b/plugins/typos-format/skills/setup/SKILL.md
@@ -45,10 +45,12 @@ restores the FAIL semantics.
    running.
 4. **Consumer typos config (informational only)** — the hook runs unconditionally and never
    gates on a config existing; typos resolves its own governing config (if any) directly from
-   the file path it is given. Report whether a `typos.toml`, `_typos.toml`, `.typos.toml`, a
-   `Cargo.toml` with `[workspace.metadata.typos]`/`[package.metadata.typos]`, or a
-   `pyproject.toml` with `[tool.typos]` governs the repo, purely as INFO — its presence or
-   absence never changes whether the hook runs.
+   the file path it is given. The hook also injects its bundled
+   `config/default-typos.toml` via `typos -c` (SHA `extend-ignore-re`); `extend-*` keys
+   merge with the discovered file rather than replacing it. Report whether a `typos.toml`,
+   `_typos.toml`, `.typos.toml`, a `Cargo.toml` with `[workspace.metadata.typos]`/
+   `[package.metadata.typos]`, or a `pyproject.toml` with `[tool.typos]` governs the repo,
+   purely as INFO — its presence or absence never changes whether the hook runs.
 5. **Hook toggle** — report the effective `typos_format_enabled` value:
    `${user_config.typos_format_enabled}` (unexpanded or empty means default `true`).
 6. **Write mode** — report the effective `typos_format_write_changes` value:


### PR DESCRIPTION
Closes #3133

## Summary

The typos-format hook never fired on `NotebookEdit`, and its agent-channel disclosure ceiling sat above the platform's 10,000-character cap. The bundled `-c` config was also undocumented; a write-mode fixture now pins that it merges with a repo `_typos.toml` rather than replacing it.

## Fix

- Register `NotebookEdit` on the PostToolUse matcher (`Write|Edit|NotebookEdit`) and accept `tool_input.notebook_path` (an explicit `file_path` still wins), so notebook cells are spell-checked. `.ipynb` stays off the write allowlist.
- Lower the agent-channel disclosure ceiling from 12,000 to 8,000 characters, matching the posture of the existing 4,000-character user-channel ceiling.
- Document the bundled `config/default-typos.toml` `-c` injection in README and setup. A write-mode fixture with a repo `spellchecker:disable-line` pragma stays unrewritten when `CLAUDE_PLUGIN_ROOT` injects `-c`, pinning the merge for `extend-*` keys. Write-before-disclosure ordering (F4) is unchanged.

## Verification

`bash plugins/typos-format/hooks/typos-format.test.sh` — PASS=130 FAIL=0, including the new NotebookEdit payload cases and the bundled `-c` merge pin.

Decisive `-c` experiment (typos-cli 1.42.1): a repo `extend-ignore-re` for `spellchecker:disable-line` and a repo `extend-words` allowlist survive `-c` injection byte-identically. F1 as an override bug does not hold; the test pins that merge so it cannot regress silently.

`check-changelog-parity.sh --check-bump origin/main` passes (0.6.25).

## Related

- #3128 — skip-latch asymmetry (F2) and the two plugin-quality refutations; out of scope here
- F4 (write-before-disclosure) is a deliberate design tradeoff, left for a separate maintainer call
