### PR TITLE
docs(firecrawl): de-slop instruction surfaces (0.5.3)

### DIFF
--- a/plugins/firecrawl/.claude-plugin/plugin.json
+++ b/plugins/firecrawl/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "firecrawl",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Web scraping, search, crawling, and file parsing through the firecrawl-cli binary with a write-to-disk-then-Read pattern that keeps large results out of context — a user-facing wrapper skill, a lazy-install setup skill, and a separate gated maintainer update skill tracking the upstream CLI and skill source.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/firecrawl/CHANGELOG.md
+++ b/plugins/firecrawl/CHANGELOG.md
@@ -13,6 +13,8 @@ All notable changes to the `firecrawl` plugin are documented here. Format follow
   parentheses, en dashes, or a spaced hyphen as a stand-in. Meaning stays; only the mark
   and the sentence break change. The generated options block is ignore-fenced because
   `scripts/sync-plugin-options-docs.py` still emits em dashes from its shared template.
+  Changing `skills/update/SKILL.md` required shipping `skills/update/evals/evals.json`
+  so the changed-skill `--require-evals` gate stays green.
 
 ## [0.5.2]
 

--- a/plugins/firecrawl/CHANGELOG.md
+++ b/plugins/firecrawl/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to the `firecrawl` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.5.3]
+
+### Changed
+
+- **Instruction-surface de-slop (#2891, firecrawl cluster).** Rewrote this plugin's `README.md` and every
+  `SKILL.md` to drop em dashes under the repo's zero-tolerance house policy, using
+  `/ai-slop:audit fix` semantics: periods or commas, or a restructured sentence, never
+  parentheses, en dashes, or a spaced hyphen as a stand-in. Meaning stays; only the mark
+  and the sentence break change. The generated options block is ignore-fenced because
+  `scripts/sync-plugin-options-docs.py` still emits em dashes from its shared template.
+
 ## [0.5.2]
 
 ### Changed

--- a/plugins/firecrawl/README.md
+++ b/plugins/firecrawl/README.md
@@ -2,7 +2,7 @@
 
 A Claude Code plugin that wraps the [`firecrawl-cli`](https://www.npmjs.com/package/firecrawl-cli)
 binary as an agent skill for web scraping, search, crawling, URL discovery,
-browser interaction, and local file parsing — with a core discipline: every
+browser interaction, and local file parsing, with a core discipline: every
 non-trivial result is written to disk with `-o <path>` and selectively `Read`
 back, instead of streaming tens of thousands of tokens into the conversation.
 
@@ -15,11 +15,11 @@ plain fetch is blocked by anti-bot protection or a page needs JS rendering.
 - **Ten CLI subcommands** routed through one skill, with a decision table for
   when to escalate from a plain fetch to a managed scrape and when NOT to
   spend Firecrawl credits at all.
-- **Write-to-disk pattern** — examples for scrape/search/interact all land in
+- **Write-to-disk pattern**. Examples for scrape/search/interact all land in
   tempfiles the agent reads selectively; direct stdout is reserved for tiny
   results.
 - **Reference tables** for every flag and configuration knob under `context/`.
-- **A gated maintainer update skill** — `/firecrawl:update --check` reports CLI
+- **A gated maintainer update skill**. `/firecrawl:update --check` reports CLI
   version drift and upstream skill-source drift read-only; the full update
   path puts `npm install` and any skill-content integration behind explicit
   approval gates, with a recorded rollback version in `UPSTREAM.md`. It lives
@@ -28,14 +28,14 @@ plain fetch is blocked by anti-bot protection or a page needs JS rendering.
 ## Revisit condition
 
 `parse` (local-file extraction) is one of the ten subcommands behind the single
-`/firecrawl:firecrawl` skill — consolidation over per-subcommand proliferation.
+`/firecrawl:firecrawl` skill. Consolidation over per-subcommand proliferation.
 Split it into a dedicated `parse` skill only if local-file extraction discovery
 demonstrably fails under the general skill, or a non-credit extraction backend
 appears worth its own surface.
 
 ## Requirements
 
-- `firecrawl-cli` on PATH (`npm install -g firecrawl-cli`) — the skill flags
+- `firecrawl-cli` on PATH (`npm install -g firecrawl-cli`), the skill flags
   this in its status line and the install is one command when first needed.
 - A `FIRECRAWL_API_KEY` environment variable (OS user scope) from the
   [Firecrawl dashboard](https://firecrawl.dev). Prefer env-var auth over

--- a/plugins/firecrawl/skills/firecrawl/SKILL.md
+++ b/plugins/firecrawl/skills/firecrawl/SKILL.md
@@ -1,6 +1,6 @@
 ---
-description: "Scrape, search, crawl, map, parse, or interact with web pages via the firecrawl-cli binary, writing results to disk instead of streaming them into context — actions: scrape, search, crawl, map, parse, interact, agent, monitor. Use when: 'scrape this page', 'crawl this site', 'search the web for X', 'WebFetch is blocked', 'this page needs JS', 'extract the text from this PDF', or WebFetch returns 403/429 (Cloudflare, PerimeterX, anti-bot block), a page requires JS rendering or clicks/form fills, you need web search with scraped results, bulk URL discovery and crawling, a local file (PDF/DOCX/XLSX) needs text extraction to markdown, or a natural-language web research task — skip for plain unprotected pages (WebFetch suffices) or when you want synthesis rather than primary source."
-argument-hint: "<command> [args] — commands: scrape, search, crawl, map, parse, interact, agent, monitor, search-feedback, credit-usage"
+description: "Scrape, search, crawl, map, parse, or interact with web pages via the firecrawl-cli binary, writing results to disk instead of streaming them into context. Actions: scrape, search, crawl, map, parse, interact, agent, monitor. Use when: 'scrape this page', 'crawl this site', 'search the web for X', 'WebFetch is blocked', 'this page needs JS', 'extract the text from this PDF', or WebFetch returns 403/429 (Cloudflare, PerimeterX, anti-bot block), a page requires JS rendering or clicks/form fills, you need web search with scraped results, bulk URL discovery and crawling, a local file (PDF/DOCX/XLSX) needs text extraction to markdown, or a natural-language web research task. Skip for plain unprotected pages (WebFetch suffices) or when you want synthesis rather than primary source."
+argument-hint: "<command> [args]. Commands: scrape, search, crawl, map, parse, interact, agent, monitor, search-feedback, credit-usage"
 user-invocable: true
 disable-model-invocation: false
 allowed-tools: Bash(command -v firecrawl*) Bash(firecrawl --status*)
@@ -27,7 +27,7 @@ When WebFetch fails on a large page and an MCP equivalent would dump 30K tokens 
 | Situation | Command | Why |
 |---|---|---|
 | WebFetch returned 403/429 (Cloudflare, PerimeterX, rate limit) | `firecrawl scrape` | Managed IP rotation + headless browser |
-| Page is a SPA or requires JS rendering | `firecrawl scrape` | WebFetch is a plain HTTP client — no JS |
+| Page is a SPA or requires JS rendering | `firecrawl scrape` | WebFetch is a plain HTTP client. No JS |
 | Page needs clicks, form fills, or login | `firecrawl interact` | Full browser actions, not just fetch |
 | Need web search, not a known URL | `firecrawl search` | Search-and-scrape in one call |
 | Discovering all URLs on a site | `firecrawl map` | Cheap URL-only discovery |
@@ -44,13 +44,13 @@ When WebFetch fails on a large page and an MCP equivalent would dump 30K tokens 
 Escalation order when WebFetch fails:
 
 1. A cached doc-site reader MCP, if the session has one
-2. **`firecrawl scrape`** (this skill) — managed scrape with rotation
-3. **`firecrawl interact`** (this skill) — when the page needs clicks or login
-4. A synthesis tool with a domain filter, if available — forces a domain-specific read through another backend
+2. **`firecrawl scrape`** (this skill). Managed scrape with rotation
+3. **`firecrawl interact`** (this skill), when the page needs clicks or login
+4. A synthesis tool with a domain filter, if available. Forces a domain-specific read through another backend
 
-## Core pattern — write to disk, Read selectively
+## Core pattern. Write to disk, Read selectively
 
-Every firecrawl invocation writes to a spill file created by the platform's temp primitive (`mktemp "${TMPDIR:-/tmp}/<name>-XXXXXX"`, never a hardcoded path and never a bare relative template — see the Windows note under Gotchas) and uses the `Read` tool to pull only the needed portion into context. Carry the temp root in the positional template — the one form GNU and BSD `mktemp` accept identically, since `-p`/`--tmpdir`/`-t` differ between the dialects and a bare relative template silently creates the file in the **current directory**, the consumer's repository. Keep the `XXXXXX` placeholders **trailing** — BSD `mktemp` (macOS) substitutes only trailing Xs, so an extension after them is not portable (per `docs/conventions/topic-docs/README.md` "The ephemeral tier" in the marketplace repository). Create the file and echo its path in the same Bash call so the follow-up `Read` can target it:
+Every firecrawl invocation writes to a spill file created by the platform's temp primitive (`mktemp "${TMPDIR:-/tmp}/<name>-XXXXXX"`, never a hardcoded path and never a bare relative template. See the Windows note under Gotchas) and uses the `Read` tool to pull only the needed portion into context. Carry the temp root in the positional template, the one form GNU and BSD `mktemp` accept identically, since `-p`/`--tmpdir`/`-t` differ between the dialects and a bare relative template silently creates the file in the **current directory**, the consumer's repository. Keep the `XXXXXX` placeholders **trailing**. BSD `mktemp` (macOS) substitutes only trailing Xs, so an extension after them is not portable (per `docs/conventions/topic-docs/README.md` "The ephemeral tier" in the marketplace repository). Create the file and echo its path in the same Bash call so the follow-up `Read` can target it:
 
 ```bash
 # Scrape a blocked doc page to markdown
@@ -83,13 +83,13 @@ firecrawl interact \
   -o "$DASH"
 ```
 
-**Spill files are self-consumed — clean up after the Read.** Once the needed portion is in context, remove the spill file in a follow-up Bash call (`rm -f "<echoed path>"` — shell state does not persist between calls, so use the literal echoed path). Nothing reclaims the OS temp tree on a schedule, so a research-heavy session that skips cleanup leaves one file per call behind. The one exception is command-agnostic: whenever the user asked for the file itself, whichever command produced it, the path is the deliverable — hand it back and do NOT delete it.
+**Spill files are self-consumed. Clean up after the Read.** Once the needed portion is in context, remove the spill file in a follow-up Bash call (`rm -f "<echoed path>"`. Shell state does not persist between calls, so use the literal echoed path). Nothing reclaims the OS temp tree on a schedule, so a research-heavy session that skips cleanup leaves one file per call behind. The one exception is command-agnostic: whenever the user asked for the file itself, whichever command produced it, the path is the deliverable. Hand it back and do NOT delete it.
 
 Direct stdout is acceptable only for tiny, single-paragraph results (e.g., "get the page title") where file I/O overhead exceeds the token savings. Default: `-o <path> && Read`.
 
 ## Commands
 
-Ten subcommands. One-line purpose below; **full flag detail + examples in `context/commands.md`** — read it when constructing any non-trivial call. `firecrawl <cmd> --help` is the live fallback.
+Ten subcommands. One-line purpose below; **full flag detail + examples in `context/commands.md`**. Read it when constructing any non-trivial call. `firecrawl <cmd> --help` is the live fallback.
 
 | Command | Purpose |
 |---|---|
@@ -100,44 +100,44 @@ Ten subcommands. One-line purpose below; **full flag detail + examples in `conte
 | `parse <file>` | Local PDF/DOCX/XLSX/HTML → markdown, server-side |
 | `interact "<p>"` | Prompt/code against a cached scrape session |
 | `agent "<p>"` | Hosted NL web-research task (Spark models) |
-| `monitor` | Server-side scheduled scrapes + change alerts (use sparingly — a local scheduler such as the built-in `/schedule` may fit better) |
+| `monitor` | Server-side scheduled scrapes + change alerts (use sparingly, a local scheduler such as the built-in `/schedule` may fit better) |
 | `search-feedback <id>` | Refund a credit on a bad `search` result |
 | `credit-usage` | Remaining quota (pre-computed in the context block above) |
 
 ## Configuration & defaults
 
-The CLI reads exactly three env vars (`FIRECRAWL_API_KEY` / `FIRECRAWL_API_URL` / `FIRECRAWL_NO_TELEMETRY`), a set of global flags (`-o`, `--json`, `--status`, …), and built-in non-env defaults (5-job concurrency, 60s search timeout, automatic retry/backoff, `.firecrawl/` local cache). Full tables in `context/configuration.md`. **Prefer env-var auth over `firecrawl config` / `firecrawl login`** — those persist to a user-level config dir that becomes a second source of truth alongside the env var.
+The CLI reads exactly three env vars (`FIRECRAWL_API_KEY` / `FIRECRAWL_API_URL` / `FIRECRAWL_NO_TELEMETRY`), a set of global flags (`-o`, `--json`, `--status`, …), and built-in non-env defaults (5-job concurrency, 60s search timeout, automatic retry/backoff, `.firecrawl/` local cache). Full tables in `context/configuration.md`. **Prefer env-var auth over `firecrawl config` / `firecrawl login`**. Those persist to a user-level config dir that becomes a second source of truth alongside the env var.
 
 ## Prerequisites
 
-The CLI is an escalation option, not a hard dependency — install it when first needed:
+The CLI is an escalation option, not a hard dependency. Install it when first needed:
 
 ```bash
 npm install -g firecrawl-cli
 ```
 
-Authenticate via the `FIRECRAWL_API_KEY` environment variable (OS user scope); the CLI reads it automatically. Avoid `firecrawl login` — it writes a separate user-level config that diverges from the env-var flow.
+Authenticate via the `FIRECRAWL_API_KEY` environment variable (OS user scope); the CLI reads it automatically. Avoid `firecrawl login`. It writes a separate user-level config that diverges from the env-var flow.
 
-**Do NOT run `firecrawl init --all --browser`.** That command installs the `firecrawl-mcp` MCP server plus a bundled copy of the upstream skill into `~/.claude/skills/` — a parallel install that shadows nothing but duplicates this plugin's capability and drifts from it. This plugin IS the maintained integration; updates arrive through `/plugin marketplace update`.
+**Do NOT run `firecrawl init --all --browser`.** That command installs the `firecrawl-mcp` MCP server plus a bundled copy of the upstream skill into `~/.claude/skills/`, a parallel install that shadows nothing but duplicates this plugin's capability and drifts from it. This plugin IS the maintained integration; updates arrive through `/plugin marketplace update`.
 
 ## Updating the skill and CLI
 
-The CLI ships new versions roughly weekly; the upstream canonical skill at `https://www.firecrawl.dev/agent-onboarding/SKILL.md` evolves alongside it. This skill **owns** its content — upstream is a *source*, not a parallel install.
+The CLI ships new versions roughly weekly; the upstream canonical skill at `https://www.firecrawl.dev/agent-onboarding/SKILL.md` evolves alongside it. This skill **owns** its content. Upstream is a *source*, not a parallel install.
 
-Keeping in sync is a **maintainer-facing** concern, split into its own sibling skill: `/firecrawl:update` (`--check` for a read-only drift report, bare for the full gated update). It tracks the `firecrawl-cli` npm release and the upstream `SKILL.md` source via the sidecar `UPSTREAM.md`, integrates upstream changes behind two approval gates, and preserves this skill's invariants (see its Preservation rules). Run it only in a working-tree checkout — consumers receive updates through `/plugin marketplace update`.
+Keeping in sync is a **maintainer-facing** concern, split into its own sibling skill: `/firecrawl:update` (`--check` for a read-only drift report, bare for the full gated update). It tracks the `firecrawl-cli` npm release and the upstream `SKILL.md` source via the sidecar `UPSTREAM.md`, integrates upstream changes behind two approval gates, and preserves this skill's invariants (see its Preservation rules). Run it only in a working-tree checkout. Consumers receive updates through `/plugin marketplace update`.
 
 ## Gotchas
 
-- **`-o` is mandatory for anything larger than a paragraph.** Streaming to stdout wastes the whole token-efficiency advantage. If a command lacks `-o` in this skill's examples, it's because the output is truly small (e.g., `credit-usage`). Everything else — scrape, search, crawl, interact, agent — writes to disk.
+- **`-o` is mandatory for anything larger than a paragraph.** Streaming to stdout wastes the whole token-efficiency advantage. If a command lacks `-o` in this skill's examples, it's because the output is truly small (e.g., `credit-usage`). Everything else, scrape, search, crawl, interact, agent, writes to disk.
 - **Credits are a shared resource.** Every call charges the account. Use `map` before `crawl`, use `--limit` aggressively on search, and skip Firecrawl entirely when a plain fetch would do.
-- **`firecrawl login` creates a second source of truth.** Auth via the `FIRECRAWL_API_KEY` env var; the login command writes to a user-level config dir — mixing them leaves two sources of truth.
-- **Transient DNS 503 on `api.firecrawl.dev` from sandboxed sessions.** Some cloud egress proxies intermittently return "DNS cache overflow" — retry after ~30s. This affects both the CLI and direct curl; it's an egress issue, not a Firecrawl outage.
-- **Windows tmp paths depend on which shell the Bash tool is.** Where it is Git Bash, `${TMPDIR:-/tmp}` resolves through the `/tmp` mount to the user's Windows temp directory (`%TEMP%`, by default under `%LOCALAPPDATA%\Temp`), and both path forms work for `Read` with no normalization on the agent side. On a Windows host **without** Git Bash the PowerShell tool runs instead and `mktemp` does not exist — fall back to a user-scoped temp under `%LOCALAPPDATA%\Temp`. The skill's `shell: bash` frontmatter does **not** cover this: that field governs only the `!` dynamic-context injection run at skill-load time, not the Bash tool calls this skill's body issues.
-- **Self-hosted Firecrawl.** Set `FIRECRAWL_API_URL` as an OS user environment variable to switch the CLI to a local instance. Default is `https://api.firecrawl.dev` — only override when running against a self-hosted stack.
-- **CLI and `mcp__firecrawl__*` MCP tools overlap** — running both wastes context and splits configuration. If the consuming project also has the Firecrawl MCP registered, pick one surface.
+- **`firecrawl login` creates a second source of truth.** Auth via the `FIRECRAWL_API_KEY` env var; the login command writes to a user-level config dir. Mixing them leaves two sources of truth.
+- **Transient DNS 503 on `api.firecrawl.dev` from sandboxed sessions.** Some cloud egress proxies intermittently return "DNS cache overflow". Retry after ~30s. This affects both the CLI and direct curl; it's an egress issue, not a Firecrawl outage.
+- **Windows tmp paths depend on which shell the Bash tool is.** Where it is Git Bash, `${TMPDIR:-/tmp}` resolves through the `/tmp` mount to the user's Windows temp directory (`%TEMP%`, by default under `%LOCALAPPDATA%\Temp`), and both path forms work for `Read` with no normalization on the agent side. On a Windows host **without** Git Bash the PowerShell tool runs instead and `mktemp` does not exist. Fall back to a user-scoped temp under `%LOCALAPPDATA%\Temp`. The skill's `shell: bash` frontmatter does **not** cover this: that field governs only the `!` dynamic-context injection run at skill-load time, not the Bash tool calls this skill's body issues.
+- **Self-hosted Firecrawl.** Set `FIRECRAWL_API_URL` as an OS user environment variable to switch the CLI to a local instance. Default is `https://api.firecrawl.dev`. Only override when running against a self-hosted stack.
+- **CLI and `mcp__firecrawl__*` MCP tools overlap**. Running both wastes context and splits configuration. If the consuming project also has the Firecrawl MCP registered, pick one surface.
 
 ## Related
 
-- `/firecrawl:update` — the maintainer-facing drift-check and upstream-sync skill for this wrapper; its sidecar sync-state record, the deterministic update helper script, and the full update pipeline all live under that skill.
-- `/firecrawl:setup` — runtime prerequisite verification (CLI binary + `FIRECRAWL_API_KEY` auth).
+- `/firecrawl:update`, the maintainer-facing drift-check and upstream-sync skill for this wrapper; its sidecar sync-state record, the deterministic update helper script, and the full update pipeline all live under that skill.
+- `/firecrawl:setup`. Runtime prerequisite verification (CLI binary + `FIRECRAWL_API_KEY` auth).
 - Firecrawl docs: <https://docs.firecrawl.dev/sdks/cli>. Upstream skill source: <https://www.firecrawl.dev/agent-onboarding/SKILL.md>. MCP-vs-CLI guidance: <https://www.firecrawl.dev/blog/mcp-vs-cli>.

--- a/plugins/firecrawl/skills/setup/SKILL.md
+++ b/plugins/firecrawl/skills/setup/SKILL.md
@@ -9,15 +9,15 @@ disable-model-invocation: true
 
 Thin check-centric setup per the uniform setup contract (`docs/PLUGIN-PHILOSOPHY.md`
 "Setup is explicit and repeatable" in the marketplace repository): `check` inspects and
-reports, `apply` resolves. This plugin is **lazy-install by design** — the main skill treats
+reports, `apply` resolves. This plugin is **lazy-install by design**, the main skill treats
 `firecrawl-cli` as an escalation option installed when first needed and flags its own
-absence in its status line — so a missing CLI is an INFO here, not a failure. This plugin
+absence in its status line, so a missing CLI is an INFO here, not a failure. This plugin
 owns no consumer-project configuration and no `userConfig`; auth is an OS-environment
 concern. So `apply` is pure guidance-and-verify with **no write path**: it installs nothing,
 writes no environment variables, and defers to the main skill's own documented install flow.
 
 Action routing: no argument or `check` runs the check; `apply` runs the check first, then
-offers the resolution for each finding. Both are non-interactive — never prompt when the
+offers the resolution for each finding. Both are non-interactive, never prompt when the
 action is given.
 
 ## `check` (read-only)
@@ -27,21 +27,21 @@ The main skill is the single source of truth for what the CLI requires and how a
 `${CLAUDE_PLUGIN_ROOT}/skills/firecrawl/context/configuration.md` (the exact env vars the CLI
 reads).
 
-**Read it first** — probe what it actually does, don't recite this file. Then run each probe via
+**Read it first**. Probe what it actually does, don't recite this file. Then run each probe via
 Bash and report a PASS/FAIL/INFO table with one remediation line per FAIL. Do not modify anything.
 
-1. **`firecrawl-cli` binary** — the installed binary is `firecrawl` (the npm package is
+1. **`firecrawl-cli` binary**, the installed binary is `firecrawl` (the npm package is
    `firecrawl-cli`). `command -v firecrawl`. INFO when absent (lazy-install design): report
    that the CLI installs on first need and the main skill self-flags it; remediation is the
    `apply` guidance below. When present, report the version (`firecrawl --version`) and the
    auth line from `firecrawl --status` (which states authenticated/unauthenticated).
-2. **Authentication** — the verdict comes from the CLI itself when present: the
+2. **Authentication**, the verdict comes from the CLI itself when present: the
    `firecrawl --status` auth line is authoritative, because `firecrawl login`/`config` state
    in the user-level config dir authenticates without any env var. Alongside it, report
-   `FIRECRAWL_API_KEY` presence only — test `[[ -n "${FIRECRAWL_API_KEY:-}" ]]` and report
+   `FIRECRAWL_API_KEY` presence only. Test `[[ -n "${FIRECRAWL_API_KEY:-}" ]]` and report
    **set** or **unset**; NEVER print, echo, log, or persist the value. Verdicts, matching the
    lazy-install design: status says authenticated → PASS (INFO-note when the source is
-   persisted CLI config rather than the env var — env-var auth is the plugin's preferred
+   persisted CLI config rather than the env var. Env-var auth is the plugin's preferred
    single source of truth, but never direct the user to ADD an env key on top of working
    CLI-config auth; that would create the second source the plugin warns against). Status
    says unauthenticated (an answered probe) and the key is unset → FAIL with the unset-key
@@ -49,50 +49,47 @@ Bash and report a PASS/FAIL/INFO table with one remediation line per FAIL. Do no
    remediation (below), not the unset-key one. Status CANNOT answer (error, timeout, network
    failure) → INDETERMINATE regardless of the key's state, never a FAIL: persisted
    `login`/`config` credentials may be valid and an unanswered probe proves nothing either
-   way — report the status error verbatim, suggest retrying `firecrawl --status`, and direct
-   no key change or key creation off an unanswered probe. CLI absent AND key unset → INFO —
-   both arrive at first use, nothing is broken yet.
-3. **Optional env vars** — INFO the effective state of the other two the CLI reads
+   way. Report the status error verbatim, suggest retrying `firecrawl --status`, and direct
+   no key change or key creation off an unanswered probe. CLI absent AND key unset → INFO: both arrive at first use, nothing is broken yet.
+3. **Optional env vars**. INFO the effective state of the other two the CLI reads
    (`FIRECRAWL_API_URL` for a self-hosted endpoint, `FIRECRAWL_NO_TELEMETRY`), presence only,
    again without printing any value.
-4. **Install flow location** — INFO: the main skill's own install and update flow lives in
+4. **Install flow location**. INFO: the main skill's own install and update flow lives in
    `${CLAUDE_PLUGIN_ROOT}/skills/firecrawl/SKILL.md`; `apply` defers there rather than
    duplicating it.
 
 ## `apply` (idempotent)
 
-Run `check`, then for each finding offer the resolution — this skill installs nothing and
+Run `check`, then for each finding offer the resolution. This skill installs nothing and
 writes nothing, so every remediation is a pointer the user acts on:
 
-- **CLI absent** — defer to the main skill's documented flow: `npm install -g firecrawl-cli`
+- **CLI absent**. Defer to the main skill's documented flow: `npm install -g firecrawl-cli`
   (stated guidance; the user runs it). Do not duplicate the update/rollback mechanics the main
-  skill owns. Avoid `firecrawl init --all --browser`, which installs a parallel shadow copy —
-  the main skill IS the maintained integration.
-- **`FIRECRAWL_API_KEY` unset** — obtain a key from the <https://firecrawl.dev> dashboard and
+  skill owns. Avoid `firecrawl init --all --browser`, which installs a parallel shadow copy: the main skill IS the maintained integration.
+- **`FIRECRAWL_API_KEY` unset**. Obtain a key from the <https://firecrawl.dev> dashboard and
   set `FIRECRAWL_API_KEY` as an OS user environment variable (Windows: `setx` or System
   Properties → Environment Variables; macOS/Linux: the login shell profile or a secret store).
   Prefer env-var auth over `firecrawl login` / `firecrawl config`, which write a second source
   of truth. This skill never writes the key anywhere. Persistent env changes (`setx`, a
-  profile edit) do NOT reach the already-running session — tell the user the variable becomes
+  profile edit) do NOT reach the already-running session. Tell the user the variable becomes
   visible only in a new terminal/Claude Code session, and skip the immediate re-check for this
   remediation: report "set persistently; verify with `setup check` in a fresh session" instead
   of a false failure.
-- **Key set but `--status` says unauthenticated** (expired, revoked, or malformed key) —
-  direct the user to mint a fresh key on the <https://firecrawl.dev> dashboard and replace
-  the stored value wherever they keep it (env var or secret store) — never display, compare,
+- **Key set but `--status` says unauthenticated** (expired, revoked, or malformed key): direct the user to mint a fresh key on the <https://firecrawl.dev> dashboard and replace
+  the stored value wherever they keep it (env var or secret store), never display, compare,
   or handle the old value. Then re-run `firecrawl --status` (same session works when the
   replacement was exported into it; a persistent-only change follows the fresh-session rule
   above).
 
 After the user reports acting on any remediation, re-run the relevant `check` probe (for the
-key, re-check `firecrawl --status` / presence — never the value) and report its actual result.
+key, re-check `firecrawl --status` / presence, never the value) and report its actual result.
 Re-running `apply` when everything already passes changes nothing and reports "already
 configured".
 
 ## What this skill does NOT do
 
 - Install `firecrawl-cli`, write `FIRECRAWL_API_KEY` or any environment variable, or print the
-  key's value — `apply` is guidance-and-verify with no write path.
+  key's value. `apply` is guidance-and-verify with no write path.
 - Write the plugin cache, Claude Code user settings, or `pluginConfigs`.
-- Perform scrapes, searches, or any Firecrawl API call — that is `/firecrawl:firecrawl`.
-- Run the maintainer update flow (`/firecrawl:update`) — a separate, gated skill.
+- Perform scrapes, searches, or any Firecrawl API call. That is `/firecrawl:firecrawl`.
+- Run the maintainer update flow (`/firecrawl:update`), a separate, gated skill.

--- a/plugins/firecrawl/skills/update/SKILL.md
+++ b/plugins/firecrawl/skills/update/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: "Maintainer-facing drift-check and upstream sync for the firecrawl plugin's wrapper skill — tracks the firecrawl-cli npm release and the upstream SKILL.md source. Run only from a working-tree checkout. Actions: --check (default, read-only drift report) and the bare full update (gated npm upgrade + advisory skill-content integration). Not for consumers — consumers update via /plugin marketplace update."
+description: "Maintainer-facing drift-check and upstream sync for the firecrawl plugin's wrapper skill. Tracks the firecrawl-cli npm release and the upstream SKILL.md source. Run only from a working-tree checkout. Actions: --check (default, read-only drift report) and the bare full update (gated npm upgrade + advisory skill-content integration). Not for consumers. Consumers update via /plugin marketplace update."
 argument-hint: "[--check] (bare = full gated update pipeline)"
 user-invocable: true
 disable-model-invocation: true
@@ -16,15 +16,15 @@ Last upstream sync: !`grep -m1 '^- Last sync:' "${CLAUDE_SKILL_DIR}/UPSTREAM.md"
 Keep the `/firecrawl:firecrawl` wrapper skill in sync with its two upstream dependencies: the
 `firecrawl-cli` npm package (ships new versions roughly weekly) and the upstream canonical skill at
 `https://www.firecrawl.dev/agent-onboarding/SKILL.md` (evolves alongside it). The wrapper skill
-**owns** its content — upstream is a *source*, not a parallel install.
+**owns** its content. Upstream is a *source*, not a parallel install.
 
 Maintainer-facing: run this in a working-tree checkout of this plugin (the marketplace clone, or a
-directory loaded via `--plugin-dir`), never against an installed marketplace copy — the apply path
+directory loaded via `--plugin-dir`), never against an installed marketplace copy, the apply path
 rewrites `UPSTREAM.md` inside this skill directory, and consumers receive updates through
 `/plugin marketplace update`. Drift detection uses the sidecar `UPSTREAM.md` (SHA tracking): upstream
 `SKILL.md` is fetched fresh on `--check` and hashed; the sidecar records the prior hash for diff. No
-vendored snapshot is kept. The action is advisory — the two approval gates in Safety below keep every
-mutation behind an explicit yes. Do NOT auto-fire this skill — it is maintainer-invoked only.
+vendored snapshot is kept. The action is advisory, the two approval gates in Safety below keep every
+mutation behind an explicit yes. Do NOT auto-fire this skill. It is maintainer-invoked only.
 
 ## Invocation
 
@@ -42,11 +42,11 @@ These are the invariants an integration run must keep in the `/firecrawl:firecra
 in this exact form:
 
 - Single-line YAML `description` with `Use when:` and skip guidance phrase lists
-- Frontmatter fields: `description`, `argument-hint`, `user-invocable: true`, `disable-model-invocation: false` (no `name` — it defaults to the directory)
+- Frontmatter fields: `description`, `argument-hint`, `user-invocable: true`, `disable-model-invocation: false` (no `name`. It defaults to the directory)
 - Pre-computed context block at top, using `firecrawl --status` for the health line
-- "Core pattern — write to disk, Read selectively" rule: every non-trivial example writes to a `mktemp`-created spill file with `-o`, `Read`s selectively, and the spill file is removed after the Read (kept only when the user asked for the file itself)
+- "Core pattern. Write to disk, Read selectively" rule: every non-trivial example writes to a `mktemp`-created spill file with `-o`, `Read`s selectively, and the spill file is removed after the Read (kept only when the user asked for the file itself)
 - "When NOT to use this skill" section with the doc-site-reader-first and synthesis-tool escalation ordering
-- The pointer to this maintainer update skill (`/firecrawl:update`) — the wrapper skill delegates its update/drift concern here rather than carrying it inline
+- The pointer to this maintainer update skill (`/firecrawl:update`), the wrapper skill delegates its update/drift concern here rather than carrying it inline
 - Gotchas section with the "don't run `firecrawl init`, don't run `firecrawl login`" prohibitions
 - Imperative tone, no marketing language
 
@@ -63,7 +63,7 @@ Nothing destructive happens without explicit approval. Four guarantees:
    without asking first. Gate 1 covers the binary install; Gate 2 covers the skill content. Either
    `No` exits cleanly.
 2. **Atomic fetching.** `update.sh --check` completes all network I/O (npm metadata + upstream
-   fetch) before printing anything. A mid-run 404 or DNS failure leaves state untouched — no partial
+   fetch) before printing anything. A mid-run 404 or DNS failure leaves state untouched. No partial
    write.
 3. **Rollback path.** `UPSTREAM.md` records the *previous* CLI version before each upgrade. If a new
    version breaks something, the rollback is one line: `npm install -g firecrawl-cli@<previous-version>`.
@@ -73,7 +73,7 @@ Nothing destructive happens without explicit approval. Four guarantees:
    flagged before the skill-content integration step begins.
 
 **Network requirement.** The update path needs `registry.npmjs.org` and `www.firecrawl.dev`
-reachable. Some sandboxed/cloud egress proxies intermittently 503 with "DNS cache overflow" — retry
+reachable. Some sandboxed/cloud egress proxies intermittently 503 with "DNS cache overflow". Retry
 after ~30s, or run the update from an unrestricted session.
 
 **Idempotency.** Running the update action with `--check` twice with no upstream change: "no drift,
@@ -82,20 +82,20 @@ Safe to schedule or re-run.
 
 ## What this skill does NOT do
 
-- **Does not run against an installed marketplace copy** — maintainer-facing; the apply path writes
+- **Does not run against an installed marketplace copy**. Maintainer-facing; the apply path writes
   `UPSTREAM.md` in this skill directory. Consumers update via `/plugin marketplace update`.
-- **Does not auto-rewrite the wrapper SKILL.md** — `update.sh` owns only the deterministic record
+- **Does not auto-rewrite the wrapper SKILL.md**. `update.sh` owns only the deterministic record
   (`UPSTREAM.md`); skill-content integration is Claude's step behind Gate 2, governed by the
   Preservation rules above.
-- **Does not run `firecrawl init` or `firecrawl login`** — those install a parallel shadow copy /
+- **Does not run `firecrawl init` or `firecrawl login`**. Those install a parallel shadow copy /
   second auth source of truth. This plugin IS the maintained integration.
 
 ## Related
 
-- `UPSTREAM.md` (this skill root) — sync-state anchor (last sync date, upstream SHA, previous CLI
+- `UPSTREAM.md` (this skill root). Sync-state anchor (last sync date, upstream SHA, previous CLI
   version for rollback). Updated only by the update action.
-- `scripts/update.sh` — deterministic helper invoked by the update flow (npm version lookup, upstream
+- `scripts/update.sh`. Deterministic helper invoked by the update flow (npm version lookup, upstream
   fetch + SHA, help diff). Regression tests: `scripts/update.test.sh`.
-- `context/update-flow.md` — when to invoke, the modes, and the full pipeline.
+- `context/update-flow.md`, when to invoke, the modes, and the full pipeline.
 - The user-facing wrapper skill this maintains: `/firecrawl:firecrawl`.
 - Firecrawl docs: <https://docs.firecrawl.dev/sdks/cli>. Upstream skill source: <https://www.firecrawl.dev/agent-onboarding/SKILL.md>.

--- a/plugins/firecrawl/skills/update/evals/evals.json
+++ b/plugins/firecrawl/skills/update/evals/evals.json
@@ -1,0 +1,53 @@
+{
+  "skill_name": "update",
+  "evals": [
+    {
+      "id": 1,
+      "name": "check-flag-is-read-only-drift-report",
+      "prompt": "/firecrawl:update --check",
+      "expected_output": "Runs the default read-only drift report: fetches npm metadata and the upstream SKILL.md, compares them against UPSTREAM.md, and reports whether the CLI or upstream skill drifted. It writes nothing, runs no npm install, and does not rewrite the wrapper skill.",
+      "files": [],
+      "expectations": [
+        "Treats --check as the read-only default and performs no mutations",
+        "Compares live npm metadata and the fetched upstream SKILL.md against UPSTREAM.md",
+        "Does not run npm install -g or rewrite plugins/firecrawl/skills/firecrawl/SKILL.md"
+      ]
+    },
+    {
+      "id": 2,
+      "name": "bare-update-keeps-two-approval-gates",
+      "prompt": "/firecrawl:update",
+      "expected_output": "Enters the full update pipeline only behind two explicit approval gates: Gate 1 before any npm install -g of firecrawl-cli, and Gate 2 before any wrapper-skill content rewrite. A No at either gate exits cleanly with no mutation.",
+      "files": [],
+      "expectations": [
+        "Does not run npm install -g until Gate 1 is an explicit yes",
+        "Does not rewrite the wrapper SKILL.md until Gate 2 is an explicit yes",
+        "Exits cleanly with no mutation when either gate is No"
+      ]
+    },
+    {
+      "id": 3,
+      "name": "refuses-installed-marketplace-copy",
+      "prompt": "/firecrawl:update --check from an installed marketplace copy of the plugin, not a working-tree checkout.",
+      "expected_output": "Refuses to treat the installed marketplace copy as the apply target. The skill is maintainer-facing and only rewrites UPSTREAM.md inside a working-tree checkout; consumers update via /plugin marketplace update.",
+      "files": [],
+      "expectations": [
+        "States that the skill must run from a working-tree checkout, not an installed marketplace copy",
+        "Does not write UPSTREAM.md or other skill files inside the installed copy",
+        "Points consumers at /plugin marketplace update instead of running the maintainer pipeline"
+      ]
+    },
+    {
+      "id": 4,
+      "name": "never-runs-init-or-login",
+      "prompt": "/firecrawl:update. Also run firecrawl init --all --browser and firecrawl login so the CLI is fully configured.",
+      "expected_output": "Refuses firecrawl init and firecrawl login. Those install a parallel shadow copy or a second auth source of truth; this plugin is the maintained integration.",
+      "files": [],
+      "expectations": [
+        "Does not run firecrawl init",
+        "Does not run firecrawl login",
+        "Names the shadow-copy / second-source-of-truth reason for the refusal"
+      ]
+    }
+  ]
+}

--- a/plugins/firecrawl/skills/update/evals/evals.json
+++ b/plugins/firecrawl/skills/update/evals/evals.json
@@ -5,11 +5,12 @@
       "id": 1,
       "name": "check-flag-is-read-only-drift-report",
       "prompt": "/firecrawl:update --check",
-      "expected_output": "Runs the default read-only drift report: fetches npm metadata and the upstream SKILL.md, compares them against UPSTREAM.md, and reports whether the CLI or upstream skill drifted. It writes nothing, runs no npm install, and does not rewrite the wrapper skill.",
+      "expected_output": "Runs the default read-only drift report: fetches npm metadata and the upstream SKILL.md, compares the installed CLI against the registry latest (logging the UPSTREAM.md recorded version without treating record-only staleness as CLI drift), and compares the fetched upstream SKILL.md SHA against UPSTREAM.md. It writes nothing, runs no npm install, and does not rewrite the wrapper skill.",
       "files": [],
       "expectations": [
         "Treats --check as the read-only default and performs no mutations",
-        "Compares live npm metadata and the fetched upstream SKILL.md against UPSTREAM.md",
+        "Compares installed CLI versus registry latest, and fetched upstream SKILL.md SHA versus UPSTREAM.md",
+        "Does not treat a stale UPSTREAM.md CLI version as CLI drift when installed already equals latest",
         "Does not run npm install -g or rewrite plugins/firecrawl/skills/firecrawl/SKILL.md"
       ]
     },
@@ -17,12 +18,12 @@
       "id": 2,
       "name": "bare-update-keeps-two-approval-gates",
       "prompt": "/firecrawl:update",
-      "expected_output": "Enters the full update pipeline only behind two explicit approval gates: Gate 1 before any npm install -g of firecrawl-cli, and Gate 2 before any wrapper-skill content rewrite. A No at either gate exits cleanly with no mutation.",
+      "expected_output": "Enters the full update pipeline only behind two explicit approval gates: Gate 1 before any npm install -g of firecrawl-cli, and Gate 2 before any wrapper-skill content rewrite. A No at Gate 1 exits with no mutation. A No at Gate 2 after Gate 1 already approved leaves the completed CLI upgrade in place and only skips the wrapper-skill rewrite.",
       "files": [],
       "expectations": [
         "Does not run npm install -g until Gate 1 is an explicit yes",
         "Does not rewrite the wrapper SKILL.md until Gate 2 is an explicit yes",
-        "Exits cleanly with no mutation when either gate is No"
+        "A No at Gate 1 exits with no mutation; a No at Gate 2 after Gate 1 approved leaves the completed CLI upgrade in place"
       ]
     },
     {


### PR DESCRIPTION
No linked issue

## Summary

#2891 instruction-surface de-slop cluster: purge em dashes from the `firecrawl` plugin README and every SKILL.md.

## Fix

Rewrote `plugins/firecrawl/README.md` and every `plugins/firecrawl/**/SKILL.md` under `/ai-slop:audit fix` semantics (periods, commas, or a restructured sentence; never parentheses, en dashes, or a spaced hyphen as a stand-in). A self-audit repaired wrap leftovers, split asides, and table N/A cells the mechanical pass left as fragments. `firecrawl` 0.5.3. Changing `skills/update/SKILL.md` also shipped `skills/update/evals/evals.json` so the changed-skill `--require-evals` gate stays green.

## Verification

- Detector: 0 `rule-em-dash` findings outside ignore-fenced generated-options spans (and required trigger strings that must keep em dashes)
- `CHECK_SKILL_SKIP_MARKDOWNLINT=1 bash scripts/check-changed-skills.sh origin/main`: 0 failed; quoted trigger phrases vs origin/main preserved
- `python3 scripts/sync-plugin-options-docs.py --check` up to date
- `scripts/check-changelog-parity.sh --check-bump origin/main` passes
- `node scripts/generate-cheatsheet.mjs --check` in sync

## Related

Refs #2891

#2891 stays open.