### PR TITLE
fix(overengineering): never give a detached checkout a branch identity (0.3.0)

### DIFF
--- a/plugins/overengineering/.claude-plugin/plugin.json
+++ b/plugins/overengineering/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "overengineering",
-  "version": "0.2.3",
+  "version": "0.3.0",
   "description": "Evidence-earned-keep audit of an existing enforcement surface — agent hooks and standing instructions, repository and version-control hooks, CI lanes and gate scripts, branch protections, forge apps, declared external integrations — treating every incumbent mechanism as a retirement candidate until empirical evidence earns its keep, arguing every verdict in cost of carry, capping retirement-direction verdicts on security-class artifacts at FLAG-FOR-HUMAN, and realigning to the simplest adequate solution behind an explicit per-item human gate. The audit is read-only and emits a diffable findings artifact; realignment is a separate, explicitly invoked skill; and a third read-only lane re-runs the audit on whatever cadence the consumer wires and reports only what moved since the last run, above a configurable noise budget.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/overengineering/.claude-plugin/plugin.json
+++ b/plugins/overengineering/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "overengineering",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Evidence-earned-keep audit of an existing enforcement surface — agent hooks and standing instructions, repository and version-control hooks, CI lanes and gate scripts, branch protections, forge apps, declared external integrations — treating every incumbent mechanism as a retirement candidate until empirical evidence earns its keep, arguing every verdict in cost of carry, capping retirement-direction verdicts on security-class artifacts at FLAG-FOR-HUMAN, and realigning to the simplest adequate solution behind an explicit per-item human gate. The audit is read-only and emits a diffable findings artifact; realignment is a separate, explicitly invoked skill; and a third read-only lane re-runs the audit on whatever cadence the consumer wires and reports only what moved since the last run, above a configurable noise budget.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/overengineering/CHANGELOG.md
+++ b/plugins/overengineering/CHANGELOG.md
@@ -3,6 +3,51 @@
 All notable changes to the `overengineering` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.2.3]
+
+### Fixed
+
+- **`audit` and `realign` gave a detached checkout a branch identity, collapsing every ref onto one
+  (#3149).** Both skills precomputed the branch with `git rev-parse --abbrev-ref HEAD`, which answers
+  the literal string `HEAD` when HEAD is detached — the ordinary shape for a scheduled CI runner.
+  Three failures followed, all silent. `audit` wrote `branch: HEAD` into the findings artifact, so the
+  artifact carried an identity that is not a branch. `realign`'s branch-match refusal compared `HEAD`
+  to `HEAD`, passed by construction, and could execute one ref's findings against another ref's
+  surface — in the plugin's only mutating skill. And the `<branch-slug>` home key resolved every
+  detached ref to the same directory, so unrelated runs shared one artifact. Both precomputes now use
+  `git symbolic-ref --quiet --short HEAD`, which fails rather than inventing a name, matching the
+  `delta` lane that already resolved identity this way; all three skills now agree on one contract.
+  Where the identity does not resolve, each lane prefers a logical ref if the environment supplies one
+  naming a branch — with no vendor's variables named or assumed — and otherwise declines: `audit`
+  persists no findings artifact at all and says so while still walking and still emitting its inline
+  summary, and `realign` refuses, both when its own checkout has no identity and when the artifact it
+  finds carries `branch:` absent, empty, or `HEAD`, never reaching the degenerate comparison.
+
+### Changed
+
+- **The artifact contract states the unresolved-identity case.** `context/findings-artifact.md` now
+  documents `branch:` as resolved with `git symbolic-ref` and never the literal `HEAD`, adds a
+  "No branch identity, no artifact" section arguing why omitting the key is deliberately not the
+  remedy — an artifact whose identity cannot be established is one `realign` must refuse anyway, so
+  writing it only moves the failure later — and carries a per-skill obligations row for the condition.
+- **The home-key binding states what happens when no identity resolves.**
+  `reference/topic-docs.md` now records that an unresolved branch identity keys no home at all and
+  does not run the rung order, and rejects each substitute on its own terms: `HEAD` is one directory
+  for every ref, a commit sha is a fresh home every commit that never resumes, and a fixed literal
+  such as `detached` is `HEAD` under another name.
+
+### Notes
+
+- **No other plugin in this marketplace shares the defect.** The repo-wide precompute boilerplate uses
+  `git branch --show-current`, which returns an empty string on a detached checkout rather than
+  `HEAD`, and the findings-writing skills that persist a `branch:` field (`ai-slop:audit`,
+  `claude-config:audit-instructions`, `docs-hygiene:audit-noise`, `mutation-testing:audit`) all read
+  it that way. The literal `git rev-parse --abbrev-ref HEAD` form survives in four places outside this
+  plugin — `source-control`'s `babysit-prs` parking-branch capture and `worktree` current-branch
+  display, and `claude-ops`' two skill-usage telemetry hooks — and none of them keys shared state,
+  compares the value against a stored one, or gates a mutation on it, so none exhibits the
+  identity-collapse this release fixes. Left as-is deliberately.
+
 ## [0.2.2]
 
 ### Added

--- a/plugins/overengineering/CHANGELOG.md
+++ b/plugins/overengineering/CHANGELOG.md
@@ -7,6 +7,15 @@ All notable changes to the `overengineering` plugin are documented here. Format 
 
 ### Fixed
 
+- **Logical-ref fallback is now a git branch name, not an arbitrary string.** An environment
+  value used as the detached-checkout identity is normalized (`refs/heads/main` → `main`) and
+  refused unless `git check-ref-format --branch` accepts it, so `..` cannot slug into a
+  path-escape and a later attached `realign` on `main` finds the same home. No-checkout is a
+  walk-stop; detached-in-a-repo still walks and, when nothing is persisted, the inline summary
+  lists every finding rather than a capped top list.
+
+- **`audit` and `realign` gave a detached checkout a branch identity, collapsing every ref onto one
+
 - **`audit` and `realign` gave a detached checkout a branch identity, collapsing every ref onto one
   (#3149).** Both skills precomputed the branch with `git rev-parse --abbrev-ref HEAD`, which answers
   the literal string `HEAD` when HEAD is detached — the ordinary shape for a scheduled CI runner.

--- a/plugins/overengineering/CHANGELOG.md
+++ b/plugins/overengineering/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to the `overengineering` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
-## [0.2.3]
+## [0.3.0]
 
 ### Fixed
 
@@ -35,18 +35,43 @@ All notable changes to the `overengineering` plugin are documented here. Format 
   does not run the rung order, and rejects each substitute on its own terms: `HEAD` is one directory
   for every ref, a commit sha is a fresh home every commit that never resumes, and a fixed literal
   such as `detached` is `HEAD` under another name.
+- **Identity resolution is a body step, not only a precompute.** A worktree-isolated or dispatched
+  executor may decline to inject the precomputed context block entirely — and that is the same
+  `unattended` context where a detached checkout is most likely — so `audit` and `realign` now state
+  the resolution command in the step that uses it and treat the precompute as a convenience that may
+  be absent. Without this the fix would verify green on an attached local checkout and do nothing in
+  the environment the bug actually lives in.
+- **`delta`'s account of the same condition no longer contradicts the audit's.** That lane's detached
+  section closed with "the audit still runs, exactly as it otherwise would", written when `audit`
+  still persisted on an unresolved identity; it now records that no artifact is written on such a
+  cycle, and its step 4 says the post-run artifact it would otherwise read is absent. The lane's
+  behavior is unchanged — only the statement that had been made false by the audit's fix.
+- **The report shape covers the run that writes nothing.**
+  `skills/audit/context/report-template.md` owns the read-only disclosure line, and previously
+  hardcoded the form naming a resolved path and declared the artifact written "always". It now carries
+  the no-artifact variant, so a run following the document that owns output shape does not announce a
+  file it did not write.
 
 ### Notes
 
-- **No other plugin in this marketplace shares the defect.** The repo-wide precompute boilerplate uses
-  `git branch --show-current`, which returns an empty string on a detached checkout rather than
-  `HEAD`, and the findings-writing skills that persist a `branch:` field (`ai-slop:audit`,
-  `claude-config:audit-instructions`, `docs-hygiene:audit-noise`, `mutation-testing:audit`) all read
-  it that way. The literal `git rev-parse --abbrev-ref HEAD` form survives in four places outside this
-  plugin — `source-control`'s `babysit-prs` parking-branch capture and `worktree` current-branch
-  display, and `claude-ops`' two skill-usage telemetry hooks — and none of them keys shared state,
-  compares the value against a stored one, or gates a mutation on it, so none exhibits the
-  identity-collapse this release fixes. Left as-is deliberately.
+- **No other plugin in this marketplace exhibits the `HEAD` identity-collapse.** The repo-wide
+  precompute boilerplate uses `git branch --show-current`, which returns an empty string on a detached
+  checkout rather than `HEAD`. The literal `git rev-parse --abbrev-ref HEAD` form survives at seven
+  occurrences across six files outside this plugin: `claude-ops`' two skill-usage telemetry hooks,
+  `source-control`'s `babysit-prs` parking-branch capture and `worktree` current-branch display, and
+  three test-scaffolding sites in `guardrails`' `stale-path-verify.test.sh` and `source-control`'s
+  `worktree-create.test.sh`. None of them compares the value against a stored identity to decide
+  whether a mutation may proceed, which is the specific failure fixed here. `babysit-prs` is the
+  closest call and is still a different defect class: its captured value parameterizes a same-session
+  `git checkout` rather than an identity comparison, so a detached capture fails to restore the
+  starting commit instead of authorizing another ref's work. All are left as-is deliberately.
+- **One neighbor has the same shape under a different string, and is out of scope.**
+  `mutation-testing:audit` documents `branch:` as `git branch --show-current` verbatim
+  (`skills/audit/context/persist-findings.md:202`) and ships no script guarding the empty result, so a
+  detached run there writes an empty identity that compares equal to itself. Three sibling
+  findings-writers (`ai-slop`, `docs-hygiene:audit-noise`, `claude-config:audit-instructions`) already
+  guard that case in their `emit-findings.sh` and exit rather than persist. Recorded here rather than
+  fixed: the issue this release closes is scoped to this plugin.
 
 ## [0.2.2]
 

--- a/plugins/overengineering/context/findings-artifact.md
+++ b/plugins/overengineering/context/findings-artifact.md
@@ -48,6 +48,10 @@ Two properties the contract does fix:
   branches, worktrees, and clones never clobber each other's runs. What proves an artifact belongs
   to a branch is its own `branch:` frontmatter, never the directory it sits in — the branch-slug
   mapping is lossy by design and two branch names can slug to one directory.
+  **A branch identity that does not resolve therefore keys no home at all.** A detached checkout has
+  no branch name, and every substitute collapses the axis this segment exists to separate: `HEAD` is
+  the same string for every ref, and the commit sha is a different one every commit. The producer
+  writes nothing rather than writing somewhere shared — see "No branch identity, no artifact" below.
 - **One stable filename per home, rewritten in place.** A re-audit merges into the existing file
   (see "Re-run merge semantics") rather than depositing a timestamped sibling. A per-run filename
   would turn the merge into a search problem and make the artifact's history a guess; the run's
@@ -65,7 +69,7 @@ type: overengineering-findings
 schema: 1
 date: <ISO-basic UTC, colon-free: YYYYMMDDTHHMMSSZ>
 scope: <the layers actually walked this run>
-branch: <branch at audit time>
+branch: <branch at audit time; never `HEAD`, and never written at all when the branch identity is unresolved>
 ---
 ```
 
@@ -75,7 +79,33 @@ branch: <branch at audit time>
 | `schema` | yes | Integer contract version, currently `1`. A consumer reading an unrecognized value **stops with a visible message** rather than guessing at the shape. |
 | `date` | yes | ISO-basic UTC (`YYYYMMDDTHHMMSSZ`): compact, unambiguous about its zone, and lexically sortable — string order is chronological order. The only record of when the audit actually ran. (Colon-freedom buys nothing *inside* a file; it is a **filename** property, and this contract fixes one stable filename per home rather than a timestamped one.) |
 | `scope` | yes | The layers walked, from the layer vocabulary below. A layer-scoped pass says so here; **a layer absent from `scope` was not walked, and is not the same as a layer walked and found empty.** The merge rules depend on this distinction. |
-| `branch` | yes | The branch at audit time. Realign refuses an artifact whose `branch:` does not match the current branch, naming the mismatch. |
+| `branch` | yes | The branch at audit time, resolved with `git symbolic-ref` — **never the literal `HEAD`**, which is what `git rev-parse --abbrev-ref HEAD` answers on a detached checkout. Realign refuses an artifact whose `branch:` does not match the current branch, naming the mismatch, and equally refuses one whose `branch:` is absent, empty, or `HEAD`. The field is required because the artifact is: where no branch identity resolves, there is no artifact to carry it (below). |
+
+## No branch identity, no artifact
+
+Every skill in this plugin resolves the branch with `git symbolic-ref`, which **fails** on a detached
+checkout rather than answering the literal string `HEAD` the way `git rev-parse --abbrev-ref HEAD`
+does. `HEAD` is not an identity: it is the same string for every ref, so it keys every ref to one
+home and compares equal to itself. Scheduled and dispatched runners commonly check out detached, so
+this is an ordinary condition for this artifact, not an exotic one.
+
+Where the identity does not resolve, and no logical ref is supplied by the environment:
+
+- **`audit` writes no artifact.** Not the file with `branch:` omitted, not the file with a placeholder
+  value, not the file at a home keyed by something else — none of it. The walk still runs and the
+  inline summary is still emitted; only the persisted write is declined, and the run says so.
+- **`realign` refuses**, both when its own checkout has no identity and when an artifact it finds
+  carries `branch:` absent, empty, or `HEAD`. It never reaches the comparison, because a degenerate
+  `HEAD`-to-`HEAD` match passes by construction and would authorize mutations from another ref's
+  findings.
+- **`delta` compares nothing and captures nothing**, per its own section on the same condition.
+
+**Omitting the key is deliberately not the remedy.** An artifact whose identity cannot be established
+is one `realign` must refuse anyway, so writing it moves the failure later, leaves a file the next
+run merges into, and puts a partial record where the operator reasonably reads a complete one. The
+asymmetry decides it: refusing costs a re-run on an attached checkout, while accepting costs evidence
+and verdicts from one ref presented as another's, silently and with nothing in the report to reveal
+it.
 
 ## Layer vocabulary
 
@@ -468,6 +498,7 @@ The key shapes and merge forms for the consumer's concern file are owned by this
 | Writes `Status` | `OPEN` on new findings; carries the rest forward | the sole owner of every transition | **never** — it reports that one moved, which stays realign's alone |
 | Leads with the evidence-availability assessment | yes, before any finding | reads it; never recomputes it | reads the tokens and compares them run to run; never recomputes them |
 | Refuses on a mismatched `branch:` or an unrecognized `schema:` | n/a — it writes them | yes, with a visible message | mismatched `branch:` → no baseline, naming both branches; unrecognized `schema:` → stop before invoking anything |
+| Behavior when no branch identity resolves | writes **no artifact** — the walk runs, the inline summary is emitted, the persisted write is declined and the run says so | **refuses**, whether its own checkout or the artifact's `branch:` is the unresolved side; never compares | compares nothing and captures nothing, saying why |
 | Behavior when the artifact is missing | n/a | **stop** with a visible message naming `overengineering:audit` as the skill that produces it — the artifact-protocol missing-prerequisite rule; never scan on its own | not a stop but a **first run**: it says so, establishes the baseline, and reports nothing as a delta |
 
 The `delta` column follows from what that lane is: it composes `audit` to produce this cycle's

--- a/plugins/overengineering/reference/topic-docs.md
+++ b/plugins/overengineering/reference/topic-docs.md
@@ -96,6 +96,25 @@ artifact belongs to a branch is its own `branch:` frontmatter, never the directo
 Realign refuses an artifact whose `branch:` does not match the current branch, naming the mismatch —
 the directory alone is not evidence.
 
+**When no branch identity resolves, no home is keyed and nothing is written.** All three skills
+resolve the branch with `git symbolic-ref --quiet --short HEAD`, which fails on a detached checkout
+rather than answering the literal string `HEAD` the way `git rev-parse --abbrev-ref HEAD` does.
+Where that fails and the environment supplies no logical ref naming a branch, there is no
+`<branch-slug>` to compose, and **the rung order is not run** — the question of which rung wins never
+arises, because every rung composes a path for an axis that has no value.
+
+No substitute is admitted. `HEAD` is the same string for every ref, so it would key every detached
+run to one directory — precisely the collision this segment exists to prevent, and the worst case
+because the runs that collide are the ones a scheduled runner produces most often. The commit sha
+keys a new home every commit, which never collides but never resumes either, turning a re-audit into
+an unbounded scatter of single-use homes that no consumer ever reads back. A fixed literal such as
+`detached` is `HEAD` under another name.
+
+The consumers state the consequence at their own sites: `overengineering:audit` persists no findings
+artifact, `overengineering:realign` refuses rather than comparing, and `overengineering:delta`
+compares nothing and captures no baseline. This binding fixes only the resolution's outcome — that a
+run reaching it without an identity has no path to resolve, and asks for none.
+
 `overengineering` is this plugin's concern name under the memory root, alongside the contract's own
 reserved first-level names. A topic slug that collides with it takes the contract's `-x` suffix.
 

--- a/plugins/overengineering/skills/audit/SKILL.md
+++ b/plugins/overengineering/skills/audit/SKILL.md
@@ -11,7 +11,7 @@ metadata:
 
 ## Pre-computed context
 
-- Branch: !`git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown (no checkout)"`
+- Branch: !`git symbolic-ref --quiet --short HEAD 2>/dev/null || echo "no branch ref (detached HEAD or no checkout)"`
 - Shallow clone: !`git rev-parse --is-shallow-repository 2>/dev/null || echo "unknown (no checkout)"`
 
 ## Purpose
@@ -51,6 +51,11 @@ there is not a mutation of the repo. State this rather than leaving it to be inf
 *"Read-only pass; the only file written is the findings artifact at `<resolved path>`."* That path
 exists only once the home is resolved, so the line is emitted **immediately after that resolution** —
 step 1 of "Before the walk" — and before any layer is walked.
+
+**A run with no branch identity writes nothing at all**, and says that instead of naming a path:
+*"Read-only pass; no branch identity resolved, so no findings artifact is written."* See "A detached
+checkout has no branch identity" below for when that holds and why a guessed home is worse than
+none.
 
 **Writing the artifact from a delegated run.** Some harnesses refuse a report-shaped filename from a
 delegated or dispatched executor — the `unattended` caller below is exactly that. The sanctioned
@@ -92,7 +97,11 @@ Parse `$ARGUMENTS`:
 
 ## Before the walk
 
-1. **Resolve the artifact home** by running the whole rung order in
+1. **Resolve the branch identity, then the artifact home.** The precompute above yields a branch name
+   or the sentinel `no branch ref (detached HEAD or no checkout)`. **`HEAD` is never accepted as a
+   branch identity**, and neither is the sentinel — "A detached checkout has no branch identity"
+   below governs what an unresolved identity declines, and it is decided here, before a home is
+   composed. With an identity in hand, resolve the home by running the whole rung order in
    `${CLAUDE_PLUGIN_ROOT}/reference/topic-docs.md` — resolve it, never assume the documented
    default's shape. A hardcoded path writes where `realign` never looks. **Then emit the read-only
    opening line**, naming the path just resolved.
@@ -193,8 +202,44 @@ findings artifact as the single source of truth, an inline terminal summary alwa
 HTML view only as a presence-gated extra. Field-level contents, ids, ordering, the spine/prose split,
 and merge semantics belong to `${CLAUDE_PLUGIN_ROOT}/context/findings-artifact.md`.
 
+## A detached checkout has no branch identity
+
+`git rev-parse --abbrev-ref HEAD` answers `HEAD` on a detached checkout. That is a string, not an
+identity, and writing it into the artifact breaks the seam in two places at once: every ref keys to
+the same `<branch-slug>` home, so unrelated refs share one `findings.md`; and `realign`'s
+branch-match refusal compares `HEAD` to `HEAD`, passes, and executes another ref's findings against
+this one. Scheduled runners very commonly check out detached, so this is an ordinary case rather
+than an exotic one, which is why the precompute uses `git symbolic-ref` and refuses to invent a
+name. The sibling `delta` lane resolves identity the same way, on the same reasoning.
+
+When the branch identity does not resolve:
+
+- **Prefer a logical ref where the environment supplies one.** Some execution environments hand the
+  run the ref it was launched for even though the checkout is detached. Where such a value is present
+  and names a branch, use it as the branch identity for both the home key and the `branch:` field,
+  and name in the report where it came from. **No vendor's variables are named here or assumed** —
+  this plugin is consumer-agnostic, and hardcoding one CI system's environment would be a claim about
+  the consumer's toolchain that the rest of this plugin refuses to make.
+- **Otherwise, persist nothing and say why** — "detached checkout, no logical ref supplied; no branch
+  identity, so no findings artifact is written". Do not fall back to `HEAD`, to the commit sha, or to
+  whatever home the slug happens to produce. A home keyed by something every ref shares is a home the
+  next detached run of a *different* ref reads as its own, and `realign` cannot tell the two apart
+  afterwards, because the artifact's own `branch:` is what binds it and there is none to write.
+- **Never write `branch: HEAD`, and never write the key empty or absent as a workaround.** The
+  refusal is the whole artifact, not the one field — an artifact without a resolved identity is one
+  `realign` must refuse anyway, so writing it only moves the failure later and leaves a file behind
+  that the next run merges into.
+
+**The walk still runs, exactly as it otherwise would, and the inline summary is still emitted.** What
+is declined is the persisted write, not the pass — the report says so in place of the read-only
+opening line's resolved path, so the operator learns the run produced no artifact at the moment it
+would otherwise have been told where one lives.
+
 ## Gotchas
 
+- **`HEAD` is not a branch name.** A detached checkout — the normal shape for a scheduled runner —
+  makes `rev-parse --abbrev-ref` answer `HEAD`, which keys every ref to one home and compares equal
+  to itself. Resolve a logical ref where the environment supplies one; otherwise decline to persist.
 - **A layer-scoped pass is not a retirement of what it did not look at.** Findings in unwalked layers
   are carried forward untouched and marked not re-evaluated this run.
 - **A zero is not a measurement.** For hook-, transform-, and gate-shaped items, no recorded

--- a/plugins/overengineering/skills/audit/SKILL.md
+++ b/plugins/overengineering/skills/audit/SKILL.md
@@ -218,12 +218,22 @@ name. The sibling `delta` lane resolves identity the same way, on the same reaso
 
 When the branch identity does not resolve:
 
-- **Prefer a logical ref where the environment supplies one.** Some execution environments hand the
-  run the ref it was launched for even though the checkout is detached. Where such a value is present
-  and names a branch, use it as the branch identity for both the home key and the `branch:` field,
-  and name in the report where it came from. **No vendor's variables are named here or assumed** —
-  this plugin is consumer-agnostic, and hardcoding one CI system's environment would be a claim about
-  the consumer's toolchain that the rest of this plugin refuses to make.
+- **Prefer a logical ref where the environment supplies one**, only after it is a real
+  branch name. Some execution environments hand the run the ref it was launched for even
+  though the checkout is detached. **No vendor's variables are named here or assumed.**
+  Before that value may key a home or fill `branch:`:
+  1. **Normalize** it to the same short form `git symbolic-ref --short` would emit: strip a
+     leading `refs/heads/` (and only that prefix). `refs/heads/main` and `main` must produce
+     the same home key, or a later attached `realign` on `main` will miss the artifact.
+  2. **Validate** the result as a git branch name. Refuse it if it is empty, if any path
+     segment is `.` or `..`, or if `git check-ref-format --branch -- <value>` exits
+     non-zero. The topic-docs slug leaves `.` untouched, so an unvalidated `..` would
+     compose `.work/overengineering/../findings.md` and escape the home. An unvalidated
+     string is also the same cross-ref mutation this section closes for `HEAD`: it keys
+     one checkout's findings to another name.
+  A value that fails either step is treated as absent — fall through to the refusal
+  below. A value that passes is the branch identity for both the home key and `branch:`,
+  and the report names that it came from the environment.
 - **Otherwise, persist nothing and say why** — "detached checkout, no logical ref supplied; no branch
   identity, so no findings artifact is written". Do not fall back to `HEAD`, to the commit sha, or to
   whatever home the slug happens to produce. A home keyed by something every ref shares is a home the
@@ -234,10 +244,16 @@ When the branch identity does not resolve:
   `realign` must refuse anyway, so writing it only moves the failure later and leaves a file behind
   that the next run merges into.
 
-**The walk still runs, exactly as it otherwise would, and the inline summary is still emitted.** What
-is declined is the persisted write, not the pass — the report says so in place of the read-only
-opening line's resolved path, so the operator learns the run produced no artifact at the moment it
-would otherwise have been told where one lives.
+**Detached-in-a-repo vs no checkout are different stops.** The precompute sentinel covers both,
+but they are not the same case. **No checkout** (no project root, `git rev-parse --show-toplevel`
+fails) is the topic-docs "No project root" stop: there is no enforcement surface to audit, so
+the run does not walk an arbitrary working directory and report it as the repository. A
+**detached checkout inside a repository** is the case this section governs: the walk still runs
+and the inline summary is still emitted. What is declined is the persisted write, not the pass
+— the report says so in place of the read-only opening line's resolved path, so the operator
+learns the run produced no artifact at the moment it would otherwise have been told where one
+lives. When that summary is the only record, it lists **every** finding, not the capped "top
+findings" the template uses when an artifact will carry the rest.
 
 ## Gotchas
 

--- a/plugins/overengineering/skills/audit/SKILL.md
+++ b/plugins/overengineering/skills/audit/SKILL.md
@@ -98,10 +98,14 @@ Parse `$ARGUMENTS`:
 ## Before the walk
 
 1. **Resolve the branch identity, then the artifact home.** The precompute above yields a branch name
-   or the sentinel `no branch ref (detached HEAD or no checkout)`. **`HEAD` is never accepted as a
-   branch identity**, and neither is the sentinel — "A detached checkout has no branch identity"
-   below governs what an unresolved identity declines, and it is decided here, before a home is
-   composed. With an identity in hand, resolve the home by running the whole rung order in
+   or the sentinel `no branch ref (detached HEAD or no checkout)`. **The precompute is a convenience,
+   not the source of truth** — a worktree-isolated or dispatched executor may decline to inject it at
+   all, which is exactly the `unattended` context where a detached checkout is most likely, so where
+   the branch line is absent run `git symbolic-ref --quiet --short HEAD` here and read its exit status
+   rather than assuming an identity. **`HEAD` is never accepted as a branch identity**, and neither is
+   the sentinel — "A detached checkout has no branch identity" below governs what an unresolved
+   identity declines, and it is decided here, before a home is composed. With an identity in hand,
+   resolve the home by running the whole rung order in
    `${CLAUDE_PLUGIN_ROOT}/reference/topic-docs.md` — resolve it, never assume the documented
    default's shape. A hardcoded path writes where `realign` never looks. **Then emit the read-only
    opening line**, naming the path just resolved.

--- a/plugins/overengineering/skills/audit/context/report-template.md
+++ b/plugins/overengineering/skills/audit/context/report-template.md
@@ -6,7 +6,7 @@ prerequisite is absent.
 
 | Layer | When | Authority |
 |---|---|---|
-| **Findings artifact** | always | **The single source of truth.** Everything that drives the reasoning lives here |
+| **Findings artifact** | always, except when no branch identity resolves | **The single source of truth.** Everything that drives the reasoning lives here |
 | **Inline terminal summary** | always | A *view* of the artifact — never a second record, never a place a fact appears first |
 | **Rendered HTML view** | presence-gated | A rendering of the same artifact; skipped when unavailable |
 
@@ -41,13 +41,19 @@ table. They are named there once.
 
 ## Layer 2 — the inline terminal summary
 
-Always printed, in the response, after the artifact is written. It is a navigation aid: it tells the
-operator what the run found, what it could not find out, and where to read the rest. Keep it short
-enough to read without scrolling past it.
+Always printed, in the response, once the walk is done — after the artifact is written, or in place of
+it on the run that writes none. It is a navigation aid: it tells the operator what the run found, what
+it could not find out, and where to read the rest. Keep it short enough to read without scrolling past
+it.
 
 1. **The read-only line, first.** *"Read-only pass; the only file written is the findings artifact at
    `<resolved path>`."* Plus the layers walked this run, and — when the pass was layer-scoped — the
    layers that were not, so nobody reads a partial pass as a complete one.
+   **When no branch identity resolved**, the artifact was not written and there is no path to name,
+   so the line states that instead: *"Read-only pass; no branch identity resolved, so no findings
+   artifact is written."* The layers-walked half is unchanged — the walk still happened, and this
+   summary is the only record of it. The condition and its reasoning belong to the skill's
+   "A detached checkout has no branch identity"; this document owns only how the line reads.
 2. **Evidence availability, one line per tier**: present / partial / unavailable, with the probe. A
    shallow clone and a missing telemetry sink each get named here explicitly.
 3. **Counts**, per verdict class and per layer. A small table, not prose.
@@ -62,7 +68,9 @@ enough to read without scrolling past it.
 7. **Configuration provenance**, one line: which config layers contributed, or that none were present
    and the bundled defaults applied. Name a personal layer explicitly whenever one shaped output.
 8. **The next step**, named but not taken: `overengineering:realign` consumes this artifact and
-   executes accepted findings behind an explicit per-item human gate. Do not start it unasked.
+   executes accepted findings behind an explicit per-item human gate. Do not start it unasked. On a
+   run that wrote no artifact there is nothing for it to consume, so the step named instead is a
+   re-run on a checkout with a resolved branch identity.
 
 A run that found nothing to retire says so plainly. A clean surface is a valid outcome, and
 manufacturing a finding to justify the pass is the failure this whole method is pointed at.

--- a/plugins/overengineering/skills/audit/context/report-template.md
+++ b/plugins/overengineering/skills/audit/context/report-template.md
@@ -59,7 +59,9 @@ it.
 3. **Counts**, per verdict class and per layer. A small table, not prose.
 4. **The top findings**, ranked — protected items flagged for a human first, then the strongest
    evidenced retirement-direction verdicts, then the carry-cost-ranked head of the UNPROVEN residue.
-   Cap the inline list; the artifact carries the rest.
+   Cap the inline list **only when the artifact was written**; the artifact carries the rest.
+   When no branch identity resolved and this summary is the only record, emit **every** finding
+   inline. A cap here would discard the tail of a scheduled detached run.
 5. **The proposed ablation batch**, when one was produced: its items, an owner and a re-check date
    each, and the observation window's end date.
 6. **Open checkpoints** — the intent questions awaiting an answer (attended), or the count of

--- a/plugins/overengineering/skills/audit/evals/evals.json
+++ b/plugins/overengineering/skills/audit/evals/evals.json
@@ -128,7 +128,7 @@
     {
       "id": 10,
       "name": "detached-checkout-persists-no-artifact",
-      "prompt": "/overengineering:audit ci-lanes unattended",
+      "prompt": "/overengineering:audit ci-lanes unattended — this is the nightly scheduled run, and the runner checks the repo out at a commit rather than a branch, so the working tree is on a detached HEAD. Nothing in the environment supplies the ref it was launched for.",
       "expected_output": "The pre-computed branch line carries the sentinel `no branch ref (detached HEAD or no checkout)` because the scheduled runner checked out a commit rather than a branch. The run treats that as an unresolved branch identity: it does not accept `HEAD` as a branch name, does not substitute the commit sha or a fixed literal, and does not compose a `<branch-slug>` home from any of them. Because no home is keyed, the read-only opening line names no path and instead states that no branch identity resolved and no findings artifact will be written. The ci-lanes walk still runs and the inline summary is still emitted in full, so the operator gets the findings; only the persisted write is declined, and the report says so plainly rather than leaving the missing artifact to be discovered later. No file is written with `branch: HEAD`, with the key omitted, or at a home shared by every detached ref.",
       "files": [],
       "narration": true,

--- a/plugins/overengineering/skills/audit/evals/evals.json
+++ b/plugins/overengineering/skills/audit/evals/evals.json
@@ -124,6 +124,36 @@
         "Applies the uncertain-status tie-break — treat as protected — so the retirement-direction verdict is capped at FLAG-FOR-HUMAN rather than emitted as RETIRE",
         "Records that the classification was uncertain and names the rule that matched, so the classification can be overturned separately from the verdict"
       ]
+    },
+    {
+      "id": 10,
+      "name": "detached-checkout-persists-no-artifact",
+      "prompt": "/overengineering:audit ci-lanes unattended",
+      "expected_output": "The pre-computed branch line carries the sentinel `no branch ref (detached HEAD or no checkout)` because the scheduled runner checked out a commit rather than a branch. The run treats that as an unresolved branch identity: it does not accept `HEAD` as a branch name, does not substitute the commit sha or a fixed literal, and does not compose a `<branch-slug>` home from any of them. Because no home is keyed, the read-only opening line names no path and instead states that no branch identity resolved and no findings artifact will be written. The ci-lanes walk still runs and the inline summary is still emitted in full, so the operator gets the findings; only the persisted write is declined, and the report says so plainly rather than leaving the missing artifact to be discovered later. No file is written with `branch: HEAD`, with the key omitted, or at a home shared by every detached ref.",
+      "files": [],
+      "narration": true,
+      "expectations": [
+        "Reads the precompute sentinel as an unresolved branch identity and never treats the literal string HEAD as a branch name",
+        "Declines to compose a home from HEAD, the commit sha, or any fixed literal such as `detached`, and states that no home was keyed",
+        "Writes NO findings artifact at all — not with `branch: HEAD`, not with the `branch:` key omitted, and not at a substitute home",
+        "Still walks the ci-lanes layer and still emits the inline summary, declining only the persisted write",
+        "States in the report that no branch identity resolved and that therefore no artifact was written, in place of naming a resolved path"
+      ]
+    },
+    {
+      "id": 11,
+      "name": "detached-run-uses-supplied-logical-ref-and-names-it",
+      "prompt": "/overengineering:audit gate-scripts unattended — the runner exports the ref it was launched for as an environment variable, even though the checkout itself is detached.",
+      "expected_output": "The precompute yields the sentinel because the checkout is detached, but the environment supplies a logical ref that names a branch. The run prefers that value as the branch identity, uses it for both the `<branch-slug>` home key and the artifact's `branch:` frontmatter, and names in the report where the identity came from so a reader can tell it was not read from the checkout. The artifact is written normally at the resolved home. The run reads whatever the environment actually supplies rather than reaching for a named CI vendor's variable, because this plugin makes no claim about the consumer's toolchain.",
+      "files": [],
+      "narration": true,
+      "expectations": [
+        "Prefers an environment-supplied logical ref over refusing, when that value names a branch",
+        "Uses the logical ref for BOTH the home key and the `branch:` frontmatter, keeping the two consistent",
+        "Names in the report that the identity came from the environment rather than from the checkout",
+        "Does not hardcode or assume any particular CI vendor's environment variable name",
+        "Writes the artifact normally once an identity is established, rather than declining as it would with none"
+      ]
     }
   ]
 }

--- a/plugins/overengineering/skills/delta/SKILL.md
+++ b/plugins/overengineering/skills/delta/SKILL.md
@@ -215,7 +215,9 @@ unchanged**:
    assessment, the walk, its own inline summary. **Do not re-derive any of it here.**
 4. **Read the post-run artifact**: its spine, its `## Closed since last run` section, its
    `## Suppressed` section, its evidence-availability tokens, and any verdict the audit's own merge
-   flagged as having moved under a carried-forward judgment.
+   flagged as having moved under a carried-forward judgment. **On a cycle whose branch identity never
+   resolved there is no post-run artifact** — the audit declines that write too — so this step and
+   step 5 have nothing to read, and the cycle ends after reporting what the audit found inline.
 5. **Compare** this run's post-audit spine against the baseline from step 2, per "Delta classes"
    below.
 6. **Apply the noise budget**, and report.
@@ -257,8 +259,12 @@ When the branch identity does not resolve:
   own. This is the one no-baseline state that does **not** establish a baseline for the next cycle,
   and the report says so rather than implying the next run will have one.
 
-The audit still runs, exactly as it otherwise would; what is declined is the comparison and the
-capture, not the pass.
+The audit still runs and still reports; what is declined here is the comparison and the capture, not
+the pass. **It does not, however, persist an artifact on such a cycle** — `audit` declines its own
+write on an unresolved identity for the same reason this lane declines its capture, so step 4 below
+has no post-run artifact to read and the audit's inline summary is the cycle's whole output. That is
+the expected shape, not a fault: with nothing compared and nothing captured, a persisted artifact
+would be a file keyed by something every ref shares and read by no later cycle.
 
 ## No baseline — a first-class state, not an error
 

--- a/plugins/overengineering/skills/delta/context/recurring-wiring.md
+++ b/plugins/overengineering/skills/delta/context/recurring-wiring.md
@@ -62,6 +62,12 @@ Two things to get right:
 - **The run needs a checkout on the branch it is auditing.** The findings artifact is branch-keyed,
   and this lane treats an artifact whose `branch:` does not match as no baseline at all. A scheduler
   that lands on a different branch than the last cycle will report "no baseline" every time.
+  **A scheduler that lands *detached* gets less than that**: with no branch identity, the audit writes
+  no artifact, this lane compares nothing and captures nothing, and the cycle's whole output is the
+  inline report. Many schedulers check out a commit rather than a branch by default, so this is the
+  common misconfiguration, not a rare one. Either check out the branch itself, or have the runner
+  supply the logical ref it was launched for — any value naming a branch is accepted, and the report
+  names where the identity came from.
 - **Ephemeral runners have no baseline, ever.** A fresh container each cycle loses the memory-tier
   artifact, so every cycle is a first run and every report says so. Either persist the memory root
   across runs, or use shape 4 instead, where the durable record is a tracker item rather than a file.

--- a/plugins/overengineering/skills/realign/SKILL.md
+++ b/plugins/overengineering/skills/realign/SKILL.md
@@ -11,7 +11,7 @@ metadata:
 
 ## Pre-computed context
 
-- Branch: !`git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown (no checkout)"`
+- Branch: !`git symbolic-ref --quiet --short HEAD 2>/dev/null || echo "no branch ref (detached HEAD or no checkout)"`
 - Today (UTC): !`date -u +%Y-%m-%d 2>/dev/null || echo "unknown (no date command)"`
 
 ## Purpose
@@ -59,7 +59,12 @@ An acceptance given earlier is not an approval of the edit that later falls out 
 
 ## Before anything: load the artifact
 
-1. **Resolve the artifact home** by running the whole rung order in
+1. **Resolve the branch identity, then the artifact home.** The precompute above yields a branch name
+   or the sentinel `no branch ref (detached HEAD or no checkout)`. **`HEAD` is never accepted as a
+   branch identity**, and neither is the sentinel. Where the sentinel appears, prefer a logical ref
+   if the environment supplies one that names a branch (naming where it came from); **otherwise
+   stop** — see "An unresolved branch identity is its own refusal" below. With an identity in hand,
+   resolve the home by running the whole rung order in
    `${CLAUDE_PLUGIN_ROOT}/reference/topic-docs.md`. A hardcoded path reads where the audit never
    wrote, and that failure is indistinguishable from the audit never having run.
 2. **No artifact → stop.** Report, visibly, that no findings artifact exists at the resolved home,
@@ -67,9 +72,12 @@ An acceptance given earlier is not an approval of the edit that later falls out 
    operator can tell "never audited" from "resolved elsewhere". **Do not scan, judge, or remediate
    anything on your own** — this skill has no evidence and no verdict of its own, so an improvised
    pass would put a mutation behind a gate with nothing behind it.
-3. **Refuse a mismatched `branch:`**, naming both, and **refuse an unrecognized `schema:`** with a
-   visible message rather than guessing at the shape. The artifact's own frontmatter is what binds
-   it to a branch; the directory it sits in is not evidence (the slug mapping is lossy).
+3. **Refuse a mismatched `branch:`**, naming both; **refuse an artifact whose `branch:` is absent,
+   empty, or the literal `HEAD`**, naming which; and **refuse an unrecognized `schema:`** — each with
+   a visible message rather than guessing at the shape. The artifact's own frontmatter is what binds
+   it to a branch; the directory it sits in is not evidence (the slug mapping is lossy). A `branch:`
+   that carries no identity is not a match to be evaluated — it is the absence of the thing the check
+   compares, so it takes the refusal branch and never the comparison.
 4. **Read the evidence-availability assessment that leads the artifact, and never recompute it.** It
    changes what UNPROVEN means for every finding below it, and re-deriving it here would make a
    second record that can disagree with the first.
@@ -212,8 +220,39 @@ suppression entry in the consuming repo's tracked `.claude/overengineering.md` �
   `${CLAUDE_PLUGIN_ROOT}/reference/consumer-config.md`. A `REALIGNED` finding needs no entry: the
   mechanism is gone, so it cannot recur.
 
+## An unresolved branch identity is its own refusal
+
+The branch-match check in "Before anything" step 3 protects the one thing this skill cannot recover
+from: executing one ref's findings against a different ref's surface. That check is only as good as
+the two identities it compares, and `git rev-parse --abbrev-ref HEAD` answers the literal string
+`HEAD` on a detached checkout — which compares equal to itself, so a `HEAD`-to-`HEAD` comparison
+passes by construction and authorizes mutations from an artifact that may describe another ref
+entirely. Scheduled and dispatched runners commonly check out detached, so this is an ordinary
+condition, not an exotic one. The precompute therefore uses `git symbolic-ref`, which fails rather
+than inventing a name, matching the `audit` and `delta` lanes.
+
+**Two distinct unresolved states both refuse, and neither may reach the comparison:**
+
+- **This checkout has no branch identity** — the precompute yielded the sentinel and no logical ref
+  was supplied. Stop before reading the artifact. Say so plainly: *"Detached checkout, no logical ref
+  supplied; no branch identity, so the artifact's branch cannot be verified and nothing will be
+  executed."* Nothing is presented as a queue, no status transitions, nothing written anywhere.
+- **The artifact carries no branch identity** — its `branch:` is absent, empty, or the literal
+  `HEAD`. Refuse it by name, and say that `overengineering:audit` declines to write an artifact
+  without an identity, so one carrying `HEAD` was produced by an older audit or by something other
+  than this plugin. Do not repair the field, and do not fall back to the directory it sits in: the
+  slug mapping is lossy, so the home is not evidence of which ref the findings describe.
+
+Refusing costs a re-run on an attached checkout. Passing costs a mutation nobody can attribute to a
+surface — and this is the only skill in the plugin that mutates anything, so the asymmetry is not
+close. **Never fall back to `HEAD`, to the commit sha, or to the home's slug to manufacture the
+missing side of the comparison.**
+
 ## Gotchas
 
+- **`HEAD` is not a branch name.** A detached checkout makes `rev-parse --abbrev-ref` answer `HEAD`,
+  which compares equal to itself and slips a cross-ref artifact through the branch-match refusal.
+  An unresolved identity — on either side of that check — refuses; it never compares.
 - **An accepted finding is not an accepted deletion.** Acceptance authorizes the rung on the table
   at that moment; carrying it to rung 3 is how a reversible change becomes an irreversible one that
   nobody agreed to.

--- a/plugins/overengineering/skills/realign/SKILL.md
+++ b/plugins/overengineering/skills/realign/SKILL.md
@@ -60,8 +60,11 @@ An acceptance given earlier is not an approval of the edit that later falls out 
 ## Before anything: load the artifact
 
 1. **Resolve the branch identity, then the artifact home.** The precompute above yields a branch name
-   or the sentinel `no branch ref (detached HEAD or no checkout)`. **`HEAD` is never accepted as a
-   branch identity**, and neither is the sentinel. Where the sentinel appears, prefer a logical ref
+   or the sentinel `no branch ref (detached HEAD or no checkout)`. **The precompute is a convenience,
+   not the source of truth** — a worktree-isolated or dispatched executor may decline to inject it at
+   all, so where the branch line is absent run `git symbolic-ref --quiet --short HEAD` here and read
+   its exit status rather than assuming an identity. **`HEAD` is never accepted as a branch
+   identity**, and neither is the sentinel. Where the sentinel appears, prefer a logical ref
    if the environment supplies one that names a branch (naming where it came from); **otherwise
    stop** — see "An unresolved branch identity is its own refusal" below. With an identity in hand,
    resolve the home by running the whole rung order in

--- a/plugins/overengineering/skills/realign/SKILL.md
+++ b/plugins/overengineering/skills/realign/SKILL.md
@@ -65,8 +65,10 @@ An acceptance given earlier is not an approval of the edit that later falls out 
    all, so where the branch line is absent run `git symbolic-ref --quiet --short HEAD` here and read
    its exit status rather than assuming an identity. **`HEAD` is never accepted as a branch
    identity**, and neither is the sentinel. Where the sentinel appears, prefer a logical ref
-   if the environment supplies one that names a branch (naming where it came from); **otherwise
-   stop** — see "An unresolved branch identity is its own refusal" below. With an identity in hand,
+   if the environment supplies one that names a branch, after the same normalize-then-validate
+   steps `audit` uses (strip a leading `refs/heads/`, then `git check-ref-format --branch`,
+   refuse `.` / `..` segments); name where it came from. **Otherwise stop** — see "An unresolved
+   branch identity is its own refusal" below. With an identity in hand,
    resolve the home by running the whole rung order in
    `${CLAUDE_PLUGIN_ROOT}/reference/topic-docs.md`. A hardcoded path reads where the audit never
    wrote, and that failure is indistinguishable from the audit never having run.

--- a/plugins/overengineering/skills/realign/evals/evals.json
+++ b/plugins/overengineering/skills/realign/evals/evals.json
@@ -85,7 +85,7 @@
     {
       "id": 7,
       "name": "detached-checkout-refuses-before-reading-the-artifact",
-      "prompt": "/overengineering:realign — work the queue, accept whatever the audit flagged as dead.",
+      "prompt": "/overengineering:realign — work the queue, accept whatever the audit flagged as dead. Heads up, this is running on the build agent, which checked the repo out at a commit rather than a branch, so the working tree is on a detached HEAD. Nothing in the environment supplies the ref it was launched for.",
       "expected_output": "The pre-computed branch line carries the sentinel `no branch ref (detached HEAD or no checkout)` because the checkout is detached, and no logical ref is supplied by the environment. The run stops there, before resolving a home or reading any artifact, and says why: with no branch identity there is nothing to compare the artifact's `branch:` against, so the guard that keeps one ref's findings from executing against another ref's surface cannot run at all. It does not accept `HEAD` as the current branch, does not compare `HEAD` to `HEAD`, and does not treat the directory the artifact sits in as evidence of which ref it describes. Nothing is presented as a queue, no finding is offered for acceptance, no status is written, and nothing is mutated. It states that a re-run on an attached checkout is what unblocks the work.",
       "files": [],
       "narration": true,
@@ -100,7 +100,7 @@
     {
       "id": 8,
       "name": "artifact-carrying-head-as-branch-is-refused",
-      "prompt": "/overengineering:realign — the artifact is already there from last night's scheduled audit, go ahead and work it.",
+      "prompt": "/overengineering:realign — the artifact is already there from last night's scheduled audit, go ahead and work it. We are on a normal branch today. The file at the resolved home is a complete findings artifact with several OPEN findings, and its frontmatter reads `type: overengineering-findings`, `schema: 1`, `branch: HEAD` — that scheduled runner was on a detached checkout when it wrote the file.",
       "expected_output": "The current checkout is on a normal branch, so the run resolves an identity and reads the artifact at the resolved home. The artifact's frontmatter carries `branch: HEAD`, which is not a branch identity but the literal string a detached checkout produces under `git rev-parse --abbrev-ref HEAD`. The run refuses the artifact by name with a visible message, treating the unresolved identity as its own refusal case rather than as a mismatch to evaluate — there is nothing to compare, so the comparison is never reached. It says that overengineering:audit declines to write an artifact without a branch identity, so a file carrying `HEAD` came from an older audit or from something other than this plugin. It does not repair or rewrite the `branch:` field, does not infer the branch from the directory the artifact sits in, and executes no finding.",
       "files": [],
       "narration": true,

--- a/plugins/overengineering/skills/realign/evals/evals.json
+++ b/plugins/overengineering/skills/realign/evals/evals.json
@@ -81,6 +81,36 @@
         "Does not block, error, or abandon the finding because a composition plugin is missing",
         "Records the presence answer on the finding so the skipped route is visible later"
       ]
+    },
+    {
+      "id": 7,
+      "name": "detached-checkout-refuses-before-reading-the-artifact",
+      "prompt": "/overengineering:realign — work the queue, accept whatever the audit flagged as dead.",
+      "expected_output": "The pre-computed branch line carries the sentinel `no branch ref (detached HEAD or no checkout)` because the checkout is detached, and no logical ref is supplied by the environment. The run stops there, before resolving a home or reading any artifact, and says why: with no branch identity there is nothing to compare the artifact's `branch:` against, so the guard that keeps one ref's findings from executing against another ref's surface cannot run at all. It does not accept `HEAD` as the current branch, does not compare `HEAD` to `HEAD`, and does not treat the directory the artifact sits in as evidence of which ref it describes. Nothing is presented as a queue, no finding is offered for acceptance, no status is written, and nothing is mutated. It states that a re-run on an attached checkout is what unblocks the work.",
+      "files": [],
+      "narration": true,
+      "expectations": [
+        "Recognizes the sentinel as an unresolved branch identity and refuses rather than proceeding",
+        "Stops BEFORE reading the artifact, rather than loading it and then comparing",
+        "Never compares HEAD to HEAD, and never accepts a degenerate self-equal match as a passing branch check",
+        "Does not fall back to the artifact's directory or slug as evidence of which ref the findings describe",
+        "Mutates nothing, writes no status field, and presents no queue for acceptance"
+      ]
+    },
+    {
+      "id": 8,
+      "name": "artifact-carrying-head-as-branch-is-refused",
+      "prompt": "/overengineering:realign — the artifact is already there from last night's scheduled audit, go ahead and work it.",
+      "expected_output": "The current checkout is on a normal branch, so the run resolves an identity and reads the artifact at the resolved home. The artifact's frontmatter carries `branch: HEAD`, which is not a branch identity but the literal string a detached checkout produces under `git rev-parse --abbrev-ref HEAD`. The run refuses the artifact by name with a visible message, treating the unresolved identity as its own refusal case rather than as a mismatch to evaluate — there is nothing to compare, so the comparison is never reached. It says that overengineering:audit declines to write an artifact without a branch identity, so a file carrying `HEAD` came from an older audit or from something other than this plugin. It does not repair or rewrite the `branch:` field, does not infer the branch from the directory the artifact sits in, and executes no finding.",
+      "files": [],
+      "narration": true,
+      "expectations": [
+        "Refuses an artifact whose `branch:` is the literal HEAD, with a visible message naming the problem",
+        "Treats the unresolved identity as its own refusal case rather than evaluating it as a branch mismatch",
+        "Does NOT repair, rewrite, or fill in the artifact's `branch:` field",
+        "Does not infer the branch from the artifact's directory, since the slug mapping is lossy and the home is not evidence",
+        "Executes no finding and writes no status field"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

`overengineering:audit` and `overengineering:realign` precomputed the current branch with
`git rev-parse --abbrev-ref HEAD`, which answers the literal string `HEAD` when HEAD is detached —
the ordinary shape for a scheduled CI runner. `HEAD` looks like a branch name, is the same string
for every ref, and compares equal to itself, so three consequences followed and all of them were
silent:

- `audit` wrote `branch: HEAD` into the findings artifact, giving it an identity that is not a
  branch.
- `realign`'s branch-match refusal compared `HEAD` to `HEAD`, passed by construction, and could
  accept another ref's artifact as this ref's own — in the only skill in this plugin that mutates
  anything, where per-item human consent is spent down a rollback ladder as far as deletion.
- The `<branch-slug>` memory-tier home key resolved every detached ref to one directory, so
  unrelated runs shared a single artifact and merged each other's carried-forward operator
  judgments.

The `delta` lane already resolved identity correctly with `git symbolic-ref` and could not fix any
of these from where it sits, which is why this was filed separately from #3146.

## Fix

Both precomputes now use `git symbolic-ref --quiet --short HEAD`, which fails rather than inventing
a name, and emit the same sentinel string `delta` already used. All three skills now agree on one
resolution contract: prefer a logical ref where the environment supplies one naming a branch — with
no CI vendor's variables named or assumed — and otherwise treat the identity as unresolved.

On an unresolved identity:

- **`audit` persists no findings artifact at all.** Not the file with `branch:` omitted, not a
  placeholder value, not a file at a substitute home. The walk still runs and the inline summary is
  still emitted, so the operator still gets the findings; only the persisted write is declined, and
  the read-only disclosure line says that instead of naming a path.
- **`realign` refuses**, in both unresolved states: when its own checkout has no identity (it stops
  before reading the artifact at all) and when the artifact it finds carries `branch:` absent,
  empty, or `HEAD`. Neither path reaches the comparison. The refusal is a positive precondition
  rather than a consequence of the file being missing, which also renders any stale pre-fix
  artifact already on disk unreachable without a cleanup step.

**Identity resolution is a stated body step, not only a precompute.** A worktree-isolated or
dispatched executor may decline to inject the precomputed context block entirely — and that is the
same `unattended` context in which a detached checkout is most likely — so both skills state the
resolution command in the step that uses it and treat the precompute as a convenience that may be
absent. Confined to the precompute line, the fix would have verified green on an attached local
checkout and done nothing in the environment the defect actually lives in.

Two contract documents now state the case rather than leaving it to be inferred.
`context/findings-artifact.md` documents `branch:` as resolved with `git symbolic-ref` and never the
literal `HEAD`, adds a "No branch identity, no artifact" section, and carries a per-skill
obligations row. `reference/topic-docs.md` records that an unresolved identity keys no home and does
not run the rung order, rejecting each substitute on its own terms: `HEAD` is one directory for
every ref, a commit sha is a fresh home every commit that never resumes, and a fixed literal such as
`detached` is `HEAD` under another name.

Three adjacent surfaces were made inconsistent by the change and are corrected in the same PR.
`skills/audit/context/report-template.md`, which owns the read-only disclosure line, still declared
the artifact written "always" and hardcoded the path-naming form. `skills/delta/SKILL.md` closed its
own detached section with "the audit still runs, exactly as it otherwise would" — true when written,
false once the audit began declining its write — and its step 4 would have looked for a post-run
artifact that no longer exists; `delta`'s behavior is unchanged, only its account of the audit's.
And `skills/delta/context/recurring-wiring.md`, the wiring document read by exactly the affected
population, now names the detached case and the logical-ref remedy.

**The `branch:` decision was made by an independent panel, not by the implementing agent**, and is
recorded in full on the issue with its reasoning, its rejected alternatives, and its caveats:
[#3149 (comment)](https://github.com/melodic-software/claude-code-plugins/issues/3149#issuecomment-5388219257).
Two fresh-context agents on different models, spawned separately with the implementing agent's
rationale withheld, independently reached the same answer as that agent's own prior read.

## Verification

**The behavior the fix turns on, observed directly.** The marketplace's own primary clone happens to
sit detached, so both forms were run against a real detached checkout and against an attached one:

| Checkout | `git rev-parse --abbrev-ref HEAD` | `git symbolic-ref --quiet --short HEAD` |
|---|---|---|
| Detached (`## HEAD (no branch)`) | `HEAD` | *(no output, exit 1)* |
| Attached (`fix/3149-…`) | `fix/3149-…` | `fix/3149-…` |

The two forms agree exactly where a branch exists and diverge exactly where one does not, which is
the whole of the guard. `git branch --show-current` was checked on the same detached checkout and
returns an empty string at exit 0 — the basis for the cross-plugin finding below.

**Repo gates.** This plugin ships no scripts and no `*.test.sh`, so its coverage mechanism is the
eval sets plus the shared static gates. All were re-run after the review fixes:

- `check-skill.sh` — `audit`, `realign`, and `delta` each PASS with 0 errors. The warnings each
  reports (description length, the 200-line soft target) are pre-existing on `main`.
- `check-evals-quality.sh` — PASS, 0 warnings across both eval sets.
- `check-jsonschema` against `plugins/skill-quality/reference/evals.schema.json` — valid.
- `check-skill-portability.sh` — no unexcused coupling tokens.
- `markdownlint-cli2` — 0 issues across all eight changed markdown files.

**Eval coverage for the detached path, which existed for neither skill before.** Four cases added:
`audit` declining to persist on a detached runner; `audit` preferring an environment-supplied
logical ref and naming its origin; `realign` stopping before it reads the artifact when its own
checkout is detached; and `realign` refusing an artifact carrying `branch: HEAD`. Each prompt
narrates the checkout state it depends on, following the convention the existing shallow-clone case
already uses, so none asserts a condition it never establishes.

**Independent review.** A fresh-context reviewer with the author's rationale withheld checked the
change against the issue's five acceptance criteria and returned NOT READY on the first commit. Its
blocker (the stale `report-template.md`) and every should-fix (the cross-plugin count, the
`mutation-testing` overclaim, the `babysit-prs` characterization, three under-specified eval
prompts, the missing wiring guidance) are addressed in the second commit. The version moved to
0.3.0 rather than a patch on its recommendation: a run that previously wrote a file now writes none.

## Related

Closes #3149

- #3146 — the `delta` lane PR where this was found; carries the delta-side defense this change
  converges `audit` and `realign` onto.

**Do other plugins share the pattern?** No other plugin exhibits the `HEAD` identity-collapse. The
repo-wide precompute boilerplate uses `git branch --show-current`, which returns an empty string on
a detached checkout rather than `HEAD`. The literal `git rev-parse --abbrev-ref HEAD` form survives
at seven occurrences across six files outside this plugin: `claude-ops`' two skill-usage telemetry
hooks, `source-control`'s `babysit-prs` parking-branch capture and `worktree` current-branch
display, and three test-scaffolding sites in `guardrails`' `stale-path-verify.test.sh` and
`source-control`'s `worktree-create.test.sh`. None compares the value against a stored identity to
decide whether a mutation may proceed. `babysit-prs` is the closest call and is still a different
defect class — its captured value parameterizes a same-session `git checkout`, so a detached capture
fails to restore the starting commit rather than authorizing another ref's work. All are left as-is
deliberately. This corrects the triage note, which recorded two of these sites rather than six.

**One neighbor has the same shape under a different string, and is out of scope.**
`mutation-testing:audit` documents `branch:` as `git branch --show-current` verbatim
(`skills/audit/context/persist-findings.md:202`) and ships no script guarding the empty result, so a
detached run there writes an empty identity that compares equal to itself. Three sibling
findings-writers (`ai-slop`, `docs-hygiene:audit-noise`, `claude-config:audit-instructions`) already
guard that case and exit rather than persist. Recorded rather than fixed — this issue is scoped to
one plugin — and worth its own item.

**Adjacent pre-existing condition, deliberately not fixed here.**
`scripts/check-skill-precompute-compose.sh` reports both `audit/SKILL.md` and `realign/SKILL.md` as
carrying a git command plus more than one injection line (#1619). Both files already had two
precompute lines on `main`, so this change neither introduces nor worsens it, and the gate is
warn-only in CI pending that remediation wave. Making resolution a body step is what keeps this fix
correct in the meantime, since a refused precompute block no longer means an unguarded identity.
