### PR TITLE
docs(rate-limit-guard): de-slop instruction surfaces (0.7.11)

### DIFF
--- a/plugins/rate-limit-guard/.claude-plugin/plugin.json
+++ b/plugins/rate-limit-guard/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "rate-limit-guard",
-  "version": "0.7.10",
+  "version": "0.7.11",
   "description": "Shared rate-limit guard for loop lanes: a statusline wrapper tees the subscription rate-limit windows to a fixed machine-scope file, a StopFailure hook records rate-limit stops reactively, and a reader contract fixes how consuming sessions pause and resume.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/rate-limit-guard/CHANGELOG.md
+++ b/plugins/rate-limit-guard/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to the `rate-limit-guard` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.7.11]
+
+### Changed
+
+- **Instruction-surface de-slop (#2891, guardrails cluster).** Rewrote this plugin's `README.md` and every
+  `SKILL.md` to drop em dashes under the repo's zero-tolerance house policy, using
+  `/ai-slop:audit fix` semantics: periods or commas, or a restructured sentence, never
+  parentheses, en dashes, or a spaced hyphen as a stand-in. Meaning stays; only the mark
+  and the sentence break change. The generated options block is ignore-fenced because
+  `scripts/sync-plugin-options-docs.py` still emits em dashes from its shared template.
+
 ## [0.7.10]
 
 ### Fixed

--- a/plugins/rate-limit-guard/README.md
+++ b/plugins/rate-limit-guard/README.md
@@ -1,38 +1,39 @@
 # rate-limit-guard
 
 A Claude Code plugin that makes the machine's shared subscription rate-limit windows observable to
-every session that needs them — so autonomous loop lanes can pause **before** hitting a limit and
+every session that needs them, so autonomous loop lanes can pause **before** hitting a limit and
 resume on their own after the reset. Four parts:
 
-- **Statusline shim** (`scripts/statusline-shim.sh`) — the durable wiring target. Installed once to
+- **Statusline shim** (`scripts/statusline-shim.sh`), the durable wiring target. Installed once to
   `~/.claude/rate-limit-guard/bin/`, it resolves whichever tee version is installed at run time, so
   a plugin update never requires re-wiring and an uninstall degrades to your statusline running
   alone. Pure Bash builtins: it adds no measurable time to a refresh.
-- **Statusline tee** (`scripts/statusline-tee.sh`) — a transparent wrapper around your statusline
+- **Statusline tee** (`scripts/statusline-tee.sh`), a transparent wrapper around your statusline
   command. Each refresh it atomically writes the session's `rate_limits` (both the 5-hour and
   7-day windows), a `captured_at` timestamp, and the session-distinguishing fields to the fixed
   machine-scope contract path `~/.claude/rate-limit-guard/rate-limits.json`, then passes your
   statusline through byte-for-byte. With no statusline configured it doubles as a minimal
   standalone statusline.
-- **StopFailure hook** (`hooks/record-rate-limit-stop.sh`) — the reactive fallback. When a turn
+- **StopFailure hook** (`hooks/record-rate-limit-stop.sh`), the reactive fallback. When a turn
   ends on a rate-limit API error, it appends a detection record to
   `~/.claude/rate-limit-guard/stop-events.jsonl`. StopFailure output and exit codes are ignored by
   the harness, so the hook is side-effect-only by design.
-- **Reader contract** (`reference/reader-contract.md`) — the authoritative consumer contract: the
+- **Reader contract** (`reference/reader-contract.md`), the authoritative consumer contract: the
   fixed tee path, the 90%-of-either-window pause threshold, the staleness rule, pause-end
   semantics, capability-detect fail-open, and drain-then-pause.
 
 ## Behavior
 
-- **Transparent by contract.** No tee outcome — missing `jq`, unwritable path, a rename blocked by
-  a concurrent reader — ever changes the wrapped statusline's output or exit code. Missing `jq` is
+- **Transparent by contract.** No tee outcome ever changes the wrapped statusline's output or
+  exit code, including missing `jq`, an unwritable path, or a rename blocked by a concurrent
+  reader. Missing `jq` is
   surfaced as a visible one-line notice, never a silent skip.
 - **Atomic, last-writer-wins snapshot.** Concurrent sessions write one path; readers never see torn
   JSON (temp file + rename, with a brief retry for the Windows rename-over-open-target case).
 - **Fail-open capability detection.** Sessions whose auth exposes no `rate_limits` (API-key,
   enterprise) tee an honest snapshot without the key; consumers treat that as unknown and run
   reactive-only rather than throttling on fabricated data. Cloud / remote sessions with no
-  statusline producer typically have no tee file at all — the same unknown → reactive-only
+  statusline producer typically have no tee file at all. That is the same unknown → reactive-only
   classification, documented as the expected degraded mode in
   [`reference/reader-contract.md`](reference/reader-contract.md) ("Cloud / remote sessions"), with
   a documented residual that a live cloud producer is out of scope until one exists.
@@ -53,9 +54,9 @@ resume on their own after the reset. Four parts:
 The StopFailure hook is active immediately. The statusline tee needs two operator steps, both
 one-time:
 
-1. `/rate-limit-guard:setup apply` — installs the statusline shim to
+1. `/rate-limit-guard:setup apply` installs the statusline shim to
    `~/.claude/rate-limit-guard/bin/statusline-shim.sh`. The shim is inert until step 2.
-2. `/rate-limit-guard:setup check` — verifies prerequisites and prints the exact `settings.json`
+2. `/rate-limit-guard:setup check` verifies prerequisites and prints the exact `settings.json`
    statusline edit (wrapping your existing command, or standalone) for you to apply. The plugin
    never edits your settings itself.
 
@@ -66,22 +67,22 @@ version bump and then takes the whole statusline down when the path disappears. 
 the newest installed tee at run time, so plugin updates need no re-wiring, and it passes your
 statusline through unchanged when no tee is installed (including after uninstall).
 
-Running alongside `context-guard`? The tees are transparent wrappers, so they nest — each through
+Running alongside `context-guard`? The tees are transparent wrappers, so they nest, each through
 its own shim, with the innermost command still owning stdout and the exit code. Both setup skills
 print that combined form.
 
 ## Requirements
 
-The scripts run on Bash (Git Bash on native Windows — install
+The scripts run on Bash (Git Bash on native Windows; install
 [Git for Windows](https://code.claude.com/docs/en/setup#set-up-on-windows); the statusline wiring
 invokes `bash` explicitly) and need [`jq`](https://jqlang.org/download/) on `PATH` for the tee and
-the standalone statusline. Proactive window data requires Claude.ai subscription auth (Pro/Max) —
+the standalone statusline. Proactive window data requires Claude.ai subscription auth (Pro/Max).
 `rate_limits` appears only there, per the
 [statusline reference](https://code.claude.com/docs/en/statusline); on other auth the guard is
 reactive-only. The tee updates only while an interactive session refreshes the statusline.
 
 Cost: the tee adds roughly 0.6–0.9 s per statusline refresh on Windows/Git Bash (process-spawn
-bound — `jq` and `date`), and correspondingly less on native POSIX shells. The statusline is not on
+bound, `jq` and `date`), and correspondingly less on native POSIX shells. The statusline is not on
 the input path, so this is display latency, not typing latency; `refreshInterval` in your settings
 governs how often it runs.
 
@@ -94,7 +95,7 @@ One `userConfig` option:
 | `rate_limit_guard_enabled` | Kill switch for the StopFailure detection hook **and** the statusline tee's snapshot write (default `true`). |
 
 Set it with `/plugin configure rate-limit-guard@<marketplace>`, or headless via `claude plugin install
-rate-limit-guard@<marketplace> -s <scope> --config rate_limit_guard_enabled=false` — against an
+rate-limit-guard@<marketplace> -s <scope> --config rate_limit_guard_enabled=false`, against an
 already-installed plugin that prints `already installed` and still writes the value, verified on
 Claude Code 2.1.240 for a non-sensitive option at `user` scope. Never uninstall to reconfigure: that
 drops the whole stored `pluginConfigs` entry and resets every option to its manifest default.
@@ -103,7 +104,7 @@ drops the whole stored `pluginConfigs` entry and resets every option to its mani
 `CLAUDE_PLUGIN_OPTION_RATE_LIMIT_GUARD_ENABLED`. The statusline tee cannot: it is invoked by
 absolute path from the operator's own `statusLine` setting, and Claude Code exports those variables
 to *hook* processes only, so the tee reads `pluginConfigs` from the settings files directly. Its
-precedence is **managed settings → user settings → environment**, highest first — a managed
+precedence is **managed settings → user settings → environment**, highest first. A managed
 `rate_limit_guard_enabled: false` is an organization's policy and wins over any user value. Every
 degraded read (no settings file, no `jq`, malformed JSON) leaves the tee enabled, and no outcome of
 that gate ever changes what your statusline prints.
@@ -121,6 +122,7 @@ Written for the loop-lane convention's three lanes (work-items `work-loop` and `
 source-control `babysit-loop`), which inline the reader contract's operable floor. Any session or
 tool on the machine may read the same files under the same contract.
 
+<!-- ai-slop-ignore-start: generated options block; source is plugin.json + scripts/sync-plugin-options-docs.py -->
 <!-- BEGIN GENERATED: plugin options — edit plugin.json, then run scripts/sync-plugin-options-docs.py -->
 
 ### Options reference
@@ -193,10 +195,11 @@ hands a configured value to a hook process; the value comes from the routes abov
 - [Manage installed plugins](https://code.claude.com/docs/en/discover-plugins#manage-installed-plugins) — enabling, disabling, `/plugin list`
 
 <!-- END GENERATED: plugin options -->
+<!-- ai-slop-ignore-end -->
 
 ## Tuning: `RLG_TEE_ASYNC`
 
-Not a plugin option — a plain environment variable the statusline tee reads directly, so it sits
+Not a plugin option. A plain environment variable the statusline tee reads directly, so it sits
 outside the generated block above: Claude Code does not prompt for it and no settings scope
 carries it.
 
@@ -206,7 +209,7 @@ carries it.
 
 The snapshot is a side effect: nothing the status line prints depends on it, and the
 [reader contract](reference/reader-contract.md) budgets ten minutes of staleness. Detaching skips
-no work — every refresh still takes the lock and writes — it only stops the render waiting.
+no work. Every refresh still takes the lock and writes. It only stops the render waiting.
 
 **Whether that helps depends on how many sessions you keep open, not on your refresh interval.**
 MSYS has no native `fork()`, so forking a bash subshell holding the payload costs 75–200 ms on
@@ -221,7 +224,7 @@ status line + tee:
 | Ten sessions at 1 Hz, median | **2265 ms** | 4476 ms |
 | Ten sessions, peak `bash` processes | **50** | 71 |
 
-Turn it on if you work in one or two windows. Leave it off if you run many — at ten sessions it
+Turn it on if you work in one or two windows. Leave it off if you run many. At ten sessions it
 roughly doubles both latency and process count. On Linux and macOS, where `fork()` is cheap, the
 crossover sits much further out; the numbers above are the Windows worst case.
 

--- a/plugins/rate-limit-guard/skills/setup/SKILL.md
+++ b/plugins/rate-limit-guard/skills/setup/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: "Verify the rate-limit-guard plugin's wiring on this machine — jq, the installed statusline shim, statusline wiring (including legacy version-pinned plugin-cache paths), tee freshness, and the StopFailure hook — print the exact statusline edit for the operator to apply, and install the statusline shim. Use when: 'set up rate-limit-guard', 'is the rate-limit tee working', 'wire the rate-limit statusline', the tee file is stale, or a consuming loop lane reports guard mode unknown. Actions: check (read-only; never edits settings), apply (writes ONLY ~/.claude/rate-limit-guard/bin/statusline-shim.sh, on explicit request)."
+description: "Verify the rate-limit-guard plugin's wiring on this machine: jq, the installed statusline shim, statusline wiring (including legacy version-pinned plugin-cache paths), tee freshness, and the StopFailure hook. Print the exact statusline edit for the operator to apply, and install the statusline shim. Use when: 'set up rate-limit-guard', 'is the rate-limit tee working', 'wire the rate-limit statusline', the tee file is stale, or a consuming loop lane reports guard mode unknown. Actions: check (read-only; never edits settings), apply (writes ONLY ~/.claude/rate-limit-guard/bin/statusline-shim.sh, on explicit request)."
 argument-hint: "check | apply"
 user-invocable: true
 disable-model-invocation: true
@@ -10,38 +10,38 @@ disable-model-invocation: true
 Narrow-write setup. This plugin's **configuration** surface is three kinds of thing setup cannot
 conformingly write:
 
-- **A system tool** (`jq`) — `check` probes it; installing it is the operator's.
+- **A system tool** (`jq`). `check` probes it; installing it is the operator's.
 - **One native `userConfig` toggle** (`rate_limit_guard_enabled`), whose only stored home is the
   `pluginConfigs` setup must never write. Reconfiguration routes through Claude Code's native flow:
   `/plugin configure rate-limit-guard@<marketplace>` interactively, any time. Headless, rerun the
-  install with the new value — `claude plugin install rate-limit-guard@<marketplace> -s <scope>
+  install with the new value. `claude plugin install rate-limit-guard@<marketplace> -s <scope>
   --config rate_limit_guard_enabled=<value>`. Against an already-installed plugin it prints
-  `already installed` **and still writes the value** — verified on Claude Code 2.1.240 (a
+  `already installed` **and still writes the value**, verified on Claude Code 2.1.240 (a
   non-sensitive option at `user` scope: a non-default value written to an installed plugin, then
   restored). The short-circuit is about the install, not the config write. Re-verify before relying
-  on it outside those conditions — a `sensitive` option, or `project`/`local` scope, were not
+  on it outside those conditions. A `sensitive` option, or `project`/`local` scope, were not
   covered. Do **not** uninstall to reconfigure: uninstalling drops this plugin's entire stored
   `pluginConfigs` entry, resetting every option in the README's Options reference table to its
   manifest default. `-s` defaults to `user`, so pass the scope the plugin is *actually* installed
-  at — `claude plugin list` reports it per plugin — and run from that project's directory when the
+  at. `claude plugin list` reports it per plugin. Run from that project's directory when the
   scope is `project` or `local`, or the write lands at a scope that does not load.
   Afterwards, keep the two claims apart. The write is issued and the stored value is what you
   passed; the RUNNING session's behavior is not. The rendered `${user_config.*}` is injected at
   skill load and each hook receives its `CLAUDE_PLUGIN_OPTION_*` from an environment fixed at
-  session start, so a same-session `check` still reports the OLD value — reporting that as a
+  session start, so a same-session `check` still reports the OLD value. Reporting that as a
   failed write would be wrong. Verify the effective value by rerunning `check` in a **fresh
   session**, and never claim an unobserved change.
-- **The statusline wiring**, which lives in the **user's own** `settings.json` — neither
+- **The statusline wiring**, which lives in the **user's own** `settings.json`, neither
   `userConfig` nor tracked project config, and a Claude Code settings surface setup must never
   mutate.
 
 So `check` inspects, reports PASS/FAIL/INFO with one remediation line per FAIL, and **prints the
-exact statusline edit for the operator to apply by hand** — fully resolved, marked as the
+exact statusline edit for the operator to apply by hand**, fully resolved, marked as the
 operator's, and naming what re-invalidates it. Silence would not be the conforming response on an
 unwritable surface; a printed edit is.
 
 What obliges an `apply` is not configuration at all. The tee's and the hook's machine files under
-`~/.claude/rate-limit-guard/` remain runtime-owned plugin data, not an operator-editable surface —
+`~/.claude/rate-limit-guard/` remain runtime-owned plugin data, not an operator-editable surface,
 but the **statusline shim** `~/.claude/rate-limit-guard/bin/statusline-shim.sh` is an owned
 writable artifact this plugin must place, because it is the durable path the operator's own wiring
 names. `apply` writes that one file and nothing else.
@@ -55,7 +55,7 @@ statusline down with it. So the operator wires the **shim**, never the tee: the 
 path that never changes, resolves the newest installed tee at run time, and degrades to running the
 wrapped command alone when no tee is installed.
 
-The scripts are the source of truth for their own behavior — read
+The scripts are the source of truth for their own behavior. Read
 `${CLAUDE_PLUGIN_ROOT}/scripts/statusline-shim.sh`,
 `${CLAUDE_PLUGIN_ROOT}/scripts/statusline-tee.sh` and
 `${CLAUDE_PLUGIN_ROOT}/hooks/record-rate-limit-stop.sh` first; probe what they actually do rather
@@ -64,23 +64,23 @@ owned by `${CLAUDE_PLUGIN_ROOT}/reference/reader-contract.md`.
 
 ## `check` (read-only)
 
-1. **`jq`** — `command -v jq`. FAIL if absent: without it the wrapper cannot tee (it stays
+1. **`jq`.** `command -v jq`. FAIL if absent: without it the wrapper cannot tee (it stays
    transparent and shows a visible notice) and the standalone statusline degrades. Remediation:
    install jq (<https://jqlang.org/download/>).
-2. **Installed shim state** — the shim is the wiring target, so check it before the wiring. Compare
+2. **Installed shim state.** The shim is the wiring target, so check it before the wiring. Compare
    `~/.claude/rate-limit-guard/bin/statusline-shim.sh` against
    `${CLAUDE_PLUGIN_ROOT}/scripts/statusline-shim.sh` (the installed copy is byte-identical by
    contract, so `cmp -s` is the test):
-   - **Absent** — FAIL when the statusline is wired to it (that wiring cannot run), INFO otherwise.
+   - **Absent.** FAIL when the statusline is wired to it (that wiring cannot run), INFO otherwise.
      Remediation: `apply`.
-   - **Present and identical** — PASS. Nothing about it needs revisiting on a plugin update; that
+   - **Present and identical.** PASS. Nothing about it needs revisiting on a plugin update; that
      is the whole point of the shim.
-   - **Present but differing** — classify by what the installed revision can still do, not by the
+   - **Present but differing.** Classify by what the installed revision can still do, not by the
      fact that it differs. Report the shipped `# shim-revision:` marker against the installed one
      either way, and offer `apply` as the refresh.
-     - Installed revision **>= 3** — INFO: an older-but-adequate or hand-edited copy that still
+     - Installed revision **>= 3.** INFO: an older-but-adequate or hand-edited copy that still
        resolves the newest tee correctly. A refresh is housekeeping.
-     - Installed revision **< 3, or unmarked** — FAIL. Revision 3 is the first that skips a
+     - Installed revision **< 3, or unmarked.** FAIL. Revision 3 is the first that skips a
        candidate whose version directory carries the orphan marker; every earlier revision keeps
        teeing from an UNINSTALLED plugin's directory for the ~14 days before Claude Code reaps it,
        writing snapshots the operator has no reason to expect. That is a behavior defect in the
@@ -89,64 +89,64 @@ owned by `${CLAUDE_PLUGIN_ROOT}/reference/reader-contract.md`.
      - **The migration matters more than the classification.** The durable copy at
        `~/.claude/rate-limit-guard/bin/statusline-shim.sh` is what the statusline actually runs;
        a plugin update never overwrites it. An operator who ran `apply` before 0.4.3 therefore
-       keeps running the old shim until they re-run `apply` — and if they uninstall the plugin
+       keeps running the old shim until they re-run `apply`, and if they uninstall the plugin
        first, this skill is gone and the stale shim keeps teeing with no remaining way to reach
        the remediation. Say that in the finding, so the reason to act now is on screen.
-   - **The SHIPPED source is absent** (no `${CLAUDE_PLUGIN_ROOT}/scripts/statusline-shim.sh`) —
+   - **The SHIPPED source is absent** (no `${CLAUDE_PLUGIN_ROOT}/scripts/statusline-shim.sh`).
      INFO, and skip the comparison entirely: this installed plugin version predates the shim
      (< 0.2.0). Never report the operator's installed copy as drifted on this branch. Remediation:
      `/plugin update rate-limit-guard`, then re-run `check`. Until then the legacy version-pinned
      wiring in step 3 is the only wiring this version can offer.
-3. **Statusline wiring state** — read (never write) every settings scope that can carry a
+3. **Statusline wiring state.** Read (never write) every settings scope that can carry a
    `statusLine` (user `~/.claude/settings.json`, project `.claude/settings.json`, local
    `.claude/settings.local.json`) and determine which one owns the EFFECTIVE command (the most
    specific scope wins). All wiring states below are evaluated against that effective command,
-   and the printed edit in step 6 targets THAT scope's file — wiring the user file while a
+   and the printed edit in step 6 targets THAT scope's file. Wiring the user file while a
    project-level `statusLine` shadows it would apply cleanly and never run; when a shadow
    exists, say so explicitly and print the edit for the shadowing file (or note that removing
    the override is the alternative). Distinguish FOUR states:
-   - **No `statusLine` configured** — the wrapper is not running because nothing is. Print the
+   - **No `statusLine` configured.** The wrapper is not running because nothing is. Print the
      standalone wiring from the template below (the shim is then the whole statusline).
-   - **`statusLine` present, command references neither the shim nor `statusline-tee.sh`** —
+   - **`statusLine` present, command references neither the shim nor `statusline-tee.sh`.**
      wrapper missing. Print the wrapped wiring below with the user's current command preserved as
      the wrapped command.
-   - **`statusLine` references a `rate-limit-guard` `statusline-tee.sh` under the plugin cache** —
+   - **`statusLine` references a `rate-limit-guard` `statusline-tee.sh` under the plugin cache.**
      LEGACY VERSION-PINNED WIRING, regardless of whether that file currently exists. It is running
      today only until the next version bump, and it breaks the whole statusline once the old
      version directory is pruned (~14 days after an update). Report it as the failure mode the shim
      exists to remove, and print the shim wiring as the fix (`apply` first if the shim is not
      installed). An interim `[ -f … ]` existence guard around such a path is the same state: it
      survives pruning but still stops teeing on a version bump.
-   - **`statusLine` invokes `~/.claude/rate-limit-guard/bin/statusline-shim.sh`** — PASS. No path
+   - **`statusLine` invokes `~/.claude/rate-limit-guard/bin/statusline-shim.sh`.** PASS. No path
      comparison against `${CLAUDE_PLUGIN_ROOT}` applies or is meaningful here; the shim resolves
      the tee at run time.
-4. **Tee freshness** — probe the fixed contract path `~/.claude/rate-limit-guard/rate-limits.json`:
+4. **Tee freshness.** Probe the fixed contract path `~/.claude/rate-limit-guard/rate-limits.json`:
    - `jq -e '.rate_limits and .captured_at'` passes and `captured_at` is within the reader
      contract's 10-minute staleness window → PASS (proactive mode available).
    - File fresh but `rate_limits` absent → INFO: this session's auth exposes no subscription
      windows (API-key or enterprise auth); consumers correctly run reactive-only. Not a defect.
    - File absent or stale while the wiring in step 3 looked correct → FAIL: the wrapper is wired
      but not running (statusline refreshes only in interactive sessions; also re-check steps 2 and
-     3 — a shim that is wired but not installed produces exactly this). Note the file only updates
+     3, because a shim that is wired but not installed produces exactly this). Note the file only updates
      while some interactive session is active.
-5. **StopFailure hook** — INFO: the hook needs no wiring (it registers via the plugin's
+5. **StopFailure hook.** INFO: the hook needs no wiring (it registers via the plugin's
    `hooks/hooks.json`); confirm the plugin is enabled (`/plugin` → Installed) and report the
    effective kill switch `${user_config.rate_limit_guard_enabled}` (unexpanded or empty means the
-   default `true`). Report whether `~/.claude/rate-limit-guard/stop-events.jsonl` exists — absent
+   default `true`). Report whether `~/.claude/rate-limit-guard/stop-events.jsonl` exists. Absent
    just means no rate-limit stop has been recorded yet.
-6. **Print the operator edit** — always print the applicable `settings.json` statusline edit,
-   marked clearly as the operator's to apply. The wiring target is the SHIM's fixed path — never
+6. **Print the operator edit.** Always print the applicable `settings.json` statusline edit,
+   marked clearly as the operator's to apply. The wiring target is the SHIM's fixed path, never
    `${CLAUDE_PLUGIN_ROOT}`, which is version-pinned and belongs in no operator file:
 
    **Unwrap before you compose.** `<current statusline command>` below means the operator's OWN
    renderer, never the raw effective `command` string. Before substituting, strip every leading
-   guard-shim invocation from that string — `bash <path>/rate-limit-guard/bin/statusline-shim.sh`
-   and `bash <path>/context-guard/bin/statusline-shim.sh`, in whatever order they appear — plus any
+   guard-shim invocation from that string: `bash <path>/rate-limit-guard/bin/statusline-shim.sh`
+   and `bash <path>/context-guard/bin/statusline-shim.sh`, in whatever order they appear, plus any
    legacy `bash <plugin-cache>/…/statusline-tee.sh` prefix, and treat what remains as the renderer.
    Substituting the raw string instead is what produces `context → rate → rate → renderer` when the
    sibling plugin was configured first, or a doubled self-wrap on a re-run: each duplicated tee runs
    and writes on EVERY refresh and costs another 0.6–0.9 s (below). Unwrapping also makes the
-   printed edit idempotent — re-running `check` on already-correct wiring prints the wiring it
+   printed edit idempotent. Re-running `check` on already-correct wiring prints the wiring it
    already has.
 
    Wrapping an existing statusline command (preserve the user's unwrapped command verbatim as the
@@ -172,7 +172,7 @@ owned by `${CLAUDE_PLUGIN_ROOT}/reference/reader-contract.md`.
    }
    ```
 
-   Shell-syntax guard: the wrapped form passes the user's command as ARGV — it only works for
+   Shell-syntax guard: the wrapped form passes the user's command as ARGV. It only works for
    plain `executable arg…` commands. If the current command contains shell syntax (an inline env
    assignment like `THEME=dark my-statusline`, a pipe, `&&`, `;`, or quoting), print the
    shell-wrapped variant instead:
@@ -188,16 +188,16 @@ owned by `${CLAUDE_PLUGIN_ROOT}/reference/reader-contract.md`.
 
    `<escaped original command>` is the original command POSIX-escaped for single-quote embedding:
    replace every `'` in it with `'\''` before substituting (then JSON-escape the whole `command`
-   string as usual). Show the final, fully escaped line — never hand the operator a template with
+   string as usual). Show the final, fully escaped line. Never hand the operator a template with
    raw quotes left to fix. Verify your printed edit round-trips: run
    `printf '%s\n' '<escaped original command>'` and confirm the output matches the original
    command.
 
-   Sibling tees compose by nesting, each through its OWN shim — the tees are transparent wrappers,
+   Sibling tees compose by nesting, each through its OWN shim. The tees are transparent wrappers,
    so the innermost command still owns stdout and the exit code. Print this form (its tee outermost,
    matching that plugin's setup skill) only when `context-guard` is installed AND its shim is
    already present at `~/.claude/context-guard/bin/statusline-shim.sh`. The sibling shim is written
-   by `/context-guard:setup apply`, which the operator may not have run yet — naming a path that
+   by `/context-guard:setup apply`, which the operator may not have run yet. Naming a path that
    does not exist reintroduces exactly the failure this wiring exists to remove, because `bash
    <missing-path>` exits 127 before the operator's renderer ever runs. When the sibling plugin is
    installed but its shim is absent, print the single-shim form above and say that
@@ -214,7 +214,7 @@ owned by `${CLAUDE_PLUGIN_ROOT}/reference/reader-contract.md`.
 
    The shell-syntax guard applies UNCHANGED to this form: `<current statusline command>` is the
    innermost ARGV here too, so a command carrying shell syntax must be substituted as
-   `sh -c '<escaped original command>'` — never raw. Substituting `THEME=dark my-statusline` raw
+   `sh -c '<escaped original command>'`, never raw. Substituting `THEME=dark my-statusline` raw
    makes `THEME=dark` the executable, which fails `command not found` (127) instead of setting the
    variable. The shim paths are the only part that nests; the innermost substitution rule never
    changes:
@@ -234,13 +234,13 @@ owned by `${CLAUDE_PLUGIN_ROOT}/reference/reader-contract.md`.
    `refreshInterval` sets how often that runs; the statusline is not on the input path, so the
    cost is display latency, not typing latency.
 
-   Windows note: the command must run under Git Bash — `bash` is invoked explicitly for exactly
+   Windows note: the command must run under Git Bash. `bash` is invoked explicitly for exactly
    that reason (the script's stated shell requirement); with Git Bash absent Claude Code routes
    statusline commands through PowerShell and this wiring does not apply (statusline reference,
    "Windows configuration"). State this with the printed edit: the wiring is applied ONCE and
-   survives every later plugin update, because the shim — not the version-pinned cache path — is
+   survives every later plugin update, because the shim, not the version-pinned cache path, is
    what the settings file names.
-7. **Dotfiles tracking proposal** — the printed edit changes a durable user-scope file the operator
+7. **Dotfiles tracking proposal.** The printed edit changes a durable user-scope file the operator
    maintains. When the operator's home directory is managed by a dotfiles system (chezmoi, yadm, a
    bare-repo setup, ...), surface the reminder to capture the `settings.json` change through that
    system's own add/track flow so the wiring survives machine rebuilds. This skill only surfaces
@@ -252,13 +252,13 @@ Copy `${CLAUDE_PLUGIN_ROOT}/scripts/statusline-shim.sh` to
 `~/.claude/rate-limit-guard/bin/statusline-shim.sh`, creating `bin/` if needed, and `chmod +x` the
 result (a no-op on Windows ACL volumes; the wiring invokes it through `bash` anyway):
 
-- The installed copy is **byte-identical** to the shipped source — never a rewrite, never a
+- The installed copy is **byte-identical** to the shipped source, never a rewrite, never a
   templated variant. That is what makes `check` step 2 a plain `cmp`.
 - **Idempotent**: if the file already exists and compares equal, write nothing and say so.
   Otherwise overwrite it (this is the update path after a plugin version bump changes the shim)
   and report the `# shim-revision:` values, old → new.
 - The shim is **inert until wired**: installing it starts nothing. Only the operator's
-  `settings.json` edit — step 6 of `check`, which this skill never applies — puts it on the
+  `settings.json` edit, step 6 of `check`, which this skill never applies, puts it on the
   statusline path. Say that explicitly when reporting the write.
 - After installing, print the wiring edit (`check` step 6) so the operator's next action is in
   front of them, and note that a statusline already wired to the shim needs NO change now or on
@@ -271,7 +271,7 @@ result (a no-op on Windows ACL volumes; the wiring invokes it through `bash` any
 
 Uninstalling the plugin removes the cache directory, not the operator's files. Nothing breaks: the
 shim finds no tee and passes the wrapped statusline through unchanged (a wired-standalone shim
-prints one notice line instead). Two operator cleanup steps remain, and their ORDER matters —
+prints one notice line instead). Two operator cleanup steps remain, and their ORDER matters.
 report both together, in this order, when asked how to back this out:
 
 1. **Unwrap the `statusLine` command first**, restoring the operator's own renderer (or removing
@@ -279,7 +279,7 @@ report both together, in this order, when asked how to back this out:
 2. **Then remove `~/.claude/rate-limit-guard/`.**
 
 Deleting the directory while the wiring still names the shim leaves `settings.json` invoking a
-missing file: `bash <missing-path>` exits 127 and takes the WHOLE statusline down — the exact
+missing file: `bash <missing-path>` exits 127 and takes the WHOLE statusline down, the exact
 failure the shim exists to prevent. The shim's own no-tee fallback cannot cover this, because the
 fallback lives in the file that was just deleted.
 
@@ -287,10 +287,10 @@ fallback lives in the file that was just deleted.
 
 - Write the plugin cache, Claude Code user settings, or `pluginConfigs`, per the uniform setup
   contract (`docs/PLUGIN-PHILOSOPHY.md` "Setup is explicit and repeatable" in the marketplace
-  repository). Nor `settings.json` (user or project) or any other Claude Code settings surface —
+  repository). Nor `settings.json` (user or project) or any other Claude Code settings surface.
   the printed edit is the operator's to apply.
 - Install `jq` or any system package.
-- Write to the contract files — the wrapper and the hook own `rate-limits.json` and
+- Write to the contract files. The wrapper and the hook own `rate-limits.json` and
   `stop-events.jsonl`; `apply` owns only `bin/statusline-shim.sh`.
-- Write anywhere outside `~/.claude/rate-limit-guard/` — including the sibling `context-guard`
+- Write anywhere outside `~/.claude/rate-limit-guard/`, including the sibling `context-guard`
   directory, whose own setup skill installs that plugin's shim.


### PR DESCRIPTION
No linked issue

## Summary

Refs #2891. Instruction-surface de-slop shard for the `rate-limit-guard` plugin only. Other plugins stay on main.

## Fix

Rewrote `plugins/rate-limit-guard/README.md` and every `plugins/rate-limit-guard/**/SKILL.md` under `/ai-slop:audit fix` semantics (periods, commas, or a restructured sentence; never parentheses, en dashes, or a spaced hyphen as a stand-in). A self-audit repaired wrap leftovers and asides the mechanical pass left as fragments. `rate-limit-guard` 0.7.11. The generated options block is ignore-fenced because `scripts/sync-plugin-options-docs.py` still emits em dashes from its shared template.

## Verification

- Detector (rule-em-dash enabled, isolated config): 0 `rule-em-dash` findings outside ignore-fenced generated-options spans
- `CHECK_SKILL_SKIP_MARKDOWNLINT=1 bash scripts/check-changed-skills.sh origin/main`: 0 failed; quoted trigger phrases vs origin/main preserved
- `python3 scripts/sync-plugin-options-docs.py --check` up to date
- `scripts/check-changelog-parity.sh --check-bump origin/main` passes
- `node scripts/generate-cheatsheet.mjs --check` in sync

## Related

Refs #2891
