### PR TITLE
docs(mutation-testing): de-slop instruction surfaces (0.3.6)

### DIFF
--- a/plugins/mutation-testing/.claude-plugin/plugin.json
+++ b/plugins/mutation-testing/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "mutation-testing",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "Measures whether a test suite can actually detect faults, not merely execute code: `/mutation-testing:principles` answers operator, mutant-state, and metric questions from the primary literature; `/mutation-testing:setup` verifies the ecosystem's mutation tool and writes the tracked config; `/mutation-testing:audit` runs diff-scoped mutation analysis and reports surviving mutants, verifying that tracked source was restored and failing the run when it cannot, delegating the productive-versus-arid judgment to a fresh-context reviewer and test authoring to the test lane, and optionally persisting survivors as a findings file the review fix pass consumes.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/mutation-testing/CHANGELOG.md
+++ b/plugins/mutation-testing/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to the `mutation-testing` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.3.6]
+
+### Changed
+
+- **Instruction-surface de-slop (#2891, mutation-testing cluster).** Rewrote this plugin's `README.md` and every
+  `SKILL.md` to drop em dashes under the repo's zero-tolerance house policy, using
+  `/ai-slop:audit fix` semantics: periods or commas, or a restructured sentence, never
+  parentheses, en dashes, or a spaced hyphen as a stand-in. Meaning stays; only the mark
+  and the sentence break change.
+
 ## [0.3.5]
 
 ### Changed

--- a/plugins/mutation-testing/README.md
+++ b/plugins/mutation-testing/README.md
@@ -1,25 +1,25 @@
 # mutation-testing
 
-A Claude Code plugin for the **test stage** of a disciplined dev workflow — measuring whether a test
+A Claude Code plugin for the **test stage** of a disciplined dev workflow. It measures whether a test
 suite can actually *detect* faults, not merely *execute* code. Three skills, one concern: proving the
 tests are checking something.
 
 | Skill | What it does |
 |---|---|
-| `/mutation-testing:principles` | Knowledge router — mutant states, operator catalogs, mutation score vs covered-code score vs test strength vs MSI, the oracle gap, equivalent mutants, arid nodes, and why not to gate on the score. Five reference spokes load on demand; a quick decision guide answers the common questions with no file load. |
-| `/mutation-testing:setup` | Verify and configure — detect the ecosystem, confirm the mutation tool is installed and drives the project's test runner, measure the baseline suite, settle the diff target and operator set, write the tracked config and an empty arid-node suppression record. `check` inspects read-only; `apply` interviews and writes. |
-| `/mutation-testing:audit` | Diff-scoped mutation analysis, read-only with respect to tracked source. At most one mutant per changed line, executed against the cached covering tests, always reverted. Survivor triage is delegated to a fresh-context reviewer; the report ranks files by oracle gap and hands survivors to the test-authoring lane. `--persist-findings` additionally writes the survivors into the memory tier as a findings file the `review:fanout` `fix` action consumes, after proving that destination outside tracked space — by probing the checkout that governs it, or by establishing from two independent signals that none does. |
+| `/mutation-testing:principles` | Knowledge router. Mutant states, operator catalogs, mutation score vs covered-code score vs test strength vs MSI, the oracle gap, equivalent mutants, arid nodes, and why not to gate on the score. Five reference spokes load on demand; a quick decision guide answers the common questions with no file load. |
+| `/mutation-testing:setup` | Verify and configure. Detect the ecosystem, confirm the mutation tool is installed and drives the project's test runner, measure the baseline suite, settle the diff target and operator set, write the tracked config and an empty arid-node suppression record. `check` inspects read-only; `apply` interviews and writes. |
+| `/mutation-testing:audit` | Diff-scoped mutation analysis, read-only with respect to tracked source. At most one mutant per changed line, executed against the cached covering tests, always reverted. Survivor triage is delegated to a fresh-context reviewer; the report ranks files by oracle gap and hands survivors to the test-authoring lane. `--persist-findings` additionally writes the survivors into the memory tier as a findings file the `review:fanout` `fix` action consumes, after proving that destination outside tracked space, by probing the checkout that governs it or by establishing from two independent signals that none does. |
 
 ## Why this exists
 
 Coverage tells you a line **executed**. It cannot tell you the line was **checked**. A file at 95%
 coverage and 40% covered-code mutation score has tests that run the code and assert almost nothing
-about it — and a coverage report will call that file healthy.
+about it, and a coverage report will call that file healthy.
 
 ## Works in any repo
 
 - **Reads your conventions, assumes none.** Ecosystem, test runner, source roots, and diff target
-  come from your own project — detected from what exists, confirmed with you at setup, then recorded
+  come from your own project. Detected from what exists, confirmed with you at setup, then recorded
   in a tracked config file so runs are deterministic.
 - **Cross-plugin refs degrade gracefully.** Test authoring defers to `/testing:write` when the
   `testing` plugin is installed and hands the survivor list back otherwise; failing-suite diagnosis
@@ -34,7 +34,7 @@ about it — and a coverage report will call that file healthy.
 
 - **No score gate.** The config has no threshold field. A mutation score has a permanent, unknowable
   ceiling below 100% because equivalent mutants cannot all be removed, and every point is
-  purchasable by suppressing a mutant — so a gate selects for suppression over testing. Report the
+  purchasable by suppressing a mutant, so a gate selects for suppression over testing. Report the
   number; rank by the gap; let the surviving mutants be the finding.
 - **No whole-repo nightly ratchet.** Diff-scoped, at most one mutant per changed line. The
   un-scoped, un-suppressed, gated shape is the one that kept this technique unused for three
@@ -54,9 +54,9 @@ about it — and a coverage report will call that file healthy.
 
 `/mutation-testing:setup apply` writes two tracked files in the consuming repo:
 
-- `.claude/mutation-testing.md` — tool, invocation command, diff target, mutate globs, operator set,
+- `.claude/mutation-testing.md`. Tool, invocation command, diff target, mutate globs, operator set,
   timeout, measured baseline suite time, optional mutant cap.
-- `.claude/mutation-testing-arid.md` — the arid-node suppression record, shaped by the marketplace's
+- `.claude/mutation-testing-arid.md`, the arid-node suppression record, shaped by the marketplace's
   finding-suppression convention: a mapping keyed by a derived `finding_id`, every entry carrying all
   five required keys (`check`, `claim`, `sites`, `reason`, `date`) with the id derived from its own
   constituents. An entry missing any of them is malformed and does not suppress.
@@ -65,7 +65,7 @@ They are kept separate deliberately: a config diff reads as a policy change, a s
 as an accepted finding. **Their layering also differs.** The config layers per the config-cascade
 convention (user-global → team → `.local.md` overlay, later wins). The suppression record sits in the
 cascade's policy-floor precedence-inversion class: on a conflict the **team** layer wins, and a
-personal-layer entry for an id the team layer does not carry **does not suppress at all** — it is
+personal-layer entry for an id the team layer does not carry **does not suppress at all**. It is
 reported `personal-only, not applied`. A personal layer is a draft surface there, so one developer
 cannot hide a finding the team never accepted.
 
@@ -75,11 +75,11 @@ This plugin declares no `userConfig` options.
 
 The reference material is distilled from primary sources, fetched 2026-08-10:
 
-- [Stryker — mutant states and metrics](https://stryker-mutator.io/docs/mutation-testing-elements/mutant-states-and-metrics/),
+- [Stryker. Mutant states and metrics](https://stryker-mutator.io/docs/mutation-testing-elements/mutant-states-and-metrics/),
   [Stryker.NET configuration](https://stryker-mutator.io/docs/stryker-net/configuration/),
   [StrykerJS incremental](https://stryker-mutator.io/docs/stryker-js/incremental/)
 - [PIT](https://pitest.org/) and its [mutation operators](https://pitest.org/quickstart/mutators/)
-- [Infection — MSI](https://infection.github.io/guide/)
+- [Infection. MSI](https://infection.github.io/guide/)
 - Petrović & Ivanković, *State of Mutation Testing at Google*, ICSE-SEIP 2018
   (<https://dl.acm.org/doi/10.1145/3183519.3183521>)
 - Petrović, Ivanković, Fraser & Just, *Practical Mutation Testing at Scale*

--- a/plugins/mutation-testing/skills/audit/SKILL.md
+++ b/plugins/mutation-testing/skills/audit/SKILL.md
@@ -23,8 +23,8 @@ Arguments: `$ARGUMENTS`
 
 - **Scope** (optional): a path limiting which changed files are considered. Default: every changed
   file inside the configured `mutate` globs.
-- **`--full`**: mutate the whole configured scope instead of the diff. Expensive and rarely correct
-State the estimated cost from `baseline-suite-ms` and confirm before running.
+- **`--full`**: mutate the whole configured scope instead of the diff. Expensive and rarely correct.
+  State the estimated cost from `baseline-suite-ms` and confirm before running.
 - **`--paths <globs>`**: mutate these paths regardless of the diff.
 - **`--max <n>`**: cap generated mutants for this run, overriding `max-mutants`.
 - **`--no-suppress`**: include mutants that the arid-node record would otherwise suppress, marked as

--- a/plugins/mutation-testing/skills/audit/SKILL.md
+++ b/plugins/mutation-testing/skills/audit/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: "Run diff-scoped mutation analysis and report surviving mutants — the code under test is restored and the restoration verified — tracked source is either byte-identical at the end or the run fails naming what it could not restore, and no test is written by this skill. Generates at most one mutant per changed line, executes the covering tests, then delegates the productive-versus-arid-versus-equivalent judgment to a fresh-context reviewer before reporting; ranks files by oracle gap and hands survivors to the test-authoring lane. Use when: 'run mutation testing', 'are my tests actually checking this', 'mutation score for this change', 'my coverage is high but I do not trust it', 'audit test quality', 'persist the surviving mutants for the fix pass', after tests go green and before review. Flags: `--full` (whole configured scope, not the diff), `--paths <globs>`, `--max <n>`, `--no-suppress` (report suppressed arid mutants too), `--persist-findings` (also write the survivors as a findings file the review fix pass consumes)."
+description: "Run diff-scoped mutation analysis and report surviving mutants, the code under test is restored and the restoration verified, tracked source is either byte-identical at the end or the run fails naming what it could not restore, and no test is written by this skill. Generates at most one mutant per changed line, executes the covering tests, then delegates the productive-versus-arid-versus-equivalent judgment to a fresh-context reviewer before reporting; ranks files by oracle gap and hands survivors to the test-authoring lane. Use when: 'run mutation testing', 'are my tests actually checking this', 'mutation score for this change', 'my coverage is high but I do not trust it', 'audit test quality', 'persist the surviving mutants for the fix pass', after tests go green and before review. Flags: `--full` (whole configured scope, not the diff), `--paths <globs>`, `--max <n>`, `--no-suppress` (report suppressed arid mutants too), `--persist-findings` (also write the survivors as a findings file the review fix pass consumes)."
 argument-hint: "[scope] [--full] [--paths <globs>] [--max <n>] [--no-suppress] [--persist-findings]"
 user-invocable: true
 disable-model-invocation: false
@@ -24,7 +24,7 @@ Arguments: `$ARGUMENTS`
 - **Scope** (optional): a path limiting which changed files are considered. Default: every changed
   file inside the configured `mutate` globs.
 - **`--full`**: mutate the whole configured scope instead of the diff. Expensive and rarely correct
-  — state the estimated cost from `baseline-suite-ms` and confirm before running.
+State the estimated cost from `baseline-suite-ms` and confirm before running.
 - **`--paths <globs>`**: mutate these paths regardless of the diff.
 - **`--max <n>`**: cap generated mutants for this run, overriding `max-mutants`.
 - **`--no-suppress`**: include mutants that the arid-node record would otherwise suppress, marked as
@@ -39,14 +39,14 @@ Three properties, stated first because everything below depends on them:
 1. **Read-only with respect to tracked source.** A mutant is applied, measured, and reverted.
    Restoration is verified against the Phase 0 snapshot at the earliest point the configured write
    regime permits, so a run **either** ends with tracked source byte-identical to tracked source at
-   the start **or** ends in failure naming what it could not restore — never in a reported outcome
+   the start **or** ends in failure naming what it could not restore, never in a reported outcome
    over edited source. The first tracked path that cannot be confirmed restored is that failure: no
    later phase runs and nothing is persisted ([Phase 3](#phase-3--execute)). Per the
-   naming doctrine's verb contract, `audit` reports and stops — and bare invocation does exactly
+   naming doctrine's verb contract, `audit` reports and stops, and bare invocation does exactly
    that. `--persist-findings` is the explicit user override that verb contract sanctions
-   (the marketplace's `docs/PLUGIN-PHILOSOPHY.md` verb table). Its writes — the findings file, and
+   (the marketplace's `docs/PLUGIN-PHILOSOPHY.md` verb table). Its writes, the findings file and
    the self-ignore guard's own `.gitignore` when a governing checkout was found and the guard heals
-   that root — are each **proven outside tracked space before that write is made**, never in tracked
+   that root, are each **proven outside tracked space before that write is made**, never in tracked
    source and never in a file another producer owns.
 2. **No tests are written here.** Survivors are handed to the test-authoring lane. This skill never
    both creates a gap and closes it.
@@ -67,7 +67,7 @@ Refuse to proceed, with the specific remediation, when any of these fail:
   with the project's own test command before returning here.
 
 Record the baseline run's result and wall-clock. Every later "killed" verdict is meaningful only
-against a green baseline captured in this run — not against the one `setup` recorded, which may be
+against a green baseline captured in this run, not against the one `setup` recorded, which may be
 stale.
 
 **Capture `git status --porcelain` here.** This is *the Phase 0 snapshot* every later restoration
@@ -77,8 +77,7 @@ difference it exists to detect.
 
 **Resolve the write regime here too**, because it decides which restoration gate
 [Phase 3](#phase-3--execute) can run: does the configured tool write mutants out of tree, rewrite the
-working file whole once, or apply and revert it per mutant? Read the project's own config for it —
-the out-of-tree default of most tools is user-changeable, so the tool's reputation is not the answer.
+working file whole once, or apply and revert it per mutant? Read the project's own config for it. The out-of-tree default of most tools is user-changeable, so the tool's reputation is not the answer.
 State the resolved regime in the scope report. Refuse when the regime is in-tree per mutant and the
 tool offers neither per-mutant observability nor interrupt safety: the gate that regime requires
 cannot be run, and a check that cannot run is not a check.
@@ -87,7 +86,7 @@ cannot be run, and a check that cannot run is not a check.
 
 1. Resolve the changed lines: `git diff --unified=0 <diff-target>...HEAD` for the files inside the
    configured `mutate` globs, intersected with any `--paths` or scope argument.
-2. Drop lines with no test coverage, if a coverage report is available — a mutant on an uncovered
+2. Drop lines with no test coverage, if a coverage report is available, a mutant on an uncovered
    line reports "no coverage", which the coverage report already said more cheaply.
 3. Apply the arid-node suppression record per
    [`context/suppression.md`](context/suppression.md), which owns this plugin's read of the
@@ -99,7 +98,7 @@ cannot be run, and a check that cannot run is not a check.
    dropped and every entry that would have applied is marked as such.
 
    Entries are dispositioned **only when their anchored node is one this run generated a mutant
-   for** — inside the changed-line set from step 1, after the coverage drop in step 2. Anything else
+   for**. Inside the changed-line set from step 1, after the coverage drop in step 2. Anything else
    is *not-examined*: left untouched and counted, never resolved. Scope by node, not by file: a file
    with a suppressed survivor at line 100 and an unrelated edit at line 10 was "touched" but that
    node was never examined, and treating it as a disappearance would fail the skill's own self-check
@@ -109,14 +108,14 @@ cannot be run, and a check that cannot run is not a check.
    finishes and one that does not.
 5. Report the scope before running: files, changed lines, mutants to be generated, suppressed count,
    and the estimated wall-clock from `baseline-suite-ms × mutants`. If a cap truncates the set, say
-   what was dropped — a truncated run must never read as a clean one.
+   what was dropped, a truncated run must never read as a clean one.
 
 ## Phase 2 — Generate
 
 **At most one mutant per changed line.** Not every operator at every location. The marginal value of
 a second mutant on a line is near zero: if the line is unchecked, one mutant proves it.
 
-Where the configured tool supports diff-scoped generation, use it — `--since`, `--incremental`,
+Where the configured tool supports diff-scoped generation, use it. `--since`, `--incremental`,
 `--git-diff-lines`. Where `tool: manual`, apply the single-operator protocol from the `principles`
 skill's `tooling.md`: prefer statement/block removal, then relational-operator inversion.
 
@@ -124,64 +123,64 @@ skill's `tooling.md`: prefer statement/block removal, then relational-operator i
 
 For each mutant: apply, run the cached covering tests, record the state
 (killed / survived / no-coverage / timeout / invalid), revert. **Where the mutant was written to
-tracked source, verify the revert** — which regime below says when that is.
+tracked source, verify the revert**, which regime below says when that is.
 
 **This phase is a deterministic gate and is deliberately not delegated.** The tests' pass/fail *is*
 the verdict; there is no judgment to bias and no independence to buy. Spending a subagent here would
-be delegation cost with nothing bought — the narrow exemption the fresh-eyes rule states for
+be delegation cost with nothing bought, the narrow exemption the fresh-eyes rule states for
 mechanical judgments.
 
 **Verify restoration against the Phase 0 snapshot, not against a clean tree.** Phase 0 rejects a
 dirty *target* but permits unrelated dirty files elsewhere, so an unconditional "tree is clean" probe
-would report a restoration failure on a repo that merely has unrelated work in progress — and, worse,
+would report a restoration failure on a repo that merely has unrelated work in progress. And, worse,
 would teach the reader to ignore that line. Compare the after-state against that snapshot: equality
 is success, and any difference in a **tracked** path is a failed restore. Tracked, not merely
-mutated — a run that leaves an adjacent tracked file modified has broken the same invariant, and
+mutated, a run that leaves an adjacent tracked file modified has broken the same invariant, and
 untracked scratch output is not tracked source and does not trip it.
 
-**When that comparison can run depends on where the mutant is written — a property of the configured
+**When that comparison can run depends on where the mutant is written, a property of the configured
 tool that Phase 0 resolves from the project's config, never from the tool's reputation.** One axis,
 three regimes:
 
-- **Out-of-tree** — every established tool in its default configuration: the mutant goes to a
+- **Out-of-tree**. Every established tool in its default configuration: the mutant goes to a
   sandbox, a temporary file, or memory, and tracked source is only ever read. There is no revert to
   verify because there was no write. The gate is a **Phase 0 precondition that the out-of-tree mode
-  is actually in effect** — the setting is user-changeable, so read it — plus **one end-of-run
+  is actually in effect**, the setting is user-changeable, so read it, plus **one end-of-run
   comparison** as a backstop against crash paths no tool documents. Where a tool has no in-place
   option at all, that precondition is a constant rather than a check.
-- **In-tree, whole-file** — a tool that rewrites the working file once and restores it itself. One
+- **In-tree, whole-file**, a tool that rewrites the working file once and restores it itself. One
   write and one tool-owned restore, so an **end-of-run comparison** is right and sufficient. Run it
   in a `finally`, not on the return path: "end of run" here means **however the run ends**, including
   a tool that is killed and never returns. This is the regime with a real in-tree write and a restore
-  nobody controls, so an abnormal exit is exactly when the comparison matters most — and it is the
+  nobody controls, so an abnormal exit is exactly when the comparison matters most, and it is the
   one path where a missing check would be silent rather than loud. Phase 0 says plainly that the
   restore is best-effort: signal coverage is undocumented, and a second interrupt can abort it
   mid-move.
-- **In-tree, per mutant** — `tool: manual`, and any tool that applies and reverts the working file
+- **In-tree, per mutant**. `tool: manual`, and any tool that applies and reverts the working file
   once per mutant. This is the only regime where pile-on is real, and the in-loop rule applies in
   full: **compare after every revert**, because a failed revert means the trap itself failed, the
   next mutant lands on unrestored source, and every verdict after that describes a tree nobody wrote.
-  Guarantee the revert on every exit path — apply as a patch reverted in a trap or `finally`, never
-  an edit depending on a later step — and run the comparison on those paths too: a trap fires outside
+  Guarantee the revert on every exit path. Apply as a patch reverted in a trap or `finally`, never
+  an edit depending on a later step, and run the comparison on those paths too: a trap fires outside
   the loop, so the loop's own comparison never sees a crashed run, and a revert that merely *ran* is
   not a revert that *worked*. Where such a tool offers neither per-mutant observability nor interrupt
   safety, Phase 0 **refuses** rather than gates: a check that cannot run is not a check.
 
-**Do not go hunting for a per-mutant revert on the first two regimes.** Under mutant schemata — the
-architecture the established tools use — every mutant is written once and selected at run time by an
+**Do not go hunting for a per-mutant revert on the first two regimes.** Under mutant schemata. The
+architecture the established tools use. Every mutant is written once and selected at run time by an
 environment variable or switch, so there is no Nth write and no Nth revert to observe, and the
 per-mutant hooks those tools expose report a *result*, not a filesystem event. An end-of-run
 comparison loses nothing there: the in-loop check buys localisation and pile-on prevention across
 many write/revert cycles, and where there was one write neither exists. Never substitute the tool's
-own exit status for the comparison — a harness that restores by writing the file back reports success
+own exit status for the comparison, a harness that restores by writing the file back reports success
 for a write it never re-read.
 
 **The first failed restore ends the run**, identically in all three regimes. Only *when* the
 comparison can run varies. It is terminal, not a finding reported beside the others:
 
-- Apply no further mutants — which bites only where mutants are applied one at a time; the remaining
+- Apply no further mutants, which bites only where mutants are applied one at a time; the remaining
   two carry the rule everywhere else.
-- Enter no later phase — no triage, no ranked report, and **no findings file, `--persist-findings`
+- Enter no later phase. No triage, no ranked report, and **no findings file, `--persist-findings`
   or not**.
 - Return a **failure** verdict naming every unrestored path and the recovery command. The failure is
   the whole report; nothing may push it off the screen.
@@ -190,7 +189,7 @@ Stopping rather than reporting is what `docs/conventions/liveness-assertion/READ
 contract" item 1 requires of a surface that cannot vouch for its own outcome, and continuing would
 produce both false-green shapes that doc names at once. The ranked report would read exactly like a
 normal run while tracked source sits mutated; and under `--persist-findings` the run would hand an
-apply relay a conforming findings file whose every `Location` asserts a restored tree — findings
+apply relay a conforming findings file whose every `Location` asserts a restored tree. Findings
 measured against a state that no longer exists, fenced onto source that is now corrupt.
 
 ## Phase 4 — Triage (fresh context)
@@ -199,15 +198,15 @@ Every surviving mutant is one of three things, and the difference is a judgment:
 
 | Disposition | Meaning | Downstream |
 |---|---|---|
-| **Productive** | A genuine gap — the behavior is unchecked | Hand to the test-authoring lane |
-| **Equivalent** | Semantically identical to the original; no test can kill it | **Not** a suppression — the check is wrong for that node |
-| **Arid** | Killable, but killing it would not improve the suite | Propose a complete suppression entry — its `claim` binding a node kind from the vocabulary, its `reason` naming the unasserted behavior. Without that, the verdict is *unclassified*, not arid |
+| **Productive** | A genuine gap, the behavior is unchecked | Hand to the test-authoring lane |
+| **Equivalent** | Semantically identical to the original; no test can kill it | **Not** a suppression, the check is wrong for that node |
+| **Arid** | Killable, but killing it would not improve the suite | Propose a complete suppression entry. Its `claim` binding a node kind from the vocabulary, its `reason` naming the unasserted behavior. Without that, the verdict is *unclassified*, not arid |
 
 **This judgment is delegated to a fresh-context (non-fork) subagent, mandatorily.** It is the
 `self-grade` bias class: a context that generated the mutants and ran them is the weakest place to
 decide whether its own findings are worth reporting, and a fork inherits that reasoning rather than
-removing it. Hand over the artifact — the mutated line, its surrounding code, and the tests that
-covered it — never the reasoning that produced the mutant.
+removing it. Hand over the artifact, the mutated line, its surrounding code, and the tests that
+covered it, never the reasoning that produced the mutant.
 
 For the **equivalence** call specifically, prefer a cross-vendor advisor when one is installed and
 set up (invoked per its own documentation), falling back to the same-vendor fresh-context subagent.
@@ -215,25 +214,24 @@ Equivalence is formally undecidable, so the risk is a correlated blind spot rath
 attention, and that is the case the top rung of the ladder exists for.
 
 **Every verdict that WITHHOLDS a survivor must cite evidence, and a verdict that cannot is reported
-as *unclassified*.** Equivalent and arid are the two that withhold, so the rule binds both — asserting
+as *unclassified*.** Equivalent and arid are the two that withhold, so the rule binds both. Asserting
 either from inspection alone is exactly where this technique manufactures false confidence:
 
 - **Equivalent** requires the demonstration: what was run, what was identical, and under which inputs.
-- **Arid** requires a complete proposed suppression entry — all five keys, id derived from them —
+- **Arid** requires a complete proposed suppression entry, all five keys, id derived from them,
   whose `claim` is `arid(kind=<node-kind>)` with `<node-kind>` drawn from the vocabulary enumerated in
   the `principles` skill's
   [`scaling-and-suppression.md`](../principles/reference/scaling-and-suppression.md) "The node-kind
-  vocabulary" — that same section owns the rule that **a survivor fitting no node kind is not arid** —
-  and whose `reason` names the behavior the suite deliberately
-  does not assert on. "Killing this would not improve the suite" is a conclusion, not the evidence
+  vocabulary", and whose `reason` names the behavior the suite deliberately
+  does not assert on. That same section owns the rule that **a survivor fitting no node kind is not arid**. "Killing this would not improve the suite" is a conclusion, not the evidence
   for one. Aridity is the easier label to reach for, because its bar is otherwise a judgment about
-  value rather than about observable behavior — the node-kind membership test is what makes it
+  value rather than about observable behavior, the node-kind membership test is what makes it
   checkable rather than rhetorical.
 
 **This bar lives here, at classification, rather than at persist time, so one survivor has ONE
 disposition.** Phase 5 reports and Phase 6 persists from the same classification, so an operator
 reading the report and then the findings file cannot be shown "arid" in one and "unclassified" in the
-other. It also means the bar binds a bare run, not only `--persist-findings` — the human-facing
+other. It also means the bar binds a bare run, not only `--persist-findings`, the human-facing
 report is exactly where an unevidenced withholding claim does its damage.
 
 ## Phase 5 — Report
@@ -245,7 +243,7 @@ skill's [`${CLAUDE_PLUGIN_ROOT}/skills/principles/reference/metrics.md`](../prin
 oracle gap = mutation score − code coverage
 ```
 
-A large **negative** gap is the bad direction — exercised but not checked. So rank **ascending**,
+A large **negative** gap is the bad direction. Exercised but not checked. So rank **ascending**,
 most negative first. The top row is where the reader's belief about the suite is most wrong, which
 is the only thing this metric is good for.
 
@@ -287,7 +285,7 @@ garnish: a suppression the operator wrote that the contract **declined to enact*
 important to show as one that applied, and provenance per entry is what distinguishes a team floor
 from a personal draft.
 
-Report the covered-code score as the headline and the plain mutation score beside it — the first
+Report the covered-code score as the headline and the plain mutation score beside it, the first
 answers "are my tests weak", the second mixes that with "do I have tests at all".
 
 Then stop, unless `--persist-findings` was passed. Remediation is delegated. This phase is reached
@@ -303,24 +301,24 @@ persisted, never whether the tree they describe still exists.
 
 **This gate reads Phase 3's verdict; it never re-derives one.** The comparison against the Phase 0
 snapshot has already run by the time this phase is reachable, so a run that persists over a failed
-restore is not missing a check — it is declining to read one it already holds.
+restore is not missing a check. It is declining to read one it already holds.
 
 The flag exists because the survivors this skill detects are real findings with
 no route to a remediation surface: writing one conforming file is that route, and it needs no wiring
-on the consuming side — the `review:fanout` `fix` action locates its input by frontmatter, never by
+on the consuming side, the `review:fanout` `fix` action locates its input by frontmatter, never by
 provenance.
 
 The mechanics are owned by [`context/persist-findings.md`](context/persist-findings.md), which reads
 the detector-findings producer contract for this plugin. Six things there are easy to get wrong and
 are not optional: the destination comes from the contract's **whole** rung order, taking its
 **non-interactive collapse** for the rungs that confirm or ask, never a hardcoded default;
-**each** write this phase makes — the findings file, and the self-ignore guard's `.gitignore` where a
-governing checkout was found — is proven outside tracked space before **that** write is made, against
+**each** write this phase makes, the findings file and the self-ignore guard's `.gitignore` where a
+governing checkout was found, is proven outside tracked space before **that** write is made, against
 the checkout that governs the destination rather than the invoking worktree, with the guard's own
 write proven before the guard heals rather than reported afterwards, and with **nothing written at
-all** where a resolved root has no governing checkout — the guard's create-when-absent rule could
+all** where a resolved root has no governing checkout, the guard's create-when-absent rule could
 land on a tracked-but-deleted `.gitignore` with no check having been possible, and the findings file
-on a tracked deletion it would modify rather than create — while the contract's
+on a tracked deletion it would modify rather than create, while the contract's
 `${CLAUDE_PLUGIN_DATA}` fallback is written normally, being outside every checkout by construction
 (a memory root inside tracked space leaves `git status`
 identical either way and so cannot detect itself, while a root outside the worktree is a layout the
@@ -335,25 +333,25 @@ Persisting does not trade away the property in "The contract this skill holds": 
 reachable only from a run whose restoration verified, and a destination that cannot be proven
 outside tracked space is not written to at all.
 
-**This producer's remediation is off-site** — the missing assertion belongs in the covering test, not
+**This producer's remediation is off-site**, the missing assertion belongs in the covering test, not
 at the mutated node the row's `Location` names. Every emitted row names that target in `Action`, and
 the consumer surfaces such a row to a human rather than auto-applying it. The spoke records why
 `Location` is never retargeted and no column is invented.
 
-## Remediation — delegated
+## Remediation. Delegated
 
-- **Write the killing tests** — `/testing:write` when the `testing` plugin is installed, handed the
+- **Write the killing tests**. `/testing:write` when the `testing` plugin is installed, handed the
   survivor list. Otherwise report the survivors and let the user author tests with their project's
   own conventions; do not author them here.
-- **Verify the new test actually kills the mutant** — re-run this skill scoped to that file. This is
+- **Verify the new test actually kills the mutant**. Re-run this skill scoped to that file. This is
   the property that makes the loop trustworthy: the agent that wrote the test cannot grade itself
   into a pass, because the harness re-runs the mutant. A test that does not turn the mutant red has
   not closed the gap, however plausible it reads.
-- **Record accepted arid mutants** — append to `.claude/mutation-testing-arid.md` per
+- **Record accepted arid mutants**. Append to `.claude/mutation-testing-arid.md` per
   [`context/suppression.md`](context/suppression.md). A complete entry carries all five required keys
   (`check`, `claim`, `sites`, `reason`, `date`) with the `finding_id` derived from the constituents,
   never hand-written. The user accepts each entry; this skill proposes and never writes suppressions
-  unprompted, and writes only the **team** layer — a personal-layer entry would not suppress anything.
+  unprompted, and writes only the **team** layer, a personal-layer entry would not suppress anything.
   An **equivalent** mutant is never recorded here; the convention's record is not for a finding that
   is simply wrong.
 
@@ -366,25 +364,25 @@ Each one produces a *plausible* result, which is what makes them worth listing.
   failing. This is the most dangerous failure mode because the number looks excellent. Phase 0 stops
   on it; never skip that probe to save a suite run.
 - **Flaky tests inflate the score by an unknown margin.** A flaky failure kills a mutant by accident.
-  There is no correction factor — either fix the flakes or report the score with the caveat attached.
+  There is no correction factor. Either fix the flakes or report the score with the caveat attached.
 - **Test selection is fixed overhead per target, not per mutant.** Measured in this repository: for
   the most-depended-on shared library, selection alone exceeded 120 seconds while the resulting
   suite set was 64 of 390 suites; a leaf file selected 2. Re-deriving the selection inside the
   mutant loop is the difference between a run that finishes and one that does not.
-- **A timeout counts as detected, and that is correct** — an infinite loop *is* a detected behavior
+- **A timeout counts as detected, and that is correct**, an infinite loop *is* a detected behavior
   change. But a score leaning heavily on timeouts is being carried by wall-clock rather than
   assertions; report the timeout share when it is large.
 - **"No coverage" is not a weak test, it is an absent one.** Keeping it out of the headline number
   is the entire reason the covered-code score is the one reported.
-- **A partially-completed run must report as partial.** Mutants that never ran are named as not-run —
+- **A partially-completed run must report as partial.** Mutants that never ran are named as not-run,
   never counted as killed, never silently omitted. The same rule applies to a mutant set truncated
-  by a cap. **A run cut short by a failed restore is not this case** — it reports failure, not a
+  by a cap. **A run cut short by a failed restore is not this case**. It reports failure, not a
   partial result ([Phase 3](#phase-3--execute)). A partial report describes a tree that is intact;
   that one is not.
 - **Reaching for a withholding label is the standard way this technique manufactures false
   confidence.** "Equivalent" is the convenient explanation for any survivor whose test is hard to
   write, and "arid" is the easier of the two to reach for because its bar is **otherwise** a judgment
-  about value rather than about observable behavior — the node-kind membership test is what makes it
+  about value rather than about observable behavior, the node-kind membership test is what makes it
   checkable. Require the demonstration for either; report the claim as unclassified when none exists.
 - **A persisted findings file written to the wrong directory fails silently.** Nothing reports the
   miss: the run says it persisted, the file exists, and the consumer never scans that path. It is the

--- a/plugins/mutation-testing/skills/audit/SKILL.md
+++ b/plugins/mutation-testing/skills/audit/SKILL.md
@@ -23,8 +23,8 @@ Arguments: `$ARGUMENTS`
 
 - **Scope** (optional): a path limiting which changed files are considered. Default: every changed
   file inside the configured `mutate` globs.
-- **`--full`**: mutate the whole configured scope instead of the diff. Expensive and rarely correct.
-  State the estimated cost from `baseline-suite-ms` and confirm before running.
+- **`--full`**: mutate the whole configured scope instead of the diff. Expensive and rarely correct,
+  state the estimated cost from `baseline-suite-ms` and confirm before running.
 - **`--paths <globs>`**: mutate these paths regardless of the diff.
 - **`--max <n>`**: cap generated mutants for this run, overriding `max-mutants`.
 - **`--no-suppress`**: include mutants that the arid-node record would otherwise suppress, marked as

--- a/plugins/mutation-testing/skills/principles/SKILL.md
+++ b/plugins/mutation-testing/skills/principles/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: "Answers mutation-testing questions from the primary literature (DeMillo/Lipton/Sayward, Jia & Harman, Google's ICSE-SEIP papers, and the Stryker/PIT/Infection tool docs), producing WHY reasoning about what a surviving mutant means. Use when: 'what is mutation testing', 'mutation score vs coverage', 'what is test strength', 'killed vs survived mutant', 'equivalent mutant', 'which mutation operators', 'why is my mutation score low', 'is mutation testing worth it', 'should we gate on mutation score', 'what is an arid node', 'coupling effect', 'competent programmer hypothesis' — not for HOW to run a mutation tool in your project (use `/mutation-testing:setup` and `/mutation-testing:audit`)."
+description: "Answers mutation-testing questions from the primary literature (DeMillo/Lipton/Sayward, Jia & Harman, Google's ICSE-SEIP papers, and the Stryker/PIT/Infection tool docs), producing WHY reasoning about what a surviving mutant means. Use when: 'what is mutation testing', 'mutation score vs coverage', 'what is test strength', 'killed vs survived mutant', 'equivalent mutant', 'which mutation operators', 'why is my mutation score low', 'is mutation testing worth it', 'should we gate on mutation score', 'what is an arid node', 'coupling effect', 'competent programmer hypothesis', not for HOW to run a mutation tool in your project (use `/mutation-testing:setup` and `/mutation-testing:audit`)."
 argument-hint: "[question or concept]"
 user-invocable: true
 disable-model-invocation: false
@@ -10,7 +10,7 @@ metadata:
 
 # Mutation Testing Knowledge Base
 
-Distilled from the primary sources — the foundational papers, the industrial-scale reports, and the
+Distilled from the primary sources, the foundational papers, the industrial-scale reports, and the
 tool documentation that defines the vocabulary everyone else borrows. Reference files in
 `reference/` are source-attributed; this file routes and answers the common questions without a load.
 
@@ -26,52 +26,52 @@ tool documentation that defines the vocabulary everyone else borrows. Reference 
 
 ## Quick decision guide (no load required)
 
-**"What is mutation testing?"** — Coverage tells you a line *executed*. It cannot tell you the line
+**"What is mutation testing?"**. Coverage tells you a line *executed*. It cannot tell you the line
 was *checked*. Mutation testing introduces a small deliberate fault (a **mutant**), re-runs the
 tests, and observes: tests fail → the mutant is **killed**, something genuinely asserted on that
 behavior; tests pass → the mutant **survived**, that line ran and nothing noticed it was wrong. The
 mutation is always reverted; the source is unchanged at the end.
 
-**"Is it just better coverage?"** — It answers a different question. Coverage measures execution;
+**"Is it just better coverage?"**. It answers a different question. Coverage measures execution;
 mutation testing measures *fault detection*. PIT states it directly: line coverage "does **not** check
 that your tests are actually able to **detect faults**." A file at 100% coverage and 40% mutation
 score has tests that run the code and assert almost nothing about it.
 
-**"Which number do I look at?"** — The **covered-code** one, always. Plain mutation score mixes two
+**"Which number do I look at?"**. The **covered-code** one, always. Plain mutation score mixes two
 unrelated problems: "my tests are weak" and "I have no tests here." The covered-code variant
 (PIT calls it *test strength*, Infection calls it *Covered Code MSI*) isolates the first. A wide gap
 between the two means the coverage you have is thin, not that the tests are bad.
 
-**"Should we fail the build on a mutation score?"** — No, and this is the single most common way
+**"Should we fail the build on a mutation score?"**. No, and this is the single most common way
 adoption fails. The score is depressed by equivalent mutants that no test can ever kill, so a hard
 threshold rewards suppressing mutants over writing tests. Report it; do not gate on it.
 See [scaling-and-suppression.md](reference/scaling-and-suppression.md).
 
-**"Isn't this too slow to be practical?"** — Naive whole-repo mutation testing is, and that is why
+**"Isn't this too slow to be practical?"**. Naive whole-repo mutation testing is, and that is why
 the technique sat unused for thirty years. The industrial answer is architectural, not
 computational: mutate only the **changed lines**, at most **one mutant per line**, suppress
 uninteresting nodes, and surface the result as a review-time prompt rather than a report. Google
 reports a median of **7 mutants per changelist** under that regime against **820** for traditional
 mutagenesis.
 
-**"A mutant survived. Now what?"** — Three possible answers, and telling them apart is the whole
+**"A mutant survived. Now what?"**. Three possible answers, and telling them apart is the whole
 skill:
 
-1. **Productive** — a real gap. Write a test that kills it.
-2. **Equivalent** — the mutated program is semantically identical to the original, so no test can
+1. **Productive**, a real gap. Write a test that kills it.
+2. **Equivalent**, the mutated program is semantically identical to the original, so no test can
    kill it. Not a defect, not a suppression; the check itself is wrong for that node.
-3. **Arid** — killable, but killing it would not improve the suite (a log line, a trivial
+3. **Arid**. Killable, but killing it would not improve the suite (a log line, a trivial
    accessor). Suppress it *with a written reason*.
 
-**"Why can't the tool tell me which?"** — Deciding equivalence is undecidable in general
+**"Why can't the tool tell me which?"**. Deciding equivalence is undecidable in general
 (Jia & Harman). That is why the classification is a judgment step, and why
 `/mutation-testing:audit` delegates it to a fresh context rather than to the context that authored
 the tests.
 
 ## What this skill does NOT do
 
-- Run a mutation tool — that is `/mutation-testing:audit`.
-- Install or configure one — that is `/mutation-testing:setup`.
+- Run a mutation tool. That is `/mutation-testing:audit`.
+- Install or configure one. That is `/mutation-testing:setup`.
 - Answer general test-design questions (mocking, four pillars, classical vs London). Those belong to
   `/tdd:principles` when the `tdd` plugin is installed; without it, consult your project's own
   test-design guidance.

--- a/plugins/mutation-testing/skills/setup/SKILL.md
+++ b/plugins/mutation-testing/skills/setup/SKILL.md
@@ -24,8 +24,8 @@ runs the check first, then the write flow.
 (`~/.claude/mutation-testing.md`) → team (`${CLAUDE_PROJECT_DIR}/.claude/mutation-testing.md`) →
 local overlay (`.claude/mutation-testing.local.md`), later layers overriding scalars and unioning
 lists. This skill writes only the **team** file; a higher overlay is the user's to change. Report
-explicitly when an overlay changes the team file's effect, and warn. Rather than silently
-presenting the team file as effective, when a layer cannot be read.
+explicitly when an overlay changes the team file's effect, and warn when a layer cannot be read,
+rather than silently presenting the team file as effective.
 
 The arid-node suppression record is a **separate** surface, `.claude/mutation-testing-arid.md`,
 shaped by the finding-suppression convention. Keeping it separate from the config keeps the config

--- a/plugins/mutation-testing/skills/setup/SKILL.md
+++ b/plugins/mutation-testing/skills/setup/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: "Verify and configure the mutation-testing plugin for this repository. check inspects the ecosystem's mutation tool (installed, runnable, supported test runner), the baseline suite's health, and the tracked .claude/mutation-testing.md config across its merge layers, read-only; apply detects the ecosystem, installs or names the tool, interviews for the diff target and operator set, and writes the config plus an empty arid-node suppression record. Use when: 'set up mutation testing', 'is mutation testing configured', 'which mutation tool for this repo', 'mutation-testing setup', or the audit skill reports missing config or an unavailable tool. Re-runnable — safe to invoke again to reconfigure."
+description: "Verify and configure the mutation-testing plugin for this repository. check inspects the ecosystem's mutation tool (installed, runnable, supported test runner), the baseline suite's health, and the tracked .claude/mutation-testing.md config across its merge layers, read-only; apply detects the ecosystem, installs or names the tool, interviews for the diff target and operator set, and writes the config plus an empty arid-node suppression record. Use when: 'set up mutation testing', 'is mutation testing configured', 'which mutation tool for this repo', 'mutation-testing setup', or the audit skill reports missing config or an unavailable tool. Re-runnable. Safe to invoke again to reconfigure."
 argument-hint: "check | apply"
 user-invocable: true
 disable-model-invocation: true
@@ -20,12 +20,12 @@ runs the check first, then the write flow.
 
 ## The config merge model
 
-`.claude/mutation-testing.md` resolves across the documented cascade layers — user-global
+`.claude/mutation-testing.md` resolves across the documented cascade layers. User-global
 (`~/.claude/mutation-testing.md`) → team (`${CLAUDE_PROJECT_DIR}/.claude/mutation-testing.md`) →
 local overlay (`.claude/mutation-testing.local.md`), later layers overriding scalars and unioning
 lists. This skill writes only the **team** file; a higher overlay is the user's to change. Report
-explicitly when an overlay changes the team file's effect, and warn — rather than silently
-presenting the team file as effective — when a layer cannot be read.
+explicitly when an overlay changes the team file's effect, and warn. Rather than silently
+presenting the team file as effective, when a layer cannot be read.
 
 The arid-node suppression record is a **separate** surface, `.claude/mutation-testing-arid.md`,
 shaped by the finding-suppression convention. Keeping it separate from the config keeps the config
@@ -34,7 +34,7 @@ reviewable: a config diff is a policy change, a suppression diff is an accepted 
 **Its layering is not the config's, and the difference is the whole point.** The config's later
 layers override; the suppression record sits in the cascade's policy-floor precedence-inversion
 class, so on a conflict for the same `finding_id` the **team** layer wins, and **a personal-layer
-entry for an id the team layer does not carry does not suppress at all** — it is reported
+entry for an id the team layer does not carry does not suppress at all**. It is reported
 `personal-only, not applied`. A personal layer is a draft surface here. Treating it as "layered the
 same way" would let one developer silently hide a finding the team never accepted. The full
 contract, including id derivation and the four dispositions, is owned by the audit skill's
@@ -43,63 +43,63 @@ contract, including id derivation and the four dispositions, is owned by the aud
 ## `check` (read-only)
 
 Report a PASS / FAIL / INFO table with one remediation line per FAIL. Modify nothing, and do **not**
-run a mutation analysis — that is `/mutation-testing:audit`.
+run a mutation analysis. That is `/mutation-testing:audit`.
 
-1. **Ecosystem detected** — identify the stack from manifests that actually exist (`package.json`,
+1. **Ecosystem detected**. Identify the stack from manifests that actually exist (`package.json`,
    `*.csproj`/`*.sln`, `pom.xml`/`build.gradle`, `composer.json`, `pyproject.toml`). Report what was
    found and which mutation tool it implies. No recognized ecosystem → INFO naming the manual path
    in the `principles` skill's `tooling.md`, not FAIL.
-2. **Tool present and runnable** — invoke the tool's own version command. Absent → FAIL with the
+2. **Tool present and runnable**. Invoke the tool's own version command. Absent → FAIL with the
    install line for this ecosystem. Present but erroring → FAIL quoting the error; a tool that
    installs but cannot start is the common case and is worth distinguishing.
-3. **Test runner supported** — confirm the project's runner is one the tool drives. Report the
+3. **Test runner supported**. Confirm the project's runner is one the tool drives. Report the
    detected runner and the tool's support status. Unsupported → FAIL; this blocks every later step,
    so report it before anything about scores.
-4. **Baseline suite is green** — run the project's test command once, unmutated, and report the
+4. **Baseline suite is green**. Run the project's test command once, unmutated, and report the
    result. Red → FAIL. A red baseline kills every mutant and reports a perfect score, so no mutation
    result is meaningful until this passes. Record the wall-clock; it is the input to the timeout
    setting and to whether diff-scoping is sufficient.
-5. **Known flakiness** — ask, and check for a documented flaky-test list or retry configuration.
+5. **Known flakiness**. Ask, and check for a documented flaky-test list or retry configuration.
    Flakiness present → INFO with the consequence stated plainly: mutants killed by a flaky failure
    inflate the score by an unknown margin.
-6. **Config presence (effective, across layers)** — report the merged result and which layer
+6. **Config presence (effective, across layers)**. Report the merged result and which layer
    contributes what: tool, diff target, operator set, timeout, paths to mutate. Nothing readable →
    FAIL; unlike an inference-speeding config, this one is required.
-7. **Diff target resolves** — the configured target must resolve in this repository
+7. **Diff target resolves**, the configured target must resolve in this repository
    (`git rev-parse --verify <target>`). Unresolvable → FAIL naming it; a stale default here silently
    scopes a run to nothing or to everything.
-8. **Suppression record** — report presence and entry count of `.claude/mutation-testing-arid.md`
+8. **Suppression record**. Report presence and entry count of `.claude/mutation-testing-arid.md`
    across layers. Absent is a valid state (no suppressions) → INFO. Present → validate **every**
    entry against the full contract in
    [`${CLAUDE_PLUGIN_ROOT}/skills/audit/context/suppression.md`](../audit/context/suppression.md), not a subset of it:
-   - **All five required keys present** — `check`, `claim`, `sites` (each with `surface` and an
+   - **All five required keys present**. `check`, `claim`, `sites` (each with `surface` and an
      `anchor/v<N>`), `reason`, `date`. Missing any one → FAIL, naming the entry and the key. A
      partial parse is not offered: an entry with `sites`, `reason`, and `date` but no `check` or
      `claim` is malformed and must not be reported as usable, because the audit would otherwise
      suppress a mutant on a location match the contract never authorized.
-   - **Constituents hash to the key** — re-derive `finding_id` from `(check, claim, sites)` and
+   - **Constituents hash to the key**. Re-derive `finding_id` from `(check, claim, sites)` and
      compare. A mismatch → FAIL. This is the case a hand-edited constituent beside a stale key
      produces, and it silently stops suppressing if unchecked.
-   - **`claim` is a bound canonical id, not prose** — `arid(kind=<node-kind>)` where `<node-kind>` is
+   - **`claim` is a bound canonical id, not prose**. `arid(kind=<node-kind>)` where `<node-kind>` is
      a **member of the enumerated table** in
      `${CLAUDE_PLUGIN_ROOT}/skills/principles/reference/scaling-and-suppression.md`
      ("The node-kind vocabulary"). Validate by membership in
      that table, not by shape: a single-word kind that is not in it is indistinguishable from prose
      that happens to be one word, and passing it would make every suppression self-justifying. Free
      prose, or a kind outside the table → FAIL, listing the accepted kinds.
-   - **Personal-only entries** — any id present in a `.local.md` layer but absent from the team layer
+   - **Personal-only entries**. Any id present in a `.local.md` layer but absent from the team layer
      is reported `personal-only, not applied`, with promotion to the team layer named as the remedy.
      This is INFO, not FAIL: the entry is legal, it simply does not suppress.
-   - Report the contributing layer for every entry. A malformed layer degrades soft — report it and
+   - Report the contributing layer for every entry. A malformed layer degrades soft. Report it and
      continue, never fail the whole read.
-9. **Tracked, not ignored** — both the config and the suppression record must be committed to be
+9. **Tracked, not ignored**. Both the config and the suppression record must be committed to be
    team-shared, and *not ignored* is only half of that. Run **both** probes per file:
    `git ls-files --error-unmatch <path>` (is it tracked?) and `git check-ignore -v <path>`
    (is it ignored?). Untracked → FAIL, naming the `git add` that fixes it; ignored → FAIL with the
    matching pattern. Checking only `check-ignore` is the trap: immediately after `apply` writes them
    the files are untracked but not ignored, so `check-ignore` is silent and the probe would report
    success on two files no teammate will ever receive. The `.local.md` overlays are expected to be
-   both untracked and ignored — INFO, not FAIL.
+   both untracked and ignored. INFO, not FAIL.
 
 ## `apply` (idempotent)
 
@@ -110,7 +110,7 @@ unambiguous; ask only where the answer is genuinely the user's.
    changes. Nothing is dropped without the user confirming.
 2. **Detect and propose the tool.** From the ecosystem, name the tool and the exact install command,
    and ask before installing anything. Installing a dependency into the consumer's project is the
-   user's decision, not this skill's — propose, never install unprompted.
+   user's decision, not this skill's. Propose, never install unprompted.
 3. **Settle the diff target.** Default to the repository's own default branch as resolved from
    `origin/HEAD`, not a hardcoded `main` or `master`. Confirm it resolves.
 4. **Settle the operator set.** Default to the tool's defaults, and say why: optional and
@@ -122,14 +122,14 @@ unambiguous; ask only where the answer is genuinely the user's.
 7. **Write the config** following
    [`${CLAUDE_PLUGIN_ROOT}/skills/setup/templates/config-template.md`](templates/config-template.md).
 8. **Create the suppression record empty**, with its header comment and an empty `suppressions:`
-   mapping — a **mapping, never a list**, since a list is taken whole and one personal entry would
+   mapping, a **mapping, never a list**, since a list is taken whole and one personal entry would
    discard the team's entire accepted set. An empty record makes the first suppression an edit to a
    reviewed file rather than the creation of a new one.
 9. **Stage both files for commit and say so.** They are team-shared surfaces; leaving them untracked
    is the failure probe 9 exists to catch, and `apply` is where it is cheapest to fix. Offer the
    `git add`; never commit on the user's behalf.
-10. **Verify after remediation.** Re-run the `check` probes on what was written — including both
-    halves of probe 9, tracked *and* not-ignored — then offer the overlay convention: personal
+10. **Verify after remediation.** Re-run the `check` probes on what was written, including both
+    halves of probe 9, tracked *and* not-ignored, then offer the overlay convention: personal
     config overrides in `.claude/mutation-testing.local.md`, and recommend `.claude/*.local.*` in
     `.gitignore` if not already covered. State plainly that the same overlay pattern does **not**
     give personal suppressions effect: an arid entry in a `.local.md` is a draft until promoted to
@@ -145,11 +145,11 @@ re-run this setup to reconfigure.
 
 ## What this skill does NOT do
 
-- Run a mutation analysis — that is `/mutation-testing:audit`. `check` runs the *unmutated* suite
+- Run a mutation analysis. That is `/mutation-testing:audit`. `check` runs the *unmutated* suite
   once to establish the baseline, and nothing more.
 - Install anything without asking.
 - Write the plugin cache, Claude Code user settings, or `pluginConfigs`.
-- Write machine-local state — configuration lives in the consumer's tracked files, never in the
+- Write machine-local state. Configuration lives in the consumer's tracked files, never in the
   plugin directory or the plugin data directory.
 - Set a score threshold. The config template deliberately has no such field; see the `principles`
   skill's `scaling-and-suppression.md` for why gating on the score inverts the incentive.


### PR DESCRIPTION
No linked issue

## Summary

#2891 instruction-surface de-slop cluster: purge em dashes from the `mutation-testing` plugin README and every SKILL.md.

## Fix

Rewrote `plugins/mutation-testing/README.md` and every `plugins/mutation-testing/**/SKILL.md` under `/ai-slop:audit fix` semantics (periods, commas, or a restructured sentence; never parentheses, en dashes, or a spaced hyphen as a stand-in). Meaning-preserving self-audit repaired asides the first pass reattached to the wrong noun. Cited Phase headings and the fenced report template keep their em dashes so in-plugin anchors and persist-findings citations stay byte-identical. `mutation-testing` 0.3.6.

## Verification

- Detector: 0 `rule-em-dash` findings outside ignore-fenced generated-options spans (and required trigger strings that must keep em dashes)
- `CHECK_SKILL_SKIP_MARKDOWNLINT=1 bash scripts/check-changed-skills.sh origin/main`: 0 failed; quoted trigger phrases vs origin/main preserved
- `python3 scripts/sync-plugin-options-docs.py --check` up to date
- `scripts/check-changelog-parity.sh --check-bump origin/main` passes
- `node scripts/generate-cheatsheet.mjs --check` in sync

## Related

Refs #2891

#2891 stays open.