### PR TITLE
docs(bugs): de-slop instruction surfaces (0.9.1)

### DIFF
--- a/plugins/bugs/.claude-plugin/plugin.json
+++ b/plugins/bugs/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "bugs",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Produces a structured five-field bug report — title, steps to reproduce, expected vs actual, severity with justification, and suggested fix location — from an informal defect description. Read-only by default: it emits the report and never edits code, opens a PR, or files an issue on its own.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/bugs/CHANGELOG.md
+++ b/plugins/bugs/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to the `bugs` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.9.1]
+
+### Changed
+
+- **Instruction-surface de-slop (#2891, bugs cluster).** Rewrote this plugin's `README.md` and every
+  `SKILL.md` to drop em dashes under the repo's zero-tolerance house policy, using
+  `/ai-slop:audit fix` semantics: periods or commas, or a restructured sentence, never
+  parentheses, en dashes, or a spaced hyphen as a stand-in. Meaning stays; only the mark
+  and the sentence break change. The generated options block is ignore-fenced because
+  `scripts/sync-plugin-options-docs.py` still emits em dashes from its shared template.
+
 ## [0.9.0]
 
 ### Changed

--- a/plugins/bugs/README.md
+++ b/plugins/bugs/README.md
@@ -1,23 +1,23 @@
 # bugs
 
-A Claude Code plugin for the front of the bug lifecycle — **read-only by default**.
+A Claude Code plugin for the front of the bug lifecycle. **Read-only by default**.
 It finds defects and captures them in a structured, five-field report; it does not
 fix them, open a PR, or file an issue on its own.
 
 | Skill | What it does |
 |---|---|
-| `/bugs:write` | Turns an informal defect description — one you already observed — into the five-field report. |
+| `/bugs:write` | Turns an informal defect description, one you already observed, into the five-field report. |
 | `/bugs:scan` | Hunts for defects **nobody has observed yet** in resting code, verifies each candidate adversarially, and reports what survives. |
 | `/bugs:setup` | `check` inspects both configuration surfaces read-only; `apply` writes the tracked lane config `scan` reads. |
 
 Invoke `/bugs:write <description>` (or let Claude reach for it
 when you describe a defect). The five fields are:
 
-1. **Title** — present tense, one line
-2. **Steps to reproduce** — backed by the source or the reporter; never invented
+1. **Title**. Present tense, one line
+2. **Steps to reproduce**. Backed by the source or the reporter; never invented
 3. **Expected vs actual** behavior
 4. **Severity** (`low` / `medium` / `high` / `critical`) with a one-sentence justification
-5. **Suggested fix location** — a file path and function/class, **no patch**
+5. **Suggested fix location**, a file path and function/class, **no patch**
 
 ## Behavior
 
@@ -25,13 +25,13 @@ when you describe a defect). The five fields are:
   PR, or files an issue unless you explicitly hand the report off.
 - **Never fabricates.** Any field it cannot back from the source, a test, or the
   reporter is marked `(unknown — needs reporter confirmation)` and surfaced under
-  Notes — a flagged gap, not an invented step.
+  Notes, a flagged gap, not an invented step.
 - **Knows when there is no bug.** If a quick survey shows the behavior is correct,
   it emits a short "No bug confirmed" summary instead of a report.
 - **Routes non-defects away.** Feature requests, investigations, and generic chores
   are recognized and pointed elsewhere rather than forced into the bug shape.
 
-## Usage — `/bugs:write`
+## Usage. `/bugs:write`
 
 ```text
 /bugs:write [--file] [--quick|--full] [--no-survey] <bug description>
@@ -47,8 +47,8 @@ when you describe a defect). The five fields are:
 
 ## Hunting bugs nobody has reported yet
 
-`/bugs:write` needs a defect you already noticed. `/bugs:scan` needs nothing —
-no diff, no failing test, no stack trace, no comment marker. It reads resting code and
+`/bugs:write` needs a defect you already noticed. `/bugs:scan` needs nothing.
+No diff, no failing test, no stack trace, no comment marker. It reads resting code and
 looks for what is wrong in it.
 
 ```text
@@ -58,10 +58,10 @@ looks for what is wrong in it.
 | Flag | Effect |
 |------|--------|
 | (none) | Rotate: self-select the next lane from the tracked lane config, hunt it, report |
-| `<path\|feature\|diff>` | Hunt exactly that scope — no rotation |
+| `<path\|feature\|diff>` | Hunt exactly that scope. No rotation |
 | `--lane <name>` | Hunt the named lane's globs |
 | `--track` | File the verified findings as raw intake through the `work-items` seam |
-| `--dry-run` | Report to stdout only — persists nothing, advances no rotation |
+| `--dry-run` | Report to stdout only. Persists nothing, advances no rotation |
 
 One invocation is **one bounded pass**, which makes it usable interactively, from a loop,
 or as a daily routine. Two properties are worth knowing before you rely on it:
@@ -70,7 +70,7 @@ or as a daily routine. Two properties are worth knowing before you rely on it:
   a separate fresh-context gate is then told to *refute* every candidate they produced. Only
   survivors reach the report, each labeled `reproduced` or `verified-by-reading`, and refuted
   candidates stay in the report with the argument that killed them.
-- **A bare run is read-only toward your repository and stays within a budget** — it stops at
+- **A bare run is read-only toward your repository and stays within a budget**. It stops at
   three verified findings or a complete lane sample. Filing happens only when you pass
   `--track`, and a complete lane sample is never reported as the lane being bug-free.
 
@@ -81,7 +81,7 @@ and anything security-relevant routes to the `review:security-review` lane.
 
 Two surfaces with two different owners.
 
-**Personal — one optional `userConfig` value**, prompted by Claude Code at enable time:
+**Personal.** One optional `userConfig` value, prompted by Claude Code at enable time:
 
 | Option | Type | Effect |
 |--------|------|--------|
@@ -90,19 +90,19 @@ Two surfaces with two different owners.
 Claude Code owns this value: current releases ignore plugin `userConfig` values placed in
 project or local settings, and changes route through Claude Code's own configuration prompt.
 
-**Team — the tracked `.claude/bugs.md`**, which `/bugs:scan` reads for its lanes
+**Team, the tracked `.claude/bugs.md`**, which `/bugs:scan` reads for its lanes
 (`lanes`) and its filing policy (`filing_posture`). It is layered per the marketplace's
-config-cascade convention — a user-global file, this tracked team file, and a gitignored local
+config-cascade convention, a user-global file, this tracked team file, and a gitignored local
 overlay. All layers are optional: with no config at all, `scan` rotates over bundled generic
 default lanes. Keys, defaults, layer order, and per-key merge semantics live in
 [`reference/config.md`](reference/config.md), their single home.
 
 Run `/bugs:setup` to work on either surface. `check` (the default) reports both read-only:
 the rendered `output_dir` and which layer supplied each lane config value. `apply` writes the
-tracked file and nothing else — it drafts lane candidates from your repository, confirms them one
+tracked file and nothing else. It drafts lane candidates from your repository, confirms them one
 at a time, and never touches settings, `pluginConfigs`, the local overlay, or your `.gitignore`.
 
-Project-specific conventions — naming, areas, tracker choice, priority labels — are
+Project-specific conventions, naming, areas, tracker choice, priority labels, are
 read from the **consuming project's own `CLAUDE.md` / rules**; the plugin imposes
 none of its own.
 
@@ -117,12 +117,12 @@ gh issue create --type Bug --body-file <report-path>
 
 Let `gh` prompt for the title interactively. `--type Bug` sets the native GitHub Issue
 Type (org repos; omit on repos without native Issue Types, adding a `type: bug` label instead). If filing non-interactively, never paste
-the reporter's title text into the command string — write it to a file and pass
+the reporter's title text into the command string. Write it to a file and pass
 `--title "$(cat <title-file>)"`: the substitution result is a quoted argument value and
 is not re-parsed, so backticks or `$( )` in reporter text cannot execute.
 
 If a work-item tracker MCP tool is available, the skill can hand off to that instead.
-Otherwise the emitted report is the deliverable — copy it into your tracker.
+Otherwise the emitted report is the deliverable. Copy it into your tracker.
 
 ## Install
 
@@ -131,6 +131,7 @@ Otherwise the emitted report is the deliverable — copy it into your tracker.
 /plugin install bugs@<marketplace>
 ```
 
+<!-- ai-slop-ignore-start: generated options block; source is plugin.json + scripts/sync-plugin-options-docs.py -->
 <!-- BEGIN GENERATED: plugin options — edit plugin.json, then run scripts/sync-plugin-options-docs.py -->
 
 ### Options reference
@@ -203,6 +204,7 @@ hands a configured value to a hook process; the value comes from the routes abov
 - [Manage installed plugins](https://code.claude.com/docs/en/discover-plugins#manage-installed-plugins) — enabling, disabling, `/plugin list`
 
 <!-- END GENERATED: plugin options -->
+<!-- ai-slop-ignore-end -->
 
 ## License
 

--- a/plugins/bugs/skills/scan/SKILL.md
+++ b/plugins/bugs/skills/scan/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: "Proactively hunt unobserved bugs in resting code: a read-only two-stage scan — recall-biased per-lens hunter subagents, then a separate fresh-context default-refute gate — over a target path/feature/diff or a rotated lane, emitting only verified 5-field findings. Use when: 'find a bug', 'bug hunt', 'scan for bugs', 'hunt for bugs in <X>'. Skip when: reviewing a diff (`review:code-review`); security auditing (`review:security-review`); root-causing an observed failure (`debugging:debug`); doc/config/code/arch claim drift, all dimensions (`codebase-health:audit`); structural tidying (`code-tidying:tidy`); comment markers (`work-items:scan-todos`); coverage gaps (`testing:audit`, `mutation-testing:audit`). Disambiguation: 'scan repo for issues' is the upstream known-issue registry (`claude-ops:known-issues`); 'file a bug' you already observed is `bugs:write`. Bare invocation neither edits nor files; `--track` files verified findings as raw intake (subject to the team's `filing_posture`)."
+description: "Proactively hunt unobserved bugs in resting code: a read-only two-stage scan, recall-biased per-lens hunter subagents, then a separate fresh-context default-refute gate, over a target path/feature/diff or a rotated lane, emitting only verified 5-field findings. Use when: 'find a bug', 'bug hunt', 'scan for bugs', 'hunt for bugs in <X>'. Skip when: reviewing a diff (`review:code-review`); security auditing (`review:security-review`); root-causing an observed failure (`debugging:debug`); doc/config/code/arch claim drift, all dimensions (`codebase-health:audit`); structural tidying (`code-tidying:tidy`); comment markers (`work-items:scan-todos`); coverage gaps (`testing:audit`, `mutation-testing:audit`). Disambiguation: 'scan repo for issues' is the upstream known-issue registry (`claude-ops:known-issues`); 'file a bug' you already observed is `bugs:write`. Bare invocation neither edits nor files; `--track` files verified findings as raw intake (subject to the team's `filing_posture`)."
 argument-hint: "[<path|feature|diff>] [--lane <name>] [--track] [--dry-run]"
 user-invocable: true
 disable-model-invocation: false
@@ -24,29 +24,29 @@ Arguments: `$ARGUMENTS`
 ## Purpose
 
 `/bugs:scan` is the front of the bug lifecycle: it hunts defects **nobody has observed yet**, in
-code that is resting. Every other finding-producer in reach needs an oracle first — a diff, a failing
+code that is resting. Every other finding-producer in reach needs an oracle first, a diff, a failing
 test, a stack trace, a factual claim, a comment marker. This one needs none of them.
 
 One invocation is **one bounded pass**: hunt a target (or a rotated lane), verify each candidate
 through a separate fresh-context gate, report what survives in the plugin's five-field shape, stop.
 That makes it equally usable interactively ("find a bug in the billing module"), from a `/loop`, or as
-a daily operator routine — the same bounded unit either way.
+a daily operator routine, the same bounded unit either way.
 
 The design premise, taken from published practice: per-run recall is low and the raw false-positive
 rate is high, so **recall and precision are separated into two stages**. Hunters are told to be
 generous; the verification gate is told to refute. A finding that reaches the report survived an agent
 whose job was to kill it.
 
-## Verb contract — read-only toward the repository
+## Verb contract. Read-only toward the repository
 
 Bare invocation is **read-only**: it never edits code, never branches, never pushes, never files a
 tracker item. Filing sits behind `--track`, and model auto-invocation never supplies `--track` on its
-own — a user (or a standing lane rule) must ask for it.
+own. A user (or a standing lane rule) must ask for it.
 
 **Reconciliation:** persisting the findings report and its cursor block under `${CLAUDE_PLUGIN_DATA}`
 is plugin-owned state, not target-repo mutation. The scanned repository's working tree, index, and
 history are untouched by a bare run. `--dry-run` goes further: it emits the findings to stdout and
-persists **nothing** — no report file, no cursor advance, no filing.
+persists **nothing**. No report file, no cursor advance, no filing.
 
 Durable cursor state never lives in `.work/`. Anything a wrapping session leaves under `.work/` is a
 checkout-local cache that a fresh clone or a `git clean` erases; the ladder below must re-derive the
@@ -63,7 +63,7 @@ cursor from rungs 1–3 without it, and never treats a cache note as authority.
 | `--dry-run` | **Plan-and-report only** | Full hunt + verification, report to stdout, zero persistence and zero cursor advance. Composable with any mode; overrides `--track`. |
 
 Lane definitions (`lanes`, `filing_posture`) resolve from `.claude/bugs.md` per the cascade
-contract — keys, layers, and merge semantics live in
+contract. Keys, layers, and merge semantics live in
 [`${CLAUDE_PLUGIN_ROOT}/reference/config.md`](../../reference/config.md), which is their single home.
 When no layer declares lanes, use the bundled generic default lanes in
 [`context/lenses.md`](context/lenses.md).
@@ -75,27 +75,27 @@ Which lane comes next is derived **statelessly**, first rung that answers wins:
 1. **Tracker history.** When the `work-items` plugin is installed and a tracker binding resolves,
    search items (`--state all`) for the provenance line `Filed by /bugs:scan (lane: <name>)`.
    The most recently filed lane is the previous lane; take the next one in declaration order. Confirm
-   the search actually ran against a bound tracker before trusting an empty result — an unbound
+   the search actually ran against a bound tracker before trusting an empty result. An unbound
    tracker returns nothing, which is not the same answer as "no prior scan filings".
 2. **Persisted-report cursor.** Otherwise resolve the report directory by the **same precedence
-   persistence uses** — Step 4 below defers to `/bugs:write`'s Step 4, and so does this rung;
+   persistence uses**. Step 4 below defers to `/bugs:write`'s Step 4, and so does this rung;
    reading a directory reports no longer land in is how a configured `output_dir` silently strands the
    cursor. Then search **backward from the newest report** for the newest one carrying a *valid*
-   rotation cursor block — one that names the rotation lane (see
-   [`context/findings-report.md`](context/findings-report.md)) — and use it the same way. Reports
+   rotation cursor block, one that names the rotation lane (see
+   [`context/findings-report.md`](context/findings-report.md)), and use it the same way. Reports
    without such a block are skipped, not read as a cursor: `/bugs:write`'s reports share that
    directory and carry none, and a targeted scan's report must never advance rotation. If no report
    carries one, fall through to rung 3.
 3. **Date-derived floor.** Otherwise pick deterministically: index the declared lane list by
    `(days since 1970-01-01 UTC) mod (lane count)`. Zero state, no history, still rotates daily.
 
-State the rung you used in the report — an operator reading a rotation run should be able to tell
+State the rung you used in the report. An operator reading a rotation run should be able to tell
 tracker-derived rotation from the zero-state floor.
 
 **Reset semantics.** Deleting the plugin-data reports (or scanning from a fresh machine) drops the run
 to rung 3, which is a valid state, not an error. `<project-slug>` is the kebab-cased basename of the
 project root, so two checkouts sharing a basename (`~/work/api` and `~/oss/api`) share one cursor
-directory — name the absolute project root in the report so a reader can spot the collision. Two
+directory. Name the absolute project root in the report so a reader can spot the collision. Two
 sessions started the same day on a zero-state checkout will select the **same** lane; that is accepted
 for V1 (the dedupe steps below absorb the duplicate findings) rather than jittered, because a
 deterministic floor is what makes daily coverage predictable.
@@ -106,7 +106,7 @@ deterministic floor is what makes daily coverage predictable.
 - **Candidate cap:** at most 10 candidates per hunt wave reach the verification gate. Rank by
   evidence strength and drop the tail rather than widening the wave.
 - **Refill cap:** if a whole wave is refuted, at most **2** refill waves. Then report the refuted set
-  and stop — an unbounded refill loop is a token sink against a ~1:50 signal-to-noise base rate.
+  and stop. An unbounded refill loop is a token sink against a ~1:50 signal-to-noise base rate.
 - **"Lane exhausted" means the sample is complete, not that the lane is bug-free.** V1 is
   budget-bounded sampling; never claim exhaustive coverage of a lane in the report.
 
@@ -114,11 +114,11 @@ Zero verified findings is a clean, successful outcome. Do **not** invent a findi
 
 ## The scan pipeline
 
-Process one unit at a time — one target, or one lane. A unit is closed when its verified findings are
+Process one unit at a time. One target, or one lane. A unit is closed when its verified findings are
 reported and deduped (and filed, under `--track` when the team's `filing_posture` allows it); only
 then does the cursor advance.
 
-### Step 1 — Resolve scope
+### Step 1. Resolve scope
 
 Resolve the mode, the lane globs, and `filing_posture` from the config cascade. Enumerate the concrete
 file list. If the enumeration exceeds ~40 files, narrow to the highest-signal subset (recently
@@ -126,10 +126,10 @@ changed, highest fan-in, most branch-dense) and say in the report that you sampl
 
 **Done when** you can name the exact file list the hunters will read.
 
-### Step 2 — Dispatch hunters (recall stage)
+### Step 2. Dispatch hunters (recall stage)
 
-Dispatch **one subagent per lens** over the resolved scope, each with the four-part contract —
-objective, output format, tool/source guidance, task boundaries — spelled out in
+Dispatch **one subagent per lens** over the resolved scope, each with the four-part contract:
+objective, output format, tool/source guidance, and task boundaries, spelled out in
 [`context/lenses.md`](context/lenses.md). Size the fan-out to the surface: a single small file may
 warrant one or two lenses; a full lane warrants all five. Every hunter is read-only, must attach a
 verbatim evidence quote to every candidate, and is explicitly told that **returning no candidate is a
@@ -137,29 +137,28 @@ valid and expected outcome**.
 
 **Done when** every dispatched lens has returned, and the merged candidate list is capped at 10.
 
-### Step 3 — Verification gate (precision stage)
+### Step 3. Verification gate (precision stage)
 
 Dispatch a **separate fresh-context subagent per candidate** using the prompt contract in
 [`context/verification-gate.md`](context/verification-gate.md). The hunter that found a candidate
-never grades it — a model re-checking its own work rubber-stamps it. The gate's default stance is
+never grades it. A model re-checking its own work rubber-stamps it. The gate's default stance is
 **refute**: it must try to construct the concrete input path that triggers the claimed fault, and if it
 cannot, the candidate dies. **If uncertain, it is NOT a finding.**
 
 Survivors are labeled `reproduced` (a check was actually run) or `verified-by-reading` (the fault is
 established from the source, with the reproduction argument stated). Refuted candidates are **retained
-with their refuting argument** — a high-kill gate catches some true positives, so they are never
+with their refuting argument**. A high-kill gate catches some true positives, so they are never
 silently dropped.
 
 **Done when** every candidate carries a verdict and a label or a refuting argument.
 
-### Step 4 — Assemble and dedupe the report
+### Step 4. Assemble and dedupe the report
 
 Format per [`context/findings-report.md`](context/findings-report.md): the five fields per finding
-(from `/bugs:write`'s shape), plus the evidence label and lens id, then the refuted tail and —
-on a rotation run — the cursor metadata block; a targeted run emits the no-cursor line in its place.
+(from `/bugs:write`'s shape), plus the evidence label and lens id, then the refuted tail and, on a rotation run, the cursor metadata block; a targeted run emits the no-cursor line in its place.
 Before persisting, run the same duplicate scan `/bugs:write` performs
-over the output directory — see Step 2 ("Survey before you write") in
-[`${CLAUDE_PLUGIN_ROOT}/skills/write/SKILL.md`](../write/SKILL.md) — and drop or merge findings that
+over the output directory. See Step 2 ("Survey before you write") in
+[`${CLAUDE_PLUGIN_ROOT}/skills/write/SKILL.md`](../write/SKILL.md), and drop or merge findings that
 restate a prior report.
 
 Persist to the path `/bugs:write --file` resolves (its Step 4 owns that precedence:
@@ -168,38 +167,37 @@ fallback). Do not reinvent either mechanism here. Under `--dry-run`, skip persis
 
 **Done when** the report is emitted, and (outside `--dry-run`) persisted with its path stated.
 
-### Step 5 — `--track` filing (explicit only)
+### Step 5. `--track` filing (explicit only)
 
-**Posture gate first.** Resolve `filing_posture` from the config cascade — see
+**Posture gate first.** Resolve `filing_posture` from the config cascade. See
 [`${CLAUDE_PLUGIN_ROOT}/reference/config.md`](../../reference/config.md), whose bundled default is
 `manual-only` when no layer declares it. When it resolves to `manual-only`, file nothing: print one
-notice — "filing skipped: filing_posture is manual-only (<layer, or bundled default>); report-only" —
-and stop at the report, the same degrade shape as an absent `work-items`. Only `allowed` reaches the
+notice, "filing skipped: filing_posture is manual-only (<layer, or bundled default>); report-only", and stop at the report, the same degrade shape as an absent `work-items`. Only `allowed` reaches the
 beats below.
 
 Then presence-gated on `work-items`. Follow the dogfood-filing beats by invoking
-`/work-items:track add` — never by pathing into another plugin's files:
+`/work-items:track add`, never by pathing into another plugin's files:
 
 1. **Dedupe.** Search items over `--state all` first; sameness is judged by underlying cause, not
    wording. An open match gets a comment instead of a second item; a closed match is reopened or
    linked from a fresh item.
 2. **Categorize as raw intake.** A scan filing records what was observed, not a verified diagnosis.
 3. **File** through `track add`, which owns the body template and the argv-safe write. The body
-   carries the five fields, and a provenance line — `Filed by /bugs:scan (lane: <name>)` — which
+   carries the five fields, and a provenance line, `Filed by /bugs:scan (lane: <name>)`, which
    is what rung 1 of the cursor ladder later recognizes.
 4. **Mark `needs-triage` on the right axis, resolved from the live label set.** Priority axis: pass
    `--priority needs-triage` on the `track add` call, replacing the filing floor (never two
    `priority:` labels). Status axis: apply the status marker as a separate label after creation.
-   **Create no labels** — if the marker does not exist in the live set, say so and file without it.
+   **Create no labels.** If the marker does not exist in the live set, say so and file without it.
    The filer does not self-triage.
 
 **Degrade:** if `work-items` is absent, or no tracker binding resolves, do not improvise a filing path.
-Print one notice — "filing skipped: <reason>; report-only" — and stop at the report.
+Print one notice, "filing skipped: <reason>; report-only", and stop at the report.
 
 **Done when** each verified finding is filed, matched to an existing item, or explicitly skipped with a
 printed reason.
 
-### Step 6 — Hand off
+### Step 6. Hand off
 
 Recommend, do not auto-invoke:
 
@@ -209,10 +207,10 @@ Recommend, do not auto-invoke:
 
 ## What this skill does NOT do
 
-- **Does not fix anything.** No edits, no patches, no PRs — even for an obviously trivial defect.
+- **Does not fix anything.** No edits, no patches, no PRs. Even for an obviously trivial defect.
 - **Does not file on bare invocation.** Filing needs `--track`.
 - **Does not review a diff.** That is `/review:code-review`'s lane; this reads resting code.
-- **Does not verify factual claims** in docs or config against code — all four `codebase-health:audit`
+- **Does not verify factual claims** in docs or config against code. All four `codebase-health:audit`
   dimensions own that.
 - **Does not chase coverage gaps** (`testing:audit`, `mutation-testing:audit`), structural drift
   (`code-tidying:tidy`), or comment markers (`work-items:scan-todos`).
@@ -238,13 +236,13 @@ Recommend, do not auto-invoke:
 
 ## Cross-references
 
-- [`context/lenses.md`](context/lenses.md) — the five hunter lens contracts, the evidence-quote and
+- [`context/lenses.md`](context/lenses.md), the five hunter lens contracts, the evidence-quote and
   no-candidate rules, and the bundled generic default lanes
-- [`context/verification-gate.md`](context/verification-gate.md) — the default-refute gate prompt and
+- [`context/verification-gate.md`](context/verification-gate.md), the default-refute gate prompt and
   the retained-refuted output contract
-- [`context/findings-report.md`](context/findings-report.md) — report format, evidence labels, refuted
+- [`context/findings-report.md`](context/findings-report.md). Report format, evidence labels, refuted
   tail, cursor metadata block
-- [`${CLAUDE_PLUGIN_ROOT}/reference/config.md`](../../reference/config.md) — `.claude/bugs.md`
+- [`${CLAUDE_PLUGIN_ROOT}/reference/config.md`](../../reference/config.md). `.claude/bugs.md`
   keys, layers, and merge semantics
-- [`${CLAUDE_PLUGIN_ROOT}/skills/write/SKILL.md`](../write/SKILL.md) — the five-field report shape, the
+- [`${CLAUDE_PLUGIN_ROOT}/skills/write/SKILL.md`](../write/SKILL.md), the five-field report shape, the
   duplicate scan, and the persistence path precedence this skill reuses

--- a/plugins/bugs/skills/setup/SKILL.md
+++ b/plugins/bugs/skills/setup/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: "Verify and configure the bugs plugin for this repository. check inspects both surfaces read-only — the rendered output_dir userConfig value, and the tracked .claude/bugs.md lane config across its cascade layers; apply writes or updates that tracked file and nothing else. Use when: 'set up bugs', 'configure bugs', 'bugs setup', 'where do bug reports land', you want --file reports committed alongside code, or '/bugs:scan' needs project lanes and a filing posture. Actions: check (read-only, default) | apply (creates or updates the tracked lane config; output_dir still routes through Claude Code's own configuration prompt)."
+description: "Verify and configure the bugs plugin for this repository. check inspects both surfaces read-only, the rendered output_dir userConfig value, and the tracked .claude/bugs.md lane config across its cascade layers; apply writes or updates that tracked file and nothing else. Use when: 'set up bugs', 'configure bugs', 'bugs setup', 'where do bug reports land', you want --file reports committed alongside code, or '/bugs:scan' needs project lanes and a filing posture. Actions: check (read-only, default) | apply (creates or updates the tracked lane config; output_dir still routes through Claude Code's own configuration prompt)."
 argument-hint: "check|apply"
 user-invocable: true
 disable-model-invocation: true
@@ -14,20 +14,20 @@ Confirm where `/bugs:write --file` writes reports, and manage the tracked projec
 
 | Surface | Holds | Written by |
 |---|---|---|
-| `output_dir` — native `userConfig` | one operator's personal `--file` destination on one machine | Claude Code's own plugin configuration prompt — never this skill |
-| `.claude/bugs.md` — tracked, cascade-layered | team policy: `/bugs:scan` lanes and filing posture | `apply` here, team layer only |
+| `output_dir`. Native `userConfig` | one operator's personal `--file` destination on one machine | Claude Code's own plugin configuration prompt, never this skill |
+| `.claude/bugs.md`. Tracked, cascade-layered | team policy: `/bugs:scan` lanes and filing posture | `apply` here, team layer only |
 
 This is the narrow-write setup shape: `apply` is bounded to the one writable artifact this plugin
 owns, and the unwritable surface beside it stays check-only. `output_dir` is a personal value that
 Claude Code prompts for when the plugin is enabled, stores in user settings, and ignores in
-`pluginConfigs` entries under project and local settings on current releases (≥ 2.1.207) — so an
+`pluginConfigs` entries under project and local settings on current releases (≥ 2.1.207), so an
 `apply` could only write the `pluginConfigs` the uniform setup contract forbids, and reconfiguration
 routes through the native flow instead.
 
 Official contract: <https://code.claude.com/docs/en/plugins-reference#user-configuration>.
 
 Keys, layers, merge semantics, the `output_dir` partition rule, and the file format live in
-[`${CLAUDE_PLUGIN_ROOT}/reference/config.md`](../../reference/config.md) — their single home. Read it
+[`${CLAUDE_PLUGIN_ROOT}/reference/config.md`](../../reference/config.md), their single home. Read it
 before checking or writing; never restate its keys here, and never let this skill and that reference
 disagree.
 
@@ -54,70 +54,70 @@ Modify nothing. Report both surfaces, then one remediation line per gap.
 4. If the recommended value differs from the effective one, direct the user to Claude Code's
    plugin configuration prompt for `bugs` (interactive `/plugin configure bugs@<marketplace>` any
    time; headless, rerun `claude plugin install bugs@<marketplace> -s <scope> --config
-   output_dir=<path>` — against an already-installed plugin it prints `already installed` and
+   output_dir=<path>`. Against an already-installed plugin it prints `already installed` and
    still writes the value, verified on Claude Code 2.1.240 for a non-sensitive option at `user`
    scope. Never uninstall to reconfigure: that drops the whole stored `pluginConfigs` entry and
    resets every option to its manifest default). Claude Code owns persistence. Do not hand-edit
    any `pluginConfigs` key.
-5. Tell the user to rerun `check` after reconfiguration — in a fresh session, since the rendered
-   value is injected at load — then verify and report the effective destination.
+5. Tell the user to rerun `check` after reconfiguration, in a fresh session, since the rendered
+   value is injected at load, then verify and report the effective destination.
 
 ### B. `.claude/bugs.md` (tracked lane config)
 
-Anchor at the repo root — `${CLAUDE_PROJECT_DIR}` when set, otherwise `git rev-parse --show-toplevel`
-— never at the CWD, then report **each layer separately** and the effective merged result:
+Anchor at the repo root. Use `${CLAUDE_PROJECT_DIR}` when set, otherwise `git rev-parse --show-toplevel`,
+never the CWD. Then report **each layer separately** and the effective merged result:
 
 1. **Per-layer presence.** Name every layer of the surface (the reference's layer table is
    authoritative) and say for each: absent, present-and-parsed, or malformed. A malformed layer
-   degrades soft — surface the error, name the layer, and resolve as if it were absent.
+   degrades soft. Surface the error, name the layer, and resolve as if it were absent.
 2. **Effective config and provenance.** Report the merged `lanes` and `filing_posture` and which
-   layer supplied each value, honoring the reference's merge semantics — including an explicit
+   layer supplied each value, honoring the reference's merge semantics, including an explicit
    empty-list opt-out, which is reported as an opt-out, not as a broken layer. All layers absent is
-   a valid, fully working state: INFO, never FAIL — `/bugs:scan` falls through to its bundled
+   a valid, fully working state: INFO, never FAIL. `/bugs:scan` falls through to its bundled
    generic default lanes.
 3. **Per-layer version-control verdict.** A present team file must be tracked, which takes **two**
-   probes — not-ignored and actually-tracked. Run `git check-ignore -v .claude/bugs.md`; a
-   non-empty result is FAIL, naming the matching pattern — teammates would never receive it. Then run
+   probes: not-ignored and actually-tracked. Run `git check-ignore -v .claude/bugs.md`; a
+   non-empty result is FAIL, naming the matching pattern. Teammates would never receive it. Then run
    `git ls-files --error-unmatch .claude/bugs.md`; a non-zero exit on a present file is also
-   FAIL — "present but untracked — commit it so teammates receive it". The ignore probe alone cannot
+   FAIL, "present but untracked, commit it so teammates receive it". The ignore probe alone cannot
    see this: an untracked, unignored file returns the same empty output as a healthy tracked one, so
    `check` would bless a config nobody else ever receives. The `.local.md` overlay must be
    gitignored; staged or unignored is FAIL. The user-global layer sits outside the worktree, so no git
-   verdict applies to it — say so rather than running a command whose answer is meaningless.
+   verdict applies to it. Say so rather than running a command whose answer is meaningless.
 4. **Unreachable layers.** When a layer cannot be read (the user-global one often is not), WARN that
    it was not considered rather than presenting the rest as the whole effective config.
-5. **Unknown keys.** Report them as inert, naming their layer — including `output_dir`, which is not
+5. **Unknown keys.** Report them as inert, naming their layer, including `output_dir`, which is not
    a recognized key here per the reference's partition rule.
 
 ## `apply` (idempotent, bounded to `.claude/bugs.md`)
 
-Run `check` first, then converge the **team** file — the only artifact this action writes. Never
+Run `check` first, then converge the **team** file, the only artifact this action writes. Never
 touch `settings.json`, `settings.local.json`, managed settings, `pluginConfigs`, `userConfig`, the
 user-global layer, the `.local.md` overlay, or the consumer's `.gitignore`. An `output_dir` change
 requested here is routed to the native flow in `check` step A4, never written.
 
 1. **Read the effective config first, across every layer**, and present it. Where a user-global or
-   overlay layer changes the team file's effect — adding lanes, replacing one by name, opting out
-   with an empty list, or supplying `filing_posture` nearest-wins — say so explicitly: a team-scope
+   overlay layer changes the team file's effect, adding lanes, replacing one by name, opting out
+   with an empty list, or supplying `filing_posture` nearest-wins, say so explicitly: a team-scope
    edit alone will not account for it, and re-adding a lane an overlay opts out of will not restore
    it on this machine. Prompt the user to also update that layer; do not edit it for them.
-2. **Draft lanes from the repository.** Before asking anything, infer candidates from what exists —
+2. **Draft lanes from the repository.** Before asking anything, infer candidates from what exists:
    entrypoint and API directories, the highest-churn source areas in `git log`, and any subsystem
    the repo's own docs treat as critical. Propose kebab-case lane names with globs relative to the
    repo root. Degrade to the bundled generic default lanes as the proposal when history or layout
    gives nothing to infer from.
 3. **Confirm, one decision at a time.** Present each drafted lane with a recommendation; let the
    user accept, edit, or drop it. Then settle `filing_posture`, stating what each value permits per
-   the reference — and that neither value ever lets a bare invocation file.
+   the reference, and that neither value ever lets a bare invocation file.
 4. **Write conservatively.** Scaffold the file in the reference's documented format when absent; for
-   an existing file, make a targeted update — fill absent keys at their documented defaults,
+   an existing file, make a targeted update. Fill absent keys at their documented defaults,
    preserve prose and keys you do not recognize, and *report* rather than silently rewrite anything
    you cannot reconcile. Never overwrite blind, and never rewrite a file you did not first read.
 5. **Verify after writing.** Re-run the `check` B probes against the file on disk: it parses, every
    lane declares `name` and `globs`, the globs match real paths (a lane matching nothing is reported
    as skipped), and `git check-ignore -v .claude/bugs.md` confirms it is not ignored. A file
    just scaffolded here is legitimately untracked until it is staged, so
-   `git ls-files --error-unmatch` will not match yet — that is not a FAIL at this point; state the
+   `git ls-files --error-unmatch` will not match yet. That is not a FAIL at this point; state the
    commit obligation instead (step 7). Report the values you observed, never an unobserved change.
 6. **Recommend the overlay line, do not write it.** Personal deviations belong in
    `.claude/bugs.local.md`; recommend the consumer add the recursive `.gitignore` line the
@@ -129,7 +129,7 @@ Re-running `apply` when everything already matches changes nothing and reports "
 ## Output
 
 Report, for each surface: the effective state and the layer that supplied it, the recommended state,
-and what changed — the tracked file's path and the keys written, plus whether the user must still
+and what changed, the tracked file's path and the keys written, plus whether the user must still
 change the Claude-owned `output_dir` through Claude Code's own flow. Do not claim a configuration
 change until it is observed: for the tracked file, by re-reading it; for `output_dir`, by a rerun in
 a fresh session.

--- a/plugins/bugs/skills/write/SKILL.md
+++ b/plugins/bugs/skills/write/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: "Produce a structured 5-field bug report (title, steps to reproduce, expected vs actual, severity with justification, suggested fix location) from an informal description. Read-only — never modifies code, never opens PRs, never files issues by default. Use when: 'there is a bug in <X>', 'report a bug', 'file a bug', 'bug-report this', '<symbol> gives wrong output when <condition>', 'I am seeing <error> in <file>', 'expected X got Y', 'write this up as a bug'. Skip when: deep investigation is needed, a fix is already in progress, or the request is a feature request (missing capability) rather than a defect. Emits Markdown to stdout by default; with --file, persists a report file and can hand off to a work-item tracker for filing."
+description: "Produce a structured 5-field bug report (title, steps to reproduce, expected vs actual, severity with justification, suggested fix location) from an informal description. Read-only, never modifies code, never opens PRs, never files issues by default. Use when: 'there is a bug in <X>', 'report a bug', 'file a bug', 'bug-report this', '<symbol> gives wrong output when <condition>', 'I am seeing <error> in <file>', 'expected X got Y', 'write this up as a bug'. Skip when: deep investigation is needed, a fix is already in progress, or the request is a feature request (missing capability) rather than a defect. Emits Markdown to stdout by default; with --file, persists a report file and can hand off to a work-item tracker for filing."
 argument-hint: "[--file] [--quick|--full] [--no-survey] <bug description>"
 user-invocable: true
 disable-model-invocation: false
@@ -20,15 +20,15 @@ Arguments: `$ARGUMENTS`
 
 ## Purpose
 
-`/bugs` produces a five-field structured report so the next session (or a human) can act without re-asking on vague repro, missing severity, no fix location, or hand-wavy expected/actual. **Read-only** — it captures, it does not fix, and it does not file (unless you explicitly ask).
+`/bugs` produces a five-field structured report so the next session (or a human) can act without re-asking on vague repro, missing severity, no fix location, or hand-wavy expected/actual. **Read-only**. It captures, it does not fix, and it does not file (unless you explicitly ask).
 
-This is the **bug-intake** stage. It sits upstream of filing the report into a work-item tracker, and it is independent of any downstream fix workflow — when the report itself is the deliverable (a Slack message, a PR comment, a verbal handoff), that is all this skill needs to do.
+This is the **bug-intake** stage. It sits upstream of filing the report into a work-item tracker, and it is independent of any downstream fix workflow, when the report itself is the deliverable (a Slack message, a PR comment, a verbal handoff), that is all this skill needs to do.
 
 Five fields: title, steps to reproduce, expected vs actual, severity (with justification), and suggested fix location. A `(unknown — needs reporter confirmation)` placeholder is used for any field that cannot be backed from the source, rather than inventing one.
 
 A sharp report captured up front saves the next session from re-asking. Unrepresented reproduction steps cost far more to recover later than to capture now.
 
-## Trigger conditions — when to invoke
+## Trigger conditions, when to invoke
 
 Invoke when ANY hold:
 
@@ -37,45 +37,45 @@ Invoke when ANY hold:
 - The user states a behavioural mismatch ("expected `X`, got `Y`", "`X` returns wrong value when `Y`")
 - The user asks for a structured report from informal context
 
-## Skip conditions — when to NOT invoke
+## Skip conditions, when to NOT invoke
 
-- **Investigation needed** — the bug needs reproduce-first diagnosis, not just capture. If your project provides a debugging or investigation skill, hand off to it; otherwise scope the investigation separately from this read-only capture.
-- **Fix already in progress** — this skill only captures; it does not complete a fix.
-- **Feature request** (a missing capability, not a defect) — this is product intent, not a bug. If your project provides a PRD or requirements-intake skill, route there; otherwise capture it as a feature request, not a five-field bug report.
-- **Generic chore** (a TODO, docs gap, or non-defect task) — file it directly in your tracker; it does not need the five-field bug shape.
+- **Investigation needed**, the bug needs reproduce-first diagnosis, not just capture. If your project provides a debugging or investigation skill, hand off to it; otherwise scope the investigation separately from this read-only capture.
+- **Fix already in progress**. This skill only captures; it does not complete a fix.
+- **Feature request** (a missing capability, not a defect). This is product intent, not a bug. If your project provides a PRD or requirements-intake skill, route there; otherwise capture it as a feature request, not a five-field bug report.
+- **Generic chore** (a TODO, docs gap, or non-defect task). File it directly in your tracker; it does not need the five-field bug shape.
 
 If it is ambiguous, surface the question once and let the user pick.
 
 ## The bugs process
 
-### Step 1 — Skip-condition check (MANDATORY)
+### Step 1. Skip-condition check (MANDATORY)
 
 If the request matches a skip condition, STOP and recommend the right path. Do not produce a bug report for a feature request, an investigation task, or a generic chore.
 
-### Step 2 — Survey before you write
+### Step 2. Survey before you write
 
 A fast breadth pass before deep work. In parallel:
 
 - `Glob`/`Grep` for the symbol named in the description (function, class, file, error message)
-- If more than one symbol matches, the description is ambiguous — ask which one
-- `git log --oneline -10 -- <suspected-file>` if a file is named — a recent change may be the cause
+- If more than one symbol matches, the description is ambiguous. Ask which one
+- `git log --oneline -10 -- <suspected-file>` if a file is named, a recent change may be the cause
 - Check the output directory (see Step 4) for prior bug reports on the same area, to avoid duplicates
 
-Skip the survey when `--no-survey` was passed (unconditionally — the flag means "trust the description"), or when `--quick` was passed AND the description names a single unambiguous symbol.
+Skip the survey when `--no-survey` was passed (unconditionally, the flag means "trust the description"), or when `--quick` was passed AND the description names a single unambiguous symbol.
 
-### Step 3 — Targeted Q&A
+### Step 3. Targeted Q&A
 
-Ask ONE question at a time. Use `AskUserQuestion` when 2-4 named options exist (e.g. "which `flush()` — there are 3 in the repo: …"); use prose for open-ended questions.
+Ask ONE question at a time. Use `AskUserQuestion` when 2-4 named options exist (e.g. "which `flush()`? There are 3 in the repo: …"); use prose for open-ended questions.
 
-Question priority order — only ask if the field cannot be backed from context:
+Question priority order. Only ask if the field cannot be backed from context:
 
 | Field | Highest-value question |
 |-------|------------------------|
 | Steps to reproduce | "Walk me through the smallest sequence that triggers it." |
 | Expected vs actual | "What did you expect? What did you see instead?" |
 | Severity | "Who or what is blocked? Production users / dev workflow / cosmetic?" |
-| Fix location | (do not ask — derive from the survey; if unknown, mark `(unknown — needs reporter confirmation)`) |
-| Title | (do not ask — derive from symptom + symbol) |
+| Fix location | (do not ask. Derive from the survey; if unknown, mark `(unknown — needs reporter confirmation)`) |
+| Title | (do not ask. Derive from symptom + symbol) |
 
 Stop conditions: every required field has a backed answer OR an explicit `(unknown — needs reporter confirmation)` placeholder. Modifiers:
 
@@ -87,29 +87,29 @@ Stop conditions: every required field has a backed answer OR an explicit `(unkno
 | `--no-survey` | Trust the description; only ask when a field would otherwise be invented |
 | `--file` | Write the report to a file (see Step 4) instead of only stdout; then offer to file it in a tracker |
 
-### Step 4 — Emit the report
+### Step 4. Emit the report
 
-Default: emit Markdown to stdout (read-only). Follow the 5-field template — see [`context/template.md`](context/template.md) for the full structure with a worked example.
+Default: emit Markdown to stdout (read-only). Follow the 5-field template. See [`context/template.md`](context/template.md) for the full structure with a worked example.
 
 `--file` mode: write the report to a file with frontmatter `type: bug-report`. Resolve the output directory in this precedence, and always tell the user the final path:
 
 1. If the consumer configured `output_dir`, write to `${user_config.output_dir}`.
-2. Otherwise, write to `${CLAUDE_PLUGIN_DATA}/bug-reports/<project-slug>/`, where `<project-slug>` is the kebab-cased basename of the project root (`${CLAUDE_PROJECT_DIR}`, or the git toplevel when unset). The plugin data directory is per-plugin, not per-project — without the slug, Step 2's duplicate scan would match another repository's report on the same symbol.
+2. Otherwise, write to `${CLAUDE_PLUGIN_DATA}/bug-reports/<project-slug>/`, where `<project-slug>` is the kebab-cased basename of the project root (`${CLAUDE_PROJECT_DIR}`, or the git toplevel when unset). The plugin data directory is per-plugin, not per-project. Without the slug, Step 2's duplicate scan would match another repository's report on the same symbol.
 3. If neither resolves, fall back to `${CLAUDE_PROJECT_DIR}/.bug-reports/` and state clearly where the file landed.
 
 Filename: derive a slug from the title (kebab-case, ~40-char cap), prefix an ISO basic UTC timestamp with no colons (Windows-safe), e.g. `20260502T143000Z-bug-pricefor-discount-math.md`. If the title cannot yet produce a slug, fall back to the timestamp alone.
 
-### Step 5 — Hand off
+### Step 5. Hand off
 
 After emitting the report, recommend the next step (do NOT auto-invoke):
 
-- **File it as a work item** — if you are in a GitHub repository and the `gh` CLI is available. `--body-file` needs a report file on disk: in `--file` mode use the emitted report path; in default stdout mode first save the report (offer to re-run the write step or Write it to a temp file). Then run `gh issue create --type Bug --body-file <report>` and let `gh` prompt for the title interactively. If filing non-interactively, never interpolate the reporter's title text into the command string — write the title to a file first, then run `gh issue create --type Bug --title "$(cat <title-file>)" --body-file <report>`: the command-substitution RESULT is a quoted argument value and is not re-parsed, so backticks or `$( )` inside the reporter's text cannot execute. `--type Bug` sets the native GitHub Issue Type — an org-repo feature (the same one the work-items lanes set); on a personal / non-org repo without native Issue Types, drop the flag and add a `type: bug` label instead when the repo defines one. If a work-item tracker MCP tool is available, use it. Map the severity to your tracker's priority labels if it has them.
-- **A fix is next** — if your project provides an investigation or implementation workflow, route there; otherwise scope the fix separately.
-- **The report is the deliverable** (Slack, PR comment, hand-off) — done; copy/paste the stdout.
+- **File it as a work item**, if you are in a GitHub repository and the `gh` CLI is available. `--body-file` needs a report file on disk: in `--file` mode use the emitted report path; in default stdout mode first save the report (offer to re-run the write step or Write it to a temp file). Then run `gh issue create --type Bug --body-file <report>` and let `gh` prompt for the title interactively. If filing non-interactively, never interpolate the reporter's title text into the command string. Write the title to a file first, then run `gh issue create --type Bug --title "$(cat <title-file>)" --body-file <report>`: the command-substitution RESULT is a quoted argument value and is not re-parsed, so backticks or `$( )` inside the reporter's text cannot execute. `--type Bug` sets the native GitHub Issue Type, an org-repo feature (the same one the work-items lanes set); on a personal / non-org repo without native Issue Types, drop the flag and add a `type: bug` label instead when the repo defines one. If a work-item tracker MCP tool is available, use it. Map the severity to your tracker's priority labels if it has them.
+- **A fix is next.** If your project provides an investigation or implementation workflow, route there; otherwise scope the fix separately.
+- **The report is the deliverable** (Slack, PR comment, hand-off). Done; copy/paste the stdout.
 
 ## Severity rubric
 
-Severity is `low / medium / high / critical` with a one-line justification. It is not "how upset is the reporter" — it is blast radius × blocking factor × data-integrity impact:
+Severity is `low / medium / high / critical` with a one-line justification. It is not "how upset is the reporter". It is blast radius × blocking factor × data-integrity impact:
 
 | Severity | Use when |
 |----------|----------|
@@ -118,7 +118,7 @@ Severity is `low / medium / high / critical` with a one-line justification. It i
 | `medium` | Feature broken for a narrow case, has a workaround, edge-case data issue |
 | `low` | Cosmetic, documentation, dev-experience, or tooling drift |
 
-If a tracker uses priority labels (e.g. `p0`/`p1`/`p2`/`p3` or `priority:high`), map this rubric onto them when filing. If severity cannot be calibrated from context, ask ONE question — do not invent it.
+If a tracker uses priority labels (e.g. `p0`/`p1`/`p2`/`p3` or `priority:high`), map this rubric onto them when filing. If severity cannot be calibrated from context, ask ONE question. Do not invent it.
 
 ## What this skill does NOT do
 
@@ -126,7 +126,7 @@ If a tracker uses priority labels (e.g. `p0`/`p1`/`p2`/`p3` or `priority:high`),
 - **Does not invent reproduction steps.** If a step cannot be backed from the source, a test, or the reporter's description, it is marked `(unknown — needs reporter confirmation)` and surfaced under Notes. Flag a gap rather than fabricate one.
 - **Does not file the report by default.** The user reads the report and decides. `--file` persists it; filing into a tracker is an explicit hand-off in Step 5.
 - **Does not investigate the bug.** Step 2's survey is a fast grounding pass, not deep work. A fix that needs real investigation should be scoped separately.
-- **Does not auto-fix typos in the user's description.** "There is a bug in `flusH()`" may be intentional in some languages — ask one question.
+- **Does not auto-fix typos in the user's description.** "There is a bug in `flusH()`" may be intentional in some languages. Ask one question.
 - **Does not run a broad exploration or research pass.** If a fix needs deep investigation, recommend scoping it separately rather than doing it here.
 
 ## Gotchas
@@ -134,10 +134,10 @@ If a tracker uses priority labels (e.g. `p0`/`p1`/`p2`/`p3` or `priority:high`),
 - **Repro steps must be backed.** If you cannot derive them from the user's description, the source, or a test, mark `(unknown — needs reporter confirmation)`. Inventing repro is worse than admitting a gap.
 - **Severity is blast radius, not frustration.** Use the rubric; justify in one sentence.
 - **Suggested fix location is not a patch.** Name the file path and function/class. No code, no diff, no "just change line X to Y". The fixer decides the patch.
-- **Title in present tense.** "`priceFor` returns wrong total when `discountPercent` is non-zero" — not "fixed pricing bug" or "pricing was broken".
+- **Title in present tense.** "`priceFor` returns wrong total when `discountPercent` is non-zero", not "fixed pricing bug" or "pricing was broken".
 - **When there is no bug, do not emit a report.** If the survey and Q&A reveal the behaviour is correct, emit the short "No bug confirmed" summary instead (see `context/template.md`).
 
 ## Cross-references
 
-- [`context/template.md`](context/template.md) — full Markdown template, worked example, `--file` frontmatter, and the "No bug confirmed" form
-- Consumer conventions (naming, areas, priority labels, tracker choice) come from the consuming project's own `CLAUDE.md` / rules — this skill reads them rather than imposing its own
+- [`context/template.md`](context/template.md). Full Markdown template, worked example, `--file` frontmatter, and the "No bug confirmed" form
+- Consumer conventions (naming, areas, priority labels, tracker choice) come from the consuming project's own `CLAUDE.md` / rules. This skill reads them rather than imposing its own


### PR DESCRIPTION
No linked issue

## Summary

#2891 instruction-surface de-slop cluster: purge em dashes from the `bugs` plugin README and every SKILL.md.

## Fix

Rewrote `plugins/bugs/README.md` and every `plugins/bugs/**/SKILL.md` under `/ai-slop:audit fix` semantics (periods, commas, or a restructured sentence; never parentheses, en dashes, or a spaced hyphen as a stand-in). Meaning-preserving self-audit repaired asides the first pass reattached to the wrong noun. The generated options block is ignore-fenced because the shared generator still emits em dashes. `bugs` 0.9.1.

## Verification

- Detector: 0 `rule-em-dash` findings outside ignore-fenced generated-options spans (and required trigger strings that must keep em dashes)
- `CHECK_SKILL_SKIP_MARKDOWNLINT=1 bash scripts/check-changed-skills.sh origin/main`: 0 failed; quoted trigger phrases vs origin/main preserved
- `python3 scripts/sync-plugin-options-docs.py --check` up to date
- `scripts/check-changelog-parity.sh --check-bump origin/main` passes
- `node scripts/generate-cheatsheet.mjs --check` in sync

## Related

Refs #2891

#2891 stays open.