### PR TITLE
fix(docs-hygiene): close nested fences only on a matching-or-longer delimiter (0.21.3)

### DIFF
--- a/plugins/docs-hygiene/.claude-plugin/plugin.json
+++ b/plugins/docs-hygiene/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "docs-hygiene",
-  "version": "0.21.2",
+  "version": "0.21.3",
   "description": "Documentation-hygiene toolkit: compress (flavor-trim markdown with a semantic-diff safety net), audit-noise (classify markdown noise), extract-ssot (deduplicate repeated content into a single source of truth), audit-encapsulation (detect citations into skill-private surfaces), rename-references (sweep stale references after renames), audit-derivability (classify whether a whole document earns its existence — could a fresh agent re-derive it from the code?), audit-progressive-disclosure (grade instruction files against a load-tier model for split opportunities and hub/spoke disclosure defects), write-for-agents (authoring-time doctrine that fires while agent-consumed markdown is being written), and write-for-humans (the same moment for the other reader — end-user READMEs, RFCs, release notes and guides — resolving the consuming project's own style guide first).",
   "author": {
     "name": "Melodic Software",

--- a/plugins/docs-hygiene/CHANGELOG.md
+++ b/plugins/docs-hygiene/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog — docs-hygiene plugin
 
+## [0.21.3]
+
+### Fixed
+
+- **`audit-noise`'s fence tracker no longer treats a nested fence as closed at
+  the inner closer (#3190).** The scanner flipped a single `in_fence` boolean on
+  any line beginning with three or more backticks or tildes, without recording
+  the delimiter that opened the block. A four-backtick outer fence wrapping a
+  three-backtick example therefore closed at the inner ` ``` `, and everything
+  between the inner close and the true outer close was scanned as ordinary prose.
+
+  The tracker now records the opening delimiter character and run length, and
+  treats a later fence line as the matching close only when it uses the same
+  character at a run length greater than or equal to the opener — CommonMark's
+  close rule, which is what documentation uses to show a fenced example inside a
+  fenced example. Ordinary three-backtick and tilde fences are unchanged.
+
+  Shared pre-shape infrastructure: every finding shape inherits the corrected
+  exemption, including the `ticket-pr-residue` false positive on
+  `docs/conventions/finding-suppression/README.md` that surfaced the defect.
+
 ## [0.21.2]
 
 ### Fixed

--- a/plugins/docs-hygiene/skills/audit-noise/scripts/detect.sh
+++ b/plugins/docs-hygiene/skills/audit-noise/scripts/detect.sh
@@ -221,8 +221,10 @@ audit_file() {
   local in_exempt=0 line_num=0
   local in_ignored_para=0 skip_next=0
   local in_frontmatter=0 in_fence=0
+  local fence_char="" fence_len=0
   local -a shapes=()
   local shape tier excerpt line heading_text
+  local fence_delim fence_dchar fence_dlen
 
   while IFS= read -r line || [[ -n "$line" ]]; do
     line_num=$((line_num + 1))
@@ -241,11 +243,23 @@ audit_file() {
     fi
 
     # Fenced code blocks (``` or ~~~): never scan fence lines or their body.
-    if [[ "$line" =~ ^(\`\`\`|~~~) ]]; then
-      if [[ $in_fence -eq 1 ]]; then
-        in_fence=0
-      else
+    # CommonMark closes a fence only with the same character at a run length
+    # greater than or equal to the opener, so a four-backtick outer fence
+    # wrapping a three-backtick example stays open through the inner close.
+    # A bare toggle keyed on "line starts with 3+" treats the inner fence as
+    # the outer close and then scans the remaining example as prose.
+    if [[ "$line" =~ ^(\`{3,}|~{3,}) ]]; then
+      fence_delim="${BASH_REMATCH[1]}"
+      fence_dchar="${fence_delim:0:1}"
+      fence_dlen=${#fence_delim}
+      if [[ $in_fence -eq 0 ]]; then
         in_fence=1
+        fence_char="$fence_dchar"
+        fence_len=$fence_dlen
+      elif [[ "$fence_dchar" == "$fence_char" && $fence_dlen -ge $fence_len ]]; then
+        in_fence=0
+        fence_char=""
+        fence_len=0
       fi
       in_ignored_para=0
       continue

--- a/plugins/docs-hygiene/skills/audit-noise/scripts/detect.test.sh
+++ b/plugins/docs-hygiene/skills/audit-noise/scripts/detect.test.sh
@@ -410,6 +410,47 @@ assert_not_contains "fenced citation not flagged" "$fence_out" "inside a fence"
 assert_not_contains "fenced ghost-ref not flagged" "$fence_out" "foo-slice"
 assert_contains "post-fence citation still flagged" "$fence_out" "real prose"
 
+# A longer outer fence wrapping a standard inner fence must stay closed only
+# at the matching-or-longer closer. A naive 3+ toggle treats the inner close
+# as the outer close and then scans the remaining example as prose.
+NESTED_FENCE="$TEST_TMPDIR/nested-fence.md"
+cat >"$NESTED_FENCE" <<'EOF'
+# Nested fence fixture
+
+````markdown
+An example suppression record:
+
+```yaml
+reason: "Conflicts with org policy; exception requested, tracked in #482."
+```
+
+Empirically observed inside the outer fence after the inner close.
+.work/foo-slice/PLAN.md
+````
+
+After the outer fence Empirically observed in real prose.
+EOF
+nested_out="$(bash "$DETECT" "$NESTED_FENCE")"
+assert_not_contains "content after an inner fence close stays exempt" \
+  "$nested_out" "inside the outer fence"
+assert_not_contains "inner-fence ticket residue is not scanned" "$nested_out" "tracked in #482"
+assert_not_contains "nested-fence ghost-ref is not scanned" "$nested_out" "foo-slice"
+assert_contains "prose after the true outer close still flags" "$nested_out" "real prose"
+
+TILDE_FENCE="$TEST_TMPDIR/tilde-fence.md"
+cat >"$TILDE_FENCE" <<'EOF'
+# Tilde fence fixture
+
+~~~text
+Empirically observed inside a tilde fence.
+~~~
+
+After the tilde fence Empirically observed in real prose.
+EOF
+tilde_out="$(bash "$DETECT" "$TILDE_FENCE")"
+assert_not_contains "ordinary tilde fence body stays exempt" "$tilde_out" "inside a tilde fence"
+assert_contains "prose after a tilde fence still flags" "$tilde_out" "real prose"
+
 INLINE_FIXTURE="$TEST_TMPDIR/inline-code.md"
 cat >"$INLINE_FIXTURE" <<'EOF'
 # Inline fixture


### PR DESCRIPTION
Closes #3190

## Summary

`audit-noise` flipped a single `in_fence` boolean on any line beginning with three or more backticks or tildes. A four-backtick outer fence wrapping a three-backtick example therefore closed at the inner fence, and everything between the inner close and the true outer close was scanned as prose.

This is shared pre-shape infrastructure — every finding shape inherited the false positive. The reported case is `docs/conventions/finding-suppression/README.md:64`, a `ticket-pr-residue` hit on an example suppression record inside a documentation fence.

## Fix

The tracker now records the opening delimiter character and run length, and treats a later fence line as the close only when it uses the same character at a run length greater than or equal to the opener (CommonMark's close rule). Ordinary three-backtick and tilde fences are unchanged.

## Verification

- `detect.test.sh` — 139 checks passed, including a nested ```` / ``` fixture and a tilde-fence regression
- Reproduction: `detect.sh docs/conventions/finding-suppression/README.md` reports `T2=0` (was `ticket-pr-residue` on line 64)
- `skill-quality:check docs-hygiene:audit-noise` — PASS
- `check-changelog-parity.sh --check-bump origin/main` — PASS

## Related

- Refs #3162 — surfaced this; recorded it as a pre-existing exemption defect
- Refs #2742 / #2794 — earlier scanner-exemption work covering the flat code-fence case