### PR TITLE
docs(prototype): de-slop instruction surfaces (0.9.4)

### DIFF
--- a/plugins/prototype/.claude-plugin/plugin.json
+++ b/plugins/prototype/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "prototype",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "Builds throwaway code to answer a design question before committing to architecture — a logic facet (an interactive terminal app over a portable state model) and a UI facet (radically different visual variants on one route).",
   "author": {
     "name": "Melodic Software",

--- a/plugins/prototype/CHANGELOG.md
+++ b/plugins/prototype/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to the `prototype` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.9.4]
+
+### Changed
+
+- **Instruction-surface de-slop (#2891, prototype cluster).** Rewrote this plugin's `README.md` and every
+  `SKILL.md` to drop em dashes under the repo's zero-tolerance house policy, using
+  `/ai-slop:audit fix` semantics: periods or commas, or a restructured sentence, never
+  parentheses, en dashes, or a spaced hyphen as a stand-in. Meaning stays; only the mark
+  and the sentence break change. The generated options block is ignore-fenced because
+  `scripts/sync-plugin-options-docs.py` still emits em dashes from its shared template.
+
 ## [0.9.3]
 
 ### Changed

--- a/plugins/prototype/README.md
+++ b/plugins/prototype/README.md
@@ -1,15 +1,15 @@
 # prototype
 
 A Claude Code plugin for building **throwaway code that answers a design question** before you
-commit to architecture. A prototype proves "X works like THIS" cheaply — you push buttons, watch
+commit to architecture. A prototype proves "X works like THIS" cheaply. You push buttons, watch
 state change or flip between designs, keep the answer, and delete the code.
 
 It ships **two skills**, split by the shape of the question you're answering:
 
 | Skill | Invoke | Answers |
 |---|---|---|
-| `pressure-test` | `/prototype:pressure-test <scope>` | "Does this state machine / data model / API surface feel right?" — an interactive terminal app driving a portable, liftable logic module by hand. |
-| `explore-directions` | `/prototype:explore-directions <scope>` | "What should this look like?" — several radically different visual variations on one route, switchable from a floating control bar (real stack, a self-contained HTML mockup, or — where the bundled `design` skill is available — an editable design-canvas Artifact, offered as an explicit opt-in). |
+| `pressure-test` | `/prototype:pressure-test <scope>` | "Does this state machine / data model / API surface feel right?", an interactive terminal app driving a portable, liftable logic module by hand. |
+| `explore-directions` | `/prototype:explore-directions <scope>` | "What should this look like?". Several radically different visual variations on one route, switchable from a floating control bar (real stack, a self-contained HTML mockup, or, where the bundled `design` skill is available, an editable design-canvas Artifact, offered as an explicit opt-in). |
 
 Both skills share one throwaway discipline (no persistence, skip polish, surface the state, delete
 or absorb when done) and both capture the validated answer in a durable note before the code is
@@ -17,10 +17,10 @@ thrown away.
 
 ## When to use which
 
-- **Logic** is a behavioral / feasibility spike — the question is about business logic, state
+- **Logic** is a behavioral / feasibility spike, the question is about business logic, state
   transitions, or data shape. It produces a **pure logic module** behind a disposable TUI shell;
   when the question is answered, the module lifts into production and the shell is deleted.
-- **UI** is a design prototype — the question is about appearance. It generates structurally
+- **UI** is a design prototype, the question is about appearance. It generates structurally
   different variants (not just recolors) so you can judge them side by side, then fold the winner
   into the real page.
 
@@ -36,14 +36,14 @@ which fits, a backend/logic question routes to `pressure-test` and a page/compon
 
 ## Configuration
 
-This plugin has no `userConfig`. Its only inputs are conversational — the scope you pass and the
+This plugin has no `userConfig`. Its only inputs are conversational, the scope you pass and the
 variant count you ask for (UI defaults to 3, capped at 5). It reads your project's own stack and
 conventions rather than imposing its own, and it writes throwaway code next to where your
 production code lives.
 
 ## Requirements
 
-- **Bash** for the bundled ecosystem-detection script — on native Windows,
+- **Bash** for the bundled ecosystem-detection script. On native Windows,
   install
   [Git for Windows](https://code.claude.com/docs/en/setup#set-up-on-windows) so
   it runs under Git Bash. Without Bash, detection reports "none detected" and

--- a/plugins/prototype/skills/explore-directions/SKILL.md
+++ b/plugins/prototype/skills/explore-directions/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: "Builds throwaway UI variations — several radically different visual layouts on one route, switchable from a floating control bar — to answer 'what should this look like' before committing to a design. Use when: 'mock up a UI', 'try a few designs', 'what should this page look like', 'show me options for this dashboard', 'try a different layout for the settings screen', 'prototype this screen', 'explore design options'. Runs on your real stack by default (real header, real data, real density) or as a self-contained HTML mockup (or, where the bundled design skill is available, an editable design-canvas Artifact); you flip between variants, pick one (or steal bits from each), and throw the rest away. Not for logic or state questions — use /prototype:pressure-test for those."
+description: "Builds throwaway UI variations, several radically different visual layouts on one route, switchable from a floating control bar, to answer 'what should this look like' before committing to a design. Use when: 'mock up a UI', 'try a few designs', 'what should this page look like', 'show me options for this dashboard', 'try a different layout for the settings screen', 'prototype this screen', 'explore design options'. Runs on your real stack by default (real header, real data, real density) or as a self-contained HTML mockup (or, where the bundled design skill is available, an editable design-canvas Artifact); you flip between variants, pick one (or steal bits from each), and throw the rest away. Not for logic or state questions. Use /prototype:pressure-test for those."
 argument-hint: "[scope] (e.g., /prototype:explore-directions settings page)"
 user-invocable: true
 disable-model-invocation: false
@@ -27,10 +27,10 @@ floating control bar. The user flips between variants in the browser, picks one 
 from each), then throws the rest away.
 
 The shared throwaway rules, the auto-invoke gate, and how to capture the answer live in
-[`${CLAUDE_PLUGIN_ROOT}/context/discipline.md`](../../context/discipline.md) — read it before you
+[`${CLAUDE_PLUGIN_ROOT}/context/discipline.md`](../../context/discipline.md). Read it before you
 start. This file covers only the UI facet.
 
-If the question is about logic/state rather than appearance — wrong facet. Invoke `/prototype:pressure-test` via the Skill tool.
+If the question is about logic/state rather than appearance. Wrong facet. Invoke `/prototype:pressure-test` via the Skill tool.
 
 ## When this is the right shape
 
@@ -39,61 +39,61 @@ If the question is about logic/state rather than appearance — wrong facet. Inv
 - "Try a different layout for the settings screen."
 - Any time the user would otherwise spend a day picking between vague mockups in their head
 
-## Two sub-shapes — prefer A
+## Two sub-shapes. Prefer A
 
-UI prototypes are easier to judge against the rest of the app — real header, real sidebar, real
+UI prototypes are easier to judge against the rest of the app. Real header, real sidebar, real
 data, real density. Default to sub-shape A whenever a plausible existing page exists.
 
-Two substrates back these variants — the **real stack** (default) and a **self-contained HTML
+Two substrates back these variants, the **real stack** (default) and a **self-contained HTML
 mockup**. Both run the same variant-comparison process below; only the substrate swaps. Pick by
 intent, not by mount target:
 
 - **Existing page** (or a new thing that naturally lives inside one) → real-stack **sub-shape A**
   (the default).
-- **No existing page, want it judged in the real app** — real components, real density, needs the
+- **No existing page, want it judged in the real app**. Real components, real density, needs the
   app plus a dev server → real-stack **sub-shape B**.
-- **No existing page, want the fastest standalone feel** — no app or dev server running, no app
+- **No existing page, want the fastest standalone feel**. No app or dev server running, no app
   yet, or a non-dev exploring → the **HTML mockup substrate** (below).
-- **Explicit override wins both ways** — ask for a real-stack page or an HTML mockup directly and
+- **Explicit override wins both ways**. Ask for a real-stack page or an HTML mockup directly and
   that beats the default routing.
 
 The HTML mockup is a sibling of sub-shape B: both answer "no existing page," split only by whether
 you want the variant judged inside the real app or as the fastest throwaway standalone. It is not a
 second axis layered over A and B.
 
-### Sub-shape A — adjustment to existing page (preferred)
+### Sub-shape A. Adjustment to existing page (preferred)
 
 The route already exists. Variants are rendered on the same route, gated by a `?variant=` URL param
-(or framework equivalent). Existing data fetching, params, and auth stay — only the rendered
+(or framework equivalent). Existing data fetching, params, and auth stay. Only the rendered
 subtree swaps.
 
 If you're prototyping something that doesn't have a page yet but WOULD naturally live inside one (a
-new dashboard section, a new card on settings, a new step in an existing flow) — still sub-shape A.
+new dashboard section, a new card on settings, a new step in an existing flow). Still sub-shape A.
 Mount variants inside the host page.
 
-### Sub-shape B — new page (last resort)
+### Sub-shape B. New page (last resort)
 
-Only when the thing being prototyped has no existing page to live inside — an entirely new
+Only when the thing being prototyped has no existing page to live inside, an entirely new
 top-level surface, or a flow that can't embed anywhere sensible.
 
 Create a throwaway route following the project's existing routing convention. Name it obviously as
 a prototype (include "prototype" in the path or filename). Same `?variant=` pattern.
 
-Before committing to B — is there really no existing page this could embed in? An empty route hides
+Before committing to B, is there really no existing page this could embed in? An empty route hides
 design problems a populated one would expose.
 
 ## HTML mockup substrate
 
-When the intent selector routes here — no app or dev server, no app yet, or a non-dev exploring —
+When the intent selector routes here, no app or dev server, no app yet, or a non-dev exploring,
 the variants live in one self-contained `file://` HTML page with synthetic data and an in-page
 switcher. Same variant-comparison process as the real stack; the substrate is the only thing that
 changes. Assemble one per task (there is no canned template to copy):
 
-1. **N variant containers** — one block per variant, all in the single page.
-2. **An in-memory switcher** — `file://` has no routing, so there is no `?variant=` URL; toggle
+1. **N variant containers**. One block per variant, all in the single page.
+2. **An in-memory switcher**. `file://` has no routing, so there is no `?variant=` URL; toggle
    container visibility in memory instead. Give it a floating control bar with left/right arrows
    and keyboard nav, modeled on the real-stack switcher in step 4 below.
-3. **A copy-out terminator** — a small control that lifts the winning-variant key plus notes back
+3. **A copy-out terminator**, a small control that lifts the winning-variant key plus notes back
    out as text you can paste into your durable answer.
 
 Constraints:
@@ -101,29 +101,29 @@ Constraints:
 - **Synthetic data only.** A throwaway prototype binds synthetic data, never real or captured
   values.
 - **No remote fetch by construction.** Vendor everything inline so the page opens straight from
-  `file://` — no external scripts, fonts, or data fetches. Enforce this rather than trusting it:
-  emit a restrictive CSP meta tag in the page `<head>` so the browser blocks any remote resource —
+  `file://`. No external scripts, fonts, or data fetches. Enforce this rather than trusting it:
+  emit a restrictive CSP meta tag in the page `<head>` so the browser blocks any remote resource:
   `<meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; script-src 'unsafe-inline'; img-src data:">`.
   Inline `<style>` and inline `<script>` stay allowed (the in-page switcher needs inline script);
-  only remote origins — CDNs, web fonts, `fetch`/XHR — are forbidden.
-- **Ephemeral placement.** Generate the mockup via the platform's temp primitive — never a tracked
+  only remote origins, CDNs, web fonts, `fetch`/XHR, are forbidden.
+- **Ephemeral placement.** Generate the mockup via the platform's temp primitive, never a tracked
   path and never inside the repo. On Unix/Linux/Git Bash, create a private run directory and write
-  the page inside it, echoing the directory in the same call —
-  `d=$(mktemp -d "${TMPDIR:-/tmp}/explore-directions-XXXXXX"); echo "$d"` — then writing to
+  the page inside it, echoing the directory in the same call:
+  `d=$(mktemp -d "${TMPDIR:-/tmp}/explore-directions-XXXXXX"); echo "$d"`, then writing to
   `<echoed dir>/explore-directions.html`. Echo it because shell state does not survive between Bash
   calls: the directory name is random, so an unechoed path is unrecoverable in the call that writes
-  the file. Carry the temp root in the positional template — the one form GNU and BSD `mktemp` accept identically, since `-p`/`--tmpdir`/`-t` differ between the dialects and a bare relative template silently creates the file in the **current directory**, the consumer's repository. Keep the `XXXXXX` placeholders **trailing** — BSD `mktemp` (macOS) substitutes only trailing Xs, so an extension after them is not portable (per `docs/conventions/topic-docs/README.md` "The ephemeral tier" in the marketplace repository).
+  the file. Carry the temp root in the positional template, the one form GNU and BSD `mktemp` accept identically, since `-p`/`--tmpdir`/`-t` differ between the dialects and a bare relative template silently creates the file in the **current directory**, the consumer's repository. Keep the `XXXXXX` placeholders **trailing**. BSD `mktemp` (macOS) substitutes only trailing Xs, so an extension after them is not portable (per `docs/conventions/topic-docs/README.md` "The ephemeral tier" in the marketplace repository).
   That is why the page takes a fixed name inside the generated directory rather than an
   `explore-directions-XXXXXX.html` template, which macOS cannot create at all. On Windows,
   a user-scoped temp under
   `%LOCALAPPDATA%\Temp`. One file per run. The path is handed to the user to open from `file://`,
-  so do not delete it — it must still be readable when they open it.
+  so do not delete it. It must still be readable when they open it.
 - **Markdown captures the answer.** Copy the winning-variant key and notes into your durable
   answer (per the shared discipline); the HTML is throwaway.
 - **Each variant declares its visual direction.** The mockup has no project styling system to
   inherit, so with no declared direction every variant renders in one default house aesthetic.
-  Before writing a variant, state its direction — background hex, accent hex, typeface, one-line
-  rationale — and make it differ from its siblings on that axis as well as structurally. Generic
+  Before writing a variant, state its direction. Background hex, accent hex, typeface, one-line
+  rationale, and make it differ from its siblings on that axis as well as structurally. Generic
   steering ("make it clean") only swaps one fixed palette for another; a concrete per-variant
   declaration is what produces variety.
 
@@ -131,24 +131,24 @@ Constraints:
 
 When the intent selector lands on the HTML mockup substrate AND the bundled `design` skill
 appears in this session's skill list with a description that is the design canvas (a local
-skill named `design` at any level silently overrides the bundled one — if the listed
+skill named `design` at any level silently overrides the bundled one, if the listed
 description is something else, treat the canvas as absent), offer the user a choice before
-building — never switch silently; the HTML mockup stays the default:
+building, never switch silently; the HTML mockup stays the default:
 
-- **HTML mockup (default)** — the throwaway `file://` page above; nothing persists.
-- **Design canvas** — invoke the bundled `design` skill to draft the variants as artboards on
+- **HTML mockup (default)**, the throwaway `file://` page above; nothing persists.
+- **Design canvas**. Invoke the bundled `design` skill to draft the variants as artboards on
   one pan/zoom canvas, published as an Artifact. Name the lifecycle difference in the offer:
-  the canvas is a published, versioned, persistent Artifact — default-private, shareable with
-  teammates at the user's choice — unlike the throwaway local mockup, and losing variants
+  the canvas is a published, versioned, persistent Artifact. Default-private, shareable with
+  teammates at the user's choice. Unlike the throwaway local mockup, and losing variants
   persist on it unless the user deletes or re-seeds the canvas. Hand-editing (click-to-select,
   properties panel, inline text) applies where saving is enabled for the user's account;
   otherwise the canvas is view-plus-PNG/PDF-export.
 
 The fallbacks are two distinct states, not one:
 
-- `design` **absent from the skill list** — do not offer or mention it; the HTML mockup covers
+- `design` **absent from the skill list**. Do not offer or mention it; the HTML mockup covers
   the same ground (a user whose session lacks the skill has no `/design` command either).
-- `design` **listed but the invocation is refused** (a future invocability gate) — suggest the
+- `design` **listed but the invocation is refused** (a future invocability gate). Suggest the
   user run `/design <scope>` themselves; user invocation survives such gates.
 
 The capture discipline is unchanged either way: record the winning-variant key and notes in
@@ -156,8 +156,8 @@ your durable answer; the canvas may live on under the user's account, but nothin
 the repo references it.
 
 > Verified 2026-08-18: the bundled `design` skill (an early preview of Claude Design inside
-> Claude Code) is model-invocable where enabled — its registration carries no
-> model-invocation gate — per the shipped v2.1.234 client and
+> Claude Code) is model-invocable where enabled. Its registration carries no
+> model-invocation gate, per the shipped v2.1.234 client and
 > <https://code.claude.com/docs/en/skills>. It is feature-flag-, account-, and platform-gated
 > (absent on non-first-party platforms and in headless contexts) and unnamed in the changelog,
 > so no version floor is statable. Recheck when a release changelog or the commands reference
@@ -167,7 +167,7 @@ the repo references it.
 
 ### 1. State the question and pick N
 
-Default to **3 variants**. More than 5 stops being radically different and starts being noise — cap
+Default to **3 variants**. More than 5 stops being radically different and starts being noise. Cap
 there.
 
 Write the plan in one line: "Three variants of the settings page, switchable via `?variant=`, on
@@ -181,7 +181,7 @@ Each variant must respect:
 - The project's component library / styling system
 - A clear exported component name (`VariantA`, `VariantB`, `VariantC`)
 
-**Variants must be structurally different and visually distinct** — different layout, different
+**Variants must be structurally different and visually distinct**. Different layout, different
 information hierarchy, different primary affordance; a recolor alone is not a variant. Three
 slightly-tweaked card grids isn't a UI prototype, it's wallpaper. Structure is the floor, not the
 whole exercise: on the real stack the project's styling system carries the visual axis, and where
@@ -191,7 +191,7 @@ with an explicit constraint ("do not use a card grid").
 
 ### 3. Wire them together
 
-A single switcher component on the route. Framework-idiomatic routing — use the `?variant=` param
+A single switcher component on the route. Framework-idiomatic routing. Use the `?variant=` param
 or equivalent. For sub-shape A, keep all existing data fetching above the switcher; only the
 rendered subtree changes per variant.
 
@@ -199,34 +199,34 @@ rendered subtree changes per variant.
 
 A small fixed-position bar at bottom-center with:
 
-- **Left/right arrows** — cycle between variants (wrap around)
-- **Variant label** — current key + descriptive name if exported
-- **Keyboard nav** — arrow keys cycle (don't intercept when an input/textarea is focused)
+- **Left/right arrows**. Cycle between variants (wrap around)
+- **Variant label**. Current key + descriptive name if exported
+- **Keyboard nav**. Arrow keys cycle (don't intercept when an input/textarea is focused)
 
 Requirements:
 
 - Update the URL param on switch (shareable, reload-stable)
 - Visually distinct from the page being evaluated (high-contrast pill, subtle shadow)
-- Hidden in production builds — gate on an environment check
+- Hidden in production builds. Gate on an environment check
 - Single shared component so both sub-shapes reuse it
 
 ### 5. Hand it over
 
 Surface the URL and variant keys. Interesting feedback is usually "I want the header from B with
-the sidebar from C" — that's the actual design discovered.
+the sidebar from C". That's the actual design discovered.
 
 ### 6. Capture the answer and clean up
 
-Per the shared discipline — record which variant won and why, and record the directions that lost
+Per the shared discipline. Record which variant won and why, and record the directions that lost
 with their reasons. When the verdict is a graft rather than a single winner, say which piece came
 from where **and what the discarded parts held that the graft deliberately left behind**. The
 deletions below are irreversible: whatever is not written down now is gone.
 
-- **Sub-shape A** — delete losing variants and the switcher; fold the winner into the existing page.
-- **Sub-shape B** — promote the winner to a real route; delete the throwaway route and switcher.
-- **HTML mockup substrate** — discard the mockup file once the winning-variant key and notes are
+- **Sub-shape A**. Delete losing variants and the switcher; fold the winner into the existing page.
+- **Sub-shape B**. Promote the winner to a real route; delete the throwaway route and switcher.
+- **HTML mockup substrate**. Discard the mockup file once the winning-variant key and notes are
   captured; nothing tracked is left behind.
-- **Design canvas** — capture the winning-variant key and notes the same way; then ask whether
+- **Design canvas**. Capture the winning-variant key and notes the same way; then ask whether
   the user wants the canvas kept (it persists under their account) or cleared. Nothing tracked
   references it either way.
 
@@ -235,10 +235,10 @@ Don't leave variant components or the switcher lying around. They rot fast.
 ## Anti-patterns
 
 - **Variants differing only in color or copy.** That's a tweak, not a prototype. Real variants
-  disagree about structure — and then differ visually on top of it, not instead of it.
+  disagree about structure, and then differ visually on top of it, not instead of it.
 - **Sharing too much code between variants.** A shared `<Header>` is fine; a shared `<Layout>`
   defeats the point. Each variant should be free to throw out the layout.
-- **Wiring variants to real mutations.** Read-only prototypes are fine. Stub mutations — the
+- **Wiring variants to real mutations.** Read-only prototypes are fine. Stub mutations. The
   question is "what should this look like", not "does the backend work".
 - **Promoting a prototype directly to production.** Variant code was written under prototype
   constraints (no tests, minimal error handling). Rewrite properly when folding in.

--- a/plugins/prototype/skills/pressure-test/SKILL.md
+++ b/plugins/prototype/skills/pressure-test/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: "Builds a throwaway interactive terminal app to pressure-test business logic, a state machine, a data model, or an API surface before committing to it. Use when: 'does this state machine handle X then Y', 'sanity-check this data model', 'feel out the API', 'prototype this logic', 'does this reducer handle the edge case', 'is this data shape right' — any question answered by driving state by hand and watching it change. Produces a portable pure logic module (liftable into production) behind a disposable shell — a terminal app by default, or a self-contained HTML demo a non-developer can drive by clicking buttons when no terminal fits. Captures the validated answer in a durable note. Not for visual or design questions — use /prototype:explore-directions for those."
+description: "Builds a throwaway interactive terminal app to pressure-test business logic, a state machine, a data model, or an API surface before committing to it. Use when: 'does this state machine handle X then Y', 'sanity-check this data model', 'feel out the API', 'prototype this logic', 'does this reducer handle the edge case', 'is this data shape right'. Any question answered by driving state by hand and watching it change. Produces a portable pure logic module (liftable into production) behind a disposable shell, a terminal app by default, or a self-contained HTML demo a non-developer can drive by clicking buttons when no terminal fits. Captures the validated answer in a durable note. Not for visual or design questions. Use /prototype:explore-directions for those."
 argument-hint: "[scope] (e.g., /prototype:pressure-test scheduling state machine)"
 user-invocable: true
 disable-model-invocation: false
@@ -22,16 +22,16 @@ Arguments: `$ARGUMENTS`
 
 ## Purpose
 
-A disposable interactive shell driving a state model by hand — a terminal app by default, a
+A disposable interactive shell driving a state model by hand, a terminal app by default, a
 shareable HTML demo when the audience calls for it. Use when the question is about
-**business logic, state transitions, or data shape** — things that look reasonable on paper but
+**business logic, state transitions, or data shape**. Things that look reasonable on paper but
 only feel wrong once pushed through real cases.
 
 The shared throwaway rules, the auto-invoke gate, and how to capture the answer live in
-[`${CLAUDE_PLUGIN_ROOT}/context/discipline.md`](../../context/discipline.md) — read it before you
+[`${CLAUDE_PLUGIN_ROOT}/context/discipline.md`](../../context/discipline.md). Read it before you
 start. This file covers only the logic facet.
 
-If the question is "what should this look like" — wrong facet. Invoke `/prototype:explore-directions` via the Skill tool.
+If the question is "what should this look like". Wrong facet. Invoke `/prototype:explore-directions` via the Skill tool.
 
 ## When this is the right shape
 
@@ -40,36 +40,36 @@ If the question is "what should this look like" — wrong facet. Invoke `/protot
 - "What should the API surface look like before writing it?"
 - Anything where pressing buttons and watching state change reveals the answer
 
-## Two shells — TUI default
+## Two shells. TUI default
 
-Two disposable shells can front the same portable logic module (step 3 below) — the **terminal
+Two disposable shells can front the same portable logic module (step 3 below), the **terminal
 app** (the default) and a **self-contained HTML demo**. Both run the same process; only the shell
 swaps. Route by audience:
 
 - **The driver is a developer with a terminal** → the TUI (the default below).
-- **The driver is a non-developer** — a designer, PM, or domain expert pressing the buttons — or
+- **The driver is a non-developer**, a designer, PM, or domain expert pressing the buttons, or
   **no terminal fits the handoff** → the HTML demo shell (next section): one file, nothing to
   install, opened by double-click.
-- **Explicit override wins both ways** — ask for a TUI or an HTML demo directly and that beats
+- **Explicit override wins both ways**. Ask for a TUI or an HTML demo directly and that beats
   the default routing.
 
 ## HTML demo shell
 
 When the audience routing selects it, the shell is one self-contained `file://` HTML page over the
-same pure logic module — the module lives in a single inline `<script>` block written so it could
+same pure logic module, the module lives in a single inline `<script>` block written so it could
 be lifted out unchanged; the page calls into it, and nothing flows the other direction. It
 replaces steps 4–5 below; the rest of the process holds (in step 6, the run command is the page's
 `file://` path).
 
-Lay the page out top to bottom, in **domain language** — every button and field reads like the
+Lay the page out top to bottom, in **domain language**. Every button and field reads like the
 business, not the reducer, because the driver is not reading code:
 
-1. **Title and one-line explanation** — the question from step 1, visible on the page.
-2. **State panel** — the full relevant state as a readable labelled panel (not a raw JSON dump),
+1. **Title and one-line explanation**, the question from step 1, visible on the page.
+2. **State panel**, the full relevant state as a readable labelled panel (not a raw JSON dump),
    re-rendered after every click so the change is visible.
-3. **Free-play buttons** — one button per action, always available, so the driver can poke at the
+3. **Free-play buttons**. One button per action, always available, so the driver can poke at the
    model in any order.
-4. **Guided walkthroughs** — a few scenarios worth demonstrating: the happy path, a tricky edge
+4. **Guided walkthroughs**, a few scenarios worth demonstrating: the happy path, a tricky edge
    case, an attempt at something that should be illegal. Each is a short plain-language
    description plus the ordered buttons to press; starting a walkthrough **resets to a known
    initial state** so the scenario runs the same way every time.
@@ -79,25 +79,25 @@ Constraints (the same set as explore-directions' HTML mockup substrate):
 - **Synthetic data only.** A throwaway prototype binds synthetic data, never real or captured
   values.
 - **No remote fetch by construction.** Vendor everything inline so the page opens straight from
-  `file://` — no external scripts, fonts, or data fetches. Enforce this rather than trusting it:
-  emit a restrictive CSP meta tag in the page `<head>` so the browser blocks any remote resource —
+  `file://`. No external scripts, fonts, or data fetches. Enforce this rather than trusting it:
+  emit a restrictive CSP meta tag in the page `<head>` so the browser blocks any remote resource:
   `<meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; script-src 'unsafe-inline'; img-src data:">`.
   Inline `<style>` and inline `<script>` stay allowed (the logic module and the button handlers
-  need inline script); only remote origins — CDNs, web fonts, `fetch`/XHR — are forbidden.
-- **Ephemeral placement.** Generate the page via the platform's temp primitive — never a tracked
+  need inline script); only remote origins, CDNs, web fonts, `fetch`/XHR, are forbidden.
+- **Ephemeral placement.** Generate the page via the platform's temp primitive, never a tracked
   path and never inside the repo. On Unix/Linux/Git Bash, create a private run directory and
-  write the page inside it, echoing the directory in the same call —
-  `d=$(mktemp -d "${TMPDIR:-/tmp}/pressure-test-XXXXXX"); echo "$d"` — then write to
+  write the page inside it, echoing the directory in the same call:
+  `d=$(mktemp -d "${TMPDIR:-/tmp}/pressure-test-XXXXXX"); echo "$d"`, then write to
   `<echoed dir>/pressure-test.html`. Echo it because shell state does not survive between Bash
   calls. Keep the temp root in the positional template with the `XXXXXX` trailing, and give the
-  page a fixed name inside the generated directory — the mktemp dialect traps behind those two
+  page a fixed name inside the generated directory, the mktemp dialect traps behind those two
   rules (GNU vs BSD `-p`/`-t` divergence, trailing-X-only substitution on BSD/macOS) are unpacked
   in [`explore-directions`](../explore-directions/SKILL.md)'s HTML mockup substrate section; the
   same rules apply verbatim here. On Windows, a user-scoped temp under `%LOCALAPPDATA%\Temp`. One
-  file per run. The path is handed to the user to open from `file://`, so do not delete it — it
+  file per run. The path is handed to the user to open from `file://`, so do not delete it. It
   must still be readable when they open it.
 - **Markdown captures the answer.** Copy what the demo taught into your durable answer (per the
-  shared discipline), then discard the page like any other shell — the validated logic module is
+  shared discipline), then discard the page like any other shell, the validated logic module is
   the only artifact that outlives the prototype (lifted into production per step 7).
 
 ## Process
@@ -105,16 +105,16 @@ Constraints (the same set as explore-directions' HTML mockup substrate):
 ### 1. State the question
 
 Write down what state model and what question you're prototyping. One paragraph, comment at top of
-file. A logic prototype answering the wrong question is pure waste — make the question explicit.
+file. A logic prototype answering the wrong question is pure waste. Make the question explicit.
 
 ### 2. Pick the language
 
-Use whatever the host project uses. Match existing conventions for tooling — don't add a new
+Use whatever the host project uses. Match existing conventions for tooling. Don't add a new
 runtime for a prototype.
 
 ### 3. Isolate logic in a portable module
 
-Put the logic — the bit answering the question — behind a small, pure interface that could be
+Put the logic, the bit answering the question, behind a small, pure interface that could be
 lifted into the real codebase later. The shell around it (TUI or HTML page) is throwaway; the
 logic module should not be.
 
@@ -122,16 +122,16 @@ Pick the shape that fits the question:
 
 | Shape | When |
 |-------|------|
-| **Pure reducer** — `(state, action) => state` | Actions are discrete events, state is a single value |
-| **State machine** — explicit states and transitions | "Which actions are even legal right now" is part of the question |
-| **Pure functions** over a plain data type | No implicit current state — just transformations |
+| **Pure reducer**. `(state, action) => state` | Actions are discrete events, state is a single value |
+| **State machine**. Explicit states and transitions | "Which actions are even legal right now" is part of the question |
+| **Pure functions** over a plain data type | No implicit current state. Just transformations |
 | **Class/module with clear method surface** | Logic genuinely owns ongoing internal state |
 
 Keep it pure: no I/O, no terminal code, no DOM access, no console output for control flow. The
 shell imports and calls into the logic module; nothing flows the other direction.
 
 This is what makes the prototype useful past its own lifetime. When the question's been answered,
-the validated module can be lifted into production code — the shell gets deleted.
+the validated module can be lifted into production code, the shell gets deleted.
 
 ### 4. Build the smallest TUI that exposes state
 
@@ -143,15 +143,15 @@ growing scrollback.
 
 Each frame has two parts:
 
-1. **Current state** — pretty-printed, one field per line or formatted output. Bold field names,
+1. **Current state**. Pretty-printed, one field per line or formatted output. Bold field names,
    dim less-important context (timestamps, IDs, derived values).
-2. **Actions** — listed at bottom: `[a] add item  [d] delete item  [t] tick clock  [q] quit`.
+2. **Actions**. Listed at bottom: `[a] add item  [d] delete item  [t] tick clock  [q] quit`.
 
 Behavior loop:
 
-1. Initialize state — a single in-memory object. Render the first frame on start.
+1. Initialize state, a single in-memory object. Render the first frame on start.
 2. Read one keystroke (or one line), dispatch to a handler that mutates state via the logic module.
-3. Re-render the full frame after every action — replace, don't append.
+3. Re-render the full frame after every action. Replace, don't append.
 4. Loop until quit.
 
 The whole frame should fit on one screen.
@@ -159,21 +159,21 @@ The whole frame should fit on one screen.
 ### 5. Make it runnable in one command
 
 Add a script to the project's existing task runner. The user runs the equivalent of
-`dotnet run --project <path>` or `pnpm run <name>` — never needs to remember a file path.
+`dotnet run --project <path>` or `pnpm run <name>`, never needs to remember a file path.
 
 If there's no task runner, put the command at the top of a prototype README.
 
 ### 6. Hand it over
 
-Give the user the run command (for the HTML demo shell, the page's `file://` path — send them the
-file or open it for them). Interesting moments — "wait, that shouldn't be possible" or "huh, I
-assumed X would be different" — are bugs in the IDEA. Add new actions as the user requests them.
+Give the user the run command (for the HTML demo shell, the page's `file://` path: send them the
+file or open it for them). Interesting moments, "wait, that shouldn't be possible" or "huh, I
+assumed X would be different", are bugs in the IDEA. Add new actions as the user requests them.
 Prototypes evolve.
 
 ### 7. Capture the answer
 
 When done, capture what the prototype taught (per the shared discipline). The logic module behind
-the shell is often worth keeping; the shell — TUI or HTML page — is not: lift the validated
+the shell is often worth keeping; the shell, TUI or HTML page, is not: lift the validated
 module into production and delete the shell.
 
 ## Anti-patterns
@@ -184,7 +184,7 @@ module into production and delete the shell.
 - **Blurring logic and shell.** If the reducer/state machine references console output, terminal
   codes, or the DOM, it's no longer portable. The shell (TUI or page) is a thin layer over a pure
   module.
-- **Shipping the shell to production.** The shell — TUI or HTML page — is optimized for
+- **Shipping the shell to production.** The shell, TUI or HTML page, is optimized for
   hand-driving. The logic module behind it is the reusable bit.
 - **Reaching for a framework, bundler, or server in the HTML demo shell.** One file the driver
   double-clicks; a dev server defeats "nothing to install".


### PR DESCRIPTION
No linked issue

## Summary

#2891 instruction-surface de-slop cluster: purge em dashes from the `prototype` plugin README and every SKILL.md.

## Fix

Rewrote `plugins/prototype/README.md` and every `plugins/prototype/**/SKILL.md` under `/ai-slop:audit fix` semantics (periods, commas, or a restructured sentence; never parentheses, en dashes, or a spaced hyphen as a stand-in). Meaning-preserving self-audit repaired asides the first pass reattached to the wrong noun. `prototype` 0.9.4.

## Verification

- Detector: 0 `rule-em-dash` findings outside ignore-fenced generated-options spans (and required trigger strings that must keep em dashes)
- `CHECK_SKILL_SKIP_MARKDOWNLINT=1 bash scripts/check-changed-skills.sh origin/main`: 0 failed; quoted trigger phrases vs origin/main preserved
- `python3 scripts/sync-plugin-options-docs.py --check` up to date
- `scripts/check-changelog-parity.sh --check-bump origin/main` passes
- `node scripts/generate-cheatsheet.mjs --check` in sync

## Related

Refs #2891

#2891 stays open.