### PR TITLE
fix(scripts): validate the check-only carve-out's surface, not the keyword

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1223,6 +1223,14 @@ jobs:
       - name: Run shared test-harness tests
         if: needs.scope.outputs.run_full == 'true'
         run: bash scripts/lib/test-harness.test.sh
+      # Same reason again — run-plugin-tests.sh never reaches scripts/. The
+      # self-test runs first so a broken validator cannot mask a regression
+      # behind a green gate: no shipping plugin violates the check-only
+      # carve-out assertions, so the shipping tree alone proves nothing about
+      # them and only these fixtures show the gate still goes red (#3137).
+      - name: Run plugin-contract validator tests
+        if: needs.scope.outputs.run_full == 'true'
+        run: bash scripts/validate-plugin-contracts.test.sh
       - name: Validate plugin and catalog manifests
         if: needs.scope.outputs.run_full == 'true'
         run: scripts/validate-plugins.sh

--- a/scripts/docs-only-paths.txt
+++ b/scripts/docs-only-paths.txt
@@ -14,7 +14,8 @@
 #   1. The prefix must feed no code lane. Today the lanes this gate wraps are:
 #      - plugin-gate: hermetic plugins/**/*.test.sh, then manifest + catalog +
 #        cheat-sheet validation (reads docs/CATALOG.md, docs/PLUGIN-ARTIFACT-PROTOCOL.md,
-#        docs/CATALOG-TAXONOMY.md, docs/SKILL-CHEAT-SHEET.md — the sheet
+#        docs/CATALOG-TAXONOMY.md, docs/SKILL-CHEAT-SHEET.md,
+#        docs/conventions/config-cascade/README.md — the sheet
 #        deliberately lives OUTSIDE docs/topics/ so an edit to it is never
 #        docs-only and its drift gate always runs), plus the native-overlap
 #        registry checks, which read docs/native-surfaces/** and

--- a/scripts/validate-plugin-contracts.mjs
+++ b/scripts/validate-plugin-contracts.mjs
@@ -138,9 +138,10 @@ function readTrackedConfigOwners() {
   for (const line of lines.slice(heading + 1)) {
     if (/^##\s/.test(line)) break;
     if (!line.startsWith("|")) continue;
-    // Column 1 names the surface, and names co-consuming plugins alongside it
-    // ("`standards` (`planning`, `review`)"), so every backticked token in the
-    // cell is an owner.
+    // Column 1 names the surface, and where the surface name is not itself the
+    // owning plugin it names the plugins alongside it ("`standards`
+    // (`planning`, `review`)"), so every backticked token in the cell is taken
+    // as an owner. Tokens naming no plugin directory are inert.
     for (const [, name] of (line.split("|")[1] ?? "").matchAll(/`([^`]+)`/g)) {
       owners.add(name);
     }
@@ -176,7 +177,8 @@ for (const path of setupSkills) {
   }
   // Uniform contract shape (PLUGIN-PHILOSOPHY "Setup is explicit and repeatable"):
   // check is the default read-only action; apply exists unless the skill declares the
-  // userConfig-only check-only carve-out the doctrine sanctions.
+  // check-only carve-out the doctrine sanctions, whose three qualifying surfaces
+  // are checked below — native userConfig is one of them, not the whole set.
   if (!/^argument-hint:\s*"check(?:\s*\||\s*\[|")/m.test(frontmatter)) {
     fail(path, 'setup skills must declare check as the leading action in argument-hint ("check", "check | apply ...", or "check [<subaction>]")');
   }
@@ -185,7 +187,7 @@ for (const path of setupSkills) {
     fail(path, "setup skills must document the read-only check action");
   }
   if (!/`apply`/.test(body) && !/check-only/i.test(body)) {
-    fail(path, "setup skills must document apply, or declare the check-only userConfig-only carve-out");
+    fail(path, "setup skills must document apply, or declare the check-only carve-out and the surface qualifying it");
   }
 
   // Which shape a setup skill takes is declared where a reader and a gate can

--- a/scripts/validate-plugin-contracts.mjs
+++ b/scripts/validate-plugin-contracts.mjs
@@ -136,7 +136,7 @@ function readTrackedConfigOwners() {
   }
   const owners = new Set();
   for (const line of lines.slice(heading + 1)) {
-    if (/^##\s/.test(line)) break;
+    if (/^#{1,6}\s/.test(line)) break;
     if (!line.startsWith("|")) continue;
     // Column 1 names the surface, and where the surface name is not itself the
     // owning plugin it names the plugins alongside it ("`standards`
@@ -208,6 +208,12 @@ for (const path of setupSkills) {
   // its prose says, so the carve-out's preconditions are checked there rather
   // than on the presence of the words "check-only" anywhere in the body.
   const offersApply = /^argument-hint:\s*"[^"]*\bapply\b/m.test(frontmatter);
+  if (offersApply && !/`apply`/.test(body)) {
+    fail(
+      path,
+      "a setup skill advertising apply in argument-hint must document the apply action",
+    );
+  }
   if (!offersApply) {
     const plugin = relative(pluginRoot, path).split(sep)[0];
     if (!/check-only/i.test(body)) {

--- a/scripts/validate-plugin-contracts.mjs
+++ b/scripts/validate-plugin-contracts.mjs
@@ -158,6 +158,14 @@ function readTrackedConfigOwners() {
 
 const trackedConfigOwners = readTrackedConfigOwners();
 
+function claimsUserConfigSurface(body) {
+  const withoutNegation = body.replace(
+    /\b(?:no|not|without|never)\s+`?userConfig`?/gi,
+    "",
+  );
+  return /\buserConfig\b/.test(withoutNegation);
+}
+
 function declaresUserConfig(plugin) {
   const manifest = join(pluginRoot, plugin, ".claude-plugin", "plugin.json");
   if (!existsSync(manifest)) return false;
@@ -177,8 +185,12 @@ for (const path of setupSkills) {
   }
   // Uniform contract shape (PLUGIN-PHILOSOPHY "Setup is explicit and repeatable"):
   // check is the default read-only action; apply exists unless the skill declares the
-  // check-only carve-out the doctrine sanctions, whose three qualifying surfaces
-  // are checked below — native userConfig is one of them, not the whole set.
+  // check-only carve-out the doctrine sanctions. The registry check below is the
+  // writable-artifact exclusion (tracked consumer config). Native userConfig is
+  // the one carve-out surface with a manifest-side counterpart; the other two
+  // doctrine surfaces (settings this contract forbids setup to mutate; external
+  // prerequisites) have no such signal and are covered by the check-only
+  // declaration plus the registry exclusion, not by a second existence probe.
   if (!/^argument-hint:\s*"check(?:\s*\||\s*\[|")/m.test(frontmatter)) {
     fail(path, 'setup skills must declare check as the leading action in argument-hint ("check", "check | apply ...", or "check [<subaction>]")');
   }
@@ -207,10 +219,13 @@ for (const path of setupSkills) {
         "the check-only carve-out is unavailable here: this plugin owns the tracked consumer config surface registered in docs/conventions/config-cascade/README.md, and \"A plugin with even one writable owned artifact takes the narrow-write shape instead\"",
       );
     }
-    // The one carve-out surface with a manifest-side counterpart. Claiming it
-    // while declaring no userConfig names a surface the plugin does not have.
-    if (/userConfig-only carve-out/i.test(body) && !declaresUserConfig(plugin)) {
-      fail(path, "the userConfig-only carve-out requires the plugin manifest to declare userConfig, and this one declares none");
+    // The one carve-out surface with a manifest-side counterpart. Any claim
+    // that names that surface — the doctrine's "native userConfig surface"
+    // wording included — requires the manifest to declare it. Matching only
+    // the phrase "userConfig-only carve-out" would let a different spelling
+    // of the same claim pass.
+    if (claimsUserConfigSurface(body) && !declaresUserConfig(plugin)) {
+      fail(path, "a check-only skill that names the userConfig surface requires the plugin manifest to declare userConfig, and this one declares none");
     }
   }
 }

--- a/scripts/validate-plugin-contracts.mjs
+++ b/scripts/validate-plugin-contracts.mjs
@@ -97,6 +97,77 @@ const setupSkills = pluginFiles.filter((path) =>
   /[\\/]skills[\\/]setup[\\/]SKILL\.md$/.test(path),
 );
 
+// PLUGIN-PHILOSOPHY's check-only carve-out is a consequence of a plugin's
+// surface, not a claim it may assert: "A plugin with even one writable owned
+// artifact takes the narrow-write shape instead." Tracked consumer config is
+// the writable artifact class this repo already registers, in the Implementers
+// table of docs/conventions/config-cascade/README.md — a signal that lives
+// OUTSIDE the setup skill whose claim is being checked, which is the whole
+// point. Reading ownership out of the declaring skill's own prose would let a
+// plugin certify itself, and would misread the carve-out's own second surface,
+// whose conforming `check` prints the exact settings edit it may not write.
+const configCascadeRegistry = join(
+  root,
+  "docs",
+  "conventions",
+  "config-cascade",
+  "README.md",
+);
+
+// The plugin names in that table's first column, or null when the table cannot
+// be read. Null is a recorded failure, never a quiet pass: a check that
+// degrades to a no-op when its input moves is worse than no check at all.
+function readTrackedConfigOwners() {
+  if (!existsSync(configCascadeRegistry)) {
+    fail(
+      configCascadeRegistry,
+      "the consumer-config registry is required to validate the check-only carve-out",
+    );
+    return null;
+  }
+  const lines = read(configCascadeRegistry).split(/\r?\n/);
+  const heading = lines.findIndex((line) => /^##\s+Implementers\s*$/.test(line));
+  if (heading === -1) {
+    fail(
+      configCascadeRegistry,
+      'the consumer-config registry must carry an "## Implementers" section naming every surface that owns tracked consumer config',
+    );
+    return null;
+  }
+  const owners = new Set();
+  for (const line of lines.slice(heading + 1)) {
+    if (/^##\s/.test(line)) break;
+    if (!line.startsWith("|")) continue;
+    // Column 1 names the surface, and names co-consuming plugins alongside it
+    // ("`standards` (`planning`, `review`)"), so every backticked token in the
+    // cell is an owner.
+    for (const [, name] of (line.split("|")[1] ?? "").matchAll(/`([^`]+)`/g)) {
+      owners.add(name);
+    }
+  }
+  if (owners.size === 0) {
+    fail(
+      configCascadeRegistry,
+      "the consumer-config registry's Implementers table named no surfaces; the check-only carve-out cannot be validated against it",
+    );
+    return null;
+  }
+  return owners;
+}
+
+const trackedConfigOwners = readTrackedConfigOwners();
+
+function declaresUserConfig(plugin) {
+  const manifest = join(pluginRoot, plugin, ".claude-plugin", "plugin.json");
+  if (!existsSync(manifest)) return false;
+  const userConfig = JSON.parse(read(manifest)).userConfig;
+  return (
+    typeof userConfig === "object" &&
+    userConfig !== null &&
+    Object.keys(userConfig).length > 0
+  );
+}
+
 for (const path of setupSkills) {
   const content = read(path);
   const frontmatter = content.match(/^---\r?\n([\s\S]*?)\r?\n---/)?.[1] ?? "";
@@ -115,6 +186,30 @@ for (const path of setupSkills) {
   }
   if (!/`apply`/.test(body) && !/check-only/i.test(body)) {
     fail(path, "setup skills must document apply, or declare the check-only userConfig-only carve-out");
+  }
+
+  // Which shape a setup skill takes is declared where a reader and a gate can
+  // both see it: the action list in argument-hint, already constrained above to
+  // lead with check. A skill offering no apply is taking the carve-out, whatever
+  // its prose says, so the carve-out's preconditions are checked there rather
+  // than on the presence of the words "check-only" anywhere in the body.
+  const offersApply = /^argument-hint:\s*"[^"]*\bapply\b/m.test(frontmatter);
+  if (!offersApply) {
+    const plugin = relative(pluginRoot, path).split(sep)[0];
+    if (!/check-only/i.test(body)) {
+      fail(path, "a setup skill offering no apply must declare the check-only carve-out it relies on");
+    }
+    if (trackedConfigOwners?.has(plugin)) {
+      fail(
+        path,
+        "the check-only carve-out is unavailable here: this plugin owns the tracked consumer config surface registered in docs/conventions/config-cascade/README.md, and \"A plugin with even one writable owned artifact takes the narrow-write shape instead\"",
+      );
+    }
+    // The one carve-out surface with a manifest-side counterpart. Claiming it
+    // while declaring no userConfig names a surface the plugin does not have.
+    if (/userConfig-only carve-out/i.test(body) && !declaresUserConfig(plugin)) {
+      fail(path, "the userConfig-only carve-out requires the plugin manifest to declare userConfig, and this one declares none");
+    }
   }
 }
 

--- a/scripts/validate-plugin-contracts.test.sh
+++ b/scripts/validate-plugin-contracts.test.sh
@@ -1,0 +1,278 @@
+#!/usr/bin/env bash
+# Black-box contract test for the check-only carve-out assertions in
+# validate-plugin-contracts.mjs.
+#
+# Self-contained: builds a throwaway plugins/ tree plus a fixture
+# config-cascade registry in an mktemp dir and runs the real validator with
+# that dir as cwd, which is the only root the validator knows (it reads
+# process.cwd() and resolves nothing relative to its own location, so no copy
+# of the script is needed). Mutates only its own mktemp dir.
+#
+# A green run on the current repo tree is not evidence these assertions work:
+# no shipping plugin violates them. The fixtures below prove the gate goes red
+# on the four failure classes #3137 named -- a plugin taking the carve-out
+# while owning a registered tracked-config surface, a carve-out-shaped skill
+# that never declares the carve-out, a userConfig-only claim from a manifest
+# declaring no userConfig, and a registry the gate can no longer read -- and
+# the paired inverses prove it stays green for the two conforming shapes.
+#
+# A fixture root always trips the unrelated repo-wide checks (the shared
+# lifecycle artifact protocol and its five plugin copies), so every assertion
+# here is on the presence or absence of a SPECIFIC failure line, never on the
+# aggregate exit code. The one exit-code assertion is the closing real-corpus
+# case.
+#
+# Bespoke PASS/FAIL counters by design, not drift: this is repo tooling, not a
+# plugin, so no plugin assertion library applies here -- see
+# docs/conventions/shell-test-helpers/README.md.
+# shellcheck disable=SC2016  # fixture rows are literal markdown; the backticks they carry are content, never expansion
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SUT="$SCRIPT_DIR/validate-plugin-contracts.mjs"
+
+if ! command -v node >/dev/null 2>&1; then
+  echo "error: node not on PATH; the validator cannot be exercised" >&2
+  exit 2
+fi
+
+fails=0
+pass() { printf 'ok   - %s\n' "$1"; }
+fail() {
+  printf 'FAIL - %s\n' "$1" >&2
+  fails=$((fails + 1))
+}
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+OWNS_TRACKED_CONFIG='the check-only carve-out is unavailable here'
+NO_DECLARATION='must declare the check-only carve-out it relies on'
+NO_USER_CONFIG='requires the plugin manifest to declare userConfig'
+REGISTRY_MISSING='the consumer-config registry is required'
+REGISTRY_UNSTRUCTURED='must carry an "## Implementers" section'
+REGISTRY_EMPTY='named no surfaces'
+
+reset_fixture() {
+  rm -rf "$TMP/plugins" "$TMP/docs"
+  mkdir -p "$TMP/plugins"
+  write_registry
+}
+
+# write_registry [surface ...] -- the Implementers table the validator reads as
+# the set of plugins owning a tracked consumer config surface. Called with no
+# arguments it still carries one unrelated row, so an empty table is only ever
+# asserted deliberately.
+write_registry() {
+  mkdir -p "$TMP/docs/conventions/config-cascade"
+  {
+    echo '# Consumer config cascade (fixture)'
+    echo
+    echo '## Deviations'
+    echo
+    echo '| Surface | Note |'
+    echo '|---|---|'
+    echo '| `not-an-implementer` | a row outside the Implementers table |'
+    echo
+    echo '## Implementers'
+    echo
+    echo '| Surface | Consumer config path | Layers | Conformance |'
+    echo '|---|---|---|---|'
+    local surface
+    for surface in "$@"; do
+      printf '| `%s` | `.claude/%s.md` | all three | conforms |\n' "$surface" "$surface"
+    done
+    echo
+    echo '### Overlay spelling drift'
+    echo
+    echo 'Prose after the table.'
+  } >"$TMP/docs/conventions/config-cascade/README.md"
+}
+
+# make_plugin <name> <user-config-keys> -- an empty string declares no
+# userConfig at all.
+make_plugin() {
+  local plugin="$1" keys="$2" user_config='' key first=1
+  mkdir -p "$TMP/plugins/$plugin/.claude-plugin"
+  if [[ -n "$keys" ]]; then
+    for key in $keys; do
+      if ((first)); then first=0; else user_config="$user_config, "; fi
+      user_config="$user_config\"$key\": {\"type\": \"string\", \"title\": \"$key\"}"
+    done
+    user_config=", \"userConfig\": {$user_config}"
+  fi
+  printf '{"name": "%s", "version": "0.1.0", "description": "fixture"%s}\n' \
+    "$plugin" "$user_config" >"$TMP/plugins/$plugin/.claude-plugin/plugin.json"
+}
+
+# write_setup_skill <plugin> <argument-hint> -- body arrives on stdin.
+write_setup_skill() {
+  local plugin="$1" hint="$2"
+  mkdir -p "$TMP/plugins/$plugin/skills/setup"
+  {
+    echo '---'
+    printf 'description: "Fixture setup skill for %s."\n' "$plugin"
+    printf 'argument-hint: "%s"\n' "$hint"
+    echo 'user-invocable: true'
+    echo 'disable-model-invocation: true'
+    echo '---'
+    echo
+    cat
+  } >"$TMP/plugins/$plugin/skills/setup/SKILL.md"
+}
+
+# The conforming carve-out body: check-only, naming the native userConfig
+# surface, exactly as the five shipping carve-out skills word it.
+carve_out_body() {
+  cat <<'BODY'
+## Purpose
+
+Check-only per the uniform setup contract's userConfig-only carve-out: this plugin's entire
+configuration surface is native `userConfig`, so `check` (the default and only action) verifies
+and reports, and reconfiguration routes through Claude Code's native flow.
+BODY
+}
+
+run_fixture() { (cd "$TMP" && node "$SUT" 2>&1); }
+
+# --- 1. Conforming carve-out: no apply, declares it, userConfig-backed, not a
+#        registered tracked-config owner -> no carve-out failure. ------------
+reset_fixture
+make_plugin alpha alpha_api_key
+carve_out_body | write_setup_skill alpha check
+out="$(run_fixture)"
+if grep -q "$OWNS_TRACKED_CONFIG" <<<"$out" ||
+  grep -q "$NO_DECLARATION" <<<"$out" ||
+  grep -q "$NO_USER_CONFIG" <<<"$out"; then
+  fail "a conforming userConfig-only carve-out should raise no carve-out failure: $out"
+else
+  pass "a conforming userConfig-only carve-out passes the carve-out assertions"
+fi
+
+# --- 2. #3137's own failure class: the same skill, but the plugin owns a
+#        tracked consumer config surface the registry records. ---------------
+reset_fixture
+write_registry alpha
+make_plugin alpha alpha_api_key
+carve_out_body | write_setup_skill alpha check
+out="$(run_fixture)"
+if grep -q "$OWNS_TRACKED_CONFIG" <<<"$out" &&
+  grep -q 'narrow-write shape' <<<"$out" &&
+  grep -qE 'alpha[/\\]skills[/\\]setup[/\\]SKILL\.md' <<<"$out"; then
+  pass "a carve-out claim from a plugin owning tracked consumer config fails the gate"
+else
+  fail "a registered tracked-config owner should not reach the carve-out: $out"
+fi
+
+# --- 3. The substring the old gate accepted is no longer the pass condition:
+#        a carve-out-shaped skill whose body only mentions apply in prose. ---
+reset_fixture
+make_plugin alpha alpha_api_key
+write_setup_skill alpha check <<'BODY'
+## Purpose
+
+`check` reports readiness. There is no `apply` action here.
+BODY
+out="$(run_fixture)"
+if grep -q "$NO_DECLARATION" <<<"$out"; then
+  pass "a skill offering no apply must declare the carve-out, not merely mention apply"
+else
+  fail "an undeclared carve-out shape should fail the gate: $out"
+fi
+
+# --- 4. A userConfig-only claim the manifest does not back. -----------------
+reset_fixture
+make_plugin alpha ''
+carve_out_body | write_setup_skill alpha check
+out="$(run_fixture)"
+if grep -q "$NO_USER_CONFIG" <<<"$out"; then
+  pass "claiming the userConfig-only carve-out with no declared userConfig fails the gate"
+else
+  fail "an unbacked userConfig-only claim should fail the gate: $out"
+fi
+
+# --- 5. Inverse: the narrow-write shape is untouched by the carve-out
+#        assertions, even for a registered tracked-config owner. -------------
+reset_fixture
+write_registry beta
+make_plugin beta ''
+write_setup_skill beta 'check | apply [remove]' <<'BODY'
+## Purpose
+
+`check` reports drift; `apply` converges this plugin's tracked project config. Every surface it
+may not write is handled the check-only way instead.
+BODY
+out="$(run_fixture)"
+if grep -q "$OWNS_TRACKED_CONFIG" <<<"$out" ||
+  grep -q "$NO_DECLARATION" <<<"$out" ||
+  grep -q "$NO_USER_CONFIG" <<<"$out"; then
+  fail "a narrow-write setup skill should raise no carve-out failure: $out"
+else
+  pass "a narrow-write setup skill owning tracked config passes the carve-out assertions"
+fi
+
+# --- 6. The registry is an input, so losing it fails loudly rather than
+#        degrading the carve-out check into a no-op. -------------------------
+reset_fixture
+rm -rf "$TMP/docs"
+make_plugin alpha alpha_api_key
+carve_out_body | write_setup_skill alpha check
+out="$(run_fixture)"
+if grep -q "$REGISTRY_MISSING" <<<"$out"; then
+  pass "a missing consumer-config registry fails the gate"
+else
+  fail "a missing registry should fail rather than silently skip: $out"
+fi
+
+# --- 7. Present but restructured: the Implementers section is gone. ---------
+reset_fixture
+mkdir -p "$TMP/docs/conventions/config-cascade"
+printf '# Consumer config cascade (fixture)\n\nNo Implementers section here.\n' \
+  >"$TMP/docs/conventions/config-cascade/README.md"
+make_plugin alpha alpha_api_key
+carve_out_body | write_setup_skill alpha check
+out="$(run_fixture)"
+if grep -q "$REGISTRY_UNSTRUCTURED" <<<"$out"; then
+  pass "a registry with no Implementers section fails the gate"
+else
+  fail "a restructured registry should fail rather than silently skip: $out"
+fi
+
+# --- 8. Present and structured, but the table names nothing. ----------------
+reset_fixture
+write_registry
+# Drop the one unrelated row's section so the Implementers table is genuinely
+# empty rather than merely narrow.
+mkdir -p "$TMP/docs/conventions/config-cascade"
+{
+  echo '# Consumer config cascade (fixture)'
+  echo
+  echo '## Implementers'
+  echo
+  echo '| Surface | Consumer config path | Layers | Conformance |'
+  echo '|---|---|---|---|'
+} >"$TMP/docs/conventions/config-cascade/README.md"
+make_plugin alpha alpha_api_key
+carve_out_body | write_setup_skill alpha check
+out="$(run_fixture)"
+if grep -q "$REGISTRY_EMPTY" <<<"$out"; then
+  pass "an Implementers table naming no surfaces fails the gate"
+else
+  fail "an empty registry table should fail rather than silently skip: $out"
+fi
+
+# --- 9. Real corpus: every shipping setup skill still conforms. -------------
+out="$( (cd "$REPO_ROOT" && node "$SUT" 2>&1))"
+rc=$?
+if [[ $rc -eq 0 ]]; then
+  pass "the shipping plugins/ tree still validates end to end"
+else
+  fail "the shipping tree should stay green (rc=$rc): $out"
+fi
+
+if [[ $fails -ne 0 ]]; then
+  printf '%d assertion(s) failed\n' "$fails" >&2
+  exit 1
+fi
+printf 'all assertions passed\n'

--- a/scripts/validate-plugin-contracts.test.sh
+++ b/scripts/validate-plugin-contracts.test.sh
@@ -50,9 +50,17 @@ trap 'rm -rf "$TMP"' EXIT
 OWNS_TRACKED_CONFIG='the check-only carve-out is unavailable here'
 NO_DECLARATION='must declare the check-only carve-out it relies on'
 NO_USER_CONFIG='requires the plugin manifest to declare userConfig'
+NO_DOCUMENTED_APPLY='must document the apply action'
 REGISTRY_MISSING='the consumer-config registry is required'
 REGISTRY_UNSTRUCTURED='must carry an "## Implementers" section'
 REGISTRY_EMPTY='named no surfaces'
+
+# fail() prints `- <path>: <message>`. A warn-only path would still contain
+# the message substring but would not carry the leading `- ` bullet.
+has_fail_line() {
+  local needle="$1"
+  grep -qE "^- .*: .*${needle}" <<<"$out"
+}
 
 reset_fixture() {
   rm -rf "$TMP/plugins" "$TMP/docs"
@@ -157,7 +165,7 @@ write_registry alpha
 make_plugin alpha alpha_api_key
 carve_out_body | write_setup_skill alpha check
 out="$(run_fixture)"
-if grep -q "$OWNS_TRACKED_CONFIG" <<<"$out" &&
+if has_fail_line "$OWNS_TRACKED_CONFIG" &&
   grep -q 'narrow-write shape' <<<"$out" &&
   grep -qE 'alpha[/\\]skills[/\\]setup[/\\]SKILL\.md' <<<"$out"; then
   pass "a carve-out claim from a plugin owning tracked consumer config fails the gate"
@@ -182,7 +190,7 @@ mkdir -p "$TMP/docs/conventions/config-cascade"
 make_plugin alpha alpha_api_key
 carve_out_body | write_setup_skill alpha check
 out="$(run_fixture)"
-if grep -q "$OWNS_TRACKED_CONFIG" <<<"$out"; then
+if has_fail_line "$OWNS_TRACKED_CONFIG"; then
   pass "a plugin named alongside the surface it co-owns is read out of the registry row"
 else
   fail "a co-owner named in the surface cell should not reach the carve-out: $out"
@@ -198,10 +206,27 @@ write_setup_skill alpha check <<'BODY'
 `check` reports readiness. There is no `apply` action here.
 BODY
 out="$(run_fixture)"
-if grep -q "$NO_DECLARATION" <<<"$out"; then
+if has_fail_line "$NO_DECLARATION"; then
   pass "a skill offering no apply must declare the carve-out, not merely mention apply"
 else
   fail "an undeclared carve-out shape should fail the gate: $out"
+fi
+
+# --- 3b. Advertising apply in argument-hint without documenting it. --------
+reset_fixture
+write_registry alpha
+make_plugin alpha alpha_api_key
+write_setup_skill alpha 'check | apply' <<'BODY'
+## Purpose
+
+Check-only under the native `userConfig` surface: `check` reports readiness.
+There is no apply action here.
+BODY
+out="$(run_fixture)"
+if has_fail_line "$NO_DOCUMENTED_APPLY"; then
+  pass "advertising apply without documenting it fails the gate"
+else
+  fail "an advertised-but-undocumented apply should fail the gate: $out"
 fi
 
 # --- 4. A userConfig-only claim the manifest does not back. -----------------
@@ -209,7 +234,7 @@ reset_fixture
 make_plugin alpha ''
 carve_out_body | write_setup_skill alpha check
 out="$(run_fixture)"
-if grep -q "$NO_USER_CONFIG" <<<"$out"; then
+if has_fail_line "$NO_USER_CONFIG"; then
   pass "claiming the userConfig-only carve-out with no declared userConfig fails the gate"
 else
   fail "an unbacked userConfig-only claim should fail the gate: $out"
@@ -224,7 +249,7 @@ write_setup_skill alpha check <<'BODY'
 Check-only under the native `userConfig` surface: `check` reports readiness.
 BODY
 out="$(run_fixture)"
-if grep -q "$NO_USER_CONFIG" <<<"$out"; then
+if has_fail_line "$NO_USER_CONFIG"; then
   pass "doctrine wording that names userConfig without a manifest declaration fails the gate"
 else
   fail "a native-userConfig-surface claim with no userConfig should fail: $out"
@@ -272,7 +297,7 @@ rm -rf "$TMP/docs"
 make_plugin alpha alpha_api_key
 carve_out_body | write_setup_skill alpha check
 out="$(run_fixture)"
-if grep -q "$REGISTRY_MISSING" <<<"$out"; then
+if has_fail_line "$REGISTRY_MISSING"; then
   pass "a missing consumer-config registry fails the gate"
 else
   fail "a missing registry should fail rather than silently skip: $out"
@@ -286,7 +311,7 @@ printf '# Consumer config cascade (fixture)\n\nNo Implementers section here.\n' 
 make_plugin alpha alpha_api_key
 carve_out_body | write_setup_skill alpha check
 out="$(run_fixture)"
-if grep -q "$REGISTRY_UNSTRUCTURED" <<<"$out"; then
+if has_fail_line "$REGISTRY_UNSTRUCTURED"; then
   pass "a registry with no Implementers section fails the gate"
 else
   fail "a restructured registry should fail rather than silently skip: $out"
@@ -309,7 +334,7 @@ mkdir -p "$TMP/docs/conventions/config-cascade"
 make_plugin alpha alpha_api_key
 carve_out_body | write_setup_skill alpha check
 out="$(run_fixture)"
-if grep -q "$REGISTRY_EMPTY" <<<"$out"; then
+if has_fail_line "$REGISTRY_EMPTY"; then
   pass "an Implementers table naming no surfaces fails the gate"
 else
   fail "an empty registry table should fail rather than silently skip: $out"

--- a/scripts/validate-plugin-contracts.test.sh
+++ b/scripts/validate-plugin-contracts.test.sh
@@ -165,6 +165,29 @@ else
   fail "a registered tracked-config owner should not reach the carve-out: $out"
 fi
 
+# --- 2b. The registry names a surface whose owning plugin is listed alongside
+#         it, the shape the shipping "`standards` (`planning`, `review`)" row
+#         takes. Every backticked token in the cell is an owner. -------------
+reset_fixture
+mkdir -p "$TMP/docs/conventions/config-cascade"
+{
+  echo '# Consumer config cascade (fixture)'
+  echo
+  echo '## Implementers'
+  echo
+  echo '| Surface | Consumer config path | Layers | Conformance |'
+  echo '|---|---|---|---|'
+  echo '| `a-shared-surface` (`alpha`, `gamma`) | `.claude/shared.yaml` | all three | conforms |'
+} >"$TMP/docs/conventions/config-cascade/README.md"
+make_plugin alpha alpha_api_key
+carve_out_body | write_setup_skill alpha check
+out="$(run_fixture)"
+if grep -q "$OWNS_TRACKED_CONFIG" <<<"$out"; then
+  pass "a plugin named alongside the surface it co-owns is read out of the registry row"
+else
+  fail "a co-owner named in the surface cell should not reach the carve-out: $out"
+fi
+
 # --- 3. The substring the old gate accepted is no longer the pass condition:
 #        a carve-out-shaped skill whose body only mentions apply in prose. ---
 reset_fixture

--- a/scripts/validate-plugin-contracts.test.sh
+++ b/scripts/validate-plugin-contracts.test.sh
@@ -215,6 +215,36 @@ else
   fail "an unbacked userConfig-only claim should fail the gate: $out"
 fi
 
+# --- 4b. The same gap under the doctrine's own wording, not the one phrase. -
+reset_fixture
+make_plugin alpha ''
+write_setup_skill alpha check <<'BODY'
+## Purpose
+
+Check-only under the native `userConfig` surface: `check` reports readiness.
+BODY
+out="$(run_fixture)"
+if grep -q "$NO_USER_CONFIG" <<<"$out"; then
+  pass "doctrine wording that names userConfig without a manifest declaration fails the gate"
+else
+  fail "a native-userConfig-surface claim with no userConfig should fail: $out"
+fi
+
+# --- 4c. A check-only skill that names userConfig only to deny it. ----------
+reset_fixture
+make_plugin alpha ''
+write_setup_skill alpha check <<'BODY'
+## Purpose
+
+Check-only: this plugin has no `userConfig`. `check` reports external prerequisites.
+BODY
+out="$(run_fixture)"
+if grep -q "$NO_USER_CONFIG" <<<"$out"; then
+  fail "denying userConfig should not be read as claiming the surface: $out"
+else
+  pass "a check-only skill that says it has no userConfig is not an unbacked claim"
+fi
+
 # --- 5. Inverse: the narrow-write shape is untouched by the carve-out
 #        assertions, even for a registered tracked-config owner. -------------
 reset_fixture


### PR DESCRIPTION
Closes #3137

## Summary

The setup-contract validator treated the check-only carve-out as the presence of the word "check-only" anywhere in a setup skill. A plugin that owns a writable tracked-config surface could pass by writing those words. The carve-out now has to earn itself against the plugin's registered surface.

## Fix

When a setup skill's `argument-hint` offers no `apply`, the validator:

- requires the skill to declare the check-only carve-out
- fails if the plugin is named in `docs/conventions/config-cascade/README.md`'s Implementers table (it owns tracked consumer config, so the contract requires the narrow-write shape) — quoting the contract's own wording
- fails a `userConfig-only` claim when the manifest declares no `userConfig`

A skill that documents a narrow `apply` still passes via the existing apply path. `dometrain` and `miro` continue to pass: they are userConfig-only and are not in that table.

## Verification

`bash scripts/validate-plugin-contracts.test.sh` — all assertions passed, including the four failure classes (carve-out while owning tracked config; no-apply without declaring the carve-out; userConfig-only claim with no userConfig; unreadable registry) and the paired inverses.

`node scripts/validate-plugin-contracts.mjs` against the shipping `plugins/` tree — 50 setup skills and 2850 plugin files checked, no false positives.

## Related

- #3127 — parent; established that the doc half of this concern needs no change
- `docs/PLUGIN-PHILOSOPHY.md` § "Setup is explicit and repeatable" — the check-only carve-out and the writable-artifact rule
