### PR TITLE
refactor(ci): route remaining fetch-depth: 0 call sites through checkout-with-base

### DIFF
--- a/.github/workflows/dependabot-miro-bundle.yml
+++ b/.github/workflows/dependabot-miro-bundle.yml
@@ -20,13 +20,25 @@ jobs:
       contents: write
       pull-requests: read
     steps:
-      - name: Check out PR head
+      # Default checkout is the pull_request merge commit, which always
+      # contains .github/actions/checkout-with-base. Checking out
+      # github.head_ref first would lose the action on a Dependabot branch
+      # that has not rebased onto a base that already has it — the runner
+      # then fails resolving this uses: step and never regenerates the
+      # bundle. Switch to the PR head after the composite has run so the
+      # later commit/push still lands on the Dependabot branch.
+      - name: Check out
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ github.head_ref }}
           persist-credentials: false
       - name: Fetch base
         uses: ./.github/actions/checkout-with-base
+      - name: Switch to PR head
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+        run: |
+          git fetch --no-tags origin "$HEAD_REF":"refs/remotes/origin/$HEAD_REF"
+          git checkout -B "$HEAD_REF" "origin/$HEAD_REF"
       - name: Detect miro manifest changes
         id: scope
         env:

--- a/.github/workflows/dependabot-miro-bundle.yml
+++ b/.github/workflows/dependabot-miro-bundle.yml
@@ -24,8 +24,9 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.head_ref }}
-          fetch-depth: 0
           persist-credentials: false
+      - name: Fetch base
+        uses: ./.github/actions/checkout-with-base
       - name: Detect miro manifest changes
         id: scope
         env:

--- a/.github/workflows/silent-revert-canary.yml
+++ b/.github/workflows/silent-revert-canary.yml
@@ -80,11 +80,15 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-          # Full history: the canary blames the lines a merge deleted against
-          # its parent, and replays the recorded incidents from 2026-08. A
-          # shallow clone cannot do either, and the script exits 2 rather than
-          # reporting a clean run it did not earn.
-          fetch-depth: 0
+      # Full history: the canary blames the lines a merge deleted against
+      # its parent, and replays the recorded incidents from 2026-08. A
+      # shallow clone cannot do either, and the script exits 2 rather than
+      # reporting a clean run it did not earn. fetch-base is off because
+      # this job never diffs against origin/$BASE_REF.
+      - name: Deepen history
+        uses: ./.github/actions/checkout-with-base
+        with:
+          fetch-base: "false"
 
       # Self-test first, unconditionally: a broken detector must not be able to
       # mask a real regression behind a green canary. Same never-skip,


### PR DESCRIPTION
Closes #3158

## Summary

#3207 landed `.github/actions/checkout-with-base` and converted the twenty `ci.yml` jobs that used to set `fetch-depth: 0` inline. Two other workflows still repeated that depth: `dependabot-miro-bundle.yml` (it diffs `origin/$BASE_REF`) and `silent-revert-canary.yml` (it needs full history for blame and incident replay). Those were the remaining call sites.

## Fix

Both workflows now bootstrap with the pinned `actions/checkout` (a same-repo composite still cannot be a job's first step) and call the composite for depth and, where needed, the base fetch.

- `dependabot-miro-bundle` uses the default `fetch-base: true` so `git diff origin/$BASE_REF` has a resolvable ref with no extra step of its own.
- `silent-revert-canary` passes `fetch-base: false` because it never diffs against the PR base; it only needs the unshallow.

`ci.yml` had no leftover `fetch-depth: 0`. The one-line checkout-SHA pin remains blocked by GitHub's same-repo composite chicken-and-egg — callers still pin the bootstrap checkout, as #3207 documented. This PR does not re-litigate that.

## Verification

- `rg fetch-depth: .github` is empty after this change.
- Both remaining `origin/$BASE_REF` / full-history consumers now go through the composite.
- `actionlint` / `zizmor` stay the existing contract: persist-credentials false, full SHA pin, no `GITHUB_ENV` write.

## Related

- Refs #3207 — the composite and the twenty `ci.yml` call sites.
- Refs #2914 — parent umbrella, finding 4 of 7.