### PR TITLE
fix(context-budget): never coerce a vanished bucket's null delta to zero in attribution (0.6.6)

### DIFF
--- a/plugins/context-budget/.claude-plugin/plugin.json
+++ b/plugins/context-budget/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "context-budget",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "description": "Measure a Claude Code session's fixed startup context payload per item, on the consumer's machine at a pinned, version-stamped binary — including per-tool attribution of the built-in tool pools that /context reports only as lump sums, derived live by A/B bare-name-deny differencing with enforced comparability rules (skill-listing signature, one mode, one binary), an SDK-primary exact meter degrading to a version-aware headless /context parser and then to an honest structured error (never a wrong number), and a per-project measure-toggle-remeasure ledger under the plugin data directory recording every lever's real before/after delta. Report-only: prints exact config, applies nothing.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/context-budget/CHANGELOG.md
+++ b/plugins/context-budget/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to the `context-budget` plugin.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.6]
+
+### Fixed
+
+- **Engine:** the additivity verifier no longer coerces a null bucket delta to `0`. A combined
+  deny can empty `System tools` or `System tools (deferred)` out of the snapshot; the snapshot
+  comparison correctly records that bucket's delta as `null`, but the verifier summed it with
+  `?? 0` and published a fabricated `combinedSaved: 0` as `comparable: true`. The additivity
+  record (and each per-tool row, which had the same coercion) now reports the saving as `null`
+  with `comparable: false` and a reason naming the vanished bucket
+  ([#3197](https://github.com/melodic-software/claude-code-plugins/issues/3197)). A bucket
+  absent from *both* runs remains a non-event — outside that binary's category vocabulary, not
+  a missing measurement. In sdk mode, where numbers are exact and the category vocabulary is
+  known, an omitted bucket is now recorded as an explicit `0` at snapshot time, so a combined
+  deny that empties a bucket yields a real measured delta instead of an incomparable record.
+
 ## [0.6.5]
 
 ### Changed

--- a/plugins/context-budget/CHANGELOG.md
+++ b/plugins/context-budget/CHANGELOG.md
@@ -20,6 +20,9 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   a missing measurement. In sdk mode, where numbers are exact and the category vocabulary is
   known, an omitted bucket is now recorded as an explicit `0` at snapshot time, so a combined
   deny that empties a bucket yields a real measured delta instead of an incomparable record.
+  Every synthesized zero is named in the snapshot's `caveats[]` so a standalone
+  `snapshot`/`compare`/`ledger` consumer can tell a reported 0 from a filled-in omission; the
+  vanish/`comparable: false` path remains cli-parse only.
 
 ## [0.6.5]
 

--- a/plugins/context-budget/skills/audit/reference/engine.md
+++ b/plugins/context-budget/skills/audit/reference/engine.md
@@ -64,8 +64,12 @@ All records are JSON on stdout (and `--out <file>`), schema-tagged:
   `skillListing {totalSkills, includedSkills, tokens, signature, rows}`, `caveats[]`.
 - `context-budget.attribution/1` — `baseline` (summary), ranked `perTool[]` rows
   `{tool, prefixDelta, deferredDelta, savedTokens, comparable, reasons}`, optional `additivity`
-  (`--verify-additivity`: one combined-deny run checked against the sum of parts), plus the
-  binary stamp and `skillListingSignature`.
+  (`--verify-additivity`: one combined-deny run checked against the sum of parts, with its own
+  `comparable`/`reasons`), plus the binary stamp and `skillListingSignature`. A deny can empty a
+  summed bucket out of the snapshot entirely; the bucket's delta is then null and the row (or
+  additivity record) reports `savedTokens`/`combinedSaved` as `null` with `comparable: false` and
+  the reason — a missing measurement, never a coerced zero. A bucket absent from *both* runs is
+  outside that binary's category vocabulary and simply contributes nothing.
 - `context-budget.ledger/1` — one before/after: `lever`, `emittedConfig`, `before`/`after`
   summaries, `delta` per category, `totalDelta`, `comparability`. A category present in only one
   run gets `null`, never an invented number.

--- a/plugins/context-budget/skills/audit/reference/engine.md
+++ b/plugins/context-budget/skills/audit/reference/engine.md
@@ -68,7 +68,12 @@ All records are JSON on stdout (and `--out <file>`), schema-tagged:
   `comparable`/`reasons`), plus the binary stamp and `skillListingSignature`. A deny can empty a
   summed bucket out of the snapshot entirely; the bucket's delta is then null and the row (or
   additivity record) reports `savedTokens`/`combinedSaved` as `null` with `comparable: false` and
-  the reason — a missing measurement, never a coerced zero. A bucket absent from *both* runs is
+  the reason — a missing measurement, never a coerced zero. That vanish path fires in
+  **cli-parse** mode, where an omitted bucket is genuinely ambiguous (format drift vs emptied
+  bucket). In **sdk** mode the two attributed buckets are recorded as an explicit `0` when the
+  SDK omits them (numbers are exact and the vocabulary is known), so a combined deny yields a
+  real delta; a `caveats[]` entry names every synthesized zero so a raw `snapshot`/`ledger`
+  consumer can tell a reported 0 from a filled-in omission. A bucket absent from *both* runs is
   outside that binary's category vocabulary and simply contributes nothing.
 - `context-budget.ledger/1` — one before/after: `lever`, `emittedConfig`, `before`/`after`
   summaries, `delta` per category, `totalDelta`, `comparability`. A category present in only one

--- a/plugins/context-budget/skills/audit/scripts/measure.mjs
+++ b/plugins/context-budget/skills/audit/scripts/measure.mjs
@@ -332,8 +332,17 @@ async function sdkSnapshot({ sdk, sdkVersion, sdkEntry, bin, deny, label }) {
   // combined deny that empties a bucket yields a null delta downstream where
   // a real one was measured. cli-parse absence stays genuinely ambiguous
   // (format drift vs emptied bucket) and is deliberately not zero-filled.
+  // The fill is shared snapshot plumbing (snapshot/compare/ledger see it too);
+  // a caveat names every synthesized zero so a raw consumer can tell a real
+  // reported 0 from a filled-in omission.
+  const caveats = [];
   for (const bucket of SYSTEM_TOOL_BUCKETS) {
-    if (!(bucket in categories)) categories[bucket] = 0;
+    if (!(bucket in categories)) {
+      categories[bucket] = 0;
+      caveats.push(
+        `sdk omitted "${bucket}"; recorded as measured 0 (sdk category vocabulary is known; numbers are exact)`,
+      );
+    }
   }
 
   const skillFrontmatter = usage.skills?.skillFrontmatter ?? [];
@@ -365,7 +374,7 @@ async function sdkSnapshot({ sdk, sdkVersion, sdkEntry, bin, deny, label }) {
       signature: listingSignature(skillRows),
       rows: skillRows.length,
     },
-    caveats: [],
+    caveats,
   };
 }
 

--- a/plugins/context-budget/skills/audit/scripts/measure.mjs
+++ b/plugins/context-budget/skills/audit/scripts/measure.mjs
@@ -51,6 +51,10 @@ const ERROR_SCHEMA = 'context-budget.error/1';
 
 const SPAWN_TIMEOUT_MS = 180000;
 
+// The two /context buckets a bare-name tool deny moves — the buckets the
+// attribute pipeline sums per-tool and for the additivity check.
+const SYSTEM_TOOL_BUCKETS = ['System tools', 'System tools (deferred)'];
+
 function usageError(msg) {
   process.stderr.write(`ERROR: ${msg}\n`);
   process.stderr.write('Run with --help for usage.\n');
@@ -322,6 +326,15 @@ async function sdkSnapshot({ sdk, sdkVersion, sdkEntry, bin, deny, label }) {
   const { init, usage } = result;
   const categories = {};
   for (const c of usage.categories ?? []) categories[c.name] = c.tokens;
+  // A deny that empties a bucket makes the SDK omit it rather than report 0.
+  // sdk mode's numbers are exact and its category vocabulary is known, so for
+  // the attributed buckets that absence IS a measured zero — record it, or a
+  // combined deny that empties a bucket yields a null delta downstream where
+  // a real one was measured. cli-parse absence stays genuinely ambiguous
+  // (format drift vs emptied bucket) and is deliberately not zero-filled.
+  for (const bucket of SYSTEM_TOOL_BUCKETS) {
+    if (!(bucket in categories)) categories[bucket] = 0;
+  }
 
   const skillFrontmatter = usage.skills?.skillFrontmatter ?? [];
   const skillRows = skillFrontmatter.map((s) => ({ name: s.name, source: s.source }));
@@ -529,6 +542,26 @@ function compareSnapshots(before, after, { lever = null, emittedConfig = null } 
 // attribute — per-tool attribution by bare-name deny differencing
 // ---------------------------------------------------------------------------
 
+// Saving across the attributed buckets of one comparison, honoring the
+// three states a bucket delta can be in:
+//   number     measured in both runs — use it;
+//   null       present in one run only (a deny can empty a bucket out of the
+//              snapshot entirely) — a missing measurement, NEVER zero;
+//   undefined  absent from both runs — outside this binary's category
+//              vocabulary, a non-event that contributes nothing.
+// `saved` is null when any needed bucket vanished; callers publish that as
+// incomparable with `vanished` naming the buckets, never coerce it to 0.
+function systemBucketSaving(cmp) {
+  const vanished = SYSTEM_TOOL_BUCKETS.filter((b) => b in cmp.delta && cmp.delta[b] === null);
+  if (vanished.length) return { vanished, saved: null };
+  return { vanished, saved: -SYSTEM_TOOL_BUCKETS.reduce((s, b) => s + (cmp.delta[b] ?? 0), 0) };
+}
+
+function vanishedReason(vanished) {
+  return `${vanished.join(' and ')} present in only one run — the bucket was emptied out of one `
+    + 'snapshot, so its delta is unmeasured, not zero';
+}
+
 async function runAttribute(args) {
   if (!args.tools) usageError('attribute needs --tools <T1,T2,...|from-baseline>');
   const baseline = await takeSnapshot({ ...args, deny: undefined, label: 'baseline' });
@@ -550,17 +583,19 @@ async function runAttribute(args) {
   for (const tool of tools) {
     const run = await takeSnapshot({ ...args, deny: tool, label: `deny:${tool}` });
     const cmp = compareSnapshots(baseline, run, { lever: `deny:${tool}` });
-    const prefixDelta = cmp.delta['System tools'] ?? null;
-    const deferredDelta = cmp.delta['System tools (deferred)'] ?? null;
+    const { vanished, saved } = systemBucketSaving(cmp);
     perTool.push({
       tool,
       // A deny that saves prints as a NEGATIVE delta (after minus before);
-      // savedTokens flips the sign for ranking and readability.
-      prefixDelta,
-      deferredDelta,
-      savedTokens: -((prefixDelta ?? 0) + (deferredDelta ?? 0)),
-      comparable: cmp.comparability.systemToolsComparable,
-      reasons: cmp.comparability.reasons,
+      // savedTokens flips the sign for ranking and readability. A vanished
+      // bucket makes it null — an unmeasured saving, never a zero.
+      prefixDelta: cmp.delta['System tools'] ?? null,
+      deferredDelta: cmp.delta['System tools (deferred)'] ?? null,
+      savedTokens: saved,
+      comparable: cmp.comparability.systemToolsComparable && !vanished.length,
+      reasons: vanished.length
+        ? [...cmp.comparability.reasons, vanishedReason(vanished)]
+        : cmp.comparability.reasons,
     });
   }
   perTool.sort((x, y) => (y.savedTokens ?? 0) - (x.savedTokens ?? 0));
@@ -571,15 +606,22 @@ async function runAttribute(args) {
     if (savers.length >= 2) {
       const combined = await takeSnapshot({ ...args, deny: savers.join(','), label: 'deny:combined' });
       const cmp = compareSnapshots(baseline, combined, { lever: `deny:${savers.join('+')}` });
-      const combinedSaved = -(((cmp.delta['System tools'] ?? 0)) + ((cmp.delta['System tools (deferred)'] ?? 0)));
+      // Denying every saver at once can empty a bucket out of the combined
+      // snapshot; its delta is then null and the combined saving is
+      // unmeasured — published as incomparable, never coerced to zero.
+      const { vanished, saved: combinedSaved } = systemBucketSaving(cmp);
+      const comparable = cmp.comparability.systemToolsComparable && !vanished.length;
       const sumOfParts = perTool.filter((t) => savers.includes(t.tool))
         .reduce((s, t) => s + t.savedTokens, 0);
       additivity = {
         tools: savers,
         sumOfParts,
         combinedSaved,
-        additive: cmp.comparability.systemToolsComparable && combinedSaved === sumOfParts,
-        comparable: cmp.comparability.systemToolsComparable,
+        additive: comparable && combinedSaved === sumOfParts,
+        comparable,
+        reasons: vanished.length
+          ? [...cmp.comparability.reasons, vanishedReason(vanished)]
+          : cmp.comparability.reasons,
       };
     }
   }

--- a/plugins/context-budget/skills/audit/scripts/measure.test.sh
+++ b/plugins/context-budget/skills/audit/scripts/measure.test.sh
@@ -4,11 +4,12 @@
 # Covers: the /context markdown parser (current-format fixture, the
 # stdin-warning trap, loud refusal on an unrecognized format), compare's
 # comparability rules (identical runs comparable; skill-listing signature
-# mismatch marks System tools incomparable; schema validation), and the
-# ledger (one file per run plus an appended history line; schema-checked
-# append). The live sdk / cli-parse measurement paths spawn a real Claude
-# Code binary and are exercised manually, not here — this suite must stay
-# hermetic.
+# mismatch marks System tools incomparable; schema validation), the ledger
+# (one file per run plus an appended history line; schema-checked append),
+# and the attribute/additivity pipeline in cli-parse mode against a fake
+# `claude` binary (a vanished bucket is unmeasured and incomparable, never a
+# coerced zero). The sdk measurement path spawns a real Claude Code binary
+# and is exercised manually, not here — this suite must stay hermetic.
 #
 # Prerequisites: node on PATH (the engine's own runtime — required for
 # correctness; absent, this suite fails loudly rather than skipping).
@@ -241,6 +242,120 @@ if [[ $rc -eq 2 ]]; then
   ok "ledger rejects a relative --dir"
 else
   fail "ledger accepted a relative --dir (exit $rc)"
+fi
+
+# --- attribute: additivity never coerces a vanished bucket to zero --------
+# Hermetic live-path exercise: a fake `claude` binary answers `--version` and
+# `-p /context` with deterministic category tables keyed off the deny list and
+# FAKE_MODE, so the attribute/additivity pipeline runs end-to-end in cli-parse
+# mode with no real Claude Code binary. Run from $WORK so no Agent SDK is
+# resolvable and the engine cannot leave cli-parse mode.
+
+FAKEDIR="$WORK/fakebin"
+mkdir -p "$FAKEDIR"
+cat >"$FAKEDIR/fake-claude.js" <<'EOF'
+const args = process.argv.slice(2);
+if (args.includes('--version')) { process.stdout.write('9.9.9 (fake)\n'); process.exit(0); }
+const di = args.indexOf('--disallowedTools');
+const deny = di >= 0 ? args.slice(di + 1) : [];
+const key = deny.slice().sort().join('+');
+const mode = process.env.FAKE_MODE || 'control';
+// Savings per deny set, constructed additive: combined always equals the sum.
+const prefixSaved = { AlphaTool: 1000, BetaTool: 600, GammaTool: 500, 'AlphaTool+BetaTool': 1600 };
+const deferredSaved = { AlphaTool: 400, BetaTool: 100, GammaTool: 0, 'AlphaTool+BetaTool': 500 };
+const table = { 'System tools': 18000 - (prefixSaved[key] ?? 0) };
+// The deferred bucket is dropped (omitted, not reported as 0) when:
+//   novocab      — this fake "version" has no deferred bucket in any run;
+//   vanish       — the combined deny empties it out of the snapshot (#3197);
+//   GammaTool    — a single deny empties it out of the snapshot.
+const dropDeferred = mode === 'novocab'
+  || (mode === 'vanish' && key === 'AlphaTool+BetaTool')
+  || key === 'GammaTool';
+if (!dropDeferred) table['System tools (deferred)'] = 12000 - (deferredSaved[key] ?? 0);
+table.Messages = 42;
+const lines = ['## Context Usage', '', '**Model:** fake-model', '',
+  '### Estimated usage by category', '',
+  '| Category | Tokens | Percentage |', '|---|---|---|'];
+for (const [name, tokens] of Object.entries(table)) lines.push(`| ${name} | ${tokens} | 0% |`);
+process.stdout.write(lines.join('\n') + '\n');
+EOF
+case "$(uname -s)" in
+  MINGW* | MSYS* | CYGWIN* | Windows_NT*)
+    FAKE="$FAKEDIR/fake-claude.cmd"
+    printf '@node "%%~dp0fake-claude.js" %%*\r\n' >"$FAKE"
+    ;;
+  *)
+    FAKE="$FAKEDIR/fake-claude"
+    printf '#!/usr/bin/env node\n' >"$FAKE"
+    cat "$FAKEDIR/fake-claude.js" >>"$FAKE"
+    chmod +x "$FAKE"
+    ;;
+esac
+
+# The bug (#3197): the combined deny empties the deferred bucket out of the
+# snapshot, its delta is null, and the verifier must publish the record as
+# incomparable with a null combinedSaved — never a coerced 0.
+avanish="$WORK/attr-vanish.json"
+if (cd "$WORK" && FAKE_MODE=vanish node "$ENGINE" attribute --tools AlphaTool,BetaTool --verify-additivity --binary "$FAKE" --out "$avanish" >/dev/null); then
+  assert_eq "$(jsonget "$avanish" 'j.perTool.find((t)=>t.tool==="AlphaTool").savedTokens')" "1400" \
+    "per-tool rows with both buckets present still measure" "AlphaTool row wrong"
+  assert_eq "$(jsonget "$avanish" 'j.additivity.sumOfParts')" "2100" \
+    "sum of parts is the sum of the savers" "sumOfParts wrong"
+  assert_eq "$(jsonget "$avanish" 'j.additivity.combinedSaved')" "null" \
+    "vanished bucket yields combinedSaved null, never a coerced 0" "combinedSaved fabricated from a null delta"
+  assert_eq "$(jsonget "$avanish" 'j.additivity.comparable')" "false" \
+    "vanished bucket marks the additivity record incomparable" "additivity published comparable despite a vanished bucket"
+  assert_eq "$(jsonget "$avanish" 'j.additivity.additive')" "false" \
+    "incomparable additivity is never reported additive" "additive true despite a vanished bucket"
+  if [[ "$(jsonget "$avanish" 'j.additivity.reasons.join(" ")')" == *"System tools (deferred)"* ]]; then
+    ok "additivity record names the vanished bucket in its reasons"
+  else
+    fail "vanished-bucket reason missing from additivity record"
+  fi
+else
+  fail "attribute --verify-additivity (vanish scenario) exited nonzero"
+fi
+
+# Control: all buckets present in every run — the verdict must be untouched.
+actl="$WORK/attr-control.json"
+if (cd "$WORK" && FAKE_MODE=control node "$ENGINE" attribute --tools AlphaTool,BetaTool --verify-additivity --binary "$FAKE" --out "$actl" >/dev/null); then
+  assert_eq "$(jsonget "$actl" 'j.additivity.combinedSaved')" "2100" \
+    "normal additivity case still measures the combined saving" "control combinedSaved wrong"
+  assert_eq "$(jsonget "$actl" 'j.additivity.additive')" "true" \
+    "normal additivity case still verifies additive" "control additive wrong"
+  assert_eq "$(jsonget "$actl" 'j.additivity.comparable')" "true" \
+    "normal additivity case stays comparable" "control comparable wrong"
+else
+  fail "attribute --verify-additivity (control scenario) exited nonzero"
+fi
+
+# A single deny that empties a bucket poisons that per-tool row the same way.
+agamma="$WORK/attr-gamma.json"
+if (cd "$WORK" && FAKE_MODE=control node "$ENGINE" attribute --tools AlphaTool,GammaTool --verify-additivity --binary "$FAKE" --out "$agamma" >/dev/null); then
+  assert_eq "$(jsonget "$agamma" 'j.perTool.find((t)=>t.tool==="GammaTool").savedTokens')" "null" \
+    "per-tool row with a vanished bucket reports savedTokens null" "per-tool savedTokens fabricated from a null delta"
+  assert_eq "$(jsonget "$agamma" 'j.perTool.find((t)=>t.tool==="GammaTool").comparable')" "false" \
+    "per-tool row with a vanished bucket is incomparable" "per-tool row comparable despite a vanished bucket"
+  assert_eq "$(jsonget "$agamma" 'j.additivity')" "null" \
+    "a lone comparable saver runs no additivity check" "additivity ran with fewer than two savers"
+else
+  fail "attribute (gamma scenario) exited nonzero"
+fi
+
+# A bucket absent from BOTH runs is outside the binary's category vocabulary —
+# a non-event, not a missing measurement.
+anv="$WORK/attr-novocab.json"
+if (cd "$WORK" && FAKE_MODE=novocab node "$ENGINE" attribute --tools AlphaTool,BetaTool --verify-additivity --binary "$FAKE" --out "$anv" >/dev/null); then
+  assert_eq "$(jsonget "$anv" 'j.perTool.find((t)=>t.tool==="AlphaTool").savedTokens')" "1000" \
+    "bucket absent from both runs still measures the present bucket" "vocabulary-absent bucket broke the per-tool row"
+  assert_eq "$(jsonget "$anv" 'j.perTool.find((t)=>t.tool==="AlphaTool").comparable')" "true" \
+    "bucket absent from both runs keeps the row comparable" "vocabulary-absent bucket poisoned comparability"
+  assert_eq "$(jsonget "$anv" 'j.additivity.combinedSaved')" "1600" \
+    "additivity over the present bucket alone still measures" "vocabulary-absent combinedSaved wrong"
+  assert_eq "$(jsonget "$anv" 'j.additivity.additive')" "true" \
+    "additivity over the present bucket alone still verifies" "vocabulary-absent additive wrong"
+else
+  fail "attribute (novocab scenario) exited nonzero"
 fi
 
 # --- snapshot: pinned-binary honesty --------------------------------------


### PR DESCRIPTION
Closes #3197

## Summary

The additivity verifier (and each per-tool attribution row) coerced a vanished bucket's `null` delta to `0` with `?? 0`, then published a fabricated `combinedSaved` as `comparable: true`. That is a false-negative machine: a verifier reporting success where it had no evidence.

## Fix

- **Additivity record and per-tool rows** now honor the three states a bucket delta can be in: a number (measured), `null` (present in one run only — a vanished bucket, a missing measurement), and `undefined` (absent from both runs — outside that binary's category vocabulary, a non-event). A vanished bucket yields `savedTokens`/`combinedSaved` of `null`, `comparable: false`, and a reason naming the bucket; it is never coerced to zero. The additivity record now carries `reasons` like the per-tool rows do.
- **sdk mode** records an explicit `0` for the two attributed buckets when the SDK omits them: there the numbers are exact and the vocabulary is known, so absence is a measured zero and the combined deny yields a real delta. Every synthesized zero is named in `caveats[]` so a standalone snapshot/ledger consumer can tell a reported 0 from a filled-in omission. cli-parse absence stays genuinely ambiguous and is deliberately not zero-filled.

## Verification

- The test suite now drives `attribute --verify-additivity` end-to-end in cli-parse mode against a fake `claude` binary: the vanished-bucket repro, a normal-case control, a single-deny vanish (per-tool row guard), and a bucket-absent-from-both-runs vocabulary case. Six of the new assertions fail against the old `?? 0` code (verified before the fix: fabricated `combinedSaved: 1600` with `comparable: true`); all pass after.
- Full suite: 44/44 passing on the original commit; 51/51 after the review follow-up's neighbouring catalogue-verify work is not in this PR. This branch's suite is 44/44 plus the pre-existing cases; `d1ed388` only adds caveats and docs. shellcheck and markdownlint clean on the original pass.
- Review follow-up `d1ed388`: sdk synthesized zeros now push a `caveats[]` entry; `engine.md` names the cli-parse vs sdk mode split. Both review findings classified VALID and replied on-thread.
- `compareSnapshots`' delta computation is untouched (out of scope per the issue).

## Related

N/A — this PR closes #3197 only. Sibling context-budget work (#3198, #3199, #3200) is sequential on later versions and not in this diff.