### PR TITLE
docs(overengineering): de-slop instruction surfaces (0.3.1)

### DIFF
--- a/plugins/overengineering/.claude-plugin/plugin.json
+++ b/plugins/overengineering/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "overengineering",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Evidence-earned-keep audit of an existing enforcement surface — agent hooks and standing instructions, repository and version-control hooks, CI lanes and gate scripts, branch protections, forge apps, declared external integrations — treating every incumbent mechanism as a retirement candidate until empirical evidence earns its keep, arguing every verdict in cost of carry, capping retirement-direction verdicts on security-class artifacts at FLAG-FOR-HUMAN, and realigning to the simplest adequate solution behind an explicit per-item human gate. The audit is read-only and emits a diffable findings artifact; realignment is a separate, explicitly invoked skill; and a third read-only lane re-runs the audit on whatever cadence the consumer wires and reports only what moved since the last run, above a configurable noise budget.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/overengineering/CHANGELOG.md
+++ b/plugins/overengineering/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to the `overengineering` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.3.1]
+
+### Changed
+
+- **Instruction-surface de-slop (#2891, overengineering cluster).** Rewrote this plugin's `README.md` and every
+  `SKILL.md` to drop em dashes under the repo's zero-tolerance house policy, using
+  `/ai-slop:audit fix` semantics: periods or commas, or a restructured sentence, never
+  parentheses, en dashes, or a spaced hyphen as a stand-in. Meaning stays; only the mark
+  and the sentence break change.
+
 ## [0.3.0]
 
 ### Fixed

--- a/plugins/overengineering/README.md
+++ b/plugins/overengineering/README.md
@@ -54,7 +54,7 @@ requires, so it queues verdict changes instead of acting on them.
 
 Everything that changes the repo happens through `/overengineering:realign`, which is invoked
 deliberately, consumes the findings artifact rather than scanning on its own, and stops at a per-item
-acceptance gate before every remediation. Its execution order is the method's rollback ladder. 
+acceptance gate before every remediation. Its execution order is the method's rollback ladder:
 **config-disable first, observe for a window, only then delete with a recorded rationale**. Nothing
 in that ladder is autonomous.
 
@@ -173,15 +173,15 @@ The method's reasoning is grounded in primary sources, cited in full with their 
 
 - [Martin Fowler, "Yagni"](https://martinfowler.com/bliki/Yagni.html). The four costs, the
   carry-cost frame, and the explicit scope boundary around quality-enabling practices
-- [Kohavi et al., controlled-experiment case studies](https://ai.stanford.edu/~ronnyk/ExP_DMCaseStudies.pdf)
-, the base rate behind the default-skeptical posture
-- [John Ousterhout, *A Philosophy of Software Design*](https://milkov.tech/assets/psd.pdf). 
-  incremental accumulation, and why a single removal reads as no improvement
+- [Kohavi et al., controlled-experiment case studies](https://ai.stanford.edu/~ronnyk/ExP_DMCaseStudies.pdf).
+  The base rate behind the default-skeptical posture
+- [John Ousterhout, *A Philosophy of Software Design*](https://milkov.tech/assets/psd.pdf).
+  Incremental accumulation, and why a single removal reads as no improvement
 - [Rob Ewaschuk, "My Philosophy on Alerting"](https://gist.github.com/msgodf/86a3fc7fcd3ce663ff37)
-  and the [Google SRE book, ch. 6](https://sre.google/sre-book/monitoring-distributed-systems/). 
-  the removal default and the qualitative bar that transfers more safely than any number
-- [LaunchDarkly flag-hygiene documentation](https://launchdarkly.com/docs/guides/flags/technical-debt)
-, evidence-gated decommissioning and the two-stage removal order
+  and the [Google SRE book, ch. 6](https://sre.google/sre-book/monitoring-distributed-systems/).
+  The removal default and the qualitative bar that transfers more safely than any number
+- [LaunchDarkly flag-hygiene documentation](https://launchdarkly.com/docs/guides/flags/technical-debt).
+  Evidence-gated decommissioning and the two-stage removal order
 - [Uber's Piranha (ICSE-SEIP 2020)](https://manu.sridharan.net/files/ICSE20-SEIP-Piranha.pdf). The
   one industrial-scale precedent for batched, owner-routed retirement, its human-review requirement,
   and the intentionally-dormant finding

--- a/plugins/overengineering/README.md
+++ b/plugins/overengineering/README.md
@@ -1,8 +1,8 @@
 # overengineering
 
-A Claude Code plugin that audits an existing **enforcement surface** — agent hooks and standing
+A Claude Code plugin that audits an existing **enforcement surface**. Agent hooks and standing
 instructions, repository and version-control hooks, CI lanes and gate scripts, branch protections,
-forge apps and automations, declared external integrations — and, on explicit request, helps peel
+forge apps and automations, declared external integrations, and, on explicit request, helps peel
 back what no longer earns its cost.
 
 It is the inverse of a gap audit. A gap audit asks what is missing and default-rejects new
@@ -11,9 +11,9 @@ evidence earns its keep**.
 
 | Skill | What it does |
 |---|---|
-| `/overengineering:audit` | Read-only walk of the enforcement surface. Reconstructs what each mechanism was built to solve, re-solves the problem fresh with a bias toward native and built-in mechanisms, and returns a verdict argued in cost of carry — KEEP / RETIRE / DOWNGRADE / CONSOLIDATE / UNPROVEN, with security-class artifacts capped at FLAG-FOR-HUMAN. Emits a diffable findings artifact plus an inline summary. |
+| `/overengineering:audit` | Read-only walk of the enforcement surface. Reconstructs what each mechanism was built to solve, re-solves the problem fresh with a bias toward native and built-in mechanisms, and returns a verdict argued in cost of carry. KEEP / RETIRE / DOWNGRADE / CONSOLIDATE / UNPROVEN, with security-class artifacts capped at FLAG-FOR-HUMAN. Emits a diffable findings artifact plus an inline summary. |
 | `/overengineering:realign` | The only skill that changes anything. Consumes the findings artifact and, per accepted finding, drives interview → explore/research → plan → implement through presence-gated skill composition. Nothing is touched without explicit per-item acceptance. |
-| `/overengineering:delta` | The recurring lane. Re-runs the audit, compares its findings spine against the baseline the previous cycle left behind, and reports **only what moved** since that run — above a configurable noise budget, so a repeat cycle is a short delta instead of the whole surface again. Read-only always; it never enters `realign`, and verdict changes queue for the human. |
+| `/overengineering:delta` | The recurring lane. Re-runs the audit, compares its findings spine against the baseline the previous cycle left behind, and reports **only what moved** since that run. Above a configurable noise budget, so a repeat cycle is a short delta instead of the whole surface again. Read-only always; it never enters `realign`, and verdict changes queue for the human. |
 
 The shared method all three skills apply lives once, in
 [`context/scrutiny-method.md`](context/scrutiny-method.md); no skill restates it. The artifact that
@@ -24,20 +24,20 @@ joins them is specified once, in
 
 Enforcement accumulates. Each hook, gate, guard, and standing instruction was individually
 justifiable when it landed, and nothing in a normal workflow ever revisits one. What accumulates is
-**carry cost** — the ongoing tax every retained mechanism levies on all subsequent work — and carry
+**carry cost**, the ongoing tax every retained mechanism levies on all subsequent work, and carry
 cost is invisible in exactly the place the build cost was visible: the change that introduced it.
 
 Three postures follow, and they are what make the audit different from an opinion:
 
 - **Every verdict cites evidence, or it is UNPROVEN.** Runtime records, version-control and CI
   history, incident records, and operator attestation are evidence. Documentation, headers, and
-  rationale comments are **claims to verify** — they may be stale or generated — and a finding whose
+  rationale comments are **claims to verify**, they may be stale or generated, and a finding whose
   only support is a doc says so in those words.
 - **Silence is not exoneration and not proof of waste.** A mechanism with no recorded firings is
   UNPROVEN, never a quiet KEEP and never a quick RETIRE. UNPROVEN items are ranked by carry cost and
   routed to a small, bounded, time-boxed ablation batch instead of an undifferentiated wall.
 - **Rediscovery, not critique.** Critique produces a smaller version of whatever is already there.
-  The audit reconstructs the original problem and re-solves it today — native mechanism first,
+  The audit reconstructs the original problem and re-solves it today, native mechanism first,
   then an existing mechanism already in the repo, then a narrower incumbent, and only then bespoke
   enforcement.
 
@@ -48,26 +48,26 @@ and here it is also the safety property that makes the plugin runnable on a surf
 reviewed in a year: the worst outcome of a bare run is a file in the memory tier and a wrong opinion.
 
 `/overengineering:delta` inherits that boundary unchanged and adds nothing to it: it composes the
-audit, compares two spines, and never invokes or enters `realign` — including when the operator asks
+audit, compares two spines, and never invokes or enters `realign`, including when the operator asks
 for it mid-run. A lane that can run on a schedule has nobody to give the per-item acceptance realign
 requires, so it queues verdict changes instead of acting on them.
 
 Everything that changes the repo happens through `/overengineering:realign`, which is invoked
 deliberately, consumes the findings artifact rather than scanning on its own, and stops at a per-item
-acceptance gate before every remediation. Its execution order is the method's rollback ladder —
+acceptance gate before every remediation. Its execution order is the method's rollback ladder. 
 **config-disable first, observe for a window, only then delete with a recorded rationale**. Nothing
 in that ladder is autonomous.
 
 ## Protected classes
 
-Security-class artifacts — secret and credential guards, destructive-operation guards, guards on the
+Security-class artifacts, secret and credential guards, destructive-operation guards, guards on the
 disabling of other guards, access control, supply-chain integrity, security-scanning lanes, and
-externally-constrained audit trails — are **fully audited**. What is capped is the recommendation,
+externally-constrained audit trails, are **fully audited**. What is capped is the recommendation,
 not the scrutiny: a retirement-direction verdict on one of them is emitted as **FLAG-FOR-HUMAN**,
 carrying the verdict it would have been and the whole evidence behind it. Keep-supporting evidence is
 never hidden by the cap, and where protection status is uncertain, the item is treated as protected.
 
-The set is consumer-configurable — extend it, narrow it, or empty it — through the tracked config
+The set is consumer-configurable, extend it, narrow it, or empty it, through the tracked config
 file below.
 
 ## Works in any repo
@@ -75,7 +75,7 @@ file below.
 - **Reads your surface, assumes none.** Layers, discovery probes, and evidence sources are resolved
   from what the repository actually has. A shallow clone makes history *unavailable* rather than
   silent, and the report leads with an evidence-availability assessment naming which tiers exist
-  here at all — because that changes what UNPROVEN means for every row beneath it.
+  here at all, because that changes what UNPROVEN means for every row beneath it.
 - **Forge-, CI-, and harness-neutral.** The layer vocabulary is fixed and platform-independent; a
   consumer whose forge, CI system, or agent harness differs still maps onto it.
 - **Neighbor plugins are routed to, never re-implemented.** Instruction-text findings, contested
@@ -90,8 +90,8 @@ file below.
 ## What it deliberately does not do
 
 - **No autonomous retirement.** Every removal is human-reviewed, and protected and
-  intentionally-dormant mechanisms — kill switches, break-glass paths, circuit breakers, whose
-  designed steady state is never firing — are excluded from ablation by construction.
+  intentionally-dormant mechanisms, kill switches, break-glass paths, circuit breakers, whose
+  designed steady state is never firing, are excluded from ablation by construction.
 - **No score.** Verdicts are argued, not summed. A score invites threshold-laundering, which is the
   exact failure this plugin exists to catch.
 - **No attack on quality-enabling practices.** Tests, refactoring, review, type checking, and the
@@ -111,7 +111,7 @@ file below.
 ## Configuration
 
 This plugin declares **no `userConfig` options**, deliberately. `userConfig` is a personal,
-enable-time surface and is not a coordination surface for repository artifacts — and two of this
+enable-time surface and is not a coordination surface for repository artifacts, and two of this
 plugin's settings are policy, not preference: which mechanisms it may never recommend retiring on its
 own, and which findings an operator has already judged. A protected set emptied silently in one
 operator's personal options would defeat the FLAG-FOR-HUMAN cap for everyone reading that operator's
@@ -120,11 +120,11 @@ report, with no diff anywhere to show it happened.
 Configuration therefore rides a tracked file in the consuming repo, layered per the config-cascade
 convention: `.claude/overengineering.md`, carrying
 
-- the **protected-categories set** — extend, narrow, or empty it;
+- the **protected-categories set**. Extend, narrow, or empty it;
 - **threshold overrides** for the analogical rows, each of which can also be switched off entirely;
 - the **observation window** the rollback ladder's rung 2 runs for;
-- the **delta noise budget** — what the recurring lane lists rather than counts, per delta class; and
-- optional **suppression entries** — the durable record of a judgment an operator has already made,
+- the **delta noise budget**. What the recurring lane lists rather than counts, per delta class; and
+- optional **suppression entries**. The durable record of a judgment an operator has already made,
   shaped by the marketplace's finding-suppression contract and written only behind realign's
   per-item gate.
 
@@ -141,7 +141,7 @@ the bundled defaults apply and the run says so.
 
 `/overengineering:delta` is the recurring lane, and it is a **single-pass mechanic**: it runs once,
 compares once, reports once, and exits. **This plugin adopts no cadence and ships no schedule
-file** — a plugin that scheduled itself on install would be an unratified standing commitment in
+file**. A plugin that scheduled itself on install would be an unratified standing commitment in
 somebody else's repository, which is the exact class of thing it exists to find and retire. Four
 consumer-agnostic wiring shapes, and the trade each makes, are in
 [`skills/delta/context/recurring-wiring.md`](skills/delta/context/recurring-wiring.md).
@@ -157,8 +157,8 @@ intent needs an authorization an unattended cycle has nobody to give, and the op
 
 ## Where the artifacts land
 
-Both files the plugin writes — the findings artifact, and the spine baseline the delta lane captures
-at the end of each cycle for the next one to compare against — are memory tier, concern-scoped,
+Both files the plugin writes, the findings artifact, and the spine baseline the delta lane captures
+at the end of each cycle for the next one to compare against, are memory tier, concern-scoped,
 branch-keyed, and never committed;
 [`reference/topic-docs.md`](reference/topic-docs.md) owns the resolution and the placement of each.
 Both are ephemeral by design: the findings artifact is rewritten in place on every re-audit, with
@@ -171,18 +171,18 @@ tracked suppression entries instead.
 The method's reasoning is grounded in primary sources, cited in full with their qualifiers in
 [`context/scrutiny-method.md`](context/scrutiny-method.md):
 
-- [Martin Fowler, "Yagni"](https://martinfowler.com/bliki/Yagni.html) — the four costs, the
+- [Martin Fowler, "Yagni"](https://martinfowler.com/bliki/Yagni.html). The four costs, the
   carry-cost frame, and the explicit scope boundary around quality-enabling practices
 - [Kohavi et al., controlled-experiment case studies](https://ai.stanford.edu/~ronnyk/ExP_DMCaseStudies.pdf)
-  — the base rate behind the default-skeptical posture
-- [John Ousterhout, *A Philosophy of Software Design*](https://milkov.tech/assets/psd.pdf) —
+, the base rate behind the default-skeptical posture
+- [John Ousterhout, *A Philosophy of Software Design*](https://milkov.tech/assets/psd.pdf). 
   incremental accumulation, and why a single removal reads as no improvement
 - [Rob Ewaschuk, "My Philosophy on Alerting"](https://gist.github.com/msgodf/86a3fc7fcd3ce663ff37)
-  and the [Google SRE book, ch. 6](https://sre.google/sre-book/monitoring-distributed-systems/) —
+  and the [Google SRE book, ch. 6](https://sre.google/sre-book/monitoring-distributed-systems/). 
   the removal default and the qualitative bar that transfers more safely than any number
 - [LaunchDarkly flag-hygiene documentation](https://launchdarkly.com/docs/guides/flags/technical-debt)
-  — evidence-gated decommissioning and the two-stage removal order
-- [Uber's Piranha (ICSE-SEIP 2020)](https://manu.sridharan.net/files/ICSE20-SEIP-Piranha.pdf) — the
+, evidence-gated decommissioning and the two-stage removal order
+- [Uber's Piranha (ICSE-SEIP 2020)](https://manu.sridharan.net/files/ICSE20-SEIP-Piranha.pdf). The
   one industrial-scale precedent for batched, owner-routed retirement, its human-review requirement,
   and the intentionally-dormant finding
 

--- a/plugins/overengineering/skills/audit/SKILL.md
+++ b/plugins/overengineering/skills/audit/SKILL.md
@@ -49,8 +49,8 @@ The one write it performs is the **findings artifact**, at the memory-tier home 
 is a machine-local, self-ignored scratch root outside the repository's tracked content, writing
 there is not a mutation of the repo. State this rather than leaving it to be inferred:
 *"Read-only pass; the only file written is the findings artifact at `<resolved path>`."* That path
-exists only once the home is resolved, so the line is emitted **immediately after that resolution**. 
-step 1 of "Before the walk", and before any layer is walked.
+exists only once the home is resolved, so the line is emitted **immediately after that resolution**,
+which is step 1 of "Before the walk", and before any layer is walked.
 
 **A run with no branch identity writes nothing at all**, and says that instead of naming a path:
 *"Read-only pass; no branch identity resolved, so no findings artifact is written."* See "A detached
@@ -60,8 +60,8 @@ none.
 **Writing the artifact from a delegated run.** Some harnesses refuse a report-shaped filename from a
 delegated or dispatched executor, the `unattended` caller below is exactly that. The sanctioned
 route is the file-write tool: write the full content to a neutral filename in the artifact's own
-directory, then rename it to the contract's filename. **A shell content-write is never acceptable**. 
-it routes the deliverable around the write path the harness governs, and quoting, expansion, and
+directory, then rename it to the contract's filename. **A shell content-write is never acceptable.**
+It routes the deliverable around the write path the harness governs, and quoting, expansion, and
 encoding silently transform what it carries. Where neither route is available, say so and stop.
 
 **Two auxiliary writes are sanctioned, and only these.** (a) The topic-docs **self-ignore guard**:
@@ -194,7 +194,7 @@ harness. Layers are the ten forge-neutral names in the artifact's vocabulary, an
 probe in the walk resolves what a consumer actually declares.
 
 **Custody is detected, never assumed.** A managed, vendored, or synced file, a copy whose upstream
-is another repository, a shared workflow this repo only references, an organization-level policy. 
+is another repository, a shared workflow this repo only references, or an organization-level policy,
 is identified from the consumer's *own* declarations: a sync manifest, a code-owners entry, a header
 the consumer maintains, a documented upstream. Where custody is upstream, remediation is a delegation
 (§12), not an in-repo edit, and patching a managed copy locally creates drift the next sync reverts.
@@ -249,15 +249,15 @@ but they are not the same case. **No checkout** (no project root, `git rev-parse
 fails) is the topic-docs "No project root" stop: there is no enforcement surface to audit, so
 the run does not walk an arbitrary working directory and report it as the repository. A
 **detached checkout inside a repository** is the case this section governs: the walk still runs
-and the inline summary is still emitted. What is declined is the persisted write, not the pass
-, the report says so in place of the read-only opening line's resolved path, so the operator
+and the inline summary is still emitted. What is declined is the persisted write, not the pass.
+The report says so in place of the read-only opening line's resolved path, so the operator
 learns the run produced no artifact at the moment it would otherwise have been told where one
 lives. When that summary is the only record, it lists **every** finding, not the capped "top
 findings" the template uses when an artifact will carry the rest.
 
 ## Gotchas
 
-- **`HEAD` is not a branch name.** A detached checkout, the normal shape for a scheduled runner. 
+- **`HEAD` is not a branch name.** A detached checkout, the normal shape for a scheduled runner,
   makes `rev-parse --abbrev-ref` answer `HEAD`, which keys every ref to one home and compares equal
   to itself. Resolve a logical ref where the environment supplies one; otherwise decline to persist.
 - **A layer-scoped pass is not a retirement of what it did not look at.** Findings in unwalked layers

--- a/plugins/overengineering/skills/audit/SKILL.md
+++ b/plugins/overengineering/skills/audit/SKILL.md
@@ -1,6 +1,6 @@
 ---
-description: "Audit an existing enforcement surface — agent hooks, standing instructions, repository and version-control hooks, CI lanes, gate scripts, branch protections, forge apps, declared integrations — under an evidence-earned-keep model: every incumbent is a retirement candidate until evidence earns its keep, every verdict cites an empirical source or is classed UNPROVEN, and security-class items are capped at flag-for-human. Read-only — it walks and reports; everything it writes unasked stays in the self-ignored memory tier, and its one tracked write (persisting the resolved artifact home to the concern file) happens only on explicit confirmation. Use when: 'audit our enforcement surface', 'is our CI overengineered', 'are these hooks still earning their keep', 'what automation can we retire', 'too many guards', 'process cruft', 'do we still need this gate', 'enforcement clutter', 'retire dead automation', 'why does this check exist'. Pass one or more layers to scope a pass, or `unattended` for a dispatched or scheduled run. Not for proposing NEW automation, and it never mutates the surface it walks — the sibling `realign` skill executes accepted findings behind a per-item human gate."
-argument-hint: "[layer ...] [unattended] — layer: agent-hooks|agent-instructions|repo-hooks|vcs-hooks|ci-lanes|gate-scripts|satellite-workflows|branch-protection|forge-apps|external-integrations|all (default: all)"
+description: "Audit an existing enforcement surface. Agent hooks, standing instructions, repository and version-control hooks, CI lanes, gate scripts, branch protections, forge apps, declared integrations. Under an evidence-earned-keep model: every incumbent is a retirement candidate until evidence earns its keep, every verdict cites an empirical source or is classed UNPROVEN, and security-class items are capped at flag-for-human. Read-only. It walks and reports; everything it writes unasked stays in the self-ignored memory tier, and its one tracked write (persisting the resolved artifact home to the concern file) happens only on explicit confirmation. Use when: 'audit our enforcement surface', 'is our CI overengineered', 'are these hooks still earning their keep', 'what automation can we retire', 'too many guards', 'process cruft', 'do we still need this gate', 'enforcement clutter', 'retire dead automation', 'why does this check exist'. Pass one or more layers to scope a pass, or `unattended` for a dispatched or scheduled run. Not for proposing NEW automation, and it never mutates the surface it walks. The sibling `realign` skill executes accepted findings behind a per-item human gate."
+argument-hint: "[layer ...] [unattended]. Layer: agent-hooks|agent-instructions|repo-hooks|vcs-hooks|ci-lanes|gate-scripts|satellite-workflows|branch-protection|forge-apps|external-integrations|all (default: all)"
 user-invocable: true
 disable-model-invocation: false
 shell: bash
@@ -20,13 +20,13 @@ Walk the enforcement surface that governs work in this repository and report whi
 earn their carry cost. The posture is the inverse of a gap audit: every incumbent is a retirement
 candidate until evidence earns its keep, and silence is not evidence in either direction.
 
-**The surface is everything that governs work here, wherever it is registered** — settings scopes the
+**The surface is everything that governs work here, wherever it is registered**. Settings scopes the
 harness merges from outside the tree (user, machine, organization level) and forge controls living in
 a control plane included. Such an item is audited like any other; what changes is only the
 remediation, which is out-of-repo custody's delegation (§12). Out-of-repo is never a reason to skip.
 
 The method is **not restated here.** Read `${CLAUDE_PLUGIN_ROOT}/context/scrutiny-method.md` before
-judging anything and cite its sections in the findings — the verdict ladder (§6), the evidence tiers
+judging anything and cite its sections in the findings, the verdict ladder (§6), the evidence tiers
 (§2), the three liveness questions (§3), intent reconstruction (§4), rediscovery (§5), the protected
 classes and their cap (§7), UNPROVEN triage (§8), the analogical thresholds (§9), the scope boundary
 (§10), the rollback ladder (§11), and ownership (§12). A paraphrase of any of those in a finding is a
@@ -36,21 +36,21 @@ that one document.
 **Two doc roots, different directories.** Shared docs sit at the plugin root
 (`${CLAUDE_PLUGIN_ROOT}/context/…`, `${CLAUDE_PLUGIN_ROOT}/reference/…`); this skill's lane docs sit
 under `${CLAUDE_PLUGIN_ROOT}/skills/audit/context/…` and are linked relatively below, with their
-plugin-relative path as the link text — resolving one against the plugin root lands on nothing.
+plugin-relative path as the link text, resolving one against the plugin root lands on nothing.
 
 ## Read-only contract
 
 **This skill reports only. It never mutates the surface it walks.** No hook is disabled, no workflow
-edited, no gate script deleted, no setting changed, no branch rule touched — not even a formatting
+edited, no gate script deleted, no setting changed, no branch rule touched, not even a formatting
 fix in a file it happened to read.
 
 The one write it performs is the **findings artifact**, at the memory-tier home resolved through
 `${CLAUDE_PLUGIN_ROOT}/reference/topic-docs.md`. That write *is* the deliverable, and the memory tier
-is a machine-local, self-ignored scratch root outside the repository's tracked content — writing
+is a machine-local, self-ignored scratch root outside the repository's tracked content, writing
 there is not a mutation of the repo. State this rather than leaving it to be inferred:
 *"Read-only pass; the only file written is the findings artifact at `<resolved path>`."* That path
-exists only once the home is resolved, so the line is emitted **immediately after that resolution** —
-step 1 of "Before the walk" — and before any layer is walked.
+exists only once the home is resolved, so the line is emitted **immediately after that resolution**. 
+step 1 of "Before the walk", and before any layer is walked.
 
 **A run with no branch identity writes nothing at all**, and says that instead of naming a path:
 *"Read-only pass; no branch identity resolved, so no findings artifact is written."* See "A detached
@@ -58,18 +58,18 @@ checkout has no branch identity" below for when that holds and why a guessed hom
 none.
 
 **Writing the artifact from a delegated run.** Some harnesses refuse a report-shaped filename from a
-delegated or dispatched executor — the `unattended` caller below is exactly that. The sanctioned
+delegated or dispatched executor, the `unattended` caller below is exactly that. The sanctioned
 route is the file-write tool: write the full content to a neutral filename in the artifact's own
-directory, then rename it to the contract's filename. **A shell content-write is never acceptable** —
+directory, then rename it to the contract's filename. **A shell content-write is never acceptable**. 
 it routes the deliverable around the write path the harness governs, and quoting, expansion, and
 encoding silently transform what it carries. Where neither route is available, say so and stop.
 
 **Two auxiliary writes are sanctioned, and only these.** (a) The topic-docs **self-ignore guard**:
 the convention's once-per-session check that the resolved memory root gitignores itself, creating
-that root-local `.gitignore` (announced) when absent — a memory-tier write, never the consumer's
+that root-local `.gitignore` (announced) when absent, a memory-tier write, never the consumer's
 root `.gitignore`. (b) The resolution rungs' **concern-file persistence** (rungs 2–4 of
 `${CLAUDE_PLUGIN_ROOT}/reference/topic-docs.md`): a tracked write that happens only on the user's
-explicit confirmation of the offered location — declining leaves the resolution session-local and
+explicit confirmation of the offered location, declining leaves the resolution session-local and
 the run proceeds; a non-interactive or `unattended` run skips the ask-and-persist rungs entirely and
 never performs it. Anything beyond the findings artifact and these two is outside the contract.
 
@@ -80,37 +80,37 @@ human gate. Name it as the next step; never start it unasked.
 
 Parse `$ARGUMENTS`:
 
-- **Layer scope** — one or more values from the layer vocabulary owned by
+- **Layer scope**. One or more values from the layer vocabulary owned by
   `${CLAUDE_PLUGIN_ROOT}/context/findings-artifact.md`; default `all`. A mature repository's surface
   runs past a hundred items and does not fit one context window, so layer-scoped passes are the
   supported way to cover it: they compose because a re-run merges into the same artifact by stable
-  finding id. Record exactly the layers walked in the artifact's `scope` — a layer absent from
+  finding id. Record exactly the layers walked in the artifact's `scope`, a layer absent from
   `scope` was not walked, which is not the same as walked and found empty, and the merge rules turn
   on that difference.
-- **`unattended`** (also accepted as `--unattended`) — selects the unattended disposition for
+- **`unattended`** (also accepted as `--unattended`). Selects the unattended disposition for
   low-confidence intent (`scrutiny-method` §4): record `OPEN-INTENT`, ask nothing, guess nothing.
   **Attended is the default.** The harness gives a prose skill no reliable probe for whether a human
-  is watching, so the caller owns the flag — a dispatched worker, a scheduled lane, or a background
+  is watching, so the caller owns the flag, a dispatched worker, a scheduled lane, or a background
   run passes it. Never infer the mode.
-- Anything else — a free-text focus hint (a path, a mechanism name). Narrow attention with it; it
+- Anything else, a free-text focus hint (a path, a mechanism name). Narrow attention with it; it
   does not change the layer scope, and a hint that matches nothing is reported, not silently dropped.
 
 ## Before the walk
 
 1. **Resolve the branch identity, then the artifact home.** The precompute above yields a branch name
    or the sentinel `no branch ref (detached HEAD or no checkout)`. **The precompute is a convenience,
-   not the source of truth** — a worktree-isolated or dispatched executor may decline to inject it at
+   not the source of truth**. A worktree-isolated or dispatched executor may decline to inject it at
    all, which is exactly the `unattended` context where a detached checkout is most likely, so where
    the branch line is absent run `git symbolic-ref --quiet --short HEAD` here and read its exit status
    rather than assuming an identity. **`HEAD` is never accepted as a branch identity**, and neither is
-   the sentinel — "A detached checkout has no branch identity" below governs what an unresolved
+   the sentinel. "A detached checkout has no branch identity" below governs what an unresolved
    identity declines, and it is decided here, before a home is composed. With an identity in hand,
    resolve the home by running the whole rung order in
-   `${CLAUDE_PLUGIN_ROOT}/reference/topic-docs.md` — resolve it, never assume the documented
+   `${CLAUDE_PLUGIN_ROOT}/reference/topic-docs.md`, resolve it, never assume the documented
    default's shape. A hardcoded path writes where `realign` never looks. **Then emit the read-only
    opening line**, naming the path just resolved.
-2. **Resolve consumer configuration** — protected categories, threshold overrides, the observation
-   window, and suppression entries — from the consuming repo's `.claude/overengineering.md` through
+2. **Resolve consumer configuration**. Protected categories, threshold overrides, the observation
+   window, and suppression entries, from the consuming repo's `.claude/overengineering.md` through
    the config-cascade layering. Keys, defaults, per-key merge forms, and which layer may weaken what
    are owned by `${CLAUDE_PLUGIN_ROOT}/reference/consumer-config.md`. All layers absent is a valid
    state: the bundled defaults apply and the run says so. When a personal layer materially shapes
@@ -134,7 +134,7 @@ Read it at the start of the walk, not per layer.
 Two properties of the walk matter enough to state here:
 
 - **Write the artifact per layer, as the walk proceeds.** A partial artifact is a checkpoint, not a
-  failure — a context-exhausted run then dies with its completed layers persisted and a later pass
+  failure, a context-exhausted run then dies with its completed layers persisted and a later pass
   merges into them.
 - **Answer the three liveness questions independently for every item** (§3). Inferring one from
   another is what produces every false green the method enumerates.
@@ -146,8 +146,8 @@ empirical source or is classed UNPROVEN naming the tier consulted and whether it
 unavailable** (§2). Documentation, headers, and rationale text are claims to verify, never evidence;
 support that stays doc-only is marked unverified in the finding.
 
-Protected items are audited in full and their evidence reported — §7 caps the *recommendation*, not
-the scrutiny — and where protection status is uncertain, §7's tie-break treats the item as protected.
+Protected items are audited in full and their evidence reported, §7 caps the *recommendation*, not
+the scrutiny, and where protection status is uncertain, §7's tie-break treats the item as protected.
 A threshold that fires is cited with its source and its analogical label verbatim (§9); a threshold
 the consumer disabled is not cited at all, and the qualitative bar carries the argument instead.
 
@@ -155,11 +155,11 @@ the consumer disabled is not cited at all, and the qualitative bar carries the a
 
 When intent reconstruction scores MEDIUM or LOW (§4), the disposition is fixed by run mode:
 
-- **Attended (default)** — surface checkpoint questions: recommendation first, one small numbered
+- **Attended (default)**. Surface checkpoint questions: recommendation first, one small numbered
   set, batched rather than drip-fed. When `planning:interview` is installed, reuse its question
   mechanics; when that plugin is absent, ask the same questions inline as a numbered list in the
-  response — the fallback is the questions themselves, so nothing is lost but the mechanics.
-- **Unattended** — record `OPEN-INTENT` and move on. An invented intent becomes the fence the next
+  response, the fallback is the questions themselves, so nothing is lost but the mechanics.
+- **Unattended**. Record `OPEN-INTENT` and move on. An invented intent becomes the fence the next
   audit refuses to remove.
 
 "I don't know" is an accepted answer. It routes the item to the empirical track in §8 with its intent
@@ -174,14 +174,14 @@ so a skipped route is visible rather than silent.
 
 | Finding class | Route (presence-gated) | Inline fallback when absent |
 |---|---|---|
-| The finding is about instruction *text* — a standing instruction that is stale, over-prescriptive, or contradicts another surface | `claude-config:audit-instructions`, when that plugin is installed | Keep the finding in the `agent-instructions` layer with its evidence, and leave the text edit to the operator — report the wording, do not rewrite it |
+| The finding is about instruction *text*. A standing instruction that is stale, over-prescriptive, or contradicts another surface | `claude-config:audit-instructions`, when that plugin is installed | Keep the finding in the `agent-instructions` layer with its evidence, and leave the text edit to the operator. Report the wording, do not rewrite it |
 | An agent-layer standing-instruction ablation the evidence cannot settle on its own | `claude-config:unhobble`, when that plugin is installed | Route the item to §8's bounded ablation batch instead, at rung 1 of §11's rollback ladder with the observation window and its end date recorded |
-| The operator asks what should be *added* rather than what should be retired | `claude-config:audit-automation-gaps`, when that plugin is installed | Say plainly that prospective additions are outside this skill's contract, and record no finding for them — this audit judges incumbents only |
+| The operator asks what should be *added* rather than what should be retired | `claude-config:audit-automation-gaps`, when that plugin is installed | Say plainly that prospective additions are outside this skill's contract, and record no finding for them, this audit judges incumbents only |
 | A plugin's own claims-versus-reality (a component that does not do what its manifest or description says) | `plugin-quality:audit`, when that plugin is installed | Report it as an ordinary liveness finding (§3) on the component and stop there, rather than auditing the plugin's internals |
 
 ## Incumbent-first
 
-Before proposing any remediation, search for an owner that already exists — a mechanism in this repo
+Before proposing any remediation, search for an owner that already exists, a mechanism in this repo
 that covers the concern, a native platform feature that covers it now (with the dated tech-drift
 check §5 requires), or a neighbor surface whose contract already holds it. Proposing a new mechanism
 to replace an old one, without that search, reproduces the accumulation this audit exists to reverse.
@@ -193,8 +193,8 @@ Nothing here assumes an organization, a repository, a forge, a CI system, a bran
 harness. Layers are the ten forge-neutral names in the artifact's vocabulary, and every discovery
 probe in the walk resolves what a consumer actually declares.
 
-**Custody is detected, never assumed.** A managed, vendored, or synced file — a copy whose upstream
-is another repository, a shared workflow this repo only references, an organization-level policy —
+**Custody is detected, never assumed.** A managed, vendored, or synced file, a copy whose upstream
+is another repository, a shared workflow this repo only references, an organization-level policy. 
 is identified from the consumer's *own* declarations: a sync manifest, a code-owners entry, a header
 the consumer maintains, a documented upstream. Where custody is upstream, remediation is a delegation
 (§12), not an in-repo edit, and patching a managed copy locally creates drift the next sync reverts.
@@ -231,16 +231,16 @@ When the branch identity does not resolve:
      compose `.work/overengineering/../findings.md` and escape the home. An unvalidated
      string is also the same cross-ref mutation this section closes for `HEAD`: it keys
      one checkout's findings to another name.
-  A value that fails either step is treated as absent — fall through to the refusal
+  A value that fails either step is treated as absent, fall through to the refusal
   below. A value that passes is the branch identity for both the home key and `branch:`,
   and the report names that it came from the environment.
-- **Otherwise, persist nothing and say why** — "detached checkout, no logical ref supplied; no branch
+- **Otherwise, persist nothing and say why**. "detached checkout, no logical ref supplied; no branch
   identity, so no findings artifact is written". Do not fall back to `HEAD`, to the commit sha, or to
   whatever home the slug happens to produce. A home keyed by something every ref shares is a home the
   next detached run of a *different* ref reads as its own, and `realign` cannot tell the two apart
   afterwards, because the artifact's own `branch:` is what binds it and there is none to write.
 - **Never write `branch: HEAD`, and never write the key empty or absent as a workaround.** The
-  refusal is the whole artifact, not the one field — an artifact without a resolved identity is one
+  refusal is the whole artifact, not the one field, an artifact without a resolved identity is one
   `realign` must refuse anyway, so writing it only moves the failure later and leaves a file behind
   that the next run merges into.
 
@@ -250,14 +250,14 @@ fails) is the topic-docs "No project root" stop: there is no enforcement surface
 the run does not walk an arbitrary working directory and report it as the repository. A
 **detached checkout inside a repository** is the case this section governs: the walk still runs
 and the inline summary is still emitted. What is declined is the persisted write, not the pass
-— the report says so in place of the read-only opening line's resolved path, so the operator
+, the report says so in place of the read-only opening line's resolved path, so the operator
 learns the run produced no artifact at the moment it would otherwise have been told where one
 lives. When that summary is the only record, it lists **every** finding, not the capped "top
 findings" the template uses when an artifact will carry the rest.
 
 ## Gotchas
 
-- **`HEAD` is not a branch name.** A detached checkout — the normal shape for a scheduled runner —
+- **`HEAD` is not a branch name.** A detached checkout, the normal shape for a scheduled runner. 
   makes `rev-parse --abbrev-ref` answer `HEAD`, which keys every ref to one home and compares equal
   to itself. Resolve a logical ref where the environment supplies one; otherwise decline to persist.
 - **A layer-scoped pass is not a retirement of what it did not look at.** Findings in unwalked layers

--- a/plugins/overengineering/skills/delta/SKILL.md
+++ b/plugins/overengineering/skills/delta/SKILL.md
@@ -77,7 +77,7 @@ artifact.
 Three writes are sanctioned, and only these:
 
 1. **The spine baseline**, at the memory-tier home resolved below, written **at the end of the
-   cycle** from this run's post-audit spine. Memory tier, self-ignored, branch-keyed, ephemeral. 
+   cycle** from this run's post-audit spine. Memory tier, self-ignored, branch-keyed, ephemeral:
    the same tier and the same disclosure rule as the findings artifact. Two cases write it earlier or
    not at all: a **bootstrap** cycle captures pre-audit because it has nothing else to compare
    against, and a cycle whose branch identity is unresolved writes **no** baseline at all.
@@ -463,7 +463,7 @@ documented, never adopted.
   a capture taken at the start of this one, that baseline already holds whatever status realign
   wrote in between, so the status-change class could never fire. The one exception is the bootstrap
   cycle, which is named as such and cannot see a status change. See the section above.
-- **`HEAD` is not a branch name.** A detached checkout, the normal shape for a scheduled runner. 
+- **`HEAD` is not a branch name.** A detached checkout, the normal shape for a scheduled runner,
   makes `rev-parse --abbrev-ref` answer `HEAD`, which keys every ref to one home and compares equal
   to itself, so a cross-ref spine would sail through the branch-match check. Resolve a logical ref
   where the environment supplies one; otherwise decline to compare and decline to capture.

--- a/plugins/overengineering/skills/delta/SKILL.md
+++ b/plugins/overengineering/skills/delta/SKILL.md
@@ -1,6 +1,6 @@
 ---
-description: "Report only what changed in the enforcement surface since the last audit. Re-runs `overengineering:audit`, compares this run's findings spine against the one the previous cycle left behind, and captures a fresh baseline for the next — new clutter, verdict moves, closures, status changes — filtered through a configurable noise budget, so a recurring run is a short delta instead of the whole surface again. Read-only always: it never invokes or enters `overengineering:realign`, never writes a Status, and never touches the surface it reads; verdict changes queue for the human. A first run establishes a baseline and reports no deltas. Use when: 'what changed since the last audit', 'delta since the last run', 'run the enforcement audit on a schedule', 'recurring overengineering check', 'only show me what is new', 'did any verdict move', 'weekly automation-cruft check'. Pass layers to scope the pass and `unattended` for a scheduled or dispatched run; both pass straight through to the audit."
-argument-hint: "[layer ...] [unattended] — layer: agent-hooks|agent-instructions|repo-hooks|vcs-hooks|ci-lanes|gate-scripts|satellite-workflows|branch-protection|forge-apps|external-integrations|all (default: all)"
+description: "Report only what changed in the enforcement surface since the last audit. Re-runs `overengineering:audit`, compares this run's findings spine against the one the previous cycle left behind, and captures a fresh baseline for the next run. The report covers new clutter, verdict moves, closures, and status changes, filtered through a configurable noise budget, so a recurring run is a short delta instead of the whole surface again. Read-only always: it never invokes or enters `overengineering:realign`, never writes a Status, and never touches the surface it reads; verdict changes queue for the human. A first run establishes a baseline and reports no deltas. Use when: 'what changed since the last audit', 'delta since the last run', 'run the enforcement audit on a schedule', 'recurring overengineering check', 'only show me what is new', 'did any verdict move', 'weekly automation-cruft check'. Pass layers to scope the pass and `unattended` for a scheduled or dispatched run; both pass straight through to the audit."
+argument-hint: "[layer ...] [unattended]. Layer: agent-hooks|agent-instructions|repo-hooks|vcs-hooks|ci-lanes|gate-scripts|satellite-workflows|branch-protection|forge-apps|external-integrations|all (default: all)"
 user-invocable: true
 disable-model-invocation: false
 shell: bash
@@ -19,7 +19,7 @@ run of this lane arrives in. The baseline's UTC stamps are read with an ordinary
 +%Y%m%dT%H%M%SZ` call at the moment they are written, where they are accurate anyway.
 
 **`symbolic-ref`, not `rev-parse --abbrev-ref`, and the difference is the whole guard.**
-`git rev-parse --abbrev-ref HEAD` returns the literal string `HEAD` on a detached checkout — a value
+`git rev-parse --abbrev-ref HEAD` returns the literal string `HEAD` on a detached checkout, a value
 that looks like a branch name, keys every ref to one home, and compares equal to itself, so the
 branch-match check below would pass for two entirely different refs. `git symbolic-ref` fails instead
 of inventing an identity, which is what this lane needs. Scheduled runners commonly check out
@@ -30,7 +30,7 @@ unresolved branch identity is in "The run" step 1.
 
 Run the enforcement-surface audit again and report **only what moved**. A surface that has already
 been audited does not need to be re-served every cycle; what an operator needs on the second and
-every later run is the difference — new clutter, verdicts that moved, findings that closed, statuses
+every later run is the difference, new clutter, verdicts that moved, findings that closed, statuses
 a human changed.
 
 This is the recurring lane the findings artifact's stable spine was designed for. The comparison
@@ -45,7 +45,7 @@ retire. The noise budget below is therefore a contract, not a preference, and a 
 line.
 
 The method is **not restated here.** Read `${CLAUDE_PLUGIN_ROOT}/context/scrutiny-method.md` where a
-verdict has to be read rather than re-derived — the verdict ladder (§6) whose tokens the spine
+verdict has to be read rather than re-derived, the verdict ladder (§6) whose tokens the spine
 carries, the evidence tiers (§2) whose availability frames every UNPROVEN row, the protected-class
 cap (§7), and the scope boundary (§10). Every bare `§N` in this skill is a section of that one
 document. This lane judges nothing on its own: it composes the audit, which does the judging.
@@ -53,7 +53,7 @@ document. This lane judges nothing on its own: it composes the audit, which does
 **Two doc roots, different directories.** Shared docs sit at the plugin root
 (`${CLAUDE_PLUGIN_ROOT}/context/…`, `${CLAUDE_PLUGIN_ROOT}/reference/…`); this skill's lane docs sit
 under `${CLAUDE_PLUGIN_ROOT}/skills/delta/context/…` and are linked relatively below, with their
-plugin-relative path as the link text — resolving one against the plugin root lands on nothing.
+plugin-relative path as the link text, resolving one against the plugin root lands on nothing.
 
 ## Read-only contract
 
@@ -65,7 +65,7 @@ It inherits that boundary from `overengineering:audit`, which it composes, and a
 not on a finding an earlier run already accepted, not when a route is unavailable, not when the
 operator asks for it inside this run. Realign is the only mutating surface in this plugin and it is
 gated on an explicit per-item human acceptance given at the moment the item is presented; a lane that
-can run on a schedule has nobody to give one. Name realign as the next step and stop there — the same
+can run on a schedule has nobody to give one. Name realign as the next step and stop there, the same
 posture `audit` holds, for the same reason. Where the operator wants remediation, they invoke
 `overengineering:realign` themselves, in their own session.
 
@@ -77,14 +77,14 @@ artifact.
 Three writes are sanctioned, and only these:
 
 1. **The spine baseline**, at the memory-tier home resolved below, written **at the end of the
-   cycle** from this run's post-audit spine. Memory tier, self-ignored, branch-keyed, ephemeral —
+   cycle** from this run's post-audit spine. Memory tier, self-ignored, branch-keyed, ephemeral. 
    the same tier and the same disclosure rule as the findings artifact. Two cases write it earlier or
    not at all: a **bootstrap** cycle captures pre-audit because it has nothing else to compare
    against, and a cycle whose branch identity is unresolved writes **no** baseline at all.
 2. **The findings artifact itself, written by the composed `overengineering:audit` run**, under that
    skill's own contract. This lane does not write it and does not edit it afterwards.
 3. **One queue route**, gated on an opt-in `queue_route: auto` and then on presence, and never on a
-   quiet cycle — see "Queued for the human".
+   quiet cycle, see "Queued for the human".
 
 State the first and third in the run's opening line, immediately after the home resolves and before
 the audit is invoked: *"Read-only pass; realign is never entered. Files written: the spine baseline
@@ -108,13 +108,13 @@ human may already have edited. `Status` is exactly that field: realign writes it
 realign **between** cycles, and the audit only ever writes `OPEN` on a newly-seen id and carries every
 other status forward untouched. So a start-of-cycle capture already contains the new status, the
 audit carries that same status through, and baseline and post-audit spine agree on `Status` for every
-pre-existing finding — the status-change class is dead by construction, in precisely the case it
+pre-existing finding, the status-change class is dead by construction, in precisely the case it
 exists to catch.
 
 The mechanic is therefore:
 
 1. Resolve the home and the branch identity.
-2. **Read the stored `spine-baseline.md` — the *previous* cycle's post-audit spine.** That, and
+2. **Read the stored `spine-baseline.md`, the *previous* cycle's post-audit spine.** That, and
    nothing captured this cycle, is what the comparison measures from.
 3. Invoke `overengineering:audit`.
 4. Compare **this run's post-audit spine** against the stored baseline.
@@ -131,7 +131,7 @@ reports "no baseline, this run establishes one" forever and every cycle looks li
 failures are invisible from the report, which is why the mechanic is stated here as a contract rather
 than left as an implementation detail.
 
-## The bootstrap cycle — the one pre-audit capture
+## The bootstrap cycle. The one pre-audit capture
 
 A home can hold a findings artifact and no `spine-baseline.md`: audits were run manually here before
 this lane ever ran. That first delta cycle **captures the artifact's spine pre-audit** so it has
@@ -155,15 +155,15 @@ snapshot rather than a second record are owned by
 skill does not restate them.** Two rules bind the run directly:
 
 **A capture never replaces a baseline this cycle did not consume.** The end-of-cycle capture is
-earned by having completed the comparison, and nothing else earns it. Where the cycle stopped short —
+earned by having completed the comparison, and nothing else earns it. Where the cycle stopped short. 
 the audit was never invoked, it failed, the schema was unrecognized, the homes disagreed, the branch
-identity was unresolved — the stored baseline stays exactly as it is and this run writes none.
+identity was unresolved, the stored baseline stays exactly as it is and this run writes none.
 Overwriting it would move the comparison's origin silently forward past a cycle nobody ever compared,
 and whatever moved in between would then be reported by no cycle at all.
 
 **A baseline older than one cycle widens the span rather than being discarded.** When the stored
-baseline's `source-date` predates the immediately preceding cycle — an interrupted cycle left it
-unconsumed, or a cycle consumed it and died before capturing its own — compare against it anyway and
+baseline's `source-date` predates the immediately preceding cycle, an interrupted cycle left it
+unconsumed, or a cycle consumed it and died before capturing its own, compare against it anyway and
 say so: the report's span then covers more than one cycle and names the `source-date` it is measuring
 from.
 
@@ -172,14 +172,14 @@ from.
 Parse `$ARGUMENTS`, using the same vocabulary `overengineering:audit` uses, and **pass it through
 unchanged**:
 
-- **Layer scope** — one or more values from the layer vocabulary owned by
+- **Layer scope**. One or more values from the layer vocabulary owned by
   `${CLAUDE_PLUGIN_ROOT}/context/findings-artifact.md`; default `all`. Forwarded verbatim to the
   audit, and it bounds the comparison too (see "Layers that were not walked").
-- **`unattended`** (also accepted as `--unattended`) — forwarded verbatim. A scheduled runner, a
+- **`unattended`** (also accepted as `--unattended`). Forwarded verbatim. A scheduled runner, a
   dispatched worker, and a background run all pass it. **Attended is the default**, and the mode is
   never inferred from a probe. Under `unattended` this lane asks nothing, offers nothing, and takes
   the non-interactive collapse of the home-resolution rungs.
-- Anything else — a free-text hint. It is **not** forwarded to the audit: a hint narrows what the
+- Anything else, a free-text hint. It is **not** forwarded to the audit: a hint narrows what the
   audit attends to, which would make this cycle's walk incomparable with the baseline's. Report the
   hint as declined and why, rather than dropping it silently.
 
@@ -187,10 +187,10 @@ unchanged**:
 
 1. **Resolve the branch identity, then the artifact home.** The precompute above yields a branch name
    or the `no branch ref` string. When it yields the string, the checkout is detached (or absent) and
-   **`HEAD` is never accepted as a branch identity** — see "A detached checkout has no branch
+   **`HEAD` is never accepted as a branch identity**. See "A detached checkout has no branch
    identity" below for what to do and what not to.
    Resolve the home by running the whole rung order in
-   `${CLAUDE_PLUGIN_ROOT}/reference/topic-docs.md` — resolve it, never assume the documented
+   `${CLAUDE_PLUGIN_ROOT}/reference/topic-docs.md`, resolve it, never assume the documented
    default's shape. Then emit the opening line above.
 2. **Read the stored `spine-baseline.md` at that home.** This is the comparison baseline: the
    previous cycle's post-audit spine. Dispose of it:
@@ -208,21 +208,21 @@ unchanged**:
    checking, follows its own frontmatter: its `branch:` is what binds it to a branch, and the
    directory is not evidence, because the slug mapping is lossy. A `branch:` that does not match is
    no baseline, naming both. An **unrecognized `schema:`** is a **stop, with a visible message**,
-   before invoking anything — the artifact contract makes an unrecognized `schema` a stop for every
+   before invoking anything, the artifact contract makes an unrecognized `schema` a stop for every
    consumer, and running the audit here would rewrite a file this lane cannot read.
 3. **Invoke `overengineering:audit` via the Skill tool**, passing the layer scope and `unattended`
-   exactly as received. Let it run its own contract — home resolution, config resolution, evidence
+   exactly as received. Let it run its own contract, home resolution, config resolution, evidence
    assessment, the walk, its own inline summary. **Do not re-derive any of it here.**
 4. **Read the post-run artifact**: its spine, its `## Closed since last run` section, its
    `## Suppressed` section, its evidence-availability tokens, and any verdict the audit's own merge
    flagged as having moved under a carried-forward judgment. **On a cycle whose branch identity never
-   resolved there is no post-run artifact** — the audit declines that write too — so this step and
+   resolved there is no post-run artifact**, the audit declines that write too, so this step and
    step 5 have nothing to read, and the cycle ends after reporting what the audit found inline.
 5. **Compare** this run's post-audit spine against the baseline from step 2, per "Delta classes"
    below.
 6. **Apply the noise budget**, and report.
 7. **Stamp `compared:`** on the stored baseline where one was consumed, then **capture this run's
-   post-audit spine over it** — the baseline the *next* cycle compares against. The capture is earned
+   post-audit spine over it**. The baseline the *next* cycle compares against. The capture is earned
    by the cycle having reached this step with a resolved branch identity, and a no-baseline cycle
    earns it too: it compared nothing, but it did run the audit, so it establishes the baseline the
    next cycle needs. Two cases write nothing and leave any stored baseline exactly as it is: a cycle
@@ -238,7 +238,7 @@ diffing across them manufactures change. This is a resolution defect to fix, not
 `git rev-parse --abbrev-ref HEAD` answers `HEAD` on a detached checkout. That is a string, not an
 identity, and treating it as one breaks this lane twice over: every ref keys to the same
 `<branch-slug>` home, and the branch-match check in step 2 compares `HEAD` to `HEAD`, passes, and
-accepts some other ref's spine as this ref's baseline — after which the lane reports the difference
+accepts some other ref's spine as this ref's baseline, after which the lane reports the difference
 between two refs as a delta. Scheduled runners very commonly check out detached, so this is the
 ordinary case for the mode this lane was built for, which is why the precompute uses
 `git symbolic-ref` and refuses to invent a name.
@@ -248,10 +248,10 @@ When the branch identity does not resolve:
 - **Prefer a logical ref where the environment supplies one.** Some execution environments hand the
   run the ref it was launched for even though the checkout is detached. Where such a value is present
   and names a branch, use it as the branch identity for both the home key and the match check, and
-  name in the report where it came from. **No vendor's variables are named here or assumed** — this
+  name in the report where it came from. **No vendor's variables are named here or assumed**. This
   plugin is consumer-agnostic, and hardcoding one CI system's environment would be a claim about the
   consumer's toolchain that the rest of this plugin refuses to make.
-- **Otherwise, treat the run as no baseline and say why** — "detached checkout, no logical ref
+- **Otherwise, treat the run as no baseline and say why**. "detached checkout, no logical ref
   supplied; no branch identity, so nothing is compared". Do not fall back to `HEAD`, to the commit
   sha, or to whatever home the slug happens to produce, and do not compare.
 - **Capture no baseline either.** With no branch identity, a capture would land in a home keyed by
@@ -260,13 +260,13 @@ When the branch identity does not resolve:
   and the report says so rather than implying the next run will have one.
 
 The audit still runs and still reports; what is declined here is the comparison and the capture, not
-the pass. **It does not, however, persist an artifact on such a cycle** — `audit` declines its own
+the pass. **It does not, however, persist an artifact on such a cycle**. `audit` declines its own
 write on an unresolved identity for the same reason this lane declines its capture, so step 4 below
 has no post-run artifact to read and the audit's inline summary is the cycle's whole output. That is
 the expected shape, not a fault: with nothing compared and nothing captured, a persisted artifact
 would be a file keyed by something every ref shares and read by no later cycle.
 
-## No baseline — a first-class state, not an error
+## No baseline. A first-class state, not an error
 
 No stored baseline and no artifact, a branch mismatch, an unresolved branch identity, or a fresh
 container, worktree, or branch means there is **no prior spine**. Both files are ephemeral by design
@@ -275,15 +275,15 @@ and losing them is expected, not a fault.
 In that state the lane:
 
 - says, in one line, **"No baseline; this run establishes one"**, naming the reason (absent /
-  branch mismatch, with both branches named) — except under an unresolved branch identity, which
+  branch mismatch, with both branches named). Except under an unresolved branch identity, which
   establishes nothing and says so instead, per the section above;
 - runs the audit exactly as it otherwise would, and captures its post-audit spine at the end of the
   cycle as the baseline for the next one;
-- **reports nothing as a delta** — not the findings, not the counts, not "everything is new". A
+- **reports nothing as a delta**. Not the findings, not the counts, not "everything is new". A
   first-run surface is not a change;
 - **does not restate the surface.** The composed audit already printed its own inline summary, and
   that summary is the full-surface view. Producing a second one here would be the duplicate record
-  the report contract forbids — point at it instead.
+  the report contract forbids, point at it instead.
 
 ## Layers that were not walked
 
@@ -295,7 +295,7 @@ load-bearing:
   entirely.** It is not unchanged-and-checked, and it is emphatically not closed. It contributes to
   no delta class.
 - **The report names the unwalked layers once, as a coverage line, with the count of findings held
-  in them** — never as findings. A layer-scoped cycle that read as a clean bill of health for the
+  in them**. Never as findings. A layer-scoped cycle that read as a clean bill of health for the
   whole surface would be worse than no cycle at all.
 
 The converse case is real too. A layer walked **this** run but absent from the **baseline** run's
@@ -304,19 +304,19 @@ genuine, but its "since" is the older run's stamped date, not the baseline artif
 the per-finding stamp merge rule 4 wrote where one exists, and the baseline's `date` otherwise, so
 the report's span is honest per finding rather than per run.
 
-## Delta classes — what the merge already computes, and what this lane computes
+## Delta classes. What the merge already computes, and what this lane computes
 
 The artifact's own re-run merge already computes several of these. **Read them; never re-derive
-them** — a second derivation is a second answer that can disagree with the first.
+them**. A second derivation is a second answer that can disagree with the first.
 
 | Class | Computed by | This lane's job |
 |---|---|---|
-| **Closed finding** | the merge, rule 3 | **Read `## Closed since last run`.** It carries the reason class (`artifact absent`, `renamed to <successor id>`, `layer no longer configured`), which a spine comparison cannot produce. Ignore a row whose id the baseline never carried — that is a stale section, reported once as a contract anomaly, not as a delta. |
+| **Closed finding** | the merge, rule 3 | **Read `## Closed since last run`.** It carries the reason class (`artifact absent`, `renamed to <successor id>`, `layer no longer configured`), which a spine comparison cannot produce. Ignore a row whose id the baseline never carried, that is a stale section, reported once as a contract anomaly, not as a delta. |
 | **Verdict moved under a carried-forward judgment** | the merge, rule 5 | **Read the merge's flag and carry it.** Do not shadow it with a second detection: rule 5's flag is authoritative for *"a human's decision is now out of date"*, and this lane's comparison only supplies the verdict pair and the status alongside it. One row, not two. |
 | **New finding** | the merge, rule 2 (`Status: OPEN` on an id it had not seen) | Cross-check against the baseline spine and report the verdict it opened with. |
 | **Suppression change** | the merge, via `## Suppressed` | Read it. A finding newly suppressed, or an entry that stopped suppressing, changes what the report may omit. |
 | **Verdict change on an unjudged finding** | **this lane** | Same id, `Status: OPEN` on both sides, different `Verdict` token. |
-| **Status change** | **this lane** | Same id, different `Status` between the previous cycle's post-audit spine and this one's. The audit only ever writes `OPEN` on a new finding and carries everything else forward, so a status that moved means **a human ran realign between the two cycles** — which is exactly why the baseline is captured after the audit rather than before. A start-of-cycle capture would already hold that new status and this class could never fire; a **bootstrap** cycle has such a baseline and cannot see one, and says so. |
+| **Status change** | **this lane** | Same id, different `Status` between the previous cycle's post-audit spine and this one's. The audit only ever writes `OPEN` on a new finding and carries everything else forward, so a status that moved means **a human ran realign between the two cycles**. Which is exactly why the baseline is captured after the audit rather than before. A start-of-cycle capture would already hold that new status and this class could never fire; a **bootstrap** cycle has such a baseline and cannot see one, and says so. |
 | **Member verdict change** | **this lane** | Within one container id, members matched by member id, read for a changed verdict token. |
 | **Evidence availability** | **this lane** | Per-tier token comparison. Run-level, not per-finding. |
 
@@ -324,7 +324,7 @@ them** — a second derivation is a second answer that can disagree with the fir
 the id's `check` constituent and `artifact` feeds its `sites`, so changing either changes the id: the
 old finding closes and a new one opens. A lane reporting "layer changed" has derived an id wrongly.
 
-**Evidence-only change is out of scope, by construction — not by choice.** Evidence, liveness,
+**Evidence-only change is out of scope, by construction, not by choice.** Evidence, liveness,
 intent, rediscovery, cost, and owner are prose, recomputed fresh every run, and deliberately excluded
 from the spine. A spine comparison cannot see a change in them, and no threshold makes it able to.
 Saying "evidence updates are covered" would be claiming a capability the mechanism does not have.
@@ -342,7 +342,7 @@ below are read, never redefined here: each key's type, default, and layering are
 
 **Two classes are always listed, whatever the budget says:** a verdict that moved under a
 carried-forward judgment (merge rule 5), and a status change. They are not keys held at a locked
-default — they are not keys at all, and the reasoning is owned by that same section of
+default, they are not keys at all, and the reasoning is owned by that same section of
 `consumer-config.md`.
 
 The remaining classes, each named with the key that governs it where one does:
@@ -351,9 +351,9 @@ The remaining classes, each named with the key that governs it where one does:
 |---|---|---|
 | **New finding** | list when its verdict is one `new_finding_verdicts` selects; count otherwise | A new incumbent that already earns its keep (`KEEP`) is not news for a retirement lane. |
 | **New `UNPROVEN` finding** | list the top `unproven_head` off the audit's own carry-cost ranking; count the rest | An evidence desert produces UNPROVEN in bulk, and listing it is exactly the undifferentiated wall §8 already refuses. The ranking is the audit's; this lane takes its head and does not re-rank. |
-| **Verdict change, unjudged finding** | list the moves `verdict_change` selects — boundary crossings only, every move, or none | A boundary crossing is any of: `KEEP` ↔ any of `RETIRE`/`DOWNGRADE`/`CONSOLIDATE`; either side is `FLAG-FOR-HUMAN`; or the verdict entered or left `UNPROVEN`. A move *within* the retirement-direction set (`DOWNGRADE` → `CONSOLIDATE`) changed the shape of a recommendation nobody has acted on yet, not its disposition. |
-| **Closed finding** | list the closures `closed_findings` selects — unexpected only, all, or none | A close is expected when its prior status was `REALIGNED` — the mechanism is gone because a human removed it, and re-reporting it is noise realign's own contract already anticipates. Every other close is unexpected: an `artifact absent` close under `OPEN` or `REJECTED` means something vanished that nobody decided to remove, and `renamed to …` and `layer no longer configured` are surface changes worth a glance. |
-| **Member verdict change** inside a container whose own verdict did not move | as `member_verdicts` says — counted, surfaced as rows, or omitted | A container's own verdict is the finding; a member move under an unchanged container is a detail, and container counts and member counts are two grains that must never be summed. |
+| **Verdict change, unjudged finding** | list the moves `verdict_change` selects. Boundary crossings only, every move, or none | A boundary crossing is any of: `KEEP` ↔ any of `RETIRE`/`DOWNGRADE`/`CONSOLIDATE`; either side is `FLAG-FOR-HUMAN`; or the verdict entered or left `UNPROVEN`. A move *within* the retirement-direction set (`DOWNGRADE` → `CONSOLIDATE`) changed the shape of a recommendation nobody has acted on yet, not its disposition. |
+| **Closed finding** | list the closures `closed_findings` selects. Unexpected only, all, or none | A close is expected when its prior status was `REALIGNED`. The mechanism is gone because a human removed it, and re-reporting it is noise realign's own contract already anticipates. Every other close is unexpected: an `artifact absent` close under `OPEN` or `REJECTED` means something vanished that nobody decided to remove, and `renamed to …` and `layer no longer configured` are surface changes worth a glance. |
+| **Member verdict change** inside a container whose own verdict did not move | as `member_verdicts` says. Counted, surfaced as rows, or omitted | A container's own verdict is the finding; a member move under an unchanged container is a detail, and container counts and member counts are two grains that must never be summed. |
 | **Evidence availability** | one line, always | `unchanged`, or the tiers that moved. When a tier moved, it leads the report: it changes what UNPROVEN means for every row beneath it. |
 
 **The volume cap.** When the listed set exceeds `max_items`, list the head and give the residue as
@@ -361,7 +361,7 @@ counts with a pointer to the artifact. Rank the head by class in this order: rul
 changes → boundary-crossing verdict changes → new retirement-direction findings by the audit's
 carry-cost ranking → unexpected closures. **Within a class that carries no ranking of its own, break
 the tie by the artifact's stable total order** (`${CLAUDE_PLUGIN_ROOT}/context/findings-artifact.md`,
-"Ordering") — class rank alone leaves the truncation point undetermined, and two runs over identical
+"Ordering"). Class rank alone leaves the truncation point undetermined, and two runs over identical
 input that cut a different head report a difference that did not happen. A delta report longer than
 an operator will actually read has re-served the whole surface by another route.
 
@@ -382,10 +382,10 @@ change, carrying the finding id, the verdict pair (`<was>` → `<now>`), the cur
 and the single act it invites: `overengineering:realign <finding-id>`. Rule-5 flags lead the section;
 they are the rows where the evidence moved under a decision already made.
 
-**2. Routed to a tracker — opt-in under `queue_route`, then presence-gated.** The route is a
+**2. Routed to a tracker, opt-in under `queue_route`, then presence-gated.** The route is a
 **notification, never a remediation**: it carries ids and verdict pairs and nothing that instructs a
 change. Read `queue_route` (`${CLAUDE_PLUGIN_ROOT}/reference/consumer-config.md`, under
-`delta_noise_budget`) *before* probing for a tracker — an operator who has not asked for the route is
+`delta_noise_budget`) *before* probing for a tracker, an operator who has not asked for the route is
 not to be probed on their behalf and then routed anyway. Whichever row below the run takes, record
 **the route decision and the presence answer** in the report, so a skipped route is visible rather
 than silent.
@@ -394,7 +394,7 @@ than silent.
 unset key means report-only.** The reason is the tracker's own authorization gate, not a preference
 about verbosity: `work-items:track`'s `add` action holds that *"Never file a work item on inferred
 intent. … An explicit user `/work-items:track add ...` invocation IS the authorization;
-model-initiated filing is not"* — so an unattended scheduled cycle, which is the mode this lane
+model-initiated filing is not"*, so an unattended scheduled cycle, which is the mode this lane
 exists for, has no authorization to file anything and a conforming tracker must refuse it. Setting
 the key **is** the explicit, recorded authorization the gate asks for, given once by a human in a
 file. **Do not flip this default back to `auto`**: a default-on route makes the lane's ordinary
@@ -402,8 +402,8 @@ unattended path a request the tracker is contractually obliged to decline.
 
 | `queue_route` | Condition | What the lane does |
 |---|---|---|
-| unset (the default, `inline`) | Not consulted — no probe is made | Decline the route **unconditionally**, naming the absent opt-in as the reason. The report's own `## Queued for the human` section is the queue — stated plainly, together with the fact that no durable route exists, so the queue lives only as long as this run's output |
-| `inline`, set explicitly | Not consulted — no probe is made | Identical to the row above, naming the operator's setting as the reason |
+| unset (the default, `inline`) | Not consulted. No probe is made | Decline the route **unconditionally**, naming the absent opt-in as the reason. The report's own `## Queued for the human` section is the queue. Stated plainly, together with the fact that no durable route exists, so the queue lives only as long as this run's output |
+| `inline`, set explicitly | Not consulted. No probe is made | Identical to the row above, naming the operator's setting as the reason |
 | `auto` | A work-item tracker is reachable through `work-items:track`, and that plugin is installed | Maintain **one** open queue item per branch, carrying the current queued rows. The operator's tracked `queue_route: auto` is the authorization carried into that filing, and is named as such |
 | `auto` | No such tracker is reachable | Decline the route, naming the absence. The report's own section is the queue, exactly as in the first row |
 
@@ -412,7 +412,7 @@ routed. A declined route changes where the queue is *durable*, never whether it 
 
 Four rules keep a taken route from becoming the nag:
 
-- **One item per branch, updated — never a second one.** A re-run replaces the item's rows; it does
+- **One item per branch, updated, never a second one.** A re-run replaces the item's rows; it does
   not open another and does not append a cycle log.
 - **A quiet cycle does not touch the item at all.** No "nothing changed this cycle" comment. That
   comment *is* the nag.
@@ -432,18 +432,18 @@ view and no third record.** In order:
 1. **The read-only line**, plus the span this comparison covers: `source-date` → this run's `date`,
    and whether it covers more than one cycle.
 2. **Coverage**: layers walked this run; layers not walked, with the count of findings held in them.
-3. **Evidence availability**: `unchanged`, or the tiers that moved — first when it moved.
+3. **Evidence availability**: `unchanged`, or the tiers that moved, first when it moved.
 4. **The counts table**: one row per delta class, listed / counted / omitted.
 5. **The listed rows**, in the cap's rank order.
-6. **`## Queued for the human`**, always — with the route decision and the presence answer behind
+6. **`## Queued for the human`**, always, with the route decision and the presence answer behind
    it (or that presence was not consulted, because `queue_route` is unset or `inline`).
 7. **The next step, named and not taken**: `overengineering:realign` executes accepted findings
    behind an explicit per-item human gate. Never start it.
 
 ## Recurring wiring
 
-How a consumer schedules this lane — a fixed-interval loop, a scheduled task, a CI schedule, or a
-recurring tracker item — with the trade each shape makes, is in
+How a consumer schedules this lane, a fixed-interval loop, a scheduled task, a CI schedule, or a
+recurring tracker item, with the trade each shape makes, is in
 [skills/delta/context/recurring-wiring.md](context/recurring-wiring.md). **This plugin adopts no
 schedule of its own and ships no schedule file**; the cadence is the consumer's decision, and a lane
 that scheduled itself on install would be an unratified standing commitment.
@@ -459,10 +459,10 @@ documented, never adopted.
 ## Gotchas
 
 - **The baseline is the previous cycle's post-audit spine, captured at the end of that cycle.** Not
-  a capture taken at the start of this one — that baseline already holds whatever status realign
+  a capture taken at the start of this one, that baseline already holds whatever status realign
   wrote in between, so the status-change class could never fire. The one exception is the bootstrap
   cycle, which is named as such and cannot see a status change. See the section above.
-- **`HEAD` is not a branch name.** A detached checkout — the normal shape for a scheduled runner —
+- **`HEAD` is not a branch name.** A detached checkout, the normal shape for a scheduled runner. 
   makes `rev-parse --abbrev-ref` answer `HEAD`, which keys every ref to one home and compares equal
   to itself, so a cross-ref spine would sail through the branch-match check. Resolve a logical ref
   where the environment supplies one; otherwise decline to compare and decline to capture.

--- a/plugins/overengineering/skills/delta/SKILL.md
+++ b/plugins/overengineering/skills/delta/SKILL.md
@@ -155,9 +155,10 @@ snapshot rather than a second record are owned by
 skill does not restate them.** Two rules bind the run directly:
 
 **A capture never replaces a baseline this cycle did not consume.** The end-of-cycle capture is
-earned by having completed the comparison, and nothing else earns it. Where the cycle stopped short. 
-the audit was never invoked, it failed, the schema was unrecognized, the homes disagreed, the branch
-identity was unresolved, the stored baseline stays exactly as it is and this run writes none.
+earned by having completed the comparison, and nothing else earns it. If the cycle stopped short
+for any of these reasons, the stored baseline stays exactly as it is and this run writes none:
+the audit was never invoked, the audit failed, the schema was unrecognized, the homes disagreed,
+or the branch identity was unresolved.
 Overwriting it would move the comparison's origin silently forward past a cycle nobody ever compared,
 and whatever moved in between would then be reported by no cycle at all.
 

--- a/plugins/overengineering/skills/realign/SKILL.md
+++ b/plugins/overengineering/skills/realign/SKILL.md
@@ -1,6 +1,6 @@
 ---
-description: "Execute an enforcement-surface audit's findings behind an explicit per-item human gate. Consumes the findings artifact `overengineering:audit` produced — it never scans or re-judges the surface itself — and for each finding the operator accepts drives interview → explore and research → plan → implement through presence-gated skill composition, executing every removal down the rollback ladder: config-disable first, observe for a window with a stated end date, delete last with a recorded rationale. Unproven items route to a bounded, time-boxed ablation batch; security-class items surface the capped verdict's evidence and wait for the human's own call; remediation owned by an upstream or a forge control plane becomes a delegation rather than a local patch. Use when: 'realign our enforcement surface', 'act on the audit findings', 'execute the overengineering findings', 'retire the automation we agreed to retire', 'disable this gate and observe it', 'start the ablation window', 'peel back these hooks', 'the audit says retire it, do it'. This is the only skill in this plugin that changes anything, and there is no blanket-approve path."
-argument-hint: "[finding-id ...] [layer ...] — default: every finding awaiting a decision, in the artifact's order"
+description: "Execute an enforcement-surface audit's findings behind an explicit per-item human gate. Consumes the findings artifact `overengineering:audit` produced. It never scans or re-judges the surface itself. For each finding the operator accepts, it drives interview → explore and research → plan → implement through presence-gated skill composition, executing every removal down the rollback ladder: config-disable first, observe for a window with a stated end date, delete last with a recorded rationale. Unproven items route to a bounded, time-boxed ablation batch; security-class items surface the capped verdict's evidence and wait for the human's own call; remediation owned by an upstream or a forge control plane becomes a delegation rather than a local patch. Use when: 'realign our enforcement surface', 'act on the audit findings', 'execute the overengineering findings', 'retire the automation we agreed to retire', 'disable this gate and observe it', 'start the ablation window', 'peel back these hooks', 'the audit says retire it, do it'. This is the only skill in this plugin that changes anything, and there is no blanket-approve path."
+argument-hint: "[finding-id ...] [layer ...]. Default: every finding awaiting a decision, in the artifact's order"
 user-invocable: true
 disable-model-invocation: false
 shell: bash
@@ -16,7 +16,7 @@ metadata:
 
 ## Purpose
 
-Execute what an `overengineering:audit` run found — one finding at a time, with the operator
+Execute what an `overengineering:audit` run found, one finding at a time, with the operator
 deciding each one. This is the **only** mutating surface in this plugin, and the per-item gate below
 is the entire reason it is safe to point at a surface nobody has reviewed in a year.
 
@@ -35,7 +35,7 @@ the scrutiny method, and a paraphrase of either document inside a proposal is a 
 it is presented.** Say so in the run's opening line, then hold it literally:
 
 - **One finding, one acceptance.** Accepting finding A authorizes A's remediation and nothing
-  else — not its neighbours, not the rest of its layer, not the obvious next one.
+  else, not its neighbours, not the rest of its layer, not the obvious next one.
 - **Blanket approval is not the gate.** "Approve everything", "do whatever the audit says", and a
   standing authorization from earlier in the session are all declined, out loud, with an offer to
   walk the queue instead. A gate that a sentence can switch off was never a gate.
@@ -45,12 +45,12 @@ it is presented.** Say so in the run's opening line, then hold it literally:
   authorizes the config-disable, not the deletion three rungs later; rung 3 asks again, after the
   window.
 - **Change approval shows the exact change before making it.** The file and the line, the config key
-  and its new value, or the entry to be written — shown after the plan, approved before any write,
+  and its new value, or the entry to be written, shown after the plan, approved before any write,
   then executed as shown, nothing adjacent.
 - **No operator present means present and stop.** In a dispatched, scheduled, or background run
   nobody can accept anything, so realign presents the queue and stops: no status transitions,
   nothing written anywhere. An absent operator is silence for every item at once. There is no
-  unattended mode to pass — the audit takes that flag for its own intent disposition; realign has
+  unattended mode to pass, the audit takes that flag for its own intent disposition; realign has
   nothing it may do without the gate.
 
 **Both gates are required and neither substitutes for the other.** *Item acceptance* authorizes
@@ -61,13 +61,13 @@ An acceptance given earlier is not an approval of the edit that later falls out 
 
 1. **Resolve the branch identity, then the artifact home.** The precompute above yields a branch name
    or the sentinel `no branch ref (detached HEAD or no checkout)`. **The precompute is a convenience,
-   not the source of truth** — a worktree-isolated or dispatched executor may decline to inject it at
+   not the source of truth**. A worktree-isolated or dispatched executor may decline to inject it at
    all, so where the branch line is absent run `git symbolic-ref --quiet --short HEAD` here and read
    its exit status rather than assuming an identity. **`HEAD` is never accepted as a branch
    identity**, and neither is the sentinel. Where the sentinel appears, prefer a logical ref
    if the environment supplies one that names a branch, after the same normalize-then-validate
    steps `audit` uses (strip a leading `refs/heads/`, then `git check-ref-format --branch`,
-   refuse `.` / `..` segments); name where it came from. **Otherwise stop** — see "An unresolved
+   refuse `.` / `..` segments); name where it came from. **Otherwise stop**. See "An unresolved
    branch identity is its own refusal" below. With an identity in hand,
    resolve the home by running the whole rung order in
    `${CLAUDE_PLUGIN_ROOT}/reference/topic-docs.md`. A hardcoded path reads where the audit never
@@ -75,24 +75,24 @@ An acceptance given earlier is not an approval of the edit that later falls out 
 2. **No artifact → stop.** Report, visibly, that no findings artifact exists at the resolved home,
    name `overengineering:audit` as the skill that produces one, and name the home resolved so the
    operator can tell "never audited" from "resolved elsewhere". **Do not scan, judge, or remediate
-   anything on your own** — this skill has no evidence and no verdict of its own, so an improvised
+   anything on your own**. This skill has no evidence and no verdict of its own, so an improvised
    pass would put a mutation behind a gate with nothing behind it.
 3. **Refuse a mismatched `branch:`**, naming both; **refuse an artifact whose `branch:` is absent,
-   empty, or the literal `HEAD`**, naming which; and **refuse an unrecognized `schema:`** — each with
+   empty, or the literal `HEAD`**, naming which; and **refuse an unrecognized `schema:`**. Each with
    a visible message rather than guessing at the shape. The artifact's own frontmatter is what binds
    it to a branch; the directory it sits in is not evidence (the slug mapping is lossy). A `branch:`
-   that carries no identity is not a match to be evaluated — it is the absence of the thing the check
+   that carries no identity is not a match to be evaluated, it is the absence of the thing the check
    compares, so it takes the refusal branch and never the comparison.
 4. **Read the evidence-availability assessment that leads the artifact, and never recompute it.** It
    changes what UNPROVEN means for every finding below it, and re-deriving it here would make a
    second record that can disagree with the first.
 5. **A `Status` value outside the artifact's closed vocabulary** is reported and that finding is
-   skipped — soft degradation, never a guess about what an unknown state meant.
+   skipped, soft degradation, never a guess about what an unknown state meant.
 6. **Surface a verdict that moved under a carried-forward judgment before anything else, and never
    act on it.** An `ACCEPTED` finding now recomputed to `KEEP`, or a `REJECTED` one now recomputed
    to a retirement-direction verdict, means the evidence moved under a decision the operator already
    made. **Direction is not the only trigger:** surface it too where the recomputed verdict
-   materially changes *what the acceptance authorized* without flipping direction — an `ACCEPTED`
+   materially changes *what the acceptance authorized* without flipping direction, an `ACCEPTED`
    `DOWNGRADE` now recomputed to `CONSOLIDATE` authorizes a different act on a different artifact.
    Re-confirm the act before anything proceeds; the earlier yes was given to the old one.
 
@@ -102,7 +102,7 @@ Parse `$ARGUMENTS`. **Finding ids**, and **layer names** from the artifact's lay
 narrow the queue to exactly those findings. Anything else is a free-text hint that orders the queue
 and is reported rather than dropped when it matches nothing. No argument widens the queue, and none
 replaces the gate. Bare invocation presents every finding awaiting a decision, in the artifact's own
-order; a queue too long for one sitting is said to be, not rushed — the statuses persist, so
+order; a queue too long for one sitting is said to be, not rushed, the statuses persist, so
 stopping halfway is a normal end to a run.
 
 ## The queue
@@ -112,7 +112,7 @@ Present findings in the artifact's order and dispose of each by its current stat
 | Status | What this run does with it |
 |---|---|
 | `OPEN` | Present the verdict, its evidence, its cost, and the proposed rung; ask for a decision |
-| `ACCEPTED` | Remediation was authorized in an earlier run — re-confirm the rung about to execute, then continue |
+| `ACCEPTED` | Remediation was authorized in an earlier run, re-confirm the rung about to execute, then continue |
 | `REJECTED` · `REALIGNED` | Nothing. Report it as already decided; re-asking is the noise the judgment record exists to stop |
 | `DELEGATED-EXTERNAL` | Report the delegation pointer and its state. Nothing local, ever |
 | `ABLATION-PENDING` | Gate and execute the rung-1 disable, then move to `ABLATION-ACTIVE` |
@@ -124,23 +124,23 @@ Present findings in the artifact's order and dispose of each by its current stat
 
 Interview → explore and research → plan → implement. Each composes a sibling skill **when its plugin
 is installed** and runs the documented inline fallback when it is not. Check presence, take the
-fallback, and **say which one ran** — a silent skip is indistinguishable from a step that was never
+fallback, and **say which one ran**. A silent skip is indistinguishable from a step that was never
 needed. Record the presence answer on the finding. Every skill in the `Composition` column is
 invoked via the Skill tool.
 
 | Movement | Composition (presence-gated) | Inline fallback when absent |
 |---|---|---|
-| **Interview** — settle intent, constraints, and what "done" means for this item | `/planning:interview`, when the planning plugin is installed | Ask the same questions inline as one small numbered set, recommendation first. The questions are the substance; only the mechanics are lost |
-| **Explore** — what the mechanism touches, where it is wired, what depends on it | `/discovery:explore`, when the discovery plugin is installed | Read the artifact, its registration surface, and its call sites directly, and list the blast radius in the response before proposing anything |
-| **Research** — is the native or existing mechanism the rediscovery names real, and current | `/discovery:research`, when the discovery plugin is installed | Check the current official documentation of the proposed replacement yourself and record the check with its date (§5 requires the date, not the memory) |
-| **Plan** — the rung, the exact edit, the reversal, the observation window | `/planning:plan`, when the planning plugin is installed | Write the plan in the response — goal, rung, blast radius, how it is reversed — and get it approved before any edit |
-| **Implement** — make the change | `/implementation:implement`, when the implementation plugin is installed | Make the change directly against the approved plan, one rung at a time, stopping at the same gates |
+| **Interview**. Settle intent, constraints, and what "done" means for this item | `/planning:interview`, when the planning plugin is installed | Ask the same questions inline as one small numbered set, recommendation first. The questions are the substance; only the mechanics are lost |
+| **Explore**. What the mechanism touches, where it is wired, what depends on it | `/discovery:explore`, when the discovery plugin is installed | Read the artifact, its registration surface, and its call sites directly, and list the blast radius in the response before proposing anything |
+| **Research**. Is the native or existing mechanism the rediscovery names real, and current | `/discovery:research`, when the discovery plugin is installed | Check the current official documentation of the proposed replacement yourself and record the check with its date (§5 requires the date, not the memory) |
+| **Plan**. The rung, the exact edit, the reversal, the observation window | `/planning:plan`, when the planning plugin is installed | Write the plan in the response. Goal, rung, blast radius, how it is reversed, and get it approved before any edit |
+| **Implement**. Make the change | `/implementation:implement`, when the implementation plugin is installed | Make the change directly against the approved plan, one rung at a time, stopping at the same gates |
 
-Run the movements the finding actually needs — a one-key config disable with a settled intent needs
+Run the movements the finding actually needs, a one-key config disable with a settled intent needs
 no research pass. "Skipped research: the rediscovery names a mechanism already in this repo" is a
 judgment recorded; skipping it wordlessly is not.
 
-## Execution order — the rollback ladder
+## Execution order. The rollback ladder
 
 §11 governs, in order, and the finding records the rung reached:
 
@@ -149,77 +149,77 @@ judgment recorded; skipping it wordlessly is not.
    state explicit and confirm the disable took effect rather than assuming the edit was the effect.
 2. **Observe** for the consumer's configured window, with **its end date written on the finding**. A
    window with no end date is an abandonment wearing an experiment's clothes, and the date belongs
-   on a durable pointer too — the artifact can be gone before the date arrives.
+   on a durable pointer too, the artifact can be gone before the date arrives.
 3. **Delete, with the rationale recorded** in the change description: the evidence, the observation
    result, and what re-adds it. Preserve the re-add surface where one exists.
 
 **Withdrawal is a normal outcome, not a failure.** A window showing the mechanism load-bearing ends
 at rung 1 with it re-enabled and the finding closed as KEEP, carrying the evidence the window
-produced. Say so when proposing the ladder — it is what makes rung 1 cheap to accept.
+produced. Say so when proposing the ladder, it is what makes rung 1 cheap to accept.
 
-**When rung 1 is inapplicable** — nothing registered or wired to disable: a copy nothing reads, a
-claim in a document, a lane nothing requires — the presentation records *"rung 1 inapplicable —
+**When rung 1 is inapplicable**. Nothing registered or wired to disable: a copy nothing reads, a
+claim in a document, a lane nothing requires, the presentation records *"rung 1 inapplicable. 
 `<reason>`"* rather than inventing a disable, and says why rung 2 is uninformative too (disabling
-what never fires produces no signal). A **reversible non-rung remediation** — correcting a false
-claim, registering the copy that should have been wired — is then a valid proposal, recorded as one
+what never fires produces no signal). A **reversible non-rung remediation**. Correcting a false
+claim, registering the copy that should have been wired, is then a valid proposal, recorded as one
 under its own item acceptance. And where the only remaining act is **deletion**, the acceptance must
 name the deletion explicitly: the ladder's cheap first rung is not there to soften it (see the gotcha
-below — an accepted finding is not an accepted deletion).
+below, an accepted finding is not an accepted deletion).
 
 **CONSOLIDATE** ends in removing the **redundant copy** once the survivor is named. Where that copy
 is live the ladder applies unchanged: disable, observe under the survivor, delete. Where it is inert,
-rung 1 has nothing to disable and rung 2 nothing to observe — route it by the rule above, deletion
+rung 1 has nothing to disable and rung 2 nothing to observe, route it by the rule above, deletion
 named in the acceptance.
 
-## UNPROVEN findings — the ablation track
+## UNPROVEN findings. The ablation track
 
 An UNPROVEN verdict is not an authorization to disable. Route it to §8's track: take the head of the
 carry-cost ranking the audit recorded, propose **one bounded batch** an operator can actually attend
-to, name an owner per item (§12 — ownerless is not a terminal state), set one window with its end
+to, name an owner per item (§12, ownerless is not a terminal state), set one window with its end
 date, and record a durable pointer so the batch survives the artifact. Each item still passes the
-per-item gate individually. Items below the batch keep their ranking and wait for the next window —
-dozens of concurrent windows destroy attribution and re-check nothing — and protected and
+per-item gate individually. Items below the batch keep their ranking and wait for the next window. 
+dozens of concurrent windows destroy attribution and re-check nothing, and protected and
 intentionally-dormant items (§7) never enter a batch at all.
 
 ## Protected findings
 
 A `FLAG-FOR-HUMAN` finding is a question, not a task. Present the capped retirement-direction
 verdict it would otherwise have carried, the evidence in full, the protected class that matched, and
-the rule that matched it — then **stop and wait for the operator's own call**, on that item, in
+the rule that matched it, then **stop and wait for the operator's own call**, on that item, in
 their words. Never retire a protected mechanism on this skill's own reasoning, and never reach the
 same end by routing it into an ablation batch. Where the operator overturns the classification, that
 is their decision to record, and the consumer's tracked configuration is where it belongs.
 
-## Out-of-repo custody — delegate, never patch locally
+## Out-of-repo custody. Delegate, never patch locally
 
-Where the audit's custody read placed the artifact upstream — organization-level policy, a managed
-or synced copy, a shared workflow this repo only references, a forge control plane — §12 makes the
-remediation a **delegation**. Produce the delegation artifact — an upstream change request, an
+Where the audit's custody read placed the artifact upstream, organization-level policy, a managed
+or synced copy, a shared workflow this repo only references, a forge control plane, §12 makes the
+remediation a **delegation**. Produce the delegation artifact, an upstream change request, an
 administrator issue, or written instructions handed to the owner, carrying the finding's evidence
-and the proposed rung — and set the status to `DELEGATED-EXTERNAL` with its pointer. **Never edit
+and the proposed rung, and set the status to `DELEGATED-EXTERNAL` with its pointer. **Never edit
 the out-of-repo surface in place and never patch a managed copy locally**: the next sync reverts the
 patch and leaves a report claiming the work is done.
 
 ## Statuses this skill writes
 
 This skill is the artifact's only writer of `Status`, and it writes one only as the outcome it names
-actually happens — never ahead of the operator's yes. `ACCEPTED` on acceptance; `REJECTED` when the
+actually happens, never ahead of the operator's yes. `ACCEPTED` on acceptance; `REJECTED` when the
 operator judges the finding and keeps the mechanism; `REALIGNED` when the change has landed;
 `DELEGATED-EXTERNAL` with its pointer; the `ABLATION-*` states as a batch moves through its window.
 What each one means is the contract's, not this skill's. Leave every other field exactly as the
-audit computed it — rewriting a verdict here puts this skill's opinion into the audit's record.
+audit computed it, rewriting a verdict here puts this skill's opinion into the audit's record.
 
 ## The durable judgment record
 
 A `REJECTED` finding and an `ABLATION-CONCLUDED-KEEP` one are judgments worth more than the
 memory-tier artifact a branch switch or a reclaimed container loses. **Offer** to persist each as a
-suppression entry in the consuming repo's tracked `.claude/overengineering.md` — offered, not taken:
+suppression entry in the consuming repo's tracked `.claude/overengineering.md`, offered, not taken:
 
 - **Show the exact entry before writing it**, and write only on an explicit yes, under the same
   per-item gate that authorized the remediation.
 - **The `reason` is the operator's own words.** Ask for them. Audit prose recycled into that field
   is not a stated reason, and an entry nobody can review is an entry nobody can retire.
-- **The team-tracked layer, not a personal overlay** — a personal-layer entry does not suppress, so
+- **The team-tracked layer, not a personal overlay**. A personal-layer entry does not suppress, so
   writing one there would leave the operator believing a judgment is in effect when it is not.
 - Entry keys, the constituents-authoritative rule, and the layering are owned by
   `${CLAUDE_PLUGIN_ROOT}/reference/consumer-config.md`. A `REALIGNED` finding needs no entry: the
@@ -230,7 +230,7 @@ suppression entry in the consuming repo's tracked `.claude/overengineering.md` �
 The branch-match check in "Before anything" step 3 protects the one thing this skill cannot recover
 from: executing one ref's findings against a different ref's surface. That check is only as good as
 the two identities it compares, and `git rev-parse --abbrev-ref HEAD` answers the literal string
-`HEAD` on a detached checkout — which compares equal to itself, so a `HEAD`-to-`HEAD` comparison
+`HEAD` on a detached checkout, which compares equal to itself, so a `HEAD`-to-`HEAD` comparison
 passes by construction and authorizes mutations from an artifact that may describe another ref
 entirely. Scheduled and dispatched runners commonly check out detached, so this is an ordinary
 condition, not an exotic one. The precompute therefore uses `git symbolic-ref`, which fails rather
@@ -238,18 +238,18 @@ than inventing a name, matching the `audit` and `delta` lanes.
 
 **Two distinct unresolved states both refuse, and neither may reach the comparison:**
 
-- **This checkout has no branch identity** — the precompute yielded the sentinel and no logical ref
+- **This checkout has no branch identity**. The precompute yielded the sentinel and no logical ref
   was supplied. Stop before reading the artifact. Say so plainly: *"Detached checkout, no logical ref
   supplied; no branch identity, so the artifact's branch cannot be verified and nothing will be
   executed."* Nothing is presented as a queue, no status transitions, nothing written anywhere.
-- **The artifact carries no branch identity** — its `branch:` is absent, empty, or the literal
+- **The artifact carries no branch identity**. Its `branch:` is absent, empty, or the literal
   `HEAD`. Refuse it by name, and say that `overengineering:audit` declines to write an artifact
   without an identity, so one carrying `HEAD` was produced by an older audit or by something other
   than this plugin. Do not repair the field, and do not fall back to the directory it sits in: the
   slug mapping is lossy, so the home is not evidence of which ref the findings describe.
 
 Refusing costs a re-run on an attached checkout. Passing costs a mutation nobody can attribute to a
-surface — and this is the only skill in the plugin that mutates anything, so the asymmetry is not
+surface, and this is the only skill in the plugin that mutates anything, so the asymmetry is not
 close. **Never fall back to `HEAD`, to the commit sha, or to the home's slug to manufacture the
 missing side of the comparison.**
 
@@ -257,17 +257,17 @@ missing side of the comparison.**
 
 - **`HEAD` is not a branch name.** A detached checkout makes `rev-parse --abbrev-ref` answer `HEAD`,
   which compares equal to itself and slips a cross-ref artifact through the branch-match refusal.
-  An unresolved identity — on either side of that check — refuses; it never compares.
+  An unresolved identity, on either side of that check, refuses; it never compares.
 - **An accepted finding is not an accepted deletion.** Acceptance authorizes the rung on the table
   at that moment; carrying it to rung 3 is how a reversible change becomes an irreversible one that
   nobody agreed to.
 - **Disable the copy the runtime actually reads.** Where a guard exists in both a local and a
-  packaged form, disabling the inert copy changes nothing and reports as done — confirm which one
+  packaged form, disabling the inert copy changes nothing and reports as done, confirm which one
   the live configuration registers first.
 - **Do not touch what the finding is not about.** A formatting fix, a stale comment, or an obvious
   adjacent tidy inside the same file is outside the acceptance that was given.
 - **A finding you realigned vanishes from the next audit.** Its artifact is gone, so the re-run
-  records it under closed-since-last-run instead — the contract working, not a loss.
+  records it under closed-since-last-run instead, the contract working, not a loss.
 - **Never argue a quality-enabling practice onto the ladder** (§10). Tests, review, type checking,
   and the build are outside this method, and so is the record-keeping that makes the evidence tiers
-  readable at all — retiring it would make the next audit weaker than this one.
+  readable at all, retiring it would make the next audit weaker than this one.

--- a/plugins/overengineering/skills/realign/SKILL.md
+++ b/plugins/overengineering/skills/realign/SKILL.md
@@ -157,11 +157,11 @@ judgment recorded; skipping it wordlessly is not.
 at rung 1 with it re-enabled and the finding closed as KEEP, carrying the evidence the window
 produced. Say so when proposing the ladder, it is what makes rung 1 cheap to accept.
 
-**When rung 1 is inapplicable**. Nothing registered or wired to disable: a copy nothing reads, a
-claim in a document, a lane nothing requires, the presentation records *"rung 1 inapplicable. 
+**When rung 1 is inapplicable.** Nothing registered or wired to disable: a copy nothing reads, a
+claim in a document, a lane nothing requires. The presentation records *"rung 1 inapplicable:
 `<reason>`"* rather than inventing a disable, and says why rung 2 is uninformative too (disabling
-what never fires produces no signal). A **reversible non-rung remediation**. Correcting a false
-claim, registering the copy that should have been wired, is then a valid proposal, recorded as one
+what never fires produces no signal). A **reversible non-rung remediation**, correcting a false
+claim or registering the copy that should have been wired, is then a valid proposal, recorded as one
 under its own item acceptance. And where the only remaining act is **deletion**, the acceptance must
 name the deletion explicitly: the ladder's cheap first rung is not there to soften it (see the gotcha
 below, an accepted finding is not an accepted deletion).
@@ -177,8 +177,8 @@ An UNPROVEN verdict is not an authorization to disable. Route it to §8's track:
 carry-cost ranking the audit recorded, propose **one bounded batch** an operator can actually attend
 to, name an owner per item (§12, ownerless is not a terminal state), set one window with its end
 date, and record a durable pointer so the batch survives the artifact. Each item still passes the
-per-item gate individually. Items below the batch keep their ranking and wait for the next window. 
-dozens of concurrent windows destroy attribution and re-check nothing, and protected and
+per-item gate individually. Items below the batch keep their ranking and wait for the next window.
+Dozens of concurrent windows destroy attribution and re-check nothing, and protected and
 intentionally-dormant items (§7) never enter a batch at all.
 
 ## Protected findings


### PR DESCRIPTION
No linked issue

## Summary

#2891 instruction-surface de-slop cluster: purge em dashes from the `overengineering` plugin README and every SKILL.md.

## Fix

Rewrote `plugins/overengineering/README.md` and every `plugins/overengineering/**/SKILL.md` under `/ai-slop:audit fix` semantics (periods, commas, or a restructured sentence; never parentheses, en dashes, or a spaced hyphen as a stand-in). Meaning-preserving self-audit repaired asides the first pass reattached to the wrong noun. The delta report's four change classes stay attached to the report, not the baseline. `overengineering` 0.3.1.

## Verification

- Detector: 0 `rule-em-dash` findings outside ignore-fenced generated-options spans (and required trigger strings that must keep em dashes)
- `CHECK_SKILL_SKIP_MARKDOWNLINT=1 bash scripts/check-changed-skills.sh origin/main`: 0 failed; quoted trigger phrases vs origin/main preserved
- `python3 scripts/sync-plugin-options-docs.py --check` up to date
- `scripts/check-changelog-parity.sh --check-bump origin/main` passes
- `node scripts/generate-cheatsheet.mjs --check` in sync

## Related

Refs #2891

#2891 stays open.