### PR TITLE
docs(specs): register D1–D3 against what actually shipped

### DIFF
--- a/docs/specs/agent-doc-register-detectors.md
+++ b/docs/specs/agent-doc-register-detectors.md
@@ -1,0 +1,48 @@
+# Agent-doc register detectors (D1–D3)
+
+Close-out register for [#3118](https://github.com/melodic-software/claude-code-plugins/issues/3118).
+The brief lived in that issue body; this file is the durable map of where each
+cut class landed, so a later reader does not have to reconstruct the work-map
+from closed children.
+
+**No new skill.** Each class sits on the audit that already owned its
+territory. Word count is a reported side effect, never an objective and never
+a threshold.
+
+## Register
+
+| ID | Class | Home | What shipped | Issue |
+|---|---|---|---|---|
+| D1 | Content the model already knows — an instruction carrying no proper noun, path, threshold, version, or repo-specific fact | `claude-config:audit-instructions` → `/claude-config:unhobble` | **Routing finding, not a scanner.** The #3121 measurement (`d1-model-already-knows-measurement.md`) flagged 45.1% of instruction sentences at a 94.1% false-positive rate, with zero unambiguous true positives in the 185-row sample. The predicate is model-relative and cannot be read off the text. #3124 closed unbuilt. `audit-instructions` already states the boundary: it judges instruction *text* against doctrine; `unhobble` measures the *model*. D1 is a restatement of that Recommended-follow-through, never a `type: review-findings` row. | #3121, #3124, #3188 |
+| D2 | Coercive emphasis — `CRITICAL:`, `You MUST`, all-caps imperatives, blanket "if in doubt, use X" | `claude-config:audit-instructions` | Scanner families `I28-a` / `I28-b`, body-scoped, wired to the findings relay as `rule-coercive-emphasis` and `rule-blanket-tool-default` (both IMPORTANT). | #3120 |
+| D3 | Negation with no positive alternative in the same sentence | `docs-hygiene:audit-noise` | Shape `negation`, Tier 2, wired to the findings relay as `rule-negation-without-positive` (IMPORTANT). Hard-guardrail / paired-positive / worked-example carve-outs are evidence-gated. | #3123 |
+
+## Hard constraint (all three)
+
+No finding whose remediation edits a `description`, `when_to_use`, or quoted
+`'trigger phrase'`. `plugins/skill-quality/scripts/check-skill.sh` check 3
+hard-FAILs a dropped trigger phrase versus the base ref. Detectors are
+body-scoped. A description-level concern is reported to the human, never
+routed to the apply relay.
+
+## Producer contract
+
+D2 and D3 emit `type: review-findings` files that `review:fanout fix` locates
+and applies behind the human gate, per
+[`docs/conventions/detector-findings/README.md`](../conventions/detector-findings/README.md).
+D1 never emits that file.
+
+## Out of scope here
+
+- Ceremonial-section removal by heading name — rejected in #3118; the
+  restatement *shape* (body prose that restates the always-in-context
+  `description`, or a sibling section) is D4, filed as #3186 and housed on
+  `claude-config:audit-instructions` as a D1 sibling.
+- Length or token-count targets of any kind.
+- Human-facing prose (`docs-hygiene:write-for-humans`).
+- A new apply-side skill. The apply relay exists.
+
+## Specs this register points at
+
+- [`d1-model-already-knows-measurement.md`](d1-model-already-knows-measurement.md) — D1 verdict, method, and the 94.1% bar.
+- [`agent-doc-surfaces.md`](agent-doc-surfaces.md) — the surface enumeration the D1 corpus was drawn from.

--- a/docs/specs/d1-model-already-knows-measurement.md
+++ b/docs/specs/d1-model-already-knows-measurement.md
@@ -4,7 +4,9 @@ Measurement record for [#3121](https://github.com/melodic-software/claude-code-p
 the investigation deciding whether cut class D1 — *content the model already knows* — is a scanner
 shape, a judgment shape, or a routing finding. D1 is one of three detectors specced by
 [#3118](https://github.com/melodic-software/claude-code-plugins/issues/3118); the detector it
-governs is [#3124](https://github.com/melodic-software/claude-code-plugins/issues/3124).
+governs is [#3124](https://github.com/melodic-software/claude-code-plugins/issues/3124). The
+close-out register that maps D1–D3 to what actually shipped is
+[`agent-doc-register-detectors.md`](agent-doc-register-detectors.md).
 
 This document exists because #3124's acceptance criteria bind an implementation to a number
 measured here (*"Measured false-positive rate on the #3121 sample is at or below what that


### PR DESCRIPTION
Closes #3118

## Summary

Closes the #3118 work-map by recording what each child actually shipped. The brief lived in the issue body; the spec is the durable map so a later reader does not have to reconstruct it from closed children.

## Fix

Adds `docs/specs/agent-doc-register-detectors.md` and points the D1 measurement spec at it:

- D1 (#3124): closed unbuilt; measurement lives in `unhobble` (#3188)
- D2 (#3120): `audit-instructions` I28 coercive-emphasis / blanket-tool-default
- D3 (#3123): `docs-hygiene:audit-noise` negation-without-positive
- D4 (#3186): sibling restatement — separate PR

Docs-only; no plugin version bump, so it cannot collide with #3186's `claude-config` detector work.

## Verification

- Spec exists and matches shipped rule ids
- D1 measurement spec now points at this register
- `check-lane-coverage.sh --check` — clean on this branch
- markdownlint on the two changed specs — 0 issues

## Related

- Refs #3120, #3121, #3123, #3124, #3186, #3188