### PR TITLE
docs(testing): de-slop instruction surfaces (0.7.6)

### DIFF
--- a/docs/SKILL-CHEAT-SHEET.md
+++ b/docs/SKILL-CHEAT-SHEET.md
@@ -93,8 +93,8 @@ owned by [docs/CATALOG-TAXONOMY.md](CATALOG-TAXONOMY.md).
 | [`/mutation-testing:principles`](../plugins/mutation-testing/skills/principles/SKILL.md) | `mutation-testing` | Answer mutation-testing questions from the primary literature |
 | [`/playwright:playwright`](../plugins/playwright/skills/playwright/SKILL.md) | `playwright` | Live E2E browser automation with disk-written artifacts |
 | [`/tdd:principles`](../plugins/tdd/skills/principles/SKILL.md) | `tdd` | Answer test design questions from authoritative TDD sources |
-| [`/testing:audit`](../plugins/testing/skills/audit/SKILL.md) | `testing` | Detect tests that cannot fail — report, gate, or persist |
-| [`/testing:diagnose`](../plugins/testing/skills/diagnose/SKILL.md) | `testing` | Root-cause failing tests — never retry blindly |
+| [`/testing:audit`](../plugins/testing/skills/audit/SKILL.md) | `testing` | Detect tests that cannot fail. Report, gate, or persist |
+| [`/testing:diagnose`](../plugins/testing/skills/diagnose/SKILL.md) | `testing` | Root-cause failing tests, never retry blindly |
 | [`/testing:plan`](../plugins/testing/skills/plan/SKILL.md) | `testing` | Classify changes by required test type and coverage gaps |
 | [`/testing:run-e2e`](../plugins/testing/skills/run-e2e/SKILL.md) | `testing` | Start the app, drive real flows, capture evidence |
 | [`/testing:write`](../plugins/testing/skills/write/SKILL.md) | `testing` | Write and place tests with TDD cadence across ecosystems |

--- a/plugins/testing/.claude-plugin/plugin.json
+++ b/plugins/testing/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "testing",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "description": "Test-stage discipline across all ecosystems: coverage-gap analysis and test planning (`/testing:plan`), TDD test authoring and placement (`/testing:write`), live E2E plus non-UI smoke verification (`/testing:run-e2e`), failing-test root-cause diagnosis with the reproduce → isolate → fix → retest loop (`/testing:diagnose`), and a deterministic can't-fail test audit with a fail-closed gate mode and opt-in findings persistence (`/testing:audit`).",
   "author": {
     "name": "Melodic Software",

--- a/plugins/testing/CHANGELOG.md
+++ b/plugins/testing/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to the `testing` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.7.6]
+
+### Changed
+
+- **Instruction-surface de-slop (#2891, testing cluster).** Rewrote this plugin's `README.md` and every
+  `SKILL.md` to drop em dashes under the repo's zero-tolerance house policy, using
+  `/ai-slop:audit fix` semantics: periods or commas, or a restructured sentence, never
+  parentheses, en dashes, or a spaced hyphen as a stand-in. Meaning stays; only the mark
+  and the sentence break change. The generated options block is ignore-fenced because
+  `scripts/sync-plugin-options-docs.py` still emits em dashes from its shared template.
+
 ## [0.7.5]
 
 ### Fixed

--- a/plugins/testing/README.md
+++ b/plugins/testing/README.md
@@ -23,7 +23,7 @@ behavior with tests.
   plugin's `/toolchain:check` when installed and to the project's own test command
   otherwise; TDD design questions route to `/tdd:principles`, browser mechanics to
   `/playwright:playwright`, outcome sign-off to `/verification:confirm`, and the
-  implement loop to `/implementation:implement`. Each used when installed and
+  implement loop to `/implementation:implement`. Each is used when installed and
   substituted with inline guidance or a manual handoff when absent. No step blocks on a
   missing plugin.
 - **Self-contained.** Test-type tables, the E2E evidence contract, the non-UI

--- a/plugins/testing/README.md
+++ b/plugins/testing/README.md
@@ -1,17 +1,17 @@
 # testing
 
-A Claude Code plugin for the **test stage** of a disciplined dev workflow — plan
+A Claude Code plugin for the **test stage** of a disciplined dev workflow. Plan
 what needs testing, author tests at the right level, verify the running app
 end-to-end, and diagnose failures to root cause. Five skills, one concern: proving
 behavior with tests.
 
 | Skill | What it does |
 |---|---|
-| `/testing:plan` | Coverage-gap analysis — classify changed files by required test type, identify gaps, prioritize by regression risk. |
-| `/testing:write` | Test authoring discipline — vertical-slice TDD, test-type selection, naming, placement, fixture patterns, four-pillars assessment. |
-| `/testing:run-e2e` | Live app verification — start the app via the project's orchestrator, drive UI/API flows with token-efficient browser automation, capture evidence; includes a non-UI smoke-test playbook (MCP stdio handshake, shell/PowerShell surfaces). |
-| `/testing:diagnose` | Failing-test diagnosis — failure classification, root-cause analysis (never retry blindly), then the reproduce → isolate → fix → retest → regression loop. |
-| `/testing:audit` | Can't-fail test detection — a deterministic script finds assertion-free bodies, self-identical (recomputed-expectation) assertions, and mock-only oracles across JS/TS, Python, and C#; reports with a coverage denominator, gates fail-closed via `--check`, and opt-in persists findings for a review fix pass. |
+| `/testing:plan` | Coverage-gap analysis. Classify changed files by required test type, identify gaps, prioritize by regression risk. |
+| `/testing:write` | Test authoring discipline. Vertical-slice TDD, test-type selection, naming, placement, fixture patterns, four-pillars assessment. |
+| `/testing:run-e2e` | Live app verification. Start the app via the project's orchestrator, drive UI/API flows with token-efficient browser automation, capture evidence; includes a non-UI smoke-test playbook (MCP stdio handshake, shell/PowerShell surfaces). |
+| `/testing:diagnose` | Failing-test diagnosis. Failure classification, root-cause analysis (never retry blindly), then the reproduce → isolate → fix → retest → regression loop. |
+| `/testing:audit` | Can't-fail test detection, a deterministic script finds assertion-free bodies, self-identical (recomputed-expectation) assertions, and mock-only oracles across JS/TS, Python, and C#; reports with a coverage denominator, gates fail-closed via `--check`, and opt-in persists findings for a review fix pass. |
 
 ## Works in any repo
 
@@ -23,7 +23,7 @@ behavior with tests.
   plugin's `/toolchain:check` when installed and to the project's own test command
   otherwise; TDD design questions route to `/tdd:principles`, browser mechanics to
   `/playwright:playwright`, outcome sign-off to `/verification:confirm`, and the
-  implement loop to `/implementation:implement` — each used when installed and
+  implement loop to `/implementation:implement`. Each used when installed and
   substituted with inline guidance or a manual handoff when absent. No step blocks on a
   missing plugin.
 - **Self-contained.** Test-type tables, the E2E evidence contract, the non-UI
@@ -43,7 +43,7 @@ Test structure and conventions come from your own project's `CLAUDE.md` and rule
 This plugin declares no userConfig options.
 
 `/testing:run-e2e` reads one optional consumer-project config surface,
-`.claude/testing/e2e.md` — `recording` (`video | gif | off`, default `off`) and
+`.claude/testing/e2e.md`. `recording` (`video | gif | off`, default `off`) and
 `browser_mode` (`headed | headless`, default `headless`). Both defaults preserve current
 behavior, so the file is optional. Its keys, defaults, and precedence are documented in
 the skill's bundled `run-e2e/context/e2e-config.md`; it layers per the marketplace

--- a/plugins/testing/skills/audit/SKILL.md
+++ b/plugins/testing/skills/audit/SKILL.md
@@ -1,30 +1,30 @@
 ---
-description: "Audit the test suite for tests that cannot fail — a deterministic script detects assertion-free test bodies, self-identical (recomputed-expectation) assertions, and mock-only oracles across JS/TS, Python, and C#, reports with a coverage denominator, gates fail-closed via --check, and opt-in persists a findings file the review fix pass consumes. Use when: 'audit tests for tautologies', 'find tests that cannot fail', 'assertion-free tests', 'are any of my tests vacuous', 'tautological tests', 'tests pass but prove nothing', 'gate can't-fail tests in CI', 'persist test-audit findings for the fix pass'. Flags: `--check` (exit-code gate), `--strict` (gate mock-only-oracle findings too), `--persist-findings` (write the findings file the review fix pass consumes). Read-only on the suite: findings propose repairs; nothing edits or deletes a test."
+description: "Audit the test suite for tests that cannot fail, a deterministic script detects assertion-free test bodies, self-identical (recomputed-expectation) assertions, and mock-only oracles across JS/TS, Python, and C#, reports with a coverage denominator, gates fail-closed via --check, and opt-in persists a findings file the review fix pass consumes. Use when: 'audit tests for tautologies', 'find tests that cannot fail', 'assertion-free tests', 'are any of my tests vacuous', 'tautological tests', 'tests pass but prove nothing', 'gate can't-fail tests in CI', 'persist test-audit findings for the fix pass'. Flags: `--check` (exit-code gate), `--strict` (gate mock-only-oracle findings too), `--persist-findings` (write the findings file the review fix pass consumes). Read-only on the suite: findings propose repairs; nothing edits or deletes a test."
 argument-hint: "[--check] [--strict] [--persist-findings]"
 user-invocable: true
 disable-model-invocation: false
 metadata:
   workflow-stage: test
-  summary: Detect tests that cannot fail — report, gate, or persist
+  summary: Detect tests that cannot fail. Report, gate, or persist
 ---
 
 ## Purpose
 
 A test that cannot fail is a false coverage claim: it reports green whatever the code does. This
-skill runs a **deterministic script detector** over the suite — no test execution, no judgment in
-membership — and reports every test the rules v1 catch, with a coverage denominator so "no findings"
+skill runs a **deterministic script detector** over the suite. No test execution, no judgment in
+membership, and reports every test the rules v1 catch, with a coverage denominator so "no findings"
 is never confused with "scanned nothing".
 
 Boundaries, each an incumbent this skill deliberately does not duplicate:
 
-- **`mutation-testing:audit`** proves dynamically that tests fail to detect change — it executes
+- **`mutation-testing:audit`** proves dynamically that tests fail to detect change. It executes
   mutants, costs real runtime, and judges survivors. This skill is the static complement: cheap
   AST-level detection of tests that cannot fail *by construction*. Complements, not rivals.
 - **`check-discriminating-test-skips.sh`** (this marketplace repo's own CI gate) owns the fourth
-  can't-fail shape — a skip vacating the only discriminating assertion of a case group — for bash
+  can't-fail shape, a skip vacating the only discriminating assertion of a case group, for bash
   `*.test.sh`. That rule is deliberately absent here; bash test files are out of scope v1.
 - The **repair queue** is out of scope this cycle: findings propose an assertion (repair, not
-  pruning — deleting a useless test removes the false claim and the coverage together); applying
+  pruning. Deleting a useless test removes the false claim and the coverage together); applying
   repairs belongs to the remediation lanes.
 
 ## Rules v1
@@ -35,15 +35,15 @@ states the fired condition in the run's own values.
 | Rule id | Fires when | Threshold | Confidence | Gates `--check` |
 |---|---|---|---|---|
 | `testing/audit/rule-zero-assertion` | a runnable test body contains no assertion token | 0 assertion tokens | `high` | yes |
-| `testing/audit/rule-recomputed-expectation` | an equality assertion's actual and expected sides are the identical expression — the expected value is recomputed by the code under test rather than stated | >= 1 self-identical equality assertion | `high` | yes |
+| `testing/audit/rule-recomputed-expectation` | an equality assertion's actual and expected sides are the identical expression, the expected value is recomputed by the code under test rather than stated | >= 1 self-identical equality assertion | `high` | yes |
 | `testing/audit/rule-mock-only-oracle` | a mock-constructing test whose every assertion is a mock-interaction assertion, none on a real collaborator | 100% of assertions are mock-interaction | omitted | only with `--strict` |
 
 - **`Tier` is looked up from each rule's row in the detector-findings severity crosswalk** (the
-  contract cited under Persisting findings) — IMPORTANT on every row, flat per producer. The
+  contract cited under Persisting findings). IMPORTANT on every row, flat per producer. The
   argument for each mapping lives in the crosswalk row, not here; a per-finding tier choice is
   exactly what the rule-keyed lookup forbids.
 - **`mock-only-oracle` omits `Confidence` and is advisory by default.** The pattern match is certain;
-  its defect-hood is not — deliberate interaction-style (London-school) tests are the known benign
+  its defect-hood is not. Deliberate interaction-style (London-school) tests are the known benign
   case. Per the detector-findings contract the field is `high` or omitted, never `low`.
 - **Detection bias: every heuristic errs toward not firing.** Assertion tokens match generously (a
   helper named `assertValidSum` or `checkInvariant` counts), strings/comments are masked first,
@@ -58,89 +58,89 @@ bash "${CLAUDE_PLUGIN_ROOT}/skills/audit/scripts/cant-fail-scan.sh" --check    #
 bash "${CLAUDE_PLUGIN_ROOT}/skills/audit/scripts/cant-fail-scan.sh" --findings # findings file on stdout
 ```
 
-Scan root: the current repo's git toplevel (or `$CANT_FAIL_SCAN_ROOT` to narrow/point explicitly —
+Scan root: the current repo's git toplevel (or `$CANT_FAIL_SCAN_ROOT` to narrow/point explicitly,
 a supported operator lever). Ecosystems v1: JS/TS (`*.test.*`/`*.spec.*`), Python
 (`test_*.py`/`*_test.py`), C# (`*Test.cs`/`*Tests.cs`).
 
-Present the script's findings and its coverage block as reported — the denominator is what makes a
+Present the script's findings and its coverage block as reported, the denominator is what makes a
 clean report a claim rather than an absence. A run that examined 0 test files says so and is never
 presented as a clean bill.
 
-## Gate mode (`--check`) — fail closed
+## Gate mode (`--check`). Fail closed
 
 The machine-checkable gate the [liveness-assertion contract](https://raw.githubusercontent.com/melodic-software/claude-code-plugins/main/docs/conventions/liveness-assertion/README.md)
 "Core contract" fail-loud limb requires of an advisory surface's gating form:
 
-- exit **1** — a gating rule fired (`zero-assertion`, `recomputed-expectation`; `--strict` adds
+- exit **1**, a gating rule fired (`zero-assertion`, `recomputed-expectation`; `--strict` adds
   `mock-only-oracle`).
-- exit **2** — the scan could not run, could not fully read its inputs (unresolved root, unreadable
-  test files, walk errors), or examined **0 test files** — a wrong or empty scan root and a healthy
+- exit **2**, the scan could not run, could not fully read its inputs (unresolved root, unreadable
+  test files, walk errors), or examined **0 test files**, a wrong or empty scan root and a healthy
   suite must not share an exit code. **An unread input is never a clean one.**
-- exit **0** — only a fully read, finding-free scan of at least one test file.
+- exit **0**. Only a fully read, finding-free scan of at least one test file.
 
 ## Persisting findings (`--persist-findings`)
 
-Bare invocation reports and stops — the `audit` verb's read-only contract. Under the explicit
+Bare invocation reports and stops, the `audit` verb's read-only contract. Under the explicit
 `--persist-findings` override, also write the findings file the `review:fanout` `fix` action
 consumes:
 
-1. **Read the producer contract before the first write** —
+1. **Read the producer contract before the first write**.
    <https://raw.githubusercontent.com/melodic-software/claude-code-plugins/main/docs/conventions/detector-findings/README.md>.
    It owns where the file goes, the producer-computed fields, coexistence, and what a minimal
-   producer may omit. If it cannot be fetched, do not write — report and stop; a guessed destination
+   producer may omit. If it cannot be fetched, do not write. Report and stop; a guessed destination
    reports success while the consumer never scans that path.
 2. Resolve the destination per the contract "Where the file goes": run the **whole rung order**, take
    the **non-interactive collapse** where this context cannot ask or persist config, and honor the
    **self-ignore guard** including its invalid-root rule.
 3. Generate the content with `cant-fail-scan.sh --findings` (it computes `branch:` verbatim from git,
    `date:` at write time, per-rule `Tier`/`Confidence`, repo-relative `Location`, cell escaping, and
-   the `## Surfaces` coverage line; it omits `tier:`, `## By dimension`, and `## Unparsed` — no
+   the `## Surfaces` coverage line; it omits `tier:`, `## By dimension`, and `## Unparsed`. No
    analogue, omit rather than fabricate). Write it to
    `<resolved-dir>/${TS}-cant-fail-tests.md` with `TS="$(date -u +%Y%m%dT%H%M%SZ)"`.
-4. **Never overwrite an existing path** — take `-2`, `-3`… (smallest free integer >= 2).
+4. **Never overwrite an existing path**. Take `-2`, `-3`… (smallest free integer >= 2).
 5. A run that examined test files and found nothing **still persists**: the empty table plus
-   `## Surfaces` is coverage the consumer merges. A run that examined nothing writes nothing — the
+   `## Surfaces` is coverage the consumer merges. A run that examined nothing writes nothing. The
    script already refuses `--findings` there.
 6. **Re-runs write what they currently find; never replay** a previous file's rows.
 
 ## Exemptions
 
 A deliberate case is recorded in-file: `cant-fail-ok: <reason>` on the test's declaration line, the
-line above it, or inside the body — the same recorded-decision shape as the repo gate's
+line above it, or inside the body, the same recorded-decision shape as the repo gate's
 `discriminating-skip-ok`. Exemptions are counted in the coverage block, never silent.
 
 ## What this skill does NOT do
 
 - **Edit, repair, or delete tests.** Findings propose an assertion; the repair itself is the
   remediation lanes' work (`/testing:write` for authoring, the review fix pass for applying).
-- **Execute the suite** — `/toolchain:check` runs tests; `mutation-testing:audit` executes mutants.
-- **Audit bash `*.test.sh`** — the discriminating-skip repo gate owns that shape.
-- **Write anything on bare invocation** — persisting is only ever behind `--persist-findings`.
+- **Execute the suite**. `/toolchain:check` runs tests; `mutation-testing:audit` executes mutants.
+- **Audit bash `*.test.sh`**, the discriminating-skip repo gate owns that shape.
+- **Write anything on bare invocation**. Persisting is only ever behind `--persist-findings`.
 
 ## Gotchas
 
-- **Interaction-style tests trip `mock-only-oracle` by design** — that is why it is advisory in
+- **Interaction-style tests trip `mock-only-oracle` by design**. That is why it is advisory in
   `--check` and carries no `Confidence`. A team that asserts interactions deliberately annotates
   `cant-fail-ok:` or leaves `--strict` off; a team that considers them defects gates with `--strict`.
 - **Generous assertion tokens buy false-negative risk**: a test whose only "assertion" is a helper
   named `checkout()` is suppressed by the `check` token. That is the chosen direction; do not
   tighten the token list to chase recall at precision's expense.
-- **`recomputed-expectation` v1 is the decidable core** — textually identical actual/expected on one
+- **`recomputed-expectation` v1 is the decidable core**. Textually identical actual/expected on one
   line (chains spanning lines are deliberately not matched, and only the first `expect` per line is
   examined). `x = f(a); assert x == f(a)` and C#'s generic `Assert.Equal<T>(a, a)` are the same
   defect and are not yet detected.
-- **The JS regex-literal masker triggers only after an operator or opening delimiter** — never after
+- **The JS regex-literal masker triggers only after an operator or opening delimiter**, never after
   an identifier, so a regex directly after `return` is not masked. Wrongly reading division as a
   regex would mask real code, which is the worse direction. The known cost of that narrow set is a
   premature-block-closure false positive when an unmasked regex after `return` contains a brace
-  (e.g. `return /}/;` inside a test) — `brace_delta` treats the `}` as code and closes the test
+  (e.g. `return /}/;` inside a test). `brace_delta` treats the `}` as code and closes the test
   before later assertions, so `rule-zero-assertion` can fire on a body that still has assertions.
-- **Skips are honored at both levels** — test-level (`it.skip`/`x`-prefixed/`@skip`/`[Fact(Skip=…)]`)
+- **Skips are honored at both levels**. Test-level (`it.skip`/`x`-prefixed/`@skip`/`[Fact(Skip=…)]`)
   and suite-level (<!-- spellchecker:off -->`xdescribe`<!-- spellchecker:on -->/`describe.skip`/`context.skip`/`suite.skip`): a test that does not
   run is not judged.
-- **Fixture corpora under `evals/fixtures/` are pruned** — a detector's planted-defect fixtures are
+- **Fixture corpora under `evals/fixtures/` are pruned**, a detector's planted-defect fixtures are
   not the consumer's defects. Point `$CANT_FAIL_SCAN_ROOT` at one explicitly to scan it.
-- **A platform-skipped assertion is unverified on the platform that skips it** — a green local run is
+- **A platform-skipped assertion is unverified on the platform that skips it**, a green local run is
   not evidence about a case only another platform executes. That is the same defect family this
   detector hunts, approached from the environment side, and it is out of the detector's reach: a
   visible skip is not an assertion-free body. The uncovered axis of the dropped skip rule is

--- a/plugins/testing/skills/audit/SKILL.md
+++ b/plugins/testing/skills/audit/SKILL.md
@@ -11,8 +11,7 @@ metadata:
 ## Purpose
 
 A test that cannot fail is a false coverage claim: it reports green whatever the code does. This
-skill runs a **deterministic script detector** over the suite. No test execution, no judgment in
-membership, and reports every test the rules v1 catch, with a coverage denominator so "no findings"
+skill runs a **deterministic script detector** over the suite. It does not execute tests or judge membership, but reports every test the rules v1 catch, with a coverage denominator so "no findings"
 is never confused with "scanned nothing".
 
 Boundaries, each an incumbent this skill deliberately does not duplicate:
@@ -24,7 +23,7 @@ Boundaries, each an incumbent this skill deliberately does not duplicate:
   can't-fail shape, a skip vacating the only discriminating assertion of a case group, for bash
   `*.test.sh`. That rule is deliberately absent here; bash test files are out of scope v1.
 - The **repair queue** is out of scope this cycle: findings propose an assertion (repair, not
-  pruning. Deleting a useless test removes the false claim and the coverage together); applying
+  pruning: deleting a useless test removes the false claim and the coverage together); applying
   repairs belongs to the remediation lanes.
 
 ## Rules v1

--- a/plugins/testing/skills/diagnose/SKILL.md
+++ b/plugins/testing/skills/diagnose/SKILL.md
@@ -1,12 +1,12 @@
 ---
-description: "Diagnose and fix failing tests — failure classification, root-cause analysis (never retry blindly), then the reproduce → isolate → fix → retest → regression loop. Use when: 'why does this fail', 'this test is failing', 'fix the failing tests', 'why is this test flaky', visible test failures, stack traces, or flaky tests; for authoring new tests use /testing:write, for running the suite /toolchain:check."
+description: "Diagnose and fix failing tests. Failure classification, root-cause analysis (never retry blindly), then the reproduce → isolate → fix → retest → regression loop. Use when: 'why does this fail', 'this test is failing', 'fix the failing tests', 'why is this test flaky', visible test failures, stack traces, or flaky tests; for authoring new tests use /testing:write, for running the suite /toolchain:check."
 argument-hint: "[failure] (e.g., /testing:diagnose, /testing:diagnose the frozen-logger error, /testing:diagnose loop)"
 user-invocable: true
 disable-model-invocation: false
 shell: bash
 metadata:
   workflow-stage: test
-  summary: Root-cause failing tests — never retry blindly
+  summary: Root-cause failing tests, never retry blindly
 ---
 
 ## Pre-computed context
@@ -16,22 +16,22 @@ Working tree status: !`git status --porcelain 2>/dev/null | head -20 || echo "cl
 
 ## Purpose
 
-The failure half of testing: understand WHY a test fails, then prove the fix. Never dismiss a failure, never retry blindly — "probably a timing issue" is not a diagnosis; even intermittent failures have deterministic root causes. Repo-specific shared-state workarounds and framework traps live in the consuming project's testing conventions — consult them before diagnosing.
+The failure half of testing: understand WHY a test fails, then prove the fix. Never dismiss a failure, never retry blindly. "probably a timing issue" is not a diagnosis; even intermittent failures have deterministic root causes. Repo-specific shared-state workarounds and framework traps live in the consuming project's testing conventions. Consult them before diagnosing.
 
 ## Redact
 
-Diagnosis surfaces commands, test output, stack traces, and CI logs. Redact every secret before showing it — write `<REDACTED>` in its place. Reproductions that need credentials read them from env vars, so the secret never lands in a command line, a fixture, or the regression test you commit. Captured output carries auth headers — quote only the lines carrying the diagnostic signal; if that is not enough to diagnose, say so and ask.
+Diagnosis surfaces commands, test output, stack traces, and CI logs. Redact every secret before showing it. Write `<REDACTED>` in its place. Reproductions that need credentials read them from env vars, so the secret never lands in a command line, a fixture, or the regression test you commit. Captured output carries auth headers. Quote only the lines carrying the diagnostic signal; if that is not enough to diagnose, say so and ask.
 
 ## Arguments
 
-`$ARGUMENTS` — optional failure description or `loop` to enter the fix cycle directly for an already-diagnosed bug.
+`$ARGUMENTS`, optional failure description or `loop` to enter the fix cycle directly for an already-diagnosed bug.
 
 ## Step 0: Route
 
 | Signal | Phase | Context file |
 |--------|-------|-------------|
-| Failure needs diagnosis — stack trace, assertion mismatch, flaky test | **investigate** | [context/investigate.md](context/investigate.md) |
-| Root cause known, fix needed — reproduce → isolate → fix → retest → regression | **loop** | [context/loop.md](context/loop.md) |
+| Failure needs diagnosis. Stack trace, assertion mismatch, flaky test | **investigate** | [context/investigate.md](context/investigate.md) |
+| Root cause known, fix needed. Reproduce → isolate → fix → retest → regression | **loop** | [context/loop.md](context/loop.md) |
 
 Default entry is **investigate**; it chains into **loop** once the root cause is found. Read the relevant context file before proceeding.
 
@@ -40,7 +40,7 @@ Default entry is **investigate**; it chains into **loop** once the root cause is
 | After phase | Suggest |
 |-------------|---------|
 | `investigate` | Enter the `loop` phase if a fix is needed, or report root cause. Root cause in test infrastructure → fix the test, not production code. Genuine bug → document, then fix via `/implementation:implement fix` |
-| `loop` | `/verification:confirm fix` (when the `verification` plugin is installed) when all green after the regression pass (routes fix-confirmation to the `fix` criterion — symptom resolved + no regression) |
+| `loop` | `/verification:confirm fix` (when the `verification` plugin is installed) when all green after the regression pass (routes fix-confirmation to the `fix` criterion. Symptom resolved + no regression) |
 
 ## Integration with /implementation:implement
 
@@ -48,10 +48,10 @@ When `/implementation:implement` hits a test failure during its TDD cadence it c
 
 ## What this skill does NOT do
 
-- **Does not run the suite wholesale** — `/toolchain:check` is SSOT for CLI invocation; this skill runs targeted reproductions
-- **Does not author new feature tests** — `/testing:write` (the loop's reproduce step writes only the failing test capturing the bug)
+- **Does not run the suite wholesale**. `/toolchain:check` is SSOT for CLI invocation; this skill runs targeted reproductions
+- **Does not author new feature tests**. `/testing:write` (the loop's reproduce step writes only the failing test capturing the bug)
 
 ## Gotchas
 
-- Framework traps — .NET examples: xUnit v3 rejects `--nologo` ("zero tests ran", exit 5); .NET 10 requires `dotnet test --project`; parallel-execution races. Check the consuming project's own gotcha notes before diagnosing
-- Process-global singleton symptoms ("frozen", "already initialized") — usually a shared-state fixture problem; check the consuming project's fixture conventions for the named pattern before inventing a workaround
+- Framework traps. .NET examples: xUnit v3 rejects `--nologo` ("zero tests ran", exit 5); .NET 10 requires `dotnet test --project`; parallel-execution races. Check the consuming project's own gotcha notes before diagnosing
+- Process-global singleton symptoms ("frozen", "already initialized"). Usually a shared-state fixture problem; check the consuming project's fixture conventions for the named pattern before inventing a workaround

--- a/plugins/testing/skills/diagnose/SKILL.md
+++ b/plugins/testing/skills/diagnose/SKILL.md
@@ -16,7 +16,7 @@ Working tree status: !`git status --porcelain 2>/dev/null | head -20 || echo "cl
 
 ## Purpose
 
-The failure half of testing: understand WHY a test fails, then prove the fix. Never dismiss a failure, never retry blindly. "probably a timing issue" is not a diagnosis; even intermittent failures have deterministic root causes. Repo-specific shared-state workarounds and framework traps live in the consuming project's testing conventions. Consult them before diagnosing.
+The failure half of testing: understand WHY a test fails, then prove the fix. Never dismiss a failure, never retry blindly. "Probably a timing issue" is not a diagnosis; even intermittent failures have deterministic root causes. Repo-specific shared-state workarounds and framework traps live in the consuming project's testing conventions. Consult them before diagnosing.
 
 ## Redact
 

--- a/plugins/testing/skills/plan/SKILL.md
+++ b/plugins/testing/skills/plan/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: "Analyze code changes and produce a test plan — classify changed files by required test type, identify coverage gaps, and prioritize by regression risk. Use when: 'test plan', 'what needs testing', 'where are the coverage gaps', 'what should I test here', after /implementation:implement completes, or for PR-prep coverage verification; for writing the tests use /testing:write, for running them /toolchain:check."
+description: "Analyze code changes and produce a test plan. Classify changed files by required test type, identify coverage gaps, and prioritize by regression risk. Use when: 'test plan', 'what needs testing', 'where are the coverage gaps', 'what should I test here', after /implementation:implement completes, or for PR-prep coverage verification; for writing the tests use /testing:write, for running them /toolchain:check."
 argument-hint: "[range or scope] (e.g., /testing:plan, /testing:plan HEAD~3, /testing:plan the auth module)"
 user-invocable: true
 disable-model-invocation: false
@@ -21,7 +21,7 @@ Coverage-gap analysis: what needs testing, at what level, and in what priority. 
 
 ## Arguments
 
-`$ARGUMENTS` — optional diff range or scope description. Default: uncommitted changes plus the current branch's commits vs the default branch.
+`$ARGUMENTS`, optional diff range or scope description. Default: uncommitted changes plus the current branch's commits vs the default branch.
 
 ## Process
 
@@ -48,7 +48,7 @@ Classify each changed file:
 
 ### 2. Generate the test plan
 
-For each change area, produce (test-name forms follow the project's documented pattern; when undocumented, mirror the ecosystem's idiom — the PascalCase placeholders below are illustrative (.NET/xUnit)):
+For each change area, produce (test-name forms follow the project's documented pattern; when undocumented, mirror the ecosystem's idiom, the PascalCase placeholders below are illustrative (.NET/xUnit)):
 
 ```markdown
 ## Test Plan for [branch/PR description]
@@ -87,10 +87,10 @@ Check existing tests against the plan:
 
 Not all gaps are equal. Prioritize by:
 
-1. **Regression risk** — changes to existing behavior that could break silently
-2. **Business criticality** — core domain logic > utility helpers
-3. **Complexity** — conditional logic, state machines, error paths
-4. **Integration points** — boundaries where components meet
+1. **Regression risk**. Changes to existing behavior that could break silently
+2. **Business criticality**. Core domain logic > utility helpers
+3. **Complexity**. Conditional logic, state machines, error paths
+4. **Integration points**. Boundaries where components meet
 
 ## Output
 
@@ -102,12 +102,12 @@ Present the test plan to the user. Then suggest:
 
 ## What this skill does NOT do
 
-- **Does not write tests** — `/testing:write`
-- **Does not run tests** — `/toolchain:check` (SSOT for CLI invocation)
+- **Does not write tests**. `/testing:write`
+- **Does not run tests**. `/toolchain:check` (SSOT for CLI invocation)
 
 ## Marketplace plugin skills (invoke only when installed)
 
-These enrichment skills are ecosystem-specific — the `dotnet-test` skill applies when your stack is .NET; `document-skills:webapp-testing` is stack-agnostic:
+These enrichment skills are ecosystem-specific, the `dotnet-test` skill applies when your stack is .NET; `document-skills:webapp-testing` is stack-agnostic:
 
-- **`dotnet-test:code-testing-agent`** — multi-agent pipeline for comprehensive gap analysis and structured test generation. Use when the test plan reveals significant coverage gaps requiring many new tests
-- **`document-skills:webapp-testing`** — Playwright patterns for E2E test planning. Use when the test plan includes UI or API verification scenarios that need end-to-end coverage
+- **`dotnet-test:code-testing-agent`**. Multi-agent pipeline for comprehensive gap analysis and structured test generation. Use when the test plan reveals significant coverage gaps requiring many new tests
+- **`document-skills:webapp-testing`**. Playwright patterns for E2E test planning. Use when the test plan includes UI or API verification scenarios that need end-to-end coverage

--- a/plugins/testing/skills/run-e2e/SKILL.md
+++ b/plugins/testing/skills/run-e2e/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: "End-to-end live app verification — check prerequisites, start the app, drive UI/API flows, and capture evidence (screenshots, responses, logs); includes a non-UI smoke-test playbook for libraries, MCP servers, hooks, and scripts. Use when: 'e2e', 'smoke test', 'test the app', 'run it end to end', 'does the app actually work', 'click through the UI', or when UI/API changes need runtime verification; for comprehensive build+test+lint use /verification:confirm."
+description: "End-to-end live app verification. Check prerequisites, start the app, drive UI/API flows, and capture evidence (screenshots, responses, logs); includes a non-UI smoke-test playbook for libraries, MCP servers, hooks, and scripts. Use when: 'e2e', 'smoke test', 'test the app', 'run it end to end', 'does the app actually work', 'click through the UI', or when UI/API changes need runtime verification; for comprehensive build+test+lint use /verification:confirm."
 argument-hint: "[scenario] (e.g., /testing:run-e2e, /testing:run-e2e the login flow, /testing:run-e2e non-ui)"
 user-invocable: true
 disable-model-invocation: false
@@ -16,11 +16,11 @@ Working tree status: !`git status --porcelain 2>/dev/null | head -20 || echo "cl
 
 ## Purpose
 
-Autonomous live verification of a running application: start it, navigate, interact, screenshot, assert. UI changes follow the mandatory evidence contract in [context/e2e.md](context/e2e.md); non-UI runtime surfaces route to the smoke-test playbook. The e2e-orchestrator configuration (start command, prerequisite tooling, degraded fallback) comes from the consuming project's conventions — its orchestrator (Aspire, docker-compose, tilt, a dev-server script) and any documented evidence requirements govern.
+Autonomous live verification of a running application: start it, navigate, interact, screenshot, assert. UI changes follow the mandatory evidence contract in [context/e2e.md](context/e2e.md); non-UI runtime surfaces route to the smoke-test playbook. The e2e-orchestrator configuration (start command, prerequisite tooling, degraded fallback) comes from the consuming project's conventions. Its orchestrator (Aspire, docker-compose, tilt, a dev-server script) and any documented evidence requirements govern.
 
 ## Arguments
 
-`$ARGUMENTS` — optional scenario description. `non-ui` routes directly to the non-UI playbook.
+`$ARGUMENTS`, optional scenario description. `non-ui` routes directly to the non-UI playbook.
 
 ## Step 0: Route
 
@@ -29,24 +29,24 @@ Autonomous live verification of a running application: start it, navigate, inter
 | UI flows, browser evidence, API + UI orchestration | [context/e2e.md](context/e2e.md) |
 | Non-UI runtime surface (library, MCP server, hooks, scripts, infrastructure) | [context/non-ui.md](context/non-ui.md) |
 
-UI changes (Blazor / Razor / HTML / CSS / JS shipped to browser) MUST use the e2e route — the UI evidence contract is mandatory there.
+UI changes (Blazor / Razor / HTML / CSS / JS shipped to browser) MUST use the e2e route, the UI evidence contract is mandatory there.
 
 ## Step 1: Prerequisites
 
-Check tool availability per the prerequisite matrix in [context/e2e.md](context/e2e.md). When the consuming project names a prerequisite orchestrator tool/MCP, its absence hard-fails — STOP and report what's missing and how to fix it; do not attempt workarounds, because a substitute path produces unverified pass/fail results, defeating live verification.
+Check tool availability per the prerequisite matrix in [context/e2e.md](context/e2e.md). When the consuming project names a prerequisite orchestrator tool/MCP, its absence hard-fails. STOP and report what's missing and how to fix it; do not attempt workarounds, because a substitute path produces unverified pass/fail results, defeating live verification.
 
-On a hard-fail, STOP **and** write a structured verification-environment gap report to the run's evidence output before stopping. The report lists what is missing — each key, CLI, MCP, or environment the run needs — and what the operator must provide to make the run possible. The STOP still holds; the gap report is its actionable half, so the operator receives a precise list of what to supply rather than a bare failure.
+On a hard-fail, STOP **and** write a structured verification-environment gap report to the run's evidence output before stopping. The report lists what is missing, each key, CLI, MCP, or environment the run needs, and what the operator must provide to make the run possible. The STOP still holds; the gap report is its actionable half, so the operator receives a precise list of what to supply rather than a bare failure.
 
 ## Step 2: Resolve run config
 
 Two keys govern this run: `recording` (`video | gif | off`) and `browser_mode` (`headed | headless`). They live in the consumer-tracked surface `.claude/testing/e2e.md`; [context/e2e-config.md](context/e2e-config.md) owns their definitions, defaults, and precedence. Resolve them before driving:
 
-- Anchor at the repo root, then read every layer of the surface that exists — user-global, team, and local overlay — and merge `recording` and `browser_mode` per key. Report which layer supplied each effective value. The generic layer mechanics (anchoring, reading every layer, provenance, soft-degrade) are the layering contract's — see the [config-cascade contract](https://raw.githubusercontent.com/melodic-software/claude-code-plugins/main/docs/conventions/config-cascade/README.md); this step only names the surface path, the keys, and the per-key merge.
-- An explicit instruction in the session prompt overrides the file layers for that run — the keys are defaults only. The precedence ladder is in [context/e2e-config.md](context/e2e-config.md).
+- Anchor at the repo root, then read every layer of the surface that exists, user-global, team, and local overlay, and merge `recording` and `browser_mode` per key. Report which layer supplied each effective value. The generic layer mechanics (anchoring, reading every layer, provenance, soft-degrade) are the layering contract's. See the [config-cascade contract](https://raw.githubusercontent.com/melodic-software/claude-code-plugins/main/docs/conventions/config-cascade/README.md); this step only names the surface path, the keys, and the per-key merge.
+- An explicit instruction in the session prompt overrides the file layers for that run, the keys are defaults only. The precedence ladder is in [context/e2e-config.md](context/e2e-config.md).
 
 ## Step 3: Drive the run (subagent-isolated)
 
-Delegate the drive loop to a subagent: it starts the app, navigates, interacts, and captures evidence, returning only the evidence paths. The orchestrator consumes those paths — it never carries the browser session in its own context.
+Delegate the drive loop to a subagent: it starts the app, navigates, interacts, and captures evidence, returning only the evidence paths. The orchestrator consumes those paths. It never carries the browser session in its own context.
 
 Pass the resolved config through to the executor:
 
@@ -57,18 +57,18 @@ The workflow steps themselves live in [context/e2e.md](context/e2e.md).
 
 ## Handoff
 
-- Surface verification available → the bundled `/verify` skill (Claude Code ≥2.1.145) covers the same surface, but is [user-invoked by default from v2.1.215](https://code.claude.com/docs/en/skills#bundled-skills) — before v2.1.215 Claude could also run it on its own, and from v2.1.225 a runtime gate governs invocability rather than a fixed version cutoff, so two clients on one version can differ. Suggest the user run it and consume its findings rather than delegating to it, on every version: the suggestion holds across the whole `≥2.1.145` availability window and across either invocability state, delegation does not. The orchestrator path in this skill runs unchanged either way. Verified 2026-08-10 against the linked reference and the shipped 2.1.223–2.1.226 clients; recheck trigger: a Claude Code release whose changelog names `/verify` or bundled-skill invocability
+- Surface verification available → the bundled `/verify` skill (Claude Code ≥2.1.145) covers the same surface, but is [user-invoked by default from v2.1.215](https://code.claude.com/docs/en/skills#bundled-skills), before v2.1.215 Claude could also run it on its own, and from v2.1.225 a runtime gate governs invocability rather than a fixed version cutoff, so two clients on one version can differ. Suggest the user run it and consume its findings rather than delegating to it, on every version: the suggestion holds across the whole `≥2.1.145` availability window and across either invocability state, delegation does not. The orchestrator path in this skill runs unchanged either way. Verified 2026-08-10 against the linked reference and the shipped 2.1.223–2.1.226 clients; recheck trigger: a Claude Code release whose changelog names `/verify` or bundled-skill invocability
 - All scenarios pass → invoke `/verification:confirm outcome` via the Skill tool when the `verification` plugin is installed (composes intent + evidence; chains back here when needed); otherwise report the captured evidence for outcome sign-off directly
 - Visual bugs or API errors found → invoke `/testing:diagnose` via the Skill tool
 - Scenario planning needed first → invoke `/testing:plan` via the Skill tool
 
 ## What this skill does NOT do
 
-- **Does not own browser-automation mechanics** — `/playwright:playwright` (when the playwright plugin is installed) covers sessions, snapshots, tracing, Windows quirks; this skill owns the broader orchestrator + API + UI story
-- **Does not replace `/verification:confirm`** — that skill orchestrates the mechanical prerequisite (build+test+lint) + outcome verification
+- **Does not own browser-automation mechanics**. `/playwright:playwright` (when the playwright plugin is installed) covers sessions, snapshots, tracing, Windows quirks; this skill owns the broader orchestrator + API + UI story
+- **Does not replace `/verification:confirm`**. That skill orchestrates the mechanical prerequisite (build+test+lint) + outcome verification
 
 ## Gotchas
 
-- **Semantic locators ONLY** — accessibility-based element refs from snapshots, never CSS selectors or XPath that break on cosmetic changes
-- Orchestrator version coupling + health-check waits — wait for the orchestrator's health signal before driving flows; don't poll blindly
-- Playwright CLI vs MCP token budget (~27K vs ~114K per workflow) — CLI by default; detail in [context/e2e.md](context/e2e.md)
+- **Semantic locators ONLY**. Accessibility-based element refs from snapshots, never CSS selectors or XPath that break on cosmetic changes
+- Orchestrator version coupling + health-check waits. Wait for the orchestrator's health signal before driving flows; don't poll blindly
+- Playwright CLI vs MCP token budget (~27K vs ~114K per workflow). CLI by default; detail in [context/e2e.md](context/e2e.md)

--- a/plugins/testing/skills/write/SKILL.md
+++ b/plugins/testing/skills/write/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: "Write and place tests across all ecosystems — TDD cadence (Red→Green→Refactor in vertical slices), test naming, test-type selection, project placement, and fixture patterns. Use when: 'write tests', 'test this', 'where should this test go', 'add test coverage', 'write a unit test for this', or when code was just written without tests; for diagnosing failures use /testing:diagnose, for coverage-gap analysis /testing:plan, for running tests /toolchain:check."
+description: "Write and place tests across all ecosystems. TDD cadence (Red→Green→Refactor in vertical slices), test naming, test-type selection, project placement, and fixture patterns. Use when: 'write tests', 'test this', 'where should this test go', 'add test coverage', 'write a unit test for this', or when code was just written without tests; for diagnosing failures use /testing:diagnose, for coverage-gap analysis /testing:plan, for running tests /toolchain:check."
 argument-hint: "[task] (e.g., /testing:write, /testing:write the new handler, /testing:write organize)"
 user-invocable: true
 disable-model-invocation: false
@@ -16,11 +16,11 @@ Working tree status: !`git status --porcelain 2>/dev/null | head -20 || echo "cl
 
 ## Purpose
 
-Authoring discipline for tests: what to test, how to name it, which test type fits, and where the test lives. `/implementation:implement` calls this skill during its TDD cadence; `/toolchain:check` owns test INVOCATION (the actual commands, SSOT). Test STRUCTURE configuration (frameworks, project locations, naming, fixture conventions) belongs to the consuming project — read its testing conventions (its `CLAUDE.md` / rules / test-structure docs) before writing tests, and infer from existing test projects when nothing is documented.
+Authoring discipline for tests: what to test, how to name it, which test type fits, and where the test lives. `/implementation:implement` calls this skill during its TDD cadence; `/toolchain:check` owns test INVOCATION (the actual commands, SSOT). Test STRUCTURE configuration (frameworks, project locations, naming, fixture conventions) belongs to the consuming project. Read its testing conventions (its `CLAUDE.md` / rules / test-structure docs) before writing tests, and infer from existing test projects when nothing is documented.
 
 ## Arguments
 
-`$ARGUMENTS` — optional task description. `organize` (or a placement-shaped question) routes to the placement guidance; anything else is authoring.
+`$ARGUMENTS`, optional task description. `organize` (or a placement-shaped question) routes to the placement guidance; anything else is authoring.
 
 ## Step 0: Route
 
@@ -39,25 +39,25 @@ Read the relevant context file before proceeding. Both draw on the consuming pro
 
 ## Cross-cutting principles
 
-- **Test behavior, not implementation** — assert on what the user sees or what the API returns, not internal state (Kent C. Dodds: "The more your tests resemble the way your software is used, the more confidence they can give you")
-- **Four Pillars** (Vladimir Khorikov): protection against regressions, resistance to refactoring, fast feedback, maintainability — every test scores well on all four
-- **Naming** — use the project's documented naming pattern; when undocumented, mirror the consuming ecosystem's own idiom (never impose one language's convention on another). The forms below are illustrative (.NET/xUnit) — adapt casing/separators to the target ecosystem: unit `{Method}_Should{Behavior}_When{Condition}`, integration `{Subject}_{Behavior}`, architecture `{Subject}_Should{Constraint}`
+- **Test behavior, not implementation**. Assert on what the user sees or what the API returns, not internal state (Kent C. Dodds: "The more your tests resemble the way your software is used, the more confidence they can give you")
+- **Four Pillars** (Vladimir Khorikov): protection against regressions, resistance to refactoring, fast feedback, maintainability. Every test scores well on all four
+- **Naming**. Use the project's documented naming pattern; when undocumented, mirror the consuming ecosystem's own idiom (never impose one language's convention on another). The forms below are illustrative (.NET/xUnit). Adapt casing/separators to the target ecosystem: unit `{Method}_Should{Behavior}_When{Condition}`, integration `{Subject}_{Behavior}`, architecture `{Subject}_Should{Constraint}`
 - When uncertain about a testing decision (mock or not, output vs state test), load `/tdd:principles` (when the `tdd` plugin is installed) for authoritative Beck/Khorikov guidance
 
 ## Handoff
 
-- Run the new tests by invoking `/toolchain:check` via the Skill tool (or the project's own test command when the `toolchain` plugin is absent), then continue implementation — invoke `/implementation:implement` via the Skill tool when that plugin is installed
-- **For HIGH/CRITICAL test suites** (new domain logic, security-critical behavior, regression-prone paths, mocks of non-trivial dependencies, non-deterministic dependencies like clock/random/network) call the `advisor` tool (when available in the session) — rubber-duck checkpoint before commit. Lightweight cross-model critique catches false-green or brittle tests before slow CI runs — the author writing tests for their own code is the producer verifying its own work, and this cross-model pass is that independence seam. Skip for trivial test additions
+- Run the new tests by invoking `/toolchain:check` via the Skill tool (or the project's own test command when the `toolchain` plugin is absent), then continue implementation. Invoke `/implementation:implement` via the Skill tool when that plugin is installed
+- **For HIGH/CRITICAL test suites** (new domain logic, security-critical behavior, regression-prone paths, mocks of non-trivial dependencies, non-deterministic dependencies like clock/random/network) call the `advisor` tool (when available in the session). Rubber-duck checkpoint before commit. Lightweight cross-model critique catches false-green or brittle tests before slow CI runs, the author writing tests for their own code is the producer verifying its own work, and this cross-model pass is that independence seam. Skip for trivial test additions
 - After an `organize` decision: proceed to authoring for the new test project
 - Coverage gaps still open → invoke `/testing:plan` via the Skill tool; failures while running → invoke `/testing:diagnose` via the Skill tool
 
 ## What this skill does NOT do
 
-- **Does not run test commands** — `/toolchain:check` is SSOT for CLI invocation
-- **Does not diagnose failures** — `/testing:diagnose`
-- **Does not replace the project's testing conventions** — the consuming project's rules are the source of truth for frameworks, naming, organization; this skill defers to them
+- **Does not run test commands**. `/toolchain:check` is SSOT for CLI invocation
+- **Does not diagnose failures**. `/testing:diagnose`
+- **Does not replace the project's testing conventions**, the consuming project's rules are the source of truth for frameworks, naming, organization; this skill defers to them
 
 ## Gotchas
 
-- Framework traps — `.NET`: xUnit v3 rejects `--nologo`/`-v q` (zero tests ran, exit 5); .NET 10 requires `dotnet test --project`; `Microsoft.NET.Sdk.Web` recursively compiles child directories (never nest a test project inside a Web SDK app). Check the consuming project's own gotcha notes before writing tests
-- Shared-state workarounds (collection fixtures, process-global singletons) are repo-specific — consult the consuming project's testing conventions before writing or moving tests in affected areas
+- Framework traps. `.NET`: xUnit v3 rejects `--nologo`/`-v q` (zero tests ran, exit 5); .NET 10 requires `dotnet test --project`; `Microsoft.NET.Sdk.Web` recursively compiles child directories (never nest a test project inside a Web SDK app). Check the consuming project's own gotcha notes before writing tests
+- Shared-state workarounds (collection fixtures, process-global singletons) are repo-specific. Consult the consuming project's testing conventions before writing or moving tests in affected areas


### PR DESCRIPTION
No linked issue

## Summary

#2891 instruction-surface de-slop cluster: purge em dashes from the `testing` plugin README and every SKILL.md.

## Fix

Rewrote `plugins/testing/README.md` and every `plugins/testing/**/SKILL.md` under `/ai-slop:audit fix` semantics (periods, commas, or a restructured sentence; never parentheses, en dashes, or a spaced hyphen as a stand-in). Meaning-preserving self-audit repaired asides the first pass reattached to the wrong noun. Regenerated `docs/SKILL-CHEAT-SHEET.md` so the audit summary matches the rewritten frontmatter. `testing` 0.7.6.

## Verification

- Detector: 0 `rule-em-dash` findings outside ignore-fenced generated-options spans (and required trigger strings that must keep em dashes)
- `CHECK_SKILL_SKIP_MARKDOWNLINT=1 bash scripts/check-changed-skills.sh origin/main`: 0 failed; quoted trigger phrases vs origin/main preserved
- `python3 scripts/sync-plugin-options-docs.py --check` up to date
- `scripts/check-changelog-parity.sh --check-bump origin/main` passes
- `node scripts/generate-cheatsheet.mjs --check` in sync

## Related

Refs #2891

#2891 stays open.