### PR TITLE
fix(claude-config): count unparsable emit-findings rows instead of dropping them (0.40.2)

### DIFF
--- a/plugins/claude-config/.claude-plugin/plugin.json
+++ b/plugins/claude-config/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "claude-config",
-  "version": "0.40.1",
+  "version": "0.40.2",
   "description": "Nine configuration-health skills (plus setup) for a repo's Claude Code configuration: audit (settings.json / .mcp.json / hooks / plugins / permissions drift), audit-automation-gaps (evidence-gated verdicts on automation gaps), audit-permission-grants (allow-rule / allowed-tools grants for auto-mode durability and portability), audit-permission-state (the permission rules actually in effect — every settings scope merged with per-rule provenance, what auto mode drops on entry, config written where nothing reads it, and which managed intents are enforced versus loosenable), draft-auto-mode-rules (interview and draft a paste-ready autoMode classifier block; prints only, never writes), audit-instructions (locally-owned instruction surfaces vs current model capability — proposes removals/rewrites of instructions the model no longer needs, and detects cross-surface instruction conflicts), audit-prompting-postures (the additive lane — posture guidance the prompting guide says a component's purpose needs but the component does not carry), audit-pass (one coordinated, ordered, resumable pass over a named target — three-scope inventory, run-time-derived exclusion set, stable finding identity, suppression memory, resume, one human gate — delegating every check to the plugin that owns it), and unhobble (the empirical bare-baseline experiment: reversibly strip a repo's standing instructions, log real stumbles against the current model, re-add only what evidence earns).",
   "author": {
     "name": "Melodic Software",

--- a/plugins/claude-config/CHANGELOG.md
+++ b/plugins/claude-config/CHANGELOG.md
@@ -3,6 +3,23 @@
 All notable changes to the `claude-config` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.40.2]
+
+### Fixed
+
+- **`audit-instructions` `emit-findings.sh` dropped `--from` lines that missed the intake
+  pattern, without counting them (#3279).** `nrows++` lived inside
+  `/^.+:[0-9]+:I[0-9]+(-[a-c])?$/`, so a well-formed row whose only defect was a suffix
+  outside `[a-c]` (`I28-d`), a prose line, or a blank incremented nothing and reached no
+  decline bucket. The report could not distinguish "this input had 2 rows" from "this
+  input had 5 rows and 3 were unreadable." The writer now counts first and classifies
+  second: every considered line increments `Scan rows read`, and an unmatched line lands
+  in `reason=unparsable-row`. Intake also strips a trailing `\r` before the pattern
+  match — the same strip `descr()` and `source_line()` already do — so a mixed CRLF file
+  no longer silently drops the CR-terminated rows. The scanner-output gate does the same
+  strip, so an all-CRLF file with a matching row is parsed rather than refused as
+  non-scanner input.
+
 ## [0.40.1]
 
 ### Fixed

--- a/plugins/claude-config/skills/audit-instructions/context/persist-findings.md
+++ b/plugins/claude-config/skills/audit-instructions/context/persist-findings.md
@@ -85,6 +85,13 @@ section would report fewer candidates examined than were actually looked at. Pas
 through: `--declined-carveout <n>`, which records it as its own counted line. Zero dropped → omit
 the flag.
 
+The same rule binds the writer's own intake. A `--from` line that is not a scan row — a
+well-formed `path:line:I<n>` whose suffix sits outside `[a-c]`, a prose line, a blank — still
+increments `Scan rows read` and is counted as `reason=unparsable-row`. It is never omitted from
+both the row count and every decline line. Intake strips a trailing CR before the pattern match
+(the same strip `descr()` and `source_line()` already do), so a mixed CRLF file is parsed rather
+than silently dropping the CR-terminated rows.
+
 **Surfaces outside the repository never reach the relay.** Phase A inventories user-level surfaces
 under `${CLAUDE_CONFIG_DIR:-~/.claude}` as well as repo-owned ones, but `Location` is contractually
 repo-relative and the fix action fences each remediation to it — an absolute path would have the

--- a/plugins/claude-config/skills/audit-instructions/scripts/emit-findings.sh
+++ b/plugins/claude-config/skills/audit-instructions/scripts/emit-findings.sh
@@ -12,9 +12,11 @@
 # instruction-scan.sh marks (I6, I8-a/b/c, I10, I23, I25, I27) has no
 # severity-crosswalk row, and the detector-findings contract admits no row
 # whose tier cannot be looked up from one — those stay in the human report.
-# Rows for them are counted as declined, never silently dropped. I29 rows
-# come from restatement-scan.py and are concatenated onto the same --from
-# stream.
+# Rows for them are counted as declined, never silently dropped. A --from
+# line that is not a scan row at all (suffix outside [a-c], prose, blank)
+# is counted as reason=unparsable-row, never omitted from both Scan rows
+# read and every Declined line. I29 rows come from restatement-scan.py and
+# are concatenated onto the same --from stream.
 #
 # The per-rule Tier/Action cells MIRROR the severity crosswalk in
 # docs/conventions/detector-findings/README.md ("The severity crosswalk"); that
@@ -120,8 +122,11 @@ if [[ -z "$BRANCH" ]]; then
 fi
 
 # A scan row is `<path>:<line>:<check-id>`. Anything with no such row is not
-# scanner output.
-if ! LC_ALL=C grep -qE '^.+:[0-9]+:I[0-9]+(-[a-c])?$' "$FROM"; then
+# scanner output. Strip a trailing CR first so an all-CRLF file with a matching
+# row is recognized rather than refused — the same strip the awk intake applies
+# before its pattern match.
+if ! LC_ALL=C grep -qE '^.+:[0-9]+:I[0-9]+(-[a-c])?$' \
+  < <(LC_ALL=C sed $'s/\r$//' "$FROM"); then
   echo "emit-findings.sh: $FROM has no instruction-scan.sh rows; not scanner output" >&2
   exit 3
 fi
@@ -423,8 +428,16 @@ LC_ALL=C awk \
   }
 
   # --- row intake ------------------------------------------------------------
-  /^.+:[0-9]+:I[0-9]+(-[a-c])?$/ {
+  # Count first, classify second. A line that misses the scan-row pattern still
+  # increments nrows and lands in reason=unparsable-row; it is never omitted
+  # from both Scan rows read and every Declined line. Trailing CR is stripped
+  # here the same way descr() and source_line() already strip it, so a mixed
+  # CRLF file does not silently drop the CR-terminated rows.
+  {
+    sub(/\r$/, "")
     nrows++
+  }
+  /^.+:[0-9]+:I[0-9]+(-[a-c])?$/ {
     # Split from the RIGHT: a path may contain colons, the last two fields never do.
     id = $0; sub(/^.*:/, "", id)
     rest = $0; sub(/:[^:]*$/, "", rest)
@@ -459,6 +472,12 @@ LC_ALL=C awk \
     seen[id]++
     next
   }
+  {
+    id = $0
+    sub(/^.*:/, "", id)
+    if (id == "" || id !~ /^I[0-9]+(-[A-Za-z0-9]+)?$/) id = "(unparsable)"
+    declined_unparsable[id]++
+  }
 
   END {
     printf "---\ntype: review-findings\ndate: %s\nbranch: %s\n---\n\n", date_utc, yaml_scalar(branch)
@@ -492,6 +511,8 @@ LC_ALL=C awk \
       printf "Declined candidates: %s count=%d reason=outside-repo-root (Location must be repo-relative; human report only)\n", k, declined_outofrepo[k]
     for (k in declined_unreadable)
       printf "Declined candidates: %s count=%d reason=source-line-unreadable\n", k, declined_unreadable[k]
+    for (k in declined_unparsable)
+      printf "Declined candidates: %s count=%d reason=unparsable-row\n", k, declined_unparsable[k]
     # The model lane drops carve-out candidates (destructive/security gate,
     # stated hard precondition, document about the pattern) before this script
     # sees them, so it reports their count here rather than letting the

--- a/plugins/claude-config/skills/audit-instructions/scripts/emit-findings.test.sh
+++ b/plugins/claude-config/skills/audit-instructions/scripts/emit-findings.test.sh
@@ -210,6 +210,57 @@ assert_contains "the unreadable-source decline is counted, never silent" \
   "$EOF_OUT" "reason=source-line-unreadable"
 assert_not_contains "no row is emitted with an empty excerpt" "$EOF_OUT" "frontmatter-emphasis.md:9999"
 
+# --- Case 8c: unmatched --from lines are counted, never silent (#3279) ------
+# nrows++ used to live inside the intake pattern, so I28-d (well-formed except
+# suffix outside [a-c]), prose, and a blank incremented nothing and reached no
+# decline bucket. Count first, classify second: those lines increment Scan
+# rows read and land in reason=unparsable-row. I100-a still matches and
+# declines as no-severity-crosswalk-row; I28-a still emits.
+UNPARSABLE="$TEST_TMPDIR/unparsable.txt"
+{
+  printf '%s\n' "$FIXTURES/quoted-trigger.md:8:I28-a"
+  printf '%s\n' "$FIXTURES/quoted-trigger.md:8:I28-d"
+  printf '%s\n' "this is not a scan row"
+  printf '\n'
+  printf '%s\n' "$FIXTURES/quoted-trigger.md:8:I100-a"
+} >"$UNPARSABLE"
+UNP_OUT=$(emit "$UNPARSABLE" "$TEST_TMPDIR/unparsable.md")
+UNP_ROWS=$(printf '%s\n' "$UNP_OUT" | grep -c '^| [0-9]')
+assert_eq "I28-a still emits from a mixed unparsable input" "1" "$UNP_ROWS"
+assert_contains "I28-a is the emitted Location" "$UNP_OUT" "quoted-trigger.md:8"
+assert_contains "Scan rows read counts every considered line, including unparsable" \
+  "$UNP_OUT" "Scan rows read: 5. Emitted: 1."
+assert_contains "I28-d is a counted decline, not dropped" \
+  "$UNP_OUT" "Declined candidates: I28-d count=1 reason=unparsable-row"
+assert_contains "prose and blank lines share the unparsable-row bucket" \
+  "$UNP_OUT" "Declined candidates: (unparsable) count=2 reason=unparsable-row"
+assert_contains "I100-a still declines as no-severity-crosswalk-row" \
+  "$UNP_OUT" "Declined candidates: I100-a count=1 reason=no-severity-crosswalk-row"
+
+# A CRLF-terminated matching row is parsed, not dropped. The intake pattern
+# used to anchor on $ without stripping CR, so a CR-terminated I28-a vanished.
+CRLF_ROW="$TEST_TMPDIR/crlf-row.txt"
+printf '%s\r\n' "$FIXTURES/quoted-trigger.md:8:I28-a" >"$CRLF_ROW"
+CRLF_ROW_OUT=$(emit "$CRLF_ROW" "$TEST_TMPDIR/crlf-row.md")
+assert_contains "a CRLF-terminated matching row is parsed, not dropped" \
+  "$CRLF_ROW_OUT" "quoted-trigger.md:8"
+assert_contains "and the CRLF row is counted as read and emitted" \
+  "$CRLF_ROW_OUT" "Scan rows read: 1. Emitted: 1."
+assert_not_contains "a matching CRLF row is not declined as unparsable" \
+  "$CRLF_ROW_OUT" "reason=unparsable-row"
+
+# Mixed LF + CRLF: the CR row must not vanish from the count.
+MIXCRLF="$TEST_TMPDIR/mix-crlf.txt"
+{
+  printf '%s\n' "$FIXTURES/quoted-trigger.md:8:I28-a"
+  printf '%s\r\n' "$FIXTURES/quoted-trigger.md:8:I28-d"
+} >"$MIXCRLF"
+MIXCRLF_OUT=$(emit "$MIXCRLF" "$TEST_TMPDIR/mix-crlf.md")
+assert_contains "a mixed CRLF file counts both lines" \
+  "$MIXCRLF_OUT" "Scan rows read: 2. Emitted: 1."
+assert_contains "the CRLF I28-d row is a counted decline" \
+  "$MIXCRLF_OUT" "Declined candidates: I28-d count=1 reason=unparsable-row"
+
 # --- Case 9: DOWNGRADE contract in the Action cell ---------------------------
 # The remediation is a downgrade, never a deletion: the directive survives and
 # only its volume changes. The byte-for-byte survival of a specific directive is


### PR DESCRIPTION
Closes #3279

## Summary

`claude-config:audit-instructions` `emit-findings.sh` promised that no declined candidate is dropped silently. `nrows++` lived inside the intake pattern, so a `--from` line that missed `path:line:I<n>(- [a-c])?` — `I28-d`, a prose line, a blank, or a CRLF-terminated matching row — incremented nothing and reached no decline bucket. The report could not distinguish "this input had 2 rows" from "this input had 5 rows and 3 were unreadable."

## Fix

Count first, classify second: every considered line increments `Scan rows read`, and an unmatched line lands in `reason=unparsable-row`. Intake strips a trailing CR before the pattern match (the same strip `descr()` and `source_line()` already do), and the scanner-output gate does the same strip so an all-CRLF file with a matching row is parsed rather than refused. `claude-config` 0.40.1 → 0.40.2.

## Verification

- `plugins/claude-config/skills/audit-instructions/scripts/emit-findings.test.sh`: 119/119, including Case 8c (`I28-d` counted as `unparsable-row`, prose/blank counted, `I100-a` still `no-severity-crosswalk-row`, `I28-a` still emits, CRLF-terminated matching row parsed, `Scan rows read` equals considered lines).
- Issue reproduction: `--from` with `I28-a`, `I28-d`, a prose line, a blank, and `I100-a` reported `Scan rows read: 5. Emitted: 1.` plus counted declines for `I28-d` (`unparsable-row`), prose/blank (`unparsable-row`), and `I100-a` (`no-severity-crosswalk-row`). A CRLF-terminated `I28-a` row reported `Scan rows read: 1. Emitted: 1.`

## Related

Refs #3267