### PR TITLE
feat(context-budget): retarget drifted lever citations and add verify-catalogue (0.6.7)

### DIFF
--- a/plugins/context-budget/.claude-plugin/plugin.json
+++ b/plugins/context-budget/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "context-budget",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "description": "Measure a Claude Code session's fixed startup context payload per item, on the consumer's machine at a pinned, version-stamped binary — including per-tool attribution of the built-in tool pools that /context reports only as lump sums, derived live by A/B bare-name-deny differencing with enforced comparability rules (skill-listing signature, one mode, one binary), an SDK-primary exact meter degrading to a version-aware headless /context parser and then to an honest structured error (never a wrong number), and a per-project measure-toggle-remeasure ledger under the plugin data directory recording every lever's real before/after delta. Report-only: prints exact config, applies nothing.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/context-budget/CHANGELOG.md
+++ b/plugins/context-budget/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to the `context-budget` plugin.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.7]
+
+### Changed
+
+- **Catalogue:** settings-key citations that had drifted onto the settings overview page
+  (`docs/en/settings`) now point at the per-key anchors on
+  [`settings-reference`](https://code.claude.com/docs/en/settings-reference)
+  (`disableWorkflows`, `disableArtifact`/`enableArtifact`, `includeGitInstructions`,
+  `skillOverrides`, `disableBundledSkills`, `skillListingBudgetFraction` /
+  `skillListingMaxDescChars`, `disabledMcpjsonServers`). `disableArtifact`'s emitted config is
+  the user-scope form (`enableArtifact: false`); a project-scope write is the wrong lock
+  ([#3198](https://github.com/melodic-software/claude-code-plugins/issues/3198)).
+  `verifiedAgainst` is now CLI 2.1.241 (2026-08-23).
+
+### Added
+
+- **Engine:** `verify-catalogue` greps the stamped binary for each catalogue row's settings
+  keys and env names and reports present/absent with hit counts. Run automatically on a
+  version-jump recheck; the binary is the authority on existence at the measured version, the
+  docs fetch on semantics
+  ([#3198](https://github.com/melodic-software/claude-code-plugins/issues/3198)).
+
 ## [0.6.6]
 
 ### Fixed

--- a/plugins/context-budget/CHANGELOG.md
+++ b/plugins/context-budget/CHANGELOG.md
@@ -25,7 +25,9 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   keys and env names and reports present/absent with hit counts. Run automatically on a
   version-jump recheck; the binary is the authority on existence at the measured version, the
   docs fetch on semantics
-  ([#3198](https://github.com/melodic-software/claude-code-plugins/issues/3198)).
+  ([#3198](https://github.com/melodic-software/claude-code-plugins/issues/3198)). CamelCase
+  extraction is a linear scan (no nested-quantifier ReDoS), reads every prose field (not just
+  `title`), and prefers a sibling `.exe` over a Windows `.cmd`/`.bat` shim.
 
 ## [0.6.6]
 

--- a/plugins/context-budget/skills/audit/SKILL.md
+++ b/plugins/context-budget/skills/audit/SKILL.md
@@ -127,7 +127,17 @@ catalogue's own meta:
 - **Honor recheck triggers.** A row whose trigger has plausibly fired (version jump past the
   catalogue's `verifiedAgainst`, upstream page moved) is re-verified against a fresh fetch of its
   citations before being offered — and a measured result always outranks the catalogue's stored
-  expectation.
+  expectation. On a version jump, also run the binary-strings existence check against the
+  stamped binary (docs pages move; the binary is what the consumer actually runs):
+
+  ```shell
+  node "${CLAUDE_PLUGIN_ROOT}/skills/audit/scripts/measure.mjs" verify-catalogue \
+    --binary <stamped-binary> --out <data-dir>/catalogue-verify.json
+  ```
+
+  The binary is the authority on *existence* of each key/env name at the measured version; the
+  docs fetch remains the authority on *semantics*. Report every `absent` token by name — silence
+  reads as "present".
 - **Keep the two ledgers apart** (the catalogue's `dualLedger` note): context-window occupancy
   versus per-request weight. Deferral moves weight between them; only removal clears both.
 

--- a/plugins/context-budget/skills/audit/reference/engine.md
+++ b/plugins/context-budget/skills/audit/reference/engine.md
@@ -78,6 +78,12 @@ All records are JSON on stdout (and `--out <file>`), schema-tagged:
 - `context-budget.ledger/1` — one before/after: `lever`, `emittedConfig`, `before`/`after`
   summaries, `delta` per category, `totalDelta`, `comparability`. A category present in only one
   run gets `null`, never an invented number.
+- `context-budget.catalogue-verify/1` — `verify-catalogue`: a docs-independent existence
+  check. Reads the stamped binary and reports `present`/`absent` (with hit counts) for every
+  settings key and env name the catalogue row names. The binary is the authority on *existence
+  at the measured version*; a fresh docs fetch remains the authority on *semantics*. Rows with
+  no extractable key/env name are `skipped`. Absence is a finding in the record (`absent[]`,
+  `missing`), not an invented number and not a degradation.
 - `context-budget.error/1` — the degradation record: `error`, `detail`, `remediation`. Exit 3.
 
 ## Ledger layout

--- a/plugins/context-budget/skills/audit/reference/levers.json
+++ b/plugins/context-budget/skills/audit/reference/levers.json
@@ -5,7 +5,7 @@
     "honestyRule": "A lever whose category cannot be determined for the consumer's configuration is not offered. Rows whose category is condition-dependent say so in `conditions`; the audit resolves the condition by measurement before presenting the lever.",
     "dualLedger": "Two ledgers, never conflated: the CONTEXT-WINDOW ledger (what occupies reasoning space — the /context headline) and the REQUEST ledger (what ships and is billed every turn). Deferral moves weight between them; removal clears both. Each row's category refers to the request ledger unless `conditions` says otherwise.",
     "staleness": "Every row carries `verified` (the date its claims were checked against the cited sources at the named CLI version) and `recheckTrigger`. A row whose trigger fired is re-derived from a fresh fetch of its citations before being offered — never trusted from this file alone.",
-    "verifiedAgainst": { "cliVersion": "2.1.232", "date": "2026-08-17" },
+    "verifiedAgainst": { "cliVersion": "2.1.241", "date": "2026-08-23" },
     "categories": {
       "removes-weight": "Genuinely removes tokens from the request payload (and the context window where applicable).",
       "works-but-saves-nothing-here": "The mechanism functions as documented, but under the consumer's current configuration the measured saving is zero (for example, budget-capped surfaces that redistribute freed space).",
@@ -85,10 +85,10 @@
       ],
       "citations": [
         "https://code.claude.com/docs/en/workflows",
-        "https://code.claude.com/docs/en/settings",
+        "https://code.claude.com/docs/en/settings-reference#disableworkflows",
         "https://code.claude.com/docs/en/env-vars"
       ],
-      "verified": "2026-08-17",
+      "verified": "2026-08-23",
       "recheckTrigger": "The workflows page changes its disable mechanisms, or denying/disabling Workflow stops moving the prefix bucket."
     },
     {
@@ -99,19 +99,21 @@
       "categoryBasis": "Settings and env rows documented; tool-plus-skills removal versus deny-leaves-skills measured at the verified version.",
       "conditions": null,
       "posture": "recommendable-on-fit",
-      "scope": "disableArtifact at any scope including managed (takes precedence); enableArtifact is written by the Artifacts row in /config and is IGNORED in project and local settings; env var equivalent to disableArtifact.",
+      "scope": "User or managed. Do not emit either key into project `.claude/settings.json`: enableArtifact is ignored there, and a project disableArtifact is overridden by any higher-precedence file rather than acting as a lock. enableArtifact: false is the user-scope form (the /config Artifacts row); disableArtifact is the org-wide lock (managed). Env var CLAUDE_CODE_DISABLE_ARTIFACT is equivalent for one session.",
       "detection": "disableArtifact/enableArtifact across scopes; CLAUDE_CODE_DISABLE_ARTIFACT in the environment; Artifact in the baseline tool list; artifact-* rows in the skill listing.",
-      "measurement": "attribute --tools Artifact prices the schema; snapshot before/after disableArtifact additionally shows the skill-listing rows leaving (subject to the listing cap — see cap dynamics).",
-      "emittedConfig": "{\"disableArtifact\": true}",
+      "measurement": "attribute --tools Artifact prices the schema; snapshot before/after the user-scope write additionally shows the skill-listing rows leaving (subject to the listing cap — see cap dynamics).",
+      "emittedConfig": "{\"enableArtifact\": false}",
       "caveats": [
         "Prefer this over a bare-name deny for never-publishes-artifacts operators: the deny is the weaker trim, leaving the companion skill descriptions listed.",
-        "enableArtifact requires v2.1.196+ and is scope-restricted; do not emit it into project or local settings."
+        "Emit at user scope (`~/.claude/settings.json`). A project write is the wrong scope: enableArtifact is ignored there and a project disableArtifact is not a lock.",
+        "enableArtifact requires v2.1.196+; managed disableArtifact takes precedence over a user's enableArtifact."
       ],
       "citations": [
-        "https://code.claude.com/docs/en/settings",
+        "https://code.claude.com/docs/en/settings-reference#disableartifact",
+        "https://code.claude.com/docs/en/settings-reference#enableartifact",
         "https://code.claude.com/docs/en/env-vars"
       ],
-      "verified": "2026-08-17",
+      "verified": "2026-08-23",
       "recheckTrigger": "The settings reference changes either artifact key's semantics or scope restrictions."
     },
     {
@@ -130,9 +132,9 @@
         "Trades away built-in commit/PR guidance; a repo relying on it should keep it or replace it with its own conventions."
       ],
       "citations": [
-        "https://code.claude.com/docs/en/settings"
+        "https://code.claude.com/docs/en/settings-reference#includegitinstructions"
       ],
-      "verified": "2026-08-17",
+      "verified": "2026-08-23",
       "recheckTrigger": "The settings row's wording changes, or the measured delta stops landing in System tools."
     },
     {
@@ -195,10 +197,10 @@
         "/doctor is exempt from bundled-skill kill switches and needs its own skillOverrides entry or DISABLE_DOCTOR_COMMAND to hide."
       ],
       "citations": [
-        "https://code.claude.com/docs/en/settings",
+        "https://code.claude.com/docs/en/settings-reference#skilloverrides",
         "https://code.claude.com/docs/en/skills"
       ],
-      "verified": "2026-08-17",
+      "verified": "2026-08-23",
       "recheckTrigger": "The skills page's visibility-override section changes reach (plugin skills included, say), or the listing budget mechanism changes."
     },
     {
@@ -218,9 +220,9 @@
       ],
       "citations": [
         "https://code.claude.com/docs/en/skills",
-        "https://code.claude.com/docs/en/settings"
+        "https://code.claude.com/docs/en/settings-reference#disablebundledskills"
       ],
-      "verified": "2026-08-17",
+      "verified": "2026-08-23",
       "recheckTrigger": "The skills or settings pages change the key, its survivors, or the listing budget mechanism."
     },
     {
@@ -239,10 +241,11 @@
         "This is the knob that explains why per-skill disabling saves nothing while over budget — surface it as explanation before offering it as a lever."
       ],
       "citations": [
-        "https://code.claude.com/docs/en/settings",
+        "https://code.claude.com/docs/en/settings-reference#skilllistingbudgetfraction",
+        "https://code.claude.com/docs/en/settings-reference#skilllistingmaxdescchars",
         "https://code.claude.com/docs/en/skills"
       ],
-      "verified": "2026-08-17",
+      "verified": "2026-08-23",
       "recheckTrigger": "Either settings row changes name, default, or semantics."
     },
     {
@@ -327,10 +330,10 @@
         "Author-side MCP tool-definition weight (verbose descriptions) is the mcp-tools plugin's territory when installed; this lever only includes or excludes whole servers."
       ],
       "citations": [
-        "https://code.claude.com/docs/en/settings",
+        "https://code.claude.com/docs/en/settings-reference#disabledmcpjsonservers",
         "https://code.claude.com/docs/en/mcp"
       ],
-      "verified": "2026-08-17",
+      "verified": "2026-08-23",
       "recheckTrigger": "The settings reference changes the .mcp.json approval key family."
     },
     {

--- a/plugins/context-budget/skills/audit/scripts/levers.test.sh
+++ b/plugins/context-budget/skills/audit/scripts/levers.test.sh
@@ -76,6 +76,50 @@ else
   while IFS= read -r line; do fail "$line"; done <<<"$out"
 fi
 
+# Keys that left the settings overview page for settings-reference (#3198).
+citeout="$(node -e '
+const cat = JSON.parse(require("fs").readFileSync(process.argv[1], "utf8"));
+const problems = [];
+const moved = {
+  "disable-workflows": "settings-reference#disableworkflows",
+  "disable-artifact": "settings-reference#disableartifact",
+  "include-git-instructions": "settings-reference#includegitinstructions",
+  "skill-overrides": "settings-reference#skilloverrides",
+  "disable-bundled-skills": "settings-reference#disablebundledskills",
+  "skill-listing-budget": "settings-reference#skilllistingbudgetfraction",
+  "mcp-project-servers": "settings-reference#disabledmcpjsonservers",
+};
+for (const [id, needle] of Object.entries(moved)) {
+  const lever = (cat.levers ?? []).find((l) => l.id === id);
+  if (!lever) { problems.push("missing lever " + id); continue; }
+  if (!(lever.citations ?? []).some((c) => c.includes(needle))) {
+    problems.push(id + " does not cite " + needle);
+  }
+  if ((lever.citations ?? []).some((c) => /docs\/en\/settings(?:$|#)/.test(c))) {
+    problems.push(id + " still cites the settings overview page");
+  }
+}
+const artifact = (cat.levers ?? []).find((l) => l.id === "disable-artifact");
+if (artifact) {
+  if (!String(artifact.emittedConfig || "").includes("enableArtifact")) {
+    problems.push("disable-artifact emittedConfig is not the user-scope enableArtifact form");
+  }
+  if (!/user scope/i.test([artifact.scope, ...(artifact.caveats ?? [])].join("\n"))) {
+    problems.push("disable-artifact does not say user scope");
+  }
+}
+if (cat.meta?.verifiedAgainst?.cliVersion !== "2.1.241") {
+  problems.push("verifiedAgainst.cliVersion is not 2.1.241");
+}
+console.log(problems.length ? problems.join("\n") : "CLEAN");
+' "$CATALOGUE")"
+
+if [[ "$citeout" == "CLEAN" ]]; then
+  ok "moved settings keys cite settings-reference anchors; disableArtifact is user-scope"
+else
+  while IFS= read -r line; do fail "$line"; done <<<"$citeout"
+fi
+
 echo
 echo "passed: $PASS, failed: $FAIL"
 [[ $FAIL -eq 0 ]] || exit 1

--- a/plugins/context-budget/skills/audit/scripts/measure.mjs
+++ b/plugins/context-budget/skills/audit/scripts/measure.mjs
@@ -17,11 +17,12 @@
 //              number.
 //
 // Subcommands:
-//   snapshot      one measured snapshot (optionally under --deny)
-//   attribute     baseline + one deny run per tool -> ranked per-tool deltas
-//   compare       offline: two snapshot files -> one ledger row
-//   ledger        append a row / list rows under a caller-derived data dir
-//   parse-context offline: parse a captured /context markdown file
+//   snapshot          one measured snapshot (optionally under --deny)
+//   attribute         baseline + one deny run per tool -> ranked per-tool deltas
+//   compare           offline: two snapshot files -> one ledger row
+//   ledger            append a row / list rows under a caller-derived data dir
+//   parse-context     offline: parse a captured /context markdown file
+//   verify-catalogue  grep the stamped binary for each catalogue key/env name
 //
 // Exit codes: 0 success; 2 usage error; 3 measurement unavailable or
 // unparsable (the degradation path — stdout carries a context-budget.error/1
@@ -42,12 +43,24 @@ import {
 } from 'node:fs';
 import { createRequire } from 'node:module';
 import { delimiter, dirname, isAbsolute, join, resolve, sep } from 'node:path';
-import { pathToFileURL } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
 const SNAPSHOT_SCHEMA = 'context-budget.snapshot/1';
 const ATTRIBUTION_SCHEMA = 'context-budget.attribution/1';
 const LEDGER_SCHEMA = 'context-budget.ledger/1';
 const ERROR_SCHEMA = 'context-budget.error/1';
+const CATALOGUE_SCHEMA = 'context-budget.levers/1';
+const CATALOGUE_VERIFY_SCHEMA = 'context-budget.catalogue-verify/1';
+
+const DEFAULT_CATALOGUE = join(
+  dirname(fileURLToPath(import.meta.url)), '..', 'reference', 'levers.json',
+);
+
+// Settings keys and env names the catalogue cites. Env vars are the CLAUDE_CODE_
+// / ENABLE_ / DISABLE_ family; settings keys are camelCase identifiers in the
+// row's title or emitted-config JSON. A row may override with `binaryTokens`.
+const ENV_TOKEN_RE = /\b(?:CLAUDE_CODE|ENABLE|DISABLE)_[A-Z0-9_]+\b/g;
+const CAMEL_KEY_RE = /\b[a-z][a-zA-Z0-9]*(?:[A-Z][a-zA-Z0-9]*)+\b/g;
 
 const SPAWN_TIMEOUT_MS = 180000;
 
@@ -109,6 +122,7 @@ Usage:
                        [--emitted-config <text>]
   measure.mjs ledger (--append <row-file>|--list) --dir <data-dir>
   measure.mjs parse-context --file <captured-context.md>
+  measure.mjs verify-catalogue [--binary <path>] [--catalogue <file>] [--out <file>]
 
 Exit: 0 success; 2 usage error; 3 measurement unavailable/unparsable
       (stdout then carries a ${ERROR_SCHEMA} record with a remediation).
@@ -699,6 +713,109 @@ function ledgerList(dir) {
 // main
 // ---------------------------------------------------------------------------
 
+// ---------------------------------------------------------------------------
+// verify-catalogue — binary-strings existence check (no network).
+// Docs fetch remains the authority on semantics; this is the authority on
+// whether each catalogue key/env name exists in the measured binary.
+// ---------------------------------------------------------------------------
+
+function catalogueTokens(lever) {
+  if (Array.isArray(lever.binaryTokens) && lever.binaryTokens.length) {
+    return [...new Set(lever.binaryTokens.filter((t) => typeof t === 'string' && t.length))];
+  }
+  const tokens = new Set();
+  const texts = [lever.title, lever.mechanism, lever.emittedConfig, lever.scope, lever.detection]
+    .filter((t) => typeof t === 'string')
+    .join('\n');
+  for (const m of texts.matchAll(ENV_TOKEN_RE)) tokens.add(m[0]);
+  if (typeof lever.emittedConfig === 'string') {
+    try {
+      const obj = JSON.parse(lever.emittedConfig);
+      if (obj && typeof obj === 'object' && !Array.isArray(obj)) {
+        for (const k of Object.keys(obj)) {
+          if (CAMEL_KEY_RE.test(k)) tokens.add(k);
+          CAMEL_KEY_RE.lastIndex = 0;
+        }
+      }
+    } catch { /* emittedConfig is not JSON — title/mechanism still contribute */ }
+  }
+  for (const m of (lever.title || '').matchAll(CAMEL_KEY_RE)) tokens.add(m[0]);
+  return [...tokens];
+}
+
+function countTokenHits(buf, token) {
+  const needle = Buffer.from(token, 'utf8');
+  let count = 0;
+  let idx = 0;
+  while ((idx = buf.indexOf(needle, idx)) !== -1) {
+    count += 1;
+    idx += needle.length;
+  }
+  return count;
+}
+
+function runVerifyCatalogue(args) {
+  const cataloguePath = args.catalogue || DEFAULT_CATALOGUE;
+  let cat;
+  try {
+    cat = JSON.parse(readFileSync(cataloguePath, 'utf8'));
+  } catch (e) {
+    usageError(`--catalogue unreadable JSON: ${e.message}`);
+  }
+  if (cat.schema !== CATALOGUE_SCHEMA) {
+    usageError(`--catalogue expects ${CATALOGUE_SCHEMA}; got ${JSON.stringify(cat.schema)}`);
+  }
+
+  const bin = resolveBinary(args.binary);
+  if (!bin) {
+    degrade('no-binary', 'no `claude` executable found on PATH and no --binary given',
+      'Pass --binary <path> naming the Claude Code executable whose strings to grep.');
+  }
+  let buf;
+  try {
+    buf = readFileSync(bin);
+  } catch (e) {
+    degrade('binary-unreadable', `could not read binary ${bin}: ${e.message}`,
+      'Pass --binary with a readable Claude Code executable.');
+  }
+
+  const rows = [];
+  const absent = [];
+  for (const lever of cat.levers ?? []) {
+    const names = catalogueTokens(lever);
+    const tokens = names.map((name) => {
+      const hits = countTokenHits(buf, name);
+      const present = hits > 0;
+      if (!present) absent.push({ id: lever.id, name });
+      return { name, present, hits };
+    });
+    rows.push({
+      id: lever.id,
+      tokens,
+      skipped: tokens.length === 0,
+    });
+  }
+
+  return {
+    schema: CATALOGUE_VERIFY_SCHEMA,
+    timestampUtc: nowUtc(),
+    method: 'binary-scan',
+    binary: { path: bin, version: binaryVersion(bin) },
+    catalogue: {
+      path: cataloguePath,
+      verifiedAgainst: cat.meta?.verifiedAgainst ?? null,
+    },
+    rows,
+    checked: rows.reduce((n, r) => n + r.tokens.length, 0),
+    missing: absent.length,
+    absent,
+    caveats: [
+      'binary scan is the authority on existence of each key/env name at this binary version',
+      'docs fetch remains the authority on semantics',
+    ],
+  };
+}
+
 function emit(record, outFile) {
   const text = `${JSON.stringify(record, null, 2)}\n`;
   if (outFile) {
@@ -748,6 +865,10 @@ async function main() {
       if (args.append) ledgerAppend(args.dir, args.append);
       else if (args.list) ledgerList(args.dir);
       else usageError('ledger needs --append <row-file> or --list');
+      break;
+    }
+    case 'verify-catalogue': {
+      emit(runVerifyCatalogue(args), args.out);
       break;
     }
     case 'parse-context': {

--- a/plugins/context-budget/skills/audit/scripts/measure.mjs
+++ b/plugins/context-budget/skills/audit/scripts/measure.mjs
@@ -58,9 +58,38 @@ const DEFAULT_CATALOGUE = join(
 
 // Settings keys and env names the catalogue cites. Env vars are the CLAUDE_CODE_
 // / ENABLE_ / DISABLE_ family; settings keys are camelCase identifiers in the
-// row's title or emitted-config JSON. A row may override with `binaryTokens`.
+// row's prose fields. A row may override with `binaryTokens`.
 const ENV_TOKEN_RE = /\b(?:CLAUDE_CODE|ENABLE|DISABLE)_[A-Z0-9_]+\b/g;
-const CAMEL_KEY_RE = /\b[a-z][a-zA-Z0-9]*(?:[A-Z][a-zA-Z0-9]*)+\b/g;
+
+// Linear camelCase scan — no nested quantifiers. The previous
+// /\b[a-z][a-zA-Z0-9]*(?:[A-Z][a-zA-Z0-9]*)+\b/g shape is ReDoS-vulnerable
+// on a long same-case run that then fails \b (e.g. "a" + "A"*n + "_").
+function extractCamelKeys(text) {
+  const out = [];
+  const s = String(text);
+  let i = 0;
+  while (i < s.length) {
+    const c = s.charCodeAt(i);
+    if (c >= 97 && c <= 122) {
+      const start = i;
+      i += 1;
+      let sawUpper = false;
+      while (i < s.length) {
+        const k = s.charCodeAt(i);
+        const isLower = k >= 97 && k <= 122;
+        const isUpper = k >= 65 && k <= 90;
+        const isDigit = k >= 48 && k <= 57;
+        if (!isLower && !isUpper && !isDigit) break;
+        if (isUpper) sawUpper = true;
+        i += 1;
+      }
+      if (sawUpper) out.push(s.slice(start, i));
+      continue;
+    }
+    i += 1;
+  }
+  return out;
+}
 
 const SPAWN_TIMEOUT_MS = 180000;
 
@@ -728,19 +757,27 @@ function catalogueTokens(lever) {
     .filter((t) => typeof t === 'string')
     .join('\n');
   for (const m of texts.matchAll(ENV_TOKEN_RE)) tokens.add(m[0]);
+  for (const key of extractCamelKeys(texts)) tokens.add(key);
   if (typeof lever.emittedConfig === 'string') {
     try {
       const obj = JSON.parse(lever.emittedConfig);
       if (obj && typeof obj === 'object' && !Array.isArray(obj)) {
         for (const k of Object.keys(obj)) {
-          if (CAMEL_KEY_RE.test(k)) tokens.add(k);
-          CAMEL_KEY_RE.lastIndex = 0;
+          if (extractCamelKeys(k).includes(k)) tokens.add(k);
         }
       }
-    } catch { /* emittedConfig is not JSON — title/mechanism still contribute */ }
+    } catch { /* emittedConfig is not JSON — prose fields still contribute */ }
   }
-  for (const m of (lever.title || '').matchAll(CAMEL_KEY_RE)) tokens.add(m[0]);
   return [...tokens];
+}
+
+// Prefer a sibling .exe over a Windows command shim so the scan reads the
+// payload the consumer actually runs, not the wrapper script.
+function binaryScanPath(bin) {
+  if (!/\.(cmd|bat)$/i.test(bin)) return { path: bin, viaShim: false };
+  const exe = bin.replace(/\.(cmd|bat)$/i, '.exe');
+  if (existsSync(exe)) return { path: realpathSync(exe), viaShim: true };
+  return { path: bin, viaShim: true };
 }
 
 function countTokenHits(buf, token) {
@@ -771,11 +808,12 @@ function runVerifyCatalogue(args) {
     degrade('no-binary', 'no `claude` executable found on PATH and no --binary given',
       'Pass --binary <path> naming the Claude Code executable whose strings to grep.');
   }
+  const scanned = binaryScanPath(bin);
   let buf;
   try {
-    buf = readFileSync(bin);
+    buf = readFileSync(scanned.path);
   } catch (e) {
-    degrade('binary-unreadable', `could not read binary ${bin}: ${e.message}`,
+    degrade('binary-unreadable', `could not read binary ${scanned.path}: ${e.message}`,
       'Pass --binary with a readable Claude Code executable.');
   }
 
@@ -796,11 +834,21 @@ function runVerifyCatalogue(args) {
     });
   }
 
+  const caveats = [
+    'binary scan is the authority on existence of each key/env name at this binary version',
+    'docs fetch remains the authority on semantics',
+  ];
+  if (scanned.viaShim && scanned.path === bin) {
+    caveats.push('scanned a Windows command shim; a sibling .exe was not found, so absence findings may be the wrapper rather than the payload');
+  } else if (scanned.viaShim) {
+    caveats.push(`resolved Windows command shim ${bin} to sibling ${scanned.path}`);
+  }
+
   return {
     schema: CATALOGUE_VERIFY_SCHEMA,
     timestampUtc: nowUtc(),
     method: 'binary-scan',
-    binary: { path: bin, version: binaryVersion(bin) },
+    binary: { path: scanned.path, version: binaryVersion(bin), resolvedFrom: bin },
     catalogue: {
       path: cataloguePath,
       verifiedAgainst: cat.meta?.verifiedAgainst ?? null,
@@ -809,10 +857,7 @@ function runVerifyCatalogue(args) {
     checked: rows.reduce((n, r) => n + r.tokens.length, 0),
     missing: absent.length,
     absent,
-    caveats: [
-      'binary scan is the authority on existence of each key/env name at this binary version',
-      'docs fetch remains the authority on semantics',
-    ],
+    caveats,
   };
 }
 

--- a/plugins/context-budget/skills/audit/scripts/measure.test.sh
+++ b/plugins/context-budget/skills/audit/scripts/measure.test.sh
@@ -6,10 +6,11 @@
 # comparability rules (identical runs comparable; skill-listing signature
 # mismatch marks System tools incomparable; schema validation), the ledger
 # (one file per run plus an appended history line; schema-checked append),
-# and the attribute/additivity pipeline in cli-parse mode against a fake
+# the attribute/additivity pipeline in cli-parse mode against a fake
 # `claude` binary (a vanished bucket is unmeasured and incomparable, never a
-# coerced zero). The sdk measurement path spawns a real Claude Code binary
-# and is exercised manually, not here — this suite must stay hermetic.
+# coerced zero), and verify-catalogue (binary-scan present/absent, never
+# invents presence). The sdk measurement path spawns a real Claude Code
+# binary and is exercised manually, not here — this suite must stay hermetic.
 #
 # Prerequisites: node on PATH (the engine's own runtime — required for
 # correctness; absent, this suite fails loudly rather than skipping).
@@ -356,6 +357,67 @@ if (cd "$WORK" && FAKE_MODE=novocab node "$ENGINE" attribute --tools AlphaTool,B
     "additivity over the present bucket alone still verifies" "vocabulary-absent additive wrong"
 else
   fail "attribute (novocab scenario) exited nonzero"
+fi
+
+# --- verify-catalogue: binary existence, never invents presence -----------
+# A tiny catalogue plus a byte file standing in for the binary: one row's
+# keys are in the file, one row's key is not, one row has nothing to grep.
+# The engine must report present/absent from the bytes, not from the
+# catalogue's own claims.
+
+minicat="$WORK/mini-levers.json"
+node -e '
+const fs = require("fs");
+fs.writeFileSync(process.argv[1], JSON.stringify({
+  schema: "context-budget.levers/1",
+  meta: { categories: { "removes-weight": "x" }, verifiedAgainst: { cliVersion: "9.9.9", date: "2026-01-01" } },
+  levers: [
+    {
+      id: "has-key",
+      title: "disableWorkflows / CLAUDE_CODE_DISABLE_WORKFLOWS",
+      category: "removes-weight", categoryBasis: "t", posture: "recommendable-on-fit",
+      detection: "x", measurement: "x",
+      emittedConfig: "{\"disableWorkflows\": true}",
+      citations: ["https://example.com"], verified: "2026-01-01", recheckTrigger: "x",
+    },
+    {
+      id: "missing-key",
+      title: "notInThisBinaryKey",
+      category: "removes-weight", categoryBasis: "t", posture: "recommendable-on-fit",
+      detection: "x", measurement: "x",
+      emittedConfig: "{\"notInThisBinaryKey\": true}",
+      citations: ["https://example.com"], verified: "2026-01-01", recheckTrigger: "x",
+    },
+    {
+      id: "no-tokens",
+      title: "No extractable identifier here",
+      category: "removes-weight", categoryBasis: "t", posture: "recommendable-on-fit",
+      detection: "x", measurement: "x", emittedConfig: null,
+      citations: ["https://example.com"], verified: "2026-01-01", recheckTrigger: "x",
+    },
+  ],
+}));
+' "$minicat"
+printf 'padding disableWorkflows CLAUDE_CODE_DISABLE_WORKFLOWS disableWorkflows padding' >"$WORK/fake-strings-bin"
+
+vcat="$WORK/verify-cat.json"
+if node "$ENGINE" verify-catalogue --binary "$WORK/fake-strings-bin" --catalogue "$minicat" --out "$vcat" >/dev/null; then
+  assert_eq "$(jsonget "$vcat" 'j.schema')" "context-budget.catalogue-verify/1" \
+    "verify-catalogue emits the catalogue-verify schema" "verify-catalogue schema wrong"
+  assert_eq "$(jsonget "$vcat" 'j.rows.find((r)=>r.id==="has-key").tokens.find((t)=>t.name==="disableWorkflows").present')" "true" \
+    "present key is reported present" "present key marked absent"
+  assert_eq "$(jsonget "$vcat" 'j.rows.find((r)=>r.id==="has-key").tokens.find((t)=>t.name==="disableWorkflows").hits')" "2" \
+    "hit count matches the binary occurrences" "hit count wrong"
+  assert_eq "$(jsonget "$vcat" 'j.rows.find((r)=>r.id==="has-key").tokens.find((t)=>t.name==="CLAUDE_CODE_DISABLE_WORKFLOWS").present')" "true" \
+    "present env name is reported present" "present env name marked absent"
+  assert_eq "$(jsonget "$vcat" 'j.rows.find((r)=>r.id==="missing-key").tokens.find((t)=>t.name==="notInThisBinaryKey").present')" "false" \
+    "absent key is reported absent (never invented present)" "absent key marked present"
+  assert_eq "$(jsonget "$vcat" 'j.rows.find((r)=>r.id==="no-tokens").skipped')" "true" \
+    "a row with no extractable key is skipped" "no-token row not skipped"
+  assert_eq "$(jsonget "$vcat" 'j.missing')" "1" \
+    "missing count is the absent-token total" "missing count wrong"
+else
+  fail "verify-catalogue exited nonzero on a readable fake binary"
 fi
 
 # --- snapshot: pinned-binary honesty --------------------------------------

--- a/plugins/context-budget/skills/audit/scripts/measure.test.sh
+++ b/plugins/context-budget/skills/audit/scripts/measure.test.sh
@@ -395,6 +395,14 @@ fs.writeFileSync(process.argv[1], JSON.stringify({
       detection: "x", measurement: "x", emittedConfig: null,
       citations: ["https://example.com"], verified: "2026-01-01", recheckTrigger: "x",
     },
+    {
+      id: "detection-only",
+      title: "No camel here",
+      category: "removes-weight", categoryBasis: "t", posture: "recommendable-on-fit",
+      detection: "enabledMcpjsonServers across scopes", measurement: "x",
+      emittedConfig: null,
+      citations: ["https://example.com"], verified: "2026-01-01", recheckTrigger: "x",
+    },
   ],
 }));
 ' "$minicat"
@@ -414,10 +422,49 @@ if node "$ENGINE" verify-catalogue --binary "$WORK/fake-strings-bin" --catalogue
     "absent key is reported absent (never invented present)" "absent key marked present"
   assert_eq "$(jsonget "$vcat" 'j.rows.find((r)=>r.id==="no-tokens").skipped')" "true" \
     "a row with no extractable key is skipped" "no-token row not skipped"
-  assert_eq "$(jsonget "$vcat" 'j.missing')" "1" \
-    "missing count is the absent-token total" "missing count wrong"
+  assert_eq "$(jsonget "$vcat" 'j.missing')" "2" \
+    "missing count includes detection-only absent key" "missing count wrong"
+  assert_eq "$(jsonget "$vcat" 'j.rows.find((r)=>r.id==="detection-only").tokens.find((t)=>t.name==="enabledMcpjsonServers").present')" "false" \
+    "camelCase in detection is extracted (not silently skipped)" "detection-only key not extracted"
 else
   fail "verify-catalogue exited nonzero on a readable fake binary"
+fi
+
+# ReDoS-shaped title (long same-case run then _) must finish, not hang.
+redoscat="$WORK/redos-levers.json"
+node -e '
+const fs = require("fs");
+fs.writeFileSync(process.argv[1], JSON.stringify({
+  schema: "context-budget.levers/1",
+  meta: { categories: { "removes-weight": "x" } },
+  levers: [{
+    id: "redos",
+    title: "a" + "A".repeat(80) + "_",
+    category: "removes-weight", categoryBasis: "t", posture: "recommendable-on-fit",
+    detection: "x", measurement: "x", emittedConfig: null,
+    citations: ["https://example.com"], verified: "2026-01-01", recheckTrigger: "x",
+  }],
+}));
+' "$redoscat"
+if node -e '
+const { spawnSync } = require("child_process");
+const r = spawnSync(process.execPath, [process.argv[1], "verify-catalogue", "--binary", process.argv[2], "--catalogue", process.argv[3]], { timeout: 2000, stdio: "ignore" });
+process.exit(r.error ? 1 : (r.status ?? 1));
+' "$ENGINE" "$WORK/fake-strings-bin" "$redoscat"; then
+  ok "camelCase extract finishes on a ReDoS-shaped title (no hang)"
+else
+  fail "camelCase extract hung or failed on a ReDoS-shaped title"
+fi
+
+# A .cmd path with a sibling .exe scans the exe, not the wrapper.
+printf 'wrapper-only no-keys-here' >"$WORK/shim-claude.cmd"
+printf 'payload disableWorkflows CLAUDE_CODE_DISABLE_WORKFLOWS' >"$WORK/shim-claude.exe"
+shimout="$WORK/verify-shim.json"
+if node "$ENGINE" verify-catalogue --binary "$WORK/shim-claude.cmd" --catalogue "$minicat" --out "$shimout" >/dev/null; then
+  assert_eq "$(jsonget "$shimout" 'j.rows.find((r)=>r.id==="has-key").tokens.find((t)=>t.name==="disableWorkflows").present')" "true" \
+    "Windows .cmd with sibling .exe scans the exe" "shim scan missed the sibling exe payload"
+else
+  fail "verify-catalogue on a .cmd shim exited nonzero"
 fi
 
 # --- snapshot: pinned-binary honesty --------------------------------------


### PR DESCRIPTION
Closes #3198

## Summary

The lever catalogue still cited `docs/en/settings` for keys that now live only on `settings-reference`, and `disableArtifact`'s emitted config did not say user scope. Doc pages move; the binary is the ground truth the consumer actually runs, and the recheck path had no docs-independent existence check.

## Fix

- Retarget the drifted settings-key citations to the per-key `settings-reference` anchors (`disableWorkflows`, `disableArtifact`/`enableArtifact`, `includeGitInstructions`, `skillOverrides`, `disableBundledSkills`, `skillListingBudgetFraction`/`skillListingMaxDescChars`, `disabledMcpjsonServers`).
- `disableArtifact`'s emitted config is now the user-scope form (`enableArtifact: false`); a project-scope write is the wrong lock.
- Add `verify-catalogue`: a binary scan of each row's settings keys and env names, reporting present/absent with hit counts. Run on a version-jump recheck. The binary is the authority on existence at the measured version; the docs fetch remains the authority on semantics.
- Review follow-up (`0f2e585`): camelCase extraction is a linear scan (no ReDoS), reads every prose field, and prefers a sibling `.exe` over a Windows command shim.
- `verifiedAgainst` is CLI 2.1.241 (2026-08-23).

## Verification

- `measure.test.sh`: 54/54, including hermetic `verify-catalogue` cases (present key, present env, absent key never invented present, no-token row skipped, hit count matches, detection-only camelCase extracted, ReDoS-shaped title finishes, `.cmd`+sibling `.exe` scans the exe).
- `levers.test.sh`: 2/2, including a gate that the moved keys cite `settings-reference` anchors and that `disableArtifact` says user scope.

## Related

N/A — this PR closes #3198 only. #3199 and #3200 are sequential follow-ons on later plugin versions.