### PR TITLE
fix(claude-config): admit the relative scan-row paths audit-instructions produces (0.40.1)

### DIFF
--- a/plugins/claude-config/.claude-plugin/plugin.json
+++ b/plugins/claude-config/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "claude-config",
-  "version": "0.40.0",
+  "version": "0.40.1",
   "description": "Nine configuration-health skills (plus setup) for a repo's Claude Code configuration: audit (settings.json / .mcp.json / hooks / plugins / permissions drift), audit-automation-gaps (evidence-gated verdicts on automation gaps), audit-permission-grants (allow-rule / allowed-tools grants for auto-mode durability and portability), audit-permission-state (the permission rules actually in effect — every settings scope merged with per-rule provenance, what auto mode drops on entry, config written where nothing reads it, and which managed intents are enforced versus loosenable), draft-auto-mode-rules (interview and draft a paste-ready autoMode classifier block; prints only, never writes), audit-instructions (locally-owned instruction surfaces vs current model capability — proposes removals/rewrites of instructions the model no longer needs, and detects cross-surface instruction conflicts), audit-prompting-postures (the additive lane — posture guidance the prompting guide says a component's purpose needs but the component does not carry), audit-pass (one coordinated, ordered, resumable pass over a named target — three-scope inventory, run-time-derived exclusion set, stable finding identity, suppression memory, resume, one human gate — delegating every check to the plugin that owns it), and unhobble (the empirical bare-baseline experiment: reversibly strip a repo's standing instructions, log real stumbles against the current model, re-add only what evidence earns).",
   "author": {
     "name": "Melodic Software",

--- a/plugins/claude-config/CHANGELOG.md
+++ b/plugins/claude-config/CHANGELOG.md
@@ -26,10 +26,16 @@ All notable changes to the `claude-config` plugin are documented here. Format fo
   `../outside.md`, which the fix pass would then resolve outside the working tree. Admitting
   relative paths is what makes traversal expressible, so both forms are refused in the same
   change: any path holding a `..` segment is declined outright and counted, never dropped
-  silently. A symlink inside the repository pointing outside it still resolves past the test,
-  which needs a canonicalizing syscall awk has no portable access to; that residual is recorded
-  in the fence rather than implied. Absoluteness is tested with `substr` rather than a bracket
-  expression holding both delimiters, because the runner awk is mawk.
+  silently. The segment test covers both `/` and `\` separators — `is_absolute` already
+  treats a backslash as a root/separator, so a slash-only `..` regex would admit
+  `..\outside.md` on Git Bash and emit a traversing Location. The two delimiter
+  spellings are separate regexes, not a bracket class holding both, because the runner
+  awk is mawk. A Location cell now goes through the same pipe-escape as Finding and
+  Action, so a newly admitted relative filename that contains `|` cannot split the row.
+  A symlink inside the repository pointing outside it still resolves past the test,
+  which needs a canonicalizing syscall awk has no portable access to; that residual is
+  recorded in the fence rather than implied. Absoluteness is tested with `substr` rather
+  than a bracket expression holding both delimiters.
 
 ## [0.40.0]
 

--- a/plugins/claude-config/CHANGELOG.md
+++ b/plugins/claude-config/CHANGELOG.md
@@ -3,6 +3,34 @@
 All notable changes to the `claude-config` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.40.1]
+
+### Fixed
+
+- **`audit-instructions` `emit-findings.sh` declined every relative scan-row path, dropping
+  the findings its own scanner produces (#3267).** `instruction-scan.sh` echoes the path it
+  was handed, so naming a repo-owned file relatively — the ordinary invocation, and the form
+  `SKILL.md` documents — puts a relative path on the row. `relativize_in_repo()` tested that
+  path against three absolute anchors and returned empty when none prefixed it, so the row was
+  counted as `outside-repo-root` and never reached the machine-readable relay. The stated
+  decline reason was the opposite of the truth for those rows, and the run still read as clean:
+  an audit that silently under-reports is indistinguishable from one that found nothing.
+  A path that is not absolute is now resolved against the calling directory — the same
+  directory `fm_end()`, `source_line()` and `quotes_trigger()` already read the file from, so
+  the Location can no longer name a file other than the one the row quotes — and then passes
+  the unchanged fail-closed fence. The `docs-hygiene:audit-noise` sibling joins to the repo
+  root instead, which is right there because its detector emits paths already relative to that
+  root; the two producers now agree on behavior rather than on anchor.
+- **The same fence admitted a traversing Location.** Its anchor tests are lexical, so
+  `<root>/../outside.md` prefix-matched the root while resolving outside it and relativized to
+  `../outside.md`, which the fix pass would then resolve outside the working tree. Admitting
+  relative paths is what makes traversal expressible, so both forms are refused in the same
+  change: any path holding a `..` segment is declined outright and counted, never dropped
+  silently. A symlink inside the repository pointing outside it still resolves past the test,
+  which needs a canonicalizing syscall awk has no portable access to; that residual is recorded
+  in the fence rather than implied. Absoluteness is tested with `substr` rather than a bracket
+  expression holding both delimiters, because the runner awk is mawk.
+
 ## [0.40.0]
 
 ### Added

--- a/plugins/claude-config/skills/audit-instructions/context/persist-findings.md
+++ b/plugins/claude-config/skills/audit-instructions/context/persist-findings.md
@@ -97,8 +97,10 @@ rule.
 A row whose path is not absolute is not one of them. `instruction-scan.sh` echoes the path it was
 handed, so naming a repo-owned file relatively is the ordinary invocation; such a path is resolved
 against the directory the scan is run from, which is the directory the writer reads the file from,
-and then meets the same fence. A path holding a `..` segment is refused whatever its form: the
-fence test is lexical, so a traversing path can prefix-match the root while resolving outside it.
+and then meets the same fence. A path holding a `..` segment is refused whatever its form
+(`/` or `\`; Git Bash spells a parent with a backslash): the fence test is lexical, so a
+traversing path can prefix-match the root while resolving outside it. `Location` is
+pipe-escaped the same way Finding and Action are.
 
 ## What each cell says
 

--- a/plugins/claude-config/skills/audit-instructions/context/persist-findings.md
+++ b/plugins/claude-config/skills/audit-instructions/context/persist-findings.md
@@ -94,6 +94,12 @@ fix pass either edit a file outside the working tree or consume the finding with
 and where the surface is upstream-owned, to its owning repository per the skill body's routing
 rule.
 
+A row whose path is not absolute is not one of them. `instruction-scan.sh` echoes the path it was
+handed, so naming a repo-owned file relatively is the ordinary invocation; such a path is resolved
+against the directory the scan is run from, which is the directory the writer reads the file from,
+and then meets the same fence. A path holding a `..` segment is refused whatever its form: the
+fence test is lexical, so a traversing path can prefix-match the root while resolving outside it.
+
 ## What each cell says
 
 - **`branch:`** is `git branch --show-current` verbatim.

--- a/plugins/claude-config/skills/audit-instructions/scripts/emit-findings.sh
+++ b/plugins/claude-config/skills/audit-instructions/scripts/emit-findings.sh
@@ -281,13 +281,29 @@ LC_ALL=C awk \
   # to hold. Residual, recorded rather than implied: a symlink inside the
   # repository pointing outside it still resolves past this test, which needs a
   # canonicalizing syscall awk has no portable access to.
+  #
+  # `is_absolute` already treats `\` as a separator (Git Bash / Windows). A
+  # slash-only `..` test would admit `..\outside.md`: joined as
+  # `<pwd>/..\outside.md`, the `..` is followed by `\` rather than `/` or
+  # end-of-string, the prefix check still succeeds, and Location becomes a
+  # traversing spelling. Separate regexes, not a bracket class holding both
+  # delimiters: the runner awk is mawk.
+  function has_dotdot_segment(p) {
+    if (p ~ /(^|\/)\.\.(\/|$)/) return 1
+    if (p ~ /(^|\\)\.\.(\\|$)/) return 1
+    if (p ~ /\/\.\.\\/) return 1
+    if (p ~ /\\\.\.\//) return 1
+    return 0
+  }
+
   function relativize_in_repo(p) {
     if (!is_absolute(p)) {
       sub(/^\.\//, "", p)
+      sub(/^\.\\/, "", p)
       p = caller_pwd "/" p
     }
     gsub(/\/\.\//, "/", p)
-    if (p ~ /(^|\/)\.\.(\/|$)/) return ""
+    if (has_dotdot_segment(p)) return ""
     if (repo_root_pwd != "" && index(p, repo_root_pwd "/") == 1)
       return substr(p, length(repo_root_pwd) + 2)
     if (repo_root != "" && index(p, repo_root "/") == 1)
@@ -438,7 +454,7 @@ LC_ALL=C awk \
     excerpt = trim(text)
     if (length(excerpt) > 160) excerpt = substr(excerpt, 1, 157) "..."
 
-    rows[++nemit] = "| " rule_tier(id) " | high | " loc ":" lno " | claude-config:audit-instructions | " \
+    rows[++nemit] = "| " rule_tier(id) " | high | " esc(loc) ":" lno " | claude-config:audit-instructions | " \
       esc(rid " " fired_marker(id, text) " -- " excerpt) " | " esc(rule_action(id)) " |"
     seen[id]++
     next

--- a/plugins/claude-config/skills/audit-instructions/scripts/emit-findings.sh
+++ b/plugins/claude-config/skills/audit-instructions/scripts/emit-findings.sh
@@ -154,9 +154,15 @@ DATE_UTC="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 # sub-path git reports for it. The git-reported forms stay as fallbacks.
 # (The ai-slop sibling fails OPEN on the same mismatch — Location stays
 # absolute and nothing reports it.)
+#
+# A scan row may also carry a path that is not absolute at all:
+# instruction-scan.sh echoes the caller's own argument, and naming a repo-owned
+# file relatively is the ordinary invocation. Such a path is resolved against
+# CALLER_PWD, the same directory the awk body reads the file from.
 REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || true)"
 REPO_ROOT_ALT=""
 REPO_ROOT_PWD=""
+CALLER_PWD="$(pwd)"
 if [[ -n "$REPO_ROOT" ]]; then
   REPO_ROOT_ALT="$(cd "$REPO_ROOT" 2>/dev/null && pwd)" || REPO_ROOT_ALT=""
   [[ "$REPO_ROOT_ALT" == "$REPO_ROOT" ]] && REPO_ROOT_ALT=""
@@ -178,7 +184,8 @@ fi
 
 LC_ALL=C awk \
   -v branch="$BRANCH" -v date_utc="$DATE_UTC" -v repo_root="$REPO_ROOT" \
-  -v repo_root_alt="$REPO_ROOT_ALT" -v repo_root_pwd="$REPO_ROOT_PWD" -v carveout="$CARVEOUT" '
+  -v repo_root_alt="$REPO_ROOT_ALT" -v repo_root_pwd="$REPO_ROOT_PWD" \
+  -v caller_pwd="$CALLER_PWD" -v carveout="$CARVEOUT" '
   function rule_id(id) {
     if (id == "I28-a") return "claude-config/audit-instructions/rule-coercive-emphasis"
     if (id == "I28-b") return "claude-config/audit-instructions/rule-blanket-tool-default"
@@ -233,10 +240,54 @@ LC_ALL=C awk \
     return out
   }
 
+  # is_absolute(p): true for every absolute spelling that can reach an anchor.
+  # A POSIX `/`-rooted path, a UNC or root-relative backslash path, and a
+  # drive-letter path — the last being exactly what `git rev-parse
+  # --show-toplevel` answers under Git Bash, so it is the form the anchors
+  # themselves are written in. Testing only the leading `/` would read
+  # `D:/repo/doc.md` as relative and join it to the calling directory,
+  # declining a row that relativizes correctly today.
+  #
+  # Written with substr rather than a bracket expression holding `/` and `\`:
+  # the runner awk is mawk (see the 0.39.3 changelog entry), and an unescaped
+  # delimiter inside a bracketed regex literal is where the dialects part.
+  function is_absolute(p,   c1) {
+    c1 = substr(p, 1, 1)
+    if (c1 == "/" || c1 == "\\") return 1
+    if (c1 !~ /^[A-Za-z]$/) return 0
+    if (substr(p, 2, 1) != ":") return 0
+    return (substr(p, 3, 1) == "/" || substr(p, 3, 1) == "\\")
+  }
+
   # Prefer the caller pwd spelling, then git toplevel, then cd-then-pwd.
   # Empty return means the path is not under any known spelling of the root
   # (fail closed — this producer pre-fix mode on a spelling mismatch).
+  #
+  # A path that is NOT absolute is resolved against the calling directory,
+  # because that is the directory this script already read the file from:
+  # fm_end(), source_line(), and quotes_trigger() each getline the path as
+  # written, so by the time control reaches here the excerpt in hand came out of
+  # caller_pwd/p. Anchoring the Location anywhere else would have the row name a
+  # different file than the one it quotes — a silent corruption in place of a
+  # silent drop. (The docs-hygiene sibling joins to the repo root instead, and is
+  # right to: its detector emits paths already relative to that root, where
+  # instruction-scan.sh echoes the argument it was handed, verbatim.)
+  #
+  # The anchor tests are LEXICAL, so a `..` segment defeats them:
+  # `<root>/../outside.md` starts with `<root>/` while resolving outside the
+  # repository, and would enter the relay carrying a traversing Location for the
+  # fix pass to resolve outside the working tree. Any path holding a `..`
+  # segment is refused outright — fail closed, the direction this fence exists
+  # to hold. Residual, recorded rather than implied: a symlink inside the
+  # repository pointing outside it still resolves past this test, which needs a
+  # canonicalizing syscall awk has no portable access to.
   function relativize_in_repo(p) {
+    if (!is_absolute(p)) {
+      sub(/^\.\//, "", p)
+      p = caller_pwd "/" p
+    }
+    gsub(/\/\.\//, "/", p)
+    if (p ~ /(^|\/)\.\.(\/|$)/) return ""
     if (repo_root_pwd != "" && index(p, repo_root_pwd "/") == 1)
       return substr(p, length(repo_root_pwd) + 2)
     if (repo_root != "" && index(p, repo_root "/") == 1)

--- a/plugins/claude-config/skills/audit-instructions/scripts/emit-findings.test.sh
+++ b/plugins/claude-config/skills/audit-instructions/scripts/emit-findings.test.sh
@@ -438,6 +438,84 @@ assert_contains "a pwd-spelled in-repo path is emitted, not declined" "$SPELL_OU
 assert_not_contains "and is not counted as out-of-repo" "$SPELL_OUT" "reason=outside-repo-root"
 assert_not_contains "Location carries no absolute prefix" "$SPELL_OUT" "$SPELL_LINK/doc.md"
 
+# --- Case 13d: a repo-relative scan-row path is admitted; traversal is not ---
+# instruction-scan.sh echoes the caller's own path form, so naming a repo-owned
+# file relatively — the ordinary invocation, and the form SKILL.md documents —
+# puts a relative path on the row. Declining those rows drops real findings from
+# the relay while the run still reads as clean, which is the worst failure shape
+# an audit tool has.
+RELREPO="$TEST_TMPDIR/rel-repo"
+mkdir -p "$RELREPO/sub"
+git -C "$RELREPO" init -q
+printf -- '# Body\n\nCRITICAL: You MUST always do this.\n' >"$RELREPO/doc.md"
+printf -- '# Body\n\nCRITICAL: You MUST always do this.\n' >"$RELREPO/sub/nested.md"
+printf -- '# Body\n\nCRITICAL: You MUST always do this.\n' >"$TEST_TMPDIR/outside-doc.md"
+
+(cd "$RELREPO" && bash "$SCAN" --body-only doc.md) >"$TEST_TMPDIR/rel.txt"
+assert_eq "the scanner emits the caller's relative path verbatim" \
+  "doc.md:3:I28-a" "$(cat "$TEST_TMPDIR/rel.txt")"
+(cd "$RELREPO" && bash "$EMIT" --from "$TEST_TMPDIR/rel.txt" \
+  --out "$TEST_TMPDIR/rel-find.md" --branch testbranch >/dev/null 2>&1)
+REL_OUT=$(cat "$TEST_TMPDIR/rel-find.md")
+assert_contains "a relative scan-row path is emitted, not declined" "$REL_OUT" "| doc.md:3 |"
+assert_not_contains "and is not counted as out-of-repo" "$REL_OUT" "reason=outside-repo-root"
+assert_contains "every scan row read survives to the report" \
+  "$REL_OUT" "Scan rows read: 1. Emitted: 1."
+
+# Resolved against the CALLER's directory — the same directory the emitter read
+# the file from. A Location anchored anywhere else would name a different file
+# than the one whose excerpt the row quotes, trading a silent drop for a silent
+# corruption.
+(cd "$RELREPO/sub" && bash "$SCAN" --body-only nested.md) >"$TEST_TMPDIR/relsub.txt"
+(cd "$RELREPO/sub" && bash "$EMIT" --from "$TEST_TMPDIR/relsub.txt" \
+  --out "$TEST_TMPDIR/relsub-find.md" --branch testbranch >/dev/null 2>&1)
+RELSUB_OUT=$(cat "$TEST_TMPDIR/relsub-find.md")
+assert_contains "a subdirectory-relative row carries its path from the repo root" \
+  "$RELSUB_OUT" "| sub/nested.md:3 |"
+assert_not_contains "and is not declined" "$RELSUB_OUT" "reason=outside-repo-root"
+
+# A `./` prefix is the same file, and must not reach the Location cell.
+(cd "$RELREPO" && bash "$SCAN" --body-only ./doc.md) >"$TEST_TMPDIR/reldot.txt"
+(cd "$RELREPO" && bash "$EMIT" --from "$TEST_TMPDIR/reldot.txt" \
+  --out "$TEST_TMPDIR/reldot-find.md" --branch testbranch >/dev/null 2>&1)
+assert_contains "a ./-prefixed row normalizes to a bare repo-relative Location" \
+  "$(cat "$TEST_TMPDIR/reldot-find.md")" "| doc.md:3 |"
+
+# Admitting relative paths is what makes traversal expressible, so it is refused
+# in the same fence. A relative `..` escapes the working tree outright.
+(cd "$RELREPO" && bash "$SCAN" --body-only ../outside-doc.md) >"$TEST_TMPDIR/reltrav.txt"
+(cd "$RELREPO" && bash "$EMIT" --from "$TEST_TMPDIR/reltrav.txt" \
+  --out "$TEST_TMPDIR/reltrav-find.md" --branch testbranch >/dev/null 2>&1)
+TRAV_OUT=$(cat "$TEST_TMPDIR/reltrav-find.md")
+TRAV_ROWS=$(printf '%s\n' "$TRAV_OUT" | grep -c '^| [0-9]')
+assert_eq "a traversing relative row emits nothing" "0" "$TRAV_ROWS"
+assert_contains "and the refusal is counted, never silent" "$TRAV_OUT" "reason=outside-repo-root"
+
+# The anchor test is LEXICAL, so `<root>/../outside.md` prefix-matches the root
+# while resolving outside it — it would relativize to `../outside.md` and send
+# the fix pass out of the working tree.
+printf '%s\n' "$RELREPO/../outside-doc.md:3:I28-a" >"$TEST_TMPDIR/abstrav.txt"
+(cd "$RELREPO" && bash "$EMIT" --from "$TEST_TMPDIR/abstrav.txt" \
+  --out "$TEST_TMPDIR/abstrav-find.md" --branch testbranch >/dev/null 2>&1)
+ABSTRAV_OUT=$(cat "$TEST_TMPDIR/abstrav-find.md")
+ABSTRAV_ROWS=$(printf '%s\n' "$ABSTRAV_OUT" | grep -c '^| [0-9]')
+assert_eq "an anchored path holding a .. segment emits nothing" "0" "$ABSTRAV_ROWS"
+assert_not_contains "and no traversing Location reaches the report" \
+  "$ABSTRAV_OUT" "../outside-doc.md"
+assert_contains "the traversal refusal is counted" "$ABSTRAV_OUT" "reason=outside-repo-root"
+
+# Regression guard for the absoluteness test itself: git's own toplevel spelling
+# is the drive-letter form under Git Bash, and misreading it as relative would
+# decline a row that relativizes correctly today.
+RELTOP="$(git -C "$RELREPO" rev-parse --show-toplevel)"
+printf '%s\n' "$RELTOP/doc.md:3:I28-a" >"$TEST_TMPDIR/reltop.txt"
+(cd "$RELREPO" && bash "$EMIT" --from "$TEST_TMPDIR/reltop.txt" \
+  --out "$TEST_TMPDIR/reltop-find.md" --branch testbranch >/dev/null 2>&1)
+RELTOP_OUT=$(cat "$TEST_TMPDIR/reltop-find.md")
+assert_contains "a git-toplevel-spelled absolute path still emits" "$RELTOP_OUT" "| doc.md:3 |"
+assert_not_contains "and is not re-anchored as a relative path" \
+  "$RELTOP_OUT" "reason=outside-repo-root"
+
 # --- Case 14: I29 description-restatement emits, sibling emits, fences hold --
 RESTATE="$TEST_TMPDIR/restate-repo"
 mkdir -p "$RESTATE"

--- a/plugins/claude-config/skills/audit-instructions/scripts/emit-findings.test.sh
+++ b/plugins/claude-config/skills/audit-instructions/scripts/emit-findings.test.sh
@@ -516,6 +516,45 @@ assert_contains "a git-toplevel-spelled absolute path still emits" "$RELTOP_OUT"
 assert_not_contains "and is not re-anchored as a relative path" \
   "$RELTOP_OUT" "reason=outside-repo-root"
 
+# Git Bash / Windows: `\` is a separator (`is_absolute` already treats it as
+# one). A slash-only `..` regex misses `..\outside.md`, joins it as
+# `<pwd>/..\outside.md`, prefix-matches the root, and emits a traversing
+# Location. The file is created under a literal backslash name so source_line
+# can read it on POSIX; the fence must still refuse the path form.
+printf -- '# Body\n\nCRITICAL: You MUST always do this.\n' >"$RELREPO/..\\outside-doc.md"
+printf '%s\n' '..\outside-doc.md:3:I28-a' >"$TEST_TMPDIR/reltravbs.txt"
+(cd "$RELREPO" && bash "$EMIT" --from "$TEST_TMPDIR/reltravbs.txt" \
+  --out "$TEST_TMPDIR/reltravbs-find.md" --branch testbranch >/dev/null 2>&1)
+TRAVBS_OUT=$(cat "$TEST_TMPDIR/reltravbs-find.md")
+TRAVBS_ROWS=$(printf '%s\n' "$TRAVBS_OUT" | grep -c '^| [0-9]')
+assert_eq "a backslash-separated relative traversal emits nothing" "0" "$TRAVBS_ROWS"
+assert_not_contains "and no backslash-traversing Location reaches the report" \
+  "$TRAVBS_OUT" '..\outside-doc.md'
+assert_contains "the backslash traversal refusal is counted" \
+  "$TRAVBS_OUT" "reason=outside-repo-root"
+
+# Mixed separators: `<root>/..\outside.md` is the same lexical-prefix hole.
+printf '%s\n' "$RELREPO/..\\outside-doc.md:3:I28-a" >"$TEST_TMPDIR/mixtrav.txt"
+(cd "$RELREPO" && bash "$EMIT" --from "$TEST_TMPDIR/mixtrav.txt" \
+  --out "$TEST_TMPDIR/mixtrav-find.md" --branch testbranch >/dev/null 2>&1)
+MIXTRAV_OUT=$(cat "$TEST_TMPDIR/mixtrav-find.md")
+MIXTRAV_ROWS=$(printf '%s\n' "$MIXTRAV_OUT" | grep -c '^| [0-9]')
+assert_eq "a mixed-separator anchored traversal emits nothing" "0" "$MIXTRAV_ROWS"
+assert_contains "and the mixed-separator refusal is counted" \
+  "$MIXTRAV_OUT" "reason=outside-repo-root"
+
+# A relative Location that contains `|` must not split the findings table.
+# Finding/Action already went through esc(); Location did not, and admitting
+# relative paths is what makes a `|` in the filename expressible as written.
+printf -- '# Body\n\nCRITICAL: You MUST always do this.\n' >"$RELREPO/p|q.md"
+printf '%s\n' 'p|q.md:3:I28-a' >"$TEST_TMPDIR/rellocpipe.txt"
+(cd "$RELREPO" && bash "$EMIT" --from "$TEST_TMPDIR/rellocpipe.txt" \
+  --out "$TEST_TMPDIR/rellocpipe-find.md" --branch testbranch >/dev/null 2>&1)
+LOCPIPE_ROW=$(LC_ALL=C grep -m1 '^| [0-9]' "$TEST_TMPDIR/rellocpipe-find.md")
+assert_contains "a pipe in a relative Location is escaped" "$LOCPIPE_ROW" 'p\|q.md:3'
+LOCPIPE_COLS=$(printf '%s\n' "$LOCPIPE_ROW" | sed 's/\\|//g' | awk -F'|' '{print NF}')
+assert_eq "and the row still parses as one 7-column row" "9" "$LOCPIPE_COLS"
+
 # --- Case 14: I29 description-restatement emits, sibling emits, fences hold --
 RESTATE="$TEST_TMPDIR/restate-repo"
 mkdir -p "$RESTATE"


### PR DESCRIPTION
Closes #3267

## Summary

`claude-config:audit-instructions` `instruction-scan.sh` emits scan rows in the path form the caller handed it. Naming a repo-owned surface relatively is the ordinary invocation, and `SKILL.md` documents that call. `emit-findings.sh` tested each row only against absolute repo-root anchors and declined a relative path as `outside-repo-root`, dropping the finding from the machine-readable relay while the run still read as clean.

## Fix

A path that is not absolute is resolved against the calling directory — the same directory `fm_end()`, `source_line()`, and `quotes_trigger()` already read the file from — then passes the unchanged fail-closed fence. Any path holding a `..` segment (`/` or `\`) is refused and counted, closing the lexical-prefix hole that let `<root>/../outside.md` (and the Git Bash `..\` spelling) relativize to a traversing Location. Location cells now go through the same pipe-escape as Finding and Action. `claude-config` 0.40.0 → 0.40.1.

## Verification

- `plugins/claude-config/skills/audit-instructions/scripts/emit-findings.test.sh`: 108/108, including Case 13d (relative emit, subdirectory-relative, `./` prefix, slash traversal, backslash traversal, mixed-separator traversal, Location `|`, git-toplevel absolute).
- Issue reproduction: `instruction-scan.sh --body-only withfm.md` produced `withfm.md:7:I28-a`; `emit-findings.sh --from scan.txt` reported `Scan rows read: 1. Emitted: 1.` with Location `withfm.md:7` and no `outside-repo-root` decline. The absolute-path control also emitted 1 with the same Location.

## Related

N/A — this PR closes #3267 only.