### PR TITLE
fix(scripts): honor evals warrant skips via an exemptions file

### DIFF
--- a/docs/MIGRATION-PLAYBOOK.md
+++ b/docs/MIGRATION-PLAYBOOK.md
@@ -321,18 +321,13 @@ This section is the policy; current coverage is verified on demand — a live gl
 `plugins/*/skills/*/evals/evals.json` against the tree, read against the warrant rule above — never a
 checked-in snapshot that decays the moment a skill lands.
 
-**The gate is operative, and it is broader than this policy.** `scripts/check-changed-skills.sh`
-passes `--require-evals` for every skill whose `SKILL.md` is new or modified, and
-`plugins/skill-quality/scripts/check-skill.sh` then hard-FAILs on a missing `evals/evals.json` for
-any skill shape — with no allowlist, frontmatter opt-out, or plugin-type awareness in either, and no
-way for the one CI caller to override it. So a "skip" verdict recorded here holds only until someone
-touches that `SKILL.md`, at which point CI requires evals and gets them. Read this policy as
-governing what a skill ships *absent a touch*, and expect the gate to decide otherwise the moment
-the file changes. That is a real disagreement rather than a nuance, and the pure-reference skip is
-where it still bites: the standing resolution — either the gate learns a recorded-skip mechanism
-(the repo's idiom is an exemptions file carrying the verdict, as
-`scripts/skill-count-claim-exemptions.txt` does) or this policy drops "skip" and evals become
-mandatory — is tracked in issue #3135 and is not settled here.
+**The gate honors a recorded skip.** `scripts/check-changed-skills.sh` passes `--require-evals` for
+every skill whose `SKILL.md` is new or modified, and `plugins/skill-quality/scripts/check-skill.sh`
+then hard-FAILs on a missing `evals/evals.json` — unless that skill is listed in
+`scripts/evals-warrant-exemptions.txt`. A skip becomes a reviewed, diffable line rather than an
+implicit absence; anything unlisted still fails closed. The file is stale-guarded: a row whose
+skill is gone, or that now ships `evals/evals.json`, fails the gate so the list can only shrink.
+This is the Exit A decision from #3135 — the warrant rule above and the CI gate now agree.
 
 **Rich form.** Each case carries `id`, a kebab-case `name`, a `prompt`, an `expected_output`
 description, optional `files` fixtures, and an `expectations` array of objectively-verifiable checks

--- a/plugins/skill-quality/.claude-plugin/plugin.json
+++ b/plugins/skill-quality/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "skill-quality",
-  "version": "0.19.1",
+  "version": "0.19.2",
   "description": "Skill-authoring QA tooling: a static contract checker that runs twenty-five deterministic checks over a Claude Code skill (frontmatter, explicit invocation mode, description/verb-contract polarity, per-skill listing-entry cap, trigger-keyword preservation, line caps, broken internal refs, markdownlint, gotchas surface, evals presence, precompute opportunity, completion-criteria signal, injection shell-declaration, fresh-eyes declaration conformance), a shared skill-listing budget reporter across a set of skills, and a bundled evals.json schema plus a deterministic eval-quality lint (duplicate case identities, missing fixtures, empty or vague grading criteria, set-coverage warnings). Runs against any repo's skills directory via the convention-resolution ladder — no baked layout.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/skill-quality/CHANGELOG.md
+++ b/plugins/skill-quality/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to the `skill-quality` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.19.2]
+
+### Changed
+
+- **`check`: `--require-evals` honors recorded warrant skips (#3135).** Check 14
+  still FAILs on a missing `evals/evals.json` for any unlisted skill, but a
+  reviewed row in `scripts/evals-warrant-exemptions.txt` is a durable skip —
+  the warrant policy's explicit skip classes, not a silent absence. The
+  changed-skill CI wrapper consults the same file.
+
 ## [0.19.1]
 
 ### Changed

--- a/plugins/skill-quality/README.md
+++ b/plugins/skill-quality/README.md
@@ -32,7 +32,7 @@ phrase, which quietly degrades a skill's auto-invocation. Check 3 compares the t
 - `scripts/*.test.sh` pass where present.
 - Vendored `vendor/` byte-identical vs `HEAD`; stale-tracking metadata keys preserved; sync age.
 - Gotchas surface present; `description` carries `Use when` phrasing; no committed cache artifacts;
-  action-router skills without evals WARN (FAIL with `--require-evals` for any shape); companion spoke
+  action-router skills without evals WARN (FAIL with `--require-evals` for any shape unless a recorded skip exists in `scripts/evals-warrant-exemptions.txt`); companion spoke
   dirs are referenced.
 - Precompute opportunity (advisory) — a fenced shell block gathers read-only context the skill could
   inline at load time via [`!` injection](https://code.claude.com/docs/en/skills#inject-dynamic-context)

--- a/plugins/skill-quality/scripts/check-skill.sh
+++ b/plugins/skill-quality/scripts/check-skill.sh
@@ -13,7 +13,9 @@
 #   bash check-skill.sh --help
 #
 # --require-evals (or CHECK_SKILL_REQUIRE_EVALS=1) FAILs when evals/evals.json
-# is absent for any skill shape. Without it, check 14 WARNs only on
+# is absent for any skill shape, unless the skill has a recorded skip in
+# scripts/evals-warrant-exemptions.txt (walked up from the repo root; absent
+# file = no skips). Without --require-evals, check 14 WARNs only on
 # action-router-shaped skills — the legacy fleet posture.
 #
 # Skills root resolution (first hit wins):
@@ -67,7 +69,8 @@
 #  12. description carries "Use when" trigger phrasing, single-quoted (WARN)
 #  13. No committed cache/build artifacts (__pycache__, *.pyc, node_modules) (FAIL)
 #  14. evals/evals.json presence (WARN for action-router shape; FAIL with
-#      --require-evals / CHECK_SKILL_REQUIRE_EVALS=1 for any shape)
+#      --require-evals / CHECK_SKILL_REQUIRE_EVALS=1 for any shape, unless a
+#      recorded skip exists in scripts/evals-warrant-exemptions.txt)
 #  15. Companion spoke dirs referenced from SKILL.md (WARN; orphan-spoke direction)
 #  16. metadata.category present (INFO only)
 #  17. Vendor-backed: metadata.synced not older than 180 days (WARN)
@@ -727,11 +730,44 @@ fi
 # --- Check 14: evals/evals.json presence -------------------------------------
 # Legacy fleet: action-router shape without evals WARNs (evals warranted, not
 # mandatory). Changed-skill CI passes --require-evals so any touched SKILL.md
-# must ship evals/evals.json regardless of shape.
+# must ship evals/evals.json unless a recorded skip exists (#3135).
+
+evals_warrant_exemptions_file() {
+  local d="${1:-}"
+  while [[ -n "$d" && "$d" != "/" ]]; do
+    if [[ -f "$d/scripts/evals-warrant-exemptions.txt" ]]; then
+      printf '%s\n' "$d/scripts/evals-warrant-exemptions.txt"
+      return 0
+    fi
+    d="$(dirname "$d")"
+  done
+  return 1
+}
+
+evals_warrant_skip() {
+  local skill_rel="$1" file raw
+  file="$(evals_warrant_exemptions_file "${REPO_ROOT:-$SKILL_DIR}")" || return 1
+  while IFS= read -r raw || [[ -n "$raw" ]]; do
+    raw="${raw%%#*}"
+    raw="${raw#"${raw%%[![:space:]]*}"}"
+    raw="${raw%"${raw##*[![:space:]]}"}"
+    [[ "$raw" == "$skill_rel" ]] && return 0
+  done <"$file"
+  return 1
+}
+
+evals_skill_rel=""
+if [[ "$SKILLS_ROOT" =~ /plugins/([^/]+)/skills$ ]]; then
+  evals_skill_rel="plugins/${BASH_REMATCH[1]}/skills/${SKILL_NAME}"
+fi
 
 if [[ ! -f "$SKILL_DIR/evals/evals.json" ]]; then
   if [[ "$REQUIRE_EVALS" == "1" ]]; then
-    err "skill ships no evals/evals.json — required when the skill is new or its SKILL.md changed"
+    if [[ -n "$evals_skill_rel" ]] && evals_warrant_skip "$evals_skill_rel"; then
+      note "evals skip recorded in scripts/evals-warrant-exemptions.txt for $evals_skill_rel"
+    else
+      err "skill ships no evals/evals.json — required when the skill is new or its SKILL.md changed"
+    fi
   elif grep -qE '^##+[[:space:]]+Actions?([^[:alnum:]_]|$)' "$SKILL_MD"; then
     warn "action-router-shaped skill with no evals/evals.json — check whether the skill warrants triggering evals"
   fi

--- a/plugins/skill-quality/scripts/check-skill.test.sh
+++ b/plugins/skill-quality/scripts/check-skill.test.sh
@@ -3401,6 +3401,57 @@ else
   fail "check 2b must count codepoints: 600 'é' is 600 chars, not 1200 bytes (rc=$rc): $out"
 fi
 
+# 47. --require-evals honors a recorded warrant skip (#3135).
+mkdir -p "$TMP/plugins/p1/skills/skipme" "$TMP/scripts"
+cat >"$TMP/plugins/p1/skills/skipme/SKILL.md" <<'EOF'
+---
+description: "A pure-reference fixture. Use when: 'testing warrant skips'."
+disable-model-invocation: false
+---
+
+## Purpose
+
+Pure-reference skip fixture.
+
+## Gotchas
+
+None known.
+EOF
+printf '%s\n' 'plugins/p1/skills/skipme  # test skip' >"$TMP/scripts/evals-warrant-exemptions.txt"
+out="$(cd "$TMP" && CHECK_SKILL_SKILLS_ROOT="$TMP/plugins/p1/skills" CHECK_SKILL_SKIP_MARKDOWNLINT=1 \
+  bash "$SUT" --require-evals skipme 2>&1)"
+rc=$?
+if [[ $rc -eq 0 ]] && grep -q 'evals skip recorded' <<<"$out"; then
+  pass "--require-evals honors a recorded warrant skip"
+else
+  fail "--require-evals should pass a recorded skip (rc=$rc): $out"
+fi
+
+# 48. --require-evals still FAILs an unlisted sibling in the same plugins/ tree.
+mkdir -p "$TMP/plugins/p1/skills/listed"
+cat >"$TMP/plugins/p1/skills/listed/SKILL.md" <<'EOF'
+---
+description: "An unlisted fixture. Use when: 'testing warrant unlisted'."
+disable-model-invocation: false
+---
+
+## Purpose
+
+Unlisted sibling of the skip fixture.
+
+## Gotchas
+
+None known.
+EOF
+out="$(cd "$TMP" && CHECK_SKILL_SKILLS_ROOT="$TMP/plugins/p1/skills" CHECK_SKILL_SKIP_MARKDOWNLINT=1 \
+  bash "$SUT" --require-evals listed 2>&1)"
+rc=$?
+if [[ $rc -eq 1 ]] && grep -q 'skill ships no evals/evals.json' <<<"$out"; then
+  pass "--require-evals still fails an unlisted skill"
+else
+  fail "unlisted skill should still fail --require-evals (rc=$rc): $out"
+fi
+
 if [[ $fails -ne 0 ]]; then
   printf '%d assertion(s) failed\n' "$fails" >&2
   exit 1

--- a/scripts/check-changed-skills.sh
+++ b/scripts/check-changed-skills.sh
@@ -9,8 +9,10 @@
 # and line caps, broken internal refs, evals presence, committed artifacts).
 # When a changed skill's SKILL.md is new or modified vs <base-ref>, the checker
 # is invoked with --require-evals so a missing evals/evals.json FAILs for any
-# shape; untouched legacy skills and non-SKILL.md-only touches keep the legacy
-# WARN-only posture.
+# shape, unless that skill has a recorded skip in
+# scripts/evals-warrant-exemptions.txt (the warrant policy's explicit skip
+# classes — #3135). Untouched legacy skills and non-SKILL.md-only touches keep
+# the legacy WARN-only posture.
 # Any FAIL fails this gate. It replaces the work lane's manual high-blast-radius
 # skill-diff read with a deterministic check, and is the first lane to invoke the
 # otherwise-uninvoked skill-quality checker.
@@ -49,6 +51,40 @@ if [[ ! -f "$CHECKER" ]]; then
   printf 'Error: skill checker not found: %s\n' "$CHECKER" >&2
   exit 2
 fi
+
+# Recorded evals-warrant skips. Missing file = no skips (tests, other repos).
+# A stale row is a gate failure so the list can only shrink.
+EXEMPTIONS="${EVALS_WARRANT_EXEMPTIONS:-scripts/evals-warrant-exemptions.txt}"
+evals_skip_dirs=()
+if [[ -f "$EXEMPTIONS" ]]; then
+  while IFS= read -r raw || [[ -n "$raw" ]]; do
+    raw="${raw%%#*}"
+    raw="${raw#"${raw%%[![:space:]]*}"}"
+    raw="${raw%"${raw##*[![:space:]]}"}"
+    [[ -n "$raw" ]] || continue
+    if [[ "$raw" != plugins/*/skills/* || "$raw" == */*/*/*/* ]]; then
+      printf 'FAIL: %s: not a skill path: %s\n' "$EXEMPTIONS" "$raw" >&2
+      exit 2
+    fi
+    if [[ ! -f "$raw/SKILL.md" ]]; then
+      printf 'FAIL: %s: stale row, skill gone: %s\n' "$EXEMPTIONS" "$raw" >&2
+      exit 1
+    fi
+    if [[ -f "$raw/evals/evals.json" ]]; then
+      printf 'FAIL: %s: stale row, skill now ships evals: %s\n' "$EXEMPTIONS" "$raw" >&2
+      exit 1
+    fi
+    evals_skip_dirs+=("$raw")
+  done <"$EXEMPTIONS"
+fi
+
+evals_warrant_skip() {
+  local dir="$1" listed
+  for listed in ${evals_skip_dirs[@]+"${evals_skip_dirs[@]}"}; do
+    [[ "$listed" == "$dir" ]] && return 0
+  done
+  return 1
+}
 
 # Changed skill dirs, mapped from any touched path (including vendor/ subtrees)
 # to the owning plugins/<plugin>/skills/<skill> dir and de-duplicated.
@@ -104,7 +140,11 @@ for skill_dir in "${changed[@]}"; do
   printf '=== %s ===\n' "$skill_dir"
   require_evals_args=()
   if git diff --name-only "$BASE" -- "$skill_dir/SKILL.md" | grep -q .; then
-    require_evals_args=(--require-evals)
+    if evals_warrant_skip "$skill_dir"; then
+      printf 'evals skip recorded for %s — not passing --require-evals\n' "$skill_dir"
+    else
+      require_evals_args=(--require-evals)
+    fi
   fi
   if ! CHECK_SKILL_SKILLS_ROOT="$PWD/$skills_root" \
     CHECK_SKILL_BASE_REF="$BASE" \

--- a/scripts/check-changed-skills.test.sh
+++ b/scripts/check-changed-skills.test.sh
@@ -338,6 +338,38 @@ else
 fi
 rm -rf "$r"
 
+# --- recorded warrant skip is not passed --require-evals (#3135) -----------
+r="$(mk_repo)"
+add_skill "$r" p1 skipme
+commit_all "$r" base >/dev/null
+b="$(base_sha "$r")"
+add_skill "$r" p1 skipme SKILL.md
+printf '%s\n' 'plugins/p1/skills/skipme  # test skip' >"$r/scripts/evals-warrant-exemptions.txt"
+run "$r" "$b" >/dev/null 2>&1
+if grep -q "args=skipme " "$r/checklog" 2>/dev/null &&
+  ! grep -q "args=--require-evals skipme" "$r/checklog" 2>/dev/null; then
+  ok "recorded warrant skip is not passed --require-evals"
+else
+  fail "exempted skill should not receive --require-evals, got: $(cat "$r/checklog" 2>/dev/null)"
+fi
+rm -rf "$r"
+
+# --- stale exemption (skill now ships evals) fails -------------------------
+r="$(mk_repo)"
+add_skill "$r" p1 skipme
+mkdir -p "$r/plugins/p1/skills/skipme/evals"
+printf '{}\n' >"$r/plugins/p1/skills/skipme/evals/evals.json"
+printf '%s\n' 'plugins/p1/skills/skipme  # stale' >"$r/scripts/evals-warrant-exemptions.txt"
+commit_all "$r" base >/dev/null
+b="$(base_sha "$r")"
+add_skill "$r" p1 skipme SKILL.md
+if run "$r" "$b" >/dev/null 2>&1; then
+  fail "stale evals exemption (skill ships evals) should fail"
+else
+  ok "stale evals exemption (skill ships evals) fails"
+fi
+rm -rf "$r"
+
 rm -f "$STUB"
 echo
 echo "PASS=$PASS FAIL=$FAIL"

--- a/scripts/evals-warrant-exemptions.txt
+++ b/scripts/evals-warrant-exemptions.txt
@@ -1,0 +1,23 @@
+# Recorded evals-warrant skip verdicts for scripts/check-changed-skills.sh
+# and plugins/skill-quality/scripts/check-skill.sh --require-evals.
+#
+# Policy: docs/MIGRATION-PLAYBOOK.md § "Evals — warrant policy and consumer-verify
+# recipe". A skip is a reviewed, diffable line, not an implicit absence. The
+# gate honors these rows; anything unlisted still FAILs when its SKILL.md is
+# new or modified.
+#
+# This is an AUDIT TRAIL, not a mute list. Each row records that one skill is
+# an explicit skip under the warrant rule (pure-reference, or a hook plugin
+# with no judgment-bearing skill). A setup skill is warrantable and must not
+# appear here.
+#
+# Format: `plugins/<plugin>/skills/<skill>`, optionally followed by `# reason`.
+# Blank lines and `#` lines are ignored.
+#
+# The gate FAILS on a stale row — a path that no longer exists, or a skill that
+# now ships evals/evals.json — so the list can only shrink. NEVER add a row
+# because CI is red on a skill that warrants evals. Write the evals.
+
+plugins/playbooks/skills/fable-5  # pure-reference: Fable 5 operating doctrine loaded as standing instructions; no decision contract to regress
+plugins/tdd/skills/principles  # pure-reference: answers test-design questions from a knowledge corpus; no decision contract
+plugins/evals/skills/methodology  # pure-reference: answers eval-design questions from Anthropic's guidance; no decision contract


### PR DESCRIPTION
Closes #3135

## Summary

The playbook said evals are warranted-not-mandatory with explicit skip classes. The changed-skill gate ignored those skips and hard-failed any touched `SKILL.md` without `evals/evals.json`.

## Fix

Exit A: `scripts/evals-warrant-exemptions.txt` records reviewed skip verdicts (same idiom as `skill-count-claim-exemptions.txt`). `check-changed-skills.sh` does not pass `--require-evals` for a listed skill. `check-skill.sh --require-evals` honors the same file. Rows are stale-guarded (path gone, or the skill now ships evals). Current pure-reference skips: `playbooks:fable-5`, `tdd:principles`, `evals:methodology`. Setup skills stay warrantable and are not listed. The playbook warrant-rule section now matches the gate.

## Verification

- `scripts/check-changed-skills.test.sh` — PASS=15 FAIL=0 (skip not forwarded; stale row fails)
- `plugins/skill-quality/scripts/check-skill.test.sh` — all assertions passed (recorded skip honored; unlisted sibling still fails)
- `scripts/check-changed-skills.sh origin/main` — exemptions file validates; no changed skills under `plugins/*/skills/`
- `scripts/check-changelog-parity.sh --check-bump origin/main` — pass

## Related

Refs #3127, #3115