### PR TITLE
fix(docs-hygiene): read porcelain -z so octal-escaped paths reach audit-noise (0.21.4)

### DIFF
--- a/plugins/docs-hygiene/.claude-plugin/plugin.json
+++ b/plugins/docs-hygiene/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "docs-hygiene",
-  "version": "0.21.3",
+  "version": "0.21.4",
   "description": "Documentation-hygiene toolkit: compress (flavor-trim markdown with a semantic-diff safety net), audit-noise (classify markdown noise), extract-ssot (deduplicate repeated content into a single source of truth), audit-encapsulation (detect citations into skill-private surfaces), rename-references (sweep stale references after renames), audit-derivability (classify whether a whole document earns its existence — could a fresh agent re-derive it from the code?), audit-progressive-disclosure (grade instruction files against a load-tier model for split opportunities and hub/spoke disclosure defects), write-for-agents (authoring-time doctrine that fires while agent-consumed markdown is being written), and write-for-humans (the same moment for the other reader — end-user READMEs, RFCs, release notes and guides — resolving the consuming project's own style guide first).",
   "author": {
     "name": "Melodic Software",

--- a/plugins/docs-hygiene/CHANGELOG.md
+++ b/plugins/docs-hygiene/CHANGELOG.md
@@ -1,5 +1,39 @@
 # Changelog — docs-hygiene plugin
 
+## [0.21.4]
+
+### Fixed
+
+- **`audit-noise` now discovers uncommitted paths holding a non-ASCII or control
+  byte (#3164).** This closes the residual 0.19.1 recorded at its own parse site,
+  and it is the last of the class: `detect.sh` reads `git status --porcelain -z`
+  instead of the v1 form.
+
+  v1 renders such a path as a C-quoted record with C-style octal escapes: in
+  `café.md`, the two UTF-8 bytes of the é arrive as the eight characters
+  `\303\251`. 0.19.1 stripped the quotes and undid `\"` and `\\`, but nothing
+  decoded the octal form, so the target list carried an escape sequence that names
+  no file and the audit reported a clean tree over a dirty one. The `-z` form is
+  documented as performing no quoting and no backslash-escaping, so every byte
+  arrives verbatim and there is nothing left to decode.
+
+  Rename handling becomes structural rather than textual. Under `-z` a rename
+  emits the **new** path in the record and the **original** as a following record —
+  the reverse of v1's `old -> new` display order — so that second record is
+  consumed and discarded. No arrow is matched anywhere, which subsumes 0.19.1's
+  `[RC]` split gate rather than competing with it.
+
+  `--paths-file` and `--offset`/`--limit` pagination are untouched — the change is
+  confined to the porcelain branch. 0.20.1's `SKILL.md` preview fix is orthogonal
+  and untouched; that line still previews via `grep`, and a quoted record it now
+  keeps is still displayed octal-escaped.
+
+  Regression cases cover a non-ASCII path, a control-byte (tab) path, a quoted
+  spaced path, a rename whose new path is octal-escaped, and a rename whose origin
+  record must be consumed. The rename-origin fixture renames `abcsecret.md`
+  alongside a clean committed `secret.md`, so a leaked origin record would audit a
+  file git never listed rather than asserting a string the run can never produce.
+
 ## [0.21.3]
 
 ### Fixed

--- a/plugins/docs-hygiene/CHANGELOG.md
+++ b/plugins/docs-hygiene/CHANGELOG.md
@@ -28,6 +28,9 @@
   and untouched; that line still previews via `grep`, and a quoted record it now
   keeps is still displayed octal-escaped.
 
+  Sort and dedup stay NUL-delimited (`sort -uz` into `mapfile -d ''`) so a
+  newline recovered by `-z` is not split into two nonexistent targets.
+
   Regression cases cover a non-ASCII path, a control-byte (tab) path, a quoted
   spaced path, a rename whose new path is octal-escaped, and a rename whose origin
   record must be consumed. The rename-origin fixture renames `abcsecret.md`

--- a/plugins/docs-hygiene/skills/audit-noise/scripts/detect.sh
+++ b/plugins/docs-hygiene/skills/audit-noise/scripts/detect.sh
@@ -169,7 +169,10 @@ if [[ ${#TARGETS[@]} -eq 0 ]]; then
   exit 0
 fi
 
-mapfile -t SORTED < <(printf '%s\n' "${TARGETS[@]}" | LC_ALL=C sort -u)
+# Keep NUL delimiters through sort/dedup so a path that itself contains a
+# newline (a control byte the -z read just recovered) is not split into two
+# nonexistent targets.
+mapfile -d '' -t SORTED < <(printf '%s\0' "${TARGETS[@]}" | LC_ALL=C sort -uz)
 
 # Chunk affordance: slice the sorted list so a parent can fan out without a
 # per-file shell loop (hook-bypass-safe single process per chunk).

--- a/plugins/docs-hygiene/skills/audit-noise/scripts/detect.sh
+++ b/plugins/docs-hygiene/skills/audit-noise/scripts/detect.sh
@@ -114,35 +114,28 @@ if [[ ${#TARGETS[@]} -eq 0 ]]; then
       TARGETS+=("$(resolve_existing_path "$line")")
     done <"$PATHS_FILE"
   elif [[ -n "$repo_root" ]]; then
-    # Uncommitted .md files: modified/added/renamed/untracked. Parse porcelain
-    # without $NF so paths containing spaces survive (F10).
-    while IFS= read -r line; do
-      line="${line//$'\r'/}"
-      [[ -z "$line" ]] && continue
-      # XY + space + path; rename shows "old -> new" — take the new path.
-      # Gate the split on the status letter in either column, not on the path
-      # text: an ordinary path containing " -> " is not a rename record, and
-      # splitting it yields a name that resolves to nothing, so the file drops
-      # out of the audit silently.
-      local_path="${line:3}"
-      if [[ "${line:0:1}" == [RC] || "${line:1:1}" == [RC] ]]; then
-        local_path="${local_path##* -> }"
+    # Uncommitted .md files: modified/added/renamed/untracked. Read the
+    # NUL-delimited `-z` form, which git documents as performing no quoting and
+    # no backslash-escaping: every byte of the path arrives verbatim, so there
+    # is nothing left to unquote or decode. The v1 form C-quotes any path
+    # holding a space, a quote, a backslash, or a non-ASCII/control byte, and a
+    # parse that misses one of those escapes drops the file from the target list
+    # silently — a clean run over a dirty tree.
+    while IFS= read -r -d '' record; do
+      [[ -z "$record" ]] && continue
+      # XY + space + path. Under -z a rename/copy puts the NEW path in this
+      # record and the ORIGINAL in a following record — the reverse of v1's
+      # `old -> new` display order. Consume that second record and discard it,
+      # or the audit targets a path that no longer exists. The rename is decided
+      # by the status letter alone; no arrow ever appears under -z, so an
+      # ordinary path containing " -> " cannot be mistaken for one.
+      local_path="${record:3}"
+      if [[ "${record:0:1}" == [RC] || "${record:1:1}" == [RC] ]]; then
+        IFS= read -r -d '' _rename_origin || true
       fi
-      # Untracked / quoted paths: git may wrap as "path with spaces.md"
-      if [[ "$local_path" == \"*\" ]]; then
-        local_path="${local_path#\"}"
-        local_path="${local_path%\"}"
-        # git C-quotes both " and \, so both need undoing. \" first, then \\.
-        local_path="${local_path//\\\"/\"}"
-        local_path="${local_path//\\\\/\\}"
-      fi
-      # Residual: git's octal escapes (\NNN) for control and non-ASCII bytes are
-      # not decoded, so those paths still miss. Converging this parse on
-      # `git status --porcelain -z` would close the class outright — NUL-delimited
-      # and unquoted — at the cost of reading renames as two fields, not "old -> new".
       [[ "$local_path" == *.md ]] || continue
       TARGETS+=("$local_path")
-    done < <(git status --porcelain 2>/dev/null)
+    done < <(git status --porcelain -z 2>/dev/null)
   fi
 else
   RESOLVED=()

--- a/plugins/docs-hygiene/skills/audit-noise/scripts/detect.test.sh
+++ b/plugins/docs-hygiene/skills/audit-noise/scripts/detect.test.sh
@@ -1166,6 +1166,26 @@ rename_origin_out="$(cd "$RENAME_REPO" && bash "$DETECT" 2>/dev/null)"
 assert_contains "rename resolves to the new path" "$rename_origin_out" "Summary file: moved.md"
 assert_not_contains "rename origin is consumed, not sliced into a clean committed file" "$rename_origin_out" "Summary file: secret.md"
 
+# A newline in a filename is a control byte the -z read recovers intact. If
+# sort/dedup then serializes TARGETS with newline delimiters, mapfile splits
+# the name into two nonexistent targets and the file drops out again.
+NL_REPO="$TEST_TMPDIR/newline-name-repo"
+mkdir -p "$NL_REPO"
+git -C "$NL_REPO" init -q
+git -C "$NL_REPO" config user.email fixture@example.invalid
+git -C "$NL_REPO" config user.name fixture
+nl_name="$(printf 'new\nline.md')"
+printf '# newline\n\nEmpirically observed in the newline file.\n' >"$NL_REPO/$nl_name" 2>/dev/null || true
+if fixture_landed "$NL_REPO" "$nl_name"; then
+  nl_out="$(cd "$NL_REPO" && bash "$DETECT" 2>/dev/null)"
+  assert_contains "newline-bearing path survives sort/dedup" "$nl_out" "Empirically observed in the newline file"
+else
+  # discriminating-skip-ok: the tab and non-ASCII cases already prove the
+  # escape class; this pins the post-parse sort, which not every filesystem
+  # can hold a name for.
+  skip_case "filesystem rejects a newline in a filename"
+fi
+
 # --- Final report --------------------------------------------------------------------
 
 if [[ "$FAILED" -eq 0 ]]; then

--- a/plugins/docs-hygiene/skills/audit-noise/scripts/detect.test.sh
+++ b/plugins/docs-hygiene/skills/audit-noise/scripts/detect.test.sh
@@ -14,6 +14,7 @@ trap 'rm -rf "$TEST_TMPDIR"' EXIT
 
 FAILED=0
 CASE_NUM=0
+SKIPPED=0
 
 pass() {
   CASE_NUM=$((CASE_NUM + 1))
@@ -38,6 +39,22 @@ assert_not_contains() {
   *"$3"*) fail "$1" "absent: $3" "present" ;;
   *) pass "$1" ;;
   esac
+}
+# skip_case <reason> — skip one optional case without exiting. Named to match the
+# house helper so scripts/check-discriminating-test-skips.sh can see these
+# branches; a bare `printf 'SKIP:'` is invisible to that gate. It must never
+# swallow the only discriminating coverage for a case group.
+skip_case() {
+  SKIPPED=$((SKIPPED + 1))
+  printf 'SKIP: %s\n' "$1" >&2
+}
+# fail_discriminating_skip <reason> — a skip that WOULD vacate the only
+# discriminating assertions in a case group. Counts as a failure, so a green
+# tally can never mean "every proving fixture was skipped".
+fail_discriminating_skip() {
+  CASE_NUM=$((CASE_NUM + 1))
+  FAILED=$((FAILED + 1))
+  printf 'DISCRIMINATING SKIP: [%d] %s\n' "$CASE_NUM" "$1" >&2
 }
 
 # --- Fixtures (built inline; no shipped fixture files) ---------------------------
@@ -683,7 +700,7 @@ bad_chunk_exit=0
 bash "$DETECT" --offset -1 "$CLEAN" >/dev/null 2>&1 || bad_chunk_exit=$?
 assert_exit "negative --offset exits 2" 2 "$bad_chunk_exit"
 
-# --- Porcelain discovery: tricky paths survive the parse (#3143) ----------------------
+# --- Porcelain discovery: tricky paths survive the parse (#3143 / #3164) --------------
 # A plain path passes either implementation, so each case below needs a path git
 # treats specially: one containing a literal " -> ", and one containing a backslash.
 
@@ -693,11 +710,37 @@ git -C "$PORC_REPO" init -q
 git -C "$PORC_REPO" config user.email fixture@example.invalid
 git -C "$PORC_REPO" config user.name fixture
 
-printf '# arrow\n\nEmpirically observed in the arrow file.\n' >"$PORC_REPO/notes -> draft.md"
+# Every case below needs a name the local filesystem may refuse, and a redirect to
+# such a name does not always fail: Windows substitutes a private-use codepoint for
+# '>' and drops a tab, reporting success, and the shell's own -f test then sees the
+# same substituted name and agrees the fixture is there. Only git's byte-exact view
+# of the worktree can confirm the intended name landed. Without this guard a case
+# fails — or worse, passes — for a reason that has nothing to do with the parse.
+# Caveats, since this gates whether a case runs at all: it is a substring match over
+# the whole status, not an exact record match; it requires the fixture to still be
+# DIRTY, so it returns false after the fixture is committed; and it reads the same
+# `-z` interface under test, so a `-z` regression would turn assertions into skips
+# rather than failures. The skip tally and the esc_discriminators guard below exist
+# so that degradation cannot pass silently.
+fixture_landed() { # <repo> <intended-name>
+  git -C "$1" status --porcelain -z 2>/dev/null | tr '\0' '\n' | grep -qF -- "$2"
+}
+
 printf '# plain\n\nEmpirically observed in the plain file.\n' >"$PORC_REPO/plain.md"
 
+printf '# arrow\n\nEmpirically observed in the arrow file.\n' >"$PORC_REPO/notes -> draft.md" 2>/dev/null || true
+if fixture_landed "$PORC_REPO" 'notes -> draft.md'; then
+  porc_out="$(cd "$PORC_REPO" && bash "$DETECT" 2>/dev/null)"
+  assert_contains "untracked path containing ' -> ' is not split as a rename" "$porc_out" "notes -> draft.md"
+else
+  # discriminating-skip-ok: regression guard for #3171's arrow gate, not a #3164
+  # discriminator — the -z read matches no arrow at all, so nothing here proves
+  # the fix under test.
+  find "$PORC_REPO" -maxdepth 1 -name '*draft.md' -delete 2>/dev/null
+  skip_case "filesystem rejects an arrow in a filename"
+fi
+
 porc_out="$(cd "$PORC_REPO" && bash "$DETECT" 2>/dev/null)"
-assert_contains "untracked path containing ' -> ' is not split as a rename" "$porc_out" "notes -> draft.md"
 assert_contains "ordinary untracked path still discovered" "$porc_out" "plain.md"
 
 # The gate must not cost us real renames: a genuine R record still yields the NEW path.
@@ -709,12 +752,16 @@ rename_out="$(cd "$PORC_REPO" && bash "$DETECT" 2>/dev/null)"
 assert_contains "rename record resolves to the new path" "$rename_out" "after.md"
 assert_not_contains "rename record does not keep the old path" "$rename_out" "before.md"
 
-# git C-quotes a path containing a backslash, so \\ needs undoing as well as \".
-if printf '# backslash\n\nEmpirically observed in the backslash file.\n' >"$PORC_REPO/back\\-slash.md" 2>/dev/null; then
+# git C-quotes a path containing a backslash, so that escape must not survive either.
+printf '# backslash\n\nEmpirically observed in the backslash file.\n' >"$PORC_REPO/back\\-slash.md" 2>/dev/null || true
+if fixture_landed "$PORC_REPO" 'back\-slash.md'; then
   bs_out="$(cd "$PORC_REPO" && bash "$DETECT" 2>/dev/null)"
   assert_contains "backslash path is unescaped and discovered" "$bs_out" 'back\-slash.md'
 else
-  printf 'SKIP: filesystem rejects a backslash in a filename\n'
+  # discriminating-skip-ok: regression guard for #3171's `\\` unescape, not a
+  # #3164 discriminator — the -z read never unescapes anything.
+  find "$PORC_REPO" -maxdepth 1 -name '*slash.md' -delete 2>/dev/null
+  skip_case "filesystem rejects a backslash in a filename"
 fi
 
 # --- negation shape ------------------------------------------------------------------
@@ -1011,7 +1058,16 @@ if [[ -f "$SKILL_MD" ]]; then
   skill_grep="$(sed -n 's/^Uncommitted \.md files: !`git status --porcelain 2>\/dev\/null | \(grep [^|]*\) | head.*/\1/p' "$SKILL_MD")"
   if [[ -n "$skill_grep" ]]; then
     skill_out="$(cd "$PORC_REPO" && eval "git status --porcelain 2>/dev/null | $skill_grep")"
-    assert_contains "SKILL.md preview keeps a quoted .md path" "$skill_out" 'notes -> draft.md'
+    # The quoted-path half needs the arrow fixture, which not every filesystem can
+    # hold — same hazard the porcelain cases above are gated on, so gate it the same
+    # way rather than let it fail for a reason unrelated to the preview.
+    if fixture_landed "$PORC_REPO" 'notes -> draft.md'; then
+      assert_contains "SKILL.md preview keeps a quoted .md path" "$skill_out" 'notes -> draft.md'
+    else
+      # discriminating-skip-ok: covers 0.20.1's preview grep, not this change; the
+      # ordinary-path assertion below still proves the grep was extracted and ran.
+      skip_case "filesystem rejects an arrow in a filename (SKILL.md preview parity)"
+    fi
     assert_contains "SKILL.md preview still keeps an ordinary .md path" "$skill_out" 'plain.md'
   else
     fail "SKILL.md preview grep is extractable" "a grep expression" "no match in $SKILL_MD"
@@ -1020,11 +1076,101 @@ else
   fail "SKILL.md exists for the parity check" "$SKILL_MD" "missing"
 fi
 
+# --- Porcelain discovery: octal-escaped paths survive the parse (#3164) ---------------
+# v1 porcelain renders a non-ASCII or control byte as a C-style octal escape inside a
+# quoted path: the two UTF-8 bytes of the é in `café.md` arrive as the eight characters
+# `\303\251`, which no amount of quote-stripping resolves back to a real name. The -z
+# form emits those bytes verbatim, so the path reaches the audit.
+
+ESC_REPO="$TEST_TMPDIR/porcelain-escapes-repo"
+mkdir -p "$ESC_REPO"
+git -C "$ESC_REPO" init -q
+git -C "$ESC_REPO" config user.email fixture@example.invalid
+git -C "$ESC_REPO" config user.name fixture
+
+nonascii_name='café.md'
+printf '# non-ascii\n\nEmpirically observed in the non-ASCII file.\n' >"$ESC_REPO/$nonascii_name"
+printf '# spaced\n\nEmpirically observed in the spaced file.\n' >"$ESC_REPO/spaced name.md"
+
+# Both octal-escape fixtures below prove the same thing, and neither is creatable
+# everywhere, so track whether AT LEAST ONE ran. If none did, the group has proved
+# nothing and must say so loudly rather than tally green.
+esc_discriminators=0
+
+esc_out="$(cd "$ESC_REPO" && bash "$DETECT" 2>/dev/null)"
+if fixture_landed "$ESC_REPO" "$nonascii_name"; then
+  assert_contains "octal-escaped non-ASCII path is discovered" "$esc_out" "$nonascii_name"
+  esc_discriminators=$((esc_discriminators + 1))
+else
+  # discriminating-skip-ok: the control-byte case below proves the same escape
+  # class, and the guard after it fails outright if neither fixture landed.
+  find "$ESC_REPO" -maxdepth 1 -name '*.md' ! -name 'spaced name.md' -delete 2>/dev/null
+  skip_case "filesystem rejects a non-ASCII byte in a filename"
+fi
+assert_contains "quoted spaced path is still discovered" "$esc_out" "spaced name.md"
+
+# A control byte is escaped the same way (`\t`). Not every filesystem accepts one.
+tab_name="$(printf 'tab\there.md')"
+printf '# tab\n\nEmpirically observed in the tab file.\n' >"$ESC_REPO/$tab_name" 2>/dev/null || true
+if fixture_landed "$ESC_REPO" "$tab_name"; then
+  tab_out="$(cd "$ESC_REPO" && bash "$DETECT" 2>/dev/null)"
+  assert_contains "octal-escaped control-byte path is discovered" "$tab_out" "$tab_name"
+  esc_discriminators=$((esc_discriminators + 1))
+else
+  # discriminating-skip-ok: the non-ASCII case above proves the same escape
+  # class, and the guard below fails outright if neither fixture landed.
+  find "$ESC_REPO" -maxdepth 1 -name '*here.md' -delete 2>/dev/null
+  skip_case "filesystem rejects a tab in a filename"
+fi
+
+if [[ "$esc_discriminators" -eq 0 ]]; then
+  fail_discriminating_skip "no octal-escaped fixture landed — #3164's proving coverage did not run"
+fi
+
+# A rename whose NEW path is itself octal-escaped: v1 cannot name it, so this
+# discriminates the -z read the same way the untracked cases above do.
+printf '# origin\n\nEmpirically observed in the origin file.\n' >"$ESC_REPO/origin.md"
+git -C "$ESC_REPO" add origin.md
+git -C "$ESC_REPO" commit -qm 'seed escaped-rename fixture'
+git -C "$ESC_REPO" mv origin.md "$nonascii_name-renamed.md"
+if fixture_landed "$ESC_REPO" "$nonascii_name-renamed.md"; then
+  esc_rename_out="$(cd "$ESC_REPO" && bash "$DETECT" 2>/dev/null)"
+  assert_contains "escaped rename resolves to the new path" "$esc_rename_out" "$nonascii_name-renamed.md"
+else
+  # discriminating-skip-ok: same escape class as the untracked cases above, which
+  # the esc_discriminators guard already covers.
+  skip_case "filesystem rejects a non-ASCII byte in a renamed filename"
+fi
+
+# Under -z a rename emits the NEW path first and the ORIGINAL as a following record,
+# which must be consumed and discarded. The failure mode is NOT that the audit targets
+# a path that no longer exists: the leaked record still carries the `XY ` prefix, so
+# `${record:3}` chops three characters off the ORIGINAL path. Naming the origin so that
+# chopping three characters yields a REAL, CLEAN, COMMITTED file is what makes this
+# assertion discriminate at all — the audit then reports findings against a file the
+# user never touched and git never listed. Asserting on the bare origin name instead
+# would be VACUOUS: `${"origin.md":3}` is `gin.md`, a string the run never emits, so the
+# assertion could not fail however the loop behaved. `sort -u` dedupes, so the collided
+# name must not itself be a target either.
+RENAME_REPO="$TEST_TMPDIR/rename-origin-repo"
+mkdir -p "$RENAME_REPO"
+git -C "$RENAME_REPO" init -q
+git -C "$RENAME_REPO" config user.email fixture@example.invalid
+git -C "$RENAME_REPO" config user.name fixture
+printf '# secret\n\nEmpirically observed in the secret file.\n' >"$RENAME_REPO/secret.md"
+printf '# abc\n\nEmpirically observed in the abc file.\n' >"$RENAME_REPO/abcsecret.md"
+git -C "$RENAME_REPO" add secret.md abcsecret.md
+git -C "$RENAME_REPO" commit -qm 'seed rename-origin collision fixture'
+git -C "$RENAME_REPO" mv abcsecret.md moved.md
+rename_origin_out="$(cd "$RENAME_REPO" && bash "$DETECT" 2>/dev/null)"
+assert_contains "rename resolves to the new path" "$rename_origin_out" "Summary file: moved.md"
+assert_not_contains "rename origin is consumed, not sliced into a clean committed file" "$rename_origin_out" "Summary file: secret.md"
+
 # --- Final report --------------------------------------------------------------------
 
 if [[ "$FAILED" -eq 0 ]]; then
-  printf '\nAll %d checks passed.\n' "$CASE_NUM"
+  printf '\nAll %d checks passed (%d skipped).\n' "$CASE_NUM" "$SKIPPED"
   exit 0
 fi
-printf '\n%d/%d checks failed.\n' "$FAILED" "$CASE_NUM" >&2
+printf '\n%d/%d checks failed (%d skipped).\n' "$FAILED" "$CASE_NUM" "$SKIPPED" >&2
 exit 1


### PR DESCRIPTION
Closes #3164

## Summary

`audit-noise`'s default-target router parsed `git status --porcelain` v1. 0.19.1 (#3171) undid quotes and backslashes and gated the rename split on the status letter, but nothing decoded C-style octal escapes. `café.md` arrived as a literal `\303\251` sequence that names no file, so the path dropped out of the target list and the run reported a clean tree over a dirty one.

## Fix

Read the NUL-delimited `-z` form, which git documents as performing no quoting and no backslash-escaping. Rename handling becomes structural: under `-z` the new path is in the record and the original follows as a second record, consumed and discarded. No arrow is matched anywhere, which subsumes the `[RC]` split gate.

`--paths-file` and `--offset`/`--limit` are untouched. The `SKILL.md` preview still greps v1 output and is out of scope.

## Verification

- `detect.test.sh` — 139 checks passed (0 skipped), including non-ASCII, tab, spaced, escaped-rename, and rename-origin-consumption cases
- `skill-quality:check docs-hygiene:audit-noise` — PASS (0 errors, 1 pre-existing Gotchas warning)
- `check-changelog-parity.sh --check-bump origin/main` — PASS
- Reverting the `-z` read fails the non-ASCII / control-byte / escaped-rename cases; deleting only the origin-consumption guard fails the `abcsecret.md` → `secret.md` collision case

## Related

- Refs #3171 — partial v1-parse fix that recorded this residual at the parse site
- Refs #3143 — earlier porcelain-parse class for this scanner
- Refs #3151 — sibling `-z` fix for `audit-comment-residue` (still open)