### PR TITLE
docs(instruction-placement): de-slop instruction surfaces (0.11.5)

### DIFF
--- a/plugins/instruction-placement/.claude-plugin/plugin.json
+++ b/plugins/instruction-placement/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "instruction-placement",
-  "version": "0.11.4",
+  "version": "0.11.5",
   "description": "Routes agent-instruction content to the surface that loads it at the right moment. The audit skill sweeps a repository's instruction layer and its ordinary markdown for content whose scope is narrower than the surface carrying it — conventions keyed to one file type or one subtree sitting in an always-loaded CLAUDE.md or AGENTS.md — and for normative conventions stranded in documentation Claude never loads at all, then classifies each against a routing rubric and proposes a destination whose `paths:` glob is machine-validated before it is ever offered. Safety-class content (irreversible actions, secrets, data integrity, external publication, compliance, agent authority) is hard-denied from demotion and reported as held back rather than proposed, because demotion trades guaranteed presence for conditional presence and deferred surfaces are invisible inside subagents and absent after compaction until re-triggered. Every accepted move regenerates an always-loaded index of deferred surfaces, which is what keeps a demoted rule reachable from a subagent that never receives its injection. The audit is read-only and emits a diffable findings artifact; realignment is a separate skill gated per item with no blanket-approve path; a deterministic check skill gates that every rule glob still resolves and the index is current; and a setup skill verifies the one thing no other gate can see — that the index target is a file Claude Code will actually read, since it reads CLAUDE.md and not AGENTS.md.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/instruction-placement/CHANGELOG.md
+++ b/plugins/instruction-placement/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to the `instruction-placement` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.11.5]
+
+### Changed
+
+- **Instruction-surface de-slop (#2891, instruction-placement cluster).** Rewrote this plugin's `README.md` and every
+  `SKILL.md` to drop em dashes under the repo's zero-tolerance house policy, using
+  `/ai-slop:audit fix` semantics: periods or commas, or a restructured sentence, never
+  parentheses, en dashes, or a spaced hyphen as a stand-in. Meaning stays; only the mark
+  and the sentence break change. The generated options block is ignore-fenced because
+  `scripts/sync-plugin-options-docs.py` still emits em dashes from its shared template.
+
 ## [0.11.4]
 
 ### Fixed

--- a/plugins/instruction-placement/README.md
+++ b/plugins/instruction-placement/README.md
@@ -3,8 +3,8 @@
 Routes agent-instruction content to the surface that loads it at the right moment.
 
 A convention that only matters when someone edits a `.cs` file should not be paid for in every
-session. Claude Code already provides the machinery to fix that — path-scoped rules, nested
-instruction files — but using it correctly is harder than it looks, and every way of getting it
+session. Claude Code already provides the machinery to fix that: path-scoped rules and nested
+instruction files. Using it correctly is harder than it looks, and every way of getting it
 wrong fails silently. This plugin finds the content worth moving, validates the move mechanically
 before proposing it, and executes it behind a human gate.
 
@@ -18,7 +18,7 @@ before proposing it, and executes it behind a human gate.
 | `/instruction-placement:setup` | Verify prerequisites, report config | Confirms the index target is one Claude Code will actually read, and resolves every setting with its source |
 | `/instruction-placement:delta` | Read-only movement report | Re-runs the audit and reports only what changed since last time, above a noise budget |
 
-Run `setup` first on a new repository — it catches the one failure the other gates cannot see, an
+Run `setup` first on a new repository. It catches the one failure the other gates cannot see, an
 index Claude Code never loads. Then `audit`. Nothing changes until you accept a specific finding in
 `realign`. Use `delta` for repeat runs, so a re-audit costs attention proportional to what actually
 moved. Wire `check`
@@ -38,7 +38,7 @@ bookkeeping, not a saving. The glob is the product.
 dispatched *after* its parent had loaded a nested `CLAUDE.md`, a nested `AGENTS.md`, and a
 path-scoped rule saw none of them. In a repository where the file editing is delegated, a naive
 demotion puts the C# conventions out of reach of the agent editing C#. This is why every accepted
-move regenerates an **always-loaded index** of deferred surfaces — the one thing that does reach a
+move regenerates an **always-loaded index** of deferred surfaces, the one thing that does reach a
 subagent, and that turns an invisible rule into one an ordinary `Read` can fetch.
 
 **Path scoping triggers on read, not write.** Creating a new file is not a read, so a rule governing
@@ -51,13 +51,13 @@ the path-scoped destination structurally, not by judgment.
 
 ## What this plugin does NOT buy you
 
-An earlier version of this README claimed that path-scoping improves *adherence* — that a convention
+An earlier version of this README claimed that path-scoping improves *adherence*, that a convention
 arriving when a matching file is read is followed more reliably than the same text buried in a large
 always-loaded file. **That claim was measured and not supported**, so it has been removed rather than
 softened.
 
-Across 32 trials at two bloat levels — a realistic 251-line always-loaded file and an extreme
-1,927-line one, nearly ten times the official 200-line guidance — a clear convention was followed
+Across 32 trials at two bloat levels, using a realistic 251-line always-loaded file and an extreme
+1,927-line one nearly ten times the official 200-line guidance, a clear convention was followed
 **100% of the time in both arms**. Full method, caveats, and the ceiling effect the run hit:
 [`evals/adherence-results.md`](evals/adherence-results.md).
 
@@ -72,8 +72,8 @@ on the agent's own authority.
 
 The reasoning is asymmetric consequence. Demotion trades guaranteed presence for conditional
 presence. When a style convention goes missing the cost is a nit in review; when a safety rail goes
-missing the cost is unbounded. The index mitigates absence but cannot guarantee attention —
-injection is automatic, a pointer is discretionary — so safety rails stay where injection reaches
+missing the cost is unbounded. The index mitigates absence but cannot guarantee attention.
+Injection is automatic, a pointer is discretionary, so safety rails stay where injection reaches
 them.
 
 `audit` reports what it held back and why, so the exclusion is visible. `realign` has no code path
@@ -90,7 +90,7 @@ nearest-wins, while Claude concatenates the whole ancestor chain. Subtree conten
 written as additive and self-contained, and a candidate that only makes sense as an override is
 reported rather than moved.
 
-## Scope boundary — what this plugin does not own
+## Scope boundary: what this plugin does not own
 
 Placement is one question about an instruction, and it is not the only one. Where a sibling plugin
 owns a neighbouring question, route to it rather than bending this rubric. Each is optional: when it
@@ -99,19 +99,19 @@ is not installed, keep the observation in the report rather than judging it here
 | Question | Owner |
 |---|---|
 | Is this instruction still needed by the current model? | `claude-config`'s instruction audit |
-| Is the memory layer healthy — size, index integrity, conflicts? | `claude-memory`'s audit |
+| Is the memory layer healthy: size, index integrity, conflicts? | `claude-memory`'s audit |
 | Does this whole document earn its existence? | `docs-hygiene`'s derivability audit |
 | Is this file structured well for progressive disclosure generally? | `docs-hygiene`'s progressive-disclosure audit |
 | Is the same content repeated across several files? | `docs-hygiene`'s single-source-of-truth extraction |
 | Is the prose too long or too noisy? | `docs-hygiene`'s compression and noise audits |
 
 The dividing line: those audits ask whether a piece of content is *good*, *needed*, or *duplicated*.
-This plugin asks only where it should **live**, and owns the one capability none of them has — the
+This plugin asks only where it should **live**, and owns the one capability none of them has, the
 validated move, including glob derivation and the index that keeps the result reachable.
 
 These routes are **operative, not decorative**. When a candidate raises one of these questions, the
 audit invokes the named skill via the Skill tool if its plugin is installed, and otherwise keeps the
-observation in the report as an unjudged note. A routed candidate is reported as routed — never
+observation in the report as an unjudged note. A routed candidate is reported as routed, never
 silently dropped, and never re-classified as a placement finding just because the sibling was
 missing. A section can be both misplaced and duplicated; routing one question does not cancel the
 other finding.
@@ -133,6 +133,7 @@ Conditions that should change this plugin, recorded so they are acted on rather 
 | A second consumer needs the findings artifact | Promote its contract to a documented cross-plugin seam **before** that consumer ships, per the convention registry. The contract's stability guarantees and the three promotion prerequisites are already written down in [`context/findings-artifact.md`](context/findings-artifact.md); the owner doc is deliberately not written yet, because an interface with one implementation is a guess |
 | The glob engine needs semantics bash cannot express cleanly | Reconsider the hand-rolled expander; it exists to avoid `eval` on repository content |
 
+<!-- ai-slop-ignore-start: generated options block; source is plugin.json + scripts/sync-plugin-options-docs.py -->
 <!-- BEGIN GENERATED: plugin options — edit plugin.json, then run scripts/sync-plugin-options-docs.py -->
 
 ### Options reference
@@ -207,3 +208,4 @@ hands a configured value to a hook process; the value comes from the routes abov
 - [Manage installed plugins](https://code.claude.com/docs/en/discover-plugins#manage-installed-plugins) — enabling, disabling, `/plugin list`
 
 <!-- END GENERATED: plugin options -->
+<!-- ai-slop-ignore-end -->

--- a/plugins/instruction-placement/skills/audit/SKILL.md
+++ b/plugins/instruction-placement/skills/audit/SKILL.md
@@ -1,6 +1,6 @@
 ---
-description: "Read-only sweep for instruction content on the wrong surface — conventions in an always-loaded CLAUDE.md/AGENTS.md really scoped to one file type or subtree (demote), and normative conventions stranded in ordinary docs Claude never loads (promote). Proposes a destination per candidate: a path-scoped `.claude/rules/` file whose `paths:` glob is machine-checked first, a nested AGENTS.md plus its CLAUDE.md shim, a skill, a linter, or deletion. Safety rails — irreversible actions, secrets, data, publication, compliance, agent authority — are hard-denied from demotion and held back. Every proposal is priced: deferred content is invisible to subagents and absent after compaction until re-triggered. Use when: 'my CLAUDE.md is too long', 'convert this to rules', 'what should be a path-scoped rule', 'move conventions to .claude/rules', 'find conventions in our docs', 'nested CLAUDE.md candidates', 'audit instruction placement'. Emits a findings artifact; the sibling realign skill applies what you accept."
-argument-hint: "[core|expanded] [path ...] — default: core+expanded over the whole repository"
+description: "Read-only sweep for instruction content on the wrong surface. Conventions in an always-loaded CLAUDE.md/AGENTS.md really scoped to one file type or subtree (demote), and normative conventions stranded in ordinary docs Claude never loads (promote). Proposes a destination per candidate: a path-scoped `.claude/rules/` file whose `paths:` glob is machine-checked first, a nested AGENTS.md plus its CLAUDE.md shim, a skill, a linter, or deletion. Safety rails covering irreversible actions, secrets, data, publication, compliance, and agent authority are hard-denied from demotion and held back. Every proposal is priced: deferred content is invisible to subagents and absent after compaction until re-triggered. Use when: 'my CLAUDE.md is too long', 'convert this to rules', 'what should be a path-scoped rule', 'move conventions to .claude/rules', 'find conventions in our docs', 'nested CLAUDE.md candidates', 'audit instruction placement'. Emits a findings artifact; the sibling realign skill applies what you accept."
+argument-hint: "[core|expanded] [path ...]. Default: core+expanded over the whole repository"
 user-invocable: true
 disable-model-invocation: false
 allowed-tools:
@@ -37,7 +37,7 @@ cause Claude to ignore the instructions inside them, but this plugin measured th
 and did not reproduce it: 32 trials at two bloat levels, up to 1,927 lines, found 100% compliance
 whether the convention was always-loaded or path-scoped
 ([`../../evals/adherence-results.md`](../../evals/adherence-results.md)). So propose moves on
-context cost and on reaching content Claude never loads — never by promising the operator their
+context cost and on reaching content Claude never loads, never by promising the operator their
 instructions will be followed better afterwards.
 
 This skill finds content whose scope is narrower than the surface carrying it, and content whose
@@ -62,11 +62,11 @@ what it cost before.
 
 ## The two lanes
 
-**Demote** — content already in the instruction layer, sitting higher than its scope warrants. The
+**Demote**. Content already in the instruction layer, sitting higher than its scope warrants. The
 saving is real but so is the trade: what defers is invisible to subagents and absent after
 compaction until re-triggered. Price it, every time.
 
-**Promote** — normative content in ordinary documentation that Claude loads *never*. There is no
+**Promote**. Normative content in ordinary documentation that Claude loads *never*. There is no
 presence to lose, so the gaps do not apply and any working destination is a strict improvement. The
 live risk here is duplication, not context: resolve single-source-of-truth per candidate using the
 rubric's table rather than reflexively copying.
@@ -96,7 +96,7 @@ correspond to a `SECTION` record, say so rather than inventing a boundary.
 
 **A `HINT` is raw material, not a decision.** The detector reports what the text literally says; it
 does not know whether `.ts` is the candidate's real scope. Derive the glob from the hints, then
-validate it — an unvalidated hint is not a proposal.
+validate it. An unvalidated hint is not a proposal.
 
 ## Workflow
 
@@ -116,9 +116,9 @@ validate it — an unvalidated hint is not a proposal.
 
    A glob that comes back `zero-match`, `bad-bracket`, or `over-budget` **must not be proposed**.
    Re-derive, or drop the candidate to the subtree destination, or leave it where it is. Record the
-   validation facts — match count and breadth — in the finding, because that is the evidence the
+   validation facts, match count and breadth, in the finding, because that is the evidence the
    operator gates on. An `over-broad` result is proposable but must be surfaced as such.
-6. **Price each proposal** — what leaves the always-loaded budget, subagent invisibility, and
+6. **Price each proposal**. What leaves the always-loaded budget, subagent invisibility, and
    post-compaction behavior for that specific destination.
 7. **Rank**, highest value first: always-loaded lines released × confidence, with promote-lane
    findings ranked on value alone since they carry no downside.
@@ -127,7 +127,7 @@ validate it — an unvalidated hint is not a proposal.
 
 ## Where the artifact goes
 
-Resolve the project key and write under it — `findings-artifact.md` owns the full path shape:
+Resolve the project key and write under it. `findings-artifact.md` owns the full path shape:
 
 ```bash
 "${CLAUDE_PLUGIN_ROOT}/lib/state-key.sh"
@@ -136,11 +136,11 @@ Resolve the project key and write under it — `findings-artifact.md` owns the f
 The plugin data directory is keyed to the plugin identifier and nothing else, so an unkeyed filename
 is one file per **machine**: a later run in a different repository would read this one's findings as
 its own. Never skip the key. If a prior artifact exists for this key, merge per the contract's
-re-run semantics rather than overwriting — an operator's `declined` decision must survive a re-audit.
+re-run semantics rather than overwriting. An operator's `declined` decision must survive a re-audit.
 
 ## Routing out
 
-A candidate can raise a question placement does not answer — whether the model still needs the
+A candidate can raise a question placement does not answer: whether the model still needs the
 instruction, whether it is duplicated, whether the whole file should exist. Those belong to sibling
 plugins, and each route is presence-gated with a documented fallback.
 
@@ -149,7 +149,7 @@ table and the two rules that keep routing from becoming silent dropping.
 
 ## Reporting honestly
 
-- **Say what was not swept.** The detector's `SKIP` records and `SUMMARY` are the source — report
+- **Say what was not swept.** The detector's `SKIP` records and `SUMMARY` are the source. Report
   them rather than recounting by hand. A run that covered 200 of 2,000 files while reading like a
   full audit is the failure this rule exists to prevent.
 - **Show the held-back list.** An operator who cannot see what the hard-deny gate excluded cannot
@@ -161,7 +161,7 @@ table and the two rules that keep routing from becoming silent dropping.
 ## Hard rules
 
 - **Read-only.** The only file this skill writes is its own findings artifact, outside the
-  repository. No edit to any instruction file, ever — not even an obviously correct one.
+  repository. No edit to any instruction file, ever, not even an obviously correct one.
 - **Never propose a glob that failed validation.** The check is mechanical and cheap; a guessed glob
   produces a rule that silently never fires, which is strictly worse than leaving the content alone.
 - **Never propose demoting a hard-deny candidate**, under any argument, including an operator

--- a/plugins/instruction-placement/skills/audit/SKILL.md
+++ b/plugins/instruction-placement/skills/audit/SKILL.md
@@ -118,7 +118,7 @@ validate it. An unvalidated hint is not a proposal.
    Re-derive, or drop the candidate to the subtree destination, or leave it where it is. Record the
    validation facts, match count and breadth, in the finding, because that is the evidence the
    operator gates on. An `over-broad` result is proposable but must be surfaced as such.
-6. **Price each proposal**. What leaves the always-loaded budget, subagent invisibility, and
+6. **Price each proposal**: what leaves the always-loaded budget, subagent invisibility, and
    post-compaction behavior for that specific destination.
 7. **Rank**, highest value first: always-loaded lines released × confidence, with promote-lane
    findings ranked on value alone since they carry no downside.

--- a/plugins/instruction-placement/skills/check/SKILL.md
+++ b/plugins/instruction-placement/skills/check/SKILL.md
@@ -123,8 +123,8 @@ do about it**. The three failure statuses have different fixes and saying "inval
 - **Read-only.** No `Edit`, no `Write`, no mutating `Bash`. Fixing a broken glob is the sibling
   `realign` skill's job, or the operator's.
 - **Never fabricate a verdict.** If a script cannot run, because this is not a git repository or
-  tooling is missing, report that plainly and exit non-zero. A gate that passes because it could not measure is worse
-  than no gate.
+  tooling is missing, report that plainly and exit non-zero. A gate that passes because it could
+  not measure is worse than no gate.
 - **Never consult the findings artifact.** This skill verifies the repository's actual state. An
   audit artifact is a snapshot of a past run, and a gate that trusted one could report health for a
   repository that has since broken.

--- a/plugins/instruction-placement/skills/check/SKILL.md
+++ b/plugins/instruction-placement/skills/check/SKILL.md
@@ -1,6 +1,6 @@
 ---
-description: "Deterministic pass/fail gate over a repository's path-scoped instruction surfaces — verifies every `.claude/rules/` glob actually resolves (matches at least one tracked file, valid bracket expressions, inside the documented 1,000-pattern / 4 MiB brace-expansion budget) and that the always-loaded rules index is in sync with the rules on disk. Every one of these failures is SILENT in Claude Code: a zero-match glob is a rule that never fires, an unbalanced `[` matches nothing, and an over-budget pattern is used unexpanded so its braces match no file. Use when: 'check my rules', 'are my path-scoped rules actually firing', 'is the rules index stale', 'validate paths frontmatter', 'why is my rule not loading', 'CI gate for .claude/rules', or after any change to a rule's `paths:` or to the rules tree. Read-only — reports and exits non-zero, never edits; the sibling realign skill applies fixes."
-argument-hint: "[--file <index-path>] [--breadth-max <pct>] — default: gate the whole repository"
+description: "Deterministic pass/fail gate over a repository's path-scoped instruction surfaces. Verifies every `.claude/rules/` glob actually resolves (matches at least one tracked file, valid bracket expressions, inside the documented 1,000-pattern / 4 MiB brace-expansion budget) and that the always-loaded rules index is in sync with the rules on disk. Every one of these failures is SILENT in Claude Code: a zero-match glob is a rule that never fires, an unbalanced `[` matches nothing, and an over-budget pattern is used unexpanded so its braces match no file. Use when: 'check my rules', 'are my path-scoped rules actually firing', 'is the rules index stale', 'validate paths frontmatter', 'why is my rule not loading', 'CI gate for .claude/rules', or after any change to a rule's `paths:` or to the rules tree. Read-only. Reports and exits non-zero, never edits; the sibling realign skill applies fixes."
+argument-hint: "[--file <index-path>] [--breadth-max <pct>]. Default: gate the whole repository"
 user-invocable: true
 disable-model-invocation: false
 allowed-tools:
@@ -43,13 +43,13 @@ Wire it into CI beside the linters. It is fast, deterministic, and has no judgme
 | Glob resolves | `glob-tools.sh rules` | The rule never fires for any file in the repository |
 | Bracket expressions valid | same | The pattern silently matches nothing |
 | Brace budget respected | same | The pattern is used unexpanded; its braces match nothing |
-| Glob not over-broad | same | Advisory — the rule loads so often it saves nothing |
+| Glob not over-broad | same | Advisory. The rule loads so often it saves nothing |
 | Index in sync | `render-index.sh check` | Deferred surfaces are unreachable from subagents |
 | Index target loaded at all | `render-index.sh reachable` | The index exists and Claude Code never reads it |
 
 The last one is the newest and the least obvious. Claude Code reads `CLAUDE.md`, not `AGENTS.md`. A
 repository carrying both with no import between them gets a perfectly-generated, perfectly-in-sync
-index that never enters context — the entire subagent-gap mitigation doing nothing while every other
+index that never enters context, the entire subagent-gap mitigation doing nothing while every other
 check reports green. Sync and reachability are independent questions; ask both.
 
 Over-broad is the one **warning** rather than a failure: breadth is a judgment about whether a
@@ -63,26 +63,26 @@ demotion was worth making, not a statement that the rule is broken. Everything e
 "${CLAUDE_PLUGIN_ROOT}/scripts/render-index.sh" reachable --file <index-file>
 ```
 
-`<index-file>` is a precedence order, not a procedure — take the first that exists:
+`<index-file>` is a precedence order, not a procedure. Take the first that exists:
 
 | Precedence | Target | Why |
 |---|---|---|
 | 1 | An explicit `--file` argument | The operator's own choice wins |
-| 2 | Root `AGENTS.md` | The portable home — other agents read it too |
+| 2 | Root `AGENTS.md` | The portable home. Other agents read it too |
 | 3 | Root `CLAUDE.md` | The Claude-only fallback |
 
 Name the winner in the report; the run is not complete until the output states which file was
-checked. If none exists, say so and skip the index check rather than inventing a target — the glob
+checked. If none exists, say so and skip the index check rather than inventing a target. The glob
 checks still decide the verdict.
 
 **A repository with no index block yet is not a failure.** `render-index.sh check` exits 3 for that
-case, and 3 means "nothing to compare", not "broken". Report it as a recommendation — the index is
-what makes deferred rules reachable from subagents — and leave the gate's verdict to the glob
+case, and 3 means "nothing to compare", not "broken". Report it as a recommendation. The index is
+what makes deferred rules reachable from subagents. Leave the gate's verdict to the glob
 checks. Only a repository that *has* an index and has let it drift fails on that check.
 
 ### Escalating to empirical verification
 
-Every check above is static — it reads files and reasons about what Claude Code *would* do. When the
+Every check above is static. It reads files and reasons about what Claude Code *would* do. When the
 operator asks why a rule is not firing despite a green gate, or wants proof rather than inference,
 escalate:
 
@@ -92,7 +92,7 @@ escalate:
 
 That drives the real CLI with an `InstructionsLoaded` hook and reports what actually loaded, with
 the reason for each load. It costs a model call, so it is an escalation rather than part of the
-default gate. `VERDICT UNKNOWN` means the probe could not run — report it as unmeasured, never as a
+default gate. `VERDICT UNKNOWN` means the probe could not run. Report it as unmeasured, never as a
 pass.
 
 Pass `--breadth-max` through when the operator supplies it. The default of 75% is a starting point,
@@ -109,7 +109,7 @@ SUMMARY <tab> tracked <tab> patterns <tab> invalid <tab> overbroad <tab> verdict
 ```
 
 Report per failing pattern: the rule file, the pattern, the status, and **what the operator should
-do about it** — the three failure statuses have different fixes and saying "invalid" helps nobody.
+do about it**. The three failure statuses have different fixes and saying "invalid" helps nobody.
 
 | Status | What actually happened | Fix |
 |---|---|---|
@@ -122,8 +122,8 @@ do about it** — the three failure statuses have different fixes and saying "in
 
 - **Read-only.** No `Edit`, no `Write`, no mutating `Bash`. Fixing a broken glob is the sibling
   `realign` skill's job, or the operator's.
-- **Never fabricate a verdict.** If a script cannot run — not a git repository, missing tooling —
-  report that plainly and exit non-zero. A gate that passes because it could not measure is worse
+- **Never fabricate a verdict.** If a script cannot run, because this is not a git repository or
+  tooling is missing, report that plainly and exit non-zero. A gate that passes because it could not measure is worse
   than no gate.
 - **Never consult the findings artifact.** This skill verifies the repository's actual state. An
   audit artifact is a snapshot of a past run, and a gate that trusted one could report health for a
@@ -142,7 +142,7 @@ do about it** — the three failure statuses have different fixes and saying "in
   failures and is the one that does not fail the gate. Reporting it as a failure trains operators
   to ignore the gate.
 - **A zero-match glob usually means stale content, not a typo.** The reflex is to fix the pattern.
-  Check whether the code it described still exists first — a rule for a deleted subsystem should be
+  Check whether the code it described still exists first. A rule for a deleted subsystem should be
   retired, not re-globbed.
 - **Passing because nothing could be measured is the worst outcome.** Outside a git repository, or
   with tooling missing, the scripts cannot answer. Exit non-zero and say why; a green gate that
@@ -151,7 +151,7 @@ do about it** — the three failure statuses have different fixes and saying "in
   repository can pass the first while failing the second. Reporting "index in sync" without the
   reachability verdict is the exact false assurance the previous point warns about.
 - **Rules discovery follows symlinks and does not require git.** A symlinked rule points outside the
-  repository by design — that is the documented way to share one rule set across projects — so it is
+  repository by design. That is the documented way to share one rule set across projects, so it is
   never tracked. Nested instruction files are the opposite: tracked-only, because an untracked or
   vendored `AGENTS.md` must never reach the consuming repository's always-loaded surface. If a rule
   seems missing from a report, check which of the two rules applies before assuming a bug.

--- a/plugins/instruction-placement/skills/delta/SKILL.md
+++ b/plugins/instruction-placement/skills/delta/SKILL.md
@@ -1,6 +1,6 @@
 ---
-description: "Re-run the placement audit and report only what MOVED since the last run — new candidates, findings whose source content changed, rules whose globs stopped resolving, and index drift — above a configurable noise budget, so a repeat run costs attention proportional to what actually changed rather than re-presenting a finding set the operator already decided on. Declined findings stay declined and are never resurrected by a re-run. Use when: 'what changed since the last placement audit', 'placement delta', 're-run the instruction-placement audit', 'anything new to move', 'did any rule glob break', 'weekly instruction-placement check', or from a scheduled lane. Read-only — reports movement and writes nothing but the refreshed findings artifact; realign still owns every change."
-argument-hint: "[--since <ISO date>] [--noise-budget <n>] — default: since the artifact's last run"
+description: "Re-run the placement audit and report only what MOVED since the last run: new candidates, findings whose source content changed, rules whose globs stopped resolving, and index drift, above a configurable noise budget, so a repeat run costs attention proportional to what actually changed rather than re-presenting a finding set the operator already decided on. Declined findings stay declined and are never resurrected by a re-run. Use when: 'what changed since the last placement audit', 'placement delta', 're-run the instruction-placement audit', 'anything new to move', 'did any rule glob break', 'weekly instruction-placement check', or from a scheduled lane. Read-only. Reports movement and writes nothing but the refreshed findings artifact; realign still owns every change."
+argument-hint: "[--since <ISO date>] [--noise-budget <n>]. Default: since the artifact's last run"
 user-invocable: true
 disable-model-invocation: false
 allowed-tools:
@@ -42,7 +42,7 @@ cadence.
 | [`../../context/findings-artifact.md`](../../context/findings-artifact.md) | Status vocabulary, re-run merge semantics, where the artifact lives |
 | [`../../context/routing-rubric.md`](../../context/routing-rubric.md) | Only when a genuinely new candidate needs classifying |
 
-This skill does **not** restate the merge semantics — the artifact contract owns them, and a second
+This skill does **not** restate the merge semantics. The artifact contract owns them, and a second
 statement is a second thing to drift.
 
 ## What counts as movement
@@ -58,7 +58,7 @@ Five shapes, in report order. Everything else is suppressed.
 | `stale` | A finding whose source no longer exists | The content was moved or deleted outside this plugin |
 
 `broken-glob` is the shape that most justifies running this on a cadence. A glob breaks when the
-code it described gets renamed or moved — an ordinary refactor, nowhere near the rules tree, with no
+code it described gets renamed or moved, an ordinary refactor, nowhere near the rules tree, with no
 signal at the time. Nothing else in the plugin notices between `check` runs.
 
 ## What is deliberately NOT movement
@@ -70,20 +70,20 @@ signal at the time. Nothing else in the plugin notices between `check` runs.
   section whose scope and class are unchanged is not movement. Compare what the classification
   depends on, not the bytes.
 - **Findings below the noise budget.** Default: suppress `new` findings whose confidence is low
-  *and* whose released line count is trivial. Report the count of what was suppressed — a delta that
+  *and* whose released line count is trivial. Report the count of what was suppressed. A delta that
   hides its own filtering is the thing it was built to avoid.
 
 ## Workflow
 
 Each step names what "done" looks like, so a partial run is visible rather than assumed complete.
 
-1. Resolve the state key and read the prior artifact. **No prior artifact is not an error** — say so
+1. Resolve the state key and read the prior artifact. **No prior artifact is not an error**. Say so
    and route to the full audit rather than silently running one.
    *Done when:* a prior artifact is in hand, or the run has stopped with the route stated.
 2. Run the detector and diff its `SECTION` and `RULE` records against the artifact's record of the
    last run. *Done when:* every current record is matched to a prior record or marked unmatched.
 3. Classify each difference into one of the five shapes. Only a `new` shape needs the rubric.
-   *Done when:* no difference is left unclassified — an unclassified difference is a reporting gap.
+   *Done when:* no difference is left unclassified. An unclassified difference is a reporting gap.
 4. Re-validate every previously-valid glob; a transition to invalid is `broken-glob`.
    *Done when:* the validator has run over every `RULE` record, not only the changed ones.
 5. Check index sync and reachability. *Done when:* both verdicts are recorded, since they are
@@ -96,7 +96,7 @@ Each step names what "done" looks like, so a partial run is visible rather than 
 ## Reporting
 
 Lead with the count of moved items and the window. When nothing moved, **say that plainly in one
-line and stop** — a delta run whose honest answer is "nothing changed" should cost one line to read,
+line and stop**. A delta run whose honest answer is "nothing changed" should cost one line to read,
 not a page of reassurance.
 
 Never pad a quiet run by re-listing standing findings to look useful.
@@ -108,7 +108,7 @@ Never pad a quiet run by re-listing standing findings to look useful.
 - **Never resurrect a declined finding.** Not as `new`, not as `changed`, not "for review".
 - **Never suppress silently.** The suppressed count is part of the report, always.
 - **Never re-classify an unchanged finding.** If its source content did not change, its
-  classification stands — re-deriving it invites drift between runs for no new information.
+  classification stands. Re-deriving it invites drift between runs for no new information.
 - **A missing prior artifact routes out.** This skill reports movement; it is not a full audit
   wearing a different name.
 
@@ -122,7 +122,7 @@ Never pad a quiet run by re-listing standing findings to look useful.
 - **Byte-level diffing over-reports.** A reworded sentence in a section whose scope and class are
   unchanged is not movement. Compare what the classification actually depends on.
 - **The artifact is ephemeral.** A reclaimed container or removed worktree loses it, and the next
-  run then legitimately has no baseline. That is the route-out case, not a bug — and it means
+  run then legitimately has no baseline. That is the route-out case, not a bug, and it means
   operator decisions can be lost, which is why `declined` is respected rigorously while it exists.
 - **A `changed` finding's stale line range is the dangerous part.** It is not a bookkeeping
   detail: `realign` excises by that range, so reporting `changed` without re-deriving the range

--- a/plugins/instruction-placement/skills/realign/SKILL.md
+++ b/plugins/instruction-placement/skills/realign/SKILL.md
@@ -1,6 +1,6 @@
 ---
-description: "Execute an instruction-placement audit's findings behind an explicit per-item human gate. Consumes the findings artifact the audit skill produced — it never re-judges the surface itself — and for each finding the operator accepts, performs the whole move atomically: create the path-scoped `.claude/rules/` file with its validated `paths:` glob (or the nested AGENTS.md plus its mandatory CLAUDE.md shim), excise the content from its source, regenerate the always-loaded rules index so the demoted surface stays reachable from subagents, and verify the result. Hard-denied safety content has no code path here. Use when: 'apply the placement findings', 'do the migration', 'move those conventions to rules', 'execute finding IP-004', 'realign our instruction layer', 'the audit says move it, do it'. This is the only skill in this plugin that changes anything, and there is no blanket-approve path."
-argument-hint: "[finding-id ...] — default: every finding awaiting a decision, in ranked order"
+description: "Execute an instruction-placement audit's findings behind an explicit per-item human gate. Consumes the findings artifact the audit skill produced. It never re-judges the surface itself. For each finding the operator accepts, it performs the whole move atomically: create the path-scoped `.claude/rules/` file with its validated `paths:` glob (or the nested AGENTS.md plus its mandatory CLAUDE.md shim), excise the content from its source, regenerate the always-loaded rules index so the demoted surface stays reachable from subagents, and verify the result. Hard-denied safety content has no code path here. Use when: 'apply the placement findings', 'do the migration', 'move those conventions to rules', 'execute finding IP-004', 'realign our instruction layer', 'the audit says move it, do it'. This is the only skill in this plugin that changes anything, and there is no blanket-approve path."
+argument-hint: "[finding-id ...]. Default: every finding awaiting a decision, in ranked order"
 user-invocable: true
 disable-model-invocation: false
 allowed-tools:
@@ -28,7 +28,7 @@ metadata:
 
 ## Purpose
 
-Execute what the audit found — one finding at a time, with the operator deciding each one. This is
+Execute what the audit found, one finding at a time, with the operator deciding each one. This is
 the **only** mutating surface in this plugin, and the per-item gate below is the entire reason it is
 safe to point at a repository nobody has reviewed.
 
@@ -52,14 +52,14 @@ Not restated here. A paraphrase inside a proposal is a drift seed.
 **Nothing mutates without an explicit acceptance of that finding, from the operator, at the moment
 it is presented.** Say so in the run's opening line, then hold it literally.
 
-- **One finding, one acceptance.** Accepting IP-003 authorizes IP-003 and nothing else — not its
+- **One finding, one acceptance.** Accepting IP-003 authorizes IP-003 and nothing else, not its
   neighbours, not the rest of its file, not the obvious next one.
 - **Blanket approval is not the gate.** "Approve everything", "do whatever the audit says", and a
   standing authorization from earlier in the session are all declined, out loud, with an offer to
   walk the findings one at a time. This is not pedantry: the whole value of the gate is that a human
   looked at each destination, and a blanket yes means nobody did.
 - **Present before asking.** The source and its line range, the destination, the exact `paths:` glob
-  with its validated match count, what leaves the always-loaded budget, and the cost — subagent
+  with its validated match count, what leaves the always-loaded budget, and the cost: subagent
   invisibility, and post-compaction behavior for that destination.
 - **A decline is recorded, not argued.** Write `declined` into the artifact and move on. A declined
   finding is not re-proposed by a later audit.
@@ -81,7 +81,7 @@ Three staleness checks before the first edit, because acting on a stale artifact
 lines:
 
 1. **Branch match.** The artifact's `branch:` frontmatter against the current branch. On a mismatch,
-   stop and re-audit — the directory a file sits in never proves which branch it describes.
+   stop and re-audit. The directory a file sits in never proves which branch it describes.
 2. **Source drift.** For each finding, that the cited content still exists at the cited location.
    Content that moved is re-audited, not guessed at.
 3. **Version drift.** The artifact's `claude_code_version` against the running one. On a material
@@ -111,7 +111,7 @@ Per accepted finding, in ranked order, following the recipe for its destination:
      --trigger <a file the new surface covers> --expect <the new surface>
    ```
 
-   This drives the real CLI with an `InstructionsLoaded` hook and reports what actually loaded —
+   This drives the real CLI with an `InstructionsLoaded` hook and reports what actually loaded,
    the only check in this plugin that observes Claude Code rather than reasoning about it, and the
    one that catches a surface passing every static gate while never entering context. It costs a
    model call, so it earns its place on the first move of a migration and on anything unusual, not
@@ -120,7 +120,7 @@ Per accepted finding, in ranked order, following the recipe for its destination:
 6. Record `applied` in the artifact, with the destination path.
 
 **One finding is one reviewable unit of work.** Do not batch several findings into one edit sweep
-even when they share a destination file — a reviewer needs to see which change came from which
+even when they share a destination file. A reviewer needs to see which change came from which
 accepted proposal.
 
 ## Hard rules
@@ -131,11 +131,11 @@ accepted proposal.
   compression in place. This is the one place where the operator's instruction does not carry.
 - **Never re-judge the surface.** This skill executes classifications the audit made; it does not
   reclassify, discover new candidates, or improve a destination it thinks the audit got wrong. If a
-  finding looks wrong, say so and stop — the fix is a re-audit, not an improvised alternative.
+  finding looks wrong, say so and stop. The fix is a re-audit, not an improvised alternative.
 - **Never rewrite content while moving it.** The move is a relocation. Tightening prose during a
   relocation makes the diff unreviewable and smuggles an unapproved edit past the gate.
 - **The shim is mandatory.** A nested `AGENTS.md` without a `CLAUDE.md` beside it importing it is
-  never loaded by Claude Code — measured, not inferred. Writing one without the other produces
+  never loaded by Claude Code, measured, not inferred. Writing one without the other produces
   content that silently reaches nothing.
 - **Never leave the index stale.** Regenerating it is part of the move, not a follow-up. An
   un-indexed demotion is exactly the subagent gap this plugin exists to close.
@@ -150,7 +150,7 @@ Observed failure modes. Every one leaves a repository that looks migrated and is
   whole plugin, because the result reviews as correct: a well-written conventions file, in the
   right directory, that Claude Code never loads at any level of the tree. Measured, not inferred.
 - **Forgetting the index regeneration.** The move succeeds, the rule fires on read, and the content
-  is invisible to every subagent — which in a delegation-heavy repo is most of the work. The index
+  is invisible to every subagent, which in a delegation-heavy repo is most of the work. The index
   is part of the move, not a follow-up task.
 - **Excising before creating.** An interruption between the two then deletes the only copy. The
   ordering is not stylistic; it is the difference between a recoverable and an unrecoverable

--- a/plugins/instruction-placement/skills/realign/SKILL.md
+++ b/plugins/instruction-placement/skills/realign/SKILL.md
@@ -135,8 +135,8 @@ accepted proposal.
 - **Never rewrite content while moving it.** The move is a relocation. Tightening prose during a
   relocation makes the diff unreviewable and smuggles an unapproved edit past the gate.
 - **The shim is mandatory.** A nested `AGENTS.md` without a `CLAUDE.md` beside it importing it is
-  never loaded by Claude Code, measured, not inferred. Writing one without the other produces
-  content that silently reaches nothing.
+  never loaded by Claude Code. That is measured, not inferred. Writing one without the other
+  produces content that silently reaches nothing.
 - **Never leave the index stale.** Regenerating it is part of the move, not a follow-up. An
   un-indexed demotion is exactly the subagent gap this plugin exists to close.
 - **Stop on a failed verification.** Report what failed and leave the finding `blocked`. Do not

--- a/plugins/instruction-placement/skills/setup/SKILL.md
+++ b/plugins/instruction-placement/skills/setup/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: "Verify instruction-placement's prerequisites and resolve its effective configuration for this repository — that the index target exists AND is actually reachable by Claude Code (it reads CLAUDE.md, not AGENTS.md, so an unimported AGENTS.md index is inert while every other gate reports green), that `git` backs tracked-file discovery, and that the Claude Code CLI plus `jq` are present for the optional empirical load probe. Reports the resolved index target, breadth ceiling, and index row cap, naming which came from configuration and which from a default. Use when: 'set up instruction-placement', 'configure instruction-placement', 'where will the index go', 'why is my index not loading', 'is instruction-placement working', or before a first audit on a new repository. Actions: check (read-only verification, default) | apply (point at each remediation; writes nothing on its own). Re-runnable and safe."
+description: "Verify instruction-placement's prerequisites and resolve its effective configuration for this repository. Confirm that the index target exists AND is actually reachable by Claude Code (it reads CLAUDE.md, not AGENTS.md, so an unimported AGENTS.md index is inert while every other gate reports green), that `git` backs tracked-file discovery, and that the Claude Code CLI plus `jq` are present for the optional empirical load probe. Reports the resolved index target, breadth ceiling, and index row cap, naming which came from configuration and which from a default. Use when: 'set up instruction-placement', 'configure instruction-placement', 'where will the index go', 'why is my index not loading', 'is instruction-placement working', or before a first audit on a new repository. Actions: check (read-only verification, default) | apply (point at each remediation; writes nothing on its own). Re-runnable and safe."
 argument-hint: "check | apply"
 user-invocable: true
 disable-model-invocation: true
@@ -19,7 +19,7 @@ The warrant is all three criteria, but one carries the weight. **The index targe
 referent whose validity cannot be established by a configuration prompt.** A prompt stores the path
 you typed; it cannot tell you that Claude Code will never read it. Claude Code loads `CLAUDE.md`, not
 `AGENTS.md`, so a repository carrying both with no import between them gets a perfectly generated,
-perfectly in-sync index that never enters context — with every other gate green. Verifying that is
+perfectly in-sync index that never enters context, with every other gate green. Verifying that is
 this skill's main job, and nothing else in the plugin can do it before a migration has already
 happened.
 
@@ -30,7 +30,7 @@ optional empirical load probe needs the Claude Code CLI plus `jq`.
 
 Read-only. Report each item with a verdict, and never repair anything.
 
-**1. Index target — the one that matters.** Resolve it the way `check` does (explicit argument,
+**1. Index target, the one that matters.** Resolve it the way `check` does (explicit argument,
 then root `AGENTS.md`, then root `CLAUDE.md`), then verify reachability:
 
 ```bash
@@ -41,7 +41,7 @@ then root `AGENTS.md`, then root `CLAUDE.md`), then verify reachability:
 |---|---|---|
 | `LOADED` | Claude Code reaches it | Name the file and the path it was reached by |
 | `UNREACHABLE` | it exists and is never read | **The headline finding.** Name the missing import |
-| target absent | no index home yet | Not a failure — say which file `apply` would propose |
+| target absent | no index home yet | Not a failure. Say which file `apply` would propose |
 
 **2. `git`.** Present and this is a work tree? Nested-instruction discovery is tracked-only, so
 without git it falls back to a plain walk and cannot honor the tracked-only corpus rule. Report the
@@ -49,7 +49,7 @@ degradation rather than implying full behavior.
 
 **3. Empirical probe prerequisites.** `jq` on `PATH`, and a Claude Code CLI. Both are optional: the
 static gates work without them and only `verify-load.sh` degrades. Say "optional, absent" rather
-than "missing" — an absent optional prerequisite is not a failure.
+than "missing". An absent optional prerequisite is not a failure.
 
 **4. Effective configuration.** Print each value with its **source**, so a surprising number is
 traceable:
@@ -60,7 +60,7 @@ traceable:
 | `breadth_max` | 75 | `user_config` or default |
 | `index_max_rows` | 40 | `user_config` or default |
 
-A value equal to the default is still reported with its source — "40 (default)" and "40 (configured)"
+A value equal to the default is still reported with its source. "40 (default)" and "40 (configured)"
 are different facts about a repository.
 
 ## Action: apply
@@ -94,7 +94,7 @@ does not re-verify has not finished.
 - **`UNREACHABLE` is the finding people do not expect.** Everything else can be green while the
   index does nothing. Lead with it when it fires; it is the reason this skill exists.
 - **A target that does not exist yet is not unreachable.** Those are different states with different
-  remedies — do not collapse them into one verdict.
+  remedies. Do not collapse them into one verdict.
 - **Reachability is not sync.** A reachable index can still be stale, and a stale index can still be
   reachable. `/instruction-placement:check` owns sync; this owns whether the file is read at all.
 - **The plugin works with no configuration.** Every setting has a default that behaves. Do not


### PR DESCRIPTION
No linked issue

## Summary

#2891 instruction-surface de-slop cluster: purge em dashes from the `instruction-placement` plugin README and every SKILL.md. This shard only.

## Fix

Rewrote `plugins/instruction-placement/README.md` and every `plugins/instruction-placement/**/SKILL.md` under `/ai-slop:audit fix` semantics (periods, commas, or a restructured sentence; never parentheses, en dashes, or a spaced hyphen as a stand-in). A self-audit repaired wrap leftovers and split asides the mechanical pass left as fragments. The generated options block is ignore-fenced because the shared generator still emits em dashes. `instruction-placement` 0.11.5.

## Verification

- Detector: 0 `rule-em-dash` findings outside ignore-fenced generated-options spans
- `CHECK_SKILL_SKIP_MARKDOWNLINT=1 bash scripts/check-changed-skills.sh origin/main`: 0 failed; quoted trigger phrases vs origin/main preserved
- `python3 scripts/sync-plugin-options-docs.py --check` up to date
- `scripts/check-changelog-parity.sh --check-bump origin/main` passes
- `node scripts/generate-cheatsheet.mjs --check` in sync

## Related

Refs #2891

#2891 stays open.