### PR TITLE
docs(context-budget): add git-instructions env route and resolve lean-prompt model condition (0.6.9)

### DIFF
--- a/plugins/context-budget/.claude-plugin/plugin.json
+++ b/plugins/context-budget/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "context-budget",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "description": "Measure a Claude Code session's fixed startup context payload per item, on the consumer's machine at a pinned, version-stamped binary — including per-tool attribution of the built-in tool pools that /context reports only as lump sums, derived live by A/B bare-name-deny differencing with enforced comparability rules (skill-listing signature, one mode, one binary), an SDK-primary exact meter degrading to a version-aware headless /context parser and then to an honest structured error (never a wrong number), and a per-project measure-toggle-remeasure ledger under the plugin data directory recording every lever's real before/after delta. Report-only: prints exact config, applies nothing.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/context-budget/CHANGELOG.md
+++ b/plugins/context-budget/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to the `context-budget` plugin.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.9]
+
+### Changed
+
+- **Catalogue:** `include-git-instructions` now names `CLAUDE_CODE_DISABLE_GIT_INSTRUCTIONS` as
+  the headless measurement route (env overrides the settings key in the binary; the env name
+  is not on the public env-vars page, so it stays a measurement route and the settings key
+  remains the recommended emitted config). `simple-system-prompt`'s `conditions` now resolve the
+  model-dependence from the binary's lean-prompt selector: opus-5-family models already default
+  lean, so a measured zero there is explained (already-default), not merely reported
+  ([#3200](https://github.com/melodic-software/claude-code-plugins/issues/3200)).
+
 ## [0.6.8]
 
 ### Added

--- a/plugins/context-budget/skills/audit/reference/levers.json
+++ b/plugins/context-budget/skills/audit/reference/levers.json
@@ -118,24 +118,26 @@
     },
     {
       "id": "include-git-instructions",
-      "title": "includeGitInstructions: false",
-      "mechanism": "Removes the git commit/PR instruction prose that rides inside the Bash tool's description.",
+      "title": "includeGitInstructions: false / CLAUDE_CODE_DISABLE_GIT_INSTRUCTIONS",
+      "mechanism": "Removes the git commit/PR instruction prose that rides inside the Bash tool's description. The env var overrides the settings key (binary predicate at the verified version: a set env wins; otherwise includeGitInstructions defaults true).",
       "category": "removes-weight",
-      "categoryBasis": "Settings row documented; measured at the verified version — with the saving landing in the System tools bucket, not System prompt, because the text lives in a tool description.",
+      "categoryBasis": "Settings row documented; the env override is implemented in the binary but is not on the public env-vars page. Measured at the verified version — the saving lands in the System tools bucket, not System prompt, because the text lives in a tool description.",
       "conditions": null,
       "posture": "recommendable-on-fit",
-      "scope": "Settings key.",
-      "detection": "includeGitInstructions across settings scopes.",
-      "measurement": "snapshot before/after the setting; watch System tools, not System prompt (the docs describe it as a system-prompt lever; the measured landing bucket differs — report what measures).",
+      "scope": "Settings key (recommended emitted config); env var CLAUDE_CODE_DISABLE_GIT_INSTRUCTIONS as the headless measurement route (no settings write).",
+      "detection": "includeGitInstructions across settings scopes; CLAUDE_CODE_DISABLE_GIT_INSTRUCTIONS in the environment.",
+      "measurement": "snapshot with and without CLAUDE_CODE_DISABLE_GIT_INSTRUCTIONS in the spawned environment (no settings write); watch System tools, not System prompt (the docs describe it as a system-prompt lever; the measured landing bucket differs — report what measures).",
       "emittedConfig": "{\"includeGitInstructions\": false}",
       "caveats": [
-        "Trades away built-in commit/PR guidance; a repo relying on it should keep it or replace it with its own conventions."
+        "Trades away built-in commit/PR guidance; a repo relying on it should keep it or replace it with its own conventions.",
+        "The env form is the measurement route (headless, no settings write) and is unverified-undocumented as a public env-vars row; keep the settings key as the recommended emitted config.",
+        "Headless sdk-mode /context may omit a System prompt category at this version; prompt-text deltas then surface only in the buckets that move (System tools here)."
       ],
       "citations": [
         "https://code.claude.com/docs/en/settings-reference#includegitinstructions"
       ],
       "verified": "2026-08-23",
-      "recheckTrigger": "The settings row's wording changes, or the measured delta stops landing in System tools."
+      "recheckTrigger": "The settings row's wording changes, the env override disappears from the binary, or the measured delta stops landing in System tools."
     },
     {
       "id": "simple-system-prompt",
@@ -143,20 +145,21 @@
       "mechanism": "Switches to the lean system prompt on models where the full prompt is default.",
       "category": "removes-weight",
       "categoryBasis": "Env row documented; measured large on some models and a measured no-op on models where the lean prompt is already default.",
-      "conditions": "Model-dependent: on models whose default is already lean it measures zero. Per operator decision, advice does not branch on model — measure on the consumer's session model and report the measured delta, including a zero.",
+      "conditions": "Model-dependent, and the dependence is resolvable from the binary's lean-prompt selector rather than only from a measured zero: the full-prompt path is the legacy list (model id contains `claude-3-`, `haiku`, or `sonnet`, or equals `claude-opus-4-0` / `claude-opus-4-1` / `claude-opus-4-5` / `claude-opus-4-6` / `claude-opus-4-7`); everything else — including the opus-5 family — already defaults lean, so the env var can only measure zero there. A zero on those models is explained (already-default), not merely reported. Per operator decision, advice does not branch on model — measure on the consumer's session model and report the measured delta, including an explained zero.",
       "posture": "recommendable-on-fit",
       "scope": "Environment variable only; no settings key.",
       "detection": "CLAUDE_CODE_SIMPLE_SYSTEM_PROMPT in the environment; the session model from the baseline snapshot.",
-      "measurement": "snapshot with and without the variable in the spawned environment; compare System prompt.",
+      "measurement": "snapshot with and without the variable in the spawned environment; compare System prompt (and System tools, if the prompt category is omitted).",
       "emittedConfig": "CLAUDE_CODE_SIMPLE_SYSTEM_PROMPT=1 (environment; no settings.json form)",
       "caveats": [
-        "Distinct from CLAUDE_CODE_SIMPLE (--bare): two separately registered variables. The sibling disables fetches, keychain reads, and CLAUDE.md auto-discovery — a behavior change, not a prompt trim. Never conflate them."
+        "Distinct from CLAUDE_CODE_SIMPLE (--bare): two separately registered variables. The sibling disables fetches, keychain reads, and CLAUDE.md auto-discovery — a behavior change, not a prompt trim. Never conflate them.",
+        "Headless sdk-mode /context may omit a System prompt category at this version; a lean-vs-full delta then surfaces only in the buckets that move."
       ],
       "citations": [
         "https://code.claude.com/docs/en/env-vars"
       ],
-      "verified": "2026-08-17",
-      "recheckTrigger": "Either variable's env-vars row changes, or the lean prompt becomes default everywhere (the lever then measures zero universally)."
+      "verified": "2026-08-23",
+      "recheckTrigger": "Either variable's env-vars row changes, the binary's legacy full-prompt list changes, or the lean prompt becomes default everywhere (the lever then measures zero universally)."
     },
     {
       "id": "bare-simple-mode",

--- a/plugins/context-budget/skills/audit/scripts/levers.test.sh
+++ b/plugins/context-budget/skills/audit/scripts/levers.test.sh
@@ -120,6 +120,45 @@ else
   while IFS= read -r line; do fail "$line"; done <<<"$citeout"
 fi
 
+# #3200 — env measurement route + resolvable simple-system-prompt condition.
+routeout="$(node -e '
+const cat = JSON.parse(require("fs").readFileSync(process.argv[1], "utf8"));
+const problems = [];
+const git = (cat.levers ?? []).find((l) => l.id === "include-git-instructions");
+if (!git) problems.push("missing include-git-instructions");
+else {
+  const blob = [git.title, git.mechanism, git.scope, git.detection, git.measurement, ...(git.caveats ?? [])].join("\n");
+  if (!blob.includes("CLAUDE_CODE_DISABLE_GIT_INSTRUCTIONS")) {
+    problems.push("include-git-instructions does not name CLAUDE_CODE_DISABLE_GIT_INSTRUCTIONS");
+  }
+  if (!/unverified-undocumented/i.test(blob)) {
+    problems.push("include-git-instructions does not mark the env form unverified-undocumented");
+  }
+  if (!String(git.emittedConfig || "").includes("includeGitInstructions")) {
+    problems.push("include-git-instructions dropped the settings key as emitted config");
+  }
+}
+const lean = (cat.levers ?? []).find((l) => l.id === "simple-system-prompt");
+if (!lean) problems.push("missing simple-system-prompt");
+else {
+  const cond = String(lean.conditions || "");
+  if (!/opus-5/i.test(cond)) problems.push("simple-system-prompt conditions do not name opus-5");
+  if (!/already-default|already defaults lean/i.test(cond)) {
+    problems.push("simple-system-prompt conditions do not explain a zero as already-default");
+  }
+  if (!/legacy list|claude-opus-4-0/i.test(cond)) {
+    problems.push("simple-system-prompt conditions do not cite the binary legacy-list check");
+  }
+}
+console.log(problems.length ? problems.join("\n") : "CLEAN");
+' "$CATALOGUE")"
+
+if [[ "$routeout" == "CLEAN" ]]; then
+  ok "include-git-instructions names the env route; simple-system-prompt resolves opus-5 lean default"
+else
+  while IFS= read -r line; do fail "$line"; done <<<"$routeout"
+fi
+
 echo
 echo "passed: $PASS, failed: $FAIL"
 [[ $FAIL -eq 0 ]] || exit 1


### PR DESCRIPTION
Closes #3200

## Summary

The `include-git-instructions` catalogue row only named the settings key, so a headless sweep could not measure it without a settings write. The binary implements `CLAUDE_CODE_DISABLE_GIT_INSTRUCTIONS` as an env override of that key, which is the headless measurement route. Separately, `simple-system-prompt` treated a measured zero as unexplained model-dependence even though the binary's lean-prompt selector already defaults lean on the opus-5 family.

## Fix

- `include-git-instructions` now names `CLAUDE_CODE_DISABLE_GIT_INSTRUCTIONS` as the headless measurement route (env overrides the settings key). The env name is not on the public env-vars page, so it is marked unverified-undocumented; the settings key stays the recommended emitted config.
- `simple-system-prompt` `conditions` resolve the model-dependence from the binary's legacy full-prompt list. Opus-5-family models already default lean, so a measured zero there is explained as already-default rather than merely reported.
- Catalogue honesty is unchanged: no shipped token figures. Headless sdk-mode `/context` may omit a System prompt category; deltas then surface only in the buckets that move.

## Verification

- `levers.test.sh`: 3/3 in `/tmp/wt-3200` after cherry-pick onto `origin/main` (includes #3269 / 0.6.8). New assertion: git-instructions names the env route and marks it unverified-undocumented; settings key remains emitted config; simple-system-prompt conditions name opus-5, already-default, and the legacy list.
- `measure.test.sh`: 61/61.
- Cherry-pick of `5c61666` onto current main applied cleanly; `## [0.6.9]` is a new heading above the shipped `## [0.6.8]`.

## Related

N/A — this PR closes #3200 only.
