### PR TITLE
docs(context-guard): de-slop instruction surfaces (0.7.21)

### DIFF
--- a/plugins/context-guard/.claude-plugin/plugin.json
+++ b/plugins/context-guard/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "context-guard",
-  "version": "0.7.20",
+  "version": "0.7.21",
   "description": "Per-session context-window observability plus the first shipped consumer: a statusline wrapper tees each session's context_window fields to a per-session snapshot file, a zone resolver classifies usage into smart/acceptable/dumb bands (percentage bands plus window-class token bands, conservative-min combination, zones.json SSOT with shipped defaults), a reader contract fixes how consuming sessions interpret the snapshots, and zone-crossing hooks report once per transition into a worse zone across two channels — the continuation menu to the operator, who owns that choice, and to the model only the zone determination plus the counter-steer that a zone word is not a decay signal (advisory by default; an optional blocking mode gates new mutating work on a fresh dumb-zone snapshot with handoff-writing exempt), with a PostCompact hook persisting an evidence-degraded marker.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/context-guard/CHANGELOG.md
+++ b/plugins/context-guard/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to the `context-guard` plugin.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.21]
+
+### Changed
+
+- **Instruction-surface de-slop (#2891, context-guard cluster).** Rewrote this plugin's `README.md` and every
+  `SKILL.md` to drop em dashes under the repo's zero-tolerance house policy, using
+  `/ai-slop:audit fix` semantics: periods or commas, or a restructured sentence, never
+  parentheses, en dashes, or a spaced hyphen as a stand-in. Meaning stays; only the mark
+  and the sentence break change. The generated options block is ignore-fenced because
+  `scripts/sync-plugin-options-docs.py` still emits em dashes from its shared template.
+
 ## [0.7.20]
 
 ### Fixed

--- a/plugins/context-guard/README.md
+++ b/plugins/context-guard/README.md
@@ -1,19 +1,19 @@
 # context-guard
 
 A Claude Code plugin that makes each session's context-window usage observable to any session or
-tool that needs it — so long-running workflows can route heavy work away from a degraded context
+tool that needs it, so long-running workflows can route heavy work away from a degraded context
 **before** quality slips, instead of guessing. Five parts:
 
-- **Statusline shim** (`scripts/statusline-shim.sh`) — the durable wiring target. Installed once to
+- **Statusline shim** (`scripts/statusline-shim.sh`), the durable wiring target. Installed once to
   `~/.claude/context-guard/bin/`, it resolves whichever tee version is installed at run time, so a
   plugin update never requires re-wiring and an uninstall degrades to your statusline running
   alone. Pure Bash builtins: it adds no measurable time to a refresh.
-- **Statusline tee** (`scripts/statusline-tee.sh`) — a transparent wrapper around your statusline
+- **Statusline tee** (`scripts/statusline-tee.sh`), a transparent wrapper around your statusline
   command. Each refresh it atomically writes `captured_at`, `session_id`, and the session's
   `context_window` object (copied verbatim from the statusline stdin) to the per-session path
   `~/.claude/context-guard/context/<session_id>.json`, then passes your statusline through
   byte-for-byte. With no statusline configured it doubles as a minimal standalone statusline.
-- **Zone resolver** (`scripts/context-zone.sh`) — `context-zone.sh <session_id>` prints exactly one
+- **Zone resolver** (`scripts/context-zone.sh`). `context-zone.sh <session_id>` prints exactly one
   word: `smart` / `acceptable` / `dumb` / `unknown`. Two band shapes, combined conservatively (the
   worse computable zone wins): percentage bands over `used_percentage` (shipped defaults
   smart ≤ 50 < acceptable ≤ 75 < dumb) and window-class token bands over occupancy
@@ -21,10 +21,10 @@ tool that needs it — so long-running workflows can route heavy work away from 
   200k/400k on a 1M window). Bands come from the machine-scope
   `~/.claude/context-guard/zones.json` when present and valid, else from the shipped defaults.
   Zones say *where you are*; consumers decide *what to do*.
-- **Zone-crossing hooks** (`hooks/`) — the first shipped consumer. Once per transition into a
+- **Zone-crossing hooks** (`hooks/`), the first shipped consumer. Once per transition into a
   worse zone, a PostToolBatch/UserPromptSubmit hook reports the crossing (advisory; silent on
   unchanged, improving, or `unknown` zones), **splitting the report by audience**: the
-  continuation menu — continue, `/clear`, handoff-then-`/clear`, `/compact` — renders to the
+  continuation menu. Continue, `/clear`, handoff-then-`/clear`, `/compact`. Renders to the
   operator on `systemMessage`, because choosing among them is the human's call; the model's
   channel carries the zone determination plus the counter-steer that a zone word is a measurement
   and not a decay signal, and never an exit menu. An exit menu injected into model context
@@ -33,46 +33,43 @@ tool that needs it — so long-running workflows can route heavy work away from 
   evidence-degraded marker next to the session's snapshot, and both zone consumers honor it: a
   compacted session's effective zone is dumb regardless of its post-compaction numbers. An
   optional **blocking** mode (`zone_hook_mode` userConfig) adds a PreToolUse gate that denies new
-  Write/Edit/NotebookEdit/Agent/Workflow calls on a fresh dumb-zone snapshot past a grace budget —
-  fail-open on `unknown`, with handoff-path writes, reads, Bash, and Skill invocations never
+  Write/Edit/NotebookEdit/Agent/Workflow calls on a fresh dumb-zone snapshot past a grace budget, fail-open on `unknown`, with handoff-path writes, reads, Bash, and Skill invocations never
   gated, so a durable handoff is always writable.
-- **Reader contract** (`reference/reader-contract.md`) — the authoritative consumer contract: the
+- **Reader contract** (`reference/reader-contract.md`), the authoritative consumer contract: the
   snapshot path pattern, file shape, the 10-minute staleness rule, fail-open capability detection,
   the zones.json shape, session-id discovery via `${CLAUDE_SESSION_ID}`, and the
   zone-is-not-a-compaction-indicator rule. Its companion
   `reference/cloud-headless-capture.md` is the writer-side channel inventory: why the statusline is
   the only capture channel, which other channels were checked and rejected (with sources and
-  dates) — including the two that do carry live occupancy and still cannot supply a snapshot — and
+  dates), including the two that do carry live occupancy and still cannot supply a snapshot, and
   why `unknown` in a session that runs no statusline, a cloud or headless session by default, is
   structural rather than a defect.
 
 ## Behavior
 
-- **Transparent by contract.** No tee outcome — missing `jq`, unwritable path, a rename blocked by
-  a concurrent reader — ever changes the wrapped statusline's output or exit code. Missing `jq` is
+- **Transparent by contract.** No tee outcome. Missing `jq`, unwritable path, a rename blocked by
+  a concurrent reader. Ever changes the wrapped statusline's output or exit code. Missing `jq` is
   surfaced as a visible one-line notice, never a silent skip.
 - **Per-session, atomic snapshots.** One file per session id (no cross-session last-writer-wins);
   readers never see torn JSON (temp file + rename, with a brief retry for the Windows
-  rename-over-open-target case). Stale sibling files are pruned on write with a 14-day cutoff —
-  far above the staleness window, so live-but-idle sessions always survive.
+  rename-over-open-target case). Stale sibling files are pruned on write with a 14-day cutoff, far above the staleness window, so live-but-idle sessions always survive.
 - **Path containment.** `session_id` becomes a filename, so the tee accepts only `[A-Za-z0-9_-]`
-  and skips the snapshot for anything else — the wrapped statusline is unaffected.
+  and skips the snapshot for anything else, the wrapped statusline is unaffected.
 - **Fail-open zone resolution.** Absent, stale, or unparsable snapshots, null or out-of-range
   `used_percentage`, null `current_usage` (early-session and post-`/compact` statusline states),
   a non-ISO `captured_at`, a snapshot whose embedded `session_id` differs from the requested one,
-  or missing `jq` all resolve `unknown` — consumers take their conservative path on data they
+  or missing `jq` all resolve `unknown`. Consumers take their conservative path on data they
   cannot trust, never a fabricated zone. The shipped bands are declared judgment defaults: no
   official auto-compaction threshold is documented (verified 2026-07-24); `zones.json` is the
-  tuning path. The trigger itself is operator-tunable even though its default is unpublished —
-  `autoCompactWindow`, `CLAUDE_CODE_AUTO_COMPACT_WINDOW`, `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE`, and
-  `autoCompactEnabled` / `DISABLE_AUTO_COMPACT` — and bands belong **below** whatever it resolves
+  tuning path. The trigger itself is operator-tunable even though its default is unpublished: `autoCompactWindow`, `CLAUDE_CODE_AUTO_COMPACT_WINDOW`, `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE`, and
+  `autoCompactEnabled` / `DISABLE_AUTO_COMPACT`, and bands belong **below** whatever it resolves
   to, normalized into the percentage shape, so the session reaches a boundary decision before the
   harness compacts for it. Note that `used_percentage` always measures against the model's *full*
   window, so a lowered auto-compact window no longer shows up in the percentage. The reader
   contract owns those surfaces, their verification dates, and the rationale.
 - **Integrity boundary (stated honestly).** The snapshot directory is owner-only where POSIX
   modes work; on Windows ACL volumes the `chmod` is a no-op and other local users could forge
-  snapshots. Zones are routing hints — consumers must never attach security or egress decisions
+  snapshots. Zones are routing hints. Consumers must never attach security or egress decisions
   to a zone word. See the reader contract's untrusted-data section.
 
 ## Install
@@ -84,10 +81,10 @@ tool that needs it — so long-running workflows can route heavy work away from 
 
 The tee needs two operator steps, both one-time:
 
-1. `/context-guard:setup apply` — installs the statusline shim to
+1. `/context-guard:setup apply`. Installs the statusline shim to
    `~/.claude/context-guard/bin/statusline-shim.sh` (and seeds/refreshes `zones.json`). The shim is
    inert until step 2.
-2. `/context-guard:setup check` — verifies prerequisites and prints the exact `settings.json`
+2. `/context-guard:setup check`. Verifies prerequisites and prints the exact `settings.json`
    statusline edit (wrapping your existing command, or standalone) for you to apply. The plugin
    never edits your settings itself.
 
@@ -101,16 +98,16 @@ flags legacy version-pinned wiring if you have it.
 
 ## Requirements
 
-The scripts run on Bash (Git Bash on native Windows — install
+The scripts run on Bash (Git Bash on native Windows. Install
 [Git for Windows](https://code.claude.com/docs/en/setup#set-up-on-windows); the statusline wiring
 invokes `bash` explicitly) and need [`jq`](https://jqlang.org/download/) on `PATH` for the tee, the
 zone resolver, and the standalone statusline. The snapshot updates only while an interactive
 session refreshes the statusline; `context_window` fields can be `null` early in a session and
 right after `/compact`, per the
-[statusline reference](https://code.claude.com/docs/en/statusline) — readers own null handling.
+[statusline reference](https://code.claude.com/docs/en/statusline). Readers own null handling.
 
 Cost: the tee adds roughly 0.6–0.9 s per statusline refresh on Windows/Git Bash (process-spawn
-bound — `jq` and `date`), and correspondingly less on native POSIX shells. The statusline is not on
+bound. `jq` and `date`), and correspondingly less on native POSIX shells. The statusline is not on
 the input path, so this is display latency, not typing latency; `refreshInterval` in your settings
 governs how often it runs.
 
@@ -121,7 +118,7 @@ true), `zone_hook_mode` (`advisory` default | `blocking`), and `zone_gate_grace_
 mode's grace budget, in-script default 20). The snapshot path and the 10-minute staleness rule are
 deliberately **not** configurable: they are contract constants that cross-plugin consumers inline
 from the [reader contract](reference/reader-contract.md); a per-user override would silently split
-the writer from its readers. Band numbers are the one tunable — via
+the writer from its readers. Band numbers are the one tunable. Via
 `~/.claude/context-guard/zones.json` (shape in the reader contract), which the operator's own
 statusline display may read too, so display and consumers never drift. Disabling the tee is the
 operator's edit (remove or unwrap the statusline command); disabling everything is
@@ -133,6 +130,7 @@ The plugin's own zone-crossing hooks are the first shipped consumer. Next: the `
 audit skill (zone-informed dispatch and evidence-flush decisions, conservative on `unknown`). Any
 session or tool on the machine may read the same files under the same contract.
 
+<!-- ai-slop-ignore-start: generated options block; source is plugin.json + scripts/sync-plugin-options-docs.py -->
 <!-- BEGIN GENERATED: plugin options — edit plugin.json, then run scripts/sync-plugin-options-docs.py -->
 
 ### Options reference
@@ -207,6 +205,7 @@ hands a configured value to a hook process; the value comes from the routes abov
 - [Manage installed plugins](https://code.claude.com/docs/en/discover-plugins#manage-installed-plugins) — enabling, disabling, `/plugin list`
 
 <!-- END GENERATED: plugin options -->
+<!-- ai-slop-ignore-end -->
 
 ## License
 

--- a/plugins/context-guard/README.md
+++ b/plugins/context-guard/README.md
@@ -24,7 +24,7 @@ tool that needs it, so long-running workflows can route heavy work away from a d
 - **Zone-crossing hooks** (`hooks/`), the first shipped consumer. Once per transition into a
   worse zone, a PostToolBatch/UserPromptSubmit hook reports the crossing (advisory; silent on
   unchanged, improving, or `unknown` zones), **splitting the report by audience**: the
-  continuation menu. Continue, `/clear`, handoff-then-`/clear`, `/compact`. Renders to the
+  continuation menu (continue, `/clear`, handoff-then-`/clear`, `/compact`) renders to the
   operator on `systemMessage`, because choosing among them is the human's call; the model's
   channel carries the zone determination plus the counter-steer that a zone word is a measurement
   and not a decay signal, and never an exit menu. An exit menu injected into model context
@@ -47,8 +47,8 @@ tool that needs it, so long-running workflows can route heavy work away from a d
 
 ## Behavior
 
-- **Transparent by contract.** No tee outcome. Missing `jq`, unwritable path, a rename blocked by
-  a concurrent reader. Ever changes the wrapped statusline's output or exit code. Missing `jq` is
+- **Transparent by contract.** No tee outcome (missing `jq`, unwritable path, or a rename blocked
+  by a concurrent reader) ever changes the wrapped statusline's output or exit code. Missing `jq` is
   surfaced as a visible one-line notice, never a silent skip.
 - **Per-session, atomic snapshots.** One file per session id (no cross-session last-writer-wins);
   readers never see torn JSON (temp file + rename, with a brief retry for the Windows

--- a/plugins/context-guard/skills/setup/SKILL.md
+++ b/plugins/context-guard/skills/setup/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: "Verify the context-guard plugin's wiring on this machine — jq, the installed statusline shim, statusline wiring (including legacy version-pinned plugin-cache paths), live-session snapshot freshness — print the exact statusline edit for the operator, and install the shim plus seed ~/.claude/context-guard/zones.json from the shipped defaults. Use when: 'set up context-guard', 'is the context tee working', 'wire the context statusline', a consumer reports zone unknown in a live session, or after a plugin update. Actions: check (read-only; never edits settings), apply (writes ONLY inside ~/.claude/context-guard/ — the shim and zones.json — on explicit request)."
+description: "Verify the context-guard plugin's wiring on this machine — jq, the installed statusline shim, statusline wiring (including legacy version-pinned plugin-cache paths), live-session snapshot freshness — print the exact statusline edit for the operator, and install the shim plus seed ~/.claude/context-guard/zones.json from the shipped defaults. Use when: 'set up context-guard', 'is the context tee working', 'wire the context statusline', a consumer reports zone unknown in a live session, or after a plugin update. Actions: check (read-only; never edits settings), apply (writes ONLY inside ~/.claude/context-guard/, the shim and zones.json, on explicit request)."
 argument-hint: "check | apply [defaults]"
 user-invocable: true
 disable-model-invocation: true
@@ -11,9 +11,9 @@ Narrow-write setup, because this plugin's surface splits in two. The statusline 
 **user's own** `settings.json` and the `jq` prerequisite is a system tool: neither is something
 plugin setup may write, so `check` inspects, reports PASS/FAIL/INFO with one remediation line per
 FAIL, and **prints the exact statusline edit for the operator to apply by hand**. But this plugin
-also owns its operator-home directory `~/.claude/context-guard/` — the machine file `zones.json`,
+also owns its operator-home directory `~/.claude/context-guard/`, the machine file `zones.json`,
 whose schema it defines and whose values the operator may edit, and the statusline shim
-`bin/statusline-shim.sh`, the durable path the operator's wiring names — and those owned writable
+`bin/statusline-shim.sh`, the durable path the operator's wiring names, and those owned writable
 artifacts are what oblige an `apply`. `apply` is scoped to that directory and touches nothing else.
 
 **Why the shim exists (the durable-wiring rule).** `${CLAUDE_PLUGIN_ROOT}` is version-pinned and
@@ -27,7 +27,7 @@ wrapped command alone when no tee is installed. Read
 `${CLAUDE_PLUGIN_ROOT}/scripts/statusline-shim.sh` for its actual resolution rule rather than
 reciting this paragraph.
 
-The scripts are the source of truth for their own behavior — read
+The scripts are the source of truth for their own behavior. Read
 `${CLAUDE_PLUGIN_ROOT}/scripts/statusline-tee.sh` and
 `${CLAUDE_PLUGIN_ROOT}/scripts/context-zone.sh` first; probe what they actually do rather than
 reciting this file. The consumer-facing constants (snapshot path pattern, staleness rule, default
@@ -36,24 +36,24 @@ zone bands, zones.json shape) are owned by
 
 ## `check` (read-only)
 
-1. **`jq`** — `command -v jq`. FAIL if absent: without it the wrapper cannot tee (it stays
+1. **`jq`**. `command -v jq`. FAIL if absent: without it the wrapper cannot tee (it stays
    transparent and shows a visible notice), the standalone statusline degrades, and the zone
    resolver prints `unknown`. Remediation: install jq (<https://jqlang.org/download/>).
-2. **Installed shim state** — the shim is the wiring target, so check it before the wiring. Compare
+2. **Installed shim state**, the shim is the wiring target, so check it before the wiring. Compare
    `~/.claude/context-guard/bin/statusline-shim.sh` against
    `${CLAUDE_PLUGIN_ROOT}/scripts/statusline-shim.sh` (the installed copy is byte-identical by
    contract, so `cmp -s` is the test):
-   - **Absent** — FAIL when the statusline is wired to it (that wiring cannot run), INFO otherwise.
+   - **Absent**. FAIL when the statusline is wired to it (that wiring cannot run), INFO otherwise.
      Remediation: `apply`.
-   - **Present and identical** — PASS. Nothing about it needs revisiting on a plugin update; that
+   - **Present and identical**. PASS. Nothing about it needs revisiting on a plugin update; that
      is the whole point of the shim.
-   - **Present but differing** — classify by what the installed revision can still do, not by the
+   - **Present but differing**. Classify by what the installed revision can still do, not by the
      fact that it differs. Report the shipped `# shim-revision:` marker against the installed one
      either way, say which of the two behaviors the installed copy has, and offer `apply` as the
      refresh.
-     - Installed revision **>= 3** — INFO: an older-but-adequate or hand-edited copy that still
+     - Installed revision **>= 3**. INFO: an older-but-adequate or hand-edited copy that still
        resolves the newest tee correctly. A refresh is housekeeping.
-     - Installed revision **< 3, or unmarked** — FAIL. Such a copy picks the newest tee by mtime
+     - Installed revision **< 3, or unmarked**. FAIL. Such a copy picks the newest tee by mtime
        alone, so it also resolves one left behind by an UNINSTALLED plugin and keeps teeing for
        the whole orphan grace window. The statusline keeps rendering, which is why this reads as
        harmless and is not: it is a behavior defect in what the operator is running, and INFO
@@ -61,15 +61,14 @@ zone bands, zones.json shape) are owned by
      - **The migration matters more than the classification.** The durable copy at
        `~/.claude/context-guard/bin/statusline-shim.sh` is what the statusline actually runs; a
        plugin update never overwrites it. An operator who ran `apply` before revision 3 shipped
-       therefore keeps running the old shim until they re-run `apply` — and if they uninstall the
+       therefore keeps running the old shim until they re-run `apply`, and if they uninstall the
        plugin first, this skill is gone and the stale shim keeps teeing with no remaining way to
        reach the remediation. Say that in the finding, so the reason to act now is on screen.
-   - **The SHIPPED source is absent** (no `${CLAUDE_PLUGIN_ROOT}/scripts/statusline-shim.sh`) —
-     INFO, and skip the comparison entirely: this installed plugin version predates the shim
+   - **The SHIPPED source is absent** (no `${CLAUDE_PLUGIN_ROOT}/scripts/statusline-shim.sh`): INFO, and skip the comparison entirely: this installed plugin version predates the shim
      (< 0.2.0). Never report the operator's installed copy as drifted on this branch. Remediation:
      `/plugin update context-guard`, then re-run `check`. Until then the legacy version-pinned
      wiring in step 3 is the only wiring this version can offer.
-3. **Statusline wiring state** — read (never write) every settings scope that can carry a
+3. **Statusline wiring state**. Read (never write) every settings scope that can carry a
    `statusLine` (user `~/.claude/settings.json`, project `.claude/settings.json`, local
    `.claude/settings.local.json`, and managed settings, where `statusLine` is also a valid key)
    and determine which one owns the EFFECTIVE command (the most specific scope wins among the
@@ -78,25 +77,25 @@ zone bands, zones.json shape) are owned by
    file **except** when the owning scope is managed: that file is administrator-controlled, the
    operator running this skill generally cannot change it, and no lower-scope edit can override
    it. In that case name the managed source, say the operator cannot change it from here, and
-   route to the policy administrator — do not print an operator edit for the managed file.
+   route to the policy administrator. Do not print an operator edit for the managed file.
    Wiring the user file while a project-level `statusLine` shadows it would apply cleanly and
    never run; when a non-managed shadow exists, say so explicitly and print the edit for the
    shadowing file (or note that removing the override is the alternative). Distinguish FOUR
    states:
-   - **No `statusLine` configured** — the wrapper is not running because nothing is. Print the
+   - **No `statusLine` configured**, the wrapper is not running because nothing is. Print the
      standalone wiring from the template below (the shim is then the whole statusline).
    - **`statusLine` present, command references neither the shim nor this plugin's
-     `statusline-tee.sh`** — wrapper missing. Print the wrapped wiring below with the user's
+     `statusline-tee.sh`**. Wrapper missing. Print the wrapped wiring below with the user's
      current command preserved as the wrapped command.
    - **`statusLine` references a `context-guard` `statusline-tee.sh` under the plugin cache
-     (`.../plugins/cache/<marketplace>/context-guard/<version>/scripts/…`)** — LEGACY
+     (`.../plugins/cache/<marketplace>/context-guard/<version>/scripts/…`)**. LEGACY
      VERSION-PINNED WIRING, regardless of whether that file currently exists. It is running
      today only until the next version bump, and it breaks the whole statusline once the old
      version directory is pruned (~14 days after an update). Report it as the failure mode this
      plugin's shim exists to remove, and print the shim wiring as the fix (step 2's `apply` first
      if the shim is not installed). An interim `[ -f … ]` existence guard around such a path is
      the same state: it survives pruning but still stops teeing on a version bump.
-   - **`statusLine` invokes `~/.claude/context-guard/bin/statusline-shim.sh`** — PASS. No path
+   - **`statusLine` invokes `~/.claude/context-guard/bin/statusline-shim.sh`**. PASS. No path
      comparison against `${CLAUDE_PLUGIN_ROOT}` applies or is meaningful here; the shim resolves
      the tee at run time.
 
@@ -105,8 +104,8 @@ zone bands, zones.json shape) are owned by
 
    - **The session is terminal-less.** The statusline is a terminal-interface surface, so a
      session with no terminal interface does not run a statusline even when one is wired.
-     Measured 2026-08-21 for Claude Code on the web and for a `claude -p` run — a configured
-     `statusLine` was never invoked in either — and expected on the same reasoning, though not
+     Measured 2026-08-21 for Claude Code on the web and for a `claude -p` run, a configured
+     `statusLine` was never invoked in either, and expected on the same reasoning, though not
      measured, for other non-terminal environments such as a self-hosted cloud runner. Where
      you can tell you are in such a session, report this as **INFO: no capture channel in this
      environment** regardless of which of the four wiring states applies, say that `unknown` is
@@ -119,13 +118,12 @@ zone bands, zones.json shape) are owned by
      section of `${CLAUDE_PLUGIN_ROOT}/reference/reader-contract.md` carries the consumer rule.
    - **The status line is turned off with a `statusLine` still configured.** Claude Code
      disables it entirely when managed settings set `disableAllHooks` or the folder is not
-     trusted, and narrows the source to managed settings when `allowManagedHooksOnly` is set —
-     under narrowing it runs a managed value if one is deployed and otherwise "skips your value
+     trusted, and narrows the source to managed settings when `allowManagedHooksOnly` is set; under narrowing it runs a managed value if one is deployed and otherwise "skips your value
      without warning, the status line is disabled". Report that state as **INFO: the status
      line is disabled by policy or workspace trust**, name which of the three conditions
-     applies, and route the operator to policy or trust — it is not a wiring defect, and
+     applies, and route the operator to policy or trust. It is not a wiring defect, and
      printing wiring will not fix it.
-4. **Live-session snapshot freshness** — this session's id is `${CLAUDE_SESSION_ID}`. Probe
+4. **Live-session snapshot freshness**. This session's id is `${CLAUDE_SESSION_ID}`. Probe
    `~/.claude/context-guard/context/${CLAUDE_SESSION_ID}.json`:
    - Exists and `captured_at` is within the reader contract's 10-minute staleness window → PASS
      (zone-informed consumers get real data). Also report the zone:
@@ -135,41 +133,39 @@ zone bands, zones.json shape) are owned by
    - Absent or stale while step 3 found **no `statusLine` in any scope** → INFO, not FAIL:
      nothing is writing snapshots because nothing is configured to, whether the file is missing
      or a leftover from an earlier session has gone stale. Which INFO depends on the SAME
-     condition step 3 branched on, and the two reports must agree — never print step 3's wiring
+     condition step 3 branched on, and the two reports must agree, never print step 3's wiring
      and then say nothing is broken.
      - **If step 3 took the terminal-less exception** (you could tell this session refreshes no
        statusline) this is structural: `unknown` is correct and permanent here, no other channel
        can supply one, and there is nothing to fix. Do not report a defect and do not send the
        operator to fix an install that is not broken.
-     - **Otherwise** this is the not-yet-wired state — the ordinary state of a fresh local
+     - **Otherwise** this is the not-yet-wired state, the ordinary state of a fresh local
        install, and the single most common reason `check` is run. The remediation is the wiring
        step 3 just printed; point at it, say snapshots start on the next statusline refresh once
        it is applied, and do NOT call this structural.
    - Absent or stale while step 3 reported correct wiring **and did not find the status line
      disabled and did not take the terminal-less exception** → FAIL: the wrapper is wired but
      not running (the statusline refreshes only in interactive sessions; also re-check steps 2
-     and 3 — a shim that is wired but not installed produces exactly this). Note the file only
+     and 3, a shim that is wired but not installed produces exactly this). Note the file only
      updates while this session is interactive. If step 3 found the status line disabled by
      policy or trust, or took the terminal-less exception, this is that INFO instead, not a
-     FAIL — including the measured cloud case of a correctly-wired `statusLine` that is never
+     FAIL, including the measured cloud case of a correctly-wired `statusLine` that is never
      invoked.
    - If the literal string `${CLAUDE_SESSION_ID}` appears unexpanded above, report that this
-     Claude Code version lacks the substitution and consumers will take the conservative path —
-     probe the newest file in `~/.claude/context-guard/context/` instead, labeled as such.
-5. **zones.json state** — read-only report: absent (shipped defaults in effect — percentage 50/75
+     Claude Code version lacks the substitution and consumers will take the conservative path; probe the newest file in `~/.claude/context-guard/context/` instead, labeled as such.
+5. **zones.json state**, read-only report: absent (shipped defaults in effect, percentage 50/75
    plus the window-class token bands; valid zero-config state, not a defect), present and valid
    (report the bands in effect, both shapes), or present with a malformed shape (report per shape
-   — the resolver validates percentage keys and `token_bands` independently and falls back per
+the resolver validates percentage keys and `token_bands` independently and falls back per
    shape with a stderr notice; a v1 file without `token_bands` is valid, with shipped token bands
-   silently in effect; remediation: `apply`). Note the hooks resolve zones through this same data —
-   a machine with no snapshots gets silent hooks, not errors.
-6. **Hook registration vs hook activation** — THREE separate facts, never collapsed into one
+   silently in effect; remediation: `apply`). Note the hooks resolve zones through this same data: a machine with no snapshots gets silent hooks, not errors.
+6. **Hook registration vs hook activation**. THREE separate facts, never collapsed into one
    status. A registered hook set that every hook exits out of immediately is the exact state an
    operator is diagnosing when injections or gating are missing, and reporting "active" because the
    plugin is enabled tells them the opposite of the runtime state.
-   - **Registered** — the plugin is enabled, so `hooks/hooks.json` is loaded and the matchers fire.
+   - **Registered**, the plugin is enabled, so `hooks/hooks.json` is loaded and the matchers fire.
      This follows from the plugin being enabled and says nothing about what the hooks then do.
-   - **Hook set armed** — the `context_guard_hooks_enabled` kill switch. Read its CONFIGURED value,
+   - **Hook set armed**, the `context_guard_hooks_enabled` kill switch. Read its CONFIGURED value,
      not the plugin's enablement: the value substituted here is
      `${user_config.context_guard_hooks_enabled}`. Interpret it as
      - `false` → **INERT**: registered but every hook (injection, gate, PostCompact marker) exits
@@ -182,49 +178,49 @@ zone bands, zones.json shape) are owned by
        `pluginConfigs` options block in the user `settings.json`
        (`docs/conventions/hook-config-delivery` owns why the declared `default` field is not
        delivered to hook processes).
-   - **Gate posture** — `zone_hook_mode` is `${user_config.zone_hook_mode}`, read and interpreted
+   - **Gate posture**. `zone_hook_mode` is `${user_config.zone_hook_mode}`, read and interpreted
      the same way. Only `blocking` makes the PreToolUse gate do anything; `advisory` (the in-script
      default) leaves it inert while the injection hook still runs. Report it separately: an armed
      hook set with an advisory posture is a different runtime state from an inert hook set, and
      only one of the two is a defect.
-7. **Print the operator edit** — print the applicable statusline edit for the settings file
+7. **Print the operator edit**. Print the applicable statusline edit for the settings file
    that owns the effective command (step 3), marked clearly as the operator's to apply, **except**
    when step 3 took the terminal-less exception, found the status line disabled by policy or
    trust, or found the effective command owned by managed settings. Those branches already
    forbade printing wiring the operator cannot make run (or cannot change); printing it here
    would recommend the exact ineffective remediation they suppress. When this step does print,
-   the wiring target is the SHIM's fixed path — never `${CLAUDE_PLUGIN_ROOT}`, which is
+   the wiring target is the SHIM's fixed path, never `${CLAUDE_PLUGIN_ROOT}`, which is
    version-pinned and belongs in no operator file:
 
    **Unwrap before you compose.** `<current statusline command>` below means the operator's OWN
    renderer, never the raw effective `command` string. Recover it by peeling off the wrapping this
    skill itself prints, applying BOTH rules repeatedly until a pass strips nothing:
 
-   1. **Guard-shim prefixes** — every leading `bash <path>/context-guard/bin/statusline-shim.sh` and
+   1. **Guard-shim prefixes**. Every leading `bash <path>/context-guard/bin/statusline-shim.sh` and
       `bash <path>/rate-limit-guard/bin/statusline-shim.sh`, in whatever order they appear, plus any
       legacy `bash <plugin-cache>/…/statusline-tee.sh` prefix.
-   2. **A generated `sh -c` adapter** — when what remains is EXACTLY `sh -c '<single-quoted string>'`
+   2. **A generated `sh -c` adapter**, when what remains is EXACTLY `sh -c '<single-quoted string>'`
       with nothing after the closing quote, AND, once that string is unescaped, ANY of the following
       holds, that is an adapter a previous run printed, not the renderer. Unescape it back: drop the
       leading `sh -c` and the outer quotes, then replace every `'\''` with `'`.
 
-      - **A — it is itself EXACTLY `sh -c '<single-quoted string>'`, nothing after the closing
+      - **A. It is itself EXACTLY `sh -c '<single-quoted string>'`, nothing after the closing
         quote.** A nested `sh -c` is always a layer some run added: an operator's own renderer is at
         most one `sh -c` deep. Apply the same strictness here as to the outer shape, so two readers
         peel the same number of layers.
-      - **B — it begins with a guard-shim prefix from rule 1.** This skill never puts a shim inside
+      - **B. It begins with a guard-shim prefix from rule 1.** This skill never puts a shim inside
         an adapter, and an operator would not write one inside their own `sh -c`. Leaving it sealed
         there hides it from rule 1, which strips only LEADING prefixes, and the composed wiring then
         names that shim a second time.
-      - **C — it is a command the guard below would send for wrapping.** That is the only shape this
+      - **C. It is a command the guard below would send for wrapping.** That is the only shape this
         skill's own adapter ever carries.
 
-      Branches A and B must NOT inherit the guard's top-level scoping — their evidence is the shape
+      Branches A and B must NOT inherit the guard's top-level scoping. Their evidence is the shape
       of the carried string, not the syntax in it. Absent all three, the `sh -c` was written by the
       operator and must be preserved: peeling `sh -c 'ulimit -n'` to `ulimit -n` would leave the
       shim `exec`-ing a shell builtin that no longer has a shell, and the statusline would exit 127
       instead of rendering. A trailing word (`sh -c '…' extra`) makes it a real command, not an
-      adapter — leave that alone too.
+      adapter. Leave that alone too.
 
       One shape stays ambiguous on purpose: a single `sh -c` over a merely-quoted command, which a
       version of this skill that wrongly counted quoting as a trigger also emitted. Nothing in it
@@ -237,7 +233,7 @@ zone bands, zones.json shape) are owned by
    Substituting the raw string instead is what produces `context → rate → rate → renderer` when the
    sibling plugin was configured first, or a doubled self-wrap on a re-run: each duplicated tee runs
    and writes on EVERY refresh and costs another 0.6–0.9 s (below). Skipping rule 2 compounds the
-   shell-syntax guard instead — the leftover adapter still contains shell syntax, so it is wrapped in
+   shell-syntax guard instead, the leftover adapter still contains shell syntax, so it is wrapped in
    ANOTHER `sh -c` layer, one more on every run. Unwrapping both makes the printed edit idempotent:
    re-running `check` on already-correct wiring prints byte-identical wiring, with exactly one shim
    invocation per plugin and at most one `sh -c` layer.
@@ -265,21 +261,20 @@ zone bands, zones.json shape) are owned by
    }
    ```
 
-   Shell-syntax guard: the wrapped form passes the user's command as ARGV — the shell that runs
+   Shell-syntax guard: the wrapped form passes the user's command as ARGV, the shell that runs
    the `statusLine` command splits the whole line into words and consumes its quotes, and the shim
    `exec`s those words unchanged. It therefore only works for plain `executable arg…` commands. Test
-   the UNWRAPPED renderer, never the raw effective `command` string — the rules above run first.
+   the UNWRAPPED renderer, never the raw effective `command` string, the rules above run first.
    Print the shell-wrapped variant instead when EITHER of these holds:
 
-   - It carries — UNQUOTED, at the top level — shell syntax no ARGV word can express: an inline env
+   - It carries, UNQUOTED, at the top level, shell syntax no ARGV word can express: an inline env
      assignment like `THEME=dark my-statusline`, a redirection, or any control operator (`|`, `|&`,
      `&&`, `||`, `;`, `&`, a newline).
-   - **Its command word is not an executable** — a shell builtin, function, or alias, which `exec`
+   - **Its command word is not an executable**, a shell builtin, function, or alias, which `exec`
      cannot run because there is no file to exec. `ulimit '-n'` is the standing example: `ulimit`
      exists only as a builtin, so the plain wrapped form reaches `exec ulimit -n` and the statusline
-     dies with exit 127 on every refresh. Resolve it the way the shim will —
-     `type -P <word>` finding nothing while `type -t <word>` reports `builtin`, `function`, or
-     `alias` is the test — not by matching a hardcoded list of builtin names.
+     dies with exit 127 on every refresh. Resolve it the way the shim will: `type -P <word>` finding nothing while `type -t <word>` reports `builtin`, `function`, or
+     `alias` is the test, not by matching a hardcoded list of builtin names.
 
      This trigger is load-bearing precisely because it is *not* about syntax. Such a renderer often
      carries none at all, and before the guard was scoped to real syntax the bare presence of quotes
@@ -297,7 +292,7 @@ zone bands, zones.json shape) are owned by
 
    `<escaped renderer>` is that same unwrapped renderer, POSIX-escaped for single-quote
    embedding: replace every `'` in it with `'\''` before substituting (then JSON-escape the whole
-   `command` string as usual). Show the final, fully escaped line — never hand the operator a
+   `command` string as usual). Show the final, fully escaped line, never hand the operator a
    template with raw quotes left to fix. Verify your printed edit round-trips: run
    `printf '%s\n' '<escaped renderer>'` and confirm the output matches the renderer
    byte-for-byte. The single-quoted argument reproduces exactly the quoting context the emitted
@@ -306,14 +301,14 @@ zone bands, zones.json shape) are owned by
 
    **Syntax inside a quoted argument does not count, and bare quoting is never itself a trigger.**
    The quotes make it one ordinary ARGV word that reaches the renderer intact through the plain
-   wrapped form. So an operator's own `sh -c '<string>'` — the one shape rule 2 preserves — is
+   wrapped form. So an operator's own `sh -c '<string>'`, the one shape rule 2 preserves, is
    ALREADY a plain `executable arg…` command: `sh` is the executable, `-c` and the carried string
    are two ordinary ARGV words. Substitute it VERBATIM.
 
    For an input that is ITSELF `sh -c '<string>'`, rule 2 and this guard therefore never both wrap
    it, and leave exactly one layer: rule 2 peels every generated layer before the guard runs, and
    what rule 2 preserves is a renderer this guard declines. Do not generalize that to a layer count
-   for every input — the guard adds whatever the renderer genuinely needs, which is NONE for a plain
+   for every input, the guard adds whatever the renderer genuinely needs, which is NONE for a plain
    command and ONE for top-level syntax, and that one is a layer more when the operator's own
    `sh -c` sits inside it. `sh -c 'ulimit -n' && echo ok` correctly prints TWO: the `&&` cannot be an
    ARGV word, so the adapter is mandatory, and peeling the inner `sh -c` would strand the builtin.
@@ -322,11 +317,11 @@ zone bands, zones.json shape) are owned by
    `sh -c 'ulimit -n'` into `sh -c 'sh -c '\''ulimit -n'\'''`, one more shell on every refresh and
    the same compounding rule 2 exists to prevent.
 
-   Sibling tees compose by nesting, each through its OWN shim — the tees are transparent wrappers,
+   Sibling tees compose by nesting, each through its OWN shim, the tees are transparent wrappers,
    so the innermost command still owns stdout and the exit code. Print this form only when
    `rate-limit-guard` is installed AND its shim is already present at
    `~/.claude/rate-limit-guard/bin/statusline-shim.sh`. The sibling shim is written by
-   `/rate-limit-guard:setup apply`, which the operator may not have run yet — naming a path that
+   `/rate-limit-guard:setup apply`, which the operator may not have run yet. Naming a path that
    does not exist reintroduces exactly the failure this wiring exists to remove, because `bash
    <missing-path>` exits 127 before the operator's renderer ever runs. When the sibling plugin is
    installed but its shim is absent, print the single-shim form above and say that
@@ -343,7 +338,7 @@ zone bands, zones.json shape) are owned by
 
    The shell-syntax guard applies UNCHANGED to this form: `<current statusline command>` is the
    innermost ARGV here too, so run the same test above on the same unwrapped renderer and substitute
-   whichever of the two forms it selects — never the raw string. Substituting `THEME=dark my-statusline` raw
+   whichever of the two forms it selects, never the raw string. Substituting `THEME=dark my-statusline` raw
    makes `THEME=dark` the executable, which fails `command not found` (127) instead of setting the
    variable. The shim paths are the only part that nests; the innermost substitution rule never
    changes:
@@ -362,13 +357,13 @@ zone bands, zones.json shape) are owned by
    command. `refreshInterval` sets how often that runs; the statusline is not on the input path, so
    the cost is display latency, not typing latency.
 
-   Windows note: the command must run under Git Bash — `bash` is invoked explicitly for exactly
+   Windows note: the command must run under Git Bash. `bash` is invoked explicitly for exactly
    that reason (the script's stated shell requirement); with Git Bash absent Claude Code routes
    statusline commands through PowerShell and this wiring does not apply (statusline reference,
    "Windows configuration"). State this with the printed edit: the wiring is applied ONCE and
-   survives every later plugin update, because the shim — not the version-pinned cache path — is
+   survives every later plugin update, because the shim, not the version-pinned cache path, is
    what the settings file names.
-8. **Dotfiles tracking proposal** — the printed edit changes a durable user-scope file the operator
+8. **Dotfiles tracking proposal**, the printed edit changes a durable user-scope file the operator
    maintains. When the operator's home directory is managed by a dotfiles system (chezmoi, yadm, a
    bare-repo setup, ...), surface the reminder to capture the `settings.json` change through that
    system's own add/track flow so the wiring survives machine rebuilds. This skill only surfaces
@@ -385,26 +380,25 @@ Copy `${CLAUDE_PLUGIN_ROOT}/scripts/statusline-shim.sh` to
 `~/.claude/context-guard/bin/statusline-shim.sh`, creating `bin/` if needed, and `chmod +x` the
 result (a no-op on Windows ACL volumes; the wiring invokes it through `bash` anyway):
 
-- The installed copy is **byte-identical** to the shipped source — never a rewrite, never a
+- The installed copy is **byte-identical** to the shipped source, never a rewrite, never a
   templated variant. That is what makes `check` step 2 a plain `cmp`.
 - **Idempotent**: if the file already exists and compares equal, write nothing and say so.
   Otherwise overwrite it (this is the update path after a plugin version bump changes the shim)
   and report the `# shim-revision:` values, old → new.
 - The shim is **inert until wired**: installing it starts nothing. Only the operator's
-  `settings.json` edit — step 7 of `check`, which this skill never applies — puts it on the
+  `settings.json` edit. Step 7 of `check`, which this skill never applies. Puts it on the
   statusline path. Say that explicitly when reporting the write.
-- After installing, print the wiring edit (`check` step 7) — honoring that step's exceptions —
-  so the operator's next action is in front of them when there is one, and note that a
+- After installing, print the wiring edit (`check` step 7). Honoring that step's exceptions, so the operator's next action is in front of them when there is one, and note that a
   statusline already wired to the shim needs NO change now or on any future plugin update.
 
 ### B. Seed or refresh the zones SSOT
 
 Seed or refresh `~/.claude/context-guard/zones.json` from the shipped defaults
 (`smart_max_used_percentage: 50`, `acceptable_max_used_percentage: 75`, and the window-class
-`token_bands` — the reader contract owns these numbers; read them from
+`token_bands`, the reader contract owns these numbers; read them from
 `${CLAUDE_PLUGIN_ROOT}/reference/reader-contract.md` rather than this file if they ever disagree):
 
-1. **File absent** — create the directory if needed and write exactly:
+1. **File absent**. Create the directory if needed and write exactly:
 
    ```json
    {
@@ -417,10 +411,9 @@ Seed or refresh `~/.claude/context-guard/zones.json` from the shipped defaults
    }
    ```
 
-2. **File present** — behavior is mode-explicit, never ambiguous:
+2. **File present**. Behavior is mode-explicit, never ambiguous:
    - `apply` (no argument): REPAIR-ONLY. Valid recognized band values are left untouched and
-     reported; recognized keys that are missing or invalid (non-numeric, inverted, out of range —
-     for `token_bands`, invalid per the reader contract's per-shape validity rules) are set to the
+     reported; recognized keys that are missing or invalid (non-numeric, inverted, out of range; for `token_bands`, invalid per the reader contract's per-shape validity rules) are set to the
      shipped defaults. A v1 file's ABSENT `token_bands` is repaired by adding the shipped token
      bands (absence is valid zero-config for the resolver, but the seeded SSOT should carry the
      full tunable surface). An operator's custom-but-valid thresholds are never overwritten by a
@@ -428,17 +421,16 @@ Seed or refresh `~/.claude/context-guard/zones.json` from the shipped defaults
    - `apply defaults`: set ALL recognized band keys (both percentage keys and `token_bands`) to
      the shipped defaults explicitly. This converges forward to a known state; it is not teardown,
      and it never removes the file or any key it does not recognize.
-   - Both modes **preserve every unrecognized key semantically** — same keys, same JSON values —
-     (the file is a shared SSOT the operator's own statusline may extend). Preservation is
+   - Both modes **preserve every unrecognized key semantically**. Same keys, same JSON values (the file is a shared SSOT the operator's own statusline may extend). Preservation is
      value-level, not lexical: a `jq` merge reserializes the document, so formatting and escape
      spellings may normalize (`"blue"` → `"blue"`); consumers of this file must parse it as
      JSON, never depend on its raw bytes. Use `jq` to merge so the result stays valid JSON. If
      `jq` is absent while the file exists, FAIL with the jq install remediation
-     (<https://jqlang.org/download/>) instead of attempting a merge — never risk clobbering the
+     (<https://jqlang.org/download/>) instead of attempting a merge, never risk clobbering the
      operator's keys with a jq-less rewrite. (Step 1's template write needs no jq.)
-3. **Idempotent** — a second identical `apply` produces no content change; say so.
+3. **Idempotent**, a second identical `apply` produces no content change; say so.
 4. **Report exactly what was written** (old bands → new bands, unrecognized keys preserved), and
-   remind that consumers re-read the file on their next zone decision — no restart needed.
+   remind that consumers re-read the file on their next zone decision. No restart needed.
 
 `apply` never touches `settings.json`, the snapshot directory, or anything outside
 `~/.claude/context-guard/`. Statusline wiring stays print-only (owner-approved execution-shape
@@ -448,15 +440,14 @@ decision).
 
 Uninstalling the plugin removes the cache directory, not the operator's files. Nothing breaks: the
 shim finds no tee and passes the wrapped statusline through unchanged (a wired-standalone shim
-prints one notice line instead). Two operator cleanup steps remain, and their ORDER matters —
-report both together, in this order, when asked how to back this out:
+prints one notice line instead). Two operator cleanup steps remain, and their ORDER matters. Report both together, in this order, when asked how to back this out:
 
 1. **Unwrap the `statusLine` command first**, restoring the operator's own renderer (or removing
    the field entirely if the shim was the whole statusline).
 2. **Then remove `~/.claude/context-guard/`.**
 
 Deleting the directory while the wiring still names the shim leaves `settings.json` invoking a
-missing file: `bash <missing-path>` exits 127 and takes the WHOLE statusline down — the exact
+missing file: `bash <missing-path>` exits 127 and takes the WHOLE statusline down, the exact
 failure the shim exists to prevent. The shim's own no-tee fallback cannot cover this, because the
 fallback lives in the file that was just deleted.
 
@@ -464,9 +455,8 @@ fallback lives in the file that was just deleted.
 
 - Write the plugin cache, Claude Code user settings, or `pluginConfigs`, per the uniform setup
   contract (`docs/PLUGIN-PHILOSOPHY.md` "Setup is explicit and repeatable" in the marketplace
-  repository). Nor `settings.json` (user or project) or any other Claude Code settings surface —
-  the printed edit is the operator's to apply.
+  repository). Nor `settings.json` (user or project) or any other Claude Code settings surface; the printed edit is the operator's to apply.
 - Install `jq` or any system package.
-- Write to the snapshot directory `~/.claude/context-guard/context/` — the tee owns those files.
-- Write anywhere outside `~/.claude/context-guard/` — including the sibling `rate-limit-guard`
+- Write to the snapshot directory `~/.claude/context-guard/context/`, the tee owns those files.
+- Write anywhere outside `~/.claude/context-guard/`, including the sibling `rate-limit-guard`
   directory, whose own setup skill installs that plugin's shim.


### PR DESCRIPTION
No linked issue

## Summary

#2891 instruction-surface de-slop cluster: purge em dashes from the `context-guard` plugin README and every SKILL.md.

## Fix

Rewrote `plugins/context-guard/README.md` and every `plugins/context-guard/**/SKILL.md` under `/ai-slop:audit fix` semantics (periods, commas, or a restructured sentence; never parentheses, en dashes, or a spaced hyphen as a stand-in). A self-audit repaired wrap leftovers, split asides, and table N/A cells the mechanical pass left as fragments. `context-guard` 0.7.21.

## Verification

- Detector: 0 `rule-em-dash` findings outside ignore-fenced generated-options spans (and required trigger strings that must keep em dashes)
- `CHECK_SKILL_SKIP_MARKDOWNLINT=1 bash scripts/check-changed-skills.sh origin/main`: 0 failed; quoted trigger phrases vs origin/main preserved
- `python3 scripts/sync-plugin-options-docs.py --check` up to date
- `scripts/check-changelog-parity.sh --check-bump origin/main` passes
- `node scripts/generate-cheatsheet.mjs --check` in sync

## Related

Refs #2891

#2891 stays open.