### PR TITLE
docs(visualization): de-slop instruction surfaces (0.3.4)

### DIFF
--- a/plugins/visualization/.claude-plugin/plugin.json
+++ b/plugins/visualization/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "visualization",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "On-demand visualization router: infers what in the current conversation should be shown visually, then decides the best FORM (a mermaid diagram, a markdown table, a hand-authored SVG/CSS chart, ASCII/Unicode art, a rich rendered page — or, where the bundled design skill is available, a hand-editable design canvas) and the best MEDIUM (inline terminal, a local HTML file, or a published Artifact) via a decision matrix over content shape, complexity, and a configurable medium preference. Renders good defaults and asks only when the target is genuinely ambiguous and no form was named. A form-and-medium decision layer in front of the craft capabilities — it routes chart craft and artifact-design fundamentals to those capabilities when installed and never restates them.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/visualization/CHANGELOG.md
+++ b/plugins/visualization/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to the `visualization` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.3.4]
+
+### Changed
+
+- **Instruction-surface de-slop (#2891, visualization cluster).** Rewrote this plugin's `README.md` and every
+  `SKILL.md` to drop em dashes under the repo's zero-tolerance house policy, using
+  `/ai-slop:audit fix` semantics: periods or commas, or a restructured sentence, never
+  parentheses, en dashes, or a spaced hyphen as a stand-in. Meaning stays; only the mark
+  and the sentence break change. The generated options block is ignore-fenced because
+  `scripts/sync-plugin-options-docs.py` still emits em dashes from its shared template.
+
 ## [0.3.3]
 
 ### Changed

--- a/plugins/visualization/README.md
+++ b/plugins/visualization/README.md
@@ -2,29 +2,30 @@
 
 A Claude Code plugin for on-demand visualization. One skill, one job: at any point
 in a conversation, decide **what** is most worth showing visually and **how** to
-show it, then render it — a form-and-medium router, not a craft teacher.
+show it, then render it. It is a form-and-medium router, not a craft teacher.
 
 | Skill | What it does |
 |---|---|
-| `/visualization:visualize` | Infer the target from the conversation, pick a form (mermaid diagram, table, chart, ASCII/Unicode, or a rich page) and a medium (terminal, local HTML file, or published Artifact), and render it — asking only on genuine ambiguity |
+| `/visualization:visualize` | Infer the target from the conversation, pick a form (mermaid diagram, table, chart, ASCII/Unicode, or a rich page) and a medium (terminal, local HTML file, or published Artifact), and render it, asking only on genuine ambiguity |
 
 ## What it decides
 
 Two decisions, then the output:
 
-- **Form** — matched to the *shape* of the content: a mermaid diagram for flow /
+- **Form**, matched to the *shape* of the content: a mermaid diagram for flow /
   hierarchy / sequence / state / relationships; a markdown table for attribute
   comparison; a chart for quantities; ASCII/Unicode for a small structural sketch;
   a rich rendered page for a composite or interactive view; a hand-editable design
   canvas (via the bundled `design` skill, when that presence-gated preview is
   available) for a visual layout the user would rather tweak by hand.
-- **Medium** — one of three ascending tiers, **inline terminal → local HTML file →
+- **Medium**. One of three ascending tiers, **inline terminal → local HTML file →
   published Artifact**, chosen by the form's weight, a configurable preference, and
   which surfaces are actually available.
 
-The full grounded catalog — every mermaid family, the zero-dependency chart paths,
-and the rendering-surface facts — lives in the skill's
+The full grounded catalog lives in the skill's
 [`context/decision-matrix.md`](skills/visualize/context/decision-matrix.md).
+It covers every mermaid family, the zero-dependency chart paths, and the
+rendering-surface facts.
 
 ## Router, not craft
 
@@ -33,7 +34,7 @@ chart or the fundamentals of a good page. When a chart is the right form and a
 chart-craft/dataviz capability is installed, it routes the craft there; when a rich
 page is the right medium, the page's contract and design are owned by the Artifact
 tool's own contract and an artifact-design capability. Each is invoked through its
-capability when present and degrades to a documented fallback when absent — this
+capability when present and degrades to a documented fallback when absent. This
 skill never restates their guidance.
 
 It is also **not** a comprehension aid: restating dense text in plainer words is a
@@ -67,7 +68,7 @@ rendered diagram. These facts and their sources are documented in the catalog.
 
 Configure with `/plugin configure visualization@<marketplace>`, or headless with
 `claude plugin install visualization@<marketplace> -s <scope> --config
-medium=<value>` — against an already-installed plugin that prints `already
+medium=<value>`. Against an already-installed plugin that prints `already
 installed` and still writes the value, verified on Claude Code 2.1.240 for a
 non-sensitive option at `user` scope. Never uninstall to reconfigure: that drops
 the whole stored `pluginConfigs` entry and resets every option to its manifest
@@ -86,9 +87,10 @@ its own.
 - **Third-party visualization server.** No credible egress-free, self-hostable
   visualization server exists to depend on today. Re-evaluate if one lands with a
   maintained security posture (a self-hosted AntV deployment is the current
-  candidate) — until then the skill relies only on native rendering surfaces and
+  candidate). Until then the skill relies only on native rendering surfaces and
   the presence-gated craft capabilities.
 
+<!-- ai-slop-ignore-start: generated options block; source is plugin.json + scripts/sync-plugin-options-docs.py -->
 <!-- BEGIN GENERATED: plugin options — edit plugin.json, then run scripts/sync-plugin-options-docs.py -->
 
 ### Options reference
@@ -161,3 +163,4 @@ hands a configured value to a hook process; the value comes from the routes abov
 - [Manage installed plugins](https://code.claude.com/docs/en/discover-plugins#manage-installed-plugins) — enabling, disabling, `/plugin list`
 
 <!-- END GENERATED: plugin options -->
+<!-- ai-slop-ignore-end -->

--- a/plugins/visualization/skills/visualize/SKILL.md
+++ b/plugins/visualization/skills/visualize/SKILL.md
@@ -1,6 +1,6 @@
 ---
-description: "Decide the best visual FORM and MEDIUM for what is in the conversation right now, then render it. Use when: 'visualize', 'visualize this', 'show me a diagram of this', 'diagram this', 'render this as', 'draw this', 'sketch this', 'make a picture of this', 'what is the best way to show this', 'turn this into a visual'. Infers the target from the conversation, picks a form (a mermaid diagram, a markdown table, a hand-authored SVG/CSS chart, ASCII/Unicode art, a rich rendered page — or, where the bundled design skill is available, a hand-editable design canvas) and a medium (inline terminal, a local HTML file, or a published Artifact), renders good defaults, and asks ONLY when the target is genuinely ambiguous and no form was named. It ROUTES chart craft and artifact-design fundamentals to those capabilities when installed — it does not teach them. Not for polishing a specific chart's colors/axes (a chart-craft/dataviz capability owns that) or restating dense text in plainer words (a comprehension/digest concern)."
-argument-hint: "[terminal|file|artifact] — omit to auto-decide; name a form in the request itself"
+description: "Decide the best visual FORM and MEDIUM for what is in the conversation right now, then render it. Use when: 'visualize', 'visualize this', 'show me a diagram of this', 'diagram this', 'render this as', 'draw this', 'sketch this', 'make a picture of this', 'what is the best way to show this', 'turn this into a visual'. Infers the target from the conversation, picks a form (a mermaid diagram, a markdown table, a hand-authored SVG/CSS chart, ASCII/Unicode art, a rich rendered page, or, where the bundled design skill is available, a hand-editable design canvas) and a medium (inline terminal, a local HTML file, or a published Artifact), renders good defaults, and asks ONLY when the target is genuinely ambiguous and no form was named. It ROUTES chart craft and artifact-design fundamentals to those capabilities when installed. It does not teach them. Not for polishing a specific chart's colors/axes (a chart-craft/dataviz capability owns that) or restating dense text in plainer words (a comprehension/digest concern)."
+argument-hint: "[terminal|file|artifact]. Omit to auto-decide; name a form in the request itself"
 user-invocable: true
 disable-model-invocation: false
 metadata:
@@ -14,18 +14,18 @@ metadata:
 
 On demand, at any point in a conversation, decide **what** is most worth showing
 visually and **how** to show it, then render it. This skill is a **form + medium
-router**: it makes two decisions — the form and the medium — and produces the
+router**: it makes two decisions, the form and the medium, and produces the
 output. It is not a craft teacher. The craft of a good chart, and the fundamentals
 of a good rich page, are owned by other capabilities; this skill routes to them
 and never restates them.
 
-## When this fires — and when it does not
+## When this fires, and when it does not
 
 - **Fires** when the user asks to see something visually: "visualize this",
   "diagram this", "chart this", "render this as …", "show me …", or a bare
   `/visualization:visualize`.
-- **Not chart craft.** Making a specific chart read well — palette, marks, axes,
-  legend, dark-mode contrast — is a chart-craft/dataviz capability's job. This
+- **Not chart craft.** Making a specific chart read well, including palette, marks,
+  axes, legend, and dark-mode contrast, is a chart-craft/dataviz capability's job. This
   skill decides *that a chart is the right form* and routes the craft out.
 - **Not comprehension digest.** Restating a wall of dense text in plainer words,
   or restructuring it for understanding, is a different concern. This skill is
@@ -35,32 +35,32 @@ and never restates them.
 
 Two decisions, then the rendered output:
 
-1. **Form** — the kind of visual the content wants (Step 2).
-2. **Medium** — where it is delivered (Step 3).
+1. **Form**. The kind of visual the content wants (Step 2).
+2. **Medium**. Where it is delivered (Step 3).
 
-## Step 1 — Infer the target
+## Step 1: Infer the target
 
 Read where the conversation stands and identify the single thing most worth
-showing — a process just described, a set of options compared, a trend in some
+showing: a process just described, a set of options compared, a trend in some
 numbers, a structure being designed. Usually one target dominates. If two or more
-are equally plausible and the user named no form, that is genuine ambiguity —
-carry it to Step 4. Otherwise proceed with the dominant target.
+are equally plausible and the user named no form, that is genuine ambiguity.
+Carry it to Step 4. Otherwise proceed with the dominant target.
 
-## Step 2 — Pick the form
+## Step 2: Pick the form
 
-Match the *shape* of the content to a form. The full catalog — every mermaid
+Match the *shape* of the content to a form. The full catalog lives in
+[`context/decision-matrix.md`](context/decision-matrix.md): every mermaid
 diagram family and when each fits, the zero-dependency chart primitives, and the
-rendering-surface facts these rest on — lives in
-[`context/decision-matrix.md`](context/decision-matrix.md); the summary:
+rendering-surface facts these rest on. The summary:
 
 | Content shape | Form |
 |---|---|
 | Flow, process, hierarchy, sequence, state, relationships, timeline | a **mermaid diagram** (pick the family per the catalog) |
 | Attributes or options compared across items | a **markdown table** |
-| Quantities: trend, distribution, proportion, ranking | a **chart** — route the craft to a chart-craft/dataviz capability |
+| Quantities: trend, distribution, proportion, ranking | a **chart**. Route the craft to a chart-craft/dataviz capability |
 | Small structural sketch, directory tree, box layout | **ASCII / Unicode art** |
 | A composite, interactive, or large multi-part view | a **rich rendered page** |
-| A visual layout the user would rather tweak by hand — a UI mockup, screen flow, poster, banner, one-pager | a **design canvas** — route to a design-canvas capability (the bundled `design` skill), when available |
+| A visual layout the user would rather tweak by hand: a UI mockup, screen flow, poster, banner, one-pager | a **design canvas**. Route to a design-canvas capability (the bundled `design` skill), when available |
 
 When the form is a chart and a chart-craft/dataviz capability is installed, invoke
 it for the craft (form heuristic, palette, mark specs); when it is not installed,
@@ -69,41 +69,41 @@ page, or a Unicode bar/sparkline in the terminal) and say the craft capability w
 unavailable. Never restate its craft here.
 
 When the form is a hand-tweakable visual layout, route to the design-canvas
-capability — the bundled `design` skill, when it appears in this session's skill
-list. The canvas exists only on the published-Artifact tier, so the offer is
+capability. That is the bundled `design` skill, when it appears in this session's
+skill list. The canvas exists only on the published-Artifact tier, so the offer is
 also gated on Step 3's medium selection: when an explicit `terminal`/`file`
 argument or the configured preference pins delivery on-machine ("never
-published"), do not offer the canvas — the rich rendered page or local file
+published"), do not offer the canvas. The rich rendered page or local file
 carries the layout instead. Where the medium permits publishing, offer it as an
 explicit alternative, never a silent default: the canvas is a
 published, versioned, persistent Artifact (default-private, shareable with
 teammates at the user's choice; hand-editable where saving is enabled for the
 account, view-plus-PNG/PDF-export otherwise), where this skill's other page paths
 are throwaway or plain-static. When the skill is **absent from the list**, the
-rich rendered page covers the same ground — do not mention `/design` (that user
+rich rendered page covers the same ground. Do not mention `/design` (that user
 has no such command). When it is **listed but the invocation is refused**, suggest
 the user run `/design` themselves. The canvas surface facts and their
-verified-on/recheck record live in the catalog spoke — do not restate them here.
+verified-on/recheck record live in the catalog spoke. Do not restate them here.
 
-## Step 3 — Pick the medium
+## Step 3: Pick the medium
 
 There are three delivery tiers, in ascending richness: **inline terminal → local
 HTML file → published Artifact**. Selection layers, first hit wins:
 
-1. **Explicit argument** — a `terminal` / `file` / `artifact` argument forces the tier.
-2. **Configured preference** — `${user_config.medium}`. Claude Code text-substitutes
+1. **Explicit argument**. A `terminal` / `file` / `artifact` argument forces the tier.
+2. **Configured preference**. `${user_config.medium}`. Claude Code text-substitutes
    the configured value into this line; if it still shows the literal
-   `${user_config.medium}` token or is empty, the option is unset — use the default
+   `${user_config.medium}` token or is empty, the option is unset. Use the default
    `auto`. Recognized values are `auto`, `terminal`, `file`, and `artifact`; any
    other value is reported and treated as `auto`.
-3. **Auto** — decide by the form and its weight: terminal for small, static,
+3. **Auto**. Decide by the form and its weight: terminal for small, static,
    text-representable output (tables, ASCII, short code, a `mermaid` source fence);
    a rich page for a composite, interactive, large, or truly graphical result
    (rendered diagrams, real charts, dashboards).
 
-**Surface gate — the rich page is a capability that can be absent.** A published
+**Surface gate: the rich page is a capability that can be absent.** A published
 Artifact is heavily gated (plan, sign-in, provider, and version constraints; off
-in SDK / CI / MCP contexts) — see the catalog. So when a page is warranted:
+in SDK / CI / MCP contexts). See the catalog. So when a page is warranted:
 publish an Artifact only if that surface is available; otherwise write a
 self-contained local HTML file and open it; if neither page surface is available,
 degrade **visibly** to the best terminal form with a one-line notice. Never assume
@@ -111,80 +111,80 @@ the Artifact surface exists. The `file` preference deliberately stays on the
 machine (never published); `artifact` prefers publishing but degrades the same way.
 
 **Local-file placement.** Write the local HTML file via the platform's temp
-primitive — never into the consumer's repository tree. On Unix/Linux/Git Bash,
-create a private run directory and echo it in the same call —
-`d=$(mktemp -d "${TMPDIR:-/tmp}/visualize-XXXXXX"); echo "$d"` — then write the
+primitive, never into the consumer's repository tree. On Unix/Linux/Git Bash,
+create a private run directory and echo it in the same call,
+`d=$(mktemp -d "${TMPDIR:-/tmp}/visualize-XXXXXX"); echo "$d"`, then write the
 page to `<echoed dir>/visualize.html`. Echo it because shell state does not
 survive between Bash calls: the directory name is random, so an unechoed path is
-unrecoverable in the call that writes the file. Carry the temp root in the positional template — the one form GNU and BSD `mktemp` accept identically, since `-p`/`--tmpdir`/`-t` differ between the dialects and a bare relative template silently creates the file in the **current directory**, the consumer's repository. Keep the `XXXXXX` placeholders **trailing** — BSD `mktemp` (macOS) substitutes only trailing Xs, so an extension after them is not portable (per `docs/conventions/topic-docs/README.md` "The ephemeral tier" in the marketplace repository).
+unrecoverable in the call that writes the file. Carry the temp root in the positional template, the one form GNU and BSD `mktemp` accept identically, since `-p`/`--tmpdir`/`-t` differ between the dialects and a bare relative template silently creates the file in the **current directory**, the consumer's repository. Keep the `XXXXXX` placeholders **trailing**. BSD `mktemp` (macOS) substitutes only trailing Xs, so an extension after them is not portable (per `docs/conventions/topic-docs/README.md` "The ephemeral tier" in the marketplace repository).
 That is why the page takes a fixed name inside the generated directory rather
 than a `visualize-XXXXXX.html` template, which macOS cannot create at all. On Windows,
 a user-scoped temp under
 `%LOCALAPPDATA%\Temp`. One file per run. The path is handed back to the user, so
-do not delete it — it must still be readable when they open it. Open it for the
+do not delete it. It must still be readable when they open it. Open it for the
 user (`start <path>` on Windows, `open <path>` on macOS, `xdg-open <path>` on
 Linux) and report the absolute path.
 
 A **mermaid diagram** is the sharp case: it renders natively only on a published
 Artifact. A local HTML file renders it only if the page **embeds** a mermaid
-renderer inline — keep the file self-contained; never load a renderer from the
+renderer inline. Keep the file self-contained; never load a renderer from the
 network, which breaks offline use and, for `file` or otherwise sensitive output,
 would expose the page to a third party. A plain file with a bare `mermaid` block
 does not render. So if no mermaid-capable surface is reachable and no trusted
 renderer can be embedded, deliver the mermaid **source** fence in the terminal and
-say it is unrendered — never open a page that shows source instead of the promised
+say it is unrendered. Never open a page that shows source instead of the promised
 picture.
 
 Honor a preference without overproducing: `artifact` still renders a trivial
 three-row table inline, and `terminal` degrades a rich form to its best terminal
 approximation with a visible note rather than dropping detail silently.
 
-## Step 4 — Ask only on genuine ambiguity
+## Step 4: Ask only on genuine ambiguity
 
-Two things can be ambiguous independently — **what** to show (the target) and
+Two things can be ambiguous independently: **what** to show (the target) and
 **which form**. Ask the user **one** question, with a RECOMMENDED default listed
 first, when either is genuinely ambiguous:
 
-- **Target ambiguity** — several equally plausible things to show. Ask which, *even
+- **Target ambiguity**. Several equally plausible things to show. Ask which, *even
   if a form was named*: naming "diagram this" fixes the *how*, not the *what*.
-- **Form ambiguity** — the target is clear, no form was named, and two forms fit it
+- **Form ambiguity**. The target is clear, no form was named, and two forms fit it
   about equally. Ask which form.
 
-When neither is ambiguous — a dominant target and a clear best form — proceed with
+When neither is ambiguous, meaning a dominant target and a clear best form, proceed with
 the matrix's pick: good defaults, no nagging. A specified form or medium is always
 honored and simply removes that axis from any question.
 
-## Step 5 — Render
+## Step 5: Render
 
-- **Terminal** renders GitHub-flavored markdown — tables, fenced code, blockquotes,
+- **Terminal** renders GitHub-flavored markdown: tables, fenced code, blockquotes,
   ASCII/Unicode. A ` ```mermaid ` block in the terminal is shown as **source, not a
   rendered diagram**, so emit it as portable source the user can render elsewhere,
   and prefer a page when the *rendered* diagram is the point.
 - **A rich page** follows the Artifact tool's own contract and, when an
   artifact-design capability is installed, its guidance. The page-contract facts
-  live once in [`context/decision-matrix.md`](context/decision-matrix.md) — do not
+  live once in [`context/decision-matrix.md`](context/decision-matrix.md). Do not
   restate them here.
 - Report what you produced and, for a page, its path or link.
 
 ## Gotchas
 
 - **Terminal mermaid is source, not a picture.** If the user wants to *see* the
-  rendered diagram and no page surface is available, say so — do not imply the
+  rendered diagram and no page surface is available, say so. Do not imply the
   fence renders inline.
 - **Do not overproduce a page.** A three-row comparison is a table; forcing it into
   an Artifact is worse, not richer. Match richness to the content.
 - **The Artifact surface is often unavailable.** Gate on it; never let a missing
-  surface become a silent failure — degrade visibly to a local file or terminal.
+  surface become a silent failure. Degrade visibly to a local file or terminal.
 - **Craft is not this skill's job.** If you find yourself writing palette or axis
   guidance, stop and route to the chart-craft capability instead.
 - **A newer mermaid family may not render** in the bundled artifact renderer
-  (the 13 stable families are safe; the newest set is unverified — see the
+  (the 13 stable families are safe; the newest set is unverified. See the
   catalog). Prefer a stable family, or verify before relying on a new one.
 
 ## What this skill does NOT do
 
-- **Does not teach chart craft** — palette, axes, marks route to a chart-craft/dataviz capability.
-- **Does not teach artifact-design fundamentals** — those route to an artifact-design capability and the Artifact tool's contract.
-- **Does not restate rendering-surface facts** — they live once in the catalog spoke.
-- **Does not digest or re-explain dense text** — that is a comprehension concern, not a form concern.
-- **Does not publish an Artifact when that surface is absent or when the preference is `file`** — it degrades to a local file or terminal.
+- **Does not teach chart craft**. Palette, axes, marks route to a chart-craft/dataviz capability.
+- **Does not teach artifact-design fundamentals**. Those route to an artifact-design capability and the Artifact tool's contract.
+- **Does not restate rendering-surface facts**. They live once in the catalog spoke.
+- **Does not digest or re-explain dense text**. That is a comprehension concern, not a form concern.
+- **Does not publish an Artifact when that surface is absent or when the preference is `file`**. It degrades to a local file or terminal.


### PR DESCRIPTION
No linked issue

## Summary

#2891 instruction-surface de-slop cluster: purge em dashes from the `visualization` plugin README and every SKILL.md.

## Fix

Rewrote `plugins/visualization/README.md` and every `plugins/visualization/**/SKILL.md` under `/ai-slop:audit fix` semantics (periods, commas, or a restructured sentence; never parentheses, en dashes, or a spaced hyphen as a stand-in). Meaning-preserving grammar pass after the mechanical replace. Version-only bump in `plugin.json`. New changelog heading only. The generated options block is ignore-fenced because `scripts/sync-plugin-options-docs.py` still emits em dashes from its shared template.

## Verification

- Detector (`HOME` + `CLAUDE_PROJECT_DIR` isolated so `rule-em-dash` is enabled): 0 `rule-em-dash` findings on rewritten instruction surfaces
- `CHECK_SKILL_SKIP_MARKDOWNLINT=1 bash scripts/check-changed-skills.sh origin/main`: 0 failed; quoted trigger phrases vs origin/main preserved
- `python3 scripts/sync-plugin-options-docs.py --check` up to date
- `scripts/check-changelog-parity.sh --check-bump origin/main` passes
- `node scripts/generate-cheatsheet.mjs --check` in sync

## Related

Refs #2891

#2891 stays open.