### PR TITLE
feat(context-budget): report interactive-only tools as known-uncovered (0.6.8)

### DIFF
--- a/plugins/context-budget/.claude-plugin/plugin.json
+++ b/plugins/context-budget/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "context-budget",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "description": "Measure a Claude Code session's fixed startup context payload per item, on the consumer's machine at a pinned, version-stamped binary — including per-tool attribution of the built-in tool pools that /context reports only as lump sums, derived live by A/B bare-name-deny differencing with enforced comparability rules (skill-listing signature, one mode, one binary), an SDK-primary exact meter degrading to a version-aware headless /context parser and then to an honest structured error (never a wrong number), and a per-project measure-toggle-remeasure ledger under the plugin data directory recording every lever's real before/after delta. Report-only: prints exact config, applies nothing.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/context-budget/CHANGELOG.md
+++ b/plugins/context-budget/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to the `context-budget` plugin.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.8]
+
+### Added
+
+- **Engine / report:** a full sweep no longer silently omits interactive-only tools. The
+  attribution record carries `knownUncovered` from a maintained product-level list (Artifact,
+  AskUserQuestion, SendUserFile, EnterPlanMode, ExitPlanMode) plus a class note for
+  interactive-only MCP servers. A name that was a candidate this run is dropped from that
+  list. The report contract documents known-uncovered alongside unmeasured-but-candidate
+  ([#3199](https://github.com/melodic-software/claude-code-plugins/issues/3199)).
+
 ## [0.6.7]
 
 ### Changed

--- a/plugins/context-budget/skills/audit/SKILL.md
+++ b/plugins/context-budget/skills/audit/SKILL.md
@@ -99,7 +99,10 @@ memorised inventory. Ask the operator (or take from arguments) which to measure:
   ```
 
 - The **full sweep** (`--tools from-baseline`) prices every live tool; warn that it is one run per
-  tool and let the operator opt in.
+  tool and let the operator opt in. Interactive-only tools never appear in that live list —
+  Artifact, SendUserFile, AskUserQuestion, plan-mode tools, interactive-only MCP servers. The
+  attribution record's `knownUncovered` names them; the report lists each as known-uncovered,
+  never as absent. That category is distinct from unmeasured-but-candidate.
 
 Report the ranked `perTool` table with the binary stamp, and each row's `comparable` flag: a row
 the engine marked incomparable (skill listing shifted, version changed mid-run) is reported as

--- a/plugins/context-budget/skills/audit/reference/engine.md
+++ b/plugins/context-budget/skills/audit/reference/engine.md
@@ -65,7 +65,10 @@ All records are JSON on stdout (and `--out <file>`), schema-tagged:
 - `context-budget.attribution/1` — `baseline` (summary), ranked `perTool[]` rows
   `{tool, prefixDelta, deferredDelta, savedTokens, comparable, reasons}`, optional `additivity`
   (`--verify-additivity`: one combined-deny run checked against the sum of parts, with its own
-  `comparable`/`reasons`), plus the binary stamp and `skillListingSignature`. A deny can empty a
+  `comparable`/`reasons`), `knownUncovered` (interactive-only product tools from
+  [`interactive-only-tools.json`](interactive-only-tools.json) that were not candidates this
+  run — structurally unreachable from a headless inventory, not silent zeros), plus the binary
+  stamp and `skillListingSignature`. A deny can empty a
   summed bucket out of the snapshot entirely; the bucket's delta is then null and the row (or
   additivity record) reports `savedTokens`/`combinedSaved` as `null` with `comparable: false` and
   the reason — a missing measurement, never a coerced zero. That vanish path fires in

--- a/plugins/context-budget/skills/audit/reference/interactive-only-tools.json
+++ b/plugins/context-budget/skills/audit/reference/interactive-only-tools.json
@@ -1,0 +1,15 @@
+{
+  "schema": "context-budget.interactive-only/1",
+  "purpose": "Product-level tools and capabilities that exist in some session mode but are structurally never candidates in a headless sweep. The report lists each as known-uncovered — distinct from unmeasured-but-candidate. Third-party interactive-only MCP servers are a class, not a name list.",
+  "tools": [
+    "Artifact",
+    "AskUserQuestion",
+    "SendUserFile",
+    "EnterPlanMode",
+    "ExitPlanMode"
+  ],
+  "notes": [
+    "Interactive-only MCP servers are known-uncovered as a class; third-party names are not enumerated.",
+    "Plan-mode tools are listed by the product names EnterPlanMode and ExitPlanMode; a future rename is a listing edit, not a silent omission."
+  ]
+}

--- a/plugins/context-budget/skills/audit/reference/report.md
+++ b/plugins/context-budget/skills/audit/reference/report.md
@@ -27,8 +27,15 @@ mode; the displayed fraction in cli-parse mode).
 4. **Ranked per-tool attribution.** From the attribution record: one row per measured tool —
    `savedTokens`, split into `prefixDelta` / `deferredDelta`, with the `comparable` flag. Rows
    the engine marked incomparable appear with their reason instead of their numbers. If the
-   additivity check ran, state its verdict in one line. Unmeasured tools are listed as
-   unmeasured, not omitted — silence reads as "measured zero".
+   additivity check ran, state its verdict in one line. Unmeasured tools (candidates this run
+   that were not priced) are listed as unmeasured, not omitted — silence reads as "measured
+   zero". Tools that exist only in an interactive session — Artifact, SendUserFile,
+   AskUserQuestion, plan-mode tools, interactive-only MCP servers — are listed as
+   **known-uncovered**, a distinct category from unmeasured-but-candidate: they were never
+   candidates in this headless sweep. The names come from the attribution record's
+   `knownUncovered.tools` (product-level surfaces) plus `knownUncovered.notes` (the
+   interactive-only MCP class). A name that appeared in this run's candidate list is not
+   repeated as known-uncovered.
 5. **Lever findings.** One entry per applicable catalogue lever
    ([`levers.json`](levers.json)): current detected state, honesty category (with the condition's
    measured resolution where the row has one), the measured or measurable delta, the exact
@@ -43,10 +50,10 @@ mode; the displayed fraction in cli-parse mode).
 
 ## Rules
 
-- **Nothing appears that was not measured this audit** (or explicitly labeled as unmeasured /
-  a route-out). No figure from documentation, training data, this plugin's own development
-  history, or a previous audit enters the report body; previous audits live in the ledger
-  section, labeled with their own stamps.
+- **Nothing appears that was not measured this audit** (or explicitly labeled as unmeasured,
+  known-uncovered, or a route-out). No figure from documentation, training data, this plugin's
+  own development history, or a previous audit enters the report body; previous audits live in
+  the ledger section, labeled with their own stamps.
 - **Zeros are findings.** A lever that measured zero is reported with its zero and the category
   that explains it.
 - **Precision is carried, not dropped.** `display-rounded` numbers are presented as approximate

--- a/plugins/context-budget/skills/audit/scripts/measure.mjs
+++ b/plugins/context-budget/skills/audit/scripts/measure.mjs
@@ -55,6 +55,10 @@ const CATALOGUE_VERIFY_SCHEMA = 'context-budget.catalogue-verify/1';
 const DEFAULT_CATALOGUE = join(
   dirname(fileURLToPath(import.meta.url)), '..', 'reference', 'levers.json',
 );
+const INTERACTIVE_ONLY_LISTING = join(
+  dirname(fileURLToPath(import.meta.url)), '..', 'reference', 'interactive-only-tools.json',
+);
+const INTERACTIVE_ONLY_SCHEMA = 'context-budget.interactive-only/1';
 
 // Settings keys and env names the catalogue cites. Env vars are the CLAUDE_CODE_
 // / ENABLE_ / DISABLE_ family; settings keys are camelCase identifiers in the
@@ -614,6 +618,28 @@ function vanishedReason(vanished) {
     + 'snapshot, so its delta is unmeasured, not zero';
 }
 
+function loadInteractiveOnly() {
+  let data;
+  try {
+    data = JSON.parse(readFileSync(INTERACTIVE_ONLY_LISTING, 'utf8'));
+  } catch (e) {
+    usageError(`interactive-only listing unreadable: ${e.message}`);
+  }
+  if (data.schema !== INTERACTIVE_ONLY_SCHEMA) {
+    usageError(`interactive-only listing expects ${INTERACTIVE_ONLY_SCHEMA}; got ${JSON.stringify(data.schema)}`);
+  }
+  return data;
+}
+
+function knownUncoveredRecord(candidates, listing) {
+  const seen = new Set(candidates);
+  return {
+    reason: 'interactive-only — structurally unreachable from a headless candidate list',
+    tools: (listing.tools || []).filter((t) => !seen.has(t)),
+    notes: listing.notes || [],
+  };
+}
+
 async function runAttribute(args) {
   if (!args.tools) usageError('attribute needs --tools <T1,T2,...|from-baseline>');
   const baseline = await takeSnapshot({ ...args, deny: undefined, label: 'baseline' });
@@ -690,6 +716,10 @@ async function runAttribute(args) {
     skillListingSignature: baseline.skillListing.signature,
     perTool,
     additivity,
+    knownUncovered: knownUncoveredRecord(
+      [...tools, ...(baseline.tools || [])],
+      loadInteractiveOnly(),
+    ),
     caveats: baseline.caveats,
   };
 }

--- a/plugins/context-budget/skills/audit/scripts/measure.test.sh
+++ b/plugins/context-budget/skills/audit/scripts/measure.test.sh
@@ -326,8 +326,30 @@ if (cd "$WORK" && FAKE_MODE=control node "$ENGINE" attribute --tools AlphaTool,B
     "normal additivity case still verifies additive" "control additive wrong"
   assert_eq "$(jsonget "$actl" 'j.additivity.comparable')" "true" \
     "normal additivity case stays comparable" "control comparable wrong"
+  assert_eq "$(jsonget "$actl" 'j.knownUncovered.tools.includes("Artifact")')" "true" \
+    "full-sweep-shaped attribute lists Artifact as known-uncovered" "Artifact omitted from knownUncovered"
+  assert_eq "$(jsonget "$actl" 'j.knownUncovered.tools.includes("AskUserQuestion")')" "true" \
+    "AskUserQuestion is known-uncovered, not silent" "AskUserQuestion omitted from knownUncovered"
+  assert_eq "$(jsonget "$actl" 'j.knownUncovered.tools.includes("SendUserFile")')" "true" \
+    "SendUserFile is known-uncovered, not silent" "SendUserFile omitted from knownUncovered"
+  assert_eq "$(jsonget "$actl" 'j.knownUncovered.tools.includes("EnterPlanMode")')" "true" \
+    "plan-mode EnterPlanMode is known-uncovered" "EnterPlanMode omitted from knownUncovered"
+  assert_eq "$(jsonget "$actl" 'JSON.stringify(j.knownUncovered.notes).includes("MCP")')" "true" \
+    "interactive-only MCP servers are noted as a class" "MCP class note missing"
 else
   fail "attribute --verify-additivity (control scenario) exited nonzero"
+fi
+
+# A product interactive-only name that WAS a candidate this run is not
+# repeated as known-uncovered — it is measured (or unmeasured-but-candidate).
+aart="$WORK/attr-artifact-candidate.json"
+if (cd "$WORK" && FAKE_MODE=control node "$ENGINE" attribute --tools Artifact --binary "$FAKE" --out "$aart" >/dev/null); then
+  assert_eq "$(jsonget "$aart" 'j.knownUncovered.tools.includes("Artifact")')" "false" \
+    "a candidate Artifact is not also listed as known-uncovered" "Artifact listed as both candidate and known-uncovered"
+  assert_eq "$(jsonget "$aart" 'j.perTool.some((t)=>t.tool==="Artifact")')" "true" \
+    "explicit Artifact stays a per-tool candidate" "explicit Artifact missing from perTool"
+else
+  fail "attribute --tools Artifact exited nonzero"
 fi
 
 # A single deny that empties a bucket poisons that per-tool row the same way.


### PR DESCRIPTION
Closes #3199

## Summary

A headless sweep enumerates candidates only from the live session inventory, so interactive-only tools (Artifact, SendUserFile, AskUserQuestion, plan-mode tools, interactive MCP) were silently absent from the report. The report contract promises unmeasured tools are listed as unmeasured — silence reads as measured zero — but these tools were never candidates at all.

## Fix

- Add a maintained product-level list (`interactive-only-tools.json`: Artifact, AskUserQuestion, SendUserFile, EnterPlanMode, ExitPlanMode) plus a class note for interactive-only MCP servers.
- The attribution record carries `knownUncovered` for names on that list that were not candidates this run. A name that was a candidate is dropped from known-uncovered (it is measured or unmeasured-but-candidate).
- The report contract and audit skill document known-uncovered as a distinct category from unmeasured-but-candidate.

## Verification

- `measure.test.sh`: 61/61 in the 3199 worktree after rebase onto `origin/main` (includes `d118f896` / #3259). New assertions: Artifact / AskUserQuestion / SendUserFile / EnterPlanMode listed as known-uncovered; MCP class note present; an explicit `--tools Artifact` candidate is not also listed as known-uncovered.
- `levers.test.sh`: 2/2.
- Cherry-pick of `52b31f3` onto current main applied cleanly; `## [0.6.8]` is a new heading above the shipped `## [0.6.7]`.

## Related

N/A — this PR closes #3199 only. #3200 is the next sequential context-budget version and is not in this diff.