### PR TITLE
docs(repo-hygiene): de-slop instruction surfaces (0.10.11)

### DIFF
--- a/plugins/repo-hygiene/.claude-plugin/plugin.json
+++ b/plugins/repo-hygiene/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "repo-hygiene",
-  "version": "0.10.10",
+  "version": "0.10.11",
   "description": "Repo hygiene action-router: /repo-hygiene:clean sweeps reclaimable caches, build artifacts, and stale git metadata, and can realign the working tree to a fresh-pull state — dry-run-first, with destructive tiers gated behind explicit confirmation and a session-scoped destructive-command guard. Ecosystem targets are detected at runtime; secrets, runtime dependencies, and skill data are preserved by default.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/repo-hygiene/CHANGELOG.md
+++ b/plugins/repo-hygiene/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to the `repo-hygiene` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.10.11]
+
+### Changed
+
+- **Instruction-surface de-slop (#2891, repo-hygiene cluster).** Rewrote this plugin's `README.md` and every
+  `SKILL.md` to drop em dashes under the repo's zero-tolerance house policy, using
+  `/ai-slop:audit fix` semantics: periods or commas, or a restructured sentence, never
+  parentheses, en dashes, or a spaced hyphen as a stand-in. Meaning stays; only the mark
+  and the sentence break change. The generated options block is ignore-fenced because
+  `scripts/sync-plugin-options-docs.py` still emits em dashes from its shared template.
+
 ## [0.10.10]
 
 ### Changed

--- a/plugins/repo-hygiene/README.md
+++ b/plugins/repo-hygiene/README.md
@@ -3,7 +3,7 @@
 A Claude Code plugin that returns a repository toward a known-good state.
 `/repo-hygiene:clean` is an action-router: it inventories reclaimable space,
 removes tool caches and build artifacts, prunes stale git metadata, and, as a
-deliberately-gated destructive tier. Realigns the working tree to a fresh-pull
+deliberately-gated destructive tier, realigns the working tree to a fresh-pull
 state. Every mutating path is **dry-run-first**, and the destructive tiers are
 gated behind explicit confirmation plus a session-scoped destructive-command
 guard.

--- a/plugins/repo-hygiene/README.md
+++ b/plugins/repo-hygiene/README.md
@@ -2,8 +2,8 @@
 
 A Claude Code plugin that returns a repository toward a known-good state.
 `/repo-hygiene:clean` is an action-router: it inventories reclaimable space,
-removes tool caches and build artifacts, prunes stale git metadata, and — as a
-deliberately-gated destructive tier — realigns the working tree to a fresh-pull
+removes tool caches and build artifacts, prunes stale git metadata, and, as a
+deliberately-gated destructive tier. Realigns the working tree to a fresh-pull
 state. Every mutating path is **dry-run-first**, and the destructive tiers are
 gated behind explicit confirmation plus a session-scoped destructive-command
 guard.
@@ -12,7 +12,7 @@ guard.
 
 `/repo-hygiene:clean <action>` routes every action below. Bare invocation infers
 intent from the conversation, or presents a menu and falls back to the safe `scan`.
-`/repo-hygiene:setup` is the separate, read-only prerequisite check — it verifies
+`/repo-hygiene:setup` is the separate, read-only prerequisite check. It verifies
 `git`, the optional `ghq`, and the effective destructive-guard toggle, and cleans
 nothing.
 
@@ -22,12 +22,12 @@ nothing.
 | `caches` | Remove tool / linter caches (`.pytest_cache`, `.ruff_cache`, `__pycache__`, `.turbo`, `.vs`, …) | Low |
 | `build` | Remove build artifacts (`bin`/`obj`/`build`/`dist`/`out`/`target`/`TestResults`, `*.binlog`), includes caches | Low |
 | `git` | Prune stale worktree/remote metadata and gc; audit branches (merged / PR-merged / stale) and delete only on per-branch opt-in | Low |
-| `tree` | Reset the working tree like a fresh pull — `git reset --hard` + `git clean -fdx` | **Destructive** |
+| `tree` | Reset the working tree like a fresh pull. `git reset --hard` + `git clean -fdx` | **Destructive** |
 | `tree-batch` | Run `tree` across many repos (`ghq list`, a glob, or an explicit list) behind one confirmation gate, with a separator-agnostic skip list and a dirty-by-default guard | **Destructive** |
-| `all` | Sweep `caches` + `build` + `git` — **never** the `tree` reset | Medium |
+| `all` | Sweep `caches` + `build` + `git`. **never** the `tree` reset | Medium |
 
 Tiers are cumulative (`build` includes `caches`; `all` = `build` + `git`), and
-neither `tree` nor `tree-batch` is composed into `all` — one mistaken sweep cannot
+neither `tree` nor `tree-batch` is composed into `all`. One mistaken sweep cannot
 trigger a `reset --hard`.
 
 ### Multi-repo reset (`tree-batch`)
@@ -36,7 +36,7 @@ trigger a `reset --hard`.
 without hand-rolling a loop. It skips any repo with uncommitted/untracked changes
 or unpushed commits **by default** (opt in with `--include-dirty`), and its skip
 list is matched separator-agnostically, so a `\`-path skip entry reliably protects
-a repo enumerated with `/` paths — the failure that lost an uncommitted edit in an
+a repo enumerated with `/` paths, the failure that lost an uncommitted edit in an
 ad-hoc loop. A skip entry that matches nothing is reported, never silently ignored.
 
 ```shell
@@ -52,7 +52,7 @@ ghq list -p | /repo-hygiene:clean tree-batch --repos-from - --skip melodic-softw
   local config** (`.env*`, `*.local.json`/`.jsonc`/`.md`, IDE + cloud + Codex
   config), **runtime dependencies** (`node_modules/`, `.venv/`, `vendor/`), and
   **skill-owned `data/`** directories. `tree` widens deletion only with the
-  explicit `--include-deps` / `--include-secrets` flags — and `--include-secrets`
+  explicit `--include-deps` / `--include-secrets` flags, and `--include-secrets`
   demands its own separate confirmation because it is unrecoverable.
 - **Any git-tracked file is off-limits** to selective deletion; a tracked file
   deleted by reparse-point (junction/symlink) traversal during a `tree` clean is
@@ -63,7 +63,7 @@ ghq list -p | /repo-hygiene:clean tree-batch --repos-from - --skip melodic-softw
   through the skill's own gate. Kill switch: the `clean_destructive_guard_enabled`
   userConfig option set to `false` (`/plugin configure repo-hygiene@<marketplace>`, or
   `claude plugin install repo-hygiene@<marketplace> --config clean_destructive_guard_enabled=false`;
-  user-scoped — per-repository disable means disabling the plugin in that
+  user-scoped. Per-repository disable means disabling the plugin in that
   project's `enabledPlugins`).
 - **Autonomous sessions abort** the destructive tiers rather than deleting
   unattended.
@@ -73,7 +73,7 @@ ghq list -p | /repo-hygiene:clean tree-batch --repos-from - --skip melodic-softw
 - Self-contained: the path registry, tier scripts, destructive guard, and the
   reference tables all ship inside the plugin under `${CLAUDE_PLUGIN_ROOT}`.
 - No baked layout. Ecosystem targets are generic (universal `bin`/`obj`/… globs,
-  common cache dirs) and the .NET solution is detected at runtime — nothing
+  common cache dirs) and the .NET solution is detected at runtime. Nothing
   assumes a specific repo's directory structure.
 - Conservative by default: the protected-path and preserve lists err toward
   keeping a consumer's dependencies, credentials, and IDE state.
@@ -93,6 +93,7 @@ and the `tree` tier's default-preserve classes to keep additional paths safe. A
 declared per-consumer override for the script-enforced protected list is a known
 extension point, not yet exposed as configuration.
 
+<!-- ai-slop-ignore-start: generated options block; source is plugin.json + scripts/sync-plugin-options-docs.py -->
 <!-- BEGIN GENERATED: plugin options — edit plugin.json, then run scripts/sync-plugin-options-docs.py -->
 
 ### Options reference
@@ -165,6 +166,7 @@ hands a configured value to a hook process; the value comes from the routes abov
 - [Manage installed plugins](https://code.claude.com/docs/en/discover-plugins#manage-installed-plugins) — enabling, disabling, `/plugin list`
 
 <!-- END GENERATED: plugin options -->
+<!-- ai-slop-ignore-end -->
 
 ## License
 

--- a/plugins/repo-hygiene/skills/clean/SKILL.md
+++ b/plugins/repo-hygiene/skills/clean/SKILL.md
@@ -20,7 +20,7 @@ hooks:
       hooks:
         # Shell form (no `args`) on purpose: exec form resolves `command` via PATH,
         # which on Windows finds the WSL relay (System32\bash.exe) and the guard
-        # never launches — a silent fail-open. Shell form with `shell: bash` makes
+        # never launches, a silent fail-open. Shell form with `shell: bash` makes
         # Claude Code itself resolve Git Bash on every platform.
         - type: command
           command: "bash \"${CLAUDE_PLUGIN_ROOT}/skills/clean/scripts/destructive-guard.sh\""
@@ -38,25 +38,25 @@ Current branch: !`git branch --show-current 2>/dev/null || echo "unknown"`
 
 ## Purpose
 
-Return the repo toward a known-good state. **Selective tiers** (`scan`, `caches`, `build`, `git`, `all`) remove *artifacts* while preserving secrets, runtime deps, and skill data. **`tree`** is the destructive tier — `reset --hard` + `clean -fdx`, but **safe-by-default**: it preserves the same secrets / runtime-deps / skill-data classes unless you opt in via `--include-deps` / `--include-secrets`.
+Return the repo toward a known-good state. **Selective tiers** (`scan`, `caches`, `build`, `git`, `all`) remove *artifacts* while preserving secrets, runtime deps, and skill data. **`tree`** is the destructive tier. `reset --hard` + `clean -fdx`, but **safe-by-default**: it preserves the same secrets / runtime-deps / skill-data classes unless you opt in via `--include-deps` / `--include-secrets`.
 
 Bare invocation never mutates silently: resolve intent → dry-run → user confirmation → `--apply`. Full menu, aliases, and confirmation matrix: [context/action-router.md](context/action-router.md).
 
-Bundled-script invocation uses two deliberate forms — paired `${CLAUDE_SKILL_DIR}` in this file (matches `allowed-tools`) and interpreter-led `${CLAUDE_PLUGIN_ROOT}` in routed `context/*.md` detail files. Rationale and decide-lane verdict: [reference/invocation-forms.md](reference/invocation-forms.md).
+Bundled-script invocation uses two deliberate forms. Paired `${CLAUDE_SKILL_DIR}` in this file (matches `allowed-tools`) and interpreter-led `${CLAUDE_PLUGIN_ROOT}` in routed `context/*.md` detail files. Rationale and decide-lane verdict: [reference/invocation-forms.md](reference/invocation-forms.md).
 
 ## Arguments
 
-`$ARGUMENTS` — cleanup action or alias. Resolve first:
+`$ARGUMENTS`. Cleanup action or alias. Resolve first:
 
 ```bash
 ${CLAUDE_SKILL_DIR}/scripts/resolve-clean-action.sh $ARGUMENTS
 ```
 
-When a leading action token is followed by free text, the resolver also emits a `Note: <text>` line. That note is **advisory context you must address** — a question to answer (e.g. "does this include stashes?") or a live-session constraint to honor (e.g. "6-7 live sessions, mind WIP") — not part of action selection. Surface it and act on it alongside the resolved action; never silently drop it.
+When a leading action token is followed by free text, the resolver also emits a `Note: <text>` line. That note is **advisory context you must address**, a question to answer (e.g. "does this include stashes?") or a live-session constraint to honor (e.g. "6-7 live sessions, mind WIP"), not part of action selection. Surface it and act on it alongside the resolved action; never silently drop it.
 
 ### Bare invocation (empty args)
 
-1. Infer from conversation (fresh pull → `tree`, disk space → `scan`, … — see action-router).
+1. Infer from conversation (fresh pull → `tree`, disk space → `scan`, …. See action-router).
 2. If still unclear, present the action table from [context/action-router.md](context/action-router.md) and ask ([Confirmation gate](#confirmation-gate)).
 3. Safest fallback: `scan`.
 
@@ -64,18 +64,18 @@ When a leading action token is followed by free text, the resolver also emits a 
 
 | Action | Say it as… | Risk | Pre-flight? | In `all`? |
 |--------|------------|------|-------------|-----------|
-| `scan` | Show what's reclaimable | Safe | No | — |
-| `caches` | Clear tool and linter caches | Low | Yes | — |
-| `build` | Clear build output and logs | Low | Yes (includes caches) | — |
+| `scan` | Show what's reclaimable | Safe | No | |
+| `caches` | Clear tool and linter caches | Low | Yes | |
+| `build` | Clear build output and logs | Low | Yes (includes caches) | |
 | `git` | Prune stale git metadata; audit branches + stashes | Low | No | Yes |
-| `stash` | Audit and triage stashes (age, source, diffstat) | Safe | No | — |
+| `stash` | Audit and triage stashes (age, source, diffstat) | Safe | No | |
 | `tree` | Reset working tree like a fresh pull | **Destructive** | No (always dry-run first) | **Never** |
 | `tree-batch` | Reset many repos like a fresh pull (skip-list + dirty guard) | **Destructive** | No (always dry-run first) | **Never** |
-| `all` | Sweep caches + build + git hygiene | Medium | Yes | — |
+| `all` | Sweep caches + build + git hygiene | Medium | Yes | |
 
 Tiers cumulative: `build` includes `caches`. `all` = `build` + `git`. **Neither `tree` nor `tree-batch` is ever composed into `all`.**
 
-**Fleet (batch) forms.** Each selective tier has a multi-repo form — `caches-batch`, `build-batch`, `git-batch`, `all-batch` — that runs it across a repo set behind ONE gate (§8). `tree-batch` is the destructive tier's separate batch form (§6.5).
+**Fleet (batch) forms.** Each selective tier has a multi-repo form. `caches-batch`, `build-batch`, `git-batch`, `all-batch`. That runs it across a repo set behind ONE gate (§8). `tree-batch` is the destructive tier's separate batch form (§6.5).
 
 Aliases (`fresh`, `inventory`, `artifacts`, `caches-fleet`, …): [context/action-router.md](context/action-router.md).
 
@@ -83,19 +83,19 @@ Aliases (`fresh`, `inventory`, `artifacts`, `caches-fleet`, …): [context/actio
 
 Protected-path enforcement gates `scan`, `caches`, `build`, `git`, AND `tree` (`tree` honors the same classes by default). Full list: [reference/cleanup-config.md](reference/cleanup-config.md).
 
-- **Secrets / config** — `.env*`, `*.local.json` / `.jsonc` / `.md`, IDE user config — `tree` removes only with `--include-secrets` (UNRECOVERABLE).
-- **Runtime dependencies** — `node_modules/`, `.venv/`, `vendor/` — `tree` removes only with `--include-deps` (rebuildable).
-- **Skill-owned `data/`** — user-generated synthesis — always preserved; no flag removes it.
+- **Secrets / config**. `.env*`, `*.local.json` / `.jsonc` / `.md`, IDE user config. `tree` removes only with `--include-secrets` (UNRECOVERABLE).
+- **Runtime dependencies**. `node_modules/`, `.venv/`, `vendor/`. `tree` removes only with `--include-deps` (rebuildable).
+- **Skill-owned `data/`**, user-generated synthesis, always preserved; no flag removes it.
 
-`tree` requires explicit confirmation and is never auto-invoked. Any file tracked by git is reset via `git reset --hard`, not selective deletion — and any tracked file deleted by reparse-point traversal (junction/symlink into a tracked dir) is auto-restored.
+`tree` requires explicit confirmation and is never auto-invoked. Any file tracked by git is reset via `git reset --hard`, not selective deletion, and any tracked file deleted by reparse-point traversal (junction/symlink into a tracked dir) is auto-restored.
 
-**Session-scoped destructive guard (frontmatter hook).** While this skill is active, a PreToolUse hook (`scripts/destructive-guard.sh`) blocks destructive Bash commands (`rm -rf`, `git clean -f*`, `git reset --hard`, `git checkout --`, `git stash drop`/`clear`, recursive `Remove-Item`). After the [confirmation gate](#confirmation-gate) passes, re-issue the confirmed command with the acknowledgement prefix `CLEAN_GUARD_ACK=1 <command>` — never add the prefix without the user's explicit confirmation in this session. Kill switch: the `clean_destructive_guard_enabled` userConfig option set to `false` (`/plugin configure repo-hygiene@<marketplace>`).
+**Session-scoped destructive guard (frontmatter hook).** While this skill is active, a PreToolUse hook (`scripts/destructive-guard.sh`) blocks destructive Bash commands (`rm -rf`, `git clean -f*`, `git reset --hard`, `git checkout --`, `git stash drop`/`clear`, recursive `Remove-Item`). After the [confirmation gate](#confirmation-gate) passes, re-issue the confirmed command with the acknowledgement prefix `CLEAN_GUARD_ACK=1 <command>`, never add the prefix without the user's explicit confirmation in this session. Kill switch: the `clean_destructive_guard_enabled` userConfig option set to `false` (`/plugin configure repo-hygiene@<marketplace>`).
 
 ## Confirmation gate
 
-**Question surface — every question this skill asks.** Prefer `AskUserQuestion`: its answer is the user's own and cannot be fabricated. It is not always usable, in two distinct ways — a bare-name `permissions.deny` rule or a `disallowed-tools` entry removes it from context entirely, while permission mode `dontAsk` denies it even when an allow rule names it, leaving it visible and every call failing. Fall back to the same question asked inline as a numbered choice whenever the tool is absent, denied, **or otherwise unusable** — including a denial discovered only by calling it; a denied call is an unanswered question, never an answer. Then wait for the reply. The surface varies; nothing below it does.
+**Question surface. Every question this skill asks.** Prefer `AskUserQuestion`: its answer is the user's own and cannot be fabricated. It is not always usable, in two distinct ways, a bare-name `permissions.deny` rule or a `disallowed-tools` entry removes it from context entirely, while permission mode `dontAsk` denies it even when an allow rule names it, leaving it visible and every call failing. Fall back to the same question asked inline as a numbered choice whenever the tool is absent, denied, **or otherwise unusable**, including a denial discovered only by calling it; a denied call is an unanswered question, never an answer. Then wait for the reply. The surface varies; nothing below it does.
 
-**Destructive confirmation — every `--apply`, branch deletion, and stash drop.** Show the dry-run first, then take the user's own affirmative answer, given in this interactive session, naming exactly the set just shown. A prior general request, an alias, a flag, "clean everything", approval of a different set, or silence is not confirmation — never supply or infer the answer yourself. Autonomous sessions abort here rather than ask.
+**Destructive confirmation. Every `--apply`, branch deletion, and stash drop.** Show the dry-run first, then take the user's own affirmative answer, given in this interactive session, naming exactly the set just shown. A prior general request, an alias, a flag, "clean everything", approval of a different set, or silence is not confirmation, never supply or infer the answer yourself. Autonomous sessions abort here rather than ask.
 
 ## Cleanup configuration
 
@@ -111,41 +111,41 @@ Run `resolve-clean-action.sh`. If `Action: menu`, show table + ask. Otherwise di
 
 ### 1. Scan (`scan`)
 
-`${CLAUDE_SKILL_DIR}/scripts/scan.sh` — read-only inventory. Stop if action is `scan`.
+`${CLAUDE_SKILL_DIR}/scripts/scan.sh`. Read-only inventory. Stop if action is `scan`.
 
 ### 1.5. Pre-flight (caches / build / all only)
 
-`${CLAUDE_SKILL_DIR}/scripts/preflight.sh` — see [context/preflight.md](context/preflight.md). Interactive: [confirm](#confirmation-gate) before `--apply` when non-empty. Autonomous: abort.
+`${CLAUDE_SKILL_DIR}/scripts/preflight.sh`. See [context/preflight.md](context/preflight.md). Interactive: [confirm](#confirmation-gate) before `--apply` when non-empty. Autonomous: abort.
 
 #### Dry-run → confirm → apply manifest flow (caches / build)
 
-Both selective mutating tiers pay the filesystem walk **once**. `--dry-run` writes a session-scoped manifest and prints two machine-parseable lines: `Manifest: <path>` and `Summary: planned=N bytes=K` (bytes reclaimable — surface this in the confirmation gate). After the user confirms, apply the **same** manifest with `CLEAN_GUARD_ACK=1 … --apply --manifest <path>` — apply re-stats each entry (staleness guard) and removes it without re-walking, then prints `Summary: removed=N failed=M bytes=K` and exits non-zero if `failed>0`. A killed apply **resumes** by re-running the identical `--apply --manifest <path>` (already-removed entries are idempotent no-ops). Capture `<path>` from the dry-run's `Manifest:` line and thread it through unchanged; the manifest is ephemeral (mktemp default), so pass `--manifest <path>` on the dry-run too if you need a stable location. **Build tier: repeat `--include-caches` on the apply call too** — `clean-build.sh` gates which manifest classes an apply accepts by that invocation's own `--include-caches` flag, not by what built the manifest, so an apply that omits it rejects the manifest's `caches` lines (`Rejected (wrong tier)`, `failed>0`) even though the dry-run folded them in.
+Both selective mutating tiers pay the filesystem walk **once**. `--dry-run` writes a session-scoped manifest and prints two machine-parseable lines: `Manifest: <path>` and `Summary: planned=N bytes=K` (bytes reclaimable. Surface this in the confirmation gate). After the user confirms, apply the **same** manifest with `CLEAN_GUARD_ACK=1 … --apply --manifest <path>`. Apply re-stats each entry (staleness guard) and removes it without re-walking, then prints `Summary: removed=N failed=M bytes=K` and exits non-zero if `failed>0`. A killed apply **resumes** by re-running the identical `--apply --manifest <path>` (already-removed entries are idempotent no-ops). Capture `<path>` from the dry-run's `Manifest:` line and thread it through unchanged; the manifest is ephemeral (mktemp default), so pass `--manifest <path>` on the dry-run too if you need a stable location. **Build tier: repeat `--include-caches` on the apply call too**. `clean-build.sh` gates which manifest classes an apply accepts by that invocation's own `--include-caches` flag, not by what built the manifest, so an apply that omits it rejects the manifest's `caches` lines (`Rejected (wrong tier)`, `failed>0`) even though the dry-run folded them in.
 
 ### 2. Caches
 
-`${CLAUDE_SKILL_DIR}/scripts/clean-caches.sh` — default `--dry-run`; apply per the manifest flow above (`--apply --manifest <path>`) only after confirmation.
+`${CLAUDE_SKILL_DIR}/scripts/clean-caches.sh`, default `--dry-run`; apply per the manifest flow above (`--apply --manifest <path>`) only after confirmation.
 
 ### 3. Build (includes caches)
 
-`${CLAUDE_SKILL_DIR}/scripts/clean-build.sh --include-caches` — default `--dry-run`; apply per the manifest flow above only after confirmation. `--include-caches` folds the caches tier into the one build manifest.
+`${CLAUDE_SKILL_DIR}/scripts/clean-build.sh --include-caches`, default `--dry-run`; apply per the manifest flow above only after confirmation. `--include-caches` folds the caches tier into the one build manifest.
 
 ### 4. Git
 
-**Write-safe metadata only** — not working-tree reset (that is §6 `tree`).
+**Write-safe metadata only**, not working-tree reset (that is §6 `tree`).
 
 #### 4.1 Prune and gc
 
-`${CLAUDE_SKILL_DIR}/scripts/git-prune.sh` — `--dry-run` default; `--apply` after confirmation.
+`${CLAUDE_SKILL_DIR}/scripts/git-prune.sh`. `--dry-run` default; `--apply` after confirmation.
 
 #### 4.2 Branch audit
 
-`${CLAUDE_SKILL_DIR}/scripts/git-branch-audit.sh` — deletion via the [confirmation gate](#confirmation-gate) per [context/git-branch-cleanup.md](context/git-branch-cleanup.md). Branches in the `WORKTREE` tier are checked out in a linked worktree: never offer them for `git branch -d` — route the user to the worktree-management tool to clean up the worktree first. Branches carrying `no upstream, M commits not on origin/<default>` are never-pushed local work — surface the count and confirm before any deletion.
+`${CLAUDE_SKILL_DIR}/scripts/git-branch-audit.sh`. Deletion via the [confirmation gate](#confirmation-gate) per [context/git-branch-cleanup.md](context/git-branch-cleanup.md). Branches in the `WORKTREE` tier are checked out in a linked worktree: never offer them for `git branch -d`. Route the user to the worktree-management tool to clean up the worktree first. Branches carrying `no upstream, M commits not on origin/<default>` are never-pushed local work. Surface the count and confirm before any deletion.
 
 #### 4.3 Stash audit
 
-`${CLAUDE_SKILL_DIR}/scripts/git-stash-audit.sh` — read-only per-stash facts (age, source branch, diffstat, PR/merge signal, advisory). **Never drops a stash.** Present the list and, for each stash, ask the user keep-or-drop ([Confirmation gate](#confirmation-gate)); a `possibly superseded` / `likely superseded` advisory is a hint to raise first, never an autonomous drop. Dedup a fleet sweep by the `StashStore:` key (linked worktrees share one stash ref). When the resolved action is `stash`, run only this step.
+`${CLAUDE_SKILL_DIR}/scripts/git-stash-audit.sh`. Read-only per-stash facts (age, source branch, diffstat, PR/merge signal, advisory). **Never drops a stash.** Present the list and, for each stash, ask the user keep-or-drop ([Confirmation gate](#confirmation-gate)); a `possibly superseded` / `likely superseded` advisory is a hint to raise first, never an autonomous drop. Dedup a fleet sweep by the `StashStore:` key (linked worktrees share one stash ref). When the resolved action is `stash`, run only this step.
 
-**Dropping stashes safely.** A confirmed drop is destructive and gated by the session guard — after the user confirms, re-issue as `CLEAN_GUARD_ACK=1 git stash drop <ref>`. The `Stash:` selector (`stash@{n}`) is **volatile**: the list renumbers after every drop, so dropping more than one by selector top-down retargets the wrong entry. Drop by the stable `Commit:` id (resolve it to its current selector immediately before each drop), or drop the highest-numbered selector first so lower indices stay valid.
+**Dropping stashes safely.** A confirmed drop is destructive and gated by the session guard, after the user confirms, re-issue as `CLEAN_GUARD_ACK=1 git stash drop <ref>`. The `Stash:` selector (`stash@{n}`) is **volatile**: the list renumbers after every drop, so dropping more than one by selector top-down retargets the wrong entry. Drop by the stable `Commit:` id (resolve it to its current selector immediately before each drop), or drop the highest-numbered selector first so lower indices stay valid.
 
 ### 5. All
 
@@ -153,29 +153,29 @@ Both selective mutating tiers pay the filesystem walk **once**. `--dry-run` writ
 
 ### 6. Tree (destructive)
 
-`${CLAUDE_SKILL_DIR}/scripts/git-tree-reset.sh` — default `--dry-run`. Detail: [context/git-tree-reset.md](context/git-tree-reset.md). Default-preserve; opt-in `--include-deps` / `--include-secrets`; `--allow-unpushed` when HEAD is ahead of upstream.
+`${CLAUDE_SKILL_DIR}/scripts/git-tree-reset.sh`, default `--dry-run`. Detail: [context/git-tree-reset.md](context/git-tree-reset.md). Default-preserve; opt-in `--include-deps` / `--include-secrets`; `--allow-unpushed` when HEAD is ahead of upstream.
 
-**Mandatory gate:** show dry-run output → [confirmation gate](#confirmation-gate) → only then `--apply`. Surface the dry-run's `PreserveDeps` / `PreserveSecrets` / `AheadCount` lines in the confirmation so the user knows what survives. An exit 4 (`unpushed-commits`) or non-zero `AheadCount` means HEAD has unpushed commits — confirm loss before adding `--allow-unpushed`. Autonomous sessions: abort. Post-step: after a tree reset that removed dependencies, suggest reinstalling them with the project's own bootstrap/setup and re-validating the environment. For a truly pristine tree, close running dev tooling first (MCP servers, telemetry collectors, build/test watchers) — live processes recreate ignored dirs (`obj/`, `node_modules/`, and the like) the moment they are deleted, and may hold locks that surface as `Unremovable:`.
+**Mandatory gate:** show dry-run output → [confirmation gate](#confirmation-gate) → only then `--apply`. Surface the dry-run's `PreserveDeps` / `PreserveSecrets` / `AheadCount` lines in the confirmation so the user knows what survives. An exit 4 (`unpushed-commits`) or non-zero `AheadCount` means HEAD has unpushed commits. Confirm loss before adding `--allow-unpushed`. Autonomous sessions: abort. Post-step: after a tree reset that removed dependencies, suggest reinstalling them with the project's own bootstrap/setup and re-validating the environment. For a truly pristine tree, close running dev tooling first (MCP servers, telemetry collectors, build/test watchers). Live processes recreate ignored dirs (`obj/`, `node_modules/`, and the like) the moment they are deleted, and may hold locks that surface as `Unremovable:`.
 
-### 6.5. Tree batch — multi-repo (destructive)
+### 6.5. Tree batch. Multi-repo (destructive)
 
-`${CLAUDE_SKILL_DIR}/scripts/git-tree-reset-batch.sh` — default `--dry-run`. Runs §6 `tree` across a set of repos behind one gate, with a separator-agnostic skip list and a dirty-by-default guard. Detail + examples: [context/git-tree-reset-batch.md](context/git-tree-reset-batch.md). Additive over §6 — the batch layer runs no destructive git itself; each per-repo reset delegates to the unchanged `git-tree-reset.sh`, preserving every single-repo gate.
+`${CLAUDE_SKILL_DIR}/scripts/git-tree-reset-batch.sh`, default `--dry-run`. Runs §6 `tree` across a set of repos behind one gate, with a separator-agnostic skip list and a dirty-by-default guard. Detail + examples: [context/git-tree-reset-batch.md](context/git-tree-reset-batch.md). Additive over §6, the batch layer runs no destructive git itself; each per-repo reset delegates to the unchanged `git-tree-reset.sh`, preserving every single-repo gate.
 
 Repo sources: `--repo` (repeatable; a shell glob expands to these) and `--repos-from FILE|-` (ingests `ghq list -p` output). Skip list: `--skip ENTRY` / `--skip-from FILE` (absolute path, `owner/repo`, or bare `repo`; separator-agnostic). Passthrough to the child: `--force-default-branch` / `--include-deps` / `--include-secrets`.
 
-**Mandatory gate (single, batch-wide):** show the `--dry-run` whole-batch plan (per-repo `Outcome`/`Reason`, the `Summary` totals, and any `UnmatchedSkip:` warnings) → [confirmation gate](#confirmation-gate) **once** → only then `--apply` **once**. Do not gate per repo. A fresh-clone fleet is typically all on the default branch, so expect an all-blocked dry-run unless `--force-default-branch` — surface that in the confirmation. `--include-dirty` re-enables the exact data-loss vector (resets repos with uncommitted/untracked changes or unpushed commits); it needs its own explicit confirmation naming the dirty repos, exactly like `--include-secrets`. Autonomous sessions: abort.
+**Mandatory gate (single, batch-wide):** show the `--dry-run` whole-batch plan (per-repo `Outcome`/`Reason`, the `Summary` totals, and any `UnmatchedSkip:` warnings) → [confirmation gate](#confirmation-gate) **once** → only then `--apply` **once**. Do not gate per repo. A fresh-clone fleet is typically all on the default branch, so expect an all-blocked dry-run unless `--force-default-branch`. Surface that in the confirmation. `--include-dirty` re-enables the exact data-loss vector (resets repos with uncommitted/untracked changes or unpushed commits); it needs its own explicit confirmation naming the dirty repos, exactly like `--include-secrets`. Autonomous sessions: abort.
 
 ### 7. Orphaned path removal (destructive, on explicit request only)
 
-`${CLAUDE_SKILL_DIR}/scripts/remove-path.sh <target>` — default `--dry-run`. Removes a whole clone or leftover directory under the ghq root (`--root` overrides) — e.g. a local clone whose upstream repository was deleted. Not composed into any tier and never inferred: run it only when the user explicitly asks to delete that path. Guards resolve paths physically and require the target to share the root's filesystem device (symlink/junction/cross-mount ancestors cannot escape containment), and refuse the containment root, symlink targets, linked worktrees (that lifecycle belongs to `git worktree remove`), any plain directory still holding nested git repos (normal, bare, or worktree), any target holding ignored skill-owned `data/` (irreplaceable — no override; move it out first), and any repo with uncommitted changes, stashes, registered worktrees, ignored secret-class files (`--include-secrets` to discard), or unpushed refs (`--allow-unpushed` to discard).
+`${CLAUDE_SKILL_DIR}/scripts/remove-path.sh <target>`, default `--dry-run`. Removes a whole clone or leftover directory under the ghq root (`--root` overrides), e.g. a local clone whose upstream repository was deleted. Not composed into any tier and never inferred: run it only when the user explicitly asks to delete that path. Guards resolve paths physically and require the target to share the root's filesystem device (symlink/junction/cross-mount ancestors cannot escape containment), and refuse the containment root, symlink targets, linked worktrees (that lifecycle belongs to `git worktree remove`), any plain directory still holding nested git repos (normal, bare, or worktree), any target holding ignored skill-owned `data/` (irreplaceable. No override; move it out first), and any repo with uncommitted changes, stashes, registered worktrees, ignored secret-class files (`--include-secrets` to discard), or unpushed refs (`--allow-unpushed` to discard).
 
 **Mandatory gate:** show dry-run output → [confirmation gate](#confirmation-gate) → only then `--apply`. Surface `Kind` / `UnpushedRefs` / `SecretsCount` / `SkillData` in the confirmation. Autonomous sessions: abort.
 
-**Documented boundaries.** Containment is path- and device-based (physical resolution plus a same-device check). A *same-device* `mount --bind` under the root shares the root's filesystem device, so no path-based check can detect it; closing that would require a Linux-only mount-table (`/proc/self/mountinfo`) model that would also refuse legitimate under-root mounts, so it stays out of scope for this local, dry-run-default, explicit-`--apply` tool. The unpushed-ref guard covers `refs/heads` and `refs/tags`; other locally-created namespaces (e.g. `refs/notes`) are not scanned, and auto-generated ones (`refs/prefetch/*` from git-maintenance, `refs/replace/*`) are intentionally not treated as unpushed — `--allow-unpushed` is the escape hatch for any local ref. The secret scan gates only ignored (unrecoverable) files; tracked files are git's domain (recoverable via reset/remote, and separately blocked when dirty or unpushed).
+**Documented boundaries.** Containment is path- and device-based (physical resolution plus a same-device check). A *same-device* `mount --bind` under the root shares the root's filesystem device, so no path-based check can detect it; closing that would require a Linux-only mount-table (`/proc/self/mountinfo`) model that would also refuse legitimate under-root mounts, so it stays out of scope for this local, dry-run-default, explicit-`--apply` tool. The unpushed-ref guard covers `refs/heads` and `refs/tags`; other locally-created namespaces (e.g. `refs/notes`) are not scanned, and auto-generated ones (`refs/prefetch/*` from git-maintenance, `refs/replace/*`) are intentionally not treated as unpushed. `--allow-unpushed` is the escape hatch for any local ref. The secret scan gates only ignored (unrecoverable) files; tracked files are git's domain (recoverable via reset/remote, and separately blocked when dirty or unpushed).
 
-### 8. Batch — multi-repo selective tiers (`caches-batch` / `build-batch` / `git-batch` / `all-batch`)
+### 8. Batch. Multi-repo selective tiers (`caches-batch` / `build-batch` / `git-batch` / `all-batch`)
 
-`${CLAUDE_SKILL_DIR}/scripts/clean-batch.sh --tier <caches|build|git|all>` — default `--dry-run`. Runs the §2–§5 selective tiers across a set of repos behind one gate, the selective-tier sibling of §6.5 `tree-batch`. Detail + examples: [context/clean-batch.md](context/clean-batch.md). Additive over the single-repo tiers — the batch layer runs no removal itself; each per-repo action delegates to the unchanged child (`clean-caches.sh` / `clean-build.sh` / `git-prune.sh`), preserving every child gate. **`tree` is not batched here** (use §6.5); **branch audit/deletion is not batched** (interactive per-branch deletion can't sit behind one gate) — batch `git` is prune/gc/remote-prune only, once per unique shared object store.
+`${CLAUDE_SKILL_DIR}/scripts/clean-batch.sh --tier <caches|build|git|all>`, default `--dry-run`. Runs the §2–§5 selective tiers across a set of repos behind one gate, the selective-tier sibling of §6.5 `tree-batch`. Detail + examples: [context/clean-batch.md](context/clean-batch.md). Additive over the single-repo tiers, the batch layer runs no removal itself; each per-repo action delegates to the unchanged child (`clean-caches.sh` / `clean-build.sh` / `git-prune.sh`), preserving every child gate. **`tree` is not batched here** (use §6.5); **branch audit/deletion is not batched** (interactive per-branch deletion can't sit behind one gate). Batch `git` is prune/gc/remote-prune only, once per unique shared object store.
 
 Repo sources: `--repo` (repeatable; a shell glob expands to these) and `--repos-from FILE|-` (ingests `ghq list -p`; backslash paths normalized). Skip list: `--skip ENTRY` / `--skip-from FILE` (same separator-agnostic matcher as `tree-batch`).
 
@@ -185,7 +185,7 @@ Repo sources: `--repo` (repeatable; a shell glob expands to these) and `--repos-
 
 | Surface | Relationship |
 |-------|-------------|
-| A worktree-management tool | Removes git worktree directories — not in-place reset |
+| A worktree-management tool | Removes git worktree directories, not in-place reset |
 | The project's build / verify workflow | Rebuild after `build` or `tree` |
 | The project's bootstrap/setup | Restore dependencies after `tree` |
 | The project's environment-validation tooling | Full env validation after `tree` or `all` |

--- a/plugins/repo-hygiene/skills/setup/SKILL.md
+++ b/plugins/repo-hygiene/skills/setup/SKILL.md
@@ -9,57 +9,57 @@ disable-model-invocation: true
 
 Thin check-centric setup per the uniform setup contract (`docs/PLUGIN-PHILOSOPHY.md`
 "Setup is explicit and repeatable" in the marketplace repository): `check` inspects and reports,
-`apply` points at what it found. The warrant is criterion (b), external prerequisites — `git`,
+`apply` points at what it found. The warrant is criterion (b), external prerequisites. `git`,
 which every
 git-touching tier of `/repo-hygiene:clean` and the tracked-file safety guarantee depend on, and the
-optional `ghq` the fleet batch actions enumerate repositories from — neither of which a native
+optional `ghq` the fleet batch actions enumerate repositories from. Neither of which a native
 configuration prompt can see, and each of which setup can only verify. The
 `clean_destructive_guard_enabled` option is a native `userConfig` toggle whose only stored home is
 the `pluginConfigs` this contract forbids setup to write, so this setup is check-only: `apply`
 installs nothing, writes nothing, and is idempotent by construction.
 
 Action routing: no argument or `check` runs the check; `apply` runs the check first, then points at
-each remediation. Both are non-interactive — never prompt when the action is given.
+each remediation. Both are non-interactive, never prompt when the action is given.
 
 ## `check` (read-only)
 
 The clean skill and its bundled scripts (`${CLAUDE_PLUGIN_ROOT}/skills/clean/`) are the single
 source of truth for what each tier requires.
 
-**Read it first** — probe what it actually does, don't recite this file. Then run each probe via
+**Read it first**. Probe what it actually does, don't recite this file. Then run each probe via
 Bash and report a PASS/FAIL/INFO table with one remediation line per FAIL. Do not modify anything.
 
 Install nothing, and run no mutating tier.
 
-1. **`git` on `PATH`** — `command -v git`, and report the resolved path and version. FAIL when
+1. **`git` on `PATH`**. `command -v git`, and report the resolved path and version. FAIL when
    absent, and state what is lost rather than a blanket "the plugin is broken":
    - `scan` resolves the repository through git and reports `not a git repository` when it cannot;
      the `git`, `stash`, `tree`, and `tree-batch` tiers are git operations outright.
    - The **any git-tracked file is off-limits** guarantee is enforced against the index by the
      shared `${CLAUDE_PLUGIN_ROOT}/skills/clean/scripts/lib/clean-common.sh`
      (`git ls-files --error-unmatch`), so even the `caches` and
-     `build` tiers reach git through it — as does restoring a tracked file deleted by reparse-point
+     `build` tiers reach git through it, as does restoring a tracked file deleted by reparse-point
      traversal during a `tree` clean. No tier is safe to run without git.
-2. **`ghq`** (optional) — `command -v ghq`. Present: INFO, `ghq list -p` can feed `tree-batch` and
-   the other `*-batch` actions. Absent: INFO, not a defect — the batch actions still take `--repo`
+2. **`ghq`** (optional). `command -v ghq`. Present: INFO, `ghq list -p` can feed `tree-batch` and
+   the other `*-batch` actions. Absent: INFO, not a defect, the batch actions still take `--repo`
    (repeatable, glob-expanded) and `--repos-from FILE|-`; only the `ghq`-derived enumeration is
    unavailable. Report this rather than letting an empty repo list look like a bug.
-3. **A POSIX shell for the bundled scripts** — every tier script and the destructive guard are
+3. **A POSIX shell for the bundled scripts**. Every tier script and the destructive guard are
    `bash`. On Windows that means Git Bash must be present; the guard is registered in **shell form**
    with `shell: bash` precisely so Claude Code resolves it rather than a `PATH` lookup finding the
    WSL relay. Report the shell as INFO on Unix; FAIL on Windows when no Git Bash resolves, since the
    scripts and the guard alike cannot launch.
-4. **Destructive-guard registration and toggle** — INFO, and be precise about *where* the guard
+4. **Destructive-guard registration and toggle**. INFO, and be precise about *where* the guard
    lives, because the answer is the reason it is session-scoped:
    - It registers from the `hooks:` block in `${CLAUDE_PLUGIN_ROOT}/skills/clean/SKILL.md`
-     frontmatter, not from a plugin-level `hooks/hooks.json` — this plugin ships none. Claude Code
+     frontmatter, not from a plugin-level `hooks/hooks.json`. This plugin ships none. Claude Code
      arms it once `/repo-hygiene:clean` is invoked and keeps it armed for the rest of that session,
      so a session that never invoked the skill has no guard and nothing is wrong with that.
    - Report the effective `${user_config.clean_destructive_guard_enabled}` (an unexpanded token or
      an empty value means the manifest default `true`). The rendered value is injected when this
      skill loads, so a change made now is observed only in a **fresh session**.
    - The option is **user-scoped**: plugin option values are read from user, `--settings`, and
-     managed settings only — never from a project's `.claude/settings.json`. So there is no
+     managed settings only, never from a project's `.claude/settings.json`. So there is no
      per-repository value of this toggle. To vary the behavior for one repository, enable or disable
      the plugin in that project's `enabledPlugins` instead.
 
@@ -67,33 +67,32 @@ Install nothing, and run no mutating tier.
 
 Run `check`, then point at each resolution. Both prerequisites are system tools and the one option
 lives in Claude Code's native configuration surface, so `apply` writes nothing and installs
-nothing — re-running it after everything passes changes nothing and reports "already configured":
+nothing. Re-running it after everything passes changes nothing and reports "already configured":
 
 - **Missing `git`:** the platform's own install channel (<https://git-scm.com/downloads>). This
   plugin never downloads a tool.
 - **Missing `ghq` and fleet actions wanted:** install it (<https://github.com/x-motemen/ghq>), or
-  keep using `--repo` / `--repos-from` and say so — this is a convenience, not a blocker.
+  keep using `--repo` / `--repos-from` and say so. This is a convenience, not a blocker.
 - **Missing Git Bash on Windows:** install Git for Windows; nothing in this plugin runs without it.
 - **Toggle off (or on):** direct to `/plugin configure repo-hygiene@<marketplace>` (interactive, any
-  time). Headless: rerun the install with the new value —
-  `claude plugin install repo-hygiene@<marketplace> -s <scope> --config clean_destructive_guard_enabled=true`
+  time). Headless: rerun the install with the new value: `claude plugin install repo-hygiene@<marketplace> -s <scope> --config clean_destructive_guard_enabled=true`
   (repeatable per key). Against an already-installed plugin it
-  prints `already installed` **and still writes the value** — verified on Claude Code 2.1.240 (a
+  prints `already installed` **and still writes the value**. Verified on Claude Code 2.1.240 (a
   non-sensitive option at `user` scope: a non-default value written to an installed plugin, then
   restored). The short-circuit is about the install, not the config write. Re-verify before relying
-  on it outside those conditions — a `sensitive` option, or `project`/`local` scope, were not
+  on it outside those conditions, a `sensitive` option, or `project`/`local` scope, were not
   covered. Do **not** uninstall to reconfigure: uninstalling drops this plugin's entire stored
   `pluginConfigs` entry, resetting every option in the README's Options reference table to its
   manifest default. `-s` defaults to `user`, so pass the scope `claude plugin list` reports for this
   plugin, and run from that project's directory for a `project`/`local` scope, or the write lands at
   a scope that does not load. This skill never writes user settings or `pluginConfigs`. Afterwards
-  rerun `check` **in a fresh session** — the rendered token is injected at skill load — and report
+  rerun `check` **in a fresh session**, the rendered token is injected at skill load, and report
   the observed effective toggle value; never claim an unobserved change.
 
 ## What this skill does NOT do
 
-- Scan, clean, prune, or reset anything — those are `/repo-hygiene:clean`'s tiers, with their own
+- Scan, clean, prune, or reset anything. Those are `/repo-hygiene:clean`'s tiers, with their own
   dry-run-first and confirmation contract.
-- Install `git`, `ghq`, or any tool, during either `check` or `apply` — guidance only.
+- Install `git`, `ghq`, or any tool, during either `check` or `apply`. Guidance only.
 - Write the plugin cache, Claude Code user settings, or `pluginConfigs`. Nor any other Claude Code
   settings surface.


### PR DESCRIPTION
No linked issue

## Summary

#2891 instruction-surface de-slop cluster: purge em dashes from the `repo-hygiene` plugin README and every SKILL.md.

## Fix

Rewrote `plugins/repo-hygiene/README.md` and every `plugins/repo-hygiene/**/SKILL.md` under `/ai-slop:audit fix` semantics (periods, commas, or a restructured sentence; never parentheses, en dashes, or a spaced hyphen as a stand-in). A self-audit repaired wrap leftovers, split asides, and table N/A cells the mechanical pass left as fragments. `repo-hygiene` 0.10.11.

## Verification

- Detector: 0 `rule-em-dash` findings outside ignore-fenced generated-options spans (and required trigger strings that must keep em dashes)
- `CHECK_SKILL_SKIP_MARKDOWNLINT=1 bash scripts/check-changed-skills.sh origin/main`: 0 failed; quoted trigger phrases vs origin/main preserved
- `python3 scripts/sync-plugin-options-docs.py --check` up to date
- `scripts/check-changelog-parity.sh --check-bump origin/main` passes
- `node scripts/generate-cheatsheet.mjs --check` in sync

## Related

Refs #2891

#2891 stays open.