### PR TITLE
fix(markdown-format): trim PATH-probe dump to plausible directories (0.11.29)

### DIFF
--- a/docs/formatter-path-probes.md
+++ b/docs/formatter-path-probes.md
@@ -11,7 +11,9 @@ This document is the fleet checklist. Per-hook notices must:
 1. Say the skip is for **this edit** (the probe re-runs; only the notice latches).
 2. Name the environment-inheritance cause (not "install it again").
 3. Prefer a **repo-local / filesystem** install route when one exists.
-4. Append `PATH probed: …` so the miss is diagnosable.
+4. Append `PATH probed: …` so the miss is diagnosable. Prefer plausible
+   directories (user/repo install locations); collapse Claude Code plugin-bin
+   entries to a count so the dump stays short enough for a later re-notice.
 5. **Never** widen the probe into nvm/rbenv layout guesses — that is bootstrap work
    (#2739 / #2748), not a hook-side search expansion.
 

--- a/plugins/markdown-format/.claude-plugin/plugin.json
+++ b/plugins/markdown-format/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "markdown-format",
-  "version": "0.11.28",
+  "version": "0.11.29",
   "description": "Auto-format and lint Markdown on edit via markdownlint-cli2 — only in repos that carry their own markdownlint config.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/markdown-format/CHANGELOG.md
+++ b/plugins/markdown-format/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to the `markdown-format` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.11.29]
+
+### Changed
+
+- **PATH-probe dump trims plugin-bin directories (#3134).** The missing-tool
+  notice still prints `PATH probed:` so a miss is checkable, but Claude Code
+  plugin-bin entries (dozens per session, previously ~4,570 bytes/channel)
+  collapse to a count. Plausible user/repo directories stay listed. Unblocks a
+  short re-notice for the shared skip-latch work.
+
 ## [0.11.28]
 
 ### Changed

--- a/plugins/markdown-format/CHANGELOG.md
+++ b/plugins/markdown-format/CHANGELOG.md
@@ -10,7 +10,8 @@ All notable changes to the `markdown-format` plugin are documented here. Format 
 - **PATH-probe dump trims plugin-bin directories (#3134).** The missing-tool
   notice still prints `PATH probed:` so a miss is checkable, but Claude Code
   plugin-bin entries (dozens per session, previously ~4,570 bytes/channel)
-  collapse to a count. Plausible user/repo directories stay listed. Unblocks a
+  collapse to a count. Plausible user/repo directories stay listed. Empty PATH
+  components (cwd) are preserved as `.` rather than dropped. Unblocks a
   short re-notice for the shared skip-latch work.
 
 ## [0.11.28]

--- a/plugins/markdown-format/README.md
+++ b/plugins/markdown-format/README.md
@@ -96,7 +96,8 @@ the hook exits `0` and reports a once-per-session notice to both Claude
 (`additionalContext`) and you (`systemMessage`). Only the notice latches —
 the binary probe re-runs on every Markdown edit and recovers mid-session when
 the tool becomes resolvable. A missing-`markdownlint-cli2` notice includes a
-`PATH probed:` line naming the PATH the hook process actually searched. When
+`PATH probed:` line naming the plausible directories the hook process actually
+searched (Claude Code plugin-bin entries collapse to a count). When
 the edited file is outside a repository the notice names a durable user-scope
 directory already on that PATH instead of recommending a repo-local
 `npm i -D`. The hook never falls back to `npx`, installs a package, or

--- a/plugins/markdown-format/hooks/markdown-format.sh
+++ b/plugins/markdown-format/hooks/markdown-format.sh
@@ -642,6 +642,48 @@ markdownlint_skip_remediation() {
   printf '%s' ". This hook does not invoke npx or download tools."
 }
 
+# Format the PATH-probe diagnostic (#3134). Keep directories that could
+# plausibly hold a user- or repo-installed markdownlint-cli2, and collapse
+# Claude Code plugin-bin entries (dozens per session) to a count. Dumping the
+# raw PATH was 4,570 bytes/channel and made a later re-notice unaffordable.
+format_probed_path() {
+  if [[ -z "${PATH+x}" ]]; then
+    printf '%s' '<unset>'
+    return 0
+  fi
+  if [[ -z "$PATH" ]]; then
+    printf '%s' '<empty>'
+    return 0
+  fi
+  local keep="" omitted=0 p oldifs="$IFS"
+  IFS=':'
+  # shellcheck disable=SC2086 # intentional IFS-split of PATH
+  for p in $PATH; do
+    case "$p" in
+    */.claude/plugins/* | */plugins/cache/*)
+      omitted=$((omitted + 1))
+      ;;
+    *)
+      if [[ -n "$keep" ]]; then
+        keep="${keep}:${p}"
+      else
+        keep="$p"
+      fi
+      ;;
+    esac
+  done
+  IFS="$oldifs"
+  if ((omitted > 0)); then
+    if [[ -n "$keep" ]]; then
+      printf '%s (+%d plugin-bin directories omitted)' "$keep" "$omitted"
+    else
+      printf '%s' "<plugin-bin directories only: ${omitted} omitted>"
+    fi
+  else
+    printf '%s' "$keep"
+  fi
+}
+
 MDLINT=()
 if command -v markdownlint-cli2 >/dev/null 2>&1; then
   MDLINT=(markdownlint-cli2)
@@ -657,7 +699,8 @@ else
   # edit and recovers silently mid-session when the tool becomes resolvable —
   # there is no skip latch. Saying "skipped for this session" made operators
   # and agents stop retrying. The trailing PATH line is the probe diagnostic
-  # (what this hook process actually searched); do not widen the probe to
+  # (plausible directories this hook process actually searched; plugin-bin
+  # entries collapse to a count — #3134); do not widen the probe to
   # nvm/rbenv layout guesses — that is a separate environment/bootstrap fix.
   #
   # Remediation is scoped (#2868): `npm i -D` is the reliable route only
@@ -667,7 +710,7 @@ else
   if hook::notice_once "markdown-format-markdownlint" "$INPUT"; then
     hook::emit_skip_notice PostToolUse \
       "markdown-format: markdownlint-cli2 was not found on this hook's PATH or as a contained repository-local node_modules/.bin executable — Markdown lint skipped for this edit (probe re-runs on every Markdown edit; only this notice latches once per session — there is no skip latch). $(markdownlint_skip_remediation)
-PATH probed: ${PATH:-<unset>}"
+PATH probed: $(format_probed_path)"
   fi
   emit_tel "skipped" '[]'
   exit 0

--- a/plugins/markdown-format/hooks/markdown-format.sh
+++ b/plugins/markdown-format/hooks/markdown-format.sh
@@ -655,10 +655,20 @@ format_probed_path() {
     printf '%s' '<empty>'
     return 0
   fi
-  local keep="" omitted=0 p oldifs="$IFS"
-  IFS=':'
-  # shellcheck disable=SC2086 # intentional IFS-split of PATH
-  for p in $PATH; do
+  # Split on ':' while preserving empty fields. `IFS=:; for p in $PATH`
+  # drops them, and an empty component is cwd (`PATH=/usr/bin:`).
+  local keep="" omitted=0 p rest="$PATH" last=0
+  while ((last == 0)); do
+    if [[ "$rest" == *:* ]]; then
+      p="${rest%%:*}"
+      rest="${rest#*:}"
+    else
+      p="$rest"
+      last=1
+    fi
+    if [[ -z "$p" ]]; then
+      p="."
+    fi
     case "$p" in
     */.claude/plugins/* | */plugins/cache/*)
       omitted=$((omitted + 1))
@@ -672,7 +682,6 @@ format_probed_path() {
       ;;
     esac
   done
-  IFS="$oldifs"
   if ((omitted > 0)); then
     if [[ -n "$keep" ]]; then
       printf '%s (+%d plugin-bin directories omitted)' "$keep" "$omitted"

--- a/plugins/markdown-format/hooks/markdown-format.test.sh
+++ b/plugins/markdown-format/hooks/markdown-format.test.sh
@@ -948,6 +948,34 @@ if printf '%s' "$OUT_NO_MDLINT" | jq -e '
 else
   fail "missing markdownlint latch/PATH diagnostic wrong: $OUT_NO_MDLINT"
 fi
+# #3134: plugin-bin directories collapse to a count; plausible dirs stay.
+PLUGIN_BIN_HOME="$WORK/fake-plugin-home"
+mkdir -p "$PLUGIN_BIN_HOME/.local/bin"
+plugin_bins=""
+i=0
+while ((i < 20)); do
+  d="$PLUGIN_BIN_HOME/.claude/plugins/cache/mp/plugin-${i}/bin"
+  mkdir -p "$d"
+  plugin_bins="${plugin_bins}:${d}"
+  i=$((i + 1))
+done
+PD_TRIM="$(mktemp -d "$WORK/pd.XXXXXX")"
+OUT_TRIM="$(cd "$UNRELATED" && printf '{"tool_input":{"file_path":"%s"}}' "$FA" |
+  env -u CLAUDE_PROJECT_DIR BASH_ENV="$NO_MDLINT_ENV" CLAUDE_PLUGIN_DATA="$PD_TRIM" \
+    CLAUDE_PLUGIN_OPTION_MARKDOWN_FORMAT_ENABLED=true \
+    PATH="/usr/bin:${PLUGIN_BIN_HOME}/.local/bin${plugin_bins}:/bin" \
+    bash "$HOOK")"
+if printf '%s' "$OUT_TRIM" | jq -e --arg local "$PLUGIN_BIN_HOME/.local/bin" '
+  (.hookSpecificOutput.additionalContext | contains("PATH probed:")) and
+  (.hookSpecificOutput.additionalContext | contains("/usr/bin")) and
+  (.hookSpecificOutput.additionalContext | contains($local)) and
+  (.hookSpecificOutput.additionalContext | contains("+20 plugin-bin directories omitted")) and
+  ((.hookSpecificOutput.additionalContext | contains(".claude/plugins/cache/mp/plugin-0/bin")) | not)
+' >/dev/null 2>&1; then
+  ok "PATH probed trims plugin-bin directories to a count"
+else
+  fail "PATH probed trim wrong: $OUT_TRIM"
+fi
 # In-repo missing-tool: repo-local `npm i -D` is still the reliable route (#2868).
 if printf '%s' "$OUT_NO_MDLINT" | jq -e '
   (.hookSpecificOutput.additionalContext | contains("npm i -D markdownlint-cli2")) and

--- a/plugins/markdown-format/hooks/markdown-format.test.sh
+++ b/plugins/markdown-format/hooks/markdown-format.test.sh
@@ -976,6 +976,23 @@ if printf '%s' "$OUT_TRIM" | jq -e --arg local "$PLUGIN_BIN_HOME/.local/bin" '
 else
   fail "PATH probed trim wrong: $OUT_TRIM"
 fi
+# Empty PATH components are cwd. Word-split with IFS=: would drop them.
+PD_EMPTY="$(mktemp -d "$WORK/pd.XXXXXX")"
+OUT_EMPTY="$(cd "$UNRELATED" && printf '{"tool_input":{"file_path":"%s"}}' "$FA" |
+  env -u CLAUDE_PROJECT_DIR BASH_ENV="$NO_MDLINT_ENV" CLAUDE_PLUGIN_DATA="$PD_EMPTY" \
+    CLAUDE_PLUGIN_OPTION_MARKDOWN_FORMAT_ENABLED=true \
+    PATH="/usr/bin::${PLUGIN_BIN_HOME}/.local/bin${plugin_bins}:/bin:" \
+    bash "$HOOK")"
+if printf '%s' "$OUT_EMPTY" | jq -e --arg local "$PLUGIN_BIN_HOME/.local/bin" '
+  (.hookSpecificOutput.additionalContext | contains("PATH probed: /usr/bin:.:")) and
+  (.hookSpecificOutput.additionalContext | contains($local)) and
+  (.hookSpecificOutput.additionalContext | contains(":/bin:.")) and
+  (.hookSpecificOutput.additionalContext | contains("+20 plugin-bin directories omitted"))
+' >/dev/null 2>&1; then
+  ok "PATH probed preserves empty components as cwd"
+else
+  fail "PATH probed empty-component trim wrong: $OUT_EMPTY"
+fi
 # In-repo missing-tool: repo-local `npm i -D` is still the reliable route (#2868).
 if printf '%s' "$OUT_NO_MDLINT" | jq -e '
   (.hookSpecificOutput.additionalContext | contains("npm i -D markdownlint-cli2")) and


### PR DESCRIPTION
Closes #3134

## Summary

The markdown-format missing-tool notice dumped the entire hook PATH, including dozens of Claude Code plugin-bin directories (4,570 bytes/channel). That size blocked a short re-notice for the shared skip-latch work.

## Fix

`PATH probed:` still names the directories this hook process searched. Plugin-bin entries (`*/.claude/plugins/*`, `*/plugins/cache/*`) collapse to a count. User and repo directories stay listed. Unset and empty PATH stay diagnosable.

## Verification

- `plugins/markdown-format/hooks/markdown-format.test.sh` — PASS=160 FAIL=0, including a new case that a 20-entry plugin-bin PATH is omitted and `/usr/bin` plus a user-scope dir remain
- `scripts/check-changelog-parity.sh --check-bump origin/main` — pass

## Related

Refs #3128 (S1 re-notice is unblocked by a short dump; not implemented here)