### PR TITLE
docs: de-slop root README instruction surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Melodic Software — Claude Code plugins
+# Melodic Software. Claude Code plugins
 
 A public [Claude Code](https://code.claude.com/docs) plugin marketplace of reusable, repo-agnostic
 skills, hooks, and agents. Each plugin is designed to work in any repository and to be customized by
@@ -14,7 +14,7 @@ consumers without editing the plugin itself.
 Browse and manage with `/plugin`. To refresh after updates: `/plugin marketplace update melodic-software`.
 
 When you consume this repo from a local `directory` source, the install cache keys on semver
-`version`, not commit — so several commits under one version leave early installs on a stale
+`version`, not commit, so several commits under one version leave early installs on a stale
 snapshot and `plugin update` can report "already at the latest version" while SHA lags. See
 [`docs/MIGRATION-PLAYBOOK.md`](docs/MIGRATION-PLAYBOOK.md) ("Same-version commit drift") and
 [#2061](https://github.com/melodic-software/claude-code-plugins/issues/2061).
@@ -24,7 +24,7 @@ snapshot and `plugin update` can report "already at the latest version" while SH
 Some catalog entries declare `relevance` signals so Claude Code can suggest the plugin when a
 session's work matches (matching runs locally; nothing is reported anywhere). Suggestions are
 opt-in per marketplace: they surface only after an administrator allowlists the marketplace in
-[managed settings](https://code.claude.com/docs/en/settings#settings-files) — declare the
+[managed settings](https://code.claude.com/docs/en/settings#settings-files). Declare the
 marketplace source AND allowlist its name in the same file:
 
 ```json
@@ -51,41 +51,41 @@ user opts in with `/plugin enable`; an existing install is never flipped by cata
 
 ## Finding your way
 
-- Not sure which skill to invoke? Start at the [skill cheat sheet](docs/SKILL-CHEAT-SHEET.md) — a
+- Not sure which skill to invoke? Start at the [skill cheat sheet](docs/SKILL-CHEAT-SHEET.md). A
   scan-and-go map from what you're doing to the skill to use.
-- [Plugin catalog](docs/CATALOG.md) — every plugin by category, generated from the manifests and
+- [Plugin catalog](docs/CATALOG.md). Every plugin by category, generated from the manifests and
   kept in sync by CI. New plugins clear the per-plugin migration gate in
   [`docs/MIGRATION-PLAYBOOK.md`](docs/MIGRATION-PLAYBOOK.md).
-- [Catalog taxonomy](docs/CATALOG-TAXONOMY.md) — the category vocabulary the catalog is grouped by.
+- [Catalog taxonomy](docs/CATALOG-TAXONOMY.md). The category vocabulary the catalog is grouped by.
 
 ## What's here
 
-- `.claude-plugin/marketplace.json` — the marketplace catalog.
-- `plugins/` — one directory per plugin.
-- `lib/` — single source of truth for the shared shell helpers; the self-contained copies vendored
+- `.claude-plugin/marketplace.json`, the marketplace catalog.
+- `plugins/`, one directory per plugin.
+- `lib/`, single source of truth for the shared shell helpers; the self-contained copies vendored
   under `plugins/`, into hook and skill-script directories alike, are synced from here by
   each helper's own `scripts/sync-<helper>.sh` and CI rejects drift, so never edit a copy.
-- `scripts/` — repo-level CI checks, sync scripts, and catalog generators, with their tests
+- `scripts/`, repo-level CI checks, sync scripts, and catalog generators, with their tests
   alongside.
-- `prompts/` — launch-prompt templates meant to be filled in and pasted into a session; unlike
+- `prompts/`, launch-prompt templates meant to be filled in and pasted into a session; unlike
   `lib/`, nothing copies them, and plugin skills cite them by path.
-- `.claude/` — this checkout's own Claude Code configuration (session and PR-linkage hooks, the
+- `.claude/`, this checkout's own Claude Code configuration (session and PR-linkage hooks, the
   source-control convention). It governs work done here and ships to no one.
-- `.github/` — workflows plus the policy files they read (runner policy, security paths, recurring
+- `.github/`, workflows plus the policy files they read (runner policy, security paths, recurring
   schedule, PR template).
-- `docs/MIGRATION-PLAYBOOK.md` — design charter, extensibility model, the per-plugin migration
+- `docs/MIGRATION-PLAYBOOK.md`, design charter, extensibility model, the per-plugin migration
   gate, and the local development loop.
-- `docs/` — further design records and audits (CI runner routing, extensibility-contract smoke
+- `docs/`, further design records and audits (CI runner routing, extensibility-contract smoke
   tests, migration audits).
-- `CLAUDE.md` — operating rules for AI agents working in this repo (fresh-docs mandate + plugin
+- `CLAUDE.md`, operating rules for AI agents working in this repo (fresh-docs mandate + plugin
   design rules).
-- `docs/OFFICIAL-DOCS.md` — canonical index of the official Claude Code doc pages the mandate
+- `docs/OFFICIAL-DOCS.md`, canonical index of the official Claude Code doc pages the mandate
   sends you to.
 
 ## Validate a change
 
 The shell suites here are spawn-bound, and Git Bash on Windows pays roughly
-140 ms per process spawn against roughly 3 ms on Linux — so running every
+140 ms per process spawn against roughly 3 ms on Linux, so running every
 `**/*.test.sh` locally is an hours-long wall on a Windows box and nobody does
 it. Run the suites that actually cover your change instead:
 
@@ -97,7 +97,7 @@ scripts/affected-tests.sh path/to/file.sh # explicit paths instead of a diff
 ```
 
 It maps a changed file to its co-located suite, to any suite that names it, and
-to its dependents transitively — and it fans a shared-lib change out to every
+to its dependents transitively, and it fans a shared-lib change out to every
 carrying plugin by reading the `copies=(...)` array out of that lib's
 `scripts/sync-*.sh` manifest, the same manifest CI's `*-sync` lanes enforce. The
 fan-out is derived on every run, never transcribed, so a new carrying plugin is
@@ -110,7 +110,7 @@ convention: shell `*.test.sh`, Node `*.test.js` and `*.test.mjs`, Python
 be derived from a suite path; those are named as `NOT RUN` and `--run` exits 3
 rather than reporting success over suites that never executed.
 
-A changed file that maps to nothing is an **error**, not an empty selection —
+A changed file that maps to nothing is an **error**, not an empty selection. 
 "zero suites" must never be read as "nothing to run". Path classes that
 genuinely carry no suite are recorded, with the CI lane that does cover them, in
 [`scripts/affected-tests-no-suite.txt`](scripts/affected-tests-no-suite.txt);
@@ -122,7 +122,7 @@ The runner is deliberately sequential: parallelising it measured sublinear
 (the suites are spawn-bound), and several guardrails suites assert wall-clock
 ceilings that fail spuriously under concurrency. Selection is the lever.
 
-CI is unaffected — it still runs everything.
+CI is unaffected, it still runs everything.
 
 ## Official documentation
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ convention: shell `*.test.sh`, Node `*.test.js` and `*.test.mjs`, Python
 be derived from a suite path; those are named as `NOT RUN` and `--run` exits 3
 rather than reporting success over suites that never executed.
 
-A changed file that maps to nothing is an **error**, not an empty selection. 
+A changed file that maps to nothing is an **error**, not an empty selection.
 "zero suites" must never be read as "nothing to run". Path classes that
 genuinely carry no suite are recorded, with the CI lane that does cover them, in
 [`scripts/affected-tests-no-suite.txt`](scripts/affected-tests-no-suite.txt);


### PR DESCRIPTION
No linked issue

## Summary

#2891 instruction-surface de-slop cluster: purge em dashes from the marketplace root `README.md`.

## Fix

Rewrote `README.md` under `/ai-slop:audit fix` semantics (periods, commas, or a restructured sentence; never parentheses, en dashes, or a spaced hyphen as a stand-in). Meaning stays; only the mark and the sentence break change. No plugin version bump.

## Verification

- Detector: 0 `rule-em-dash` findings on `README.md`
- `node scripts/generate-cheatsheet.mjs --check` in sync
- `python3 scripts/sync-plugin-options-docs.py --check` up to date
- `scripts/affected-tests.sh README.md`: recorded no-suite class

## Related

Refs #2891

#2891 stays open.