### PR TITLE
docs(skill-quality): de-slop instruction surfaces (0.20.1)

### DIFF
--- a/plugins/skill-quality/.claude-plugin/plugin.json
+++ b/plugins/skill-quality/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "skill-quality",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "description": "Skill-authoring QA tooling: a static contract checker that runs twenty-five deterministic checks over a Claude Code skill (frontmatter, explicit invocation mode, description/verb-contract polarity, per-skill listing-entry cap, trigger-keyword preservation, line caps, broken internal refs, markdownlint, gotchas surface, evals presence, precompute opportunity, completion-criteria signal, injection shell-declaration, fresh-eyes declaration conformance), a shared skill-listing budget reporter across a set of skills, and a bundled evals.json schema plus a deterministic eval-quality lint (duplicate case identities, missing fixtures, empty or vague grading criteria, set-coverage warnings). Runs against any repo's skills directory via the convention-resolution ladder — no baked layout.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/skill-quality/CHANGELOG.md
+++ b/plugins/skill-quality/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to the `skill-quality` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.20.1]
+
+### Changed
+
+- **Instruction-surface de-slop (#2891, skill-quality cluster).** Rewrote this plugin's `README.md` and every
+  `SKILL.md` to drop em dashes under the repo's zero-tolerance house policy, using
+  `/ai-slop:audit fix` semantics: periods or commas, or a restructured sentence, never
+  parentheses, en dashes, or a spaced hyphen as a stand-in. Meaning stays; only the mark
+  and the sentence break change. The generated options block is ignore-fenced because
+  `scripts/sync-plugin-options-docs.py` still emits em dashes from its shared template.
+
 ## [0.20.0]
 
 ### Changed

--- a/plugins/skill-quality/README.md
+++ b/plugins/skill-quality/README.md
@@ -3,7 +3,7 @@
 A Claude Code plugin for **skill-authoring QA**: it runs a static, deterministic contract gate over a
 skill directory, reports the shared listing-budget estimate across a set of skills, and validates a
 skill's `evals.json` against a bundled schema plus a deterministic eval-quality lint. No model
-invocation anywhere — the same checks run identically in a session, a pre-commit hook, or CI.
+invocation anywhere. The same checks run identically in a session, a pre-commit hook, or CI.
 
 The one failure static analysis catches best is a rewrite silently dropping a `description` trigger
 phrase, which quietly degrades a skill's auto-invocation. Check 3 compares the trigger phrases against
@@ -11,20 +11,20 @@ phrase, which quietly degrades a skill's auto-invocation. Check 3 compares the t
 
 | Skill | What it does |
 |---|---|
-| `/skill-quality:check` | Runs the contract gate (`check`), reports the shared listing budget (`listing-budget`), or schema-validates and quality-lints evals (`validate-evals`) — for one skill, a set of roots, or every skill. |
+| `/skill-quality:check` | Runs the contract gate (`check`), reports the shared listing budget (`listing-budget`), or schema-validates and quality-lints evals (`validate-evals`) for one skill, a set of roots, or every skill. |
 | `/skill-quality:setup` | `check` (default) resolves and verifies the skills directory; `apply` routes a non-default `skills_root` change through Claude Code. |
 
 ## Checks
 
-`check` runs `check-skill.sh` — twenty-five checks, reported as `FAIL:` (blocking) or `WARN:` (advisory):
+`check` runs `check-skill.sh`. Twenty-five checks, reported as `FAIL:` (blocking) or `WARN:` (advisory):
 
 - Frontmatter parses; `description` present; a declared `name` is kebab-case and matches the skill
-  directory (in a plugin skill it also WARNs as redundant — the field defaults to the directory).
+  directory (in a plugin skill it also WARNs as redundant, because the field defaults to the directory).
 - `description` + `when_to_use` within the 1536-char **per-skill** listing-entry cap (overflow
-  truncates that entry) — a different, narrower limit from the shared budget below.
+  truncates that entry). A different, narrower limit from the shared budget below.
 - Trigger-keyword preservation vs `HEAD` (skipped for a new, uncommitted skill).
 - `SKILL.md` under 500 lines (hard) / 200 lines (soft, advisory).
-- Backtick- and link-cited skill-internal supporting files resolve — when a path that misses instead
+- Backtick- and link-cited skill-internal supporting files resolve. When a path that misses instead
   resolves under a sibling skill, the finding names that sibling and the
   `${CLAUDE_PLUGIN_ROOT}/skills/<sibling>/...` cross-skill form, while keeping the hand-verify
   caveat (the sibling hit is evidence, not proof: paths can collide).
@@ -34,36 +34,36 @@ phrase, which quietly degrades a skill's auto-invocation. Check 3 compares the t
 - Gotchas surface present; `description` carries `Use when` phrasing; no committed cache artifacts;
   action-router skills without evals WARN (FAIL with `--require-evals` for any shape unless a recorded skip exists in `scripts/evals-warrant-exemptions.txt`); companion spoke
   dirs are referenced.
-- Precompute opportunity (advisory) — a fenced shell block gathers read-only context the skill could
+- Precompute opportunity (advisory). A fenced shell block gathers read-only context the skill could
   inline at load time via [`!` injection](https://code.claude.com/docs/en/skills#inject-dynamic-context)
   instead of a per-invocation tool call.
-- `!`-injection portability — bash-only syntax without a `shell:` declaration fails; portable-looking
+- `!`-injection portability. Bash-only syntax without a `shell:` declaration fails; portable-looking
   but undeclared warns; an injected command with no `|| <fallback>` continuation warns.
-- Fresh-eyes declaration conformance — same-context judgment language (a curated, advisory heuristic)
+- Fresh-eyes declaration conformance. Same-context judgment language (a curated, advisory heuristic)
   expects fresh-context delegation wording or a `fresh-eyes-exempt` directive nearby; malformed or
   reason-less directives fail. Contract: `skills/check/reference/fresh-eyes-declarations.md`.
-- `metadata.summary` within 100 Unicode codepoints — the key is the generated skill cheat
+- `metadata.summary` within 100 Unicode codepoints. The key is the generated skill cheat
   sheet's row source; the cap keeps rows scannable. An absent key is no finding.
-- Completion-criteria signal (advisory) — a numbered procedure of three or more steps with
+- Completion-criteria signal (advisory). A numbered procedure of three or more steps with
   no observable done-condition token.
-- Explicit invocation mode — marketplace plugin skills must state
+- Explicit invocation mode. Marketplace plugin skills must state
   `disable-model-invocation`; elsewhere a missing key warns.
-- Description/verb-contract polarity (advisory) — the description lead contradicts the
+- Description/verb-contract polarity (advisory). The description lead contradicts the
   Naming verb contract or the body (read-only vs mutate). `--fix` in the listing is the
   compliant override shape.
 
-`listing-budget` runs `check-listing-budget.sh` — an always-advisory report on the **shared** budget
+`listing-budget` runs `check-listing-budget.sh`. An always-advisory report on the **shared** budget
 every loaded skill draws from together (`skillListingBudgetFraction`, default 1% of the model's context
 window). This is the aggregate limit `check`'s per-skill cap above does not cover: nothing else in the
 gate checks it, so a marketplace's skill count can silently overflow the live listing with no local
 signal. It never asserts a live value it cannot observe (the model's context window and a consumer's
-settings are both unknowable statically) — it reports against a documented, overridable default and
+settings are both unknowable statically). It reports against a documented, overridable default and
 always exits 0.
 
 Only **listing-eligible** skills are counted: `disable-model-invocation: true` keeps a skill's
 description out of the model-visible listing entirely, so it spends none of the shared budget. A
 consumer's `skillOverrides` can free further descriptions with `"name-only"`, which repository
-content cannot reveal — so the reported figure is an upper bound for anyone who sets it.
+content cannot reveal, so the reported figure is an upper bound for anyone who sets it.
 
 ```shell
 /skill-quality:check my-skill                  # gate one skill
@@ -73,12 +73,12 @@ content cannot reveal — so the reported figure is an upper bound for anyone wh
 /skill-quality:check listing-budget plugins/*/skills  # pool every plugin's root into one aggregate
 ```
 
-## Skills directory — never baked in
+## Skills directory is never baked in
 
 The checker resolves the skills root through the convention-resolution ladder, first hit wins:
 
-1. `${user_config.skills_root}` — set only when your skills live outside `.claude/skills`.
-2. `${CLAUDE_PROJECT_DIR}/.claude/skills` — the conventional default.
+1. `${user_config.skills_root}`. Set only when your skills live outside `.claude/skills`.
+2. `${CLAUDE_PROJECT_DIR}/.claude/skills`. The conventional default.
 
 `CHECK_SKILL_SKILLS_ROOT` is honored as a one-run environment override the checker reads directly;
 the setup skill neither writes nor persists it. When your skills live at the default location, no
@@ -93,13 +93,13 @@ configuration is needed:
 
 `validate-evals` checks a skill's `evals/evals.json` against the bundled
 `reference/evals.schema.json`. Every case requires `id`, `prompt`, and at least one non-empty
-grading criterion — `expected_output`, `expectations`, or `assertions` (a case that cannot be
+grading criterion: `expected_output`, `expectations`, or `assertions` (a case that cannot be
 graded is not an eval); the rich form adds `name` (kebab-case) and `files`.
-Evals are warranted, not mandatory — a skill shipping none is not a failure.
+Evals are warranted, not mandatory. A skill shipping none is not a failure.
 
 After the schema, `check-evals-quality.sh` (bash + jq) lints eval CONTENT deterministically.
-`FAIL:` tier — duplicate case ids/names, empty criterion items, `files` fixture entries that
-resolve to no path under the skill or evals directory. `WARN:` tier (advisory, exit 0) — a case
+`FAIL:` tier: duplicate case ids/names, empty criterion items, `files` fixture entries that
+resolve to no path under the skill or evals directory. `WARN:` tier (advisory, exit 0): a case
 carrying both `expectations` and `assertions`, identical prompt+files pairs, vague whole-item
 phrasing ("the output is good"), a thin sole-criterion `expected_output`, a set with no
 refusal/guardrail or anti-pattern case, and (Q4 prose) an empty `files` list with
@@ -110,13 +110,14 @@ stands alone.
 
 ## Requirements
 
-- A skills root — via `CHECK_SKILL_SKILLS_ROOT`, `CLAUDE_PROJECT_DIR`, or a git repository
+- A skills root via `CHECK_SKILL_SKILLS_ROOT`, `CLAUDE_PROJECT_DIR`, or a git repository
   (last-resort default `.claude/skills`). Git-backed checks (trigger preservation, vendor
   identity, stale metadata, committed artifacts) skip with a note outside a repo so
   marketplace plugin-cache installs (plain trees) still run the rest of the gate.
 - `npx` (Node) is optional; without it the markdownlint check downgrades to a warning and the other
   twenty-four still gate.
 
+<!-- ai-slop-ignore-start: generated options block; source is plugin.json + scripts/sync-plugin-options-docs.py -->
 <!-- BEGIN GENERATED: plugin options — edit plugin.json, then run scripts/sync-plugin-options-docs.py -->
 
 ### Options reference
@@ -189,3 +190,4 @@ hands a configured value to a hook process; the value comes from the routes abov
 - [Manage installed plugins](https://code.claude.com/docs/en/discover-plugins#manage-installed-plugins) — enabling, disabling, `/plugin list`
 
 <!-- END GENERATED: plugin options -->
+<!-- ai-slop-ignore-end -->

--- a/plugins/skill-quality/skills/check/SKILL.md
+++ b/plugins/skill-quality/skills/check/SKILL.md
@@ -1,6 +1,6 @@
 ---
-description: "Skill-authoring QA for Claude Code skills. Use when: 'check this skill', 'skill quality', 'lint my skill', 'is this SKILL.md valid', 'validate skill frontmatter', 'check skill before publishing', 'validate evals.json', 'shared listing budget', 'is the skill listing overflowing', or before shipping a skill or plugin. Actions: `check [<skill-name>]` runs a twenty-five-check static contract gate (frontmatter, explicit invocation mode, description/verb-contract polarity, per-skill listing-entry cap, trigger-keyword preservation vs HEAD, line caps, broken internal refs, markdownlint, gotchas surface, evals presence, precompute opportunity, completion-criteria signal, injection shell-declaration, fresh-eyes declaration conformance) and reports PASS/FAIL with warnings; `validate-evals [<skill-name>]` checks a skill's evals/evals.json against the bundled schema, then runs a deterministic eval-quality lint (duplicate case ids/names, missing fixtures, empty or vague grading criteria, set-coverage warnings); `listing-budget [<root> ...]` reports the SHARED aggregate listing-budget estimate across every listing-eligible skill under the resolved root(s) — advisory only, never blocks. Not for: writing new skills, or running model-graded evals."
-argument-hint: "[check|validate-evals|listing-budget] [<skill-name-or-root> ...] — omit the action for check; omit the name/root to run over every skill under the resolved root"
+description: "Skill-authoring QA for Claude Code skills. Use when: 'check this skill', 'skill quality', 'lint my skill', 'is this SKILL.md valid', 'validate skill frontmatter', 'check skill before publishing', 'validate evals.json', 'shared listing budget', 'is the skill listing overflowing', or before shipping a skill or plugin. Actions: `check [<skill-name>]` runs a twenty-five-check static contract gate (frontmatter, explicit invocation mode, description/verb-contract polarity, per-skill listing-entry cap, trigger-keyword preservation vs HEAD, line caps, broken internal refs, markdownlint, gotchas surface, evals presence, precompute opportunity, completion-criteria signal, injection shell-declaration, fresh-eyes declaration conformance) and reports PASS/FAIL with warnings; `validate-evals [<skill-name>]` checks a skill's evals/evals.json against the bundled schema, then runs a deterministic eval-quality lint (duplicate case ids/names, missing fixtures, empty or vague grading criteria, set-coverage warnings); `listing-budget [<root> ...]` reports the SHARED aggregate listing-budget estimate across every listing-eligible skill under the resolved root(s). Advisory only, never blocks. Not for: writing new skills, or running model-graded evals."
+argument-hint: "[check|validate-evals|listing-budget] [<skill-name-or-root> ...]. Omit the action for check; omit the name/root to run over every skill under the resolved root"
 user-invocable: true
 disable-model-invocation: false
 shell: bash
@@ -12,11 +12,11 @@ metadata:
 ## Purpose
 
 Static, deterministic quality gate for skill authoring. The `check` action runs the bundled
-`check-skill.sh` — twenty-five checks with no model invocation, so results are reproducible in CI or a
+`check-skill.sh`. Twenty-five checks with no model invocation, so results are reproducible in CI or a
 pre-commit hook. The `validate-evals` action checks a skill's `<skill>/evals/evals.json` against the bundled
-JSON schema, then runs the bundled `check-evals-quality.sh` — a deterministic eval-quality lint
+JSON schema, then runs the bundled `check-evals-quality.sh`, a deterministic eval-quality lint
 (duplicate case ids/names, missing fixtures, empty or vague grading criteria, set-coverage
-warnings) that goes beyond structure without ever running a model-graded eval. The `listing-budget` action runs `check-listing-budget.sh` — a separate, always-advisory
+warnings) that goes beyond structure without ever running a model-graded eval. The `listing-budget` action runs `check-listing-budget.sh`, a separate, always-advisory
 report on the SHARED listing budget every loaded skill draws from together (a different, cross-skill
 limit from `check`'s per-skill entry cap). Catches the failure that static analysis catches best: a
 rewrite silently dropping a `description` trigger phrase, which degrades auto-invocation.
@@ -24,11 +24,11 @@ rewrite silently dropping a `description` trigger phrase, which degrades auto-in
 ## Skills-directory resolution
 
 The checker never assumes a repo layout (convention-resolution ladder). It resolves the skills root in
-this order — first hit wins:
+this order. First hit wins:
 
-1. `${user_config.skills_root}` — set it when your skills live outside `.claude/skills` (run
+1. `${user_config.skills_root}`. Set it when your skills live outside `.claude/skills` (run
    `/skill-quality:setup` to configure).
-2. `${CLAUDE_PROJECT_DIR}/.claude/skills` — the conventional default.
+2. `${CLAUDE_PROJECT_DIR}/.claude/skills`. The conventional default.
 
 The skill passes the resolved root to the script via the `CHECK_SKILL_SKILLS_ROOT` environment
 variable. When `skills_root` is configured, export it before invoking the script:
@@ -38,12 +38,12 @@ CHECK_SKILL_SKILLS_ROOT="${user_config.skills_root}" \
   bash "${CLAUDE_PLUGIN_ROOT}/scripts/check-skill.sh" <skill-name>
 ```
 
-When it is unset, invoke the script plain — it falls back to `${CLAUDE_PROJECT_DIR}/.claude/skills`.
+When it is unset, invoke the script plain. It falls back to `${CLAUDE_PROJECT_DIR}/.claude/skills`.
 
 **Gating a marketplace-installed skill.** A `plugin:skill` name (e.g. `source-control:setup`) is
 NOT auto-resolved: the checker resolves a bare skill name under one root and deliberately does not
-reverse-engineer Claude Code's plugin-cache layout to locate an install. That layout is internal —
-only the cache's existence is documented, the `<marketplace>/<plugin>/<version>` nesting is not, and
+reverse-engineer Claude Code's plugin-cache layout to locate an install. That layout is internal.
+Only the cache's existence is documented, the `<marketplace>/<plugin>/<version>` nesting is not, and
 the version dir changes on every update
 ([plugins-reference](https://code.claude.com/docs/en/plugins-reference)). To gate an installed skill,
 point the root at its installed skills dir explicitly:
@@ -54,20 +54,20 @@ CHECK_SKILL_SKILLS_ROOT=~/.claude/plugins/cache/<marketplace>/<plugin>/<version>
 ```
 
 The cache is a **copy, not a git checkout**, so the git-backed checks (3 trigger-preservation, 8
-vendor byte-identity, 9 stale-metadata) no-op against it — a "new skill / skipped" result is
+vendor byte-identity, 9 stale-metadata) no-op against it. A "new skill / skipped" result is
 expected there, not a defect. Passing a `plugin:skill` name unresolved prints this exact guidance.
 
 ## Arguments
 
 Parse `$ARGUMENTS`:
 
-- **`check <skill-name>`** (default action) — run the static contract gate over one skill.
-- **`check`** *(no name)* — run the gate over every skill under the resolved root.
-- **`validate-evals <skill-name>`** — validate one skill's `<skill>/evals/evals.json` against the schema.
-- **`validate-evals`** *(no name)* — validate every skill's `<skill>/evals/evals.json` that exists.
-- **`listing-budget`** *(no root)* — report the shared listing-budget estimate over every
+- **`check <skill-name>`** (default action). Run the static contract gate over one skill.
+- **`check`** *(no name)*. Run the gate over every skill under the resolved root.
+- **`validate-evals <skill-name>`**. Validate one skill's `<skill>/evals/evals.json` against the schema.
+- **`validate-evals`** *(no name)*. Validate every skill's `<skill>/evals/evals.json` that exists.
+- **`listing-budget`** *(no root)*. Report the shared listing-budget estimate over every
   listing-eligible skill under the resolved root.
-- **`listing-budget <root> [<root> ...]`** — pool every listing-eligible skill under each given root
+- **`listing-budget <root> [<root> ...]`**. Pool every listing-eligible skill under each given root
   into ONE shared aggregate (e.g. every plugin's skills dir in a marketplace repo). Every root given
   must exist.
 
@@ -86,7 +86,7 @@ Parse `$ARGUMENTS`:
 3. Report per skill:
    - **PASS / FAIL** from the script's exit code (0 = pass, 1 = one or more `FAIL:` lines).
    - The `FAIL:` lines verbatim (each is an actionable defect).
-   - `WARN:` lines grouped after failures (advisory — soft line target, missing gotchas surface,
+   - `WARN:` lines grouped after failures (advisory: soft line target, missing gotchas surface,
      action-router without evals, orphan spokes, an injection with no `shell:` whose commands
      only *look* portable, an injected command carrying no `|| <fallback>`, same-context
      judgment language with no fresh-eyes declaration or a stale exemption directive, and a
@@ -94,36 +94,36 @@ Parse `$ARGUMENTS`:
 4. For a multi-skill run, end with a one-line rollup: `N passed, M failed`.
 
 The `FAIL:` messages are self-describing. Do not re-derive their meaning; surface them and, when the
-user asks, fix the cited skill. A broken-internal-ref FAIL points at a `SKILL.md:<line>` — hand-verify
+user asks, fix the cited skill. A broken-internal-ref FAIL points at a `SKILL.md:<line>`. Hand-verify
 that line before editing, since it may be an illustrative example path rather than a real broken ref.
 
 ## Action: validate-evals
 
 1. Locate `<skills-root>/<skill-name>/evals/evals.json`. If absent, report that the skill ships no
-   evals (not a failure — evals are warranted, not mandatory).
+   evals (not a failure, because evals are warranted, not mandatory).
 2. Read the bundled schema at
    [`${CLAUDE_PLUGIN_ROOT}/reference/evals.schema.json`](../../reference/evals.schema.json) and the
    skill's `evals.json`.
 3. If a JSON-schema validator is available (`check-jsonschema`, `ajv`, or `python -m jsonschema`),
    run it and report conformance. Otherwise validate structurally against the schema: `skill_name`
    and a non-empty `evals` array are required; each case requires `id`, `prompt`, and at least one
-   non-empty grading criterion — a non-empty `expected_output` string, a non-empty `expectations`
+   non-empty grading criterion: a non-empty `expected_output` string, a non-empty `expectations`
    array, or a non-empty `assertions` array (a case that cannot be graded is not an eval); a
    rich-form case may add `name` (kebab-case) and `files`.
 4. Report each violation with its JSON path, or confirm the file conforms.
-5. Run the deterministic eval-quality lint over every located file (all at once — the script
-   accepts multiple paths):
+5. Run the deterministic eval-quality lint over every located file, all at once. The script
+   accepts multiple paths:
 
    ```shell
    bash "${CLAUDE_PLUGIN_ROOT}/scripts/check-evals-quality.sh" <skills-root>/<skill>/evals/evals.json
    ```
 
-   Report its `FAIL:` lines verbatim (each is an actionable defect — duplicate case ids/names,
+   Report its `FAIL:` lines verbatim (each is an actionable defect: duplicate case ids/names,
    an unresolvable `files` fixture, an empty criterion item), then its `WARN:` lines grouped
-   after (advisory quality heuristics — vague criterion phrasing, thin sole-criterion
+   after (advisory quality heuristics: vague criterion phrasing, thin sole-criterion
    `expected_output`, identical prompt+files pairs, a set with no refusal/anti-pattern case).
    The script exits 0 when only warnings remain; run `--help` for the full Q1-Q9 check list.
-   If `jq` is absent the script exits 2 — report that the quality lint was skipped for that
+   If `jq` is absent the script exits 2. Report that the quality lint was skipped for that
    reason; the schema verdict from steps 3-4 still stands.
 
 ## Action: listing-budget
@@ -137,21 +137,21 @@ that line before editing, since it may be an illustrative example path rather th
    ```
 
 3. Report the printed aggregate, the budget it was compared against (and whether that budget is the
-   documented default, a fixed override, or a reconstructed one — the script labels which), and the
+   documented default, a fixed override, or a reconstructed one, and the script labels which), and the
    biggest contributors when it overflows. The action is complete when the report names all three
    of those elements; the script exiting 0 alone is not the done-condition (it is advisory and
    always exits 0 on a successful run).
 
 This is a **different, cross-skill limit** from `check`'s per-skill entry cap (`description` +
 `when_to_use` <= 1536 chars): the shared budget every loaded skill draws from together
-(`skillListingBudgetFraction`, default 1% of the model's context window). It is always advisory —
-exit 0 regardless of overflow — because the live budget depends on the model's context window and a
+(`skillListingBudgetFraction`, default 1% of the model's context window). It is always advisory.
+The script exits 0 regardless of overflow, because the live budget depends on the model's context window and a
 consumer's own settings, neither of which this static check can observe. Point `/doctor` at the live
 session for the authoritative resolved cost.
 
 **Only listing-eligible skills count.** A skill with `disable-model-invocation: true` has its
 description kept out of the model-visible listing entirely, so it spends none of the shared budget
-and the report skips it — counting those would overstate the aggregate. A consumer's
+and the report skips it. Counting those would overstate the aggregate. A consumer's
 `skillOverrides` can free further descriptions by collapsing entries to `"name-only"`, which
 repository content cannot reveal, so the reported figure is an upper bound for anyone who sets it.
 A missing explicit root and a nonnumeric override are both environment errors (exit 2), never a
@@ -160,7 +160,7 @@ silent skip or a coerced-to-zero budget.
 ## Cross-skill invocation (doctrine)
 
 The Skill tool takes one skill per call; a step needing two skills is two calls. Do not instruct
-Skill-tool invocation of a `disable-model-invocation: true` (user-invoked-only) target — tell the
+Skill-tool invocation of a `disable-model-invocation: true` (user-invoked-only) target. Tell the
 user to run `/plugin:skill` instead. This gate does not automate that reachability check; author
 and review against the invariant.
 
@@ -168,67 +168,67 @@ and review against the invariant.
 
 - A git repository is optional. Git-backed checks (trigger-keyword preservation, vendor
   byte-identity, stale-tracking metadata, committed-artifact scan) skip with a note when cwd
-  is outside a repo — marketplace plugin-cache installs are plain trees. Set
+  is outside a repo. Marketplace plugin-cache installs are plain trees. Set
   `CHECK_SKILL_SKILLS_ROOT` (or `CLAUDE_PROJECT_DIR`) so the non-git checks still resolve a
   skills root; without either and without a git toplevel, the script exits 2 naming the
   missing root.
 - `check-skill.sh` runs `npx markdownlint-cli2` for check 6; when `npx` is absent that check downgrades
   to a WARN rather than failing, so a run on a machine without Node still gates on the other twenty.
-- **Check 6 defers to the repo's markdownlint config — run it from inside that repo.** `markdownlint-cli2`
+- **Check 6 defers to the repo's markdownlint config. Run it from inside that repo.** `markdownlint-cli2`
   discovers the nearest `.markdownlint-cli2.jsonc` from its working directory. Run the checker from
   *outside* the target repo (or against a marketplace-installed skill in the plugin cache, which has no
-  config) and markdownlint applies its DEFAULTS — so rules a repo deliberately disables (commonly
+  config) and markdownlint applies its DEFAULTS, so rules a repo deliberately disables (commonly
   `MD013` line-length for injection blocks and tables, `MD041` first-line-heading for a frontmatter/H2
   start, `MD060` table-pipe style) fire as spurious failures on a skill that passes in-repo. This is the
   usual cause of a "shipped marketplace skill fails the marketplace's own gate" report: it is a
-  wrong-config artifact, not a real regression. **Injection blocks are not special-cased** — a declared
+  wrong-config artifact, not a real regression. **Injection blocks are not special-cased**. A declared
   `shell:` block with long lines is MD013-subject like any other content; whether it fails is entirely the
   consumer's markdownlint config's call (disable `MD013`, or wrap the lines), never something this gate
   overrides. In this marketplace's own CI the division of labor is explicit: the skill-quality gate skips
   markdownlint (`CHECK_SKILL_SKIP_MARKDOWNLINT=1` in the repo's `check-changed-skills.sh` gate) and the
   hygiene lane lints all repo markdown, SKILL.md included, under the repo config.
 - Trigger-keyword preservation compares the working tree against `HEAD` by default, so a brand-new skill
-  (no committed version) skips check 3 — that is expected, not a silent pass. For a post-commit audit
+  (no committed version) skips check 3. That is expected, not a silent pass. For a post-commit audit
   (where `HEAD` == the working tree hides an already-committed change), set `CHECK_SKILL_BASE_REF` to a
   ref before the change (e.g. `HEAD^` or a merge-base) and run on a clean tree; it reroutes checks 3/8/9.
 - Trigger-drop protection tracks single-quoted `'phrase'` triggers. An unquoted `Use when:` list is not
   tracked by check 3; check 12 warns so those phrases get quoted and covered. A dropped phrase found
-  verbatim in a sibling skill's description/when_to_use under the same skills root — where the
-  sibling did NOT already carry it at the base ref — is a trigger MOVE: it WARNs instead of failing,
+  verbatim in a sibling skill's description/when_to_use under the same skills root, where the
+  sibling did NOT already carry it at the base ref, is a trigger MOVE: it WARNs instead of failing,
   because the listing still routes the phrase. Phrases absent everywhere, and phrases the sibling
   carried all along (coincidental overlap, not a move), still fail.
 - Check 19 (injection shell-declaration) FAILs only when a `!` injection carries *detectable*
   bash-only syntax (`/dev/null`, `command -v`, a pipe into a Unix text tool) AND no `shell:` is
   declared; portable-looking commands downgrade to a WARN, since static analysis cannot prove
-  portability. A `shell:` declaration is trusted wholesale — the check does not validate that the
+  portability. A `shell:` declaration is trusted wholesale. The check does not validate that the
   injected commands actually match the declared shell (so `shell: pwsh` with bash-only commands is
-  out of scope). Both checks 19 and 20 scan the injected command text only — a bash-only token in a
+  out of scope). Both checks 19 and 20 scan the injected command text only. A bash-only token in a
   plain `` ```bash `` example or in prose never trips them.
 - Check 21 (fresh-eyes declaration conformance) is WARN-only on its judgment-language heuristic;
   only a malformed or reason-less `fresh-eyes-exempt` directive FAILs. Its proximity window is
-  per-file, so a declaration living in a referenced spoke file cannot satisfy it — the WARN says
+  per-file, so a declaration living in a referenced spoke file cannot satisfy it. The WARN says
   so; hand-verify before editing. Literal directive examples belong inside code fences (both
   detectors are fence- and inline-span-aware); a bare `<class>` placeholder in prose FAILs as an
   unknown class. Spec: `reference/fresh-eyes-declarations.md`.
 - Check 18 (precompute opportunity) is an advisory heuristic, never a FAIL. It cannot tell an
   instruction-to-run shell block from an illustrative example, so a WARN is a candidate to judge, not a
-  defect — like a check-5 ref, hand-verify the block before converting it. It reads only fenced shell
+  defect. Like a check-5 ref, hand-verify the block before converting it. It reads only fenced shell
   blocks (not prose "run `git status` first") and stays silent whenever the skill already uses any `!`
   injection, so it under-reports by design; a clean run is not proof there is no precompute opportunity.
 - Check 23 (completion-criteria signal) is an advisory heuristic, never a FAIL. It fires only when a
-  numbered procedure of three or more steps carries NO completion-signal token at all — it detects
+  numbered procedure of three or more steps carries NO completion-signal token at all. It detects
   the absence of any done-condition, and cannot grade whether a stated criterion is observable or
   good; its broad token set means it under-reports by design. The write-side doctrine whose floor it
   checks is `docs-hygiene:write-for-agents` (steps state observable completion criteria; guard
-  premature completion, post-completion obligations, and legwork) — when authoring new agent docs or
+  premature completion, post-completion obligations, and legwork). When authoring new agent docs or
   fixing a flagged procedure, invoke `/docs-hygiene:write-for-agents` via the Skill tool.
 - Check 24 (explicit invocation mode) FAILs a marketplace plugin skill (`plugins/*/skills/*`) whose
   frontmatter omits `disable-model-invocation`, and only WARNs anywhere else: the absent-key default
   is already `false`, so a consumer's own skill is informed by this fleet's convention rather than
   broken by it. A non-boolean value FAILs everywhere: the check reads the bare scalar, so a quoted
   `"false"` fails as the YAML string it is, while a trailing `# comment` naming the exception class
-  is fine. The rubric that owns the decision — the
-  model-invoked default and the only three exception classes a `true` may claim — is
+  is fine. The rubric that owns the decision, the
+  model-invoked default and the only three exception classes a `true` may claim, is
   [`docs/conventions/invocation-mode/README.md`](https://github.com/melodic-software/claude-code-plugins/blob/main/docs/conventions/invocation-mode/README.md).
   Class attribution is NOT machine-checkable: only a `setup` skill's `true` is deterministic (class
   (ii), the PLUGIN-PHILOSOPHY setup contract), so every other `true` emits a note to hand-verify
@@ -243,21 +243,21 @@ and review against the invariant.
   `audit` skill should gain a `--fix` path, and any rename. A WARN is a candidate to
   hand-verify, not a mandate to rewrite the fleet. Trigger phrases, "read-only by default",
   the noun "remediation", and a negated "or rewrites" list do not advertise mutation.
-- `check-evals-quality.sh` requires `jq` (exit 2 without it — the schema validation of
+- `check-evals-quality.sh` requires `jq` (exit 2 without it, and the schema validation of
   `validate-evals` steps 3-4 is unaffected). Its WARN-tier checks (Q5-Q9) are lexical heuristics:
   Q9 (set-coverage) detects refusal/anti-pattern cases by wording, so a set whose guardrail case
-  phrases the prohibition unusually can WARN despite covering it — read the set before adding a
+  phrases the prohibition unusually can WARN despite covering it. Read the set before adding a
   case. It deliberately does NOT flag low case count: the marketplace's low volume is a recorded
   divergence from the evaluation guidance, revisited when the deferred eval runner lands.
 - `check-evals-quality.sh` resolves each case's `files` entries relative to the skill directory
   first, then the evals directory. An entry that is prose (environment description) rather than a
-  real path FAILs Q4 — describe environment state in the case's `prompt` parenthetical instead,
+  real path FAILs Q4. Describe environment state in the case's `prompt` parenthetical instead,
   or ship a fixture. When `files` is empty/absent, path-shaped tokens in `prompt`/`expected_output`
   that resolve nowhere WARN under the same Q4 roots unless the case sets `narration: true`.
 - `listing-budget` never asserts a resolved live value (context window and `skillListingBudgetFraction`
-  are both consumer settings this static check cannot observe) — it reports against a documented,
+  are both consumer settings this static check cannot observe). It reports against a documented,
   overridable default and always exits 0. A clean report is a signal to investigate against `/doctor`
   in a live session, not a guarantee nothing is dropped there. In this marketplace's own repo, each
   plugin owns its own `plugins/<plugin>/skills/` root, so gating the whole marketplace means pooling
   every plugin's root into one call (`check-listing-budget.sh plugins/*/skills`) rather than running it
-  once per plugin in isolation — the repo's `check-changed-skills.sh` CI gate does this on every run.
+  once per plugin in isolation. The repo's `check-changed-skills.sh` CI gate does this on every run.

--- a/plugins/skill-quality/skills/setup/SKILL.md
+++ b/plugins/skill-quality/skills/setup/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: "Verify where this repository's skills live for skill-quality — the resolved skills_root — and explain how to change the personal skills_root option through Claude Code. Use when: 'set up skill-quality', 'configure skill-quality', or the checker reports a missing skills directory. Actions: check (read-only verification, default) | apply (route a skills_root change once you've chosen a location). Re-runnable and safe."
+description: "Verify where this repository's skills live for skill-quality, the resolved skills_root, and explain how to change the personal skills_root option through Claude Code. Use when: 'set up skill-quality', 'configure skill-quality', or the checker reports a missing skills directory. Actions: check (read-only verification, default) | apply (route a skills_root change once you've chosen a location). Re-runnable and safe."
 argument-hint: "check | apply"
 user-invocable: true
 disable-model-invocation: true
@@ -10,7 +10,7 @@ disable-model-invocation: true
 Thin check-centric setup per the uniform setup contract (`docs/PLUGIN-PHILOSOPHY.md`
 "Setup is explicit and repeatable" in the marketplace repository): `check` resolves and verifies the
 skills root, `apply` resolves what it found. `skills_root` is a personal `userConfig` scalar owned by
-Claude Code's native configuration surface — Claude Code prompts for it when the plugin is enabled,
+Claude Code's native configuration surface. Claude Code prompts for it when the plugin is enabled,
 stores non-sensitive options in user settings, and ignores project/local `pluginConfigs` entries on
 current releases (≥ 2.1.207). This skill never writes it; `apply` verifies and routes.
 
@@ -18,11 +18,11 @@ Official contract (verified 2026-07-18):
 <https://code.claude.com/docs/en/plugins-reference#user-configuration>.
 
 Action routing: no argument or `check` runs the check; `apply` runs the check first, then the
-reconfiguration guidance. Both are non-interactive — never prompt when the action is given.
+reconfiguration guidance. Both are non-interactive. Never prompt when the action is given.
 
 ## `check` (read-only)
 
-Read the rendered `${user_config.skills_root}` value — never inspect or edit settings files or
+Read the rendered `${user_config.skills_root}` value. Never inspect or edit settings files or
 `pluginConfigs` directly. Resolve the candidate root, verify it, and report PASS/FAIL/INFO with one
 remediation per FAIL. Do not modify anything.
 
@@ -31,18 +31,18 @@ remediation per FAIL. Do not modify anything.
    the zero-config default `.claude/skills` applies).
 2. **Verify** the resolved root exists and enumerates skills (child `SKILL.md` files). PASS with the
    directory and skill count; FAIL when it is absent or empty, with the resolution result in the
-   remediation line — never claim success for a missing directory.
+   remediation line. Never claim success for a missing directory.
 
 ## `apply` (idempotent)
 
-Run `check`, then resolve what it found. This skill has no legitimate write of its own — `skills_root`
-lives in Claude Code's native config surface, which setup must not hand-edit — so `apply` is
+Run `check`, then resolve what it found. This skill has no legitimate write of its own. `skills_root`
+lives in Claude Code's native config surface, which setup must not hand-edit, so `apply` is
 verify-and-route:
 
 - **Skills not found / wrong root (FAIL):** if the skills live somewhere other than the resolved root,
   the personal `skills_root` should point there. Reconfigure through the path below, then rerun `check`.
 - **Reconfiguring the personal option:** `/plugin configure skill-quality@<marketplace>` (interactive, any time).
-  Headless: rerun the install with the new value —
+  Headless: rerun the install with the new value.
   `claude plugin install skill-quality@<marketplace> -s <scope> --config skills_root=<dir>`. Against
   an already-installed plugin it prints `already installed` and still writes the value, verified on
   Claude Code 2.1.240 for a non-sensitive option at `user` scope; a `sensitive` option, and
@@ -57,7 +57,7 @@ verify-and-route:
   behalf.
 
 After any reconfiguration, rerun `check` **in a fresh session** and verify by invoking
-`/skill-quality:check` via the Skill tool — without turning setup into the full quality audit. The
+`/skill-quality:check` via the Skill tool, without turning setup into the full quality audit. The
 fresh session is not optional: the rendered `${user_config.skills_root}` is injected when this skill
 loads, so a same-session rerun still resolves the OLD root and would report a correct write as a
 failure. Re-running `apply` when the root resolves and enumerates changes nothing and reports


### PR DESCRIPTION
No linked issue

## Summary

#2891 instruction-surface de-slop cluster: purge em dashes from the `skill-quality` plugin README and every SKILL.md. This shard only.

## Fix

Rewrote `plugins/skill-quality/README.md` and every `plugins/skill-quality/**/SKILL.md` under `/ai-slop:audit fix` semantics (periods, commas, or a restructured sentence; never parentheses, en dashes, or a spaced hyphen as a stand-in). A self-audit repaired wrap leftovers and split asides the mechanical pass left as fragments. The generated options block is ignore-fenced because the shared generator still emits em dashes. `skill-quality` 0.20.1.

## Verification

- Detector: 0 `rule-em-dash` findings outside ignore-fenced generated-options spans
- `CHECK_SKILL_SKIP_MARKDOWNLINT=1 bash scripts/check-changed-skills.sh origin/main`: 0 failed; quoted trigger phrases vs origin/main preserved
- `python3 scripts/sync-plugin-options-docs.py --check` up to date
- `scripts/check-changelog-parity.sh --check-bump origin/main` passes
- `node scripts/generate-cheatsheet.mjs --check` in sync

## Related

Refs #2891

#2891 stays open.