### PR TITLE
fix(ai-slop, testing): quote YAML-indicator branch names in findings frontmatter (0.3.7, 0.7.5)

### DIFF
--- a/plugins/ai-slop/.claude-plugin/plugin.json
+++ b/plugins/ai-slop/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "ai-slop",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "Detects and removes AI-writing tells (slop) in checked-in markdown prose: em dashes, emoji formatting, AI vocabulary, negative parallelisms, chatbot phrases, filler, stacked hedging, citation artifacts, and the rest of a catalog distilled from Wikipedia's Signs of AI writing. Read-only audit by default with a deterministic detector plus a judgment rubric; an explicit fix action rewrites findings behind a semantic-diff guard. Findings conform to the detector-findings convention so the review fanout fix relay can consume them.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/ai-slop/CHANGELOG.md
+++ b/plugins/ai-slop/CHANGELOG.md
@@ -13,7 +13,8 @@
   name stays a byte-identical unquoted scalar and the wire format for the common path does not
   move. The predicate is deliberately identical to the one `claude-config`'s and `testing`'s
   emitters use: three producers answer one frontmatter contract, and a consumer must not see three
-  shapes.
+  shapes. Implicit YAML types (`true`, `null`, `123`, `yes`, dates) are quoted the same way, because
+  a bare scalar would type-coerce and the consumer's exact branch match would still drop the file.
 
 ## [0.3.6]
 

--- a/plugins/ai-slop/CHANGELOG.md
+++ b/plugins/ai-slop/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [0.3.7]
+
+- **A branch name beginning with a YAML indicator silently dropped every finding it emitted.**
+  `emit-findings.sh` interpolated the branch into its findings frontmatter as a bare plain scalar,
+  and `git check-ref-format --branch` accepts `@foo`, `!foo`, `#foo` and `&foo`. Emitted bare,
+  `#foo` and `&foo` parse to null and `@foo`/`!foo` are outright YAML parse errors, so the
+  `branch:` value a consumer reads is not the branch name. The consumer admits a findings file
+  only when that value matches the current branch exactly, so the whole file went unmatched — with
+  no error, and nothing distinguishing it from "no findings". Frontmatter now goes through a
+  `yaml_scalar()` helper that quotes only when the plain form would misparse, so an ordinary branch
+  name stays a byte-identical unquoted scalar and the wire format for the common path does not
+  move. The predicate is deliberately identical to the one `claude-config`'s and `testing`'s
+  emitters use: three producers answer one frontmatter contract, and a consumer must not see three
+  shapes.
+
 ## [0.3.6]
 
 - **`emit-findings.sh` double-escaped a pipe the source already escaped, and left Location

--- a/plugins/ai-slop/skills/audit/scripts/detect.test.sh
+++ b/plugins/ai-slop/skills/audit/scripts/detect.test.sh
@@ -544,6 +544,63 @@ else
   fi
 fi
 
+# --- emit: branch names that are YAML indicators ---------------------------------
+#
+# git accepts branch names beginning with a YAML indicator: `git check-ref-format
+# --branch` calls "@foo", "!foo", "#foo" and "&foo" all valid. Emitted as a bare
+# plain scalar, "#foo" and "&foo" parse to null and "@foo"/"!foo"/"*foo" are
+# parse errors. The consumer (review/fanout fix-pass-mode.md "Step 1") admits a
+# findings file only when its `branch:` value equals the current branch EXACTLY,
+# so a misparse silently drops every finding for that branch — no error, and
+# nothing distinguishing it from "no findings".
+#
+# Both directions are asserted. Quoting is CONDITIONAL, so an ordinary branch
+# name must stay a byte-identical plain scalar: a helper that quoted
+# unconditionally would pass a quoted-only assertion while moving the wire
+# format for every ordinary branch. `*foo` is not a legal git branch name, but
+# --branch takes an arbitrary string, so the predicate is still asserted on it.
+emit_branch_line() {
+  # emit_branch_line <branch> -> the emitted `branch:` frontmatter line
+  local b="$1" out="$TEST_TMPDIR/findings/ybranch.md"
+  rm -f "$out"
+  bash "$EMIT" --from "$DETOUT" --out "$out" --branch "$b" >/dev/null 2>&1
+  LC_ALL=C grep -m1 '^branch:' "$out"
+}
+
+for b in '@foo' '!foo' '#foo' '*foo' '&foo'; do
+  got="$(emit_branch_line "$b")"
+  want="branch: \"$b\""
+  if [[ "$got" == "$want" ]]; then
+    pass "emit: indicator branch '$b' is emitted as a quoted scalar"
+  else
+    fail "emit: indicator branch '$b' is emitted as a quoted scalar" "$want" "$got"
+  fi
+done
+
+for b in 'main' 'feat/3179-slug' 'release-1.2_x'; do
+  got="$(emit_branch_line "$b")"
+  want="branch: $b"
+  if [[ "$got" == "$want" ]]; then
+    pass "emit: ordinary branch '$b' stays an unquoted plain scalar"
+  else
+    fail "emit: ordinary branch '$b' stays an unquoted plain scalar" "$want" "$got"
+  fi
+done
+
+# The quoting must survive a branch name carrying the quote character itself —
+# otherwise the emitted scalar is quoted but unparseable, trading a silent drop
+# for a hard consumer failure. A BACKSLASH is deliberately not asserted: git
+# rejects it in a branch name (`git check-ref-format --branch 'a\b'` fails), and
+# awk consumes it as an escape at the -v assignment boundary before the helper
+# ever runs, so an assertion here would pin an awk -v artifact on an input that
+# cannot occur rather than this producer's quoting.
+got="$(emit_branch_line '@with"quote')"
+if [[ "$got" == 'branch: "@with\"quote"' ]]; then
+  pass "emit: a quote character inside an indicator branch is escaped"
+else
+  fail "emit: a quote character inside an indicator branch is escaped" 'branch: "@with\"quote"' "$got"
+fi
+
 # --- Roster agreement: every rule's tier is asserted -----------------------------
 #
 # emit-findings.sh's rule_tier() declares itself a MIRROR of the severity

--- a/plugins/ai-slop/skills/audit/scripts/detect.test.sh
+++ b/plugins/ai-slop/skills/audit/scripts/detect.test.sh
@@ -562,18 +562,51 @@ fi
 emit_branch_line() {
   # emit_branch_line <branch> -> the emitted `branch:` frontmatter line
   local b="$1" out="$TEST_TMPDIR/findings/ybranch.md"
-  rm -f "$out"
-  bash "$EMIT" --from "$DETOUT" --out "$out" --branch "$b" >/dev/null 2>&1
-  LC_ALL=C grep -m1 '^branch:' "$out"
+  # Non-overwrite naming would divert a leftover sibling to ybranch-2.md.
+  rm -f "$TEST_TMPDIR/findings/ybranch"*.md
+  # Stdin closed: a missing-file grep that fell through to stdin would hang
+  # the suite (the Windows Git Bash failure mode that blocked the first
+  # widening of this loop). The emitter itself does not read stdin.
+  bash "$EMIT" --from "$DETOUT" --out "$out" --branch "$b" </dev/null >/dev/null 2>&1 || true
+  [[ -f "$out" ]] || {
+    printf 'MISSING\n'
+    return 0
+  }
+  LC_ALL=C grep -m1 '^branch:' "$out" </dev/null || true
 }
 
-for b in '@foo' '!foo' '#foo' '*foo' '&foo'; do
+# EVERY character in the predicate's indicator class is asserted, not a sample.
+# A five-name sample stayed green after `|`, `>`, `%`, backtick, `"` and `'`
+# were dropped from a sibling — the drift acceptance criterion 3 forbids.
+# `-foo` is omitted: git rejects it, and --branch treats a leading `-` as a
+# missing option value (exit 2), so no caller can reach the predicate with it.
+for b in '?foo' ':foo' ',foo' '[foo' ']foo' '{foo' '}foo' '#foo' \
+  '&foo' '*foo' '!foo' '|foo' '>foo' '%foo' '@foo' '`foo' "'foo"; do
   got="$(emit_branch_line "$b")"
   want="branch: \"$b\""
   if [[ "$got" == "$want" ]]; then
     pass "emit: indicator branch '$b' is emitted as a quoted scalar"
   else
     fail "emit: indicator branch '$b' is emitted as a quoted scalar" "$want" "$got"
+  fi
+done
+
+# The double-quote indicator, whose expected form carries an escape.
+got="$(emit_branch_line '"foo')"
+if [[ "$got" == 'branch: "\"foo"' ]]; then
+  pass 'emit: indicator branch (leading double quote) is quoted and escaped'
+else
+  fail 'emit: indicator branch (leading double quote) is quoted and escaped' 'branch: "\"foo"' "$got"
+fi
+
+# Non-leading `: ` and ` #` also force quoting: both end a plain scalar early.
+for b in 'has: colon' 'has #hash'; do
+  got="$(emit_branch_line "$b")"
+  want="branch: \"$b\""
+  if [[ "$got" == "$want" ]]; then
+    pass "emit: branch '$b' is quoted (plain scalar would end early)"
+  else
+    fail "emit: branch '$b' is quoted (plain scalar would end early)" "$want" "$got"
   fi
 done
 

--- a/plugins/ai-slop/skills/audit/scripts/detect.test.sh
+++ b/plugins/ai-slop/skills/audit/scripts/detect.test.sh
@@ -620,8 +620,21 @@ for b in 'main' 'feat/3179-slug' 'release-1.2_x'; do
   fi
 done
 
+# YAML implicit types: git accepts these as branch names, but a bare scalar
+# becomes a boolean, null, or number and the consumer's exact-match drops
+# every finding.
+for b in true null 123 yes FALSE '~'; do
+  got="$(emit_branch_line "$b")"
+  want="branch: \"$b\""
+  if [[ "$got" == "$want" ]]; then
+    pass "emit: implicit-type branch '$b' is quoted"
+  else
+    fail "emit: implicit-type branch '$b' is quoted" "$want" "$got"
+  fi
+done
+
 # The quoting must survive a branch name carrying the quote character itself —
-# otherwise the emitted scalar is quoted but unparseable, trading a silent drop
+# otherwise the emitted scalar is quoted but unparsable, trading a silent drop
 # for a hard consumer failure. A BACKSLASH is deliberately not asserted: git
 # rejects it in a branch name (`git check-ref-format --branch 'a\b'` fails), and
 # awk consumes it as an escape at the -v assignment boundary before the helper

--- a/plugins/ai-slop/skills/audit/scripts/emit-findings.sh
+++ b/plugins/ai-slop/skills/audit/scripts/emit-findings.sh
@@ -142,6 +142,28 @@ fi
 
 LC_ALL=C awk -v branch="$BRANCH" -v date_utc="$DATE_UTC" \
   -v repo_root="$REPO_ROOT" -v repo_root_alt="$REPO_ROOT_ALT" -v repo_root_pwd="$REPO_ROOT_PWD" '
+  # Quote a frontmatter value only when the plain form would misparse. git
+  # accepts branch names starting with a YAML indicator ("@foo", "!foo",
+  # "#foo"); emitted bare, "#foo" reads as a comment and the rest as
+  # indicators, so the value the consumer compares is not the branch name.
+  function yaml_implicit_typed(s,   l) {
+    l = tolower(s)
+    if (l ~ /^(true|false|yes|no|on|off|null|~)$/) return 1
+    if (s ~ /^[+-]?[0-9]+$/) return 1
+    if (s ~ /^[+-]?[0-9]*\.[0-9]+([eE][+-]?[0-9]+)?$/) return 1
+    if (s ~ /^[0-9]{4}-[0-9]{2}-[0-9]{2}/) return 1
+    if (s ~ /^0[xXoObB][0-9a-fA-F_]+$/) return 1
+    return 0
+  }
+  function yaml_scalar(s) {
+    if (s ~ /^[-?:,\[\]{}#&*!|>%@`"\x27]/ || s ~ /: / || s ~ / #/ || s ~ /^$/ || s ~ /[ \t]$/ || yaml_implicit_typed(s)) {
+      gsub(/\\/, "\\\\", s)
+      gsub(/"/, "\\\"", s)
+      return "\"" s "\""
+    }
+    return s
+  }
+
   # Tier/Action mirror of the severity crosswalk (see header comment).
   function rule_tier(slug) {
     if (slug == "rule-knowledge-cutoff-disclaimer" || slug == "rule-llm-citation-artifacts" ||
@@ -254,7 +276,7 @@ LC_ALL=C awk -v branch="$BRANCH" -v date_utc="$DATE_UTC" \
     next
   }
   END {
-    printf "---\ntype: review-findings\ndate: %s\nbranch: %s\n---\n\n", date_utc, branch
+    printf "---\ntype: review-findings\ndate: %s\nbranch: %s\n---\n\n", date_utc, yaml_scalar(branch)
     print "## Findings"
     print ""
     print "| Rank | Tier | Confidence | Location | Surface(s) | Finding | Action |"

--- a/plugins/ai-slop/skills/audit/scripts/emit-findings.sh
+++ b/plugins/ai-slop/skills/audit/scripts/emit-findings.sh
@@ -146,6 +146,20 @@ LC_ALL=C awk -v branch="$BRANCH" -v date_utc="$DATE_UTC" \
   # accepts branch names starting with a YAML indicator ("@foo", "!foo",
   # "#foo"); emitted bare, "#foo" reads as a comment and the rest as
   # indicators, so the value the consumer compares is not the branch name.
+  # The consumer (review/fanout fix-pass-mode.md "Step 1") admits a findings
+  # file only on an EXACT branch match, so a misparse silently drops every
+  # finding for that branch.
+  #
+  # Conditional, not unconditional: an ordinary name stays a byte-identical
+  # plain scalar, so the wire format for the common path does not move.
+  # Predicate deliberately IDENTICAL to the two sibling producers
+  # (claude-config/audit-instructions/scripts/emit-findings.sh and
+  # testing/audit/scripts/cant-fail-scan.sh) — three producers answering one
+  # frontmatter contract must agree, or a consumer sees three shapes.
+  # A plain scalar YAML implicitly TYPES is also unsafe: git accepts branch
+  # names like `true`, `null`, `no`, `123` and `2026-08-23`, and a consumer
+  # reading those back gets a boolean, a null, a number or a date rather than
+  # the exact branch string the relay matches on. Quote them too.
   function yaml_implicit_typed(s,   l) {
     l = tolower(s)
     if (l ~ /^(true|false|yes|no|on|off|null|~)$/) return 1

--- a/plugins/testing/.claude-plugin/plugin.json
+++ b/plugins/testing/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "testing",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "description": "Test-stage discipline across all ecosystems: coverage-gap analysis and test planning (`/testing:plan`), TDD test authoring and placement (`/testing:write`), live E2E plus non-UI smoke verification (`/testing:run-e2e`), failing-test root-cause diagnosis with the reproduce → isolate → fix → retest loop (`/testing:diagnose`), and a deterministic can't-fail test audit with a fail-closed gate mode and opt-in findings persistence (`/testing:audit`).",
   "author": {
     "name": "Melodic Software",

--- a/plugins/testing/CHANGELOG.md
+++ b/plugins/testing/CHANGELOG.md
@@ -20,6 +20,8 @@ All notable changes to the `testing` plugin are documented here. Format follows
   unquoted scalar and the wire format for the common path does not move. The predicate is
   deliberately identical to the one `claude-config`'s and `ai-slop`'s emitters use: three
   producers answer one frontmatter contract, and a consumer must not see three shapes.
+  Implicit YAML types (`true`, `null`, `123`, `yes`, dates) are quoted the same way, because a
+  bare scalar would type-coerce and the consumer's exact branch match would still drop the file.
 
 ## [0.7.4]
 

--- a/plugins/testing/CHANGELOG.md
+++ b/plugins/testing/CHANGELOG.md
@@ -3,6 +3,24 @@
 All notable changes to the `testing` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.7.5]
+
+### Fixed
+
+- **A branch name beginning with a YAML indicator silently dropped every finding `audit`
+  emitted.** `cant-fail-scan.sh --findings` interpolated the checked-out branch into its findings
+  frontmatter as a bare plain scalar, and `git check-ref-format --branch` accepts `@foo`, `!foo`,
+  `#foo` and `&foo`. Emitted bare, `#foo` and `&foo` parse to null and `@foo`/`!foo` are outright
+  YAML parse errors, so the `branch:` value a consumer reads is not the branch name. The consumer
+  admits a findings file only when that value matches the current branch exactly, so the whole
+  file went unmatched — with no error, and nothing distinguishing it from "no findings". That is
+  the hidden-findings failure mode this scanner exists to prevent, reached through the frontmatter
+  rather than through the scan. Frontmatter now goes through a `yaml_scalar()` helper that quotes
+  only when the plain form would misparse, so an ordinary branch name stays a byte-identical
+  unquoted scalar and the wire format for the common path does not move. The predicate is
+  deliberately identical to the one `claude-config`'s and `ai-slop`'s emitters use: three
+  producers answer one frontmatter contract, and a consumer must not see three shapes.
+
 ## [0.7.4]
 
 ### Fixed

--- a/plugins/testing/skills/audit/scripts/cant-fail-scan.sh
+++ b/plugins/testing/skills/audit/scripts/cant-fail-scan.sh
@@ -325,6 +325,54 @@ esc_cell() {
   printf '%s' "$s"
 }
 
+yaml_scalar() {
+  # Quote a frontmatter value only when the plain form would misparse. git
+  # accepts branch names starting with a YAML indicator ("@foo", "!foo",
+  # "#foo"); emitted bare, "#foo" reads as a comment and the rest as
+  # indicators, so the value the consumer compares is not the branch name.
+  # The consumer (review/fanout fix-pass-mode.md "Step 1") admits a findings
+  # file only on an EXACT branch match, so a misparse silently drops every
+  # finding for that branch — the hidden-findings shape reached through the
+  # frontmatter rather than through the scan.
+  #
+  # Conditional, not unconditional: an ordinary name stays a byte-identical
+  # plain scalar, so the wire format for the common path does not move.
+  # Predicate deliberately IDENTICAL to the two sibling awk producers
+  # (claude-config/audit-instructions/scripts/emit-findings.sh and
+  # ai-slop/audit/scripts/emit-findings.sh) — three producers answering one
+  # frontmatter contract must agree, or a consumer sees three shapes. The
+  # indicator set below is the same 19 characters as their awk character
+  # class, and the ": " / " #" / empty / trailing-blank tests mirror theirs.
+  # Space and tab only in the trailing test (NOT [:space:]), matching awk's
+  # /[ \t]$/.
+  local s="$1" needs_quote=0
+  case "${s:0:1}" in
+    '-' | '?' | ':' | ',' | '[' | ']' | '{' | '}' | '#' | '&' | '*' | '!' | '|' | '>' | '%' | '@' | '`' | '"' | "'")
+      needs_quote=1
+      ;;
+    *) ;;
+  esac
+  case "$s" in
+    *': '* | *' #'*) needs_quote=1 ;;
+    *) ;;
+  esac
+  if [[ -z "$s" || "$s" == *[$' \t'] ]]; then needs_quote=1; fi
+  lc=$(printf '%s' "$s" | tr '[:upper:]' '[:lower:]')
+  case "$lc" in
+    true | false | yes | no | on | off | null | '~') needs_quote=1 ;;
+  esac
+  if [[ "$s" =~ ^[+-]?[0-9]+$ || "$s" =~ ^0[xXoObB][0-9a-fA-F_]+$ ]]; then
+    needs_quote=1
+  fi
+  if ((needs_quote)); then
+    s="${s//\\/\\\\}"
+    s="${s//\"/\\\"}"
+    printf '"%s"' "$s"
+  else
+    printf '%s' "$s"
+  fi
+}
+
 emit_findings_file() {
   local branch ts i rank conf
   branch="$(git -C "$ROOT" branch --show-current 2>/dev/null | tr -d '\r')"
@@ -345,7 +393,7 @@ emit_findings_file() {
     exit 2
   fi
   ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-  printf -- '---\ntype: review-findings\ndate: %s\nbranch: %s\n---\n\n## Findings\n\n' "$ts" "$branch"
+  printf -- '---\ntype: review-findings\ndate: %s\nbranch: %s\n---\n\n## Findings\n\n' "$ts" "$(yaml_scalar "$branch")"
   printf '| Rank | Tier | Confidence | Location | Surface(s) | Finding | Action |\n'
   printf '|------|------|------------|----------|------------|---------|--------|\n'
   rank=0

--- a/plugins/testing/skills/audit/scripts/cant-fail-scan.sh
+++ b/plugins/testing/skills/audit/scripts/cant-fail-scan.sh
@@ -357,11 +357,15 @@ yaml_scalar() {
     *) ;;
   esac
   if [[ -z "$s" || "$s" == *[$' \t'] ]]; then needs_quote=1; fi
-  lc=$(printf '%s' "$s" | tr '[:upper:]' '[:lower:]')
-  case "$lc" in
-    true | false | yes | no | on | off | null | '~') needs_quote=1 ;;
+  case "$s" in
+  true | True | TRUE | false | False | FALSE | yes | Yes | YES | no | No | NO | \
+  on | On | ON | off | Off | OFF | null | Null | NULL | '~')
+    needs_quote=1
+    ;;
+  *) ;;
   esac
-  if [[ "$s" =~ ^[+-]?[0-9]+$ || "$s" =~ ^0[xXoObB][0-9a-fA-F_]+$ ]]; then
+  if [[ "$s" =~ ^[+-]?[0-9]+$ || "$s" =~ ^[+-]?[0-9]*\.[0-9]+([eE][+-]?[0-9]+)?$ ||
+        "$s" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2} || "$s" =~ ^0[xXoObB][0-9a-fA-F_]+$ ]]; then
     needs_quote=1
   fi
   if ((needs_quote)); then

--- a/plugins/testing/skills/audit/scripts/cant-fail-scan.test.sh
+++ b/plugins/testing/skills/audit/scripts/cant-fail-scan.test.sh
@@ -227,12 +227,18 @@ yb_branch_line() {
   mkdir -p "$repo"
   git -C "$TMP_ROOT" init -q -b "$b" "yb$slot" 2>/dev/null
   cp "$FIX/sanity/one-assertion-free.test.js" "$repo/"
-  CANT_FAIL_SCAN_ROOT="$repo" bash "$SCAN" --findings 2>/dev/null |
+  CANT_FAIL_SCAN_ROOT="$repo" bash "$SCAN" --findings </dev/null 2>/dev/null |
     LC_ALL=C grep -m1 '^branch:'
 }
 
+# EVERY git-reachable indicator character is asserted, not a sample. A
+# four-name sample stayed green after `|`, `>`, `%`, backtick, `"` and `'`
+# were dropped from this producer — the drift acceptance criterion 3 forbids.
+# `-`, `?`, `:`, `[` and `*` are rejected by `git check-ref-format --branch`,
+# so no checkout can reach them here; they are asserted against ai-slop's
+# emitter, which takes --branch as an arbitrary string.
 yb_slot=0
-for b in '@foo' '!foo' '#foo' '&foo'; do
+for b in ',foo' ']foo' '{foo' '}foo' '#foo' '&foo' '!foo' '|foo' '>foo' '%foo' '@foo' '`foo' "'foo"; do
   yb_slot=$((yb_slot + 1))
   got="$(yb_branch_line "$b" "$yb_slot")"
   want="branch: \"$b\""
@@ -242,6 +248,15 @@ for b in '@foo' '!foo' '#foo' '&foo'; do
     fail "indicator branch '$b' is emitted as a quoted scalar" "expected [$want], got [$got]"
   fi
 done
+
+# The double-quote indicator, whose expected form carries an escape.
+yb_slot=$((yb_slot + 1))
+got="$(yb_branch_line '"foo' "$yb_slot")"
+if [[ "$got" == 'branch: "\"foo"' ]]; then
+  pass 'indicator branch (leading double quote) is quoted and escaped'
+else
+  fail 'indicator branch (leading double quote) is quoted and escaped' "got [$got]"
+fi
 
 for b in 'main' 'feat/3179-slug' 'release-1.2_x'; do
   yb_slot=$((yb_slot + 1))

--- a/plugins/testing/skills/audit/scripts/cant-fail-scan.test.sh
+++ b/plugins/testing/skills/audit/scripts/cant-fail-scan.test.sh
@@ -269,8 +269,19 @@ for b in 'main' 'feat/3179-slug' 'release-1.2_x'; do
   fi
 done
 
+for b in true null 123 yes FALSE; do
+  yb_slot=$((yb_slot + 1))
+  got="$(yb_branch_line "$b" "$yb_slot")"
+  want="branch: \"$b\""
+  if [[ "$got" == "$want" ]]; then
+    pass "implicit-type branch '$b' is quoted"
+  else
+    fail "implicit-type branch '$b' is quoted" "expected [$want], got [$got]"
+  fi
+done
+
 # The quoting must survive a branch name carrying the quote character itself —
-# otherwise the emitted scalar is quoted but unparseable, trading a silent drop
+# otherwise the emitted scalar is quoted but unparsable, trading a silent drop
 # for a hard consumer failure. (A backslash is not legal in a git branch name,
 # so only the quote case is reachable through a real checkout here.)
 yb_slot=$((yb_slot + 1))

--- a/plugins/testing/skills/audit/scripts/cant-fail-scan.test.sh
+++ b/plugins/testing/skills/audit/scripts/cant-fail-scan.test.sh
@@ -202,6 +202,70 @@ out="$(CANT_FAIL_SCAN_ROOT="$EMPTY" bash "$SCAN" --findings 2>&1 >/dev/null)" ||
 assert_exit "--findings over nothing examined refuses (exit 2)" 2 "$rc"
 assert_contains "nothing-examined refusal says why" "$out" "0 test files were examined"
 
+# --- branch names that are YAML indicators ------------------------------------
+#
+# git accepts branch names beginning with a YAML indicator: `git check-ref-format
+# --branch` calls "@foo", "!foo", "#foo" and "&foo" all valid. Emitted as a bare
+# plain scalar, "#foo" and "&foo" parse to null and "@foo"/"!foo" are outright
+# parse errors. The consumer (review/fanout fix-pass-mode.md "Step 1") admits a
+# findings file only when its `branch:` value equals the current branch EXACTLY,
+# so a misparse silently drops every finding for that branch — no error, and
+# nothing distinguishing it from "no findings".
+#
+# This producer reads the CHECKED-OUT branch, so each case needs a real repo on
+# a real branch rather than a flag. `*foo` is not a legal git branch name and so
+# cannot be reached here; the predicate is asserted on it in ai-slop's suite,
+# whose emitter takes --branch as an arbitrary string.
+#
+# Both directions are asserted. Quoting is CONDITIONAL, so an ordinary branch
+# name must stay a byte-identical plain scalar: a helper that quoted
+# unconditionally would pass a quoted-only assertion while moving the wire
+# format for every ordinary branch.
+yb_branch_line() {
+  # yb_branch_line <branch> <slot> -> the emitted `branch:` frontmatter line
+  local b="$1" slot="$2" repo="$TMP_ROOT/yb$2"
+  mkdir -p "$repo"
+  git -C "$TMP_ROOT" init -q -b "$b" "yb$slot" 2>/dev/null
+  cp "$FIX/sanity/one-assertion-free.test.js" "$repo/"
+  CANT_FAIL_SCAN_ROOT="$repo" bash "$SCAN" --findings 2>/dev/null |
+    LC_ALL=C grep -m1 '^branch:'
+}
+
+yb_slot=0
+for b in '@foo' '!foo' '#foo' '&foo'; do
+  yb_slot=$((yb_slot + 1))
+  got="$(yb_branch_line "$b" "$yb_slot")"
+  want="branch: \"$b\""
+  if [[ "$got" == "$want" ]]; then
+    pass "indicator branch '$b' is emitted as a quoted scalar"
+  else
+    fail "indicator branch '$b' is emitted as a quoted scalar" "expected [$want], got [$got]"
+  fi
+done
+
+for b in 'main' 'feat/3179-slug' 'release-1.2_x'; do
+  yb_slot=$((yb_slot + 1))
+  got="$(yb_branch_line "$b" "$yb_slot")"
+  want="branch: $b"
+  if [[ "$got" == "$want" ]]; then
+    pass "ordinary branch '$b' stays an unquoted plain scalar"
+  else
+    fail "ordinary branch '$b' stays an unquoted plain scalar" "expected [$want], got [$got]"
+  fi
+done
+
+# The quoting must survive a branch name carrying the quote character itself —
+# otherwise the emitted scalar is quoted but unparseable, trading a silent drop
+# for a hard consumer failure. (A backslash is not legal in a git branch name,
+# so only the quote case is reachable through a real checkout here.)
+yb_slot=$((yb_slot + 1))
+got="$(yb_branch_line '@with"quote' "$yb_slot")"
+if [[ "$got" == 'branch: "@with\"quote"' ]]; then
+  pass "a quote character inside an indicator branch is escaped"
+else
+  fail "a quote character inside an indicator branch is escaped" "got [$got]"
+fi
+
 # report mode never claims a clean bill over nothing
 rc=0
 out="$(CANT_FAIL_SCAN_ROOT="$EMPTY" bash "$SCAN" 2>&1)" || rc=$?


### PR DESCRIPTION
## Summary

Two `detector-findings` producers interpolated the branch name into findings frontmatter as a bare YAML plain scalar. `git check-ref-format --branch` accepts `@foo`, `!foo`, `#foo` and `&foo`. Emitted bare, `#foo` and `&foo` parse to null and `@foo`/`!foo` are YAML parse errors, so the `branch:` value a consumer reads is not the branch name.

The consumer admits a findings file only when that value equals the current branch exactly (`review:fanout` fix-pass-mode.md Step 1), so a misparse silently dropped every finding for that branch — with no error, and nothing distinguishing it from "no findings".

## Fix

Both producers now route the value through a `yaml_scalar()` helper, matching the reference already on `main` in `claude-config:audit-instructions`. Quoting is **conditional**: an ordinary branch name stays a byte-identical unquoted scalar. The predicate is duplicated per producer rather than extracted into a shared library (plugins are portable). Tests now iterate the whole reachable indicator class, not a five-name sample.

ai-slop 0.3.5, testing 0.7.5.

## Verification

- `plugins/ai-slop/skills/audit/scripts/detect.test.sh` — 116/116
- `plugins/testing/skills/audit/scripts/cant-fail-scan.test.sh` — 89/89
- `scripts/check-changelog-parity.sh --check-bump origin/main` — pass
- markdownlint on both changelogs — 0 issues

The leading-single-quote case (`'foo`) that hung the first widening on Windows Git Bash does not hang here. Stdin is closed on emit/grep so a missing-file grep cannot fall through to stdin.

## Related

Closes #3179