### PR TITLE
docs(autonomy): de-slop instruction surfaces (0.22.8)

### DIFF
--- a/plugins/autonomy/.claude-plugin/plugin.json
+++ b/plugins/autonomy/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "autonomy",
-  "version": "0.22.7",
+  "version": "0.22.8",
   "description": "Governed autonomous agent operation: role-topology, binding-seam, wiring-vs-advisor, telemetry, return-accounting, trigger-dispatch, per-work-class guardrail-matrix, standing-routine-catalog, and design-only runner-charter contracts for climbing the AI-adoption ladder, plus a guided-setup skill that discovers an adopting org's state, writes its schema-versioned binding, wires standards-pinned OTLP emission with a zero-cost file-artifact default, wires human-attested return capture at the task boundary, wires signal adapters with one governed dispatch entrypoint, binds the five-class guardrail matrix to an org's isolation substrates with an in-boundary live-validation probe before recording each fail-closed binding, and stands up standing-routine-catalog classes as scheduled temporal signal adapters behind the one governed queue with free scheduling defaults wired as reviewable changes and each routine's work-class mapping homed on the security surface.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/autonomy/CHANGELOG.md
+++ b/plugins/autonomy/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to the `autonomy` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.22.8]
+
+### Changed
+
+- **Instruction-surface de-slop (#2891, autonomy cluster).** Rewrote this plugin's `README.md` and every
+  `SKILL.md` to drop em dashes under the repo's zero-tolerance house policy, using
+  `/ai-slop:audit fix` semantics: periods or commas, or a restructured sentence, never
+  parentheses, en dashes, or a spaced hyphen as a stand-in. Meaning stays; only the mark
+  and the sentence break change. The generated options block is ignore-fenced because
+  `scripts/sync-plugin-options-docs.py` still emits em dashes from its shared template.
+
 ## [0.22.7]
 
 ### Fixed

--- a/plugins/autonomy/README.md
+++ b/plugins/autonomy/README.md
@@ -12,61 +12,61 @@ state and records that binding.
   wiring-vs-advisor principle governing how setup lands changes.
 - **Telemetry contract** (`reference/telemetry.md`): standards-pinned OTLP from every execution
   context, the `autonomy.work_item.url` join attribute, one causal tree by context propagation,
-  sink classes with a zero-cost file-artifact default — plus the setup telemetry slice, its
+  sink classes with a zero-cost file-artifact default, plus the setup telemetry slice, its
   snippet templates, and the emission-conformance check.
 - **Return-accounting convention** (`reference/return-accounting.md`): the two human-attested
   return questions captured as a tracker-resident record at the task boundary of
-  autonomous-class work, joinable to cost telemetry by the join attribute — plus the setup
+  autonomous-class work, joinable to cost telemetry by the join attribute, plus the setup
   capture slice and its close-boundary templates. Agents prompt and aggregate; they never
   estimate the human fields.
 - **Trigger-dispatch contract** (`reference/trigger-dispatch.md`): four signal-surface
   classes normalized by adapters into the governed work-item queue under six class-generic
   obligations, a schema-versioned signal envelope, security-surface work-class stamping, and
   one dispatch entrypoint (push kick + scheduled drain through the queue seam's race-safe
-  lease) — plus the setup trigger/dispatch slice, its adapter and acknowledgment templates,
+  lease), plus the setup trigger/dispatch slice, its adapter and acknowledgment templates,
   and the signal-envelope conformance check.
 - **Guardrail matrix** (`reference/guardrails.md`): five semantic work classes (`C1`–`C5`)
-  crossed with six enforcement columns — isolation floor, verification layers, verification
-  topology, merge policy, cost tier, escalation — as one progressive-disclosure hub with
+  crossed with six enforcement columns. Isolation floor, verification layers, verification
+  topology, merge policy, cost tier, escalation, as one progressive-disclosure hub with
   on-demand leaves (isolation ladder, work classes, security review, verification topology,
   admission policy), human-ratified promotion with automatic fail-closed demotion, and a
   two-surface binding split by governance sensitivity
   (security axes on the settings-as-code home outside agent blast radius; non-security remaps
-  repo-local) — plus the contract-owned security-binding schema and its semantic check, and the
+  repo-local), plus the contract-owned security-binding schema and its semantic check, and the
   setup guardrail slice that detects substrates per surface, live-validates isolation with an
   in-boundary probe before binding, folds in security-review wiring, and fail-closes autonomous
   dispatch where no `L2` substrate exists.
 - **Standing-routine catalog** (`reference/routines.md`): the routine classes an adopting org can
-  stand up as governed background maintenance — a progressive-disclosure hub whose glance-layer
+  stand up as governed background maintenance, a progressive-disclosure hub whose glance-layer
   table classifies every class (judgment, output, access → derived guardrail row) under
   contract-owned catalog-to-matrix mapping rules, with `reference/routines/` definition leaves for
   the v1 subset and the invariant that a routine is a scheduled `temporal`-class trigger adapter
-  behind the governed queue, never a private execution or merge path — plus the setup routine slice
+  behind the governed queue, never a private execution or merge path, plus the setup routine slice
   that discovers scheduling surfaces, wires the free CI-cron/local-scheduler defaults as reviewable
   changes, homes each routine's work-class mapping on the security surface, and
   detect-diff-reconciles existing org schedulers and bots instead of duplicating them.
 - **Routine prerequisite resolution** (`reference/prerequisite-resolution.md`): fail-closed,
   per-identity-per-surface verdicts (`supported` / `conditional` / `unsupported` / `unknown`) for
   which catalog identities can run against a repository, composing owning seams rather than a new
-  prober — with `deferred(<trigger>)` (the row's own join trigger) marking `join:` rows that
+  prober, with `deferred(<trigger>)` (the row's own join trigger) marking `join:` rows that
   have no identities yet. Per-identity
   facts live in each `v1` leaf; `generated/identity-prerequisites.json` is the drift-gated
   emission derived from those leaves (generator under `skills/setup/scripts/`);
   `skills/setup/scripts/resolve-prerequisites.mjs` is the deterministic per-surface resolver;
   the setup skill's prerequisite-resolution slice (`check` / `apply`) consumes it.
 - **Runner design pack** (`reference/runner.md`): the architect-ready design contract for the
-  autonomous-drain runner — the composition spine and its eight seams, the lifecycle state
+  autonomous-drain runner, the composition spine and its eight seams, the lifecycle state
   model, the two-family stop-criteria taxonomy with terminal-handoff escalation and
   severity-routed notification fan-out, the matrix-derived launch backend set, and the topology
   ownership seam map, as a progressive-disclosure hub with `reference/runner/` leaves. Design
-  only — the build stays gated on the charter's own triggers and the runner-execution home
+  only, the build stays gated on the charter's own triggers and the runner-execution home
   stays unborn; setup records nothing runner-specific beyond the escalation notification routes
   (severity axis + personal-push tier) bound through the security binding.
 - **Autonomous-pipeline reminder** (`reference/autonomous-pipeline-reminder.md`): a drop-in
   standing reminder for an adopting org's *own* pipeline, against the two stopping failures a
-  pipeline cannot recover from — a turn ending on unexecuted intent, and a turn stopping to ask
+  pipeline cannot recover from, a turn ending on unexecuted intent, and a turn stopping to ask
   permission nobody is there to give. States where it does not apply (an attended lane wants the
-  opposite posture) and what the `lane-stop-gate` hook does and does not cover of it — one clause
+  opposite posture) and what the `lane-stop-gate` hook does and does not cover of it. One clause
   deterministically, the rest by instruction alone.
 
   **Provenance.** The clause set is this repository's own wording of guidance in Anthropic's Claude
@@ -78,14 +78,14 @@ state and records that binding.
   because `reference/` docs are written in surface classes and may not name vendors.
   **Recheck trigger:** that section changing its clause set, or a second model guide stating the same
   guidance in materially different terms.
-- **Guided setup** (`/autonomy:setup`): discovery-first interview of the adopting org's state —
-  role homes, substrate availability, budget posture — writing a schema-versioned binding under
+- **Guided setup** (`/autonomy:setup`): discovery-first interview of the adopting org's state:
+  role homes, substrate availability, budget posture, writing a schema-versioned binding under
   `.claude/autonomy/` as reviewable changes. Never assumes any particular org or repo shape.
 
 ## Roadmap (deferred, trigger-gated)
 
 Each capability below lands with its own work package; none ships before its contracts are
-locked (no step-skipping — trust before scale).
+locked (no step-skipping. Trust before scale).
 
 | Capability | Trigger |
 |---|---|
@@ -115,12 +115,12 @@ local machine only).
 
 Completion is signaled either way (a shell hook cannot re-run the `/goal` evaluator model): the exact
 sentinel token in the agent's final message, or a marker file. The marker is consumed (deleted) when
-it authorizes a stop — one marker, one stop — so a file left in the checkout by a prior completed
+it authorizes a stop, one marker, one stop, so a file left in the checkout by a prior completed
 run never authorizes the stops of a later lane run. It is the settings-scoped,
-cross-session sibling of `/goal`'s session-only completion condition — use `/goal` for a single
+cross-session sibling of `/goal`'s session-only completion condition. Use `/goal` for a single
 session, this gate for a standing lane.
 
-**Default OFF** — a Stop-blocking hook must never engage for an interactive session.
+**Default OFF**, a Stop-blocking hook must never engage for an interactive session.
 
 **Config is honored from trusted sources only (#1784).** The gate never takes its config off the
 bare `CLAUDE_PLUGIN_OPTION_*` environment: for an unconfigured key, a watched repository's own
@@ -129,43 +129,43 @@ sentinel, or marker path) the watched repository controls is not a gate
 (`docs/conventions/hook-config-delivery`). Per-key precedence, mirroring Claude Code's own settings
 merge:
 
-1. **Managed settings** (fixed root-owned paths + `managed-settings.d/` drop-ins) — an org can veto
+1. **Managed settings** (fixed root-owned paths + `managed-settings.d/` drop-ins), an org can veto
    with `lane_stop_gate_enabled: false`.
    [Server-managed settings](https://code.claude.com/docs/en/server-managed-settings) are
-   deliberately excluded — their only on-disk artifact is the user-writable cache
+   deliberately excluded. Their only on-disk artifact is the user-writable cache
    `~/.claude/remote-settings.json`, which fails the root-owned trust test (the page itself calls
-   the channel "a client-side control, not a security boundary") — so an org vetoing via the server
+   the channel "a client-side control, not a security boundary"), so an org vetoing via the server
    channel must also deliver an endpoint `managed-settings.json` to veto lanes (the gate reads that
    file directly; Claude Code itself ignores endpoint sources when server keys arrive).
-2. **The per-session arm record** — the `claude-ops` lane launcher arms a lane at launch: give the
+2. **The per-session arm record**, the `claude-ops` lane launcher arms a lane at launch: give the
    lane a `settings` object requesting the gate in its lanes-config entry (see that skill's
    `context/config.md`), and the launcher runs this plugin's `hooks/lane-stop-gate-arm.sh` (writing
    a record under the plugin's own install-derived data directory) and injects the random record id
    as `lane_stop_gate_arm_id` in the session's `--settings`. The id is a capability pointer, never
    authority: the gate validates it, honors only its own store, binds it to the first presenting
-   session, and expires it after 7 days. The record is not consumed on a stop — a lane is one
-   session across many `/loop` cycles, each of whose stops must stay gated — so it lives for the
+   session, and expires it after 7 days. The record is not consumed on a stop, a lane is one
+   session across many `/loop` cycles, each of whose stops must stay gated, so it lives for the
    claiming session and is retired by TTL plus the launcher's relaunch sweep. To arm a hand-launched
    session, run the arm helper from the installed plugin the same way, then pass the id via
    `--settings '{"pluginConfigs":{"autonomy@<marketplace>":{"options":{"lane_stop_gate_arm_id":"<id>"}}}}'`.
-3. **User `settings.json`**, located from the hook's own install path — a *persistent* enable that
+3. **User `settings.json`**, located from the hook's own install path, a *persistent* enable that
    also gates interactive sessions, which defeats the default-OFF design; prefer the launcher.
 
-A `--settings`-only `lane_stop_gate_enabled=true` (the pre-0.12.0 opt-in) is **no longer honored** —
-that value reaches the hook only as the forgeable env mirror. The gate says so with a visible
+A `--settings`-only `lane_stop_gate_enabled=true` (the pre-0.12.0 opt-in) is **no longer honored**.
+That value reaches the hook only as the forgeable env mirror. The gate says so with a visible
 once-per-session notice instead of disengaging silently, which is also how a stale (pre-arming)
 lane launcher surfaces. A `--plugin-dir` checkout install has no trusted user-settings or record
 location, so only managed settings can enable the gate there.
 
 It is fail-open (unreadable stdin / missing `jq` / a `SubagentStop` never trips it) and bounded
 against runaway by the `stop_hook_active` one-nudge guard plus Claude Code's consecutive-block cap.
-It catches a graceful self-stop only — a closed laptop, a killed process, or `/loop` expiry emit no
+It catches a graceful self-stop only, a closed laptop, a killed process, or `/loop` expiry emit no
 `Stop` event.
 
 When the consuming repo sets `HOOK_TELEMETRY_SINK`, the gate emits one fire-and-forget envelope per
 evaluated outcome (`hook: "lane-stop-gate"`; payload contract in the marketplace's hook-telemetry
 convention, `data/lane-stop-gate.schema.json`), so premature lane stops are measurable fleet-wide.
-The payload is a fixed vocabulary — never the sentinel token, marker path, cwd, or branch.
+The payload is a fixed vocabulary, never the sentinel token, marker path, cwd, or branch.
 
 | userConfig option | Default | Effect |
 |---|---|---|
@@ -179,12 +179,12 @@ The payload is a fixed vocabulary — never the sentinel token, marker path, cwd
 
 ## Configuration
 
-Setup writes tracked config to `.claude/autonomy/` in the consuming repo (concern-named — the
+Setup writes tracked config to `.claude/autonomy/` in the consuming repo (concern-named. The
 config outlives any plugin restructure). Personal overlays follow the marketplace overlay
 convention: `.claude/autonomy/**/*.local.*` stays gitignored; layers resolve per the
-binding-seam ladder — user-global → org binding (when pointed) → project → local overlay —
-additively.
+binding-seam ladder: user-global → org binding (when pointed) → project → local overlay, additively.
 
+<!-- ai-slop-ignore-start: generated options block; source is plugin.json + scripts/sync-plugin-options-docs.py -->
 <!-- BEGIN GENERATED: plugin options — edit plugin.json, then run scripts/sync-plugin-options-docs.py -->
 
 ### Options reference
@@ -265,3 +265,4 @@ hands a configured value to a hook process; the value comes from the routes abov
 - [Manage installed plugins](https://code.claude.com/docs/en/discover-plugins#manage-installed-plugins) — enabling, disabling, `/plugin list`
 
 <!-- END GENERATED: plugin options -->
+<!-- ai-slop-ignore-end -->

--- a/plugins/autonomy/README.md
+++ b/plugins/autonomy/README.md
@@ -26,7 +26,7 @@ state and records that binding.
   lease), plus the setup trigger/dispatch slice, its adapter and acknowledgment templates,
   and the signal-envelope conformance check.
 - **Guardrail matrix** (`reference/guardrails.md`): five semantic work classes (`C1`–`C5`)
-  crossed with six enforcement columns. Isolation floor, verification layers, verification
+  crossed with six enforcement columns: isolation floor, verification layers, verification
   topology, merge policy, cost tier, escalation, as one progressive-disclosure hub with
   on-demand leaves (isolation ladder, work classes, security review, verification topology,
   admission policy), human-ratified promotion with automatic fail-closed demotion, and a
@@ -78,8 +78,9 @@ state and records that binding.
   because `reference/` docs are written in surface classes and may not name vendors.
   **Recheck trigger:** that section changing its clause set, or a second model guide stating the same
   guidance in materially different terms.
-- **Guided setup** (`/autonomy:setup`): discovery-first interview of the adopting org's state:
-  role homes, substrate availability, budget posture, writing a schema-versioned binding under
+- **Guided setup** (`/autonomy:setup`): discovery-first interview of the adopting org's state,
+  covering role homes, substrate availability, and budget posture, that writes a schema-versioned
+  binding under
   `.claude/autonomy/` as reviewable changes. Never assumes any particular org or repo shape.
 
 ## Roadmap (deferred, trigger-gated)
@@ -159,7 +160,7 @@ location, so only managed settings can enable the gate there.
 
 It is fail-open (unreadable stdin / missing `jq` / a `SubagentStop` never trips it) and bounded
 against runaway by the `stop_hook_active` one-nudge guard plus Claude Code's consecutive-block cap.
-It catches a graceful self-stop only, a closed laptop, a killed process, or `/loop` expiry emit no
+It catches a graceful self-stop only: a closed laptop, a killed process, or `/loop` expiry emit no
 `Stop` event.
 
 When the consuming repo sets `HOOK_TELEMETRY_SINK`, the gate emits one fire-and-forget envelope per

--- a/plugins/autonomy/skills/setup/SKILL.md
+++ b/plugins/autonomy/skills/setup/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: "Configure the autonomy plugin for this repository: discover the adopting org's state (role homes, substrate availability, budget posture), interview where discovery cannot infer, and write the schema-versioned binding under .claude/autonomy/. Use when: 'set up autonomy', 'autonomy setup', 'configure autonomy', 'bind the autonomy contracts', or another autonomy capability reports a missing binding. Re-runnable — safe to invoke again to reconfigure."
+description: "Configure the autonomy plugin for this repository: discover the adopting org's state (role homes, substrate availability, budget posture), interview where discovery cannot infer, and write the schema-versioned binding under .claude/autonomy/. Use when: 'set up autonomy', 'autonomy setup', 'configure autonomy', 'bind the autonomy contracts', or another autonomy capability reports a missing binding. Re-runnable. Safe to invoke again to reconfigure."
 argument-hint: "check | apply [--org-policy-home <locator>|none] [--budget-posture free|paid-opt-in]"
 user-invocable: true
 disable-model-invocation: true
@@ -11,14 +11,14 @@ Discovery phase of autonomy adoption (v0). Maps the roles in
 [`${CLAUDE_PLUGIN_ROOT}/reference/role-topology.md`](${CLAUDE_PLUGIN_ROOT}/reference/role-topology.md) to this org's real instances
 and records the result as the schema-versioned binding the resolution ladder in
 [`${CLAUDE_PLUGIN_ROOT}/reference/binding-seam.md`](${CLAUDE_PLUGIN_ROOT}/reference/binding-seam.md) reads at the repo-local layer. Never assumes
-any org, repo, tracker, or fleet shape — discovery reads what exists, the interview fills what
+any org, repo, tracker, or fleet shape. Discovery reads what exists, the interview fills what
 it cannot infer, and every landed change is reviewable per
 [`${CLAUDE_PLUGIN_ROOT}/reference/wiring-vs-advisor.md`](${CLAUDE_PLUGIN_ROOT}/reference/wiring-vs-advisor.md).
 
 ## Actions
 
 - **`check`** (read-only): resolve the effective binding across ALL rungs of the binding-seam
-  resolution ladder — user-global (`~/.claude/autonomy/`) → project (`.claude/autonomy/`) →
+  resolution ladder. User-global (`~/.claude/autonomy/`) → project (`.claude/autonomy/`) →
   local overlay (`.claude/autonomy/**/*.local.*`), additive, PLUS the org rung when the merged
   layers carry an `org_policy_home` pointer: fetch the org binding via the host CLI with the
   consumer's own auth and fold it in at its ladder position. Report what is bound, what is
@@ -26,7 +26,7 @@ it cannot infer, and every landed change is reviewable per
   WARNED as not-considered, never silently omitted. No writes.
 - **`apply`** (idempotent): run discovery, then write or update the project binding. Re-running
   reads the existing binding and proposes deltas; it never overwrites blind and never touches
-  unrelated user content. All project paths anchor at the PROJECT ROOT — resolve
+  unrelated user content. All project paths anchor at the PROJECT ROOT. Resolve
   `${CLAUDE_PROJECT_DIR}` (fall back to the repository toplevel) before writing; invoking the
   skill from a subdirectory must never create a nested `.claude/autonomy/`.
 
@@ -34,7 +34,7 @@ it cannot infer, and every landed change is reviewable per
 
 | Argument | Values | Headless default |
 |---|---|---|
-| action | `check` \| `apply` | — (required) |
+| action | `check` \| `apply` |. (required) |
 | `--org-policy-home` | repository locator, optionally `#<path>` to the binding document \| `none` | `none` |
 | `--budget-posture` | `free` \| `paid-opt-in` | `free` |
 
@@ -42,7 +42,7 @@ A locator without `#<path>` triggers document discovery at bind time (the bindin
 document is found by its schema-versioned shape per the org repo's own layout) and the
 resolved path is persisted alongside the pointer so later fetches are deterministic.
 
-`apply` with every argument supplied runs non-interactively — no prompts — so automation and
+`apply` with every argument supplied runs non-interactively, no prompts, so automation and
 headless use work. With arguments missing, discovery infers first and interviews only the
 gaps (convention ladder: config present → use it; absent → infer and persist; cannot infer →
 ask and offer to persist; otherwise → safe free-tier default).
@@ -50,11 +50,11 @@ ask and offer to persist; otherwise → safe free-tier default).
 ## Discovery (apply)
 
 1. **Role homes**: inspect the repository and, when a host CLI with the consumer's own auth is
-   available, the org — which repositories hold the CI-orchestration, settings-as-code, and
+   available, the org, which repositories hold the CI-orchestration, settings-as-code, and
    org-policy roles. A solo/no-org adopter terminates at the binding-seam contract's terminal
    default: the repo-local binding is the whole binding, free-tier defaults throughout.
 2. **Substrate availability**: what execution surfaces exist (local machine, CI runners,
-   self-run infrastructure) — recorded as declared posture, not probed destructively.
+   self-run infrastructure). Recorded as declared posture, not probed destructively.
 3. **Budget posture**: `free` unless the user explicitly opts into `paid-opt-in`; anything
    paid is advisory + explicit opt-in with cost surfaced first (wiring-vs-advisor).
 
@@ -63,22 +63,22 @@ ask and offer to persist; otherwise → safe free-tier default).
 `apply` writes `.claude/autonomy/binding.json` with these serialized keys:
 
 - `schema_version` (string, from `"1.0"`);
-- `roles` — an object keyed by the kebab-case role names of the role-topology contract
+- `roles`, an object keyed by the kebab-case role names of the role-topology contract
   (`capability-distribution-home`, `ci-orchestration-home`, `settings-as-code-home`,
   `org-policy-home`, `runner-execution-home`); a value MAY be null (unborn role, or no org
-  instance — never invented);
-- `org_policy_home` — the pointer (or `null`), with its resolved document path when
+  instance, never invented);
+- `org_policy_home`, the pointer (or `null`), with its resolved document path when
   discovered;
-- `budget_posture` — `free` | `paid-opt-in`;
-- `substrate` — an object with kebab-case surface keys (`local-machine`, `ci-runners`,
+- `budget_posture`. `free` | `paid-opt-in`;
+- `substrate`, an object with kebab-case surface keys (`local-machine`, `ci-runners`,
   `self-run-infrastructure`), boolean values.
 
 The same file name is the shape at EVERY layer: the user-global layer is
 `~/.claude/autonomy/binding.json`, the project layer `.claude/autonomy/binding.json`, and
 each layer's personal overlay `binding.local.json` beside it. The project file is tracked
 (team-shared); recommend the consumer `.gitignore` line: `.claude/autonomy/**/*.local.*`.
-Layers resolve per the binding-seam ladder — user-global → org binding (when pointed) →
-project → local overlay — additively. Capability slices (like telemetry below) add their
+Layers resolve per the binding-seam ladder. User-global → org binding (when pointed) →
+project → local overlay. Additively. Capability slices (like telemetry below) add their
 sections ADDITIVELY under their slice name: a binding without a slice's section is valid
 (absent-section tolerance) and no schema major bump is needed for an additive section.
 
@@ -89,7 +89,7 @@ Wires the emitting state of
 for all three execution contexts, discovery-first. Everything lands as reviewable changes;
 paid sinks are advisory + explicit opt-in with cost surfaced first.
 
-1. **Detect an existing observability stack** — interview + repo/env inspection (`OTEL_*`
+1. **Detect an existing observability stack**. Interview + repo/env inspection (`OTEL_*`
    endpoints in settings/env blocks, collector configs, known backend config files). Found →
    wire emission toward it: agent-session env block (settings `env`) and a CI emission snippet
    pointing at the org's endpoint. Paid/hosted stack → advisory with cost surfaced before any
@@ -100,25 +100,25 @@ paid sinks are advisory + explicit opt-in with cost surfaced first.
      directory per run;
    - agent-session signals via the ephemeral per-job collector in the same template (single
      static OSS collector binary + file-exporter config writing JSON-lines into the same
-     artifact directory — per-job, no standing infrastructure);
+     artifact directory. Per-job, no standing infrastructure);
    - interactive sessions get the same coverage: env block toward the discovered stack when
      one exists, else a local collector instance (same binary + config template) exporting
      into a local query-on-read store directory.
    - Cost caveat surfaced on private repos: artifact storage and per-job collector runtime
      draw from metered pools.
-3. **Agent-session wiring (Claude Code specifics)** — `CLAUDE_CODE_ENABLE_TELEMETRY=1`,
+3. **Agent-session wiring (Claude Code specifics)**. `CLAUDE_CODE_ENABLE_TELEMETRY=1`,
    per-signal `OTEL_*_EXPORTER` values, and for work-item-dispatched sessions
    `OTEL_RESOURCE_ATTRIBUTES` carrying `autonomy.work_item.url=<canonical item URL>` (the
-   vendor attaches resource attributes to every metric datapoint and event — verified against
+   vendor attaches resource attributes to every metric datapoint and event. Verified against
    the official monitoring doc). Headless `-p` sessions inherit `TRACEPARENT`/`TRACESTATE`
-   from the environment only under the enhanced-telemetry beta — the default surface starts
-   a fresh root and joins query-side via the resource attribute (verified empirically) — and
+   from the environment only under the enhanced-telemetry beta, the default surface starts
+   a fresh root and joins query-side via the resource attribute (verified empirically). And
    interactive sessions deliberately ignore inbound trace context. Traces stay beta behind
    `CLAUDE_CODE_ENHANCED_TELEMETRY_BETA=1`; the slice treats spans as optional and never
    depends on beta span shapes.
-4. **Record the binding** — sink class, endpoint or artifact path, and the semconv pin land
+4. **Record the binding**. Sink class, endpoint or artifact path, and the semconv pin land
    as the `telemetry` section of the schema-versioned binding.
-5. **Conformance** — run
+5. **Conformance**. Run
    [`scripts/check-emission-conformance.mjs`](scripts/check-emission-conformance.mjs) against
    produced OTLP JSON-lines to verify the pinned `schemaUrl` and the join attribute before
    declaring the emitting state reached.
@@ -155,26 +155,26 @@ splits policy into. This section owns resolution; the [guardrail slice below](#g
 (detect → bind → live-validate → fail-closed) is the action that produces the security binding
 this order resolves.
 
-**Two-surface split.** Security-sensitive guardrail axes — isolation bindings with their
+**Two-surface split.** Security-sensitive guardrail axes. Isolation bindings with their
 runtime markers, merge policy, verification blocking knobs, per-class verification
 topology, promotion state, escalation
-routes, admission rules and caps — bind ONLY in the security binding document in the
+routes, admission rules and caps. Bind ONLY in the security binding document in the
 settings-as-code home, outside the blast radius of the agents it governs. Its schema is
 contract-owned and ships at
 [`schemas/guardrails-security-binding.schema.json`](schemas/guardrails-security-binding.schema.json);
 [`scripts/check-security-binding.mjs`](scripts/check-security-binding.mjs) validates a
 document (schema shape + the semantic rules the schema cannot express) and, with
 `--evidence`, resolves each promotion cell's EFFECTIVE state against a promotion-evidence
-source — the bound state is a ceiling contrary evidence lowers without writing the
+source, the bound state is a ceiling contrary evidence lowers without writing the
 binding. Non-security axes remap in the additive `guardrails` section of the repo-local
 binding: class→label strings (which local label means which work class) and
-cost-tier→model names — vocabulary remaps only, never policy content.
+cost-tier→model names. Vocabulary remaps only, never policy content.
 
 **A third home that is not a governance surface.** Two axes of the
 [verification-topology leaf](${CLAUDE_PLUGIN_ROOT}/reference/guardrails/verification-topology.md)
 bind in this plugin's `userConfig` rather than either governance surface: the verification lens
-pool, and whether the advisory visual narration lane runs. Neither counts anything — the pool
-contributes to no floor, and the narration lane has no security-binding cell at all — so neither can
+pool, and whether the advisory visual narration lane runs. Neither counts anything, the pool
+contributes to no floor, and the narration lane has no security-binding cell at all, so neither can
 weaken a floor, which is what lets them sit on an operator surface. Plugin options resolve from
 user, `--settings`, and managed settings only; a watched repository's own `.claude/settings.json` is
 not read for them, so a repo cannot dial its own verification. The slice proposes neither as a
@@ -187,22 +187,22 @@ security axis.
 
 **Security-binding locator registry.** When settings-as-code is a separate repository,
 the org-policy home carries the repo→security-binding-document registry the dispatch seam
-resolves each repository's security binding through — one registry, resolvable per repo,
+resolves each repository's security binding through. One registry, resolvable per repo,
 on the org governance surface.
 
 **Agent-unwritable bootstrap for security resolution.** The repo-local `org_policy_home`
-pointer is tolerable for non-security defaults only — a repo-writable pointer would let
+pointer is tolerable for non-security defaults only, a repo-writable pointer would let
 an agent redirect the whole chain to a forged policy repository carrying a forged
 registry, binding, and matching runtime markers. For SECURITY resolution the seam pins
 the org-policy-home identity from an agent-unwritable bootstrap: org-level platform
 configuration outside repo blast radius (an org-level setting or variable repo agents
 cannot write) or the executor's trusted deployment config. Any security resolution that
-would depend on a repo-writable pointer — or an unresolvable locator — fail-closes
+would depend on a repo-writable pointer, or an unresolvable locator, fail-closes
 autonomous dispatch, naming the compliant path (pin the home in org-level configuration
 or the executor's deployment config).
 
-**Fail-closed.** An absent or invalid security binding blocks autonomous dispatch —
-every signal enqueues human-gated. Documented defaults exist only for non-security axes;
+**Fail-closed.** An absent or invalid security binding blocks autonomous dispatch.
+Every signal enqueues human-gated. Documented defaults exist only for non-security axes;
 no security axis ever resolves from a documented default or a repo-local surface.
 
 ## Guardrail slice
@@ -215,40 +215,40 @@ produces the security binding it resolves. Everything lands as reviewable change
 SKUs are advisory + explicit opt-in with cost surfaced.
 
 **This slice PREPARES, never writes the security surface directly.** The security binding lives
-in the settings-as-code home, outside the blast radius of the agents it governs — a surface the
+in the settings-as-code home, outside the blast radius of the agents it governs, a surface the
 running agent cannot write (that is the whole point of the split). So the slice produces the
 binding document and its locator-registry entry as REVIEWABLE CHANGES a human lands on the
 governance surface (a proposed change on the settings-as-code home, a registry entry on the
-org-policy home) — it never mutates the agent-unwritable surface in place. Nothing autonomous
+org-policy home). It never mutates the agent-unwritable surface in place. Nothing autonomous
 depends on the binding until that human-landed change exists.
 
-1. **Detect substrates per level per machine surface** — for each execution surface the
+1. **Detect substrates per level per machine surface**. For each execution surface the
    trigger/dispatch slice recorded (the same surface ids the security binding's
    `isolation_bindings` key on), inspect what isolation substrates are available at each ladder
    level per the [isolation-ladder leaf](${CLAUDE_PLUGIN_ROOT}/reference/guardrails/isolation-ladder.md):
    an `L2` whole-process OS-sandbox wrap or default-deny-egress container, an `L3` kernel-separated
-   VM/microVM or hosted ephemeral executor. Detection is PER SURFACE — a substrate present on one
+   VM/microVM or hosted ephemeral executor. Detection is PER SURFACE, a substrate present on one
    surface says nothing about another, and the flat "some surface has L2" answer never satisfies a
    different dispatch surface.
-2. **Detect-diff-reconcile against existing guardrail surfaces** — never greenfield-assume, never
+2. **Detect-diff-reconcile against existing guardrail surfaces**, never greenfield-assume, never
    silently overwrite. Before proposing any binding value, read the org's EXISTING guardrail
-   surfaces — sandbox/runner configurations, branch protections, review workflows and scanner
-   configuration — and DIFF the detected state against them. Where an existing surface already
+   surfaces. Sandbox/runner configurations, branch protections, review workflows and scanner
+   configuration, and DIFF the detected state against them. Where an existing surface already
    encodes a policy (a branch protection rule, a configured scanner, an isolation setting), the
    slice reconciles: it surfaces the diff and proposes the binding that matches or tightens the
    existing surface, and it never overwrites an existing surface as a side effect of binding. A
    pre-existing surface is authoritative input to reconcile against, not a blank field to fill.
-3. **Live-validate BEFORE recording** — the empirical probe per substrate class (recipe in
+3. **Live-validate BEFORE recording**, the empirical probe per substrate class (recipe in
    [`templates/isolation-probe.md`](templates/isolation-probe.md)). A candidate `L2`/`L3`
    substrate is validated by running, INSIDE the boundary, three probes that MUST all fail:
-   - a **denied-egress smoke test** — a network fetch MUST fail against two well-known external
+   - a **denied-egress smoke test**, a network fetch MUST fail against two well-known external
      hosts under different operators AND against every destination the level binding ratifies as
      component-reachable (a boundary that lets egress through is not an `L2` boundary, and a probe
      that samples only what the base policy denies never looks where an installed component may
      already have widened it);
-   - a **host-credential-path read attempt** — a read of a host credential path MUST be absent or
+   - a **host-credential-path read attempt**, a read of a host credential path MUST be absent or
      denied (a boundary that leaks host secrets is not an `L2` boundary);
-   - a **workspace host-write containment check** — randomized canaries written inside MUST all be
+   - a **workspace host-write containment check**. Randomized canaries written inside MUST all be
      absent on the host after teardown (a boundary the host later executes writes from is not an
      `L2` boundary).
 
@@ -258,69 +258,69 @@ depends on the binding until that human-landed change exists.
    local/private/encoded/special-use deny lists). Each host credential path checks against
    `--credential-roots <path,...>` DENY-BY-DEFAULT: a filesystem credential entry proves absence only
    when its recorded host-side expansion resolves under a configured trusted root, and with no roots
-   configured every filesystem credential entry is untrusted and the level fails closed — a
+   configured every filesystem credential entry is untrusted and the level fails closed. A
    cloud-metadata-endpoint route and a well-known credential env token stay bounded closed sets that
    need no allowlist. The allowlist SHAPE (that these seams exist, and their schema) is a
    repo-committed convention; the host-secret-sensitive root VALUES, which reveal where an org's
    credentials live, bind per the deployment's secret-binding classification (a machine/userConfig
    binding), never inlined into the committed binding document.
 
-   Only when the probe transcript proves ALL THREE failures — denied egress, absent host credentials,
-   and contained workspace host-writes — does the binding for that level on that
+   Only when the probe transcript proves ALL THREE failures. Denied egress, absent host credentials,
+   and contained workspace host-writes. Does the binding for that level on that
    surface land; the transcript's reference is recorded in the level binding's `probe_evidence`
-   field (schema-required — a binding without probe evidence is invalid per
+   field (schema-required, a binding without probe evidence is invalid per
    [`scripts/check-security-binding.mjs`](scripts/check-security-binding.mjs)). A binding never
    lands ahead of the probe that proves its boundary.
-4. **Bind level → substrate per surface** — record each validated substrate under its surface in
+4. **Bind level → substrate per surface**. Record each validated substrate under its surface in
    `isolation_bindings` (surface id → level token → substrate instance + the human-ratified
    `substrate_class` and `component_reachable_hosts` + `probe_evidence` + the non-forgeable
    `runtime_markers` the dispatch seam attests against), plus the merge policy,
    verification-blocking knobs, each class's `verification_topology`, escalation routes, and
-   admission rules and caps — all on the
+   admission rules and caps. All on the
    prepared security-binding change, validated by
    [`scripts/check-security-binding.mjs`](scripts/check-security-binding.mjs) against
    [`schemas/guardrails-security-binding.schema.json`](schemas/guardrails-security-binding.schema.json)
    before it is proposed.
-   The lens pool and the advisory visual narration lane are NOT binding fields — they resolve from
+   The lens pool and the advisory visual narration lane are NOT binding fields. They resolve from
    plugin `userConfig` per the [third home above](#guardrail-binding-resolution), and proposing
    either here is invalid.
-5. **Security-review wiring folds in here (no separate capability)** — the security-review policy
+5. **Security-review wiring folds in here (no separate capability)**, the security-review policy
    is one part of this single guardrail slice, never a near-duplicate setup capability. Wire the
    [security-review leaf's](${CLAUDE_PLUGIN_ROOT}/reference/guardrails/security-review.md) two
    layers (deterministic scanners + AI security review) into the binding's `verification_blocking`
    knobs, detect-diff-reconciling against the org's existing scanners, review workflows, and branch
-   protections. Free-path scanner classes satisfy every blocking obligation on the DEFAULT path —
+   protections. Free-path scanner classes satisfy every blocking obligation on the DEFAULT path:
    zero paid dependencies. Entitlement-gated paid code-scanning SKUs stay advisory + explicit
    opt-in with cost surfaced at opt-in time; an entitlement gap routes the tool to the advisory
    path, never silently passing a blocking layer.
-6. **Fail-closed verify** — when NO substrate on a surface reaches the `L2` floor, autonomous
+6. **Fail-closed verify**, when NO substrate on a surface reaches the `L2` floor, autonomous
    dispatch is BLOCKED for that surface and the slice names the compliant paths (provision an
    `L2`-capable substrate on the surface, or route the surface's work to a surface that has one,
    or keep the surface human-gated). Silent degrade to a lower level is never conforming. Under
    `dispatch_posture: human-gated-only` a surface with no `L2` binding is the org's DECLARED
-   posture, not a defect — the verify reports blocked autonomous dispatch as declared, and the
+   posture, not a defect, the verify reports blocked autonomous dispatch as declared, and the
    binding still validates.
 
 ## Routine slice
 
 Wires the standing-routine state of the
 [routine catalog](${CLAUDE_PLUGIN_ROOT}/reference/routines.md): a routine is a scheduled
-`temporal`-class signal adapter behind the governed queue — never a private execution or merge
+`temporal`-class signal adapter behind the governed queue, never a private execution or merge
 path. This slice is discovery-first and detect-diff-reconciles against the org's EXISTING
 schedulers and bots. Everything free lands as reviewable changes; paid or preview scheduling
 surfaces are advisory + explicit opt-in with cost surfaced. Like the
-[guardrail slice](#guardrail-slice) it PREPARES the security surface, never writes it — a
+[guardrail slice](#guardrail-slice) it PREPARES the security surface, never writes it. A
 routine's work-class mapping is admission data proposed as a reviewable change on the
 settings-as-code home, and nothing dispatches autonomously until a human lands it.
 
 **Routine identity.** A routine is addressed by its IDENTITY: the bare `<class-token>` for a
 single-posture class, or `<class-token>/<posture-token>` (kebab-case segments) for a
-multi-posture class whose catalog leaf defines more than one work-class posture — e.g.
+multi-posture class whose catalog leaf defines more than one work-class posture, e.g.
 `doc-freshness-sweep/advisory` and `doc-freshness-sweep/docs-change`,
 `ci-health-review/advisory` and `ci-health-review/ci-config-change`,
 `dependency-update-wave/mechanical` and `dependency-update-wave/changelog-informed` (the
 canonical posture tokens live in the catalog leaves). A multi-posture class binds PER-POSTURE
-identities, never its bare token — each posture is a distinct work class and therefore a distinct
+identities, never its bare token. Each posture is a distinct work class and therefore a distinct
 identity on a distinct emitting surface. The handler serializes its identity as the envelope's
 `signal.routine`, and its platform-attested producer as `signal.producer_identity`, required on
 every routine-fired temporal signal.
@@ -328,23 +328,22 @@ every routine-fired temporal signal.
 **Binding-home split by governance sensitivity (the guardrail contract's split).** A routine's
 `signal.work_class` is stamped, per
 [`${CLAUDE_PLUGIN_ROOT}/reference/trigger-dispatch.md`](${CLAUDE_PLUGIN_ROOT}/reference/trigger-dispatch.md)'s
-classification rules, from the PROTECTED identity↔surface association the security binding homes —
-NOT from the `--routine` argument, the scheduled workflow file, or the emitted `signal.raw_link`,
+classification rules, from the PROTECTED identity↔surface association the security binding homes. NOT from the `--routine` argument, the scheduled workflow file, or the emitted `signal.raw_link`,
 all of which are CLAIMS an agent-writable job could forge and are never trust anchors. That
 association is ADMISSION data: it binds ONLY in the security binding's
 `admission.classification.temporal` home
 ([`schemas/guardrails-security-binding.schema.json`](schemas/guardrails-security-binding.schema.json)),
-on the settings-as-code home outside the agents' blast radius — for reconciled existing bots
+on the settings-as-code home outside the agents' blast radius. For reconciled existing bots
 exactly as for freshly wired routines. Each entry is keyed by routine identity and carries
 `{"class": "C1"–"C5", "source_surface": "<surfaces-map id>", "run_link_prefix": "<prefix>",
 "producer_identity": "<platform-attested producer ref>"}`: the class the identity's signals
 stamp, the one scheduling surface permitted to emit them, the run permalink namespace ratified
-for that surface — a platform run URL prefix (`https://…`) for a `ci-cron` surface, or a durable
-`file:` or artifact-store URI prefix for a `local-scheduler` surface (weaker authority — a
+for that surface, a platform run URL prefix (`https://…`) for a `ci-cron` surface, or a durable
+`file:` or artifact-store URI prefix for a `local-scheduler` surface (weaker authority. A
 developer-machine run record or the org's artifact store), which may be repo-scoped and SHARED
-across the repo's schedules rather than disjoint per entry — AND the `producer_identity`, the
+across the repo's schedules rather than disjoint per entry, AND the `producer_identity`, the
 platform-attested workflow-file or scheduler-unit reference that pins WHICH schedule fired within
-that namespace. **One identity per emitting surface** — no two `classification.temporal` entries
+that namespace. **One identity per emitting surface**. No two `classification.temporal` entries
 may share a `source_surface`, and **producer identities are unique across entries**, so the
 producer the platform attests (through the execution-surface attestation and the signal's raw
 link and producer reference) is bound to exactly ONE identity. Admission validates the envelope's `(signal.routine, resolved source surface)` pair
@@ -353,72 +352,72 @@ the attested `signal.producer_identity` equals the entry's ratified `producer_id
 stamping `signal.work_class`; an absent entry, a `source_surface` that does not equal the attested
 surface, a raw link outside the ratified prefix, or a producer identity that does not match is
 fail-closed human-gated. A swapped `--routine` selector therefore cannot launder high-risk work as
-a benign class — claiming a different identity resolves to THAT identity's own surface and
+a benign class. Claiming a different identity resolves to THAT identity's own surface and
 producer, which the platform-attested producer will not match (a shared run-link namespace no
 longer distinguishes schedules on its own). A repo-local class source would be the precise agent-writable bypass
-the trigger contract's classification obligation forbids. The NON-security keys — cadence,
-enablement, surface choice — are the ONLY routine data that lands repo-local: they go in the
+the trigger contract's classification obligation forbids. The NON-security keys, cadence,
+enablement, surface choice, are the ONLY routine data that lands repo-local: they go in the
 additive `routines` section of the repo-local autonomy binding under `.claude/autonomy/` (the same
 artifact the `triggers` section lives in), NEVER in the security binding, whose schema carries only
 the `admission.classification.temporal` entries. Two artifacts, two validators; the security axis
 resolves from the security binding always, non-security refinement repo-local, per the guardrail
 resolution order.
 
-1. **Discover scheduling surfaces + budget posture** — interview and inspect which scheduling
+1. **Discover scheduling surfaces + budget posture**. Interview and inspect which scheduling
    surfaces this org has: CI-cron on the CI-orchestration home, a developer-machine scheduler,
    self-run infrastructure, a vendor-hosted preview scheduler (marked examples, not a closed
-   list — research the live surfaces at setup time, never from this doc; preview schedulers are
+   list. Research the live surfaces at setup time, never from this doc; preview schedulers are
    moving targets). Record each surface's transport (`poll`, or `push-lifecycle` where the
-   surface renews subscriptions) and its `scheduler_class` — the closed discriminator the
+   surface renews subscriptions) and its `scheduler_class`, the closed discriminator the
    signal-envelope check branches on: `ci-cron` where the surface issues an https run permalink,
    `local-scheduler` where it does not (a durable `file:`/artifact URI stands in). Per-org
    absence of a surface is a binding outcome, never a blocker; budget posture defaults `free`.
-2. **Detect-diff-reconcile existing schedulers and bots** — before wiring anything, read what
+2. **Detect-diff-reconcile existing schedulers and bots**, before wiring anything, read what
    already runs: org schedulers, dependency bots, scheduled scanners, existing cron. A live
    agent-judgment bot (a dependency-update bot, a triage bot) IS an instance of a catalog routine
    class, not a rival mechanism: record it in the binding under its routine identity
    (posture-qualified for a multi-posture class) and its surface, reconcile its cadence, and NEVER
    stand up a second mechanism for the same concern. The
-   no-agent-session rule holds through reconciliation — a wholly deterministic scheduled check is
+   no-agent-session rule holds through reconciliation, a wholly deterministic scheduled check is
    not a routine and keeps running with no agent session, filing work items through the trigger
    adapters; only its judgment-bearing successor, where one exists, is the routine, and a hybrid
    class (e.g. `dependency-update-wave`) reconciles as its split: detection half judgment-free,
    judgment half the routine. A stale or duplicate bot is surfaced as the diff and reconciled,
    never silently overwritten.
-3. **Wire free defaults as reviewable changes** — for each enabled routine on a free surface the
+3. **Wire free defaults as reviewable changes**. For each enabled routine on a free surface the
    wiring is reviewable changes across role homes, never one agent-written file:
    - the CI-cron handler shape from
      [`templates/routine-definitions.md`](templates/routine-definitions.md) lands on the
      CI-orchestration home (the scheduled job that emits the routine's `temporal` signal into the
      queue);
-   - the enabling settings — which routine identities are on, at what cadence, on which surface —
+   - the enabling settings, which routine identities are on, at what cadence, on which surface,
      land as the `routines` section of the repo-local autonomy binding under `.claude/autonomy/`
      (the same artifact as the `triggers` section);
-   - the protected identity↔surface association — each routine identity →
+   - the protected identity↔surface association, each routine identity →
      `{class, source_surface, run_link_prefix, producer_identity}`, one entry per identity, no two
-     sharing a surface and no two sharing a `producer_identity` —
-     lands as the `admission.classification.temporal` change PREPARED for the security binding on
+     sharing a surface and no two sharing a `producer_identity`, lands as the
+     `admission.classification.temporal` change PREPARED for the security binding on
      the settings-as-code home (a separate artifact from the autonomy binding above).
 
    Every shape enqueues through the trigger contract's `temporal` adapter and the one dispatch
    entrypoint; no routine executes work in its own handler and no second scheduling path is
    created.
-4. **Advise paid/preview surfaces** — a vendor-hosted or preview scheduler that carries a
+4. **Advise paid/preview surfaces**, a vendor-hosted or preview scheduler that carries a
    plan/seat cost is advisory + explicit opt-in, cost surfaced first, never the default path. An
    entitlement gap routes the surface to the advisory step; the free CI-cron/local-scheduler floor
    covers the default path with zero paid dependencies.
-5. **Record the binding** — the `routines` section of the repo-local autonomy binding under
-   `.claude/autonomy/` (additive, absent-section tolerance, no major bump — the SAME artifact and
+5. **Record the binding**, the `routines` section of the repo-local autonomy binding under
+   `.claude/autonomy/` (additive, absent-section tolerance, no major bump, the SAME artifact and
    shape as the `triggers` section), NON-security keys only. This section NEVER enters the security
    binding; the ratified `admission.classification.temporal` entries are a separate artifact under
    the security schema and checker.
 
    | Key | Value |
    |---|---|
-   | `surfaces` | object keyed by scheduling-surface id, the SAME shape the [trigger slice](#triggerdispatch-slice)'s `surfaces` map uses (`{"class": "temporal", "transport": "poll"\|"push-lifecycle", "scheduler_class": "ci-cron"\|"local-scheduler", "execution_surface": "<recorded id>"}`; a `local-scheduler` surface using an org artifact store also declares `artifact_schemes`). Record a surface here ONLY when the trigger slice has not already recorded it — [`scripts/check-signal-envelope.mjs`](scripts/check-signal-envelope.mjs)'s resolver merges every section's `surfaces` map and refuses an id recorded in two sections as ambiguous; a routine riding an already-recorded surface REFERENCES its id, it does not re-declare it |
-   | `enabled` | object keyed by the FULL routine identity (`<class-token>` or `<class-token>/<posture-token>`) — each entry `{"source_surface": "<surfaces-map id>", "cadence": "<schedule expression or token>", "enabled": <bool>}`; cadence, enablement, and surface choice ONLY. Its `source_surface` MUST agree with the same identity's `source_surface` in the security binding's `admission.classification.temporal` — binding review and the envelope checker catch drift. The class, its `run_link_prefix`, and its `producer_identity` are NOT here; an identity with no protected classification entry, or one whose surface disagrees, stays unclassified and fail-closed human-gated |
+   | `surfaces` | object keyed by scheduling-surface id, the SAME shape the [trigger slice](#triggerdispatch-slice)'s `surfaces` map uses (`{"class": "temporal", "transport": "poll"\|"push-lifecycle", "scheduler_class": "ci-cron"\|"local-scheduler", "execution_surface": "<recorded id>"}`; a `local-scheduler` surface using an org artifact store also declares `artifact_schemes`). Record a surface here ONLY when the trigger slice has not already recorded it. [`scripts/check-signal-envelope.mjs`](scripts/check-signal-envelope.mjs)'s resolver merges every section's `surfaces` map and refuses an id recorded in two sections as ambiguous; a routine riding an already-recorded surface REFERENCES its id, it does not re-declare it |
+   | `enabled` | object keyed by the FULL routine identity (`<class-token>` or `<class-token>/<posture-token>`). Each entry `{"source_surface": "<surfaces-map id>", "cadence": "<schedule expression or token>", "enabled": <bool>}`; cadence, enablement, and surface choice ONLY. Its `source_surface` MUST agree with the same identity's `source_surface` in the security binding's `admission.classification.temporal`. Binding review and the envelope checker catch drift. The class, its `run_link_prefix`, and its `producer_identity` are NOT here; an identity with no protected classification entry, or one whose surface disagrees, stays unclassified and fail-closed human-gated |
 
-6. **Conformance** — the wired state is reached when
+6. **Conformance**, the wired state is reached when
    [`scripts/check-signal-envelope.mjs`](scripts/check-signal-envelope.mjs), run with BOTH
    `--binding` at the repo-local autonomy binding (the `routines`/`triggers` surfaces) AND
    `--security-binding` at the security binding (the `admission.classification.temporal` entries),
@@ -439,16 +438,16 @@ Detail lives in
 
 **Liveness.** The slice `check` is an engine health-check surface: it invokes
 [`scripts/resolve-prerequisites.mjs`](scripts/resolve-prerequisites.mjs) end-to-end and
-fails loud on internal failure — never a verdict-shaped fallback.
+fails loud on internal failure, never a verdict-shaped fallback.
 
-1. **`check`** — for each scheduling surface already recorded under `triggers` / `routines`
+1. **`check`**. For each scheduling surface already recorded under `triggers` / `routines`
    (this slice declares no `surfaces` map of its own), report per-identity verdicts with
    provenance via
    [`scripts/check-prerequisite-resolution.mjs`](scripts/check-prerequisite-resolution.mjs).
    A bare repo yields `unsupported` / `unknown` for every identity, never an error.
-2. **`apply`** — detect-diff-reconcile against existing `prerequisite_resolution`
+2. **`apply`**. Detect-diff-reconcile against existing `prerequisite_resolution`
    declarations; a declaration contradicting a ran-negative probe is a finding (identity
-   stays negative while the finding is open — ADR 0011 Decision 2). The prose-context pass
+   stays negative while the finding is open. ADR 0011 Decision 2). The prose-context pass
    reads `CLAUDE.md` / `AGENTS.md` (session-reachable only by reference) / `README` to
    *propose* declarations into **non-security keys only**; the human ratifies; the slice
    writes the additive section (`surface_refs` + `declarations`, no `surfaces` map).
@@ -463,11 +462,11 @@ fails loud on internal failure — never a verdict-shaped fallback.
 
 The [runner design pack](${CLAUDE_PLUGIN_ROOT}/reference/runner.md) is bindable-when-born:
 until a build trigger fires and the runner-execution home is born, setup records NOTHING
-runner-specific — no probe, no wiring, no binding section for the unborn home. The single
+runner-specific. No probe, no wiring, no binding section for the unborn home. The single
 exception is escalation notification routes, which already home on the security surface: the
 severity axis (`notice`/`attention`/`urgent`) and the personal-push tier are prepared as route
 options through the security binding's `escalation_severity`, `escalation_severity_routes`, and
-`escalation_ack` keys — a reviewable change on the settings-as-code home like every other
+`escalation_ack` keys, a reviewable change on the settings-as-code home like every other
 security axis, never repo-local. The route set, its two-step severity resolution, and the
 per-class default severities are specified by the
 [runner escalation leaf](${CLAUDE_PLUGIN_ROOT}/reference/runner/escalation.md); this note points
@@ -475,21 +474,21 @@ there rather than restating them.
 
 ## Gotchas
 
-Editing- and run-time failure modes — the two-binding split (repo-local autonomy binding vs the
+Editing- and run-time failure modes, the two-binding split (repo-local autonomy binding vs the
 separate security binding), the spell gate splitting coined hyphenated compounds, and a scheduling
-surface recorded in two `surfaces` maps resolving as ambiguous — are catalogued in
+surface recorded in two `surfaces` maps resolving as ambiguous, are catalogued in
 [`context/gotchas.md`](context/gotchas.md).
 
 ## What this skill does NOT do
 
-- Wire capability slices that have not shipped yet — each lands with its own work package and
+- Wire capability slices that have not shipped yet. Each lands with its own work package and
   extends this skill (the runner charter execution pack remains the next such slice after
   prerequisite-resolution).
-- Estimate, impute, or backfill the two human-attested return fields — ever.
+- Estimate, impute, or backfill the two human-attested return fields. Ever.
 - Write the plugin cache, Claude Code user settings, or `pluginConfigs`, per the uniform setup
   contract (`docs/PLUGIN-PHILOSOPHY.md` "Setup is explicit and repeatable" in the marketplace
   repository). Nor platform settings.
-- Assume the shape of any particular org or fleet — a run against an unknown repo asks or
+- Assume the shape of any particular org or fleet, a run against an unknown repo asks or
   defaults; it never guesses silently.
-- Recommend or privilege any observability vendor — sink classes only; the deployment picks
+- Recommend or privilege any observability vendor. Sink classes only; the deployment picks
   instances.

--- a/plugins/autonomy/skills/setup/SKILL.md
+++ b/plugins/autonomy/skills/setup/SKILL.md
@@ -34,7 +34,7 @@ it cannot infer, and every landed change is reviewable per
 
 | Argument | Values | Headless default |
 |---|---|---|
-| action | `check` \| `apply` |. (required) |
+| action | `check` \| `apply` | (required) |
 | `--org-policy-home` | repository locator, optionally `#<path>` to the binding document \| `none` | `none` |
 | `--budget-posture` | `free` \| `paid-opt-in` | `free` |
 
@@ -265,9 +265,9 @@ depends on the binding until that human-landed change exists.
    credentials live, bind per the deployment's secret-binding classification (a machine/userConfig
    binding), never inlined into the committed binding document.
 
-   Only when the probe transcript proves ALL THREE failures. Denied egress, absent host credentials,
-   and contained workspace host-writes. Does the binding for that level on that
-   surface land; the transcript's reference is recorded in the level binding's `probe_evidence`
+   The binding for that level on that surface lands only when the probe transcript proves ALL
+   THREE failures: denied egress, absent host credentials, and contained workspace host-writes;
+   the transcript's reference is recorded in the level binding's `probe_evidence`
    field (schema-required, a binding without probe evidence is invalid per
    [`scripts/check-security-binding.mjs`](scripts/check-security-binding.mjs)). A binding never
    lands ahead of the probe that proves its boundary.


### PR DESCRIPTION
No linked issue

## Summary

#2891 instruction-surface de-slop cluster: purge em dashes from the `autonomy` plugin README and every SKILL.md.

## Fix

Rewrote `plugins/autonomy/README.md` and every `plugins/autonomy/**/SKILL.md` under `/ai-slop:audit fix` semantics (periods, commas, or a restructured sentence; never parentheses, en dashes, or a spaced hyphen as a stand-in). Meaning-preserving self-audit repaired asides the first pass reattached to the wrong noun. The generated options block is ignore-fenced because the shared generator still emits em dashes. `autonomy` 0.22.8.

## Verification

- Detector: 0 `rule-em-dash` findings outside ignore-fenced generated-options spans (and required trigger strings that must keep em dashes)
- `CHECK_SKILL_SKIP_MARKDOWNLINT=1 bash scripts/check-changed-skills.sh origin/main`: 0 failed; quoted trigger phrases vs origin/main preserved
- `python3 scripts/sync-plugin-options-docs.py --check` up to date
- `scripts/check-changelog-parity.sh --check-bump origin/main` passes
- `node scripts/generate-cheatsheet.mjs --check` in sync

## Related

Refs #2891

#2891 stays open.