### PR TITLE
fix(docs-hygiene): close audit-noise recall gap and stop judging only scanner-flagged files (0.21.9)

### DIFF
--- a/plugins/docs-hygiene/.claude-plugin/plugin.json
+++ b/plugins/docs-hygiene/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "docs-hygiene",
-  "version": "0.21.8",
+  "version": "0.21.9",
   "description": "Documentation-hygiene toolkit: compress (flavor-trim markdown with a semantic-diff safety net), audit-noise (classify markdown noise), extract-ssot (deduplicate repeated content into a single source of truth), audit-encapsulation (detect citations into skill-private surfaces), rename-references (sweep stale references after renames), audit-derivability (classify whether a whole document earns its existence — could a fresh agent re-derive it from the code?), audit-progressive-disclosure (grade instruction files against a load-tier model for split opportunities and hub/spoke disclosure defects), write-for-agents (authoring-time doctrine that fires while agent-consumed markdown is being written), and write-for-humans (the same moment for the other reader — end-user READMEs, RFCs, release notes and guides — resolving the consuming project's own style guide first).",
   "author": {
     "name": "Melodic Software",

--- a/plugins/docs-hygiene/CHANGELOG.md
+++ b/plugins/docs-hygiene/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog — docs-hygiene plugin
 
+## [0.21.9]
+
+### Fixed
+
+- **`audit-noise` recall gap and the large-corpus false-clean path (#3129).** The
+  scanner's matchers were literal tripwires (`## Why this file exists` only,
+  `was renamed to` but not `Renamed from`, bullet `/slug` plus a literal em dash,
+  no table form of `enum-list`) while the skill table described the shapes
+  semantically. A repo-wide audit then judged *only scanner-flagged files*, so a
+  corpus whose real drift used the paraphrases reported clean.
+
+  Detection now matches preamble at any ATX level (`Why this file exists`,
+  `Motivation`, `Rationale`), rename narration in both directions, `enum-list`
+  tables that name a slash-command, bolded roster lines, and "the following N
+  plugins". The large-corpus default judges scanner-flagged files *and* a
+  bounded sample of scanner-negative files, and must not report fully-clean from
+  the scanner set alone. `detect.sh` prints `status: no-targets` on stdout when
+  nothing was scanned (visible even under the skill's `2>/dev/null` house
+  pattern). Admission verdicts and Tier 3 "likely legitimate" rows are documented
+  as judgment-pass output, which the scanner never emitted.
+
+  False-negative fixtures: `evals/fixtures/recall-paraphrases.md`. Narrowing a
+  matcher back to its literal-only form fails those cases.
+
 ## [0.21.8]
 
 ### Changed

--- a/plugins/docs-hygiene/skills/audit-noise/SKILL.md
+++ b/plugins/docs-hygiene/skills/audit-noise/SKILL.md
@@ -87,8 +87,12 @@ Shared clean-tree / no-scope shape: [`../../context/clean-tree-fallback.md`](../
    tracked `.md` minus `**/evals/fixtures/**` and `CHANGELOG.md`; slice-scoped files (contract and
    memory tiers) sectioned separately in the report; scan via a chunked `detect.sh` pass
    (`detect.sh --paths-file <list> --offset N --limit M` — one process per chunk, no
-   per-file shell loop); on a
-   large corpus, judge only scanner-flagged files, fanning out a small number of concurrent
+   per-file shell loop); judge every scanner-flagged file AND a bounded sample of
+   scanner-negative files (enough that a fresh full-corpus judgment pass cannot find
+   real drift this report called clean). Never report a fully-clean result from
+   scanner-flagged files alone: the scanner is a structural matcher, not a complete
+   reading of the shape table, and judgment is required for paraphrases it still
+   misses. Fan out a small number of concurrent
    subagents with one fresh-context verification pass over the merged verdicts; report first —
    this skill stays read-only either way, and the author applies any treatment edits only after
    reviewing the report (report-vs-fix-as-you-go is the author's call; report-first is the
@@ -147,7 +151,21 @@ Shared clean-tree / no-scope shape: [`../../context/clean-tree-fallback.md`](../
 
 ## Output schema
 
-Per target file, the existence pre-check verdict precedes the in-page findings:
+Two writers, one report. `detect.sh` emits `File:` / `Finding *:` / `Summary *:`
+lines only. It does **not** emit admission verdicts, and it does **not** emit
+Tier 3 for any of the nine named shapes (each has a fixed default tier in
+`audit_noise_shape_tier`). A `T3=` count from the scanner is reserved for an
+unrecognized shape name, which should not occur. Admission and any Tier 3
+"likely legitimate" row are **judgment-pass** rulings the operator writes after
+reading the scanner facts. Do not treat scanner stdout as if it contained
+`admission PASS` / `admission FAIL`.
+
+A run that scanned nothing is distinct on stdout from a run that scanned files
+and found nothing: `detect.sh` prints `status: no-targets` in the first case
+(even when stderr is discarded, which the pre-computed context above does). A
+clean audit prints `Summary total: files=<N>` with `N>0` and zero findings.
+
+Per target file, the judgment-pass existence pre-check precedes the in-page findings:
 
 ```text
 <file>: admission PASS

--- a/plugins/docs-hygiene/skills/audit-noise/evals/evals.json
+++ b/plugins/docs-hygiene/skills/audit-noise/evals/evals.json
@@ -157,6 +157,21 @@
         "The reason given ties to the dropped-trigger-phrase auto-invocation regression",
         "No `description` or `when_to_use` is edited"
       ]
+    },
+    {
+      "id": 13,
+      "name": "recall-paraphrases-are-findings-not-clean",
+      "prompt": "Declutter this file: read evals/fixtures/recall-paraphrases.md relative to the skill directory and audit it for noise.",
+      "expected_output": "Flags the off-level '### Why this file exists' and the '## Motivation' heading as preamble, the 'Renamed from foo to bar' line as a citation, the 'following three plugins' sentence and the table rows naming `/net-audit` / `/net-lint` and the '- **Agent config** —' roster line as enum-list. Does not report the file clean. Does not skip judgment of this file on the grounds that a large-corpus shortcut judges only scanner-flagged files — that shortcut is gone.",
+      "files": ["evals/fixtures/recall-paraphrases.md"],
+      "expectations": [
+        "The `### Why this file exists` heading is flagged as preamble (any ATX level, not only `##`)",
+        "The `## Motivation` heading is flagged as preamble",
+        "The `Renamed from foo to bar` line is flagged as a citation",
+        "The table rows naming `/net-audit` and `/net-lint` are flagged as enum-list",
+        "The `- **Agent config** —` roster line is flagged as enum-list",
+        "The file is not reported clean"
+      ]
     }
   ]
 }

--- a/plugins/docs-hygiene/skills/audit-noise/evals/fixtures/recall-paraphrases.md
+++ b/plugins/docs-hygiene/skills/audit-noise/evals/fixtures/recall-paraphrases.md
@@ -1,0 +1,22 @@
+# Consumer registry
+
+## Registry
+
+### Why this file exists
+
+Orientation at a heading level the literal `##`-only matcher missed.
+
+## Motivation
+
+Same preamble shape, different title.
+
+Renamed from foo to bar during the 0.2 cutover.
+
+The following three plugins consume this rule.
+
+| Consumer | Role |
+|---|---|
+| `/net-audit` | scans the tree |
+| `/net-lint` | checks the tree |
+
+- **Agent config** — personal overlay the team file must not absorb

--- a/plugins/docs-hygiene/skills/audit-noise/scripts/detect.sh
+++ b/plugins/docs-hygiene/skills/audit-noise/scripts/detect.sh
@@ -164,6 +164,7 @@ done
 TARGETS=(${EXPANDED[@]+"${EXPANDED[@]}"})
 
 if [[ ${#TARGETS[@]} -eq 0 ]]; then
+  echo "status: no-targets"
   echo "Summary total: files=0 T1=0 T2=0 T3=0"
   echo "Note: no markdown targets — pass file paths or edit some .md files"
   exit 0
@@ -193,6 +194,7 @@ if [[ "$OFFSET" -gt 0 || "$LIMIT" -gt 0 ]]; then
 fi
 
 if [[ ${#SORTED[@]} -eq 0 ]]; then
+  echo "status: no-targets"
   echo "Summary total: files=0 T1=0 T2=0 T3=0"
   echo "Note: chunk offset/limit selected no targets"
   exit 0
@@ -449,5 +451,8 @@ for file in "${SORTED[@]}"; do
   audit_file "$file"
 done
 
+if [[ "$files_audited" -eq 0 ]]; then
+  echo "status: no-targets"
+fi
 printf 'Summary total: files=%s T1=%s T2=%s T3=%s\n' "$files_audited" "$total_t1" "$total_t2" "$total_t3"
 exit 0

--- a/plugins/docs-hygiene/skills/audit-noise/scripts/detect.test.sh
+++ b/plugins/docs-hygiene/skills/audit-noise/scripts/detect.test.sh
@@ -1433,6 +1433,64 @@ else
   skip_case "filesystem rejects a newline in a filename"
 fi
 
+# --- Recall paraphrases (false-negative regression, #3129) ---------------------------
+# These forms are in the shape table's semantic definition and were silent
+# under the old literal tripwires. Narrowing the matchers back to
+# `## Why this file exists` / `was renamed to` / `- /slug —` only must fail
+# this block.
+
+RECALL="$SCRIPT_DIR/../evals/fixtures/recall-paraphrases.md"
+recall_out="$(bash "$DETECT" "$RECALL" 2>/dev/null)"
+assert_contains "off-level why-this-file-exists is preamble" "$recall_out" "Finding shape: preamble"
+assert_contains "Motivation heading is preamble" "$recall_out" "Motivation"
+assert_contains "Renamed from is citation" "$recall_out" "Finding shape: citation"
+assert_contains "Renamed from excerpt" "$recall_out" "Renamed from foo to bar"
+assert_contains "table slash-command is enum-list" "$recall_out" "Finding shape: enum-list"
+assert_contains "table /net-audit excerpt" "$recall_out" "/net-audit"
+assert_contains "bold roster is enum-list" "$recall_out" "Agent config"
+assert_not_contains "recall fixture is not a no-targets run" "$recall_out" "status: no-targets"
+
+# Isolated lines so each assertion can fail independently of the others.
+PREAMBLE_H3="$TEST_TMPDIR/preamble-h3.md"
+printf '%s\n' '### Why this file exists' >"$PREAMBLE_H3"
+preamble_h3_out="$(bash "$DETECT" "$PREAMBLE_H3")"
+assert_contains "H3 why-this-file-exists flags" "$preamble_h3_out" "Finding shape: preamble"
+
+MOTIVATION="$TEST_TMPDIR/motivation.md"
+printf '%s\n' '## Motivation' >"$MOTIVATION"
+motivation_out="$(bash "$DETECT" "$MOTIVATION")"
+assert_contains "Motivation heading flags" "$motivation_out" "Finding shape: preamble"
+
+RENAMED="$TEST_TMPDIR/renamed.md"
+printf '%s\n' 'Renamed from foo to bar.' >"$RENAMED"
+renamed_out="$(bash "$DETECT" "$RENAMED")"
+assert_contains "Renamed from flags as citation" "$renamed_out" "Finding shape: citation"
+
+TABLE="$TEST_TMPDIR/table.md"
+printf '%s\n' '| Consumer | Role |' '|---|---|' '| `/net-audit` | scans |' >"$TABLE"
+table_out="$(bash "$DETECT" "$TABLE")"
+assert_contains "table consumer row flags as enum-list" "$table_out" "Finding shape: enum-list"
+assert_not_contains "table separator is not a finding excerpt" "$table_out" "Finding excerpt: |---|"
+
+PLUGINS_NOUN="$TEST_TMPDIR/plugins-noun.md"
+printf '%s\n' 'The following three plugins consume this rule.' >"$PLUGINS_NOUN"
+plugins_out="$(bash "$DETECT" "$PLUGINS_NOUN")"
+assert_contains "following N plugins is enum-list" "$plugins_out" "Finding shape: enum-list"
+
+BOLD_ROSTER="$TEST_TMPDIR/bold-roster.md"
+printf '%s\n' '- **Agent config** — personal overlay' >"$BOLD_ROSTER"
+bold_out="$(bash "$DETECT" "$BOLD_ROSTER")"
+assert_contains "bold roster flags as enum-list" "$bold_out" "Finding shape: enum-list"
+
+# Empty / missing target is stdout-visible even with stderr discarded.
+missing_out="$(bash "$DETECT" "$TEST_TMPDIR/does-not-exist.md" 2>/dev/null)"
+assert_contains "missing file prints status: no-targets on stdout" "$missing_out" "status: no-targets"
+EMPTY_DIR="$TEST_TMPDIR/empty-dir"
+mkdir -p "$EMPTY_DIR"
+empty_dir_out="$(bash "$DETECT" "$EMPTY_DIR" 2>/dev/null)"
+assert_contains "empty dir prints status: no-targets on stdout" "$empty_dir_out" "status: no-targets"
+assert_not_contains "clean scanned file is not no-targets" "$clean_out" "status: no-targets"
+
 # --- Final report --------------------------------------------------------------------
 
 if [[ "$FAILED" -eq 0 ]]; then

--- a/plugins/docs-hygiene/skills/audit-noise/scripts/detect.test.sh
+++ b/plugins/docs-hygiene/skills/audit-noise/scripts/detect.test.sh
@@ -1467,6 +1467,7 @@ renamed_out="$(bash "$DETECT" "$RENAMED")"
 assert_contains "Renamed from flags as citation" "$renamed_out" "Finding shape: citation"
 
 TABLE="$TEST_TMPDIR/table.md"
+# shellcheck disable=SC2016  # literal backticks belong in the fixture text
 printf '%s\n' '| Consumer | Role |' '|---|---|' '| `/net-audit` | scans |' >"$TABLE"
 table_out="$(bash "$DETECT" "$TABLE")"
 assert_contains "table consumer row flags as enum-list" "$table_out" "Finding shape: enum-list"

--- a/plugins/docs-hygiene/skills/audit-noise/scripts/lib/noise-shapes.sh
+++ b/plugins/docs-hygiene/skills/audit-noise/scripts/lib/noise-shapes.sh
@@ -252,10 +252,62 @@ audit_noise_line_has_ticket_pr_residue() {
   return 1
 }
 
+# Opening-section rationale at any ATX heading level. Detection used to
+# require a literal `## Why this file exists` while the section-exemption
+# path already generalized across ATX levels; these must stay aligned.
+# Semantic titles from the skill table: why-this-file-exists, Motivation,
+# Rationale (file-purpose openers, not every heading that mentions "why").
+audit_noise_line_has_preamble() {
+  local line="$1"
+  [[ "$line" =~ ^#{1,6}[[:space:]]+Why[[:space:]]+this[[:space:]]+file[[:space:]]+exists([^[:alnum:]]|$) ]] && return 0
+  [[ "$line" =~ ^#{1,6}[[:space:]]+Motivation([^[:alnum:]]|$) ]] && return 0
+  [[ "$line" =~ ^#{1,6}[[:space:]]+Rationale([^[:alnum:]]|$) ]] && return 0
+  return 1
+}
+
+# Historical citations. The skill table is semantic (dated incidents,
+# rename narration, provenance); these are the structural cues, including
+# paraphrases the original literal tripwires missed (`Renamed from`).
+audit_noise_line_has_citation() {
+  local line="$1"
+  [[ "$line" =~ [Ee]mpirically[[:space:]]+observed ]] && return 0
+  [[ "$line" =~ [Ww]e[[:space:]]+pivoted[[:space:]]+from ]] && return 0
+  [[ "$line" =~ [Ww]as[[:space:]]+renamed[[:space:]]+to ]] && return 0
+  [[ "$line" =~ [Rr]enamed[[:space:]]+from ]] && return 0
+  [[ "$line" =~ [Pp]re-convention ]] && return 0
+  [[ "$line" =~ [Ll]egacy[[:space:]]+layout ]] && return 0
+  return 1
+}
+
+# Hard-coupled consumer lists. The skill table leads with "Tables/lists";
+# a table row naming a slash-command is the same roster as a bullet, and
+# a bolded name with a role separator is the same roster as `/slug`.
+# $1 = inline-code-stripped line, $2 = backtick-unwrapped line.
+audit_noise_line_has_enum_list() {
+  local stripped="$1" unwrapped="$2"
+  [[ "$stripped" =~ [Ff]ollowing[[:space:]]+([0-9]+|two|three|four|five|six|seven|eight|nine|ten)[[:space:]]+(skills|consumers|agents|modules|plugins) ]] && return 0
+  # Slash-command roster. Any common bullet; em dash, en dash, or hyphen.
+  [[ "$unwrapped" =~ ^[[:space:]]*[-*+][[:space:]]+/[a-z][a-z0-9_-]*[[:space:]]+(—|–|--|-) ]] && return 0
+  # `- **Agent config** — role` (confirmed real-drift form).
+  [[ "$unwrapped" =~ ^[[:space:]]*[-*+][[:space:]]+\*\*[^*]+[[:space:]]*— ]] && return 0
+  [[ "$unwrapped" =~ ^[[:space:]]*[-*+][[:space:]]+\*\*[^*]+\*\*[[:space:]]+(—|–|--) ]] && return 0
+  # GFM table row (not a separator) that names a slash-command consumer.
+  if [[ "$unwrapped" =~ ^[[:space:]]*\| ]] &&
+    [[ ! "$unwrapped" =~ ^[[:space:]]*\|[[:space:]]*:?-{2,} ]] &&
+    [[ "$unwrapped" =~ /[a-z][a-z0-9_-]+ ]]; then
+    return 0
+  fi
+  return 1
+}
+
 # Append matching shape names into the nameref array (avoids a per-line
 # command-substitution subshell in the detect hot loop).
 # Ghost-ref scans an unwrap (ticks removed, content kept); other shapes scan a
 # strip (inline-code spans removed) so schema examples do not self-match.
+# Shape semantics: SKILL.md "Noise shapes and treatments". These helpers are
+# the structural reading of that table; evals/fixtures/recall-paraphrases.md
+# is the false-negative reconciliation (a matcher narrowed to the old
+# literal-only form fails those cases).
 audit_noise_detect_shapes_into() {
   local -n _audit_noise_shapes_out="$1"
   local line="$2"
@@ -266,22 +318,13 @@ audit_noise_detect_shapes_into() {
   if audit_noise_line_has_ghost_ref "$unwrapped"; then
     _audit_noise_shapes_out+=('ghost-ref')
   fi
-  if [[ "$stripped" =~ ^##[[:space:]]+Why[[:space:]]+this[[:space:]]+file[[:space:]]+exists ]]; then
+  if audit_noise_line_has_preamble "$stripped"; then
     _audit_noise_shapes_out+=('preamble')
   fi
-  if [[ "$stripped" =~ [Ee]mpirically[[:space:]]+observed ]] ||
-    [[ "$stripped" =~ [Ww]e[[:space:]]+pivoted[[:space:]]+from ]] ||
-    [[ "$stripped" =~ [Ww]as[[:space:]]+renamed[[:space:]]+to ]] ||
-    [[ "$stripped" =~ [Pp]re-convention ]] ||
-    [[ "$stripped" =~ [Ll]egacy[[:space:]]+layout ]]; then
+  if audit_noise_line_has_citation "$stripped"; then
     _audit_noise_shapes_out+=('citation')
   fi
-  if [[ "$stripped" =~ [Ff]ollowing[[:space:]]+(five|four|three|six|seven|eight|nine|ten|[0-9]+)[[:space:]]+(skills|consumers|agents|modules) ]]; then
-    _audit_noise_shapes_out+=('enum-list')
-  fi
-  # Enum roster lines often wrap the slash-command in backticks; match the
-  # unwrapped form so `- `/skill`` still counts after tick removal.
-  if [[ "$unwrapped" =~ ^[[:space:]]*-[[:space:]]+/[a-z][a-z0-9_-]*[[:space:]]— ]]; then
+  if audit_noise_line_has_enum_list "$stripped" "$unwrapped"; then
     _audit_noise_shapes_out+=('enum-list')
   fi
   if [[ "$stripped" =~ [Pp]ath-scoped[[:space:]]+to ]] ||


### PR DESCRIPTION
## Summary

`docs-hygiene:audit-noise` could report a repo-wide clean result because its matchers were literal tripwires and the large-corpus default judged only scanner-flagged files. Real drift that used a table, a paraphrase, or an off-level heading never reached judgment.

## Fix

- SKILL.md: the large-corpus path judges scanner-flagged files and a bounded sample of scanner-negative files. It must not report fully-clean from the scanner set alone. Admission and Tier 3 "likely legitimate" rows are documented as judgment-pass output, which `detect.sh` never emitted.
- noise-shapes.sh: preamble at any ATX level (`Why this file exists`, `Motivation`, `Rationale`); citation includes `Renamed from`; enum-list matches tables that name a slash-command, bold roster lines, and "the following N plugins".
- detect.sh prints `status: no-targets` on stdout when nothing was scanned.
- False-negative fixture `evals/fixtures/recall-paraphrases.md` plus detect.test.sh cases. Narrowing a matcher back to its literal-only form fails those cases.

docs-hygiene 0.21.9.

## Verification

- `detect.sh` on the recall fixture: 2 preamble, 1 citation, 5 enum-list (including both table rows and the bold roster).
- Missing / empty targets print `status: no-targets` on stdout with stderr discarded.
- `detect.test.sh`: 193/193.
- `check-changelog-parity.sh --check-bump origin/main`: pass.
- `check-changed-skills.sh origin/main`: audit-noise PASS.

## Related

Closes #3129
