### PR TITLE
docs(improvement): de-slop instruction surfaces (0.1.3)

### DIFF
--- a/plugins/improvement/.claude-plugin/plugin.json
+++ b/plugins/improvement/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "improvement",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Evidence-first, cross-dimension improvement finder — point it at a repo, feature, concept, or process surface and it produces a ranked, evidence-cited list of improvement candidates led by value-to-effort, interviews on the pick, and hands off to the planning pipeline; runnable unattended as a tech-debt-sweep routine.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/improvement/CHANGELOG.md
+++ b/plugins/improvement/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to the `improvement` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.1.3]
+
+### Changed
+
+- **Instruction-surface de-slop (#2891, improvement cluster).** Rewrote this plugin's `README.md` and every
+  `SKILL.md` to drop em dashes under the repo's zero-tolerance house policy, using
+  `/ai-slop:audit fix` semantics: periods or commas, or a restructured sentence, never
+  parentheses, en dashes, or a spaced hyphen as a stand-in. Meaning stays; only the mark
+  and the sentence break change. The generated options block is ignore-fenced because
+  `scripts/sync-plugin-options-docs.py` still emits em dashes from its shared template.
+
 ## [0.1.2]
 
 ### Changed

--- a/plugins/improvement/README.md
+++ b/plugins/improvement/README.md
@@ -1,18 +1,17 @@
 # improvement
 
 A Claude Code plugin answering the question the fleet had no entry point for: **"what should we
-improve here, and how do we know?"** Two skills, one concern: finding improvement candidates —
-across dimensions, at any size — and backing every one with evidence.
+improve here, and how do we know?"** Two skills, one concern: finding improvement candidates across dimensions, at any size, and backing every one with evidence.
 
 | Skill | What it does |
 |---|---|
-| `/improvement:find` | Evidence-first improvement finder. Point it at a repo, a feature, a concept, or a process surface — with a vague or specific prompt — and it produces a ranked, evidence-cited list of improvement candidates led by the highest value-to-effort, deliberates on the picked candidate through an interview, and hands off to the planning pipeline. Runnable unattended as a tech-debt-sweep routine. |
+| `/improvement:find` | Evidence-first improvement finder. Point it at a repo, a feature, a concept, or a process surface, with a vague or specific prompt, and it produces a ranked, evidence-cited list of improvement candidates led by the highest value-to-effort, deliberates on the picked candidate through an interview, and hands off to the planning pipeline. Runnable unattended as a tech-debt-sweep routine. |
 | `/improvement:setup` | Verifies or writes the `.claude/improvement.md` config cascade and reports the effective evidence-source configuration. `check` (default) is read-only across all three layers; `apply` interviews and writes the team file. Key contract: [reference/config.md](reference/config.md). |
 
 ## Evidence-first identity
 
-Every candidate cites its evidence — repo-native signals such as churn hotspots and CI health,
-local telemetry, or (weakest) model judgment from reading the target — and ranking confidence is
+Every candidate cites its evidence. Repo-native signals such as churn hotspots and CI health,
+local telemetry, or (weakest) model judgment from reading the target, and ranking confidence is
 a function of evidence strength. When the target has no measurement at all, the top-ranked
 candidate becomes "instrument this so future runs can rank on data," handed to the pipeline like
 any other improvement. Evidence gaps are recorded, never papered over.
@@ -25,10 +24,9 @@ already does.
 ## Configuration
 
 Zero config is a fully working state: Tier 0 repo-native evidence needs nothing declared. To tune
-churn analysis or declare Tier 2 MCP telemetry sources, run `/improvement:setup` — it manages the
-`.claude/improvement.md` cascade — resolution order `~/.claude/improvement.md` (user-global), then
-the team `.claude/improvement.md`, then the gitignored `.claude/improvement.local.md` overlay —
-whose key contract lives in
+churn analysis or declare Tier 2 MCP telemetry sources, run `/improvement:setup`. It manages the
+`.claude/improvement.md` cascade. Resolution order `~/.claude/improvement.md` (user-global), then
+the team `.claude/improvement.md`, then the gitignored `.claude/improvement.local.md` overlay, whose key contract lives in
 [reference/config.md](reference/config.md).
 
 ## Running it as a standing routine
@@ -36,7 +34,7 @@ whose key contract lives in
 `/improvement:find`'s unattended mode implements the tech-debt-sweep routine shape: a scheduled
 run persists a ranked report and files top candidates as work items, with prioritization always
 human-gated. The recommended wrapper is a **weekly
-[Routine](https://code.claude.com/docs/en/routines)** — each firing gets a fresh session, and the
+[Routine](https://code.claude.com/docs/en/routines)**. Each firing gets a fresh session, and the
 routine's saved prompt is the tuning surface. Consult that docs page for current Routine
 capabilities and limits rather than relying on numbers written here.
 
@@ -45,9 +43,9 @@ capabilities and limits rather than relying on numbers written here.
 A routine fires a fresh cloud session, and this skill exists there only when the `improvement`
 plugin is installed in that session's environment. Per this marketplace's
 [docs/CLOUD-SESSIONS.md](../../docs/CLOUD-SESSIONS.md), a SessionStart-hook install is never
-visible to the session that ran it — the plugin must be pre-installed by the cloud environment's
+visible to the session that ran it, the plugin must be pre-installed by the cloud environment's
 setup script (or otherwise present before the session process starts). That is why the template
-below opens with a hard guard: if `/improvement:find` is unavailable, stop and report — a run
+below opens with a hard guard: if `/improvement:find` is unavailable, stop and report, a run
 that improvises an "improvement sweep" without the skill's contract is worse than no run.
 
 ### Recommended Routine prompt (weekly)
@@ -66,8 +64,7 @@ Tuning — edit these lines as you observe real runs:
 - Suppress previously dismissed candidates.
 ```
 
-The prompt is the tuning surface for cap, scope/size band, and dismissed-candidate handling —
-every unattended control is a soft default the invocation prompt overrides (see
+The prompt is the tuning surface for cap, scope/size band, and dismissed-candidate handling: every unattended control is a soft default the invocation prompt overrides (see
 [skills/find/context/unattended.md](skills/find/context/unattended.md)). Iterate on the wording
 after observing real runs; never fork the skill to tune a run.
 
@@ -76,7 +73,7 @@ after observing real runs; never fork the skill to tune a run.
 Where Routines are not available (or the schedule must live in the repo), wrap the same prompt in
 a scheduled workflow using [`claude-code-action@v1`](https://github.com/anthropics/claude-code-action)
 with its `plugins:` input, which solves the same fired-environment prerequisite by installing the
-plugin into the action's session. Sketch — adapt input details to the action's current README:
+plugin into the action's session. Sketch. Adapt input details to the action's current README:
 
 ```yaml
 on:
@@ -104,5 +101,5 @@ jobs:
 ### What is NOT a standing wrapper
 
 `/loop` is session-scoped only: it repeats a prompt inside one session and dies with it. It can
-babysit a working session, but it is not a standing schedule — a recurring unattended sweep needs
+babysit a working session, but it is not a standing schedule, a recurring unattended sweep needs
 a Routine or a cron workflow, which fire fresh sessions on a standing cadence.

--- a/plugins/improvement/skills/find/SKILL.md
+++ b/plugins/improvement/skills/find/SKILL.md
@@ -84,8 +84,8 @@ confidence attached to the ranking (strongest first):
 
 Two hard rules follow:
 
-- **Instrument-first.** When the target has no measurement at all. No telemetry, no usable CI
-  history, nothing above rung 4, the top-ranked candidate becomes "instrument this so future runs
+- **Instrument-first.** When the target has no measurement at all (no telemetry, no usable CI
+  history, nothing above rung 4), the top-ranked candidate becomes "instrument this so future runs
   can rank on data": a concrete baseline/instrumentation proposal (what to measure, where the
   signal lands), handed to the pipeline like any other improvement. This mirrors the SRE
   error-budget posture: measurement precedes prioritization.

--- a/plugins/improvement/skills/find/SKILL.md
+++ b/plugins/improvement/skills/find/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: "Evidence-first, cross-dimension improvement finder: scans code/architecture, performance, product-level behavior, config/automation outside the codebase (GitHub labels, Actions), and Claude Code operational setup, then returns a ranked candidate list — every candidate cites its evidence (telemetry, CI failure rates, churn hotspots, or, weakest, model judgment) and carries an S/M/L size with a value-to-effort rationale; an unmeasured target makes 'instrument this' the top candidate. Interactive default (pick, interview, pipeline handoff); caller-declared unattended mode persists the report and files top candidates as work items. Never edits anything itself — execution routes through the discovery/planning/implementation pipeline. Use when: 'what should we improve', 'find improvements', 'improvement sweep', 'improve <X>', 'highest-impact improvement', 'tech debt sweep', 'where is the highest-value work', 'what would move the needle', 'run an improvement scan'. Skip when: single-lens architecture deepening (`architecture:improve`), applying small safe code edits (`code-tidying:tidy`), verifying doc/config drift claims (`codebase-health:audit`), reviewing a diff (`review:fanout`), or sweeping TODO markers (`work-items:scan-todos`)."
+description: "Evidence-first, cross-dimension improvement finder: scans code/architecture, performance, product-level behavior, config/automation outside the codebase (GitHub labels, Actions), and Claude Code operational setup, then returns a ranked candidate list. Every candidate cites its evidence (telemetry, CI failure rates, churn hotspots, or, weakest, model judgment) and carries an S/M/L size with a value-to-effort rationale; an unmeasured target makes 'instrument this' the top candidate. Interactive default (pick, interview, pipeline handoff); caller-declared unattended mode persists the report and files top candidates as work items. Never edits anything itself. Execution routes through the discovery/planning/implementation pipeline. Use when: 'what should we improve', 'find improvements', 'improvement sweep', 'improve <X>', 'highest-impact improvement', 'tech debt sweep', 'where is the highest-value work', 'what would move the needle', 'run an improvement scan'. Skip when: single-lens architecture deepening (`architecture:improve`), applying small safe code edits (`code-tidying:tidy`), verifying doc/config drift claims (`codebase-health:audit`), reviewing a diff (`review:fanout`), or sweeping TODO markers (`work-items:scan-todos`)."
 argument-hint: "[target] [--small|--medium|--large] [--unattended] [repo-path]"
 user-invocable: true
 disable-model-invocation: false
@@ -22,11 +22,10 @@ Arguments: `$ARGUMENTS`
 
 ## Purpose
 
-This skill answers "what should we improve here, and how do we know?" — the second half of that
+This skill answers "what should we improve here, and how do we know?", the second half of that
 question is its identity. Review evaluates a diff; planning designs already-chosen work; the
 specialized finders each hunt one lens. This skill forms its own cross-dimension judgment about
-what is worth improving in a target — code, product behavior, process surfaces, operational setup —
-and grounds every proposal in cited evidence, so ranking reflects measurement, not taste. It
+what is worth improving in a target: code, product behavior, process surfaces, operational setup, and grounds every proposal in cited evidence, so ranking reflects measurement, not taste. It
 discovers and deliberates only: execution always flows through the repo's normal pipeline
 (interview → discovery → planning → implementation → verification), and this skill edits nothing in
 any mode.
@@ -36,7 +35,7 @@ any mode.
 Parse `$ARGUMENTS` and the invoking prompt for four independent narrowings; each defaults open:
 
 - **Target scope.** Bare invocation scans the whole repo across every dimension below. A targeted
-  ask — "improve <feature>", "improve <path>", "improve <concept>" — narrows the scan: map the
+  ask, "improve <feature>", "improve <path>", "improve <concept>", narrows the scan: map the
   named feature/path/concept to its concrete surfaces (files, workflows, config, ops touchpoints)
   before gathering evidence, and gather evidence for those surfaces only. A concept with no
   resolvable surface is itself a finding (likely instrument-first, below).
@@ -45,13 +44,13 @@ Parse `$ARGUMENTS` and the invoking prompt for four independent narrowings; each
 - **Repo as parameter.** One repo per invocation. An explicit repo path in the arguments makes that
   checkout the target; otherwise the current repo is. When the target is not the session's working
   directory, resolve its root once (`git -C <repo-path> rev-parse --show-toplevel`) and anchor
-  EVERY probe to it — `git -C <root>` for every git command here and in the `context/` recipes,
-  and file reads under that root — so the evidence never silently comes from the invoking repo.
+  EVERY probe to it. `git -C <root>` for every git command here and in the `context/` recipes,
+  and file reads under that root, so the evidence never silently comes from the invoking repo.
   The precomputed branch/log lines above describe the session's cwd, not the target; re-run them
-  with `-C <root>` in that case. Fleet-wide sweeps are out of scope — compose with
+  with `-C <root>` in that case. Fleet-wide sweeps are out of scope. Compose with
   `repo-fleet-hygiene` externally, one invocation per repo.
 - **Mode.** Interactive is the default. Unattended is entered ONLY when the caller declares it (see
-  Unattended mode) — never inferred from context.
+  Unattended mode), never inferred from context.
 
 ## Scan dimensions
 
@@ -66,7 +65,7 @@ dimension, gather whatever evidence its tier sources yield, then propose candida
 | Config / automation outside the codebase | GitHub labels, Actions workflows, synchronizations, branch protections, bot config |
 | Claude Code operational setup | Cloud environments, MCP servers, hooks, permission rules, plugin/skill configuration |
 
-**Docs/markdown improvement is OUT** — owned lanes (`docs-hygiene`, `codebase-health`) cover it;
+**Docs/markdown improvement is OUT**. Owned lanes (`docs-hygiene`, `codebase-health`) cover it;
 finding a docs candidate means naming the owning lane, not adding it to this list.
 
 ## Evidence ladder
@@ -74,19 +73,19 @@ finding a docs candidate means naming the owning lane, not adding it to this lis
 The skill's core mechanic. Every candidate cites its evidence, and its rung on this ladder sets the
 confidence attached to the ranking (strongest first):
 
-1. **Measured telemetry** — production/application metrics, error rates, cost or latency data from
+1. **Measured telemetry**. Production/application metrics, error rates, cost or latency data from
    a Tier 1/2 source.
-2. **Repo and CI history** — churn×complexity hotspots, CI failure ratios and duration trends,
+2. **Repo and CI history**. Churn×complexity hotspots, CI failure ratios and duration trends,
    dependency staleness. Mechanical, reproducible, repo-native.
-3. **Structural presence signals** — test-coverage presence/absence, TODO density, missing
+3. **Structural presence signals**. Test-coverage presence/absence, TODO density, missing
    automation where a class of toil demonstrably recurs.
-4. **Model judgment** — the weakest rung: this session's read of the target. Always labeled as
+4. **Model judgment**, the weakest rung: this session's read of the target. Always labeled as
    such, never dressed up as measurement.
 
 Two hard rules follow:
 
-- **Instrument-first.** When the target has no measurement at all — no telemetry, no usable CI
-  history, nothing above rung 4 — the top-ranked candidate becomes "instrument this so future runs
+- **Instrument-first.** When the target has no measurement at all. No telemetry, no usable CI
+  history, nothing above rung 4, the top-ranked candidate becomes "instrument this so future runs
   can rank on data": a concrete baseline/instrumentation proposal (what to measure, where the
   signal lands), handed to the pipeline like any other improvement. This mirrors the SRE
   error-budget posture: measurement precedes prioritization.
@@ -97,13 +96,13 @@ Two hard rules follow:
 
 ## Evidence sources (tiered, presence-gated)
 
-- **Tier 0 — repo-native, always available.** Git churn/hotspot analysis (recipe:
+- **Tier 0. Repo-native, always available.** Git churn/hotspot analysis (recipe:
   context/hotspots.md, including its shallow-history gate), CI health via GitHub Actions run data
   (recipe: context/ci-health.md), dependency staleness from the repo's own manifests,
   test-coverage presence, TODO density. These ship with the skill and need nothing installed.
-- **Tier 1 — local Claude Code telemetry.** When `claude-ops:observability` is installed, consult
+- **Tier 1. Local Claude Code telemetry.** When `claude-ops:observability` is installed, consult
   it for session/cost/hook telemetry relevant to the operational-setup dimension.
-- **Tier 2 — configured application telemetry.** Whatever MCP telemetry sources the consumer
+- **Tier 2. Configured application telemetry.** Whatever MCP telemetry sources the consumer
   declares through the `.claude/improvement.md` config cascade (team file + `.local` overlay +
   user-global; key contract in the plugin's reference/config.md). Never hardcode a vendor; if no
   source is configured, Tier 2 is an evidence gap, and product-level candidates fall back down the
@@ -111,25 +110,25 @@ Two hard rules follow:
 
 **GitHub access-path probe ladder.** For CI and repo-platform data, probe in order: GitHub MCP
 tools (`actions_*` and repo tools) → `gh` CLI → none. On "none", record the evidence gap and rank
-without CI evidence — never reconstruct CI health from guesswork.
+without CI evidence, never reconstruct CI health from guesswork.
 
 ## Lane delegation as scan input
 
 Where an installed specialized finder covers a dimension more deeply, consult it presence-gated and
-fold its findings into this skill's candidate list as inputs — delegate, never re-inline its
+fold its findings into this skill's candidate list as inputs. Delegate, never re-inline its
 method:
 
-- `architecture:improve` (deepening lens) — depth for the code/architecture dimension.
-- `claude-config:audit-automation-gaps` — depth for the Claude Code operational-setup dimension.
+- `architecture:improve` (deepening lens). Depth for the code/architecture dimension.
+- `claude-config:audit-automation-gaps`. Depth for the Claude Code operational-setup dimension.
 - Other installed finders that announce an improvement-shaped scan may be consulted the same way.
 
 Delegated findings keep their lane attribution in the evidence citation, and they compete in the
 same ranked list as native candidates. Where no lane is installed, the skill's own Tier 0 scan for
-that dimension stands alone — reuse-or-replace: never re-implement what an owned lane already does.
+that dimension stands alone. Reuse-or-replace: never re-implement what an owned lane already does.
 
 In unattended mode, consult only lanes that run without interaction; a lane whose flow is
 interview- or confirmation-driven is skipped with a `gap:` line naming it, and Tier 0 stands
-alone for that dimension — never simulate a user to drive an interactive lane.
+alone for that dimension, never simulate a user to drive an interactive lane.
 
 ## Candidate output shape
 
@@ -152,45 +151,44 @@ reader knows what the ranking could not see.
 
 1. Present the ranked candidate list (shape above), evidence gaps included.
 2. The user picks a candidate.
-3. Interview on the pick — invoke `/planning:interview` via the Skill tool when available — to reach a shared shape:
+3. Interview on the pick. Invoke `/planning:interview` via the Skill tool when available, to reach a shared shape:
    what improvement, why now, what evidence, what done looks like.
 4. Hand off to the pipeline, invoking each via the Skill tool: `/discovery:explore` (internal
    unknowns) or `/discovery:research` (external unknowns) as needed, then `/planning:plan`. The handoff artifact is the interview's
    output, with the candidate's evidence citation attached.
-5. Offer the remainder: unpicked candidates can be filed via `/work-items:track` when installed —
-   the user decides which, if any.
+5. Offer the remainder: unpicked candidates can be filed via `/work-items:track` when installed; the user decides which, if any.
 
 Where a named pipeline skill is not installed in the consuming project, summarize the equivalent
-handoff shape inline instead of blocking — but absence of a pipeline skill is never license to
+handoff shape inline instead of blocking, but absence of a pipeline skill is never license to
 implement the improvement in this session.
 
 ## Unattended mode
 
 Entered only when the **caller declares it** in the invocation prompt (a routine wrapper, a
-scheduled job, an orchestrating skill) — never sniffed from the environment, per the fleet's
+scheduled job, an orchestrating skill), never sniffed from the environment, per the fleet's
 declared-by-the-caller convention. In unattended mode:
 
 - **No questions.** No interview, no picks, no confirmation prompts. Decisions resolve by the
   defaults below or by the invocation prompt's overrides.
-- **The report is persisted** — the full ranked list plus evidence-gap lines — under
+- **The report is persisted**, the full ranked list plus evidence-gap lines, under
   `${CLAUDE_PLUGIN_DATA}`, keyed per project per the plugin-data-report-keying convention (report
   shape and keying: context/unattended.md).
 - **Top candidates are filed** via `work-items:track` when installed (absent tracker = report
   only, noted in the report). Filing behavior:
-  - *Dedupe against open work items first* — baseline behavior, not a tuning knob; filing a
+  - *Dedupe against open work items first*. Baseline behavior, not a tuning knob; filing a
     duplicate is a bug.
-  - *Adaptive filing cap* — a soft default bounding how many items one run files (following
+  - *Adaptive filing cap*, a soft default bounding how many items one run files (following
     `work-items:work-loop`'s adaptive-cap precedent), overridable by the invocation prompt.
-  - *Dismissed-candidate memory* — candidates an operator previously dismissed are suppressed by
+  - *Dismissed-candidate memory*. Candidates an operator previously dismissed are suppressed by
     default; also prompt-overridable. The routine prompt wrapping this skill is the tuning surface.
 - **Nothing else mutates, and nothing self-disposes.** The run is read-only apart from the report
   and the filed items; it never picks a candidate, never prioritizes the queue, never starts
-  implementation. Prioritization of filed items is human-gated always — the autonomy catalog's
+  implementation. Prioritization of filed items is human-gated always, the autonomy catalog's
   `tech-debt-sweep` C1 contract.
 
 ## Execution requests
 
-"Go implement this" — interactively or as a follow-up — routes through the pipeline, never through
+"Go implement this", interactively or as a follow-up, routes through the pipeline, never through
 this skill's own hands: interview the pick → `/discovery:explore` / `/discovery:research` →
 `/planning:plan` → `/implementation:implement` → `/verification:confirm`, each delegated to its
 skill by invoking it via the Skill tool. This skill performs no code edits in any mode; an execution request changes where the
@@ -199,7 +197,7 @@ handoff goes, not what this skill is allowed to touch.
 ## What this skill does NOT do / Skip when
 
 Reuse-or-replace posture: each boundary below names an owned lane this skill delegates to or steps
-aside for — it re-implements none of them.
+aside for. It re-implements none of them.
 
 | Skip when the ask is | Owned by | Why not here |
 |---|---|---|
@@ -210,8 +208,7 @@ aside for — it re-implements none of them.
 | Sweeping TODO/FIXME markers into items | `work-items:scan-todos` | Marker sweep is one narrow signal; here TODO density is evidence, not the deliverable |
 
 **Verb contract.** `find` reads as read-only, and it is: bare invocation reports and stops. The
-caller's unattended declaration IS the explicit mutation override that authorizes work-item filing —
-the same shape as the `audit` verb's autofix override — and it authorizes exactly that: report
+caller's unattended declaration IS the explicit mutation override that authorizes work-item filing, the same shape as the `audit` verb's autofix override, and it authorizes exactly that: report
 persistence and presence-gated filing. No other mutation exists in any mode; there is no flag,
 prompt, or mode that makes this skill edit the target.
 
@@ -221,9 +218,9 @@ Known traps, seeded from the research this skill was grounded on:
 
 - **Shallow or truncated clones poison churn rankings.** The hotspot recipe's history-depth gate
   (context/hotspots.md) runs first; a window the history does not cover downgrades churn to a
-  recorded evidence gap — confidently-wrong rankings from partial history are worse than no
+  recorded evidence gap. Confidently-wrong rankings from partial history are worse than no
   ranking.
-- **Never call the Actions `/timing` endpoint** — it is deprecating. CI health iterates
+- **Never call the Actions `/timing` endpoint**. It is deprecating. CI health iterates
   `/actions/runs` by `created` date windows (never deep pagination) and derives failure ratios,
   duration trends, and `run_attempt` retries per context/ci-health.md.
 - **Unattended is declared, never detected.** There is no supported way to observe

--- a/plugins/improvement/skills/setup/SKILL.md
+++ b/plugins/improvement/skills/setup/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: "Verify and configure the improvement plugin for this repository. check (default) inspects the .claude/improvement.md config cascade read-only across all three layers — user-global, team, local overlay — and reports the effective evidence-source configuration: which layers exist, what churn window and exclusion patterns resolve, and which Tier 2 MCP telemetry sources are declared. apply interviews the user and writes the team file. Zero config is a valid state — Tier 0 evidence needs nothing configured. Use when: 'set up improvement', 'configure improvement', 'is improvement configured', 'improvement setup', 'declare a telemetry source for the improvement finder', 'tune churn exclusions', or /improvement:find reports Tier 2 as an evidence gap you want closed. Re-runnable — safe to invoke again to reconfigure."
+description: "Verify and configure the improvement plugin for this repository. check (default) inspects the .claude/improvement.md config cascade read-only across all three layers, user-global, team, local overlay, and reports the effective evidence-source configuration: which layers exist, what churn window and exclusion patterns resolve, and which Tier 2 MCP telemetry sources are declared. apply interviews the user and writes the team file. Zero config is a valid state. Tier 0 evidence needs nothing configured. Use when: 'set up improvement', 'configure improvement', 'is improvement configured', 'improvement setup', 'declare a telemetry source for the improvement finder', 'tune churn exclusions', or /improvement:find reports Tier 2 as an evidence gap you want closed. Re-runnable. Safe to invoke again to reconfigure."
 argument-hint: "check | apply"
 user-invocable: true
 disable-model-invocation: true
@@ -12,9 +12,9 @@ Verify and manage the consuming repo's tracked evidence-source config at
 tuning from a declared contract instead of having nothing to consult.
 
 The config is optional in every layer: with none, the finder runs fully on Tier 0 repo-native
-evidence with the bundled churn defaults, and Tier 2 is a recorded evidence gap — so total
+evidence with the bundled churn defaults, and Tier 2 is a recorded evidence gap, so total
 absence is a reported INFO, never a FAIL. The key contract, layer paths, and merge semantics
-live in `${CLAUDE_PLUGIN_ROOT}/reference/config.md` (the single home — this skill implements
+live in `${CLAUDE_PLUGIN_ROOT}/reference/config.md` (the single home. This skill implements
 that contract and does not restate it).
 
 ## Actions
@@ -36,7 +36,7 @@ set, otherwise `git rev-parse --show-toplevel`), never at the CWD.
 ## `check` (read-only)
 
 Inspect the effective merged config and report a PASS/FAIL/INFO table with one remediation line
-per FAIL. Modify nothing, and do NOT run a scan — that is `/improvement:find`.
+per FAIL. Modify nothing, and do NOT run a scan. That is `/improvement:find`.
 
 1. **Layer presence.** Load every layer you can access and report which exist. All absent →
    INFO: the finder uses bundled defaults and records Tier 2 as an evidence gap; `apply` writes
@@ -46,20 +46,20 @@ per FAIL. Modify nothing, and do NOT run a scan — that is `/improvement:find`.
 2. **Effective configuration.** Report the merged result and which layer supplied each value:
    the effective `churn_window`, whether bundled exclusion defaults are on, declared
    `churn_exclude` additions, and every `evidence_sources` entry (name, `mcp_server`, `kind`,
-   scope) — including entries a later layer opted out, reported as removed, not broken. A
+   scope), including entries a later layer opted out, reported as removed, not broken. A
    malformed layer degrades soft: name it, resolve as if absent, report the parse error.
 3. **Key validity.** Each `evidence_sources` entry names an `mcp_server`; an entry missing it is
    FAIL, naming the entry. Where the session can enumerate available MCP servers, note (INFO)
-   any declared server not currently available — at find-time that source becomes an
+   any declared server not currently available. At find-time that source becomes an
    evidence-gap line, which may be expected on this machine.
 4. **Tracked, not ignored.** A present team file must be committed to be team-shared, and
-   "not ignored" is not "tracked" — probe both: `git check-ignore -v .claude/improvement.md`
+   "not ignored" is not "tracked". Probe both: `git check-ignore -v .claude/improvement.md`
    (non-empty result is FAIL with the matching pattern) AND
    `git ls-files --error-unmatch .claude/improvement.md` (non-zero exit is FAIL: the file is
-   present but untracked — the state immediately after `apply` writes it — so teammates will not
+   present but untracked, the state immediately after `apply` writes it, so teammates will not
    receive it until it is committed; report "untracked, commit it" and, if it is staged but
    uncommitted, say that instead via `git diff --cached --name-only`). The `.local.md` overlay is
-   expected to be gitignored — an overlay that is tracked or staged is FAIL (a personal deviation
+   expected to be gitignored, an overlay that is tracked or staged is FAIL (a personal deviation
    can reach team history); an ignored overlay is INFO.
 5. **Overlay divergence.** INFO: when the overlay or user-global layer changes the team file's
    effect (a different window, extra exclusions, an added or opted-out source), say so
@@ -72,7 +72,7 @@ invocation and the repo make values unambiguous; ask only where a value genuinel
 user.
 
 1. **Read the effective config first, across all layers**, and present the merged baseline with
-   per-layer provenance — exactly as `check` step 2 reports it. When a higher layer's opt-out or
+   per-layer provenance. Exactly as `check` step 2 reports it. When a higher layer's opt-out or
    override shapes the effective result, warn that editing the team file alone will not change
    what this machine resolves, and point at the owning layer. Nothing is dropped without the
    user confirming.
@@ -80,23 +80,23 @@ user.
    actually exists (generated/build output trees, snapshot or designer files not covered by the
    bundled defaults); keep `churn_window` at the bundled default unless the repo's history is
    young or the user says otherwise; and draft `evidence_sources` candidates from the MCP
-   servers the consumer has configured that plausibly carry telemetry — a candidate is a
+   servers the consumer has configured that plausibly carry telemetry, a candidate is a
    proposal for the user to confirm, never an assumption. No plausible source and none volunteered
    is a fine outcome: write the churn keys only, and say Tier 2 stays a declared gap.
 3. **Interview, one decision at a time**: window, exclusions, then each telemetry source (name,
    `mcp_server`, `kind`, scope, hints) with a recommendation the user accepts, edits, or
    declines.
 4. **Write the team file** in the file format defined by
-   `${CLAUDE_PLUGIN_ROOT}/reference/config.md` — a fenced YAML block holding only the keys the
+   `${CLAUDE_PLUGIN_ROOT}/reference/config.md`, a fenced YAML block holding only the keys the
    user confirmed. Never write a vendor-specific default the user did not declare.
-5. **Verify after writing.** Re-run the `check` probes on the written file — BOTH
+5. **Verify after writing.** Re-run the `check` probes on the written file. BOTH
    `git check-ignore -v .claude/improvement.md` (surface a matching pattern and offer a
    `.gitignore` fix) AND `git ls-files --error-unmatch .claude/improvement.md` (non-zero exit
-   means the file is un-ignored but still untracked — the guaranteed state right after this
-   step writes it — so report "written but untracked: commit it to share with the team", never
+   means the file is un-ignored but still untracked, the guaranteed state right after this
+   step writes it, so report "written but untracked: commit it to share with the team", never
    success). Then offer the overlay
    convention: personal overrides go in `.claude/improvement.local.md`; recommend the consumer
-   add the recursive `.claude/**/*.local.*` line to `.gitignore` if not already covered — but
+   add the recursive `.claude/**/*.local.*` line to `.gitignore` if not already covered. But
    never edit their `.gitignore` yourself.
 
 Re-running `apply` after everything passes changes nothing and reports "already configured".
@@ -109,12 +109,12 @@ one paragraph on what was written and how to re-run this setup to reconfigure.
 
 ## What this skill does NOT do
 
-- Run an improvement scan — that is `/improvement:find`; `check` only inspects config.
-- Install or configure MCP servers — it declares which configured server carries telemetry;
+- Run an improvement scan. That is `/improvement:find`; `check` only inspects config.
+- Install or configure MCP servers. It declares which configured server carries telemetry;
   provisioning the server is the consumer's own MCP setup.
-- Write the user-global layer, the `.local.md` overlay, or the consumer's `.gitignore` — team
+- Write the user-global layer, the `.local.md` overlay, or the consumer's `.gitignore`. Team
   file only; everything else is recommended, not written.
-- Write machine-local state — configuration lives in the consumer's tracked file, never in the
+- Write machine-local state. Configuration lives in the consumer's tracked file, never in the
   plugin directory or the plugin data directory.
 
 ## Gotchas
@@ -122,11 +122,10 @@ one paragraph on what was written and how to re-run this setup to reconfigure.
 - **All layers absent is healthy.** Tier 0 evidence needs no config; do not manufacture a FAIL
   (or a config file) for a repo that has not opted into Tier 2 or churn tuning.
 - **CWD is not the repo root.** Invoked from a subdirectory, a CWD-relative read finds a
-  nonexistent `<subdir>/.claude/improvement.md` and silently reports an absent config — anchor
+  nonexistent `<subdir>/.claude/improvement.md` and silently reports an absent config. Anchor
   at the root in every self-contained shell call.
 - **The team file is the only thing `apply` writes.** An effective value contributed by the
   overlay or user-global layer cannot be changed here; say which layer owns it instead of
   writing a team value that the higher layer will keep overriding.
 - **No git verdict on the user-global layer.** `git check-ignore` against a path outside the
-  worktree is meaningless (or confidently wrong when the home directory is itself a repo) —
-  the tracked/ignored probes apply to the two in-repo layers only.
+  worktree is meaningless (or confidently wrong when the home directory is itself a repo); the tracked/ignored probes apply to the two in-repo layers only.


### PR DESCRIPTION
No linked issue

## Summary

#2891 instruction-surface de-slop cluster: purge em dashes from the `improvement` plugin README and every SKILL.md.

## Fix

Rewrote `plugins/improvement/README.md` and every `plugins/improvement/**/SKILL.md` under `/ai-slop:audit fix` semantics (periods, commas, or a restructured sentence; never parentheses, en dashes, or a spaced hyphen as a stand-in). A self-audit repaired wrap leftovers, split asides, and table N/A cells the mechanical pass left as fragments. `improvement` 0.1.3.

## Verification

- Detector: 0 `rule-em-dash` findings outside ignore-fenced generated-options spans (and required trigger strings that must keep em dashes)
- `CHECK_SKILL_SKIP_MARKDOWNLINT=1 bash scripts/check-changed-skills.sh origin/main`: 0 failed; quoted trigger phrases vs origin/main preserved
- `python3 scripts/sync-plugin-options-docs.py --check` up to date
- `scripts/check-changelog-parity.sh --check-bump origin/main` passes
- `node scripts/generate-cheatsheet.mjs --check` in sync

## Related

Refs #2891

#2891 stays open.