### PR TITLE
docs(disk-hygiene): de-slop instruction surfaces (0.20.21)

### DIFF
--- a/plugins/disk-hygiene/.claude-plugin/plugin.json
+++ b/plugins/disk-hygiene/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "disk-hygiene",
-  "version": "0.20.20",
+  "version": "0.20.21",
   "description": "Context-aware disk hygiene for arbitrary directory trees: inventories orphaned and temporary artifacts, classifies evidence into review tiers, and offers exact-path cleanup only after a fresh safety preview and explicit per-tier approval. The target is read-only by default; OS-managed paths, links and mount points, VCS-tracked content without the complete checkout evidence bundle, changed entries, and live-handle uncertainty fail closed.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/disk-hygiene/CHANGELOG.md
+++ b/plugins/disk-hygiene/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to the `disk-hygiene` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.20.21]
+
+### Changed
+
+- **Instruction-surface de-slop (#2891, disk-hygiene cluster).** Rewrote this plugin's `README.md` and every
+  `SKILL.md` to drop em dashes under the repo's zero-tolerance house policy, using
+  `/ai-slop:audit fix` semantics: periods or commas, or a restructured sentence, never
+  parentheses, en dashes, or a spaced hyphen as a stand-in. Meaning stays; only the mark
+  and the sentence break change. The generated options block is ignore-fenced because
+  `scripts/sync-plugin-options-docs.py` still emits em dashes from its shared template.
+
 ## [0.20.20]
 
 ### Changed

--- a/plugins/disk-hygiene/README.md
+++ b/plugins/disk-hygiene/README.md
@@ -219,7 +219,7 @@ hand-cleaning the zone.
   defense-in-depth honoring layer over the guard.
 - **Trust-surface record (0.7.0; updated 0.17.8):** the plugin-level `hooks/hooks.json` PreToolUse
   registration is a NEW trust surface (a hook that launches in every consumer session), added
-  deliberately for guard-enforced audit-only mode and data-root authority (#1106 decision, Option E. 
+  deliberately for guard-enforced audit-only mode and data-root authority (#1106 decision, Option E,
   split registration). Its blast radius is bounded by design: a fixed launch string authored in the
   plugin's own `hooks.json` (see the 0.17.8 delta for exactly what that bounds now that the string
   reaches a shell), bundled standard-library scripts only, instant no-output deferral for any command
@@ -314,13 +314,13 @@ Verified 2026-07-16 against current primary documentation:
   [path APIs](https://docs.python.org/3.11/library/os.path.html). Non-following metadata, junction, and
   mount detection.
 - [Windows reparse-point operations](https://learn.microsoft.com/en-us/windows/win32/fileio/reparse-point-operations)
-  and [`GetLogicalDrives`](https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-getlogicaldrives)
-, the reparse attribute and available-volume enumeration.
+  and [`GetLogicalDrives`](https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-getlogicaldrives):
+  the reparse attribute and available-volume enumeration.
 - [Linux `mountinfo`](https://man7.org/linux/man-pages/man5/proc_pid_mountinfo.5.html). Current mount
   namespace and bind-mount targets, which `os.path.ismount` cannot reliably identify.
 - [Git `ls-files`](https://git-scm.com/docs/git-ls-files). The index/tracked-file authority.
-- [Windows `CreateFile`](https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createfilew)
-, sharing conflicts and directory handles via `FILE_FLAG_BACKUP_SEMANTICS`.
+- [Windows `CreateFile`](https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createfilew):
+  sharing conflicts and directory handles via `FILE_FLAG_BACKUP_SEMANTICS`.
 - [`lsof` maintained documentation](https://lsof.readthedocs.io/en/stable/). Open-file lookup; the
   recursive `+D` authority limitation is why diagnostics fail closed.
 - [POSIX `unlink`](https://pubs.opengroup.org/onlinepubs/9799919799/functions/unlink.html) and

--- a/plugins/disk-hygiene/README.md
+++ b/plugins/disk-hygiene/README.md
@@ -58,27 +58,27 @@ at preview. Backups remain the recovery boundary for user data.
   `skills/clean/scripts/hygiene.py`; `/disk-hygiene:setup check` derives the enforced value from
   there, so treat the number printed here as a convenience copy). Guarded engine calls must use the
   same absolute interpreter reported by the skill-scoped guard, so Bash aliases and functions cannot
-  replace it. **All three** hook registrations — both wired hooks and the skill-scoped belt — use
+  replace it. **All three** hook registrations, both wired hooks and the skill-scoped belt, use
   **shell form**: the `command` string names `hooks/run-python-hook.sh` directly with
   `"shell": "bash"` and no `args`, so Claude Code routes them through Git Bash itself instead of
   resolving the command on `PATH`. Exec form is the regression this plugin hit twice: as
   `"command": "bash"` in the wired hooks (#1416) and as `"command": "python3"` in the belt (#2568).
   On Windows that bare `PATH` lookup finds the WSL relay `System32\bash.exe` before Git Bash, or the
   zero-length `WindowsApps\python3.exe` App Execution Alias stub; the launch fails, and a failed
-  hook launch is non-blocking — so the guard silently enforces nothing. The launcher then resolves
+  hook launch is non-blocking, so the guard silently enforces nothing. The launcher then resolves
   Python (#1504). The guard
   registers on two surfaces: a
   plugin-level **engine gate** (`hooks/hooks.json`) that acts only on commands referencing the
-  engine — deferring everything else instantly — and enforces the kill switch and data-root
+  engine, deferring everything else instantly, and enforces the kill switch and data-root
   authority; and the skill-scoped **belt** inside the `clean` skill's context, which adds the
   deny-by-default Bash and deletion-spelling PowerShell discipline during active cleanup work. Both
   surfaces resolve the kill switch by reading `disk_hygiene_enabled` from user-scope `pluginConfigs`
   in `settings.json` (located from `${CLAUDE_PLUGIN_ROOT}`, honored only from user/managed/`--settings`
   scope since Claude Code 2.1.207, so a repo cannot forge it), register unconditionally, and fail
-  closed to enabled — the earlier bare-`${user_config.*}` argument that dropped the engine gate on a
+  closed to enabled, the earlier bare-`${user_config.*}` argument that dropped the engine gate on a
   default install is gone (since 0.9.0). Hook-lifetime caveat: docs
   scope a skill hook to the component's lifetime, but session-long firing of the belt has been
-  observed on at least one Claude Code build (producer-reported; see issue #1105) — if unrelated
+  observed on at least one Claude Code build (producer-reported; see issue #1105). If unrelated
   commands are denied after a clean run ends, start a new session and see that issue. PreToolUse
   hooks also fire inside subagents, so fanned-out workers run under the same guards. The plugin
   never downloads a runtime.
@@ -86,13 +86,13 @@ at preview. Backups remain the recovery boundary for user data.
   detector (`skills/clean/scripts/guard_launch_monitor.py`, a second hook entry in `hooks/hooks.json`,
   independent of the engine-gate guard itself) scans the session transcript for
   `hook_non_blocking_error` records naming the engine gate's own command string and warns once per
-  session with the failure count and the most recent failure's exit code, duration, and stderr — so a
+  session with the failure count and the most recent failure's exit code, duration, and stderr, so a
   guard that never ran or died mid-run no longer looks identical to a guard that ran and approved.
   This covers only the `destructive_guard.py` command string in the current session's transcript: it
   does not cover repo-hygiene's own guard (a separate plugin, verified working independently), and it
   never retroactively scans a prior session's transcript. Every hook registration routes through
-  `hooks/run-python-hook.sh` — a bash launcher that resolves Python independently of bare
-  `python3` on PATH — so when `python3` is the WindowsApps alias stub or otherwise unresolvable,
+  `hooks/run-python-hook.sh`, a bash launcher that resolves Python independently of bare
+  `python3` on PATH, so when `python3` is the WindowsApps alias stub or otherwise unresolvable,
   the detector still emits a `systemMessage` even though the guard cannot run (#1504).
 - Git is optional for ordinary trees. If a target contains or sits inside a Git worktree, Git becomes
   required so tracked content can be proven safe; otherwise cleanup for that subtree is blocked.
@@ -104,27 +104,27 @@ at preview. Backups remain the recovery boundary for user data.
   `execution-platform-unsupported` as a per-candidate blocker, and removal is a manual, per-path
   Recycle-Bin handoff offered only when `--execute` was requested and after explicit approval
   (the flag gates every deletion lane, manual included). The Recycle-Bin / Trash naming is a model-layer
-  distinction only — the engine treats Windows and macOS identically (execution unsupported); which
+  distinction only, the engine treats Windows and macOS identically (execution unsupported); which
   reversible-removal container the manual lane prefers is the model's instruction, not engine
   behavior.
-- **Windows `python3` gotcha — the Store alias stub fails the guard open.** Every hook resolves
+- **Windows `python3` gotcha, the Store alias stub fails the guard open.** Every hook resolves
   Python through `hooks/run-python-hook.sh` (rejecting the zero-length `WindowsApps\python3.exe`
   App Execution Alias stub and falling through to `python`, then `py -3`) before exec'ing the guard.
   Since 0.17.9 that includes the skill-scoped belt, which previously named `python3` directly as its
   exec-form `command` and so could not start at all against the stub. When no interpreter resolves
   anywhere on the ladder, the guard still
-  fails open — a PreToolUse hook blocks a tool call only by emitting exit code 2 or a `deny`
+  fails open, a PreToolUse hook blocks a tool call only by emitting exit code 2 or a `deny`
   decision ([Hooks](https://code.claude.com/docs/en/hooks)); a guard that never runs emits neither,
-  and Claude Code treats the non-blocking result as approval — the destructive Bash/PowerShell
+  and Claude Code treats the non-blocking result as approval, the destructive Bash/PowerShell
   command proceeds ungated (the same fail-open shape as the 0.6.3 launch-failure fix, via a
   different vector). The Stop detector emits a `systemMessage` in that case so the blind spot is
   visible. `/disk-hygiene:setup check` resolves the launcher's whole ladder and FAILs only when it
   is exhausted or the interpreter it selects is below the floor. A stubbed `python3` alongside a
-  working `python` or `py -3` is a **WARN**, not a FAIL — every guard launches there, and the
+  working `python` or `py -3` is a **WARN**, not a FAIL, every guard launches there, and the
   residual is only that a bare `python3` typed by hand still opens the Store. To clear it: disable
   the `python3` App execution alias (Settings > Apps > Advanced app settings > App execution
   aliases) or install real Python ahead of WindowsApps on `PATH`. A bare `command -v python3` /
-  `where python3` success is not proof the interpreter is real — the stub answers to the name too.
+  `where python3` success is not proof the interpreter is real, the stub answers to the name too.
 - Linux requires readable `/proc/self/mountinfo`, descriptor-relative filesystem APIs, and `lsof` for
   the optional execution lane. Absence, diagnostics, or authority gaps block cleanup.
 - macOS supports audit/report only because this implementation has no authoritative bind-mount and
@@ -183,7 +183,7 @@ hand-cleaning the zone.
 - Use `/repo-hygiene:clean` for deterministic caches, build outputs, Git metadata, or a fresh-pull reset
   inside one repository. `disk-hygiene` does not duplicate those mechanisms.
 - Use `/source-control:worktree status`/`cleanup` (if installed) for git worktree checkouts such as a
-  `.worktrees/` tree — run those actions from the checkout's own main repository, as they manage the
+  `.worktrees/` tree, run those actions from the checkout's own main repository, as they manage the
   current repository's worktrees and take no target. `disk-hygiene` protects tracked content and `.git`
   metadata but does not manage worktree lifecycle. For a redundant standalone checkout, the manual
   handoff's optional VCS evidence mode can return `clear` only after all four proof gates in the
@@ -204,7 +204,7 @@ hand-cleaning the zone.
   quoted CLI arguments.
 - **MCP / external trust:** no MCP server, agent, dependency, or third-party service is shipped.
 - **Configuration:** one non-sensitive `userConfig` boolean (`disk_hygiene_enabled`, default
-  `true`) gating the execution tiers — setting it `false` puts `/disk-hygiene:clean` in audit-only
+  `true`) gating the execution tiers, setting it `false` puts `/disk-hygiene:clean` in audit-only
   mode. Both guard surfaces resolve the toggle by reading `disk_hygiene_enabled` from user-scope
   `pluginConfigs` in `settings.json` (not the process environment). A configured `false` denies Bash
   engine invocations outright on the always-on engine gate (whether or not the clean skill is active);
@@ -219,7 +219,7 @@ hand-cleaning the zone.
   defense-in-depth honoring layer over the guard.
 - **Trust-surface record (0.7.0; updated 0.17.8):** the plugin-level `hooks/hooks.json` PreToolUse
   registration is a NEW trust surface (a hook that launches in every consumer session), added
-  deliberately for guard-enforced audit-only mode and data-root authority (#1106 decision, Option E —
+  deliberately for guard-enforced audit-only mode and data-root authority (#1106 decision, Option E. 
   split registration). Its blast radius is bounded by design: a fixed launch string authored in the
   plugin's own `hooks.json` (see the 0.17.8 delta for exactly what that bounds now that the string
   reaches a shell), bundled standard-library scripts only, instant no-output deferral for any command
@@ -228,7 +228,7 @@ hand-cleaning the zone.
   [hook-budget convention](../../docs/conventions/hook-budget/README.md)'s method (`EPOCHREALTIME`
   wall-clock around direct hook invocation with a benign representative payload; Windows 11 +
   Git Bash dev host, 2026-08-16): the engine-gate hook costs **≈ 190–300 ms per Bash/PowerShell
-  tool call** across batches (92 single runs) — ≈ 19–30% of the convention's ≤ 1 s typical
+  tool call** across batches (92 single runs). ≈ 19–30% of the convention's ≤ 1 s typical
   per-tool-call ceiling. While the `clean` skill is loaded, its frontmatter registration is a
   second matching hook that the harness launches in parallel; the pair measured concurrently
   (`&` + `wait`, 60 pairs) walls at **≈ 320–410 ms**, ≈ 1.3–1.5× the same-batch single-hook wall
@@ -237,35 +237,35 @@ hand-cleaning the zone.
   `hooks/run-python-hook.test.sh`) accounts for ≈ 24 ms, **≈ 13% of the hook's cost** in the batch
   it was measured against; the prior two-full-pass form measured ≈ 38 ms (≈ 19% of a ≈ 205 ms hook).
   On a machine where no Python 3 interpreter resolves at all the gate fails
-  open on every call — the `Stop` detector emits a `systemMessage` for that case, so the blind spot is
+  open on every call, the `Stop` detector emits a `systemMessage` for that case, so the blind spot is
   visible rather than silent (#1110, #1504). **0.9.0 delta:** the gate no longer carries a `${user_config.*}`
   argument (which, unset, dropped the whole hook and left the gate inert on a default install); it now
   registers unconditionally and resolves the kill switch by **reading** the user `settings.json` and the
-  platform managed-settings.json. The added trust surface is that settings-file *read* — bounded to a
+  platform managed-settings.json. The added trust surface is that settings-file *read*, bounded to a
   single `pluginConfigs` value, from the user file (located from `${CLAUDE_PLUGIN_ROOT}`) and the
   root-owned managed file at its fixed system path, no write. Both are the plugin's own documented CC
   config, sanctioned by the acceptance review's operator-home carve-out (criterion 4). This entry is the
   plugin-acceptance review delta for the change. **0.17.8 delta (launch form):** both wired hooks now
-  register in **shell form** — the `command` string names `hooks/run-python-hook.sh` with
-  `"shell": "bash"` and no `args` — because exec form's bare `PATH` lookup for `bash` resolved to the
+  register in **shell form**. The `command` string names `hooks/run-python-hook.sh` with
+  `"shell": "bash"` and no `args`, because exec form's bare `PATH` lookup for `bash` resolved to the
   WSL relay on Windows and the guard silently never launched (#1416). Stated plainly: a shell now
   parses the launch string, so "no shell involved" is no longer what bounds this surface. What bounds
   it instead is that the string is a **fixed literal** in the plugin's own `hooks.json` with no model-,
   repo-, or session-supplied text interpolated into it; the only values substituted are Claude Code's
   own `${CLAUDE_PLUGIN_ROOT}` and `${CLAUDE_PLUGIN_DATA}`, and each is double-quoted, so the shell's
-  re-tokenization reproduces the exec-form argument vector byte-for-byte — verified for both hooks
+  re-tokenization reproduces the exec-form argument vector byte-for-byte, verified for both hooks
   against roots containing spaces and backslashes. The limits of that quoting belong in the record
   too: Claude Code substitutes those placeholders *textually* before bash parses the result, so the
   double quotes bound whitespace and backslashes but would not neutralize a `$` or a backtick inside a
   substituted value (both placeholders resolve under Claude Code's own install and data roots). The
-  invariant is therefore **maintained by test**, not structural — `hooks/run-python-hook.test.sh`
+  invariant is therefore **maintained by test**, not structural, `hooks/run-python-hook.test.sh`
   asserts the launcher is named in `command`, `args` is absent, `shell: bash` is declared, and every
   placeholder is double-quoted, and `test_hygiene.py`'s hook helpers are form-agnostic so a shell-form
   entry can never make an assertion vacuously green. Interpolating anything beyond those two
   placeholders into the command string would open a live injection surface; a repo-wide CI gate for
   this defect class is proposed in #2569. **0.17.9 delta (launch form, skill surface):** the
   skill-scoped belt in `skills/clean/SKILL.md` frontmatter moves to the same shell form, for the same
-  reason one rung down — its exec-form `command` was the literal `python3`, which on stock Windows is
+  reason one rung down, its exec-form `command` was the literal `python3`, which on stock Windows is
   the zero-length `WindowsApps` App Execution Alias stub, so the belt could not launch there at all
   (#2568). The trust analysis above carries over with a **narrower** substitution set: a
   skill-frontmatter hook receives only `${CLAUDE_PLUGIN_ROOT}` (#1014), never `${CLAUDE_PLUGIN_DATA}`
@@ -274,7 +274,7 @@ hand-cleaning the zone.
   wherever `python3` resolved to a real interpreter, the conversion was held to argv equivalence: the
   vector `destructive_guard.py` receives is byte-identical before and after, asserted against roots
   containing spaces and backslashes; only argv[0] changes, from an interpreter name to the launcher
-  path. What this does **not** change is the guard's no-interpreter behaviour — the launcher still
+  path. What this does **not** change is the guard's no-interpreter behaviour, the launcher still
   exits 0 silently in guard mode when nothing on the ladder resolves. A direct `hygiene.py` invocation outside that skill does not read the toggle and
   answers only to the engine's own preview/approval-token gate. The toggle can only narrow the
   destructive surface, never widen it (see [the safety model](skills/clean/reference/safety-model.md)
@@ -301,32 +301,33 @@ credential, dependency, or MCP surface reopens this review.
 Verified 2026-07-16 against current primary documentation:
 
 - [Create plugins](https://code.claude.com/docs/en/plugins) and
-  [plugins reference](https://code.claude.com/docs/en/plugins-reference) — plugin structure, cache
+  [plugins reference](https://code.claude.com/docs/en/plugins-reference). Plugin structure, cache
   isolation, manifests, versions, and local `--plugin-dir` testing.
-- [Skills](https://code.claude.com/docs/en/skills) — side-effecting skills should be manual-only;
+- [Skills](https://code.claude.com/docs/en/skills). Side-effecting skills should be manual-only;
   supporting files, arguments, and skill-scoped hooks.
-- [Hooks](https://code.claude.com/docs/en/hooks) — current `PreToolUse` decision output.
-- [Create a marketplace](https://code.claude.com/docs/en/plugin-marketplaces) — relative plugin sources.
+- [Hooks](https://code.claude.com/docs/en/hooks). Current `PreToolUse` decision output.
+- [Create a marketplace](https://code.claude.com/docs/en/plugin-marketplaces). Relative plugin sources.
 - [GNU Bash shell expansions](https://www.gnu.org/software/bash/manual/html_node/Shell-Expansions.html)
-  — expansion order and the brace, tilde, parameter, command, arithmetic, process, splitting, and
+. Expansion order and the brace, tilde, parameter, command, arithmetic, process, splitting, and
   filename-expansion families rejected by the literal-command guard.
 - [Python 3.11 filesystem APIs](https://docs.python.org/3.11/library/os.html) and
-  [path APIs](https://docs.python.org/3.11/library/os.path.html) — non-following metadata, junction, and
+  [path APIs](https://docs.python.org/3.11/library/os.path.html). Non-following metadata, junction, and
   mount detection.
 - [Windows reparse-point operations](https://learn.microsoft.com/en-us/windows/win32/fileio/reparse-point-operations)
   and [`GetLogicalDrives`](https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-getlogicaldrives)
-  — the reparse attribute and available-volume enumeration.
-- [Linux `mountinfo`](https://man7.org/linux/man-pages/man5/proc_pid_mountinfo.5.html) — current mount
+, the reparse attribute and available-volume enumeration.
+- [Linux `mountinfo`](https://man7.org/linux/man-pages/man5/proc_pid_mountinfo.5.html). Current mount
   namespace and bind-mount targets, which `os.path.ismount` cannot reliably identify.
-- [Git `ls-files`](https://git-scm.com/docs/git-ls-files) — the index/tracked-file authority.
+- [Git `ls-files`](https://git-scm.com/docs/git-ls-files). The index/tracked-file authority.
 - [Windows `CreateFile`](https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createfilew)
-  — sharing conflicts and directory handles via `FILE_FLAG_BACKUP_SEMANTICS`.
-- [`lsof` maintained documentation](https://lsof.readthedocs.io/en/stable/) — open-file lookup; the
+, sharing conflicts and directory handles via `FILE_FLAG_BACKUP_SEMANTICS`.
+- [`lsof` maintained documentation](https://lsof.readthedocs.io/en/stable/). Open-file lookup; the
   recursive `+D` authority limitation is why diagnostics fail closed.
 - [POSIX `unlink`](https://pubs.opengroup.org/onlinepubs/9799919799/functions/unlink.html) and
-  [Linux `unlink(2)`](https://man7.org/linux/man-pages/man2/unlink.2.html) — open-file unlink semantics
+  [Linux `unlink(2)`](https://man7.org/linux/man-pages/man2/unlink.2.html). Open-file unlink semantics
   motivate an explicit preflight rather than relying on deletion failure.
 
+<!-- ai-slop-ignore-start: generated options block; source is plugin.json + scripts/sync-plugin-options-docs.py -->
 <!-- BEGIN GENERATED: plugin options — edit plugin.json, then run scripts/sync-plugin-options-docs.py -->
 
 ### Options reference
@@ -399,6 +400,7 @@ hands a configured value to a hook process; the value comes from the routes abov
 - [Manage installed plugins](https://code.claude.com/docs/en/discover-plugins#manage-installed-plugins) — enabling, disabling, `/plugin list`
 
 <!-- END GENERATED: plugin options -->
+<!-- ai-slop-ignore-end -->
 
 ## License
 

--- a/plugins/disk-hygiene/skills/clean/SKILL.md
+++ b/plugins/disk-hygiene/skills/clean/SKILL.md
@@ -10,11 +10,11 @@ hooks:
         # Shell form, matching hooks/hooks.json (#2568). Exec form resolves
         # `command` on PATH with no shell, and the bare `python3` this used to
         # name is the zero-length WindowsApps App Execution Alias stub on stock
-        # Windows — the hook cannot launch, and a failed launch is non-blocking,
+        # Windows, the hook cannot launch, and a failed launch is non-blocking,
         # so the belt silently enforces nothing. `hooks/run-python-hook.sh`
         # rejects that stub and falls through to `python`, then `py -3`.
         # `${CLAUDE_PLUGIN_ROOT}` is the ONLY substitution a skill-frontmatter
-        # hook receives (#1014) — never ${CLAUDE_PLUGIN_DATA} or
+        # hook receives (#1014). Never ${CLAUDE_PLUGIN_DATA} or
         # ${user_config.*}, either of which makes Claude Code refuse the launch.
         # The single-quoted YAML scalar is the same value hooks.json spells with
         # \" escapes; every path placeholder must stay double-quoted, because the
@@ -43,22 +43,22 @@ Parse `$ARGUMENTS` as the complete user-facing surface: optional `--execute`, op
 engine flags (`--output`, `--project-dir`, `--data-root` on scan; `--snapshot`, `--plan`,
 `--report`, `--confirm-tier`, `--approval-token`, `--paths`, and `--vcs-evidence` on the other
 subcommands) are supplied by this skill's command templates, not typed by the user.
-`--execute` means "deletion may be offered" on every platform — the gated engine lane where the
+`--execute` means "deletion may be offered" on every platform, the gated engine lane where the
 platform supports it, the manual handoff elsewhere; it is not approval. (Deliberate semantic
 unification, not a restatement: the flag previously read as engine-lane-only, which left the
-manual lane's gate ambiguous — consumer sessions read it both ways.) `--max-depth <N>` bounds a
+manual lane's gate ambiguous, consumer sessions read it both ways.) `--max-depth <N>` bounds a
 scan to depth N (preferred for large targets); `--confirmed-large-scan` opts into an unbounded
 full walk after the human clears the [confirmation gate](#confirmation-gate)'s scan-scope row.
 `--root-children` is the only way to address an OS-managed volume root (for example `C:\` or `/`):
 it never walks that root recursively. Without `--root-child` names the engine returns
 `root-children-selection-required` listing admitted immediate directories (OS-owned, hidden,
 system, reparse, mount, protected-shell-folder, and non-directory entries are withheld). With one
-or more explicit `--root-child <name>` flags — after the human clears the confirmation gate's
-root-children row — it audits only those admitted children into one snapshot. A general "clean
+or more explicit `--root-child <name>` flags, after the human clears the confirmation gate's
+root-children row, it audits only those admitted children into one snapshot. A general "clean
 everything" is not selection. With no target, ask once. Reject an
 OS-managed root (unless `--root-children`), a non-root mount target, a protected shell-folder root
 or descendant, a missing directory, a symlink, or a Windows reparse point. A whole-volume root that
-is not OS-managed (a Windows Dev Drive) is no longer rejected outright — it is a valid target, but
+is not OS-managed (a Windows Dev Drive) is no longer rejected outright, it is a valid target, but
 as a known-large root it is gated like a home target (see step 1): the scan returns
 `large-target-confirmation-required` unless bounded with `--max-depth` or confirmed with
 `--confirmed-large-scan`. `--root-children` is invalid on a non-OS volume root or a non-volume
@@ -67,7 +67,7 @@ target; scan those without the flag.
 - Invoke `/repo-hygiene:clean` via the Skill tool for one repository's caches, build output, Git metadata, or tree reset.
 - For git worktree checkouts (e.g. under a `.worktrees/` directory), hand off by invoking
   `/source-control:worktree status`/`cleanup` via the Skill tool (if installed), run from the checkout's own main
-  repository — those actions manage the current repository's worktrees and take no target path. The
+  repository, those actions manage the current repository's worktrees and take no target path. The
   engine already protects tracked content and `.git` metadata, but owns no worktree lifecycle.
   A standalone checkout is likewise protected by default; the narrow evidence mode in §6 is the
   only exception, and it never applies to linked worktrees whose common Git directory is outside the
@@ -79,12 +79,12 @@ target; scan those without the flag.
   retention mechanism. Report `needs-elevation` or `handle-state-unverified` and stop that tier.
 - If the `disk_hygiene_enabled` userConfig option is `false` (its value here is
   `${user_config.disk_hygiene_enabled}`), audit only and explain why execution is disabled. A
-  literal unexpanded token is not evidence the toggle is unset — resolve it deterministically by
+  literal unexpanded token is not evidence the toggle is unset, resolve it deterministically by
   running the bundled probe (the guard allows exactly this argument-free shape):
   `"<hook-python>" "${CLAUDE_PLUGIN_ROOT}/skills/setup/scripts/kill_switch_probe.py"` and honor
   the `effective` value it reports; on `degraded: true` proceed as enabled but say the configured
   value could not be read. The guard enforces the same toggle independently and denies both mutation
-  lanes in audit-only mode (`reference/safety-model.md`), so run the probe anyway — to state the
+  lanes in audit-only mode (`reference/safety-model.md`), so run the probe anyway, to state the
   configured value accurately and stop before proposing work the guard would deny. The guard is the
   backstop, not the sole enforcer. It reports its absolute Python interpreter and the authorized
   `--data-root` value in denial guidance; use that exact interpreter path as `<hook-python>` for
@@ -99,33 +99,33 @@ target; scan those without the flag.
 
 ## Confirmation gate
 
-Every question this skill asks passes this gate — the no-target prompt above, the large-scan
+Every question this skill asks passes this gate, the no-target prompt above, the large-scan
 confirmation in §1, the root-children selection for an OS-managed volume root, the removal approval
 in §5, and the unsupported-platform handoff in §6. One surface rule and one floor cover all five.
 What a valid answer must *name* is per question, because a target prompt has no tier or path list to
 name and cannot be held to a bar built for one.
 
 **Question surface.** Prefer `AskUserQuestion`: its answer is the user's own and cannot be
-fabricated. It is not always usable, in two distinct ways — a bare-name `permissions.deny` rule or a
+fabricated. It is not always usable, in two distinct ways, a bare-name `permissions.deny` rule or a
 `disallowed-tools` entry removes it from context entirely, while permission mode `dontAsk` denies it
 even when an allow rule names it, leaving it visible and every call failing. Fall back to the same
 question asked inline as a numbered choice whenever the tool is absent, denied, **or otherwise
-unusable** — including a denial discovered only by calling it; a denied call is an unanswered
+unusable**. Including a denial discovered only by calling it; a denied call is an unanswered
 question, never an answer. Then wait for the reply.
 
-**The floor — every question.** Take the user's own answer, given in this interactive session. Never
+**The floor, every question.** Take the user's own answer, given in this interactive session. Never
 supply, infer, or fabricate it: a prior general request, `--execute`, "clean everything", approval of
 another tier, or silence is not an answer. On rejection, stop.
 
-**What the answer must name — per question.** Where a row requires the answer to name something the
-skill itself produced — the resolved target, the tier, the path list — show it in the question; a bar
+**What the answer must name, per question.** Where a row requires the answer to name something the
+skill itself produced, the resolved target, the tier, the path list, show it in the question; a bar
 naming what the question never presented cannot be met.
 
 | Question | Accept only an answer naming |
 |---|---|
 | Target selection (no target given) | one directory, which must then clear every rejection in "Arguments and boundaries" |
 | Scan scope (`--confirmed-large-scan`, §1) | that target and a deliberate unbounded full walk of it |
-| Root-children selection (`--root-children`, §1) | one or more admitted immediate child directory names just listed — never "everything" or the volume root itself |
+| Root-children selection (`--root-children`, §1) | one or more admitted immediate child directory names just listed, never "everything" or the volume root itself |
 | Removal approval (§5) and manual handoff (§6) | exactly the one tier and the exact path list just shown |
 
 ## 1. Create a read-only snapshot
@@ -142,26 +142,26 @@ stay there, never in the target or `${CLAUDE_PLUGIN_ROOT}`. Run:
 ```
 
 The guard validates `--data-root` against the plugin data directory it derives itself, and denies
-the call outright when it cannot recognize the install layout — so a run reporting that denial is a
+the call outright when it cannot recognize the install layout, so a run reporting that denial is a
 coverage gap, not a clean result. (Derivation and its fail-closed rationale: `reference/safety-model.md`.)
 
 For a large root (a home directory, anything whose recursive walk could exceed the engine's entry cap),
 start with a bounded pass: add `--max-depth 1` to inventory the target's loose files and immediate children,
 then fan out deeper scans per subtree that the evidence justifies. The engine backs this with a
 deterministic gate: a scan whose target resolves to the user home directory or a non-OS volume root (a
-Windows Dev Drive — an OS-managed root still cannot be walked as a whole, and reaches the engine only via
+Windows Dev Drive, an OS-managed root still cannot be walked as a whole, and reaches the engine only via
 `--root-children`) and carries neither `--max-depth` nor `--confirmed-large-scan` returns
 `large-target-confirmation-required` (after a cheap top-level probe, not a full walk) instead of the
 unbounded traversal, so a forgotten bound never becomes an accidental whole-volume scan. `--max-depth` is
 the preferred bounded response. When the target is an OS-managed volume root, first run with
 `--root-children` alone, present the `admitted_children` list through the [confirmation
 gate](#confirmation-gate)'s root-children row, then re-run with the same flag plus each chosen `--root-child
-<name>` — one run directory, one snapshot, one report covers every selected subtree. Never invent the
-selection. Reserve `--confirmed-large-scan` for a deliberate full walk the human has confirmed — pass the
+<name>`. One run directory, one snapshot, one report covers every selected subtree. Never invent the
+selection. Reserve `--confirmed-large-scan` for a deliberate full walk the human has confirmed, pass the
 [confirmation gate](#confirmation-gate)'s scan-scope row first, the same standing before an expensive step
 that the apply lane demands before a destructive one; a general "clean my home directory" is not that
-confirmation. Every directory whose descendants were not walked — cut off by `--max-depth`, a protected
-root, or a VCS boundary — is recorded in `truncated_paths`; report them as coverage gaps, never as clean,
+confirmation. Every directory whose descendants were not walked, cut off by `--max-depth`, a protected
+root, or a VCS boundary, is recorded in `truncated_paths`; report them as coverage gaps, never as clean,
 and never plan them for removal (the preview blocks them as `truncated-not-inventoried` and skips the live
 re-verification checks a candidate with no live-I/O value left to give would otherwise still pay for). Each
 fan-out worker receives a bounded subtree and returns evidence only. The parent owns classification, the
@@ -184,7 +184,7 @@ rule below.
 
 A hint annotation is not the only trigger for triage: at a user-home target, treat any loose
 root-level entry whose `protected_reasons` is empty and that does not belong to a recognizable
-app/config convention as suspicious too — the snapshot already carries it (every walked entry is
+app/config convention as suspicious too, the snapshot already carries it (every walked entry is
 recorded with a possibly-empty `hints` list), so nothing further needs discovering, only judging.
 Read the entry's own `protected_reasons`, never one policy field: protection also comes from name
 patterns and from live filesystem state, and an entry that names a single field as its filter will
@@ -205,7 +205,7 @@ For each hinted or suspicious entry, inspect enough neighboring content and meta
 
 ## 3. Classify and report
 
-Safe tidiness leads; reclaimed space follows. Confidence is report priority, not permission — and
+Safe tidiness leads; reclaimed space follows. Confidence is report priority, not permission, and
 byte size is never a ranking key:
 
 | Tier | Minimum evidence | Default outcome |
@@ -214,14 +214,14 @@ byte size is never a ranking key:
 | Medium | Likely disposable, but one ownership/provenance fact is indirect | Review, then optionally offer its own approval |
 | Low | Name/age-only, conflicting signals, resumable or user-content possibility | Keep unless the human separately reviews and approves exact paths |
 
-Report every finding with these fields, in this order — size last:
+Report every finding with these fields, in this order, size last:
 
-1. **Provenance** — where it came from, resolved from evidence (a manifest, a config's own
+1. **Provenance**. Where it came from, resolved from evidence (a manifest, a config's own
    contents, an owning repository's source, a documented naming contract), never guessed from the
    name alone.
-2. **What it is** — intent / role of the entry (`reason` in engine plans).
-3. **Why removable** — why it is not work product, plus owner / native-GC result.
-4. **Risk** — what could go wrong if it is removed (and why that risk is acceptable at this tier).
+2. **What it is**. Intent / role of the entry (`reason` in engine plans).
+3. **Why removable**. Why it is not work product, plus owner / native-GC result.
+4. **Risk**. What could go wrong if it is removed (and why that risk is acceptable at this tier).
 5. Path, tier, evidence, disposition.
 6. Logical / reclaimable bytes as a **secondary** signal only.
 
@@ -237,16 +237,16 @@ fold the first into a byte-centric roll-up that drops it, and never read it as t
 
 **Lead the frontier with `children_rollup`.** The snapshot carries one row per immediate child the run covered, whatever
 that child's coverage, and `walked` is the single discriminator: `true` means every aggregate is exact; `false` means
-they are all `null` with `unwalked_reasons` naming the cause — never `0`, never a partial subtree sum. Rank on
+they are all `null` with `unwalked_reasons` naming the cause, never `0`, never a partial subtree sum. Rank on
 `reclaimable_local_bytes`, never on `logical_bytes`, a logical total that `size_qualifiers` flags as inflated by cloud
 placeholders, hard links, or sparse extents. The block opens no directory the walk did not, so a `--max-depth 1` pass
 returns `depth-cut`/`null` for every NON-EMPTY child: the frontier is complete, but a recursive total is bought only by
-fanning a deeper scan out over that subtree — report those rows as coverage gaps, never as small or clean.
-`scan-complete` also carries `unhinted_entries` — `entries` minus `hinted_entries`, every inventoried entry no hint
-judged — so quote hint coverage as a rate: 7 hinted of 40,247 is 0.017 %, nothing like "7 findings". Fields, reasons
+fanning a deeper scan out over that subtree, report those rows as coverage gaps, never as small or clean.
+`scan-complete` also carries `unhinted_entries`, `entries` minus `hinted_entries`, every inventoried entry no hint
+judged. So quote hint coverage as a rate: 7 hinted of 40,247 is 0.017 %, nothing like "7 findings". Fields, reasons
 and the measurement: [the safety model](reference/safety-model.md).
 
-**Relocation is out of scope.** This skill offers exactly two outcomes per finding — keep it, or approve its
+**Relocation is out of scope.** This skill offers exactly two outcomes per finding, keep it, or approve its
 exact path for deletion. There is no relocation lane and no move primitive in the engine, by design: a move
 is not a containment-checkable, revalidatable, token-bound operation the way a delete is. So when the right
 answer for a misplaced entry is "this belongs somewhere else", say so and report it as **keep**; the
@@ -255,12 +255,12 @@ keep-or-delete choice is the complete set of dispositions, and never stage a mov
 handoff.
 
 An entry's `logical_size` is reclaimable local bytes only when its `size_qualifiers` is empty. Exclude every qualified
-entry from any reclaimable-bytes total and state the qualified bytes separately with their reasons — a
+entry from any reclaimable-bytes total and state the qualified bytes separately with their reasons, a
 `cloud-placeholder` carries its REMOTE size while occupying roughly nothing locally; a `hardlinked` name shares one
 object with other names; a `sparse` file's logical size overstates local allocation; and `not-walked` means the subtree
-was never inventoried, so `logical_size` is `null` rather than `0` — except on the target's own record, which keeps its
+was never inventoried, so `logical_size` is `null` rather than `0`, except on the target's own record, which keeps its
 partial walked sum alongside a `not-walked` qualifier, so read that number as a floor. Prefer the snapshot's
-`target_reclaimable_local_bytes` (and preview/apply `reclaimable_local_bytes*`) over summing `logical_size` yourself —
+`target_reclaimable_local_bytes` (and preview/apply `reclaimable_local_bytes*`) over summing `logical_size` yourself. 
 folding qualified or unknown sizes into a total claims space that deleting the path would never return. Never treat a
 low or zero reclaimable-byte figure as a reason to skip a finding that otherwise clears the evidence bar.
 
@@ -308,8 +308,8 @@ blocker means no approval prompt and no deletion. Fix nothing behind the gate; r
 
 When status is `ready-for-explicit-approval`, show a table naming every path with provenance, what
 it is, why removable, risk, whether it is an empty directory, the single tier, and only then logical
-/ reclaimable bytes, plus the preview's approval token — then pass the
-[confirmation gate](#confirmation-gate) — the approval must name **exactly that tier and list**.
+/ reclaimable bytes, plus the preview's approval token, then pass the
+[confirmation gate](#confirmation-gate). The approval must name **exactly that tier and list**.
 Process another tier only with a new plan, preview, and question.
 
 ## 6. Apply only the confirmed preview
@@ -333,10 +333,10 @@ token.
 
 Preview reports `execution-platform-unsupported` as a per-candidate blocker on these platforms, so
 the engine never deletes there. The default outcome is the report. The manual lane is gated by
-`--execute` exactly as the engine lane is — without it, no deletion lane may be offered on any
-platform. If — and only if — `--execute` was requested and the human reviews the report and approves
+`--execute` exactly as the engine lane is, without it, no deletion lane may be offered on any
+platform. If, and only if,`--execute` was requested and the human reviews the report and approves
 an exact path list drawn from one tier in this interactive session (the §3 report spans every tier, so
-narrow it to a single tier and show that tier's paths before asking — the
+narrow it to a single tier and show that tier's paths before asking, the
 [confirmation gate](#confirmation-gate)'s removal row is the same exact-tier-and-list bar the engine
 lane clears; a general "clean it up" is still not approval), removal is a manual handoff, not an
 engine plan:
@@ -353,11 +353,11 @@ engine plan:
    ```
 
    It reruns the engine's identity/reparse/protection/descendant/VCS/handle checks per path
-   against live state and emits one verdict each — `clear`, `drifted` (identity or descendant
+   against live state and emits one verdict each, `clear`, `drifted` (identity or descendant
    set changed since the snapshot), `gone` (no longer present), or `contested` (protection,
-   VCS state, a live handle, elevation, or unverifiable state) — and never deletes anything.
+   VCS state, a live handle, elevation, or unverifiable state). And never deletes anything.
    Act only on verdict-`clear` paths. Additionally confirm any owner process named in the audit
-   evidence is still absent — that evidence is report-level, outside the engine's checks.
+   evidence is still absent, that evidence is report-level, outside the engine's checks.
 
    A standalone Git checkout can reach `clear` only through an additional, explicit evidence file.
    Never use this for a linked worktree, a tracked subdirectory, or non-Git VCS. After the operator
@@ -409,31 +409,31 @@ engine plan:
 
    **Verify one path per deletion, not one batch for all.** In a multi-path run, the first
    path's check ages while every later path is still being walked and probed, so its `clear`
-   is already stale at emission — and staler after each intervening deletion. Pair each
+   is already stale at emission, and staler after each intervening deletion. Pair each
    deletion with its own fresh single-path handoff-verify run (verify one → delete that one →
    next); reserve the multi-path form for reporting. A clear verdict is valid only at emission
    time: delete immediately, and re-run handoff-verify after any delay or interruption.
 2. Prefer reversible removal (Windows Recycle Bin / macOS Trash) over permanent deletion, and say
    which was used. That reversibility is conditional, not guaranteed: bin size caps, a
    policy-disabled bin, or a non-NTFS/network volume can silently make the same operation
-   permanent — disclose when a target's volume or policy may turn "reversible" removal permanent.
+   permanent, disclose when a target's volume or policy may turn "reversible" removal permanent.
 
-   **Path length is a different failure — not a silent downgrade but a hard stop.** Those three
+   **Path length is a different failure, not a silent downgrade but a hard stop.** Those three
    caveats all describe a reversible operation quietly turning permanent. A path longer than the
    classic Windows `MAX_PATH` (260 characters) cannot reach the Recycle Bin *at all*: the shell
-   APIs behind it reject the path, so the operation fails outright. Deep tool residue — nested
-   dependency or build trees — routinely exceeds it. The only remaining way to remove such a path
+   APIs behind it reject the path, so the operation fails outright. Deep tool residue, nested
+   dependency or build trees, routinely exceeds it. The only remaining way to remove such a path
    is a **permanent** delete through a `\\?\` long-path API, which no bin can undo.
 
    That fallback is its own irreversible action and does **not** inherit the approval given for a
    reversible removal. Stop, tell the operator this exact path cannot be recycled and why, and
    re-ask through the [confirmation gate](#confirmation-gate) for permanent deletion of that exact
-   path, named as irreversible — an approval that said "recycle these" never authorized it. If the
+   path, named as irreversible, an approval that said "recycle these" never authorized it. If the
    operator declines, skip and report the path; shortening or moving the tree to get under the
    limit is a relocation, out of scope (§3) and the operator's own action. Record such removals as
    permanent in the §6 summary, distinct from the reversible ones.
 3. Container-wide deletion commands (`Clear-RecycleBin`, emptying the Trash, or any "delete
-   everything in this container" spelling) are forbidden in the manual lane — they execute
+   everything in this container" spelling) are forbidden in the manual lane, they execute
    against the live container, so items arriving between approval (or even re-enumeration) and
    execution die under an approval that never saw them. Satisfy "empty the container" by
    enumerating the container and deleting per item under steps 1, 2, and 4; items that arrive
@@ -447,7 +447,7 @@ bar as the engine apply prompt); confirm that prompt only when the command match
 approved list. Engine invocations from PowerShell stay hard-denied.
 
 **That belt outlives this cleanup.** Claude Code registers a skill's frontmatter hooks when the
-skill is invoked and keeps them registered for the **rest of the session** — there is no
+skill is invoked and keeps them registered for the **rest of the session**. There is no
 harness-level "while the skill is active" window for hooks (#2618). So once `/disk-hygiene:clean`
 has run, the deny-by-default Bash lane and the PowerShell deletion prompts keep applying to
 unrelated later work in the same session, not only to this cleanup. Say so when a later,
@@ -464,7 +464,7 @@ activity, sparse files, hard links, compression, and delayed allocation affect i
 
 ## Gotchas
 
-Harness mechanics are not restated here — one copy only, because two is how a stale claim survived
+Harness mechanics are not restated here, one copy only, because two is how a stale claim survived
 a fix to the reference (#2618). Load [the safety model](reference/safety-model.md) when you need
 them: how the guard registers on two surfaces, how the kill switch is delivered and scoped, and
 what the PowerShell lane flags → "Kill-switch enforcement"; how the hooks launch, what that bounds,
@@ -492,7 +492,7 @@ and the residual fail-open → "Hook launch form".
   splitting/escape forms, operators, redirections, aliases, and exported functions fail closed.
 - The PowerShell lane is the inverse tradeoff: open for read-only support work, hard-denying engine
   invocations, and turning known deletion spellings into a final human permission prompt. It is a
-  raised bar, not a fail-closed lane — its flagged set is enumerated, so an unflagged mutation
+  raised bar, not a fail-closed lane, its flagged set is enumerated, so an unflagged mutation
   spelling passes it. The engine's own containment and the Bash lane remain the deletion authority.
 - The guard rejects `~` anywhere in a Bash command as a shell-expansion character, which includes
   Windows 8.3 short names (`SOMEUS~1`). Always pass long-form paths; the guard's own disclosures

--- a/plugins/disk-hygiene/skills/clean/SKILL.md
+++ b/plugins/disk-hygiene/skills/clean/SKILL.md
@@ -260,8 +260,8 @@ entry from any reclaimable-bytes total and state the qualified bytes separately 
 object with other names; a `sparse` file's logical size overstates local allocation; and `not-walked` means the subtree
 was never inventoried, so `logical_size` is `null` rather than `0`, except on the target's own record, which keeps its
 partial walked sum alongside a `not-walked` qualifier, so read that number as a floor. Prefer the snapshot's
-`target_reclaimable_local_bytes` (and preview/apply `reclaimable_local_bytes*`) over summing `logical_size` yourself. 
-folding qualified or unknown sizes into a total claims space that deleting the path would never return. Never treat a
+`target_reclaimable_local_bytes` (and preview/apply `reclaimable_local_bytes*`) over summing `logical_size` yourself.
+Folding qualified or unknown sizes into a total claims space that deleting the path would never return. Never treat a
 low or zero reclaimable-byte figure as a reason to skip a finding that otherwise clears the evidence bar.
 
 ## 4. Build one exact-tier plan

--- a/plugins/disk-hygiene/skills/setup/SKILL.md
+++ b/plugins/disk-hygiene/skills/setup/SKILL.md
@@ -76,7 +76,7 @@ fails closed like every other guard-relevant unknown in this plugin.
    absolute interpreter path (guarded engine calls must use the same absolute interpreter
    the guard reports. Bash aliases and functions cannot substitute).
 
-   On Windows, confirm the name the guard resolves is real BEFORE anything executes it. 
+   On Windows, confirm the name the guard resolves is real BEFORE anything executes it,
    including this floor check's own version probe. `python3` is the first rung of the ladder
    `hooks/run-python-hook.sh` walks for every guard surface; on stock Windows it resolves to a
    zero-length `WindowsApps\python3.exe` App Execution Alias that opens the Microsoft Store
@@ -86,7 +86,7 @@ fails closed like every other guard-relevant unknown in this plugin.
    rung, is the verdict.** A host with real Python installed without "Add to PATH" but with the
    `py` launcher has a stubbed `python3` and a perfectly working guard; failing it would report a
    healthy install as broken and send the operator to reinstall Python. So the alias probe is
-   **diagnostic input**. It says what the first rung is, and keeps setup from executing it. 
+   **diagnostic input**. It says what the first rung is, and keeps setup from executing it,
    while the verdict comes from resolving the ladder and checking the selected interpreter
    against the parsed floor.
    Order of operations: (a) locate the resolution without executing it (`Get-Command python3`
@@ -133,7 +133,7 @@ fails closed like every other guard-relevant unknown in this plugin.
    with that conditionality stated; absence is only a FAIL for worktree-containing targets.
 4. **Platform posture**. Detect the current OS family and report its documented lane per
    the README, keeping the audit and execution lanes visibly separate: Windows (full
-   **audit**. `lstat` reparse + Win32, never UAC; engine **execution unsupported**. 
+   **audit**: `lstat` reparse + Win32, never UAC; engine **execution unsupported**.
    `preview` reports `execution-platform-unsupported` as a per-candidate blocker, removal is
    a manual, per-path Recycle-Bin handoff only under `--execute` and after explicit
    approval), Linux (full audit; execution when
@@ -163,7 +163,7 @@ tool or an OS capability, so `apply` installs nothing and writes nothing, it onl
   the engine's `MIN_PYTHON`; never a plugin download.
 - missing git (worktree targets): platform install instructions.
 - toggle off: direct to `/plugin configure disk-hygiene` (interactive, any time).
-  Headless: rerun the install with the new value. 
+  Headless: rerun the install with the new value:
   `claude plugin install disk-hygiene@<marketplace> -s <scope> --config disk_hygiene_enabled=true`
   (repeatable per key). Against an already-installed plugin it prints `already installed` **and
   still writes the value**. Verified on Claude Code 2.1.240 (a non-sensitive option at `user`

--- a/plugins/disk-hygiene/skills/setup/SKILL.md
+++ b/plugins/disk-hygiene/skills/setup/SKILL.md
@@ -9,26 +9,26 @@ disable-model-invocation: true
 
 Thin check-centric setup per the uniform setup contract (`docs/PLUGIN-PHILOSOPHY.md`
 "Setup is explicit and repeatable" in the marketplace repository): `check` inspects and
-reports, `apply` resolves. This plugin owns no consumer-project configuration — targets
+reports, `apply` resolves. This plugin owns no consumer-project configuration, targets
 and modes arrive as `/disk-hygiene:clean` arguments, and the only tunable is the native
-`userConfig` toggle — so `apply` is pure guidance and writes nothing.
+`userConfig` toggle, so `apply` is pure guidance and writes nothing.
 
 Action routing: no argument or `check` runs the check; `apply` runs the check first, then
-points at each remediation. Both are non-interactive — never prompt when the action is given.
+points at each remediation. Both are non-interactive, never prompt when the action is given.
 
 ## `check` (read-only)
 
 The clean skill and its bundled scripts (`${CLAUDE_PLUGIN_ROOT}/skills/clean/`) are the
 single source of truth for what the plugin requires per platform.
 
-**Read it first** — probe what it actually does, don't recite this file. Then run each probe via
+**Read it first**. Probe what it actually does, don't recite this file. Then run each probe via
 Bash and report a PASS/FAIL/INFO table with one remediation line per FAIL. Do not modify anything.
 
 The toggle is an audit-only kill switch, not a short-circuit: the guard registers
 unconditionally and still scans with the toggle off, so most prerequisite absences keep their
 FAIL semantics regardless of the toggle. Only the execution-tier tools the audit lane never
 invokes (step 4's `lsof`-class probes) downgrade from FAIL to INFO when the toggle is
-disabled — report those informationally and note that re-enabling restores the FAIL semantics.
+disabled, report those informationally and note that re-enabling restores the FAIL semantics.
 A missing `git` stays FAIL either way: the audit lane itself calls it, and its absence degrades
 the VCS-tracked-content evidence the plugin's fail-closed posture depends on.
 
@@ -36,10 +36,10 @@ Every step-1 and step-2 failure likewise stays FAIL with the toggle disabled.
 Audit-only mode is *enforced by* the guard, every guard surface
 depends on a Python 3 interpreter resolving (every surface through
 `hooks/run-python-hook.sh`, which tries `python3`, then `python`, then `py -3`), and a
-guard that never runs can neither read nor enforce the configured `false` — so the fail-open
+guard that never runs can neither read nor enforce the configured `false`, so the fail-open
 is most dangerous in exactly this
-configuration. That covers an **exhausted** interpreter ladder — every rung absent, a stub, or
-`indeterminate` — a rung whose version probe then fails to launch at all (a corrupt or
+configuration. That covers an **exhausted** interpreter ladder, every rung absent, a stub, or
+`indeterminate`, a rung whose version probe then fails to launch at all (a corrupt or
 zero-length binary outside `WindowsApps`, a broken shim, a permission error), *and* an
 interpreter that starts but reports a version below the parsed floor. It does **not** cover a
 stubbed `python3` alongside a working `python` or `py -3`: the launcher skips the stub, every
@@ -47,76 +47,76 @@ guard launches, and that is a WARN (see step 2), not a failure to downgrade.
 Launching the version probe proves only that something executes, not that it can run
 the guard's own source: Python 3.6, for example, rejects the guard's
 `from __future__ import annotations` and exits without a deny, which PreToolUse treats as
-non-blocking — the same silent fail-open through a different door. Unproven guard execution
+non-blocking, the same silent fail-open through a different door. Unproven guard execution
 fails closed like every other guard-relevant unknown in this plugin.
 
-1. **Shell-form launcher registration** — all three registrations (both wired hooks in
+1. **Shell-form launcher registration**. All three registrations (both wired hooks in
    `hooks/hooks.json` and the skill-scoped belt in `skills/clean/SKILL.md` frontmatter) must name
    `hooks/run-python-hook.sh` directly in `command`, with `"shell": "bash"` and **no `args`**, so
    Claude Code routes them through its own Git Bash rather than a `PATH` lookup. FAIL if any
    registration carries an `args` key or sets `command` to a bare interpreter name such as `bash`
    or `python3`: that is exec form, which on Windows resolves `bash` to the WSL relay
    `System32\bash.exe` and `python3` to the zero-length `WindowsApps` App Execution Alias stub, and
-   fails to launch — and a failed hook launch is non-blocking, so the guard silently enforces
+   fails to launch, and a failed hook launch is non-blocking, so the guard silently enforces
    nothing (#1416 for the wired hooks, #2568 for the belt). Do **not** report this as a
    `PATH`-ordering problem: shell form is resolved by
    Claude Code, so reordering `PATH` neither causes nor fixes it. Also FAIL if the launcher is
    missing or not executable. Report a missing Git Bash on Windows as an environment prerequisite
    (shell form falls back to PowerShell there, which cannot run a `.sh`), not as a `PATH` fix.
-2. **Python floor on `PATH`** — the interpreter used by scanning, validation, the
+2. **Python floor on `PATH`**. The interpreter used by scanning, validation, the
    guard, and cleanup. (The guard registers on two surfaces: a plugin-level engine gate
    that acts only on engine-referencing commands, and the skill-frontmatter belt that
    Claude Code keeps armed for the rest of the session after `/disk-hygiene:clean` is
    invoked. Both register unconditionally and resolve the kill switch by
    reading `disk_hygiene_enabled` from the user `settings.json`.) The required version has one origin: the `MIN_PYTHON`
-   constant in `${CLAUDE_PLUGIN_ROOT}/skills/clean/scripts/hygiene.py` — parse it from
+   constant in `${CLAUDE_PLUGIN_ROOT}/skills/clean/scripts/hygiene.py`, parse it from
    there (`grep -m1 '^MIN_PYTHON' …`) and probe the interpreter against that value; do not
    recite a version number from this file or the README. FAIL if absent or older, naming
    the parsed floor in the remediation; the plugin never downloads a runtime. Report the
    absolute interpreter path (guarded engine calls must use the same absolute interpreter
-   the guard reports — Bash aliases and functions cannot substitute).
+   the guard reports. Bash aliases and functions cannot substitute).
 
-   On Windows, confirm the name the guard resolves is real BEFORE anything executes it —
+   On Windows, confirm the name the guard resolves is real BEFORE anything executes it. 
    including this floor check's own version probe. `python3` is the first rung of the ladder
    `hooks/run-python-hook.sh` walks for every guard surface; on stock Windows it resolves to a
    zero-length `WindowsApps\python3.exe` App Execution Alias that opens the Microsoft Store
    (or hangs) instead of running an interpreter, and executing that name from setup pops the
-   Store instead of probing. Since #2568 the stub no longer stops any guard by itself — the
+   Store instead of probing. Since #2568 the stub no longer stops any guard by itself, the
    launcher skips it and falls through to `python`, then `py -3`. **The ladder, not the first
    rung, is the verdict.** A host with real Python installed without "Add to PATH" but with the
    `py` launcher has a stubbed `python3` and a perfectly working guard; failing it would report a
    healthy install as broken and send the operator to reinstall Python. So the alias probe is
-   **diagnostic input** — it says what the first rung is, and keeps setup from executing it —
+   **diagnostic input**. It says what the first rung is, and keeps setup from executing it. 
    while the verdict comes from resolving the ladder and checking the selected interpreter
    against the parsed floor.
    Order of operations: (a) locate the resolution without executing it (`Get-Command python3`
-   / `command -v python3` — locating is inspection; running is not); (b) classify it with the
+   / `command -v python3`, locating is inspection; running is not); (b) classify it with the
    bundled inspect-only probe, launched via an interpreter that is NOT the bare name
-   `python3` (`py -3`, `python`, or an absolute interpreter path — any interpreter already
+   `python3` (`py -3`, `python`, or an absolute interpreter path, any interpreter already
    proven real):
    `"<python>" "${CLAUDE_PLUGIN_ROOT}/skills/setup/scripts/python3_alias_probe.py"`; if no
    such interpreter exists **or the one you chose emits no JSON verdict**, apply the probe's own
    portable signal directly in PowerShell. Proven real is not the same as able to run the probe:
    a pre-3.7 interpreter rejects its `from __future__ import annotations` and a legacy `python`
-   2.x fails earlier still, each before anything is classified — so a machine whose only
+   2.x fails earlier still, each before anything is classified, so a machine whose only
    alternate launcher is Python 3.6 reaches the verdict through PowerShell, not by having no
    launcher at all. The signal: a zero-length file under a `WindowsApps` path component is the stub
    (`(Get-Item -Force (Get-Command python3).Source)` → `Length` 0 plus a `ReparsePoint`
    attribute); (c) resolve the ladder in the launcher's own order, skipping any rung the probe
    classified as a stub: `python3` only when its verdict is `ok`, then `python`, then `py -3`.
-   The version probe may execute a rung only once that rung is not a stub — that is the whole
+   The version probe may execute a rung only once that rung is not a stub, that is the whole
    point of (b), and it is why the bare name `python3` is never executed on a
    `store-alias-stub` verdict. Report the absolute path of the first rung that runs and meets
    the floor.
 
-   **FAIL when the ladder is exhausted or below the floor** — no rung resolves, or the one that
+   **FAIL when the ladder is exhausted or below the floor**. No rung resolves, or the one that
    does reports a version under the parsed `MIN_PYTHON`. That is the real fail-open: the guard
    cannot run, and it emits neither exit 2 nor a `deny`. Distinguish the two for the remediation
-   wording — an interpreter that starts and reports a version below the floor is a floor miss
+   wording, an interpreter that starts and reports a version below the floor is a floor miss
    (name the parsed floor), one that fails to launch at all is an absent-interpreter failure
    (the plugin never downloads a runtime). Both keep the FAIL under a disabled toggle: a
    below-floor interpreter is not proven able to execute the guard's source, so audit-only mode
-   is unenforceable there too. `indeterminate` on **every** rung is the same case — identity the
+   is unenforceable there too. `indeterminate` on **every** rung is the same case, identity the
    probe could not read anywhere on the ladder is uncertainty about whether the guard can launch
    at all, and fails closed like every other guard-relevant unknown in this plugin.
 
@@ -124,52 +124,52 @@ fails closed like every other guard-relevant unknown in this plugin.
    stub.** Every guard launches, so nothing is failing open. State the residual plainly: the
    operator's own bare `python3` still opens the Microsoft Store, and guarded engine calls must
    use the absolute interpreter path reported above rather than that name. Offer the same
-   remediation as an optional tidy-up, not as a fix for a broken install — disable the `python3`
+   remediation as an optional tidy-up, not as a fix for a broken install, disable the `python3`
    App execution alias (Settings > Apps > Advanced app settings > App execution aliases), or put
    real Python ahead of WindowsApps on `PATH`. A bare `command -v python3` success is not
-   evidence on its own — it matches the stub too.
-3. **Git** — `command -v git`. Conditional per the README: optional for ordinary trees,
+   evidence on its own, it matches the stub too.
+3. **Git**. `command -v git`. Conditional per the README: optional for ordinary trees,
    required when a target contains or sits inside a Git worktree. Report presence as INFO
    with that conditionality stated; absence is only a FAIL for worktree-containing targets.
-4. **Platform posture** — detect the current OS family and report its documented lane per
+4. **Platform posture**. Detect the current OS family and report its documented lane per
    the README, keeping the audit and execution lanes visibly separate: Windows (full
-   **audit** — `lstat` reparse + Win32, never UAC; engine **execution unsupported** —
+   **audit**. `lstat` reparse + Win32, never UAC; engine **execution unsupported**. 
    `preview` reports `execution-platform-unsupported` as a per-candidate blocker, removal is
    a manual, per-path Recycle-Bin handoff only under `--execute` and after explicit
    approval), Linux (full audit; execution when
-   `/proc/self/mountinfo` is readable — `lsof` needed only for that optional execution
+   `/proc/self/mountinfo` is readable, `lsof` needed only for that optional execution
    lane, absent `lsof` is INFO with the reduced-capability note), macOS (audit/report
-   only by design; manual Trash handoff only under `--execute` — INFO, not a defect).
-5. **Execution kill switch** — resolve the effective `disk_hygiene_enabled` value
+   only by design; manual Trash handoff only under `--execute`. INFO, not a defect).
+5. **Execution kill switch**. Resolve the effective `disk_hygiene_enabled` value
    deterministically; never present an assumed value as the configured one. Run the bundled
    probe with the step-2 interpreter:
    `"<python>" "${CLAUDE_PLUGIN_ROOT}/skills/setup/scripts/kill_switch_probe.py"`
    and report its `effective` value together with its `source` (`configured` vs `default`).
    When the probe says `degraded: true`, report that the configured value could not be read
-   and that default `true` is being assumed — an assumption, never the configured value. The
+   and that default `true` is being assumed, an assumption, never the configured value. The
    body token `${user_config.disk_hygiene_enabled}` is at most a cross-check: if it expanded
    to a boolean that contradicts the probe, report the discrepancy instead of silently
    preferring either channel (the probe sees user settings only; managed settings or a
    `--settings` flag can carry a value the probe cannot see).
-6. **Plugin registration** — INFO: confirm the plugin is enabled for this project
+6. **Plugin registration**. INFO: confirm the plugin is enabled for this project
    (`/plugin` → Installed) rather than parsing settings files.
 
 ## `apply` (idempotent)
 
 Run `check`, then for each FAIL point at the resolution. Every prerequisite is a system
-tool or an OS capability, so `apply` installs nothing and writes nothing — it only points:
+tool or an OS capability, so `apply` installs nothing and writes nothing, it only points:
 
 - missing/old Python: the platform's own install channel for the floor `check` parsed from
   the engine's `MIN_PYTHON`; never a plugin download.
 - missing git (worktree targets): platform install instructions.
 - toggle off: direct to `/plugin configure disk-hygiene` (interactive, any time).
-  Headless: rerun the install with the new value —
+  Headless: rerun the install with the new value. 
   `claude plugin install disk-hygiene@<marketplace> -s <scope> --config disk_hygiene_enabled=true`
   (repeatable per key). Against an already-installed plugin it prints `already installed` **and
-  still writes the value** — verified on Claude Code 2.1.240 (a non-sensitive option at `user`
+  still writes the value**. Verified on Claude Code 2.1.240 (a non-sensitive option at `user`
   scope: a non-default value written to an installed plugin, then restored). The short-circuit is
   about the install, not the config write. Re-verify before relying on it outside those
-  conditions — a `sensitive` option, or `project`/`local` scope, were not covered. Do **not**
+  conditions, a `sensitive` option, or `project`/`local` scope, were not covered. Do **not**
   uninstall to reconfigure: uninstalling drops this plugin's entire stored `pluginConfigs` entry,
   resetting every option in the README's Options reference table to its manifest default. `-s`
   defaults to `user`, so pass the scope `claude plugin list` reports for this plugin, and run from
@@ -178,7 +178,7 @@ tool or an OS capability, so `apply` installs nothing and writes nothing — it 
   Afterwards, keep the two claims apart. The write is issued and the stored value is what you
   passed; the RUNNING session's behavior is not. The rendered `${user_config.*}` is injected at
   skill load and each hook receives its `CLAUDE_PLUGIN_OPTION_*` from an environment fixed at
-  session start, so a same-session `check` still reports the OLD value — reporting that as a
+  session start, so a same-session `check` still reports the OLD value, reporting that as a
   failed write would be wrong. Verify the effective value by rerunning `check` in a **fresh
   session**, and never claim an unobserved change.
 
@@ -186,6 +186,6 @@ Re-running `apply` after everything passes changes nothing and reports "already 
 
 ## What this skill does NOT do
 
-- Run an audit or cleanup — that is `/disk-hygiene:clean`.
+- Run an audit or cleanup, that is `/disk-hygiene:clean`.
 - Write the plugin cache, Claude Code user settings, or `pluginConfigs`.
-- Install any tool or runtime, during either `check` or `apply` — guidance only.
+- Install any tool or runtime, during either `check` or `apply`, guidance only.


### PR DESCRIPTION
No linked issue

## Summary

#2891 instruction-surface de-slop cluster: purge em dashes from the `disk-hygiene` plugin README and every SKILL.md.

## Fix

Rewrote `plugins/disk-hygiene/README.md` and every `plugins/disk-hygiene/**/SKILL.md` under `/ai-slop:audit fix` semantics (periods, commas, or a restructured sentence; never parentheses, en dashes, or a spaced hyphen as a stand-in). Meaning-preserving self-audit repaired asides the first pass reattached to the wrong noun. The generated options block is ignore-fenced because the shared generator still emits em dashes. `disk-hygiene` 0.20.21.

## Verification

- Detector: 0 `rule-em-dash` findings outside ignore-fenced generated-options spans (and required trigger strings that must keep em dashes)
- `CHECK_SKILL_SKIP_MARKDOWNLINT=1 bash scripts/check-changed-skills.sh origin/main`: 0 failed; quoted trigger phrases vs origin/main preserved
- `python3 scripts/sync-plugin-options-docs.py --check` up to date
- `scripts/check-changelog-parity.sh --check-bump origin/main` passes
- `node scripts/generate-cheatsheet.mjs --check` in sync

## Related

Refs #2891

#2891 stays open.