### PR TITLE
docs(education): de-slop instruction surfaces (0.8.4)

### DIFF
--- a/plugins/education/.claude-plugin/plugin.json
+++ b/plugins/education/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "education",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "Interactive multi-session learning coach: teaches a general subject or a concept grounded in the consuming repo through the Knowledge-Skills-Wisdom progression, with persistent per-topic learning state. Also a single-session domain primer, a one-shot plain-language explainer that drops anything to genuinely plain words, and a post-work comprehension check that quizzes the human on a completed change.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/education/CHANGELOG.md
+++ b/plugins/education/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to the `education` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.8.4]
+
+### Changed
+
+- **Instruction-surface de-slop (#2891, education cluster).** Rewrote this plugin's `README.md` and every
+  `SKILL.md` to drop em dashes under the repo's zero-tolerance house policy, using
+  `/ai-slop:audit fix` semantics: periods or commas, or a restructured sentence, never
+  parentheses, en dashes, or a spaced hyphen as a stand-in. Meaning stays; only the mark
+  and the sentence break change. The generated options block is ignore-fenced because
+  `scripts/sync-plugin-options-docs.py` still emits em dashes from its shared template.
+
 ## [0.8.3]
 
 ### Changed

--- a/plugins/education/README.md
+++ b/plugins/education/README.md
@@ -1,14 +1,14 @@
 # education
 
-A Claude Code plugin that coaches you through learning a subject — across
-multiple sessions — instead of lecturing at you. It runs a
+A Claude Code plugin that coaches you through learning a subject, across
+multiple sessions, instead of lecturing at you. It runs a
 **Knowledge → Skills → Wisdom** progression grounded in your real goal, and keeps
 persistent per-topic learning state so each session builds on the last.
 
 Invoke `/education:teach` with an action for coached, multi-session learning, for
 example `/education:teach topic rust-ownership`,
 `/education:teach codebase auth-flow`, or `/education:teach primer color-grading`.
-For a one-shot plain-language explanation, invoke `/education:explain` — or just
+For a one-shot plain-language explanation, invoke `/education:explain`, or just
 say "I don't get it" and let it auto-invoke. After Claude finishes a change,
 invoke `/education:quiz-me` to be quizzed on what was done.
 
@@ -17,25 +17,25 @@ invoke `/education:quiz-me` to be quizzed on what was done.
 `teach` is the multi-session coach; `explain` is its one-shot sibling; `quiz-me`
 verifies you absorbed a completed change.
 
-- **`/education:teach topic <subject>`** — learn a general subject from external
+- **`/education:teach topic <subject>`**. Learn a general subject from external
   high-trust sources (books, courses, docs, communities).
-- **`/education:teach codebase <topic>`** — learn a concept grounded in the
+- **`/education:teach codebase <topic>`**. Learn a concept grounded in the
   repository you launch it from. It discovers the repo's own docs, conventions,
-  and source at teach-time and teaches from what it finds — nothing about the
+  and source at teach-time and teaches from what it finds, nothing about the
   project is assumed.
-- **`/education:teach primer <domain>`** — a single-session vocabulary primer for
+- **`/education:teach primer <domain>`**. A single-session vocabulary primer for
   an unfamiliar domain, so you can prompt or direct work in it precisely. No
   workspace.
-- **`/education:explain [thing]`** — a one-shot, plain-language explainer. It
+- **`/education:explain [thing]`**. A one-shot, plain-language explainer. It
   drops any concept, code, error, architecture, or the previous assistant
   response to genuinely plain words (concrete analogy, zero jargon), then layers
   altitude up only on request (high-school, then peer level). An empty argument
   explains the previous assistant response, so "I don't get it" needs no topic.
   It closes by offering `/education:teach` when you want ongoing coaching rather
   than a single explanation.
-- **`/education:quiz-me`** — a post-work comprehension check. After a change is
+- **`/education:quiz-me`**. A post-work comprehension check. After a change is
   complete, it generates a self-contained HTML report of what was done (context,
-  intuition, decisions) with a quiz at the bottom you answer — verifying that
+  intuition, decisions) with a quiz at the bottom you answer, verifying that
   *you* absorbed the work, not just that the artifact is correct. It is
   non-gating by default; the `quiz_policy` setting tunes how often a quiz is
   offered. Its `recall <query>` action answers "what did we do on `<ticket>`" from
@@ -49,12 +49,12 @@ fetched or a file read that session rather than from memory.
 
 ## How it works
 
-Each topic gets a **workspace** — a mission (why you're learning this), a glossary,
+Each topic gets a **workspace**. A mission (why you're learning this), a glossary,
 curated resources, and per-concept slices (a lesson, a durable reference
 cheat-sheet, and optional practice). Learning state is treated as **your documents,
 not machine internals**: topic-mode workspaces default to a `Claude Learning/` home
 in your OS Documents folder (when one is eligible), while codebase-mode workspaces
-stay under `${CLAUDE_PLUGIN_DATA}` by default — their lessons can embed snippets
+stay under `${CLAUDE_PLUGIN_DATA}` by default, their lessons can embed snippets
 from your repo, and Documents folders are often cloud-synced. Either way the state
 survives plugin updates, stays out of your project's tree, and lets you resume a
 topic weeks later; the root is configurable (see Configuration). Durable references
@@ -64,10 +64,10 @@ refreshed before they're taught. See the skill body for the full pedagogy.
 ## Requirements
 
 - **Bash + coreutils** (`sha256sum`/`shasum`, `realpath`, `tr`, `sed`) for the
-  skill's inline mechanics — on native Windows, install
+  skill's inline mechanics, on native Windows, install
   [Git for Windows](https://code.claude.com/docs/en/setup#set-up-on-windows) so
   they run under Git Bash, which bundles all of them.
-- For `codebase` mode, launch it from the repository you want to learn — the
+- For `codebase` mode, launch it from the repository you want to learn, the
   plugin reads that repo's own docs and source.
 - `topic` mode fetches documentation URLs to ground explanations in primary
   sources; if your setup restricts `WebFetch`, allow it or seed `RESOURCES.md`
@@ -86,7 +86,7 @@ All settings are optional, with defaults that preserve zero-config behavior:
 
 | Setting | Type | Default | What it does |
 | --- | --- | --- | --- |
-| `quiz_policy` | string | `on-request` | When `quiz-me` offers a quiz: `off` (never), `on-request` (only when asked), `always` (after each completed change), `above-threshold` (when the change is large). Offer cadence only — a report is never generated without your confirmation. Unknown values act as `on-request`. |
+| `quiz_policy` | string | `on-request` | When `quiz-me` offers a quiz: `off` (never), `on-request` (only when asked), `always` (after each completed change), `above-threshold` (when the change is large). Offer cadence only, a report is never generated without your confirmation. Unknown values act as `on-request`. |
 | `report_library_dir` | directory | *(unset)* | Where `quiz-me` stores reports. Unset uses the plugin's own `${CLAUDE_PLUGIN_DATA}`; set it to a corpus checkout to redirect the library root there. Reports never land in the repo you are working in. |
 | `workspace_root` | directory | *(unset)* | Where `teach` roots learning workspaces. Unset resolves a ladder: a project declaration, this setting, a one-time ask, the OS Documents `Claude Learning/` home (topic mode only), then `${CLAUDE_PLUGIN_DATA}`. Codebase-mode workspaces stay under plugin data unless explicitly rooted elsewhere. Values inside the repo you are working in are refused. |
 
@@ -98,6 +98,7 @@ the #798 path-indirection work lands.
 Run `/education:setup` to validate the effective `quiz_policy`, report-library root,
 and teach workspace root without reading settings files.
 
+<!-- ai-slop-ignore-start: generated options block; source is plugin.json + scripts/sync-plugin-options-docs.py -->
 <!-- BEGIN GENERATED: plugin options — edit plugin.json, then run scripts/sync-plugin-options-docs.py -->
 
 ### Options reference
@@ -172,6 +173,7 @@ hands a configured value to a hook process; the value comes from the routes abov
 - [Manage installed plugins](https://code.claude.com/docs/en/discover-plugins#manage-installed-plugins) — enabling, disabling, `/plugin list`
 
 <!-- END GENERATED: plugin options -->
+<!-- ai-slop-ignore-end -->
 
 ## License
 

--- a/plugins/education/skills/explain/SKILL.md
+++ b/plugins/education/skills/explain/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: "One-shot plain-language explainer — drops any concept, code, error, architecture, or the previous assistant response to genuinely plain words (concrete analogy, zero jargon), then layers altitude up only on request (high-school, then peer level). Use when: 'I don't understand this', 'I don't get it', 'what does this actually do', 'what does this mean', 'explain simply', 'ELI5', 'rephrase that'. Empty argument targets the previous assistant response (anaphora), so 'I don't get it' needs no topic named. This changes ALTITUDE — trades precision for plain words; when the ask is instead to reorganize a dense message faithfully without losing precision (chunk it one-decision-at-a-time, define its jargon, surface the decisions), that is a STRUCTURE change, adhd:clarify (if installed), not an altitude drop. Sibling to education:teach — hand off there for multi-session coaching; this is a single-shot comprehension check, not ongoing tutoring."
+description: "One-shot plain-language explainer. Drops any concept, code, error, architecture, or the previous assistant response to genuinely plain words (concrete analogy, zero jargon), then layers altitude up only on request (high-school, then peer level). Use when: 'I don't understand this', 'I don't get it', 'what does this actually do', 'what does this mean', 'explain simply', 'ELI5', 'rephrase that'. Empty argument targets the previous assistant response (anaphora), so 'I don't get it' needs no topic named. This changes ALTITUDE. Trades precision for plain words; when the ask is instead to reorganize a dense message faithfully without losing precision (chunk it one-decision-at-a-time, define its jargon, surface the decisions), that is a STRUCTURE change, adhd:clarify (if installed), not an altitude drop. Sibling to education:teach. Hand off there for multi-session coaching; this is a single-shot comprehension check, not ongoing tutoring."
 argument-hint: "[thing to explain] (empty = the previous assistant response)"
 user-invocable: true
 disable-model-invocation: false
@@ -13,12 +13,12 @@ metadata:
 Explain one thing, once, in genuinely plain words. The object can be a concept, a
 piece of code, an error, an architecture, or the assistant's own previous output.
 The core move is an **altitude drop**: land the explanation at the lowest useful
-altitude first — a concrete analogy, zero jargon — then layer altitude back up
+altitude first, a concrete analogy, zero jargon, then layer altitude back up
 **only when the user asks for it**. Michael Scott's "Why don't you explain this to
 me like I'm five" (*The Office* US, S5E9 "The Surplus") is the tone anchor; the
 [Feynman technique](https://fs.blog/feynman-technique/) is the method.
 
-**Use when:** the user signals they didn't follow something — `I don't get it`,
+**Use when:** the user signals they didn't follow something, `I don't get it`,
 `explain simply`, `ELI5`, `what does this actually mean`, `rephrase that`. **Skip
 when:** the user wants ongoing, multi-session coaching with persistent state (hand
 off to `/education:teach`); a plain inline answer already lands (just answer).
@@ -27,11 +27,11 @@ This skill auto-invokes (no `disable-model-invocation`) because "I don't get it"
 should reach it without the user naming a command. Auto-trigger is best-effort;
 `/education:explain` is the guaranteed path.
 
-## The core move — plain-language first pass
+## The core move. Plain-language first pass
 
 1. **Identify the object.** With an argument, that is the thing. Empty argument →
    the **previous assistant response** (see "Empty argument" below).
-2. **Ground it, don't recall it.** Re-read the actual artifact this turn — the
+2. **Ground it, don't recall it.** Re-read the actual artifact this turn, the
    message just sent, the file, the error text, the code. For an external concept,
    fetch a primary source rather than leaning on parametric memory (plugin
    doctrine: knowledge is grounded, not remembered).
@@ -42,19 +42,19 @@ should reach it without the user naming a command. Auto-trigger is best-effort;
 
 Lead with the analogy and the "what it's actually doing," not with vocabulary.
 
-## Empty argument — anaphora default
+## Empty argument. Anaphora default
 
 When invoked with no argument, the object is the **assistant's own previous
-response** — the thing the user is reacting to. `I don't get it` needs no topic
+response**. The thing the user is reacting to. `I don't get it` needs no topic
 named. Re-read that prior message, find the part most likely to have lost the
 reader (the densest jargon, the biggest leap), and drop *that* to plain words.
 Do not ask "explain what?" when the conversation makes the referent obvious. But
-when there is **no prior assistant message** to resolve the anaphora against — a
+when there is **no prior assistant message** to resolve the anaphora against, a
 cold start where the user opens the conversation with `I don't get it` and nothing
-has been said yet — do not hallucinate a referent: ask "What would you like
+has been said yet, do not hallucinate a referent: ask "What would you like
 explained?" instead of proceeding blind.
 
-## Altitude layering — on request only
+## Altitude layering. On request only
 
 Start at rung 1. Climb only when the user asks ("go deeper", "more precise", "I
 actually know X"). Never front-load a higher rung.
@@ -63,16 +63,16 @@ actually know X"). Never front-load a higher rung.
 |------|----------|------|
 | 1 (default) | **Plain / ELI5** | Concrete everyday analogy, zero jargon. The floor and the default landing. |
 | 2 (on request) | **High-school** | Introduce one or two real terms of art, each defined as it appears. Keep the analogy as scaffolding. |
-| 3 (on request) | **Peer** | Full precision, jargon allowed, edge cases and tradeoffs — the explanation a colleague in the field would want. |
+| 3 (on request) | **Peer** | Full precision, jargon allowed, edge cases and tradeoffs, the explanation a colleague in the field would want. |
 
 Offer the next rung as a one-line invitation, not a wall of text: "That's the
-five-year-old version — want the high-school one?"
+five-year-old version, want the high-school one?"
 
 ## Feynman gap check
 
 The plain-language pass is a comprehension self-test, not a rewording service. If
-you **cannot** shed the jargon — if the only "explanation" you can produce still
-leans on the very terms the user didn't follow, or on hand-waving — that is a
+you **cannot** shed the jargon, if the only "explanation" you can produce still
+leans on the very terms the user didn't follow, or on hand-waving, that is a
 detected understanding gap, on the explainer's side. **Surface it honestly**
 rather than papering over it: name the specific part you cannot yet reduce and
 why, and ground harder (re-read the source, fetch the primary reference) before
@@ -82,7 +82,7 @@ mode this check exists to catch.
 ## Handoff to `education:teach`
 
 Close every explanation with a single lightweight line offering the multi-session
-path — the first-party sibling in this same plugin:
+path, the first-party sibling in this same plugin:
 
 > Want to actually learn this, not just get past it? `/education:teach topic <x>`
 > runs a multi-session coached deep-dive.
@@ -93,7 +93,7 @@ mission-driven coach when the user wants ongoing depth or practice.
 ## Gotchas
 
 - **Don't climb unasked.** The default is rung 1. Delivering the peer-level
-  explanation first defeats the point — the user already didn't follow the
+  explanation first defeats the point, the user already didn't follow the
   peer-level version.
 - **Anaphora referent is the *assistant's* output, not the user's.** Empty
   argument explains what the assistant just said, which the user is reacting to.

--- a/plugins/education/skills/quiz-me/SKILL.md
+++ b/plugins/education/skills/quiz-me/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: "Post-work comprehension check: after a change is complete, generate a self-contained HTML report of what was done (context, intuition, decisions) with a quiz at the bottom that you answer — verifying the HUMAN absorbed the work, not the artifact. Non-gating by default; the quiz_policy userConfig tunes offer cadence. Also recalls prior work from the retained report library. Use when: 'quiz me', 'quiz me on this change', 'do I understand this change', 'comprehension check', 'a quiz at the bottom that I must pass', 'I want to make sure I understand everything that happened', 'what did we do on <ticket>'. Sibling to education:teach (multi-session coach) and education:explain (one-shot explainer); this verifies comprehension of COMPLETED WORK. Not artifact verification — that is verification:confirm (if installed)."
+description: "Post-work comprehension check: after a change is complete, generate a self-contained HTML report of what was done (context, intuition, decisions) with a quiz at the bottom that you answer. Verifying the HUMAN absorbed the work, not the artifact. Non-gating by default; the quiz_policy userConfig tunes offer cadence. Also recalls prior work from the retained report library. Use when: 'quiz me', 'quiz me on this change', 'do I understand this change', 'comprehension check', 'a quiz at the bottom that I must pass', 'I want to make sure I understand everything that happened', 'what did we do on <ticket>'. Sibling to education:teach (multi-session coach) and education:explain (one-shot explainer); this verifies comprehension of COMPLETED WORK. Not artifact verification. That is verification:confirm (if installed)."
 argument-hint: "[recall <query>] (empty = quiz me on the change just completed)"
 user-invocable: true
 disable-model-invocation: false
@@ -10,7 +10,7 @@ metadata:
 
 ## Purpose
 
-Verify that the **human** absorbed a completed change — the object under test is the
+Verify that the **human** absorbed a completed change, the object under test is the
 person merging the work, never the artifact. After Claude finishes a change, generate an
 HTML report of what was done (context, intuition, decisions) with a quiz at the bottom the
 user answers. The failure mode this addresses: people glaze over plans and explainers, so
@@ -19,64 +19,64 @@ the codebase decays, degrading future prompting.
 
 Three value props:
 
-- **Representation accountability** — can the user explain this change to a reviewer?
-- **Loop retention** — keeping the user's mental model of the codebase current keeps their
+- **Representation accountability**. Can the user explain this change to a reviewer?
+- **Loop retention**. Keeping the user's mental model of the codebase current keeps their
   prompting sharp.
-- **Late intent-mismatch detection** — a failed quiz surfaces "that's not what I intended"
+- **Late intent-mismatch detection**. A failed quiz surfaces "that's not what I intended"
   while there is still time to fix it, before merge.
 
 **Use when:** the user asks to be quizzed on completed work, or to recall past work
 (`quiz me`, `do I understand this change`, `what did we do on <ticket>`). **Skip when:**
 the request is to verify the artifact (does it work / is it right), to extract the user's
-intent before work starts, or to coach a general subject — see "What this skill does NOT
+intent before work starts, or to coach a general subject, see "What this skill does NOT
 do". This skill auto-invokes (no `disable-model-invocation`) so policy-driven offers can
 fire; `/education:quiz-me` is the guaranteed path.
 
 ## Effective configuration (substituted at load)
 
 The values below substitute from this plugin's stored configuration when this skill loads.
-A surviving literal `${user_config.…}` placeholder means that key is unset — apply its
+A surviving literal `${user_config.…}` placeholder means that key is unset, apply its
 documented unset behavior.
 
 | Key | Value | Unset behavior |
 | --- | --- | --- |
-| `quiz_policy` | `${user_config.quiz_policy}` | `on-request` — act only when invoked. Values govern OFFER CADENCE only (see "Non-gating posture"). Unknown value → treat as `on-request`. |
+| `quiz_policy` | `${user_config.quiz_policy}` | `on-request`. Act only when invoked. Values govern OFFER CADENCE only (see "Non-gating posture"). Unknown value → treat as `on-request`. |
 | `report_library_dir` | `${user_config.report_library_dir}` | unset → artifacts land under `${CLAUDE_PLUGIN_DATA}` (see "Retention mechanics"). Set to a corpus checkout to redirect the library root there. |
 
 Configure via the `/plugin` dialog, or headless with `claude plugin install
 education@<marketplace> --config KEY=VALUE` (your installed marketplace name). A literal
 non-home `report_library_dir` may be blocked by the hardcoded-path
-guardrails — the same collision knowledge's `library_dir` hits (#798); adopt that issue's
+guardrails, the same collision knowledge's `library_dir` hits (#798); adopt that issue's
 path-indirection scheme for literal-path overrides once it lands.
 
 ## Action router
 
-Parse `$ARGUMENTS`: `recall` is the ONLY reserved first token. Anything else — including no
-arguments — is the default action, with any argument text taken as context describing the
+Parse `$ARGUMENTS`: `recall` is the ONLY reserved first token. Anything else, including no
+arguments, is the default action, with any argument text taken as context describing the
 change to quiz on.
 
 | Action | Purpose |
 | --- | --- |
-| *(default — empty, or any first token other than `recall`)* | Offer or generate a report + quiz for the change just completed; any argument text is context describing the change. Offer vs generate depends on who invoked it (below). |
-| `recall <query>` | Answer "what did we do on X" from the retained report library first, git/tracker archaeology second — stating which source answered (see "Recall"). |
+| *(default. Empty, or any first token other than `recall`)* | Offer or generate a report + quiz for the change just completed; any argument text is context describing the change. Offer vs generate depends on who invoked it (below). |
+| `recall <query>` | Answer "what did we do on X" from the retained report library first, git/tracker archaeology second, stating which source answered (see "Recall"). |
 
 The default action branches on **who invoked it**: a **user-initiated** invocation
-(`/education:quiz-me`, or "quiz me") is itself acceptance — generate the report + quiz
+(`/education:quiz-me`, or "quiz me") is itself acceptance, generate the report + quiz
 immediately. A **model-initiated** invocation that fires to satisfy `quiz_policy`
-`always`/`above-threshold` is an OFFER — present it and wait for the user to accept before
+`always`/`above-threshold` is an OFFER, present it and wait for the user to accept before
 generating anything (see "Non-gating posture"; generation is always user-confirmed).
 
 ## Report contract
 
 Produce a **self-contained single-file HTML** report (all CSS/JS inline, no remote fetch,
-openable via `file://`, synthetic data only — never real secrets or tokens). Markdown
+openable via `file://`, synthetic data only, never real secrets or tokens). Markdown
 fallback where the project convention prefers it. Sections: context, intuition, decisions,
-what-was-done, then the **quiz at the bottom** the user must answer — the canonical prompt
+what-was-done, then the **quiz at the bottom** the user must answer, the canonical prompt
 pattern ("a quiz at the bottom on the changes that I must pass"). Match each narrative
 section's length to what the change needs: cover the substance, but do not pad with filler,
 redundant summaries, or boilerplate.
 
-- **Answer key persists with the artifact.** Embed the key in the report — a collapsed
+- **Answer key persists with the artifact.** Embed the key in the report, a collapsed
   `<details>` block in HTML, an appendix section in the markdown fallback. Grade
   in-conversation in the same session; a later or compacted session grades by reading the
   key back from the retained artifact, re-deriving from the report + diff only when the
@@ -84,17 +84,17 @@ redundant summaries, or boilerplate.
   graded at all.
 - **A failed quiz is a signal, not a gate.** Surface it as a possible intent mismatch to
   resolve before merge; never block the merge yourself (see "Non-gating posture").
-- **Reference discipline — durable pointers only.** The report is self-contained.
+- **Reference discipline, durable pointers only.** The report is self-contained.
   Restrict any external reference to durable, checkout-independent pointers: PR/issue
   URLs, commit SHAs or permalinks, promoted docs reachable on the default branch. Never
-  link memory-tier paths (`.work/…`) or contract-slice paths (`docs/topics/…`) — both are
+  link memory-tier paths (`.work/…`) or contract-slice paths (`docs/topics/…`). Both are
   pruned or checkout-local and will dangle. Distill ephemeral inputs (exploration/research
   notes, session context) inline instead of linking them.
 
 ## Retention mechanics
 
 Artifacts NEVER land in the consuming repo's working tree. They land under a per-repo
-library keyed on **repo identity, not checkout path** — this repo's per-ticket worktrees
+library keyed on **repo identity, not checkout path**. This repo's per-ticket worktrees
 are pruned after merge, so a path-keyed slug would strand every report under a dead slug
 and leave `recall` from the main clone empty. The remote is normalized to a
 protocol-agnostic `host/org/repo` form before hashing, so the SSH and HTTPS remotes of one
@@ -123,15 +123,15 @@ repo_slug="$base-$hash"
   shared per-plugin data directory.
 - **Repo-tree guard:** resolve `report_library_dir` to an absolute path before writing; if
   it is `${CLAUDE_PROJECT_DIR}` or nested under it, refuse it, warn the user, and fall back
-  to the `${CLAUDE_PLUGIN_DATA}` default — reports must never land in the consuming repo's
+  to the `${CLAUDE_PLUGIN_DATA}` default, reports must never land in the consuming repo's
   working tree, regardless of how the userConfig is set.
-- **Filename:** `<date>-<change-slug>-<short-hash>.html` (or `.md`) — `<date>` is
+- **Filename:** `<date>-<change-slug>-<short-hash>.html` (or `.md`). `<date>` is
   `YYYY-MM-DD`, `<change-slug>` a kebab slug of the change (from the PR/ticket title),
   `<short-hash>` the short HEAD commit hash, so reports stay unique and sortable.
 
 ## Non-gating posture
 
-`quiz_policy` governs **offer cadence only** — no value ever auto-generates a report.
+`quiz_policy` governs **offer cadence only**. No value ever auto-generates a report.
 Generation is ALWAYS user-confirmed: the report + quiz is produced only after the user
 accepts an offer, and a direct invocation ("quiz me") is itself that acceptance.
 
@@ -142,15 +142,15 @@ accepts an offer, and a direct invocation ("quiz me") is itself that acceptance.
 | `always` | Suggests a quiz after each completed change. |
 | `above-threshold` | Suggests when the change meets the threshold below. |
 
-- **Threshold** (`above-threshold`): the change meets ANY of — more than 5 files touched,
+- **Threshold** (`above-threshold`): the change meets ANY of, more than 5 files touched,
   more than 200 changed LOC, or the governing plan records blast radius HIGH/CRITICAL.
   Resolve the default branch first, then judge from the merge-base diff against its
   remote-tracking ref at offer time (well-defined even after commits, and correct in a PR
   worktree with no local branch): `d="$(git remote show origin 2>/dev/null | awk '/HEAD
   branch/ {print $NF}')"; git diff --stat "$(git merge-base HEAD "origin/$d")"..HEAD`. If
-  `origin` is absent the threshold is unjudgeable — offer nothing.
+  `origin` is absent the threshold is unjudgeable, offer nothing.
 - Offers are **best-effort**, model-initiated from the description triggers and this
-  posture — there is no hook. An unknown `quiz_policy` value falls back to `on-request`.
+  posture, there is no hook. An unknown `quiz_policy` value falls back to `on-request`.
 
 ## Recall
 
@@ -159,7 +159,7 @@ retained report library (see "Retention mechanics") FIRST; fall back to git hist
 the tracker second. **State which source answered.**
 
 **Coverage boundary:** the library holds ONLY work that was actually quizzed
-(retention-at-write) — it is not a general work-history engine. When a query names work
+(retention-at-write). It is not a general work-history engine. When a query names work
 that was never quizzed, say so and route to the git/tracker archaeology fallback rather
 than implying the library is complete.
 
@@ -167,7 +167,7 @@ than implying the library is complete.
 
 This skill is an optional post-work step; it never edits another plugin's gate sequence.
 Consumers that run a staged workflow (session-flow's workflow skill, if installed) can
-route to `/education:quiz-me` as a comprehension step by pointer — the composition lives
+route to `/education:quiz-me` as a comprehension step by pointer, the composition lives
 here and in that consumer's own on-ramps, not by mutating a shared stage list.
 
 ## Gotchas
@@ -175,10 +175,10 @@ here and in that consumer's own on-ramps, not by mutating a shared stage list.
 - **The object is the human, not the artifact.** If you find yourself checking whether the
   code works, you are in the wrong skill (see "What this skill does NOT do").
 - **Never write to the consuming repo's tree.** Reports go to the retention library only;
-  a report committed into the product repo is a defect — and a `report_library_dir` pointing
+  a report committed into the product repo is a defect, and a `report_library_dir` pointing
   inside the repo tree is refused and defaulted, not honored.
 - **Embed the answer key in the artifact.** A report with no key cannot be graded in a
-  later session — the retention use case depends on it.
+  later session, the retention use case depends on it.
 - **Don't imply library completeness on `recall`.** Only quizzed work is retained; name
   the boundary and fall back to archaeology for the rest.
 - **Durable pointers only in reports.** A link to `.work/…` or `docs/topics/…` dangles the
@@ -186,8 +186,8 @@ here and in that consumer's own on-ramps, not by mutating a shared stage list.
 
 ## What this skill does NOT do
 
-- **Not artifact verification.** "Did we build the right thing, and does it work?" — object
-  = the artifact — belongs to `verification:confirm` (if installed). This skill's object is
+- **Not artifact verification.** "Did we build the right thing, and does it work?", object
+  = the artifact, belongs to `verification:confirm` (if installed). This skill's object is
   the human's comprehension of completed work.
 - **Not pre-work intent extraction.** `planning:interview` (if installed) runs BEFORE work
   to extract the USER's intent, where the user holds the answers. Here the work is done and
@@ -196,6 +196,6 @@ here and in that consumer's own on-ramps, not by mutating a shared stage list.
   `/education:teach exercise` quiz the learner on LEARNING CONTENT inside a teach workspace.
   `/education:quiz-me`'s object is the COMPLETED WORK of a change, with no learning
   workspace. Namespacing keeps them distinct.
-- **Not a merge gate.** A failed quiz is a signal to resolve, not a block — `quiz_policy`
+- **Not a merge gate.** A failed quiz is a signal to resolve, not a block, `quiz_policy`
   only tunes how often a quiz is OFFERED, never whether the merge proceeds, and no report
   generates without the user's confirmation.

--- a/plugins/education/skills/setup/SKILL.md
+++ b/plugins/education/skills/setup/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: "Validate the education plugin's quiz, report-library, and teach workspace-root configuration and explain how to change it through Claude Code's plugin configuration prompt. Use when: 'set up education', 'configure education', 'education setup', quiz offers feel wrong, report recall cannot find prior quizzes, or teach workspaces land somewhere unexpected. Actions: check (read-only verification, default and only action — this plugin's entire configuration is native userConfig, so there is nothing an apply could write)."
+description: "Validate the education plugin's quiz, report-library, and teach workspace-root configuration and explain how to change it through Claude Code's plugin configuration prompt. Use when: 'set up education', 'configure education', 'education setup', quiz offers feel wrong, report recall cannot find prior quizzes, or teach workspaces land somewhere unexpected. Actions: check (read-only verification, default and only action. This plugin's entire configuration is native userConfig, so there is nothing an apply could write)."
 argument-hint: "check"
 user-invocable: true
 disable-model-invocation: true
@@ -14,7 +14,7 @@ values. Claude Code prompts for them when the plugin is enabled and owns persist
 
 Check-only per the uniform setup contract's userConfig-only carve-out: this plugin's entire
 configuration surface is native `userConfig`, so `check` (the default and only action) verifies
-and reports, and reconfiguration routes through Claude Code's native flow — an `apply` here
+and reports, and reconfiguration routes through Claude Code's native flow, an `apply` here
 would have nothing to write except the `pluginConfigs` setup must never touch. Non-interactive:
 report and recommend; never block on a question.
 
@@ -26,20 +26,20 @@ Official contract: <https://code.claude.com/docs/en/plugins-reference#user-confi
    `${user_config.workspace_root}` values from this skill. Do not inspect or edit
    `settings.json`, `settings.local.json`, managed settings, or `pluginConfigs` directly.
 2. Explain the effective `quiz_policy`:
-   - `off` — quiz-me never offers a post-work quiz;
-   - `on-request` (default) — offers only when asked;
-   - `always` — offers after each completed change;
-   - `above-threshold` — offers when the change is large;
+   - `off`, quiz-me never offers a post-work quiz;
+   - `on-request` (default). Offers only when asked;
+   - `always`, offers after each completed change;
+   - `above-threshold`, offers when the change is large;
    - any other value is treated as `on-request` at runtime.
 3. Explain the effective report library root:
-   - empty or unexpanded `report_library_dir` — reports live under the plugin's own persistent
+   - empty or unexpanded `report_library_dir`, reports live under the plugin's own persistent
      data directory;
-   - configured directory outside the consuming project — reports and recall search that checkout;
-   - configured directory that is `${CLAUDE_PROJECT_DIR}` or nested under it — quiz-me's
+   - configured directory outside the consuming project, reports and recall search that checkout;
+   - configured directory that is `${CLAUDE_PROJECT_DIR}` or nested under it, quiz-me's
      repo-tree guard refuses it and falls back to `${CLAUDE_PLUGIN_DATA}` (same effective root
      as unset).
 4. Explain the effective teach workspace root:
-   - empty or unexpanded `workspace_root` — FIRST read the rung-3 pointer file
+   - empty or unexpanded `workspace_root`. FIRST read the rung-3 pointer file
      `${CLAUDE_PLUGIN_DATA}/workspace-root`: when present and it names an existing directory,
      report THAT path as the effective topic-mode root (it persists a prior one-time ask, and
      also records the migration-offer outcome); when absent or invalid, report the documented
@@ -47,8 +47,8 @@ Official contract: <https://code.claude.com/docs/en/plugins-reference#user-confi
      home for topic mode → plugin data); codebase-mode workspaces stay under plugin data by
      default either way (their lessons can embed private-repo snippets; Documents roots are
      often cloud-synced);
-   - configured directory outside the consuming project — both modes root there;
-   - configured directory that is `${CLAUDE_PROJECT_DIR}` or nested under it — teach's
+   - configured directory outside the consuming project, both modes root there;
+   - configured directory that is `${CLAUDE_PROJECT_DIR}` or nested under it, teach's
      repo-tree guard refuses it (a committed root requires a declaration in the project's own
      CLAUDE.md or rules), falling back to the rest of the ladder.
 5. State the tradeoff instead of asking: machine-private plugin data (default) versus a dedicated
@@ -63,8 +63,8 @@ Official contract: <https://code.claude.com/docs/en/plugins-reference#user-confi
    scope. Never uninstall to reconfigure: that drops the whole stored `pluginConfigs` entry and
    resets every option to its manifest default). Claude Code owns persistence. Do not hand-edit
    any `pluginConfigs` key.
-7. Tell the user to rerun `check` after reconfiguration — in a fresh session, since the rendered
-   values are injected at load — then verify and report the effective settings.
+7. Tell the user to rerun `check` after reconfiguration, in a fresh session, since the rendered
+   values are injected at load, then verify and report the effective settings.
 
 ## Output
 

--- a/plugins/education/skills/teach/SKILL.md
+++ b/plugins/education/skills/teach/SKILL.md
@@ -11,20 +11,20 @@ metadata:
 
 ## Purpose
 
-Teach a user interactively across multiple sessions — not by lecturing, but by coaching through the Knowledge-Skills-Wisdom progression grounded in the user's real goals. Maintains persistent learning state so each session builds on prior understanding.
+Teach a user interactively across multiple sessions. Not by lecturing, but by coaching through the Knowledge-Skills-Wisdom progression grounded in the user's real goals. Maintains persistent learning state so each session builds on prior understanding.
 
 **Use when:** user asks to learn across sessions (`teach me`, `study session`, `help me learn`, `onboard me to`). **Skip when:** one-off inline question (answer directly); task-context codebase investigation (use the project's own code-exploration tooling); extracting book knowledge to a reference file (`/knowledge:book-distill` when installed).
 
 Two modes share pedagogy but differ in source material:
 
-- **`topic`** — general subject learning. Resources come from external high-trust sources (books, courses, docs, communities).
-- **`codebase`** — repo-grounded learning. Resources come from the consuming repo's own code, docs, ADRs, conventions, discovered at teach-time (see "Codebase mode").
+- **`topic`**. General subject learning. Resources come from external high-trust sources (books, courses, docs, communities).
+- **`codebase`**. Repo-grounded learning. Resources come from the consuming repo's own code, docs, ADRs, conventions, discovered at teach-time (see "Codebase mode").
 
-**Workspace layout** (where persistent learning state lives): see "Workspace layout" below — the single source of truth every action resolves paths against. Informed by ZPD/K-S-W pedagogy research.
+**Workspace layout** (where persistent learning state lives): see "Workspace layout" below. The single source of truth every action resolves paths against. Informed by ZPD/K-S-W pedagogy research.
 
 ## Workspace layout
 
-Learning state is the user's own study material — user documents, not machine internals. Every workspace lives at `<workspace-root>/<project-slug>/<mode>/<topic>/`, where `<workspace-root>` resolves per "Workspace root resolution" below (topic mode defaults to the OS Documents folder's `Claude Learning/` home where one is eligible; codebase mode defaults to `${CLAUDE_PLUGIN_DATA}`); no root ever pollutes the consuming repo unless the project itself declares one:
+Learning state is the user's own study material. User documents, not machine internals. Every workspace lives at `<workspace-root>/<project-slug>/<mode>/<topic>/`, where `<workspace-root>` resolves per "Workspace root resolution" below (topic mode defaults to the OS Documents folder's `Claude Learning/` home where one is eligible; codebase mode defaults to `${CLAUDE_PLUGIN_DATA}`); no root ever pollutes the consuming repo unless the project itself declares one:
 
 ```text
 <workspace-root>/<project-slug>/<mode>/<topic>/
@@ -45,19 +45,19 @@ Learning state is the user's own study material — user documents, not machine 
 
 Path resolution rules every action MUST follow:
 
-- **`<project-slug>`** — **canonicalize the project path FIRST**, then derive BOTH the basename-slug and the hash from that one canonical path, so a project opened via a symlink and via its real path map to the same workspace (otherwise the alias basename would still split it — `alias-<hash>` vs `realname-<hash>`). Canonical path: `realpath "${CLAUDE_PROJECT_DIR}" 2>/dev/null || readlink -f "${CLAUDE_PROJECT_DIR}" 2>/dev/null || printf '%s' "${CLAUDE_PROJECT_DIR}"` (e.g. macOS repos under `/private/var/…`) — and when the project is a **linked git worktree**, hoist to the main repository first: if `git rev-parse --git-common-dir` names a `.git` outside the project, the directory holding it is the canonical path, so all worktrees of one repo share one workspace. Then `<project-slug>` = the **basename of the canonical path** slugified to lowercase alphanumerics and hyphens, then `-` plus the first 8 hex chars of `printf '%s' "<canonical-path>" | { sha256sum 2>/dev/null || shasum -a 256; } | cut -c1-8` (the fallback covers stock macOS). The hash discriminator is required because the basename alone collides when two clones share a directory name. Both `topic` and `codebase` workspaces are scoped under `<project-slug>` — topic learning becomes associated with the project you launched from. `scripts/list-workspaces.sh` implements this derivation (including the worktree hoist, and a compat scan that lists pre-hoist per-worktree slugs labeled `(legacy worktree slug)`); this bullet stays normative for it.
-- **`<mode>`** — literally `topic` or `codebase`, matching the action that created the workspace. This level keeps the two modes independent: `/education:teach topic auth-flow` and `/education:teach codebase auth-flow` in the same project resolve to separate workspaces (`.../topic/auth-flow/` vs `.../codebase/auth-flow/`) instead of one seeding over the other's `MISSION.md` / `RESOURCES.md`.
-- **`<topic>`** and **`<concept>`** — content-named kebab slugs (lowercase alphanumerics and hyphens only; strip `/`, `\`, `..`), NOT sequence-numbered. A deictic subject ("this repo") is first resolved to a stable content name per the Smart default rules — never slug the deixis itself. `"Domain-Driven Design"` → `domain-driven-design`; `"Rust Ownership"` → `rust-ownership`. **Record the exact raw subject/concept name** (`MISSION.md`'s `# Mission: {Topic}` title for a topic; for a concept, the lesson's `**Concept:**` line in `lesson.md` or its `<meta name="concept" content="…">` in `lesson.html` — the lesson carries the raw name in whichever of the two formats it is written, so the guard below never depends on the extension) so it is the source of truth for collision checks. **Guard against slug collisions** — distinct subjects can normalize to the same slug (`C++` and `C#` → `c`; `Node.js` and `Node JS` → `node-js`), which would silently share one workspace. Before creating a workspace whose slug directory already exists, read that existing workspace's recorded raw name; if it names a DIFFERENT subject, append `-` plus the first 4 hex chars of `printf '%s' '<raw-name>' | { sha256sum 2>/dev/null || shasum -a 256; } | cut -c1-4` to the new slug, keeping per-subject state isolated while leaving non-colliding slugs readable.
+- **`<project-slug>`**. **canonicalize the project path FIRST**, then derive BOTH the basename-slug and the hash from that one canonical path, so a project opened via a symlink and via its real path map to the same workspace (otherwise the alias basename would still split it. `alias-<hash>` vs `realname-<hash>`). Canonical path: `realpath "${CLAUDE_PROJECT_DIR}" 2>/dev/null || readlink -f "${CLAUDE_PROJECT_DIR}" 2>/dev/null || printf '%s' "${CLAUDE_PROJECT_DIR}"` (e.g. macOS repos under `/private/var/…`). And when the project is a **linked git worktree**, hoist to the main repository first: if `git rev-parse --git-common-dir` names a `.git` outside the project, the directory holding it is the canonical path, so all worktrees of one repo share one workspace. Then `<project-slug>` = the **basename of the canonical path** slugified to lowercase alphanumerics and hyphens, then `-` plus the first 8 hex chars of `printf '%s' "<canonical-path>" | { sha256sum 2>/dev/null || shasum -a 256; } | cut -c1-8` (the fallback covers stock macOS). The hash discriminator is required because the basename alone collides when two clones share a directory name. Both `topic` and `codebase` workspaces are scoped under `<project-slug>`. Topic learning becomes associated with the project you launched from. `scripts/list-workspaces.sh` implements this derivation (including the worktree hoist, and a compat scan that lists pre-hoist per-worktree slugs labeled `(legacy worktree slug)`); this bullet stays normative for it.
+- **`<mode>`**. Literally `topic` or `codebase`, matching the action that created the workspace. This level keeps the two modes independent: `/education:teach topic auth-flow` and `/education:teach codebase auth-flow` in the same project resolve to separate workspaces (`.../topic/auth-flow/` vs `.../codebase/auth-flow/`) instead of one seeding over the other's `MISSION.md` / `RESOURCES.md`.
+- **`<topic>`** and **`<concept>`**. Content-named kebab slugs (lowercase alphanumerics and hyphens only; strip `/`, `\`, `..`), NOT sequence-numbered. A deictic subject ("this repo") is first resolved to a stable content name per the Smart default rules. Never slug the deixis itself. `"Domain-Driven Design"` → `domain-driven-design`; `"Rust Ownership"` → `rust-ownership`. **Record the exact raw subject/concept name** (`MISSION.md`'s `# Mission: {Topic}` title for a topic; for a concept, the lesson's `**Concept:**` line in `lesson.md` or its `<meta name="concept" content="…">` in `lesson.html`. The lesson carries the raw name in whichever of the two formats it is written, so the guard below never depends on the extension) so it is the source of truth for collision checks. **Guard against slug collisions**. Distinct subjects can normalize to the same slug (`C++` and `C#` → `c`; `Node.js` and `Node JS` → `node-js`), which would silently share one workspace. Before creating a workspace whose slug directory already exists, read that existing workspace's recorded raw name; if it names a DIFFERENT subject, append `-` plus the first 4 hex chars of `printf '%s' '<raw-name>' | { sha256sum 2>/dev/null || shasum -a 256; } | cut -c1-4` to the new slug, keeping per-subject state isolated while leaving non-colliding slugs readable.
 - **`learning-records/NNNN-<slug>.md`** keeps `NNNN-` numbering (sanctioned ADR-style append-only log). Scan the directory for the highest existing `NNNN` and increment.
-- `${CLAUDE_PLUGIN_DATA}` is created automatically the first time it is referenced and persists across plugin updates, so workspaces survive between sessions. A user-chosen root (Documents home, configured root) gets its `Claude Learning/`-style home created only at first workspace creation there — the platform Documents directory itself is NEVER created by this skill.
+- `${CLAUDE_PLUGIN_DATA}` is created automatically the first time it is referenced and persists across plugin updates, so workspaces survive between sessions. A user-chosen root (Documents home, configured root) gets its `Claude Learning/`-style home created only at first workspace creation there, the platform Documents directory itself is NEVER created by this skill.
 
-Lessons default to interactive, self-contained `lesson.html` where the learner's host can render it; on headless hosts, and where interactivity pays nothing, the lesson is `lesson.md` (one lesson file per concept, never both — the platform-aware format decision, identity/meta, and replacement rules live in [context/lessons.md](context/lessons.md)). The durable trio — `reference.md`, learning records, `GLOSSARY.md` — stays markdown, the diffable source of truth; `exercise.md` stays markdown too, and only the workspace-less `primer` renders to a temp path.
+Lessons default to interactive, self-contained `lesson.html` where the learner's host can render it; on headless hosts, and where interactivity pays nothing, the lesson is `lesson.md` (one lesson file per concept, never both. The platform-aware format decision, identity/meta, and replacement rules live in [context/lessons.md](context/lessons.md)). The durable trio. `reference.md`, learning records, `GLOSSARY.md`. Stays markdown, the diffable source of truth; `exercise.md` stays markdown too, and only the workspace-less `primer` renders to a temp path.
 
 ## Workspace root resolution
 
 ### Effective configuration (substituted at load)
 
-The value below substitutes from this plugin's stored configuration when this skill loads. A surviving literal `${user_config.…}` placeholder means the key is unset — apply its documented unset behavior, and never paste the raw placeholder into a shell command (the probe script also filters it defensively).
+The value below substitutes from this plugin's stored configuration when this skill loads. A surviving literal `${user_config.…}` placeholder means the key is unset. Apply its documented unset behavior, and never paste the raw placeholder into a shell command (the probe script also filters it defensively).
 
 | Key | Value | Unset behavior |
 | --- | --- | --- |
@@ -67,27 +67,27 @@ The value below substitutes from this plugin's stored configuration when this sk
 
 Resolve `<workspace-root>` by the first rung that answers. Cross-root semantics: for a given `<project-slug>/<mode>/<topic>`, the ladder-highest root wins; duplicates found at lower roots are surfaced to the user, never merged.
 
-1. **Project declaration** — a `teach workspace root: <path>` declaration in the consuming project's CLAUDE.md or rules files (the repo's config-cascade convention). The only rung that may name a path inside the consuming repo — an explicit team choice that commits personal learning state. **The declared value is UNTRUSTED input** (a third-party repo's author controls it, not the person learning): it must satisfy the same value grammar as rung 2 — a plain path (absolute, `~`-home-relative, `${NAME}`/`%NAME%` env refs, or project-relative), nothing else. REFUSE — loudly, falling to the next rung — any value containing shell metacharacters, command or variable substitution syntax (`$(`, backticks, `;`, `|`, `&`, `<`, `>`, quotes, newlines), or that is not parseable as a single path. Never execute, expand, or eval a declared value.
-2. **`workspace_root` userConfig** — the table above; surfaced and validated by `/education:setup`.
+1. **Project declaration**. A `teach workspace root: <path>` declaration in the consuming project's CLAUDE.md or rules files (the repo's config-cascade convention). The only rung that may name a path inside the consuming repo. An explicit team choice that commits personal learning state. **The declared value is UNTRUSTED input** (a third-party repo's author controls it, not the person learning): it must satisfy the same value grammar as rung 2. A plain path (absolute, `~`-home-relative, `${NAME}`/`%NAME%` env refs, or project-relative), nothing else. REFUSE. Loudly, falling to the next rung. Any value containing shell metacharacters, command or variable substitution syntax (`$(`, backticks, `;`, `|`, `&`, `<`, `>`, quotes, newlines), or that is not parseable as a single path. Never execute, expand, or eval a declared value.
+2. **`workspace_root` userConfig**. The table above; surfaced and validated by `/education:setup`.
 
-**Resolved roots are inert data, from every rung.** Pass a resolved root to `list-workspaces.sh`, the assets splice, and the open-lesson command as a literal argv argument only — never interpolated into a hand-composed shell string where substitution could fire, and never as part of a command name. This applies to every place a `<workspace-root>`-derived path appears in this skill and its context docs.
-3. **Ask-once (`topic` mode only)** — first TOPIC workspace creation with rungs 1–2 unset in an interactive session: ask ONCE where learning state should live, offering the rung-4 default. A `codebase` workspace never triggers this rung and its creation never offers a Documents root — codebase state leaves plugin-data only via explicit rung 1–2 configuration (see Mode split). Persist the answer in the pointer file `${CLAUDE_PLUGIN_DATA}/workspace-root` (never a `pluginConfigs` write), and recommend making it durable via the native `workspace_root` userConfig (`/education:setup`). The pointer file is a **machine-local cache only**: before asking, adopt without asking an existing `Claude Learning/` home at the rung-4 location or an existing workspace tree at a configured root. It also records the migration-offer outcome (below). Non-interactive/headless sessions skip this rung silently; when plugin-data is unavailable, fall through silently rather than erroring.
-4. **OS Documents default — `topic` mode only.** Resolve mechanically with `bash "${CLAUDE_PLUGIN_ROOT}/skills/teach/scripts/list-workspaces.sh" --default-root`: the platform Documents directory (Windows Documents known folder resolved native-side and converted per the marketplace `docs/conventions/windows-path-emit/` convention — OneDrive-redirected and space-bearing paths handled, fail-loud; macOS `~/Documents`; Linux `xdg-user-dir DOCUMENTS`) qualifies ONLY when it already exists AND is not `$HOME` itself (unconfigured `xdg-user-dir` echoes `$HOME`), and the home inside it is the properly-cased `Claude Learning/` (English name; localize only if the user asks). Exit 1 from `--default-root` = no eligible default → rung 5.
-5. **`${CLAUDE_PLUGIN_DATA}` fallback** — headless/unset/no-Documents hosts, and the compat home where every pre-ladder workspace already lives.
+**Resolved roots are inert data, from every rung.** Pass a resolved root to `list-workspaces.sh`, the assets splice, and the open-lesson command as a literal argv argument only. Never interpolated into a hand-composed shell string where substitution could fire, and never as part of a command name. This applies to every place a `<workspace-root>`-derived path appears in this skill and its context docs.
+3. **Ask-once (`topic` mode only)**. First TOPIC workspace creation with rungs 1–2 unset in an interactive session: ask ONCE where learning state should live, offering the rung-4 default. A `codebase` workspace never triggers this rung and its creation never offers a Documents root. Codebase state leaves plugin-data only via explicit rung 1–2 configuration (see Mode split). Persist the answer in the pointer file `${CLAUDE_PLUGIN_DATA}/workspace-root` (never a `pluginConfigs` write), and recommend making it durable via the native `workspace_root` userConfig (`/education:setup`). The pointer file is a **machine-local cache only**: before asking, adopt without asking an existing `Claude Learning/` home at the rung-4 location or an existing workspace tree at a configured root. It also records the migration-offer outcome (below). Non-interactive/headless sessions skip this rung silently; when plugin-data is unavailable, fall through silently rather than erroring.
+4. **OS Documents default. `topic` mode only.** Resolve mechanically with `bash "${CLAUDE_PLUGIN_ROOT}/skills/teach/scripts/list-workspaces.sh" --default-root`: the platform Documents directory (Windows Documents known folder resolved native-side and converted per the marketplace `docs/conventions/windows-path-emit/` convention. OneDrive-redirected and space-bearing paths handled, fail-loud; macOS `~/Documents`; Linux `xdg-user-dir DOCUMENTS`) qualifies ONLY when it already exists AND is not `$HOME` itself (unconfigured `xdg-user-dir` echoes `$HOME`), and the home inside it is the properly-cased `Claude Learning/` (English name; localize only if the user asks). Exit 1 from `--default-root` = no eligible default → rung 5.
+5. **`${CLAUDE_PLUGIN_DATA}` fallback**. Headless/unset/no-Documents hosts, and the compat home where every pre-ladder workspace already lives.
 
-**Mode split:** the Documents default applies to `topic` workspaces only; **`codebase` workspaces stay under `${CLAUDE_PLUGIN_DATA}` by default**. Documents roots are commonly cloud-synced (OneDrive/iCloud), and codebase lessons embed repo snippets that must not silently leave the machine for a private repo — a codebase workspace lands at a user-chosen root only via explicit rung 1–2 configuration.
+**Mode split:** the Documents default applies to `topic` workspaces only; **`codebase` workspaces stay under `${CLAUDE_PLUGIN_DATA}` by default**. Documents roots are commonly cloud-synced (OneDrive/iCloud), and codebase lessons embed repo snippets that must not silently leave the machine for a private repo, a codebase workspace lands at a user-chosen root only via explicit rung 1–2 configuration.
 
-**Migration and compat:** plugin-data workspaces stay readable forever — rung 5 is always scanned. When an interactive session resolves a higher root while plugin-data workspaces exist, offer a ONE-TIME migration (move the tree); record the outcome either way in the rung-3 pointer file and never re-offer. Never force-migrate; if compat ever cannot stay scan-only, stop and ask the user.
+**Migration and compat:** plugin-data workspaces stay readable forever. Rung 5 is always scanned. When an interactive session resolves a higher root while plugin-data workspaces exist, offer a ONE-TIME migration (move the tree); record the outcome either way in the rung-3 pointer file and never re-offer. Never force-migrate; if compat ever cannot stay scan-only, stop and ask the user.
 
-**Root hazards (documented, not silent):** cloud-synced roots — machine-scoped slugs mean the same repo on two machines gets sibling workspaces in one synced root (no illusory continuity), and sync conflicts can collide on `learning-records/NNNN`; gitignored in-repo roots fragment across worktrees; temp roots die with the session; committed roots put personal learning state in a shared repo (explicit rung-1 team choice only).
+**Root hazards (documented, not silent):** cloud-synced roots. Machine-scoped slugs mean the same repo on two machines gets sibling workspaces in one synced root (no illusory continuity), and sync conflicts can collide on `learning-records/NNNN`; gitignored in-repo roots fragment across worktrees; temp roots die with the session; committed roots put personal learning state in a shared repo (explicit rung-1 team choice only).
 
 ## Pre-computed Context
 
-Gather with one Bash call (worktree-isolated agents refuse `$`-expansion in pre-compute blocks; #1687 — and `${user_config.*}` tokens must NEVER appear on this line: a surviving literal is a bash `bad substitution` that kills the whole call before any fallback):
+Gather with one Bash call (worktree-isolated agents refuse `$`-expansion in pre-compute blocks; #1687. And `${user_config.*}` tokens must NEVER appear on this line: a surviving literal is a bash `bad substitution` that kills the whole call before any fallback):
 
-- Plugin-data workspaces — `bash "${CLAUDE_PLUGIN_ROOT}/skills/teach/scripts/list-workspaces.sh" "${CLAUDE_PROJECT_DIR}" "${CLAUDE_PLUGIN_DATA}" 2>/dev/null || echo "none"`
+- Plugin-data workspaces, `bash "${CLAUDE_PLUGIN_ROOT}/skills/teach/scripts/list-workspaces.sh" "${CLAUDE_PROJECT_DIR}" "${CLAUDE_PLUGIN_DATA}" 2>/dev/null || echo "none"`
 
-Treat failure as `"none"` and continue. This probe covers rung 5 only. After resolving the ladder in the body, re-invoke the script as an ordinary Bash call with every resolved root as an argument, ladder-highest first — `list-workspaces.sh "${CLAUDE_PROJECT_DIR}" <root>...` — and distinguish its exits: **exit 2 = probe broken** (usage error / all roots filtered as unset) → glob the resolved roots manually before creating any workspace; a printed `none` with exit 0 = genuinely no workspaces.
+Treat failure as `"none"` and continue. This probe covers rung 5 only. After resolving the ladder in the body, re-invoke the script as an ordinary Bash call with every resolved root as an argument, ladder-highest first, `list-workspaces.sh "${CLAUDE_PROJECT_DIR}" <root>...`, and distinguish its exits: **exit 2 = probe broken** (usage error / all roots filtered as unset) → glob the resolved roots manually before creating any workspace; a printed `none` with exit 0 = genuinely no workspaces.
 
 ## Action Router
 
@@ -100,8 +100,8 @@ Parse `$ARGUMENTS`: first token = action, remainder = args. If empty or ambiguou
 | `mission` | Review or update learning mission | [context/mission.md](context/mission.md) |
 | `glossary` | Review or update compressed terminology | [context/glossary.md](context/glossary.md) |
 | `resources` | Manage curated learning sources | [context/resources.md](context/resources.md) |
-| `explain <concept>` | Teach one tightly-scoped thing (a lesson) | Writes the concept's single lesson file (`lesson.html`/`lesson.md` per [context/lessons.md](context/lessons.md)) — pedagogically ephemeral but durable machine state on disk; distill a durable `reference.md` alongside |
-| `primer <domain>` | Single-session domain primer — NO workspace | See "Primer action" below |
+| `explain <concept>` | Teach one tightly-scoped thing (a lesson) | Writes the concept's single lesson file (`lesson.html`/`lesson.md` per [context/lessons.md](context/lessons.md)). Pedagogically ephemeral but durable machine state on disk; distill a durable `reference.md` alongside |
+| `primer <domain>` | Single-session domain primer. NO workspace | See "Primer action" below |
 | `exercise` | Colocated practice for a concept | Writes `concepts/<concept>/exercise.md`; design per [context/exercises.md](context/exercises.md) |
 | `assess` | Check understanding, update learning records | [context/assessment.md](context/assessment.md) |
 | `resume` | Resume a workspace from prior session | Reads workspace state, picks up where left off |
@@ -110,61 +110,61 @@ Parse `$ARGUMENTS`: first token = action, remainder = args. If empty or ambiguou
 **Smart default:** if the user provides a subject without an action, detect mode:
 
 - Subject names a concept in the consuming repo (a module, a framework the repo uses, an internal library or abstraction the repo defines) → `codebase`
-- Subject is the whole repo or deictic — "this repo", "this codebase", "onboard me here" → `codebase`, and derive a **stable content name** rather than slugging the deixis: repo basename + a scope word (raw name `"<repo-basename> overview"` → slug `<repo-basename>-overview`), recorded as the raw subject name so two runs of the same request resolve to one workspace
+- Subject is the whole repo or deictic. "this repo", "this codebase", "onboard me here" → `codebase`, and derive a **stable content name** rather than slugging the deixis: repo basename + a scope word (raw name `"<repo-basename> overview"` → slug `<repo-basename>-overview`), recorded as the raw subject name so two runs of the same request resolve to one workspace
 - Otherwise → `topic`
 
 ## Primer action
 
 `primer <domain>` is the single-session middle tier between an inline answer and a full `topic` workspace: the user needs enough of an unfamiliar domain's vocabulary and quality criteria to prompt well NOW ("teach me color grading so I can direct the work"), not a multi-session curriculum. Purpose: turn a vague request into a precise spec by teaching what the terms of art are and what GOOD looks like.
 
-- **No workspace** — no `<topic>` directory, mission interview, glossary, or learning records. Output is the session conversation plus an optional self-contained HTML vocabulary ladder (vague term → precise spec, with copy-out) per "Lessons and Reference" HTML routing.
-- **Shape** — intake the user's starting point (one question), then build the vocabulary ladder: core terms, the quality axes experts judge by, worked good-vs-bad examples, and a closing "how to ask for what you want" prompt template.
-- **Ground per Knowledge layer** — primary sources this turn, never parametric recall.
-- **Escalate** — if the user wants depth or practice, offer `/education:teach topic <domain>` (full workspace).
+- **No workspace**. No `<topic>` directory, mission interview, glossary, or learning records. Output is the session conversation plus an optional self-contained HTML vocabulary ladder (vague term → precise spec, with copy-out) per "Lessons and Reference" HTML routing.
+- **Shape**. Intake the user's starting point (one question), then build the vocabulary ladder: core terms, the quality axes experts judge by, worked good-vs-bad examples, and a closing "how to ask for what you want" prompt template.
+- **Ground per Knowledge layer**. Primary sources this turn, never parametric recall.
+- **Escalate**. If the user wants depth or practice, offer `/education:teach topic <domain>` (full workspace).
 
 ## Resume, Status, and workspace resolution
 
-`resume` and `status` operate over the workspaces under `<workspace-root>/<project-slug>/<mode>/<topic>/` for EVERY root the ladder resolves (both modes; one body re-invocation of `list-workspaces.sh` with all roots — see "Pre-computed Context"):
+`resume` and `status` operate over the workspaces under `<workspace-root>/<project-slug>/<mode>/<topic>/` for EVERY root the ladder resolves (both modes; one body re-invocation of `list-workspaces.sh` with all roots, see "Pre-computed Context"):
 
-- **`resume [<topic>]`** — with a topic argument, resolve that workspace directly (disambiguating by `<mode>` if the same topic exists in both) and follow "Resume (subsequent sessions)". With no argument, list the workspaces sorted by most-recently-modified (git or filesystem mtime of the workspace files) and ask the user which to resume — never silently pick one when more than one exists.
-- **`status`** — for each workspace, show its mode, topic, the count of `learning-records/`, the current frontier concept, the last-touched date, and a **due-for-review flag** — from filename + mtime heuristics plus ONE cheap metadata probe: exclude superseded records via a status-line grep (`grep -l 'superseded by' learning-records/*.md` — matches the `Status:` frontmatter line without loading bodies into context), since a superseded record is not part of the active floor and would otherwise emit false due-for-review flags. One line per workspace; no full file bodies loaded — the per-concept due-for-review detail loads only on `resume` of that workspace.
-- **`explain <concept>` / `exercise` need an active workspace.** They write into `concepts/<concept>/` under a topic workspace. If exactly one workspace exists, use it; if several exist, ask which; if none exists, ask whether to start one (`topic` / `codebase`) before writing — never invent a workspace silently.
+- **`resume [<topic>]`**. With a topic argument, resolve that workspace directly (disambiguating by `<mode>` if the same topic exists in both) and follow "Resume (subsequent sessions)". With no argument, list the workspaces sorted by most-recently-modified (git or filesystem mtime of the workspace files) and ask the user which to resume. Never silently pick one when more than one exists.
+- **`status`**. For each workspace, show its mode, topic, the count of `learning-records/`, the current frontier concept, the last-touched date, and a **due-for-review flag**. From filename + mtime heuristics plus ONE cheap metadata probe: exclude superseded records via a status-line grep (`grep -l 'superseded by' learning-records/*.md`. Matches the `Status:` frontmatter line without loading bodies into context), since a superseded record is not part of the active floor and would otherwise emit false due-for-review flags. One line per workspace; no full file bodies loaded. The per-concept due-for-review detail loads only on `resume` of that workspace.
+- **`explain <concept>` / `exercise` need an active workspace.** They write into `concepts/<concept>/` under a topic workspace. If exactly one workspace exists, use it; if several exist, ask which; if none exists, ask whether to start one (`topic` / `codebase`) before writing, never invent a workspace silently.
 
-## Pedagogy — Three Layers
+## Pedagogy. Three Layers
 
-Every teaching session progresses through Knowledge → Skills → Wisdom. Don't skip layers; don't rush. Each layer has different teaching moves. The knowledge/skills balance varies by topic — theory-heavy subjects (theoretical physics) lean knowledge; practice-heavy ones (yoga, a framework) lean skills. Calibrate lesson design to the topic.
+Every teaching session progresses through Knowledge → Skills → Wisdom. Don't skip layers; don't rush. Each layer has different teaching moves. The knowledge/skills balance varies by topic. Theory-heavy subjects (theoretical physics) lean knowledge; practice-heavy ones (yoga, a framework) lean skills. Calibrate lesson design to the topic.
 
 ### Fluency vs storage strength
 
-Optimize for **storage strength** — long-term retention — not **fluency**, in-the-moment recall that gives "an illusory sense of mastery" (upstream teach-skill terms; the research literature — Bjork — names the pair storage strength vs *retrieval* strength). Storage strength is built by **desirable difficulty**: retrieval practice (recall from memory before re-showing), spacing (distributing practice over time), and interleaving (mixing related topics in practice — **skills practice only**, never knowledge presentation). The asymmetry that governs lesson design: **for acquiring knowledge, difficulty is the enemy** — it eats the working memory understanding needs, so explanations stay clear and scaffolded; **for skill acquisition, difficulty is the tool** — effortful retrieval is what builds storage strength, so practice stays effortful. Quiz design inherits this: answer options carry equal length and formatting weight so presentation never leaks the answer (see [context/exercises.md](context/exercises.md)).
+Optimize for **storage strength**, long-term retention, not **fluency**, in-the-moment recall that gives "an illusory sense of mastery" (upstream teach-skill terms; the research literature, Bjork, names the pair storage strength vs *retrieval* strength). Storage strength is built by **desirable difficulty**: retrieval practice (recall from memory before re-showing), spacing (distributing practice over time), and interleaving (mixing related topics in practice. **skills practice only**, never knowledge presentation). The asymmetry that governs lesson design: **for acquiring knowledge, difficulty is the enemy**. It eats the working memory understanding needs, so explanations stay clear and scaffolded; **for skill acquisition, difficulty is the tool**. Effortful retrieval is what builds storage strength, so practice stays effortful. Quiz design inherits this: answer options carry equal length and formatting weight so presentation never leaks the answer (see [context/exercises.md](context/exercises.md)).
 
-### Knowledge (declarative — what is it?)
+### Knowledge (declarative. What is it?)
 
 - Provide clear explanations with examples and counterexamples
-- Ground per "Research grounding" below — never parametric recall at any tier. A claim that drives a lesson is verified against a source fetched or a file Read THIS turn, not recalled from training data; the ladder decides *which* fetch, never *whether*
+- Ground per "Research grounding" below. Never parametric recall at any tier. A claim that drives a lesson is verified against a source fetched or a file Read THIS turn, not recalled from training data; the ladder decides *which* fetch, never *whether*
 - Use retrieval practice: ask the user to restate in their own words
 - Add to `GLOSSARY.md` only when the user demonstrates understanding
 
 ### Research grounding
 
-Grounding is graduated — pick the cheapest tier that grounds the claim:
+Grounding is graduated, pick the cheapest tier that grounds the claim:
 
-- **Tier 0 — already-verified sources, no dispatch.** Repo files Read this turn (codebase mode) and `RESOURCES.md` citations already verified satisfy grounding for narrow or slow-domain claims. Escalate to tier 1 when a claim is contested, broad, or fast-domain (library APIs, framework syntax, tooling).
-- **Tier 1 — per-lesson research (default for fresh external claims).** Invoke `/discovery:research` via the Skill tool when installed; fallback chain when absent: inline fetch of the authoritative source, `/context7:lookup` via the Skill tool (if installed) for library docs, `/firecrawl:firecrawl` via the Skill tool (if installed) when fetches are blocked — terminating at built-in WebSearch/WebFetch. Cap: roughly one research dispatch per session unless the subject shifts — batch open questions into one dispatch.
-- **Tier 2 — workspace seeding / broad subjects.** Invoke `/discovery:research-deep` via the Skill tool (if installed), or use dynamic workflows, to seed `RESOURCES.md` when a workspace opens on a broad subject.
-- **Tier 3 — huge-subject corpus.** Invoke `/knowledge:map-corpus` via the Skill tool plus its digest skills (if installed) to build a corpus map; `RESOURCES.md` points at the produced slices.
+- **Tier 0. Already-verified sources, no dispatch.** Repo files Read this turn (codebase mode) and `RESOURCES.md` citations already verified satisfy grounding for narrow or slow-domain claims. Escalate to tier 1 when a claim is contested, broad, or fast-domain (library APIs, framework syntax, tooling).
+- **Tier 1. Per-lesson research (default for fresh external claims).** Invoke `/discovery:research` via the Skill tool when installed; fallback chain when absent: inline fetch of the authoritative source, `/context7:lookup` via the Skill tool (if installed) for library docs, `/firecrawl:firecrawl` via the Skill tool (if installed) when fetches are blocked. Terminating at built-in WebSearch/WebFetch. Cap: roughly one research dispatch per session unless the subject shifts, batch open questions into one dispatch.
+- **Tier 2. Workspace seeding / broad subjects.** Invoke `/discovery:research-deep` via the Skill tool (if installed), or use dynamic workflows, to seed `RESOURCES.md` when a workspace opens on a broad subject.
+- **Tier 3. Huge-subject corpus.** Invoke `/knowledge:map-corpus` via the Skill tool plus its digest skills (if installed) to build a corpus map; `RESOURCES.md` points at the produced slices.
 
 Adjacent intake and sources, each invoked via the Skill tool and each only if installed: `/discovery:blindspot` when the learner doesn't know what they don't know (unknown-territory intake before the mission interview); `/dometrain:grounding` for course-grounded claims; `/x:read` when a resource lives in an X post or thread.
 
-### Skills (procedural — how to do it?)
+### Skills (procedural. How to do it?)
 
 - Emphasize deliberate practice: small tasks focused on 1-2 skills at a time
 - Couple explanation with application: explain → simple use → novel use → integrated use
 - For `codebase` mode: exercises use actual repo patterns (write a handler, add a test, implement the repo's own domain primitive)
 - Use error-driven learning: present buggy code, ask the user to diagnose
-- Tight feedback loops — immediate feedback on each attempt
+- Tight feedback loops, immediate feedback on each attempt
 
-### Wisdom (judgment — when and why?)
+### Wisdom (judgment. When and why?)
 
 - Ask about tradeoffs: "You chose X; what are the pros/cons vs Y?"
 - Present multiple solutions, ask the user to choose and justify
@@ -172,27 +172,27 @@ Adjacent intake and sources, each invoked via the Skill tool and each only if in
 - Prompt transfer: "Where else could this pattern apply?"
 - Metacognitive reflection: "What tripped you up? What pattern did you learn?"
 - For `codebase` mode: connect to the repo's ADRs, architecture decisions, design philosophy
-- **Delegate to community.** Wisdom comes from real-world interaction outside the learning environment — something an AI tutor structurally cannot provide. When a question requires wisdom, attempt to answer but also find relevant communities (subreddits, Discord servers, local meetups, courses, open-source projects) where the user can test skills in practice. Record community preferences in `RESOURCES.md`. Respect opt-outs — if the user declines community participation, don't re-suggest
+- **Delegate to community.** Wisdom comes from real-world interaction outside the learning environment. Something an AI tutor structurally cannot provide. When a question requires wisdom, attempt to answer but also find relevant communities (subreddits, Discord servers, local meetups, courses, open-source projects) where the user can test skills in practice. Record community preferences in `RESOURCES.md`. Respect opt-outs. If the user declines community participation, don't re-suggest
 
 ## Lessons and Reference
 
-The unit of teaching is a **lesson** — one tightly-scoped thing tied to the mission, completable quickly for a tangible win, in the user's zone of proximal development. Lessons are ephemeral in the **pedagogical** sense only — rarely revisited and regenerable — never in the topic-docs sense: a lesson is a member of its concept slice and stays in machine state. Alongside, distill the durable **reference** — the compressed cheat-sheet the user returns to. Authoring format, the platform-aware HTML-first default, the assets splice, reuse-first scaffolds, inline citations: [context/lessons.md](context/lessons.md).
+The unit of teaching is a **lesson**. One tightly-scoped thing tied to the mission, completable quickly for a tangible win, in the user's zone of proximal development. Lessons are ephemeral in the **pedagogical** sense only. Rarely revisited and regenerable. Never in the topic-docs sense: a lesson is a member of its concept slice and stays in machine state. Alongside, distill the durable **reference**. The compressed cheat-sheet the user returns to. Authoring format, the platform-aware HTML-first default, the assets splice, reuse-first scaffolds, inline citations: [context/lessons.md](context/lessons.md).
 
 Concept diagrams: `/visualization:visualize` when installed; otherwise native mermaid blocks (markdown fences, or `<pre class="mermaid">` where a host renders HTML) cover most structural diagrams. In-lesson charts follow the `dataviz` skill's constraints when that skill is present.
 
 ## Zone of Proximal Development
 
-Teach just beyond current understanding — challenging but achievable. Scaffold and fade:
+Teach just beyond current understanding, challenging but achievable. Scaffold and fade:
 
-1. **Check current level** — read learning records, ask what they already know
-2. **Calibrate difficulty** — not too easy (bored), not too hard (frustrated)
+1. **Check current level**. Read learning records, ask what they already know
+2. **Calibrate difficulty**. Not too easy (bored), not too hard (frustrated)
 3. **Scaffold levels** (fade as competence grows):
-   - Orientation — restate in simpler terms, break into sub-steps
-   - Heuristic hints — guiding questions ("What data structure gives O(1) lookup?")
-   - Pointing hints — highlight relevant concept or code section
-   - Partial solution — show snippet with blanks
-   - Full solution + explanation — last resort, always ask the user to explain back
-4. **Track and adapt** — update learning records when understanding demonstrated
+   - Orientation, restate in simpler terms, break into sub-steps
+   - Heuristic hints, guiding questions ("What data structure gives O(1) lookup?")
+   - Pointing hints, highlight relevant concept or code section
+   - Partial solution, show snippet with blanks
+   - Full solution + explanation, last resort, always ask the user to explain back
+4. **Track and adapt**. Update learning records when understanding demonstrated
 
 ## Teaching Dialog
 
@@ -210,21 +210,21 @@ Coach through a depth-first, one-question-at-a-time dialog:
 
 ### New Workspace (first invocation)
 
-1. Run the mission interview — WHY are they learning this? What's the concrete goal? What does success look like? **Harvest first:** extract every field the opening message already answers, confirm those in one restatement, and ask only the questions still open — never re-ask what the user already said. The interview crystallizes the raw subject name the slug + collision guard depend on, which is why it comes BEFORE creation
+1. Run the mission interview. WHY are they learning this? What's the concrete goal? What does success look like? **Harvest first:** extract every field the opening message already answers, confirm those in one restatement, and ask only the questions still open. Never re-ask what the user already said. The interview crystallizes the raw subject name the slug + collision guard depend on, which is why it comes BEFORE creation
 2. Create the workspace per "Workspace layout", at the root "Workspace root resolution" gives
 3. Write `MISSION.md` with the answers
-4. Seed `NOTES.md` from the interview's constraints and teaching-preference answers; do NOT create `GLOSSARY.md` yet — it starts with the first demonstrated term (deferral per [context/glossary.md](context/glossary.md))
-5. Seed `RESOURCES.md` — for `topic` mode, find high-trust sources; for `codebase` mode, discover and list relevant repo files/docs per "Codebase mode"
-6. Assess the starting point — what do they already know? Record it as the first learning record via the `learning-records/` scan-and-increment rule, format per [context/assessment.md](context/assessment.md)
+4. Seed `NOTES.md` from the interview's constraints and teaching-preference answers; do NOT create `GLOSSARY.md` yet. It starts with the first demonstrated term (deferral per [context/glossary.md](context/glossary.md))
+5. Seed `RESOURCES.md`. For `topic` mode, find high-trust sources; for `codebase` mode, discover and list relevant repo files/docs per "Codebase mode"
+6. Assess the starting point. What do they already know? Record it as the first learning record via the `learning-records/` scan-and-increment rule, format per [context/assessment.md](context/assessment.md)
 7. Begin teaching from their zone of proximal development
 
 ### Resume (subsequent sessions)
 
-1. Read `MISSION.md` — know WHY and the success criteria
-2. Read `GLOSSARY.md` — know what terms are established
-3. Read `NOTES.md` — recall teaching preferences
-4. Scan `learning-records/` for the latest entries — know the current frontier
-5. **Surface due-for-review concepts** — weigh each floor concept's latest record age against the domain's velocity (see "Staleness"); list what is due for spaced retrieval practice BEFORE advancing the frontier, and open with a quick retrieval question on one due concept when any exist (spacing is how storage strength gets built — see "Fluency vs storage strength")
+1. Read `MISSION.md`, know WHY and the success criteria
+2. Read `GLOSSARY.md`, know what terms are established
+3. Read `NOTES.md`, recall teaching preferences
+4. Scan `learning-records/` for the latest entries, know the current frontier
+5. **Surface due-for-review concepts**. Weigh each floor concept's latest record age against the domain's velocity (see "Staleness"); list what is due for spaced retrieval practice BEFORE advancing the frontier, and open with a quick retrieval question on one due concept when any exist (spacing is how storage strength gets built. See "Fluency vs storage strength")
 6. Pick the next concept from the zone of proximal development; open its `concepts/<concept>/` slice
 7. Before re-teaching an existing concept, run the Staleness check (see "Staleness")
 
@@ -233,18 +233,18 @@ Coach through a depth-first, one-question-at-a-time dialog:
 - Summarize what was learned
 - Prompt reflection: "What's the key takeaway? What was hardest?"
 - Update `GLOSSARY.md` if new terms demonstrated
-- Write a learning record for demonstrated understanding — `/education:quiz-me` quiz results (same-plugin sibling) count as record evidence
+- Write a learning record for demonstrated understanding, `/education:quiz-me` quiz results (same-plugin sibling) count as record evidence
 - Suggest the next session's focus
 
 ## Codebase Mode
 
-`codebase` mode grounds learning in the consuming repo, discovered at teach-time — never in baked assumptions about any particular project's layout. Discover the repo, then teach from what you find:
+`codebase` mode grounds learning in the consuming repo, discovered at teach-time. Never in baked assumptions about any particular project's layout. Discover the repo, then teach from what you find:
 
-1. **Read the repo's own guidance.** Climb from `${CLAUDE_PROJECT_DIR}` for the nearest `CLAUDE.md` / `AGENTS.md`; read `README.md`; look for `docs/`, architecture-decision records (commonly `docs/adr/`, `docs/decisions/`), and convention/rules files (`.claude/rules/`, `.cursor/rules/`, a `CONTRIBUTING` file). These state how the project intends its code to be understood. When a guidance file is empty, boilerplate, or contradicts its siblings, flag that to the user, fall back to the next source (README → docs → the code itself), and record the discrepancy in `RESOURCES.md` — never treat an empty file as guidance and never silently pick a side of a contradiction.
+1. **Read the repo's own guidance.** Climb from `${CLAUDE_PROJECT_DIR}` for the nearest `CLAUDE.md` / `AGENTS.md`; read `README.md`; look for `docs/`, architecture-decision records (commonly `docs/adr/`, `docs/decisions/`), and convention/rules files (`.claude/rules/`, `.cursor/rules/`, a `CONTRIBUTING` file). These state how the project intends its code to be understood. When a guidance file is empty, boilerplate, or contradicts its siblings, flag that to the user, fall back to the next source (README → docs → the code itself), and record the discrepancy in `RESOURCES.md`, never treat an empty file as guidance and never silently pick a side of a contradiction.
 2. **Survey the structure.** Inspect the top-level layout (`src/`, `apps/`, `libs/`, `packages/`, tests) and identify languages/frameworks from manifest files present (`package.json`, `*.csproj`/`*.sln`, `pyproject.toml`, `go.mod`, `Cargo.toml`, `pom.xml`, …). Locate the files that actually embody the concept the user wants to learn.
-3. **Persist what you discover.** Record the located files/docs into the workspace `RESOURCES.md` "Repo Sources" so later sessions don't re-derive the structure — infer once, persist, reuse. If discovery cannot find a grounding for the concept, ask the user to point you at the relevant area rather than guessing.
-4. **Ground EVERYTHING in files Read this turn (Tier 0).** Never teach a codebase lesson from a cached lesson — re-Read the live files; the repo is the durable artifact, self-freshening.
-5. **Cite the convention, not the instance.** Durable codebase references capture the pattern (dependency direction, an error-handling idiom, a dispatch mechanism), not a specific file's current contents — so they survive a refactor.
+3. **Persist what you discover.** Record the located files/docs into the workspace `RESOURCES.md` "Repo Sources" so later sessions don't re-derive the structure. Infer once, persist, reuse. If discovery cannot find a grounding for the concept, ask the user to point you at the relevant area rather than guessing.
+4. **Ground EVERYTHING in files Read this turn (Tier 0).** Never teach a codebase lesson from a cached lesson, re-Read the live files; the repo is the durable artifact, self-freshening.
+5. **Cite the convention, not the instance.** Durable codebase references capture the pattern (dependency direction, an error-handling idiom, a dispatch mechanism), not a specific file's current contents, so they survive a refactor.
 
 Use the repo's actual code as examples. Create exercises against real patterns. Connect to the repo's ADRs for "why it's done this way."
 
@@ -253,13 +253,13 @@ Use the repo's actual code as examples. Create exercises against real patterns. 
 Learning artifacts persist for months; durable teaching content (references, glossary) can rot. Handle rot by **lazy verify-on-revisit**, not stored metadata:
 
 - **No freshness frontmatter.** Don't record a `verified:` date (git owns it) or a `volatility:` tag (frozen judgment that itself rots).
-- **Staleness = age × velocity judgment.** At revisit, weigh the artifact's age against the domain's velocity — fast (library APIs, framework syntax, AI tooling) vs slow (math, music theory, established architecture). Use domain-velocity intuition to decide *whether* to re-verify, never *what* the current fact is.
+- **Staleness = age × velocity judgment.** At revisit, weigh the artifact's age against the domain's velocity. Fast (library APIs, framework syntax, AI tooling) vs slow (math, music theory, established architecture). Use domain-velocity intuition to decide *whether* to re-verify, never *what* the current fact is.
 - **Treat durable artifacts as unverified on revisit.** A reference/glossary entry from a prior session is unverified synthesis until re-grounded this turn. If stale relative to age × velocity, re-fetch the inline citation, update, THEN teach.
 - **Durable references store understanding + citations, not frozen facts.** A reference that freezes an external fact guarantees rot; instead capture the user's compressed mental model with inline citations to the authoritative source, so volatile facts stay by-reference (the citation is the re-verify target).
 
 ## What This Skill Does NOT Do
 
-- **Does not write production code** — teaches understanding, not implementation. Use the project's own implementation workflow for code changes
-- **Does not replace `/knowledge:book-distill`** — that extracts book knowledge into skill reference files; `/education:teach` delivers knowledge interactively to the user
-- **Does not do task-context codebase investigation** — that's for the project's code-exploration tooling; `/education:teach codebase` is structured learning for understanding
-- **Does not auto-invoke** — `disable-model-invocation: true`. The user initiates learning sessions
+- **Does not write production code**. Teaches understanding, not implementation. Use the project's own implementation workflow for code changes
+- **Does not replace `/knowledge:book-distill`**. That extracts book knowledge into skill reference files; `/education:teach` delivers knowledge interactively to the user
+- **Does not do task-context codebase investigation**. That's for the project's code-exploration tooling; `/education:teach codebase` is structured learning for understanding
+- **Does not auto-invoke**. `disable-model-invocation: true`. The user initiates learning sessions


### PR DESCRIPTION
No linked issue

## Summary

#2891 instruction-surface de-slop cluster: purge em dashes from the `education` plugin README and every SKILL.md.

## Fix

Rewrote `plugins/education/README.md` and every `plugins/education/**/SKILL.md` under `/ai-slop:audit fix` semantics (periods, commas, or a restructured sentence; never parentheses, en dashes, or a spaced hyphen as a stand-in). Meaning-preserving self-audit repaired asides the first pass reattached to the wrong noun. The generated options block is ignore-fenced because the shared generator still emits em dashes. `education` 0.8.4.

## Verification

- Detector: 0 `rule-em-dash` findings outside ignore-fenced generated-options spans (and required trigger strings that must keep em dashes)
- `CHECK_SKILL_SKIP_MARKDOWNLINT=1 bash scripts/check-changed-skills.sh origin/main`: 0 failed; quoted trigger phrases vs origin/main preserved
- `python3 scripts/sync-plugin-options-docs.py --check` up to date
- `scripts/check-changelog-parity.sh --check-bump origin/main` passes
- `node scripts/generate-cheatsheet.mjs --check` in sync

## Related

Refs #2891

#2891 stays open.