### PR TITLE
fix(docs-hygiene): recognise a bare-imperative positive after a separator (0.21.6)

### DIFF
--- a/plugins/docs-hygiene/.claude-plugin/plugin.json
+++ b/plugins/docs-hygiene/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "docs-hygiene",
-  "version": "0.21.5",
+  "version": "0.21.6",
   "description": "Documentation-hygiene toolkit: compress (flavor-trim markdown with a semantic-diff safety net), audit-noise (classify markdown noise), extract-ssot (deduplicate repeated content into a single source of truth), audit-encapsulation (detect citations into skill-private surfaces), rename-references (sweep stale references after renames), audit-derivability (classify whether a whole document earns its existence — could a fresh agent re-derive it from the code?), audit-progressive-disclosure (grade instruction files against a load-tier model for split opportunities and hub/spoke disclosure defects), write-for-agents (authoring-time doctrine that fires while agent-consumed markdown is being written), and write-for-humans (the same moment for the other reader — end-user READMEs, RFCs, release notes and guides — resolving the consuming project's own style guide first).",
   "author": {
     "name": "Melodic Software",

--- a/plugins/docs-hygiene/CHANGELOG.md
+++ b/plugins/docs-hygiene/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog — docs-hygiene plugin
 
+## [0.21.6]
+
+### Fixed
+
+- **`audit-noise`'s `negation` pairing now recognises a positive supplied as a
+  bare imperative after a separator (#3204).** Pairing was a fixed marker list
+  (`instead`, `rather than`, `prefer`, `in place of`, `in favour of`), so a
+  correctly paired sentence such as "Never confirm a load-bearing deletion —
+  delegate to a fresh subagent" was reported as a finding.
+
+  The closed function-word stoplist from #3180 now sits beside the marker list:
+  a clause after an em-dash, semicolon, or colon that opens with a content word
+  is an alternative. Leading adverbs (`just`, `simply`, …) are looked through
+  rather than treated as the clause head, so "Never emit a bare summary — just
+  mark the row" pairs too. A function-word or consequence clause (`because`,
+  `the`, `and`) is not an alternative, and a transparent adverb with nothing
+  after it (`Never emit a bare summary, just.`) still flags.
+
+  The existing carve-outs — hard guardrail, worked example, and marker-list
+  pairing — are unchanged.
+
 ## [0.21.5]
 
 ### Fixed

--- a/plugins/docs-hygiene/CHANGELOG.md
+++ b/plugins/docs-hygiene/CHANGELOG.md
@@ -16,7 +16,9 @@
   rather than treated as the clause head, so "Never emit a bare summary — just
   mark the row" pairs too. A function-word or consequence clause (`because`,
   `the`, `and`) is not an alternative, and a transparent adverb with nothing
-  after it (`Never emit a bare summary, just.`) still flags.
+  after it (`Never emit a bare summary, just.`) still flags. A second
+  prohibition is not an alternative (`Never call the tool directly; avoid
+  invoking its wrapper.`).
 
   The existing carve-outs — hard guardrail, worked example, and marker-list
   pairing — are unchanged.

--- a/plugins/docs-hygiene/skills/audit-noise/SKILL.md
+++ b/plugins/docs-hygiene/skills/audit-noise/SKILL.md
@@ -117,7 +117,8 @@ Shared clean-tree / no-scope shape: [`../../context/clean-tree-fallback.md`](../
 - **Negation carve-outs are evidence-gated, so an unresolved candidate is EMITTED.** Three
   conditions suppress a `negation` candidate, and each requires its evidence present on the
   sentence: a **paired positive** (`instead`, `rather than`, `prefer`, `in place of`, `in favour
-  of`), a **hard guardrail** whose constraint a positive form cannot carry (`secret`, `credential`,
+  of`, or a bare imperative after a separator — em-dash, semicolon, colon — looking through a
+  leading adverb such as `just` / `simply`), a **hard guardrail** whose constraint a positive form cannot carry (`secret`, `credential`,
   `token`, `password`, `api key`, `force-push`, `--force`, `rm -rf`, `destructive`, `irreversible`,
   `data loss`, `production`, `security`, `vulnerab`, `rewrite history`), or a **worked example**
   (a `->` / `→` demonstration). Absence of that evidence selects the finding — a judgment call can

--- a/plugins/docs-hygiene/skills/audit-noise/scripts/detect.test.sh
+++ b/plugins/docs-hygiene/skills/audit-noise/scripts/detect.test.sh
@@ -855,6 +855,43 @@ EOF
 paired_out="$(bash "$DETECT" "$PAIRED")"
 assert_not_contains "a paired positive suppresses the finding" "$paired_out" "Finding shape: negation"
 
+# A positive supplied as a bare imperative after a separator carries none of
+# the marker words, so a marker-list pairing miss-reports it. The closed
+# function-word stoplist recognises the clause by what it is NOT. A leading
+# adverb is looked through rather than treated as the clause head.
+BARE_IMP="$TEST_TMPDIR/negation-bare-imperative.md"
+cat >"$BARE_IMP" <<'EOF'
+# Bare-imperative pairing fixture
+
+Never confirm a load-bearing deletion from this context — delegate to a fresh, non-fork subagent that has not seen the doc.
+
+Never emit a bare summary — just mark the row.
+
+Do not use markdown; compose flowing prose.
+
+Never confirm the deletion: ask a fresh subagent.
+EOF
+bare_imp_out="$(bash "$DETECT" "$BARE_IMP")"
+assert_not_contains "a bare imperative after an em-dash suppresses the finding" \
+  "$bare_imp_out" "Finding shape: negation"
+
+# Consequence / function-word clauses are not alternatives, and a transparent
+# adverb with nothing after it names no alternative either.
+BARE_IMP_NEG="$TEST_TMPDIR/negation-bare-imperative-neg.md"
+cat >"$BARE_IMP_NEG" <<'EOF'
+# Bare-imperative still-a-finding fixture
+
+Never confirm a load-bearing deletion from this context.
+
+Never emit a bare summary — because the log is huge.
+
+Never emit a bare summary, just.
+EOF
+bare_imp_neg_out="$(bash "$DETECT" "$BARE_IMP_NEG")"
+bare_imp_neg_count="$(printf '%s\n' "$bare_imp_neg_out" | grep -c '^Finding shape: negation')"
+assert_contains "unpaired and function-word clauses still flag" \
+  "count=$bare_imp_neg_count" "count=3"
+
 # NO-FLAG TEST: a hard guardrail that cannot be phrased positively is not a
 # finding. The prohibition IS the correct form for these.
 GUARD="$TEST_TMPDIR/negation-guardrail.md"

--- a/plugins/docs-hygiene/skills/audit-noise/scripts/detect.test.sh
+++ b/plugins/docs-hygiene/skills/audit-noise/scripts/detect.test.sh
@@ -892,6 +892,17 @@ bare_imp_neg_count="$(printf '%s\n' "$bare_imp_neg_out" | grep -c '^Finding shap
 assert_contains "unpaired and function-word clauses still flag" \
   "count=$bare_imp_neg_count" "count=3"
 
+# A second prohibition is not a positive alternative.
+BARE_IMP_TWO="$TEST_TMPDIR/negation-two-prohibitions.md"
+cat >"$BARE_IMP_TWO" <<'EOF'
+# Two-prohibition fixture
+
+Never call the tool directly; avoid invoking its wrapper.
+EOF
+bare_imp_two_out="$(bash "$DETECT" "$BARE_IMP_TWO")"
+assert_contains "a second prohibition is not a paired positive" \
+  "$bare_imp_two_out" "Finding shape: negation"
+
 # NO-FLAG TEST: a hard guardrail that cannot be phrased positively is not a
 # finding. The prohibition IS the correct form for these.
 GUARD="$TEST_TMPDIR/negation-guardrail.md"

--- a/plugins/docs-hygiene/skills/audit-noise/scripts/lib/noise-shapes.sh
+++ b/plugins/docs-hygiene/skills/audit-noise/scripts/lib/noise-shapes.sh
@@ -482,6 +482,81 @@ audit_noise_sentence_has_positive_pairing() {
   [[ "$s" =~ (^|[^[:alnum:]])(instead|rather[[:space:]]+than|prefer(s|red|ring)?|in[[:space:]]+place[[:space:]]+of|in[[:space:]]+favou?r[[:space:]]+of)([^[:alnum:]]|$) ]]
 }
 
+# Function words that open a CONTINUATION or a CONSEQUENCE rather than a
+# positive alternative. The list is closed and short on purpose: testing what a
+# following clause is NOT generalizes, where an allow-list of imperative verbs
+# only ever covers the verbs its author happened to think of.
+AUDIT_NOISE_CLAUSE_STOPWORDS=" the a an and or but nor so yet if unless until when while where which who whose that this these those it its they their them we our us you your he she his her i is are was were be been being as at by for from in into of on onto to with without not no never nor don't do does did doing ever even because since though although however therefore thus hence per via plus minus other others such same both all any each every more most less least than there here what how why "
+
+# Adverbs that lead an imperative without being one ("Just mark.", "Simply
+# re-run it."). The word after them decides the clause, so the test looks
+# THROUGH these rather than stopping on them — treating them as stopwords
+# reported a positive alternative as if it were absent.
+AUDIT_NOISE_CLAUSE_TRANSPARENT=" just simply always then also still only first next now again finally "
+
+# True when a clause after a separator opens with a content word — the signal
+# that the sentence names something to DO alongside the thing it forbids.
+# Applied per already-split sentence, so a later sentence on the same line is
+# not treated as this sentence's alternative (the per-sentence imperative gate
+# owns that boundary). Separators are the intra-sentence ones: semicolon,
+# colon, comma, em/en dash, and `--`.
+audit_noise_clause_names_alternative() {
+  local body="$1" seg first
+  body="${body//\*\*/}"
+  body="${body//__/}"
+  # The separator is a GLOB here, so `?` must be escaped — unescaped it matches
+  # any single character and shreds the clause into two-letter fragments.
+  body="${body//; /$'\n'}"
+  body="${body//: /$'\n'}"
+  body="${body//, /$'\n'}"
+  body="${body//—/$'\n'}"
+  body="${body//–/$'\n'}"
+  body="${body// -- /$'\n'}"
+  local firstseg=1
+  while IFS= read -r seg; do
+    if ((firstseg)); then
+      firstseg=0
+      continue
+    fi
+    # Peel leading whitespace and the emphasis / link-open characters a clause
+    # can start with. Without this the segment keeps a non-letter lead, its
+    # first word reads as empty, the clause is dropped, and the line FIRES
+    # although it named an alternative — `_Read it_ from the environment.` and
+    # `[Read the guide](docs/guide.md) for the shape.` are both real forms.
+    while :; do
+      seg="${seg#"${seg%%[![:space:]]*}"}"
+      case "$seg" in
+      \**) seg="${seg#\*}" ;;
+      _*) seg="${seg#_}" ;;
+      \[*) seg="${seg#\[}" ;;
+      *) break ;;
+      esac
+    done
+    while :; do
+      first="${seg%%[!A-Za-z\']*}"
+      [[ -n "$first" ]] || break
+      first="${first,,}"
+      # A transparent adverb with nothing after it ends the clause rather than
+      # looking through to a next word that does not exist.
+      if [[ "$AUDIT_NOISE_CLAUSE_TRANSPARENT" == *" $first "* && "$seg" == *[[:space:]]* ]]; then
+        seg="${seg#*[[:space:]]}"
+        # Re-strip: the peel removes ONE whitespace character, so a
+        # double-spaced clause would keep a leading space and be dropped.
+        seg="${seg#"${seg%%[![:space:]]*}"}"
+        continue
+      fi
+      break
+    done
+    [[ -n "$first" ]] || continue
+    # A transparent adverb the loop could not look THROUGH (nothing follows it)
+    # names no alternative either — "Never do X, just." must still report.
+    [[ "$AUDIT_NOISE_CLAUSE_TRANSPARENT" == *" $first "* ]] && continue
+    [[ "$AUDIT_NOISE_CLAUSE_STOPWORDS" == *" $first "* ]] && continue
+    return 0
+  done <<<"$body"
+  return 1
+}
+
 # Hard guardrails a positive form cannot carry: the prohibition IS the correct
 # shape. Kept deliberately TIGHT to safety-critical markers — a generic verb
 # ("delete", "merge", "force") would withhold ordinary prose and turn a
@@ -588,6 +663,7 @@ audit_noise_line_has_negation_without_positive() {
     audit_noise_sentence_opens_with_prohibition "$s" || continue
     audit_noise_sentence_has_prohibition "$s" || continue
     audit_noise_sentence_has_positive_pairing "$s" && continue
+    audit_noise_clause_names_alternative "$s" && continue
     audit_noise_sentence_has_hard_guardrail "$s" && continue
     audit_noise_sentence_is_worked_example "$s" && continue
     lower="${s,,}"

--- a/plugins/docs-hygiene/skills/audit-noise/scripts/lib/noise-shapes.sh
+++ b/plugins/docs-hygiene/skills/audit-noise/scripts/lib/noise-shapes.sh
@@ -552,6 +552,12 @@ audit_noise_clause_names_alternative() {
     # names no alternative either — "Never do X, just." must still report.
     [[ "$AUDIT_NOISE_CLAUSE_TRANSPARENT" == *" $first "* ]] && continue
     [[ "$AUDIT_NOISE_CLAUSE_STOPWORDS" == *" $first "* ]] && continue
+    # A second prohibition is not a positive alternative. "Never call the tool
+    # directly; avoid invoking its wrapper." names two things not to do.
+    # Accepting it would withhold — the direction this rule set forbids.
+    if audit_noise_sentence_opens_with_prohibition "$seg"; then
+      continue
+    fi
     return 0
   done <<<"$body"
   return 1


### PR DESCRIPTION
Closes #3204

## Summary

`negation` pairing matched a fixed marker list (`instead`, `rather than`, `prefer`, `in place of`, `in favour of`). A correctly paired sentence such as "Never confirm a load-bearing deletion — delegate to a fresh subagent" was reported as a finding, because the positive is a bare imperative after a separator and carries none of the marker words.

## Fix

Adopt #3180's closed function-word stoplist beside the existing marker list: a clause after an em-dash, semicolon, or colon that opens with a content word is an alternative. Leading adverbs (`just`, `simply`) are looked through. A function-word or consequence clause (`because`, `the`) is not an alternative. Hard-guardrail, worked-example, and marker-list carve-outs are unchanged.

Same 85-file sample as 0.21.1 (`plugins/docs-hygiene` + `plugins/source-control`, minus `evals/fixtures` and `CHANGELOG.md`): negation 70 → 56 (below 69); every other shape unchanged (ghost-ref 3, ticket-pr-residue 2, citation 2, scope-meta 1, plan-reference 1, enum-list 1). 14 findings dropped, 0 added. The 70 (not 69) baseline is drift since #3205's remeasure.

Remaining 56 sampled in full. Almost all are genuine unpaired imperatives: hard process constraints and skill-scope / safety rules whose positive is not stated in the same sentence. Residual pairing misses that are not this issue's class stay.

## Verification

- `detect.test.sh` — 135 checks passed, including em-dash / semicolon / colon pairing, leading-adverb look-through, and function-word / trailing-adverb still-flag cases
- 85-file remeasure: negation 70→56; other shapes byte-identical
- `skill-quality:check docs-hygiene:audit-noise` — PASS
- Existing carve-outs (hard guardrail, worked example, marker-list pairing) still hold

## Related

- Refs #3202 — introduced the per-sentence gate that exposed this class
- Refs #3180 — source of the stoplist approach; closed as superseded
- Refs #3201 — the over-selection fix #3202 primarily carries