### PR TITLE
docs(codebase-health): de-slop instruction surfaces (0.8.3)

### DIFF
--- a/plugins/codebase-health/.claude-plugin/plugin.json
+++ b/plugins/codebase-health/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "codebase-health",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "Repo-wide drift audit between docs, config, code, and architecture: verifies every factual claim against reality via parallel subagent fan-out, severity-rates findings, and reports read-only, delegating remediation to the implementation/verification lanes. Audit dimensions are configurable through a tracked .claude/codebase-health.md config file written by the setup skill.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/codebase-health/CHANGELOG.md
+++ b/plugins/codebase-health/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to the `codebase-health` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.8.3]
+
+### Changed
+
+- **Instruction-surface de-slop (#2891, codebase-health cluster).** Rewrote this plugin's `README.md` and every
+  `SKILL.md` to drop em dashes under the repo's zero-tolerance house policy, using
+  `/ai-slop:audit fix` semantics: periods or commas, or a restructured sentence, never
+  parentheses, en dashes, or a spaced hyphen as a stand-in. Meaning stays; only the mark
+  and the sentence break change. The generated options block is ignore-fenced because
+  `scripts/sync-plugin-options-docs.py` still emits em dashes from its shared template.
+
 ## [0.8.2]
 
 ### Changed

--- a/plugins/codebase-health/README.md
+++ b/plugins/codebase-health/README.md
@@ -1,9 +1,8 @@
 # codebase-health
 
-A Claude Code plugin for repo-wide drift auditing: it verifies that a codebase's **factual claims** —
-in docs, config, code, and architecture notes — still match reality. Every claim is checked against
+A Claude Code plugin for repo-wide drift auditing: it verifies that a codebase's **factual claims** in docs, config, code, and architecture notes still match reality. Every claim is checked against
 ground truth via a parallel per-file subagent fan-out, findings are severity-rated, and the audit
-reports them read-only — remediation is delegated to the implementation/verification lanes.
+reports them read-only. Remediation is delegated to the implementation/verification lanes.
 
 Distinct from diff/PR review (which judges a change) and from Claude Code configuration audits (which
 check `settings.json` / hooks / permissions): this plugin verifies whether the repo's own written
@@ -11,18 +10,18 @@ claims about itself are true.
 
 | Skill | What it does |
 |---|---|
-| `/codebase-health:audit` | Runs the audit — prime conventions, fan out claim-extraction per file, independently validate, severity-rate, and report read-only; remediation is delegated to the implementation/verification lanes. |
+| `/codebase-health:audit` | Runs the audit. Prime conventions, fan out claim-extraction per file, independently validate, severity-rate, and report read-only; remediation is delegated to the implementation/verification lanes. |
 | `/codebase-health:setup` | `check` inspects the tracked `.claude/codebase-health.md` config read-only across its merge layers; `apply` interviews the user, infers targets from the layout, and writes the config. |
 
 ## The audit
 
 Four phases (0–3): prime the repo's conventions, discover via per-file fan-out, independently
-validate each finding (a separate agent re-verifies — never self-review), then categorize and present
+validate each finding (a separate agent re-verifies, never self-review), then categorize and present
 in a severity-rated table with a verified-non-issues proof-of-thoroughness list, drift patterns, fix
-priority, enforcement escalation, and config-gap observations. Bare invocation is read-only — it
+priority, enforcement escalation, and config-gap observations. Bare invocation is read-only. It
 reports and stops.
 
-Remediation is not owned here — fixing, verifying, self-reviewing, and retrospecting are delegated to
+Remediation is not owned here. Fixing, verifying, self-reviewing, and retrospecting are delegated to
 the dedicated lanes: `/implementation:implement` (fix) and `/verification:confirm` (verify), used as
 soft dependencies when those plugins are installed. The explicit `--fix` flag hands the Phase 3
 findings off to those lanes rather than fixing inline; when they are absent, the findings table is the
@@ -35,18 +34,18 @@ handoff and remediation is manual in the reported fix-priority order.
 ```
 
 Dimension filters (`--docs-only`, `--code-only`, `--config-only`, `--arch-only`) are mutually
-exclusive. A scope path narrows the file set. An unscoped whole-repo run is gated — the skill
+exclusive. A scope path narrows the file set. An unscoped whole-repo run is gated, the skill
 requires a scope, a filter, or explicit confirmation before fanning out, because a full fan-out spans
 every doc/config/source file.
 
 ## Configurable audit dimensions
 
-What the audit reads and how it verifies claims is **not baked in** — it comes from the consuming
+What the audit reads and how it verifies claims is **not baked in**. It comes from the consuming
 repo's tracked config, resolved additively across three layers:
 
-1. `~/.claude/codebase-health.md` — user-global base (optional)
-2. `.claude/codebase-health.md` — team config (tracked)
-3. `.claude/codebase-health.local.md` — personal overlay (gitignored)
+1. `~/.claude/codebase-health.md`. User-global base (optional)
+2. `.claude/codebase-health.md`. Team config (tracked)
+3. `.claude/codebase-health.local.md`. Personal overlay (gitignored)
 
 Each dimension declares `primary-sources` (globs where claims live), `verification-sources` (globs
 where claims are checked against ground truth), and `example-claims` (concrete `{ claim, verify-via }`
@@ -55,7 +54,7 @@ are `documentation`, `configuration`, `code-quality`, and `architecture`; the co
 globs, remove a dimension, or add custom ones.
 
 When no config is present, the audit infers targets from the repo layout, uses them, and offers to
-persist the inference via `/codebase-health:setup apply` — so the next run is deterministic. It never
+persist the inference via `/codebase-health:setup apply`, so the next run is deterministic. It never
 hardcodes a repo's layout.
 
 ```shell
@@ -69,7 +68,7 @@ team config stays tracked.
 ## Consumer conventions
 
 Phase 0 reads the consuming repo's own `CLAUDE.md` / `AGENTS.md` / `.claude/rules/` to learn what
-"correct" looks like — a claim contradicting those conventions is a finding; one following them is a
+"correct" looks like, a claim contradicting those conventions is a finding; one following them is a
 verified non-issue. Nothing project-specific is baked into the plugin.
 
 ## Install
@@ -81,7 +80,7 @@ verified non-issue. Nothing project-specific is baked into the plugin.
 
 ## Configuration
 
-No `userConfig` — audit targets flow through the tracked `.claude/codebase-health.md` config seam
+No `userConfig`. Audit targets flow through the tracked `.claude/codebase-health.md` config seam
 above (written by `/codebase-health:setup apply`). No hooks, no MCP servers, no bundled scripts, no network
 calls of its own (Phase 2 may use whatever documentation-research tools your setup provides). State:
 the audit reads and writes only the consumer's own files under the scope you give it.

--- a/plugins/codebase-health/skills/audit/SKILL.md
+++ b/plugins/codebase-health/skills/audit/SKILL.md
@@ -25,9 +25,9 @@ Parse `$ARGUMENTS` for:
 
 - **Scope** (optional): directory or file path to limit the audit (default: entire repo)
 - **`--fix`**: after reporting, hand the findings off to the remediation lanes
-  (`/implementation:implement` then `/verification:confirm`) rather than fixing inline — see
+  (`/implementation:implement` then `/verification:confirm`) rather than fixing inline. See
   [Remediation](#remediation-delegated-to-other-plugins). Per the naming doctrine's verb
-  contract, bare `audit` is READ-ONLY — it reports at Phase 3 and stops; remediation intent sits
+  contract, bare `audit` is READ-ONLY. It reports at Phase 3 and stops; remediation intent sits
   behind this explicit override. (`--review-only` is accepted as a legacy alias for the bare
   read-only default.)
 - **Dimension filters** (optional, mutually exclusive):
@@ -36,13 +36,13 @@ Parse `$ARGUMENTS` for:
   - `--config-only`: only configuration checks
   - `--arch-only`: only architecture checks
 
-If no filter is specified, audit every active dimension — the Phase 1 per-file fan-out makes
+If no filter is specified, audit every active dimension, the Phase 1 per-file fan-out makes
 dimension order irrelevant (each file gets its own subagent). Enumerate `primary-sources` across all
 active dimensions and dispatch per file.
 
 ## Read-only default
 
-Bare invocation — by the user or the model — runs the audit (Phases 0–3) and stops at the Phase 3
+Bare invocation, by the user or the model, runs the audit (Phases 0–3) and stops at the Phase 3
 report. Remediation is never inlined here; it is delegated to the `implementation`/`verification`
 lanes and hands off only under an explicit `--fix` from the user (or an equally explicit "fix what
 you find" instruction in their prose). Model auto-invocation never supplies `--fix` on its own.
@@ -51,20 +51,19 @@ you find" instruction in their prose). Model auto-invocation never supplies `--f
 
 ## Adapting to your environment (graceful degrade)
 
-The audit itself (Phases 0–3) is self-contained. Where Phase 2 names an adjacent capability —
-documentation-research tools (MCP docs servers, library-docs lookers-up, web search) — treat it as
+The audit itself (Phases 0–3) is self-contained. Where Phase 2 names an adjacent capability, documentation-research tools (MCP docs servers, library-docs lookers-up, web search), treat it as
 optional: use it if your setup provides one, otherwise follow the inline graceful-degrade guidance,
 which confidence-tags the externally-unverifiable part `needs-review` rather than guessing.
 
 Remediation is different: it is **delegated**, not inlined. Fixing, verifying, self-reviewing, and
 retrospecting are owned end-to-end by the `implementation`/`verification` lanes (see
 [Remediation](#remediation-delegated-to-other-plugins)). When those plugins are absent the
-Phase 3 findings table is the handoff — remediate manually in the reported fix-priority order — NOT
+Phase 3 findings table is the handoff, remediate manually in the reported fix-priority order, NOT
 a cue to re-inline a fix/verify/review loop here.
 
 Scope boundary with adjacent audit lanes: this skill verifies **factual claims** in docs/config
 against code state. Claude Code configuration files (`settings.json`, `.mcp.json`, hooks,
-permissions) and automation-landscape gap analysis are different lanes — when the
+permissions) and automation-landscape gap analysis are different lanes, when the
 `claude-config` plugin is installed, route those to `/claude-config:audit` and
 `/claude-config:audit-automation-gaps`, invoked via the Skill tool; otherwise state they are out of
 scope rather than
@@ -74,9 +73,9 @@ running claim-extraction over them.
 
 ## Audit dimensions & targets (tracked config seam)
 
-Per-dimension audit targets — `primary-sources` (where claims live), `verification-sources` (where
+Per-dimension audit targets. `primary-sources` (where claims live), `verification-sources` (where
 to verify), and `example-claims` (illustrative `{ claim, verify-via }` rows for the claim-extraction
-pass) — come from the consuming repo's tracked config, resolved additively across three layers:
+pass). Come from the consuming repo's tracked config, resolved additively across three layers:
 
 1. `~/.claude/codebase-health.md` (user-global, optional)
 2. `.claude/codebase-health.md` (team, tracked)
@@ -85,7 +84,7 @@ pass) — come from the consuming repo's tracked config, resolved additively acr
 The four bundled dimensions are `documentation`, `configuration`, `code-quality`, and
 `architecture`; the config may tune their globs, remove a dimension, or add custom ones.
 
-**Merge semantics when the same dimension name appears in two layers:** additive by default — the
+**Merge semantics when the same dimension name appears in two layers:** additive by default. The
 later layer's `primary-sources` and `verification-sources` globs UNION with the earlier layer's (not
 replace), and `example-claims` concatenate with duplicate `claim` text collapsed. A layer removes an
 inherited dimension by declaring it with empty source lists (an explicit opt-out), never by silent
@@ -96,11 +95,11 @@ Settle targets by this ladder:
 
 1. **Config present → use it.**
 2. **Absent → infer from the repo** (doc dirs, build manifests, source/test roots, CI workflows),
-   then **persist the inference** by offering to run `/codebase-health:setup` — so the next run is
+   then **persist the inference** by offering to run `/codebase-health:setup`, so the next run is
    deterministic.
 3. **Cannot infer → ask the user**, and offer to persist the answer via setup.
 4. **Otherwise → safe generic defaults**: documentation = `docs/**/*.md` + `README.md` + any
-   agent-instruction files; the other dimensions require inference or config — skip a dimension
+   agent-instruction files; the other dimensions require inference or config. Skip a dimension
    you cannot ground rather than guessing.
 
 Never hardcode a repo layout; read a declared value, infer-and-record, or ask.
@@ -119,7 +118,7 @@ delegated to the `implementation`/`verification` lanes and is not part of this c
 Before auditing, load what "correct" looks like in this repo:
 
 1. **Read the consuming repo's `CLAUDE.md` / `AGENTS.md` and `.claude/rules/` files** (where
-   present) — conventions, naming rules, enforcement expectations.
+   present). Conventions, naming rules, enforcement expectations.
 2. **Resolve the audit config** per the dimension seam above; read the convention files its
    `verification-sources` name.
 
@@ -132,22 +131,22 @@ reading conventions first.
 ## Phase 1: Discover
 
 The goal is exhaustive verification, not sampling. Every factual claim in every relevant file must
-be checked against reality. The most common audit failure is skipping items — thoroughness beats
+be checked against reality. The most common audit failure is skipping items. Thoroughness beats
 speed.
 
-Discovery runs as a **parallel subagent fan-out — one agent per primary-source file**, NOT a single
+Discovery runs as a **parallel subagent fan-out. One agent per primary-source file**, NOT a single
 sequential pass (fresh context per file ≈ 2× claim coverage and ~4× drift caught; a single context
-skips claims as it fills — the #1 audit failure). Each agent applies the claim-extraction method
+skips claims as it fills, the #1 audit failure). Each agent applies the claim-extraction method
 (read top-to-bottom → extract every factual claim → verify each independently → record), fenced per
 the scope-fencing rules in [`${CLAUDE_PLUGIN_ROOT}/skills/audit/context/discovery-method.md`](context/discovery-method.md).
 
-**Scope first (MANDATORY — cost gate):** require a `[scope]` or dimension filter (`--docs-only`
+**Scope first (MANDATORY. Cost gate):** require a `[scope]` or dimension filter (`--docs-only`
 etc.) for large targets; if the enumerated list exceeds ~20 files, confirm with the user before
-dispatching. Never fan out the whole repo unprompted — an unscoped run across every doc/config/
+dispatching. Never fan out the whole repo unprompted, an unscoped run across every doc/config/
 source file costs millions of tokens.
 
-Full method — claim-extraction steps, the verify-ALL-claims-on-a-line rule,
-enumerate/scope/dispatch/collect detail, and the per-finding report format — in
+Full method. Claim-extraction steps, the verify-ALL-claims-on-a-line rule,
+enumerate/scope/dispatch/collect detail, and the per-finding report format. In
 [`${CLAUDE_PLUGIN_ROOT}/skills/audit/context/discovery-method.md`](context/discovery-method.md).
 Dimension-specific claim guidance:
 [`${CLAUDE_PLUGIN_ROOT}/skills/audit/reference/audit-checklist.md`](reference/audit-checklist.md).
@@ -156,16 +155,15 @@ Dimension-specific claim guidance:
 
 ## Phase 2: Validate & Enrich
 
-Re-read each finding to confirm accuracy. This is the false-positive gate — every finding must
+Re-read each finding to confirm accuracy. This is the false-positive gate. Every finding must
 survive scrutiny before being reported.
 
 **Validate independently, not by self-review.** When Phase 1 ran as a fan-out, dispatch the
 false-positive gate as a SEPARATE subagent that re-verifies each finding against the source of
-truth — do NOT let the discovering agent grade its own findings. A model re-checking its own work
+truth. Do NOT let the discovering agent grade its own findings. A model re-checking its own work
 rubber-stamps it; an independent agent re-reading the doc claim AND the actual code catches both
 false positives and miscategorized-but-correct claims. Where the finding set is high-stakes and
-correlated blind spots are the risk, prefer a cross-vendor advisor **when one is installed and set up** —
-e.g. the OpenAI Codex plugin, when its documented surface can take this artifact, invoked per its own docs — with the
+correlated blind spots are the risk, prefer a cross-vendor advisor **when one is installed and set up**, e.g. the OpenAI Codex plugin, when its documented surface can take this artifact, invoked per its own docs, with the
 fresh-context same-vendor subagent as the stated fallback, never a route to a command that may not resolve
 (per `docs/PLUGIN-PHILOSOPHY.md` "Fresh-eyes checkpoints" in the marketplace repository).
 Fence each validator to read-only (its
@@ -174,14 +172,14 @@ findings' files + verification-sources).
 ### External research (required when the tooling exists)
 
 When your setup provides documentation-research tools (MCP docs servers, library-docs lookers-up, web
-search), using them is REQUIRED — not optional — to validate findings involving:
+search), using them is REQUIRED, not optional, to validate findings involving:
 
-- **Best-practice claims** — is the documented pattern the current recommended approach?
-- **Library API claims** — does the method/class/parameter exist in the current version?
-- **Configuration behavior** — does the setting do what the docs say?
+- **Best-practice claims**: is the documented pattern the current recommended approach?
+- **Library API claims**: does the method/class/parameter exist in the current version?
+- **Configuration behavior**: does the setting do what the docs say?
 
 Cross-reference research results against the repo's conventions (loaded in Phase 0). External
-consensus matters, but repo conventions are the primary lens — a pattern unusual industry-wide may
+consensus matters, but repo conventions are the primary lens, a pattern unusual industry-wide may
 be intentionally chosen here.
 
 **Graceful degrade when no research tool is available:** do not skip the claim and do not guess.
@@ -197,8 +195,8 @@ cost of missing a marginal issue (catchable next run).
 ### Tag findings with confidence
 
 - **verified**: confirmed by reading source files AND (where applicable) external research
-- **likely**: strong evidence, one piece ambiguous — still reported as a finding
-- **needs-review**: requires human judgment — separated from confirmed findings in the output
+- **likely**: strong evidence, one piece ambiguous. Still reported as a finding
+- **needs-review**: requires human judgment. Separated from confirmed findings in the output
 
 ---
 
@@ -206,7 +204,7 @@ cost of missing a marginal issue (catchable next run).
 
 ### Group findings per [`${CLAUDE_PLUGIN_ROOT}/skills/audit/reference/category-playbook.md`](reference/category-playbook.md)
 
-Fix order matters — see the playbook for why: Config Drift → Missing Enforcement → Code Quality →
+Fix order matters. See the playbook for why: Config Drift → Missing Enforcement → Code Quality →
 Doc Drift.
 
 ### Output format
@@ -219,14 +217,14 @@ Use this exact table with consistent `error`/`warning`/`info` severity:
 
 ### Required sections after the findings table
 
-1. **Verified non-issues** — every claim checked that turned out correct. This is the thoroughness
+1. **Verified non-issues**. Every claim checked that turned out correct. This is the thoroughness
    proof. Include at least as many verified items as findings.
-2. **Drift patterns** — group related findings and identify root causes (e.g., "7 findings trace to
+2. **Drift patterns**. Group related findings and identify root causes (e.g., "7 findings trace to
    a registration refactor where code was updated but docs weren't")
-3. **Fix priority** — recommended fix order per the category playbook
-4. **Enforcement escalation** — for each finding, what automated enforcement (formatter, linter,
+3. **Fix priority**. Recommended fix order per the category playbook
+4. **Enforcement escalation**. For each finding, what automated enforcement (formatter, linter,
    analyzer, type check, test, git hook, CI gate) could catch this class automatically?
-5. **Config-gap observations** — dimensions, globs, or `example-claims` this run showed are worth
+5. **Config-gap observations**. Dimensions, globs, or `example-claims` this run showed are worth
    adding to the tracked `.claude/codebase-health.md` (e.g. a source tree that held drift but wasn't
    a configured `primary-source`). Offer to persist them via `/codebase-health:setup apply` so the
    next run covers them deterministically.
@@ -235,18 +233,17 @@ Use this exact table with consistent `error`/`warning`/`info` severity:
 
 If the audit finds no discrepancies, report a clean bill of health:
 
-- Present the **verified non-issues** list as proof of thoroughness (this is the whole point —
-  showing what was checked)
+- Present the **verified non-issues** list as proof of thoroughness (this is the whole point: showing what was checked)
 - State explicitly: "No findings. All claims verified as correct."
 - Do NOT invent findings to justify the audit. A clean codebase is the goal, not a guaranteed list
   of issues.
-- Nothing to remediate, so no handoff. Still include the config-gap observations (§5) — a clean run
+- Nothing to remediate, so no handoff. Still include the config-gap observations (§5), a clean run
   is the best time to note coverage gaps worth persisting via `/codebase-health:setup apply`.
 
 ### Fix gate
 
 **Without `--fix`** (the default, including every model auto-invocation): present the full
-report and **STOP** — the Phase 3 report is the deliverable.
+report and **STOP**, the Phase 3 report is the deliverable.
 **With `--fix`**: present the full Phase 3 report, then hand off to the remediation lanes below.
 
 ---
@@ -255,22 +252,21 @@ report and **STOP** — the Phase 3 report is the deliverable.
 
 The audit ends at the Phase 3 report: the findings table, verified-non-issues proof, drift patterns,
 fix priority, enforcement escalation, and config-gap observations ARE the deliverable. Fixing,
-verifying, self-reviewing, and retrospecting are separate lanes owned end-to-end by other plugins —
-re-implementing them here would duplicate those skills, so this skill delegates instead.
+verifying, self-reviewing, and retrospecting are separate lanes owned end-to-end by other plugins; re-implementing them here would duplicate those skills, so this skill delegates instead.
 
-Route remediation to the dedicated lanes (soft dependencies — use when the plugin is installed):
+Route remediation to the dedicated lanes (soft dependencies. Use when the plugin is installed):
 
 - **Fix** → `/implementation:implement` (when the `implementation` plugin is installed). Hand it the
   Phase 3 findings, whose "Fix priority" section already carries the Config Drift → Missing
   Enforcement → Code Quality → Doc Drift order (see
   [`reference/category-playbook.md`](reference/category-playbook.md)); that lane owns the fix cadence
-  — TDD, build/test at each checkpoint, and the post-fix simplification pass.
+TDD, build/test at each checkpoint, and the post-fix simplification pass.
 - **Verify** → `/verification:confirm` (when the `verification` plugin is installed). Confirms the
   fixes against the repo's own build/test/lint gates with no regressions, and covers the self-review
   and retrospective that the fix lane hands it.
 
 **With `--fix`**, present the Phase 3 findings and output an explicit user-directed suggestion to run
 `/implementation:implement` with those findings, then `/verification:confirm`. Do NOT auto-invoke
-either skill — the user drives both. When those plugins are not installed, say so and stop: the
+either skill, the user drives both. When those plugins are not installed, say so and stop: the
 Phase 3 findings table is the handoff, to be remediated manually in the reported fix-priority order.
 Never re-inline a fix/verify/review/retro loop here.

--- a/plugins/codebase-health/skills/setup/SKILL.md
+++ b/plugins/codebase-health/skills/setup/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: "Verify and configure the codebase-health plugin for this repository. check inspects the tracked .claude/codebase-health.md config read-only across its merge layers (presence, dimension source lists, tracked-not-ignored); apply interviews the user, infers audit targets from the repo layout, and writes the config. Use when: 'set up codebase-health', 'is codebase-health configured', 'configure the audit', 'codebase-health setup', the audit skill reports missing or thin config, or audit dimensions need tuning. Re-runnable — safe to invoke again to reconfigure."
+description: "Verify and configure the codebase-health plugin for this repository. check inspects the tracked .claude/codebase-health.md config read-only across its merge layers (presence, dimension source lists, tracked-not-ignored); apply interviews the user, infers audit targets from the repo layout, and writes the config. Use when: 'set up codebase-health', 'is codebase-health configured', 'configure the audit', 'codebase-health setup', the audit skill reports missing or thin config, or audit dimensions need tuning. Re-runnable. Safe to invoke again to reconfigure."
 argument-hint: "check | apply"
 user-invocable: true
 disable-model-invocation: true
@@ -18,9 +18,9 @@ updates rather than overwriting blind.
 
 ## The config merge model
 
-The audit config resolves as an additive merge of the documented layers — user-global
+The audit config resolves as an additive merge of the documented layers. User-global
 (`~/.claude/codebase-health.md`) → team (`.claude/codebase-health.md`) → local overlay
-(`.claude/codebase-health.local.md`) — where a later layer's globs union with (not replace) the
+(`.claude/codebase-health.local.md`), where a later layer's globs union with (not replace) the
 earlier layer's and example-claims concatenate, **except** that a later layer declaring a dimension
 with empty source lists is an explicit opt-out that *removes* that inherited dimension. This skill
 writes only the **team** file; changes to a higher overlay are the user's to make.
@@ -28,22 +28,22 @@ writes only the **team** file; changes to a higher overlay are the user's to mak
 ## `check` (read-only)
 
 Inspect the effective merged config and report a PASS/FAIL/INFO table with one remediation line per
-FAIL. Modify nothing, and do NOT run an audit — that is `/codebase-health:audit`.
+FAIL. Modify nothing, and do NOT run an audit. That is `/codebase-health:audit`.
 
-1. **Config presence (effective, across layers)** — load every layer you can access and report the
+1. **Config presence (effective, across layers)**. Load every layer you can access and report the
    *effective merged* result honoring opt-outs (dimensions present, glob counts, example-claim counts),
    and which layer contributes what. No layer readable and no team file → INFO: the audit re-infers
    targets each run; `apply` writes `.claude/codebase-health.md` to make the run deterministic. When a
    higher layer (a user-global base outside the repo) cannot be read, WARN it was not considered rather
    than presenting the team file alone as the effective config.
-2. **Dimension source lists** — for each dimension present in the team file, its declared source lists
+2. **Dimension source lists**. For each dimension present in the team file, its declared source lists
    parse and name real paths/globs. A dimension whose source list is malformed or fails to parse is
    FAIL, naming it. A dimension deliberately zeroed (empty source lists) by an overlay is INFO (an opt-out),
    reported as removed, not broken.
-3. **Tracked, not ignored** — a present team file must be committed to be team-shared: run
+3. **Tracked, not ignored**, a present team file must be committed to be team-shared: run
    `git check-ignore -v .claude/codebase-health.md`; a non-empty result is FAIL with the matching
-   pattern. The `.local.md` overlay is expected to be ignored — INFO, not FAIL.
-4. **Overlay divergence** — INFO: when a local or user-global overlay changes the team file's effect
+   pattern. The `.local.md` overlay is expected to be ignored. INFO, not FAIL.
+4. **Overlay divergence**. INFO: when a local or user-global overlay changes the team file's effect
    (adds globs, or opts a dimension out with empty source lists), say so explicitly, since `apply`
    writes only the team file.
 
@@ -53,13 +53,13 @@ Run `check`, then interview and write the config. Proceed non-interactively wher
 the repo make the values unambiguous; ask only where a dimension's targets genuinely need the user.
 
 1. **Read the effective config first, across all layers.** Load every layer you can access and present a
-   short summary of the *effective merged* result — honoring opt-outs, so a dimension a higher layer
-   deliberately zeroed out is reported as removed, not present — and report which layer contributes what.
-   When a local or user-global layer changes the team file's effect — whether it *adds* globs or *opts a
-   dimension out* with empty source lists — **say so explicitly**, because this step writes only the
+   short summary of the *effective merged* result. Honoring opt-outs, so a dimension a higher layer
+   deliberately zeroed out is reported as removed, not present, and report which layer contributes what.
+   When a local or user-global layer changes the team file's effect. Whether it *adds* globs or *opts a
+   dimension out* with empty source lists. **say so explicitly**, because this step writes only the
    *team* file. A team-scope edit alone will not account for what a higher overlay contributes; in
    particular, when a local (or user-global) opt-out zeroes a dimension, accepting a team-scope
-   *re-enable* here will not restore that dimension on this machine — the overlay keeps removing it — so
+   *re-enable* here will not restore that dimension on this machine, the overlay keeps removing it, so
    prompt the user to also remove or update the opt-out in that overlay, not just re-enable it in the
    team file. When a higher layer cannot be read (a user-global base is often outside the repo and
    OS-specific), **warn that it was not considered** rather than presenting the team file alone as the
@@ -68,28 +68,26 @@ the repo make the values unambiguous; ask only where a dimension's targets genui
 2. **Explore the repo to draft defaults.** Before asking anything, infer candidates:
    - **documentation** primary-sources: doc directories (`docs/`, `README.md`), agent-instruction
      files (`AGENTS.md`, `CLAUDE.md`), ADR directories, convention docs.
-   - **configuration** primary-sources: build config, lint config, CI workflows, git-hook config —
-     detected from what actually exists (e.g. `Directory.Build.props`, `pyproject.toml`,
+   - **configuration** primary-sources: build config, lint config, CI workflows, git-hook config, detected from what actually exists (e.g. `Directory.Build.props`, `pyproject.toml`,
      `package.json`, `.github/workflows/`, `lefthook.yml`, `.editorconfig`).
    - **code-quality** primary-sources: source roots; verification-sources: test roots **plus the
-     same source roots** — a cross-file DRY/SOLID claim is validated by reading peer source files,
+     same source roots**, a cross-file DRY/SOLID claim is validated by reading peer source files,
      which a discovery agent can only read when they are in `verification-sources` (the fence forbids
      the other primary-source files). Omitting them makes cross-file findings unreachable.
    - **architecture** primary-sources: dependency manifests + architecture docs;
      verification-sources: analyzers / architecture tests where present **plus the dependency
-     manifests and source roots** — dependency-direction and boundary claims need peer manifests
+     manifests and source roots**. Dependency-direction and boundary claims need peer manifests
      readable, for the same fence reason.
 3. **Interview, one decision at a time.** Present each dimension's drafted globs with a
    recommendation; let the user accept, edit, or remove the dimension. Offer custom dimensions
    last ("anything else this repo should audit as its own lane?").
 4. **Draft example-claims.** For each accepted dimension, read one or two representative
    primary-source files and propose 2–4 concrete `{ claim, verify-via }` rows drawn from real
-   sentences in them. Concrete rows teach the discovery pass what drift looks like in THIS repo —
-   the highest-value part of the config. The user approves or edits each row.
+   sentences in them. Concrete rows teach the discovery pass what drift looks like in THIS repo, the highest-value part of the config. The user approves or edits each row.
 5. **Write the config.** Materialize `.claude/codebase-health.md` following the structure in
    [`${CLAUDE_PLUGIN_ROOT}/skills/setup/templates/config-template.md`](templates/config-template.md) (replace every placeholder comment
    with real values; drop unused placeholder rows).
-6. **Verify after remediation.** Re-run the `check` probes on the written file — dimension source lists
+6. **Verify after remediation.** Re-run the `check` probes on the written file. Dimension source lists
    parse and name real paths, and `git check-ignore -v .claude/codebase-health.md` confirms it is
    tracked, not ignored (surface the matching pattern and offer to fix `.gitignore` before reporting
    success). Then **offer the overlay convention**: personal overrides go in
@@ -106,6 +104,6 @@ was written and how to re-run this setup to reconfigure.
 
 ## What this skill does NOT do
 
-- Run an audit — that is `/codebase-health:audit`. `check` only inspects config.
-- Write machine-local state — configuration lives in the consumer's tracked file, never in the
+- Run an audit. That is `/codebase-health:audit`. `check` only inspects config.
+- Write machine-local state. Configuration lives in the consumer's tracked file, never in the
   plugin directory or the plugin data directory.

--- a/plugins/codebase-health/skills/setup/SKILL.md
+++ b/plugins/codebase-health/skills/setup/SKILL.md
@@ -55,8 +55,8 @@ the repo make the values unambiguous; ask only where a dimension's targets genui
 1. **Read the effective config first, across all layers.** Load every layer you can access and present a
    short summary of the *effective merged* result. Honoring opt-outs, so a dimension a higher layer
    deliberately zeroed out is reported as removed, not present, and report which layer contributes what.
-   When a local or user-global layer changes the team file's effect. Whether it *adds* globs or *opts a
-   dimension out* with empty source lists. **say so explicitly**, because this step writes only the
+   When a local or user-global layer changes the team file's effect, whether it *adds* globs or *opts a
+   dimension out* with empty source lists, **say so explicitly**, because this step writes only the
    *team* file. A team-scope edit alone will not account for what a higher overlay contributes; in
    particular, when a local (or user-global) opt-out zeroes a dimension, accepting a team-scope
    *re-enable* here will not restore that dimension on this machine, the overlay keeps removing it, so


### PR DESCRIPTION
No linked issue

## Summary

#2891 instruction-surface de-slop cluster: purge em dashes from the `codebase-health` plugin README and every SKILL.md.

## Fix

Rewrote `plugins/codebase-health/README.md` and every `plugins/codebase-health/**/SKILL.md` under `/ai-slop:audit fix` semantics (periods, commas, or a restructured sentence; never parentheses, en dashes, or a spaced hyphen as a stand-in). A self-audit repaired wrap leftovers, split asides, and table N/A cells the mechanical pass left as fragments. `codebase-health` 0.8.3.

## Verification

- Detector: 0 `rule-em-dash` findings outside ignore-fenced generated-options spans (and required trigger strings that must keep em dashes)
- `CHECK_SKILL_SKIP_MARKDOWNLINT=1 bash scripts/check-changed-skills.sh origin/main`: 0 failed; quoted trigger phrases vs origin/main preserved
- `python3 scripts/sync-plugin-options-docs.py --check` up to date
- `scripts/check-changelog-parity.sh --check-bump origin/main` passes
- `node scripts/generate-cheatsheet.mjs --check` in sync

## Related

Refs #2891

#2891 stays open.