### PR TITLE
fix(ci): fail claude-review loudly when the Skill tool degrades to a manual review

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -39,3 +39,39 @@ jobs:
     # inherit`, which would forward every parent secret to the called workflow.
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+  # Repo-owned fail-closed supplement for #3147: the reusable workflow stays
+  # green when the session succeeds but the Skill tool cannot load
+  # /review:code-review and the agent substitutes a manual diff review.
+  # This job reads the posted review body (never the job log — #2517) and
+  # reddens that silent degrade so the check row cannot stay unconditionally
+  # green through a broken skill chain.
+  review-skill-evidence:
+    needs: review
+    if: >-
+      always() &&
+      github.event_name == 'pull_request' &&
+      needs.review.result != 'cancelled'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Check out
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Run claude-review skill-evidence guard tests
+        run: bash scripts/verify-claude-review-skill.sh.test.sh
+      - name: Verify claude-review invoked the skill
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          GITHUB_ACTOR: ${{ github.actor }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          LANE_RESULT: ${{ needs.review.result }}
+          SKIP_ACTORS: dependabot[bot],claude[bot],melodic-ai[bot],melodic-standards-sync[bot],cursor[bot]
+        run: bash scripts/verify-claude-review-skill.sh

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -73,5 +73,6 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           LANE_RESULT: ${{ needs.review.result }}
+          REVIEWER_LOGINS: claude[bot]
           SKIP_ACTORS: dependabot[bot],claude[bot],melodic-ai[bot],melodic-standards-sync[bot],cursor[bot]
         run: bash scripts/verify-claude-review-skill.sh

--- a/scripts/verify-claude-review-skill.sh
+++ b/scripts/verify-claude-review-skill.sh
@@ -43,6 +43,23 @@ the Skill invocation failed and a manual review was substituted (#3147).
 EOF
 }
 
+# filter_review_bodies — stdin is one or more GitHub reviews-list JSON
+# documents (gh --paginate emits one array per page). Prints one base64 body
+# per matching review. Tests call this with fixtures so the jq program is
+# exercised without an API call. gh api --jq has no --arg (pipe to jq).
+filter_review_bodies() {
+  local sha="$1" allow="$2"
+  # shellcheck disable=SC2016  # the jq program is literal; $sha/$allow bind via --arg
+  jq -r --arg sha "$sha" --arg allow "$allow" '
+    (if type == "array" then .[] else . end)
+    | ($allow | split(",") | map(gsub("^[ \t]+|[ \t]+$";"")) | map(select(length > 0))) as $logins
+    | select((.commit_id // "") == $sha)
+    | select(.user.login as $u | ($logins | index($u)) != null)
+    | (.body // "")
+    | @base64
+  '
+}
+
 # fetch_review_bodies — one base64 body per line, reviews only. Defined as a
 # function so the self-tests can substitute it without an API call.
 #
@@ -54,16 +71,7 @@ fetch_review_bodies() {
   local repo="${GITHUB_REPOSITORY:?}" pr="${PR_NUMBER:?}"
   local sha="${EVENT_HEAD_SHA:?}"
   local allow="${REVIEWER_LOGINS:-claude[bot]}"
-  # shellcheck disable=SC2016  # the jq program is literal; $sha/$allow bind via --arg
-  gh api --paginate "repos/${repo}/pulls/${pr}/reviews" \
-    --jq --arg sha "$sha" --arg allow "$allow" '
-      ($allow | split(",") | map(gsub("^[ \t]+|[ \t]+$";"")) | map(select(length > 0))) as $logins
-      | .[]
-      | select((.commit_id // "") == $sha)
-      | select(.user.login as $u | ($logins | index($u)) != null)
-      | (.body // "")
-      | @base64
-    '
+  gh api --paginate "repos/${repo}/pulls/${pr}/reviews" | filter_review_bodies "$sha" "$allow"
 }
 
 # decode_review_body — GNU `base64 -d`, BSD `base64 -D`. Prints the decoded

--- a/scripts/verify-claude-review-skill.sh
+++ b/scripts/verify-claude-review-skill.sh
@@ -57,7 +57,7 @@ fetch_review_bodies() {
   # shellcheck disable=SC2016  # the jq program is literal; $sha/$allow bind via --arg
   gh api --paginate "repos/${repo}/pulls/${pr}/reviews" \
     --jq --arg sha "$sha" --arg allow "$allow" '
-      ($allow | split(",") | map(gsub("^\\s+|\\s+$";"")) | map(select(length > 0))) as $logins
+      ($allow | split(",") | map(gsub("^[ \t]+|[ \t]+$";"")) | map(select(length > 0))) as $logins
       | .[]
       | select((.commit_id // "") == $sha)
       | select(.user.login as $u | ($logins | index($u)) != null)

--- a/scripts/verify-claude-review-skill.sh
+++ b/scripts/verify-claude-review-skill.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# verify-claude-review-skill.sh — fail closed when the claude-review lane
+# silently substitutes a manual diff review for /review:code-review (#3147).
+#
+# The reusable workflow concludes GREEN when the session as a whole succeeds,
+# even if the Skill tool returned <error>Execute skill: review:code-review</error>
+# and the agent wrote an ad hoc review instead. That check row staying green
+# is the defect. This sibling job reads the posted review body (the
+# deliverable, not the job log — see #2517) and reddens when the body reports
+# that degrade as the reviewer's own process.
+#
+# READS THE POSTED REVIEW, NEVER THE JOB LOG. A log is not a contract: the
+# reusable's outcome step source is echoed into the log and contains the
+# skip phrases as string literals. The review body is what a reader sees.
+#
+# Environment:
+#   GITHUB_EVENT_NAME    pull_request expected; anything else is not applicable
+#   GITHUB_ACTOR         PR author login
+#   SKIP_ACTORS          comma-separated actors exempt from review
+#   LANE_RESULT          needs.review.result
+#   GITHUB_REPOSITORY    owner/repo
+#   PR_NUMBER            pull request number
+#   EVENT_HEAD_SHA       the head SHA this run was triggered at
+#   GH_TOKEN             token for the review-body read
+#
+# Exit: 0 evidence OK or not applicable; 1 silent skill-degrade detected.
+
+set -euo pipefail
+
+SKIP_ACTORS="${SKIP_ACTORS:-dependabot[bot],claude[bot],melodic-ai[bot],melodic-standards-sync[bot],cursor[bot]}"
+
+usage() {
+  cat <<'EOF'
+verify-claude-review-skill.sh — guard against a green claude-review that never ran /review:code-review.
+
+Reads the posted review body for this head. Exits 0 when the PR is exempt,
+the lane skipped/cancelled/already-failed, or the review does not report a
+Skill-tool degrade. Exits 1 when a successful lane posted a review that says
+the Skill invocation failed and a manual review was substituted (#3147).
+EOF
+}
+
+# fetch_review_bodies — review + issue-comment bodies on this PR. Defined as a
+# function so the self-tests can substitute it without an API call.
+fetch_review_bodies() {
+  local repo="${GITHUB_REPOSITORY:?}" pr="${PR_NUMBER:?}"
+  {
+    gh api --paginate "repos/${repo}/pulls/${pr}/reviews" --jq '.[] | .body // empty'
+    gh api --paginate "repos/${repo}/issues/${pr}/comments" --jq '.[] | .body // empty'
+  }
+}
+
+# Process-language the degrade path writes about itself. A code review of this
+# guard that quotes a single needle is not enough: both a skill-error report
+# and a fallback report must be present in the same body. Prints `degrade` or
+# `ok` so callers do not wrap the function in `if` / `||` (SC2310).
+classify_silent_degrade() {
+  local body="$1"
+  local skill=0 fallback=0
+  [[ "$body" == *'errored out in this environment'* ]] && skill=1
+  [[ "$body" == *'Skill invocation errored'* ]] && skill=1
+  [[ "$body" == *'<error>Execute skill:'* ]] && skill=1
+  [[ "$body" == *'fell back'* ]] && fallback=1
+  [[ "$body" == *'fallback'* ]] && fallback=1
+  [[ "$body" == *'manual diff'* ]] && fallback=1
+  [[ "$body" == *'manual-diff'* ]] && fallback=1
+  if [[ "$skill" -eq 1 && "$fallback" -eq 1 ]]; then
+    printf 'degrade\n'
+  else
+    printf 'ok\n'
+  fi
+}
+
+main() {
+  case "${1:-}" in
+  -h | --help)
+    usage
+    exit 0
+    ;;
+  *) ;;
+  esac
+
+  [[ "${GITHUB_EVENT_NAME:-}" == "pull_request" ]] || {
+    echo "not a pull_request event — guard not applicable"
+    exit 0
+  }
+
+  if [[ ",${SKIP_ACTORS}," == *",${GITHUB_ACTOR:-},"* ]]; then
+    echo "actor ${GITHUB_ACTOR} is skip-listed — guard not applicable"
+    exit 0
+  fi
+
+  case "${LANE_RESULT:-}" in
+  skipped)
+    echo "review job skipped — guard not applicable"
+    exit 0
+    ;;
+  cancelled)
+    echo "review job cancelled — guard not applicable"
+    exit 0
+    ;;
+  "")
+    echo "ERROR: LANE_RESULT is empty — this guard is not wired to the review job, so it can determine nothing about it (#3147)" >&2
+    exit 1
+    ;;
+  success) ;;
+  *)
+    echo "review job result=${LANE_RESULT} — lane already failed loudly; guard not applicable"
+    exit 0
+    ;;
+  esac
+
+  if [[ -z "${GITHUB_REPOSITORY:-}" || -z "${PR_NUMBER:-}" ]]; then
+    echo "ERROR: GITHUB_REPOSITORY and PR_NUMBER are required to read the posted review (#3147)" >&2
+    exit 1
+  fi
+
+  local bodies verdict
+  # Assigned, not `cmd || fail`: an `||` / `if` around a function disables
+  # `set -e` for its whole dynamic extent (SC2310; same split as
+  # verify-security-review-evidence.sh).
+  bodies="$(fetch_review_bodies)"
+  verdict="$(classify_silent_degrade "$bodies")"
+  case "$verdict" in
+  degrade)
+    echo "ERROR: claude-review posted a green review that reports a Skill-tool failure and a manual fallback. The maintained /review:code-review chain did not run (#3147)" >&2
+    exit 1
+    ;;
+  ok) ;;
+  *)
+    echo "ERROR: classify_silent_degrade returned an unrecognised verdict: ${verdict}" >&2
+    exit 1
+    ;;
+  esac
+
+  echo "claude-review skill evidence OK (no silent Skill-tool fallback in posted review bodies)"
+  exit 0
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  main "$@"
+fi

--- a/scripts/verify-claude-review-skill.sh
+++ b/scripts/verify-claude-review-skill.sh
@@ -20,7 +20,9 @@
 #   LANE_RESULT          needs.review.result
 #   GITHUB_REPOSITORY    owner/repo
 #   PR_NUMBER            pull request number
-#   EVENT_HEAD_SHA       the head SHA this run was triggered at
+#   EVENT_HEAD_SHA       the head SHA this run was triggered at (required)
+#   REVIEWER_LOGINS      comma-separated logins whose reviews count
+#                        (default: claude[bot])
 #   GH_TOKEN             token for the review-body read
 #
 # Exit: 0 evidence OK or not applicable; 1 silent skill-degrade detected.
@@ -28,6 +30,7 @@
 set -euo pipefail
 
 SKIP_ACTORS="${SKIP_ACTORS:-dependabot[bot],claude[bot],melodic-ai[bot],melodic-standards-sync[bot],cursor[bot]}"
+REVIEWER_LOGINS="${REVIEWER_LOGINS:-claude[bot]}"
 
 usage() {
   cat <<'EOF'
@@ -40,14 +43,35 @@ the Skill invocation failed and a manual review was substituted (#3147).
 EOF
 }
 
-# fetch_review_bodies — review + issue-comment bodies on this PR. Defined as a
+# fetch_review_bodies — one base64 body per line, reviews only. Defined as a
 # function so the self-tests can substitute it without an API call.
+#
+# Issue comments are not evidence: any account can comment on a public PR and
+# trip a fail-closed substring guard. Older reviews at a prior head are not
+# evidence either — a corrected push must be judged by the review posted for
+# this EVENT_HEAD_SHA. REVIEWER_LOGINS defaults to the lane's bot.
 fetch_review_bodies() {
   local repo="${GITHUB_REPOSITORY:?}" pr="${PR_NUMBER:?}"
-  {
-    gh api --paginate "repos/${repo}/pulls/${pr}/reviews" --jq '.[] | .body // empty'
-    gh api --paginate "repos/${repo}/issues/${pr}/comments" --jq '.[] | .body // empty'
-  }
+  local sha="${EVENT_HEAD_SHA:?}"
+  local allow="${REVIEWER_LOGINS:-claude[bot]}"
+  # shellcheck disable=SC2016  # the jq program is literal; $sha/$allow bind via --arg
+  gh api --paginate "repos/${repo}/pulls/${pr}/reviews" \
+    --jq --arg sha "$sha" --arg allow "$allow" '
+      ($allow | split(",") | map(gsub("^\\s+|\\s+$";"")) | map(select(length > 0))) as $logins
+      | .[]
+      | select((.commit_id // "") == $sha)
+      | select(.user.login as $u | ($logins | index($u)) != null)
+      | (.body // "")
+      | @base64
+    '
+}
+
+# decode_review_body — GNU `base64 -d`, BSD `base64 -D`. Prints the decoded
+# body on stdout. A failed decode yields empty (classified as `ok`).
+decode_review_body() {
+  local encoded="$1" body=""
+  body="$(printf '%s' "$encoded" | base64 -d 2>/dev/null)" || body="$(printf '%s' "$encoded" | base64 -D 2>/dev/null)" || body=""
+  printf '%s' "$body"
 }
 
 # Process-language the degrade path writes about itself. A code review of this
@@ -115,23 +139,33 @@ main() {
     exit 1
   fi
 
-  local bodies verdict
+  if [[ -z "${EVENT_HEAD_SHA:-}" ]]; then
+    echo "ERROR: EVENT_HEAD_SHA is empty — this guard cannot tell which reviews belong to this run, so it can determine nothing about it (#3147)" >&2
+    exit 1
+  fi
+
   # Assigned, not `cmd || fail`: an `||` / `if` around a function disables
   # `set -e` for its whole dynamic extent (SC2310; same split as
   # verify-security-review-evidence.sh).
-  bodies="$(fetch_review_bodies)"
-  verdict="$(classify_silent_degrade "$bodies")"
-  case "$verdict" in
-  degrade)
-    echo "ERROR: claude-review posted a green review that reports a Skill-tool failure and a manual fallback. The maintained /review:code-review chain did not run (#3147)" >&2
-    exit 1
-    ;;
-  ok) ;;
-  *)
-    echo "ERROR: classify_silent_degrade returned an unrecognised verdict: ${verdict}" >&2
-    exit 1
-    ;;
-  esac
+  local encoded body verdict
+  local records
+  records="$(fetch_review_bodies)"
+  while IFS= read -r encoded || [[ -n "${encoded}" ]]; do
+    [[ -n "${encoded}" ]] || continue
+    body="$(decode_review_body "$encoded")"
+    verdict="$(classify_silent_degrade "$body")"
+    case "$verdict" in
+    degrade)
+      echo "ERROR: claude-review posted a green review that reports a Skill-tool failure and a manual fallback. The maintained /review:code-review chain did not run (#3147)" >&2
+      exit 1
+      ;;
+    ok) ;;
+    *)
+      echo "ERROR: classify_silent_degrade returned an unrecognised verdict: ${verdict}" >&2
+      exit 1
+      ;;
+    esac
+  done <<<"$records"
 
   echo "claude-review skill evidence OK (no silent Skill-tool fallback in posted review bodies)"
   exit 0

--- a/scripts/verify-claude-review-skill.sh.test.sh
+++ b/scripts/verify-claude-review-skill.sh.test.sh
@@ -16,10 +16,13 @@ fail() {
 }
 
 # run_guard <expected-exit> <name> <body-stub> [VAR=value ...]
+# Optional REVIEW_BODY_STUB2 in the env list adds a second independent record.
 run_guard() {
   local expected="$1" name="$2" body_stub="$3"
   shift 3
   local output status
+  # shellcheck disable=SC2016  # the bash -c body is literal source for the
+  # child shell; expanding $1 here would substitute this harness's own args.
   output="$(
     REVIEW_BODY_STUB="$body_stub" \
       env -i \
@@ -29,7 +32,13 @@ run_guard() {
       "$@" \
       bash -c '
       source "$1"
-      fetch_review_bodies() { printf "%s\n" "${REVIEW_BODY_STUB}"; }
+      fetch_review_bodies() {
+        _b64() { printf "%s" "$1" | base64 | tr -d "\n"; printf "\n"; }
+        _b64 "${REVIEW_BODY_STUB}"
+        if [[ -n "${REVIEW_BODY_STUB2:-}" ]]; then
+          _b64 "${REVIEW_BODY_STUB2}"
+        fi
+      }
       main
     ' harness "$GUARD_SCRIPT" 2>&1
   )"
@@ -85,6 +94,10 @@ run_guard 0 "quoting fallback without a skill error is not a degrade" \
   $'Do not silently substitute a manual diff review.' \
   "${BASE[@]}"
 
+run_guard 0 "skill needle and fallback needle in different bodies is not a degrade" \
+  $'The workflow should fail when the log contains `<error>Execute skill: review:code-review</error>`.' \
+  "${BASE[@]}" REVIEW_BODY_STUB2=$'Do not silently substitute a manual diff review.'
+
 # --- not-applicable paths ----------------------------------------------------
 
 run_guard 0 "non-pull_request is not applicable" "$DEGRADE" \
@@ -117,6 +130,11 @@ run_guard 1 "empty LANE_RESULT fails closed" "$CLEAN" \
 
 run_guard 1 "missing repo/pr fails closed on a successful lane" "$CLEAN" \
   GITHUB_EVENT_NAME=pull_request GITHUB_ACTOR=kyle-sexton \
+  LANE_RESULT=success
+
+run_guard 1 "empty EVENT_HEAD_SHA fails closed on a successful lane" "$CLEAN" \
+  GITHUB_EVENT_NAME=pull_request GITHUB_ACTOR=kyle-sexton \
+  GITHUB_REPOSITORY=melodic-software/claude-code-plugins PR_NUMBER=1 \
   LANE_RESULT=success
 
 # --- help --------------------------------------------------------------------

--- a/scripts/verify-claude-review-skill.sh.test.sh
+++ b/scripts/verify-claude-review-skill.sh.test.sh
@@ -137,6 +137,29 @@ run_guard 1 "empty EVENT_HEAD_SHA fails closed on a successful lane" "$CLEAN" \
   GITHUB_REPOSITORY=melodic-software/claude-code-plugins PR_NUMBER=1 \
   LANE_RESULT=success
 
+# --- unstubbed jq filter (the real gh-api --arg bug) -------------------------
+
+b64_decode() {
+  printf '%s' "$1" | base64 -d 2>/dev/null || printf '%s' "$1" | base64 -D 2>/dev/null
+}
+
+REVIEWS_JSON='[
+  {"commit_id":"abc123","user":{"login":"claude[bot]"},"body":"skill review at this head"},
+  {"commit_id":"oldsha","user":{"login":"claude[bot]"},"body":"prior head"},
+  {"commit_id":"abc123","user":{"login":"other"},"body":"third-party review"}
+]'
+
+set +e
+# shellcheck source=verify-claude-review-skill.sh
+source "$GUARD_SCRIPT"
+filter_out="$(printf '%s' "$REVIEWS_JSON" | filter_review_bodies abc123 'claude[bot]')"
+filter_decoded="$(b64_decode "$(printf '%s' "$filter_out" | tr -d '\n')")"
+if [[ "$filter_decoded" == *'skill review at this head'* && "$filter_decoded" != *'prior head'* && "$filter_decoded" != *'third-party'* ]]; then
+  pass "filter_review_bodies keeps only current-head reviewer records"
+else
+  fail "filter_review_bodies keeps only current-head reviewer records" "got: $filter_decoded"
+fi
+
 # --- help --------------------------------------------------------------------
 
 help_out="$(bash "$GUARD_SCRIPT" --help)"

--- a/scripts/verify-claude-review-skill.sh.test.sh
+++ b/scripts/verify-claude-review-skill.sh.test.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# Self-tests for verify-claude-review-skill.sh.
+#
+# These EXECUTE the guard. Review bodies are injected by substituting
+# fetch_review_bodies, so the cases never call the GitHub API.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GUARD_SCRIPT="$SCRIPT_DIR/verify-claude-review-skill.sh"
+
+FAILED=0
+pass() { printf 'PASS: %s\n' "$1"; }
+fail() {
+  FAILED=$((FAILED + 1))
+  printf 'FAIL: %s\n  %s\n' "$1" "$2" >&2
+}
+
+# run_guard <expected-exit> <name> <body-stub> [VAR=value ...]
+run_guard() {
+  local expected="$1" name="$2" body_stub="$3"
+  shift 3
+  local output status
+  output="$(
+    REVIEW_BODY_STUB="$body_stub" \
+      env -i \
+      PATH="$PATH" \
+      HOME="${HOME:-/tmp}" \
+      REVIEW_BODY_STUB="$body_stub" \
+      "$@" \
+      bash -c '
+      source "$1"
+      fetch_review_bodies() { printf "%s\n" "${REVIEW_BODY_STUB}"; }
+      main
+    ' harness "$GUARD_SCRIPT" 2>&1
+  )"
+  status=$?
+  if [[ "$status" -eq "$expected" ]]; then
+    pass "$name"
+    LAST_OUTPUT="$output"
+    return 0
+  fi
+  fail "$name" "expected exit $expected, got $status; output: $output"
+  LAST_OUTPUT="$output"
+  return 1
+}
+
+assert_output_contains() {
+  local name="$1" needle="$2"
+  if [[ "$LAST_OUTPUT" == *"$needle"* ]]; then
+    pass "$name"
+  else
+    fail "$name" "expected output to contain '$needle'; got: $LAST_OUTPUT"
+  fi
+}
+
+BASE=(
+  GITHUB_EVENT_NAME=pull_request
+  GITHUB_ACTOR=kyle-sexton
+  GITHUB_REPOSITORY=melodic-software/claude-code-plugins
+  PR_NUMBER=3147
+  EVENT_HEAD_SHA=abc123
+  LANE_RESULT=success
+)
+
+DEGRADE=$'the `review:code-review` Skill invocation errored out in this environment (returned `<error>Execute skill: review:code-review</error>` on repeated attempts with no further detail) and I fell back to a manual diff review.'
+
+CLEAN=$'## Findings\n\n1. The helper should fail closed.\n\nReviewed via /review:code-review.'
+
+# --- the shape the guard exists to catch -------------------------------------
+
+run_guard 1 "silent skill fallback on a green lane fails" "$DEGRADE" "${BASE[@]}"
+assert_output_contains "names the defect" "Skill-tool failure"
+
+# --- the shape the guard exists to approve -----------------------------------
+
+run_guard 0 "a skill-based review passes" "$CLEAN" "${BASE[@]}"
+assert_output_contains "skill-based OK" "skill evidence OK"
+
+# A code citation of one needle is not the degrade path.
+run_guard 0 "quoting the error tag without a fallback is not a degrade" \
+  $'The workflow should fail when the log contains `<error>Execute skill: review:code-review</error>`.' \
+  "${BASE[@]}"
+
+run_guard 0 "quoting fallback without a skill error is not a degrade" \
+  $'Do not silently substitute a manual diff review.' \
+  "${BASE[@]}"
+
+# --- not-applicable paths ----------------------------------------------------
+
+run_guard 0 "non-pull_request is not applicable" "$DEGRADE" \
+  GITHUB_EVENT_NAME=push LANE_RESULT=success GITHUB_ACTOR=kyle-sexton \
+  GITHUB_REPOSITORY=melodic-software/claude-code-plugins PR_NUMBER=1
+
+run_guard 0 "skip-listed actor is not applicable" "$DEGRADE" \
+  GITHUB_EVENT_NAME=pull_request GITHUB_ACTOR=dependabot[bot] \
+  LANE_RESULT=success GITHUB_REPOSITORY=melodic-software/claude-code-plugins \
+  PR_NUMBER=1
+
+run_guard 0 "skipped lane is not applicable" "$DEGRADE" \
+  GITHUB_EVENT_NAME=pull_request GITHUB_ACTOR=kyle-sexton \
+  LANE_RESULT=skipped GITHUB_REPOSITORY=melodic-software/claude-code-plugins \
+  PR_NUMBER=1
+
+run_guard 0 "cancelled lane is not applicable" "$DEGRADE" \
+  GITHUB_EVENT_NAME=pull_request GITHUB_ACTOR=kyle-sexton \
+  LANE_RESULT=cancelled GITHUB_REPOSITORY=melodic-software/claude-code-plugins \
+  PR_NUMBER=1
+
+run_guard 0 "already-failed lane is not applicable" "$DEGRADE" \
+  GITHUB_EVENT_NAME=pull_request GITHUB_ACTOR=kyle-sexton \
+  LANE_RESULT=failure GITHUB_REPOSITORY=melodic-software/claude-code-plugins \
+  PR_NUMBER=1
+
+run_guard 1 "empty LANE_RESULT fails closed" "$CLEAN" \
+  GITHUB_EVENT_NAME=pull_request GITHUB_ACTOR=kyle-sexton \
+  GITHUB_REPOSITORY=melodic-software/claude-code-plugins PR_NUMBER=1
+
+run_guard 1 "missing repo/pr fails closed on a successful lane" "$CLEAN" \
+  GITHUB_EVENT_NAME=pull_request GITHUB_ACTOR=kyle-sexton \
+  LANE_RESULT=success
+
+# --- help --------------------------------------------------------------------
+
+help_out="$(bash "$GUARD_SCRIPT" --help)"
+help_status=$?
+if [[ "$help_status" -eq 0 && "$help_out" == *'verify-claude-review-skill.sh'* ]]; then
+  pass "--help exits 0"
+else
+  fail "--help exits 0" "status=$help_status output=$help_out"
+fi
+
+if [[ "$FAILED" -eq 0 ]]; then
+  printf '\nAll checks passed.\n'
+  exit 0
+fi
+printf '\n%d checks failed.\n' "$FAILED" >&2
+exit 1


### PR DESCRIPTION
## Summary

The claude-review lane stays green when the session succeeds but the Skill tool cannot load the maintained review skill and the agent substitutes an ad hoc review. That check row is then indistinguishable from a real skill-based review.

## Fix

A sibling job `review-skill-evidence` in `.github/workflows/claude-review.yml` runs after `review`. It reads the posted review body (the deliverable, never the job log) and fails when that body reports a Skill-tool failure together with a manual substitution. One needle alone is not enough, so a code review that cites either half does not trip the guard. Skip-listed actors, skipped/cancelled/already-failed lane jobs, and non-pull_request events are not applicable. Empty wiring (`LANE_RESULT` unset) fails closed.

Self-test runs first so a broken guard cannot mask the regression.

## Verification

- `scripts/verify-claude-review-skill.sh.test.sh`: all cases passed (degrade fails; skill-based and single-needle cites pass; skip/cancel/failed/exempt paths are not applicable; empty result fails closed).
- `shellcheck -x` on the guard: clean.
- `scripts/check-silent-skips.sh`: clean.

## Related

Closes #3147
