### PR TITLE
docs(context-budget): de-slop instruction surfaces (0.6.10)

### DIFF
--- a/plugins/context-budget/.claude-plugin/plugin.json
+++ b/plugins/context-budget/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "context-budget",
-  "version": "0.6.9",
+  "version": "0.6.10",
   "description": "Measure a Claude Code session's fixed startup context payload per item, on the consumer's machine at a pinned, version-stamped binary — including per-tool attribution of the built-in tool pools that /context reports only as lump sums, derived live by A/B bare-name-deny differencing with enforced comparability rules (skill-listing signature, one mode, one binary), an SDK-primary exact meter degrading to a version-aware headless /context parser and then to an honest structured error (never a wrong number), and a per-project measure-toggle-remeasure ledger under the plugin data directory recording every lever's real before/after delta. Report-only: prints exact config, applies nothing.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/context-budget/CHANGELOG.md
+++ b/plugins/context-budget/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to the `context-budget` plugin.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.10]
+
+### Changed
+
+- **Instruction-surface de-slop (#2891, context-budget cluster).** Rewrote this plugin's `README.md` and every
+  `SKILL.md` to drop em dashes under the repo's zero-tolerance house policy, using
+  `/ai-slop:audit fix` semantics: periods or commas, or a restructured sentence, never
+  parentheses, en dashes, or a spaced hyphen as a stand-in. Meaning stays; only the mark
+  and the sentence break change. The generated options block is ignore-fenced because
+  `scripts/sync-plugin-options-docs.py` still emits em dashes from its shared template.
+
 ## [0.6.9]
 
 ### Changed

--- a/plugins/context-budget/README.md
+++ b/plugins/context-budget/README.md
@@ -1,12 +1,12 @@
 # context-budget
 
 Measure a Claude Code session's fixed startup context payload **per item**, on your machine, at a
-pinned binary — and record what every trim actually saved.
+pinned binary, and record what every trim actually saved.
 
 `/context` already itemises skills, agents, and MCP tools. What it structurally cannot itemise is
 the built-in tool pool: `System tools` and `System tools (deferred)` are lump sums, and together
 they are typically the largest single contributor to the fixed payload. This plugin attributes
-them per tool by A/B differencing — a baseline headless session versus one session per candidate
+them per tool by A/B differencing: a baseline headless session versus one session per candidate
 tool with that tool denied by bare name. The deltas are compositional, so a basket of trims can be
 priced from its members.
 
@@ -19,16 +19,16 @@ priced from its members.
 
 ## Skills
 
-- `/context-budget:setup` — read-only prerequisite check: `node` (the hook launches it by bare
+- `/context-budget:setup`. Read-only prerequisite check: `node` (the hook launches it by bare
   name, and a launch failure is non-blocking, so the checkpoint can be configured on yet never
   fire), the `claude` CLI the engine measures against, the optional Agent SDK that enables exact
   mode, and the effective `settings_write_ask_enabled` value. Installs nothing.
-- `/context-budget:audit` — take a stamped baseline snapshot, attribute the built-in tool pools
+- `/context-budget:audit`. Take a stamped baseline snapshot, attribute the built-in tool pools
   over the live tool list, present catalogue levers with their honesty categories, and ledger
   any before/after the operator produces. Read-only on bare invocation: it prints exact config
   (for persistent denies, a `permissions.deny` entry) and applies nothing. With the explicit
   `fix` argument, a guided per-lever walkthrough may edit **project** settings after per-diff
-  approval — user-global `~/.claude/settings.json` is only ever printed, and every applied lever
+  approval. User-global `~/.claude/settings.json` is only ever printed, and every applied lever
   is re-measured and ledgered before the next.
 
 ## Hook
@@ -41,7 +41,7 @@ non-managed hooks). Kill switch: the `settings_write_ask_enabled` plugin option.
 ## What makes the numbers trustworthy
 
 - **Nothing is shipped, everything is measured.** The skill contains no token figures, tool
-  inventories, or thresholds — those drift with every CLI release. Every number in a report was
+  inventories, or thresholds. Those drift with every CLI release. Every number in a report was
   produced by a run on the consumer's machine during that audit.
 - **Every report is stamped** with the measured binary path and version, the measurement mode,
   and the session kind. Machines with two CLI installs get an answer per binary, not a blend.
@@ -58,11 +58,11 @@ non-managed hooks). Kill switch: the `settings_write_ask_enabled` plugin option.
 - **Honest degradation.** Exact mode uses the Agent SDK's structured context usage. Without the
   SDK, the engine parses headless `/context` output version-aware (display-rounded, and flagged
   as resting on an undocumented surface). When neither works, it emits a structured error with a
-  remediation — never a wrong number.
+  remediation, never a wrong number.
 
 ## Prerequisites
 
-- `node` (required — the engine's runtime).
+- `node` (required, the engine's runtime).
 - The Claude Code CLI (`claude` on PATH, or pass the engine an explicit `--binary`).
 - Optional, for exact mode: `@anthropic-ai/claude-agent-sdk`, installed once into the plugin's
   data directory (the audit skill offers the command; it is the operator's call since it needs
@@ -84,6 +84,7 @@ passed.
 - Measurements describe **headless** sessions of the **local CLI**; interactive sessions and
   cloud/web surfaces can compose the payload differently, and reports say so.
 
+<!-- ai-slop-ignore-start: generated options block; source is plugin.json + scripts/sync-plugin-options-docs.py -->
 <!-- BEGIN GENERATED: plugin options — edit plugin.json, then run scripts/sync-plugin-options-docs.py -->
 
 ### Options reference
@@ -156,3 +157,4 @@ hands a configured value to a hook process; the value comes from the routes abov
 - [Manage installed plugins](https://code.claude.com/docs/en/discover-plugins#manage-installed-plugins) — enabling, disabling, `/plugin list`
 
 <!-- END GENERATED: plugin options -->
+<!-- ai-slop-ignore-end -->

--- a/plugins/context-budget/skills/audit/SKILL.md
+++ b/plugins/context-budget/skills/audit/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: "Measure a Claude Code session's fixed startup context payload per item, on this machine at a pinned binary — including per-tool attribution of the built-in tool pools that /context reports only as lump sums, derived live by A/B deny differencing, with a per-project before/after ledger for every lever toggled. Reports only measured numbers; ships none. Use when: 'what is eating my context window at startup', 'measure my startup payload', 'which built-in tools cost the most', 'what would denying this tool save', 'context budget audit', 'baseline my context before trimming', 'did that settings change actually save tokens'. Read-only — measures and reports; changes no configuration."
+description: "Measure a Claude Code session's fixed startup context payload per item, on this machine at a pinned binary, including per-tool attribution of the built-in tool pools that /context reports only as lump sums, derived live by A/B deny differencing, with a per-project before/after ledger for every lever toggled. Reports only measured numbers; ships none. Use when: 'what is eating my context window at startup', 'measure my startup payload', 'which built-in tools cost the most', 'what would denying this tool save', 'context budget audit', 'baseline my context before trimming', 'did that settings change actually save tokens'. Read-only: measures and reports; changes no configuration."
 argument-hint: "[--full-sweep] every live tool | [--tools T1,T2] chosen tools | [--ledger] history | [fix] guided trim (explicit override)"
 user-invocable: true
 disable-model-invocation: false
@@ -10,12 +10,12 @@ metadata:
 
 ## Purpose
 
-`/context` itemises skills, agents, and MCP tools natively — for those, run it and read the tables.
+`/context` itemises skills, agents, and MCP tools natively. For those, run it and read the tables.
 What it structurally cannot itemise is the built-in tool pool: `System tools` and
 `System tools (deferred)` are lump sums, and together they are typically the largest single
 contributor to the fixed startup payload. This skill measures that attribution on the consumer's
-own machine by A/B differencing — a baseline session versus one session per candidate tool with
-that tool denied by bare name — which is compositional (deltas add), so a basket of trims can be
+own machine by A/B differencing: a baseline session versus one session per candidate tool with
+that tool denied by bare name, which is compositional (deltas add), so a basket of trims can be
 priced from its members.
 
 Two rules govern everything this skill says, per the plugin's
@@ -42,16 +42,16 @@ Two rules govern everything this skill says, per the plugin's
 
 This skill measures **the local Claude Code CLI, in a headless session**. On cloud or web surfaces
 (where the container's binary and settings are not the operator's own), the numbers describe the
-container, not the operator's machine — say so in the report. Interactive sessions can differ from
+container, not the operator's machine. Say so in the report. Interactive sessions can differ from
 headless ones (deferral eligibility is partly server-decided); the stamp's `sessionKind: headless`
 is the honest boundary of the claim.
 
 ## Prerequisites
 
-- `node` — required for correctness. Absent: stop and report the gap; do not estimate.
+- `node`. Required for correctness. Absent: stop and report the gap; do not estimate.
 - The Claude Code CLI (`claude` on PATH, or a `--binary` path the operator names).
-- `@anthropic-ai/claude-agent-sdk` — required for exact mode only. Absent, the engine degrades to
-  parsing headless `/context` output (display-rounded, and undocumented as a `-p` surface — the
+- `@anthropic-ai/claude-agent-sdk`. Required for exact mode only. Absent, the engine degrades to
+  parsing headless `/context` output (display-rounded, and undocumented as a `-p` surface. The
   record carries both caveats). To enable exact mode, offer the operator this one-time install
   into the plugin's own data directory (network access; their call):
 
@@ -67,7 +67,7 @@ is the honest boundary of the claim.
 bash "${CLAUDE_PLUGIN_ROOT}/lib/state-key.sh"
 ```
 
-The audit's artifacts live under `${CLAUDE_PLUGIN_DATA}/audit/<state-key>/` — keyed by project so
+The audit's artifacts live under `${CLAUDE_PLUGIN_DATA}/audit/<state-key>/`, keyed by project so
 one machine's many checkouts never share a ledger. Pass this resolved absolute path wherever
 `<data-dir>` appears below. Note near the ledger that uninstalling the plugin from its last scope
 deletes this directory unless `--keep-data` is passed.
@@ -82,12 +82,12 @@ node "${CLAUDE_PLUGIN_ROOT}/skills/audit/scripts/measure.mjs" snapshot \
 Each measurement spawns a short-lived headless session against the pinned binary (the `/context`
 prompt is handled by the CLI itself, so no model API call is made) and records: per-category
 tokens, the live tool list, per-agent tokens, the skill-listing signature, and the binary stamp.
-Exit 3 means measurement is unavailable — the JSON record names the remediation; relay it and
+Exit 3 means measurement is unavailable. The JSON record names the remediation; relay it and
 stop. Never substitute an estimate.
 
 ### 3. Attribute the built-in tool pools
 
-Candidates come from the **live tool list in the baseline record** (`tools`) — never from a
+Candidates come from the **live tool list in the baseline record** (`tools`), never from a
 memorised inventory. Ask the operator (or take from arguments) which to measure:
 
 - A **chosen set** (fast; one ~5–60 s run per tool):
@@ -99,21 +99,21 @@ memorised inventory. Ask the operator (or take from arguments) which to measure:
   ```
 
 - The **full sweep** (`--tools from-baseline`) prices every live tool; warn that it is one run per
-  tool and let the operator opt in. Interactive-only tools never appear in that live list —
+  tool and let the operator opt in. Interactive-only tools never appear in that live list:
   Artifact, SendUserFile, AskUserQuestion, plan-mode tools, interactive-only MCP servers. The
   attribution record's `knownUncovered` names them; the report lists each as known-uncovered,
   never as absent. That category is distinct from unmeasured-but-candidate.
 
 Report the ranked `perTool` table with the binary stamp, and each row's `comparable` flag: a row
 the engine marked incomparable (skill listing shifted, version changed mid-run) is reported as
-such, not as a number. Note which bucket moved — a deny that empties a *deferred* tool's schema
+such, not as a number. Note which bucket moved. A deny that empties a *deferred* tool's schema
 reduces request weight without changing the context-usage headline, so present `prefixDelta` and
 `deferredDelta` separately, never merged into one figure.
 
 ### 4. Present levers from the catalogue
 
 Levers come from the catalogue at
-[`${CLAUDE_PLUGIN_ROOT}/skills/audit/reference/levers.json`](reference/levers.json) — data rows,
+[`${CLAUDE_PLUGIN_ROOT}/skills/audit/reference/levers.json`](reference/levers.json), data rows,
 each carrying its honesty category, category basis, posture, detection, measurement route,
 emitted config, official citations, verified date, and recheck trigger. Rules, from the
 catalogue's own meta:
@@ -122,14 +122,14 @@ catalogue's own meta:
   whose category cannot be determined for this consumer's configuration is not offered.
 - **Resolve conditions by measurement, not assumption.** A row whose `conditions` names a
   configuration dependency (cap saturation, model default, surface) is measured here before its
-  category is asserted — a condition-dependent lever presented without resolving the condition is
+  category is asserted. A condition-dependent lever presented without resolving the condition is
   the exact failure this plugin exists to prevent.
 - **Respect postures.** `never-recommend` rows (net-negative) are disclosed with their price,
   never offered as actions; `disclose-only` rows are explained, not pushed; `report-only` rows
   (vendor weight) appear as the honest unaddressable floor.
 - **Honor recheck triggers.** A row whose trigger has plausibly fired (version jump past the
   catalogue's `verifiedAgainst`, upstream page moved) is re-verified against a fresh fetch of its
-  citations before being offered — and a measured result always outranks the catalogue's stored
+  citations before being offered, and a measured result always outranks the catalogue's stored
   expectation. On a version jump, also run the binary-strings existence check against the
   stamped binary (docs pages move; the binary is what the consumer actually runs):
 
@@ -139,7 +139,7 @@ catalogue's own meta:
   ```
 
   The binary is the authority on *existence* of each key/env name at the measured version; the
-  docs fetch remains the authority on *semantics*. Report every `absent` token by name — silence
+  docs fetch remains the authority on *semantics*. Report every `absent` token by name. Silence
   reads as "present".
 - **Keep the two ledgers apart** (the catalogue's `dualLedger` note): context-window occupancy
   versus per-request weight. Deferral moves weight between them; only removal clears both.
@@ -167,7 +167,7 @@ The audit's deliverable follows the report contract at
 smart-zone headline (reclaimed reasoning space, never cost), measured category totals, the ranked
 per-tool table with incomparable rows carrying reasons instead of numbers, lever findings grouped
 by honesty category with citations and emitted config, route-outs, then degradations and caveats.
-Persist it to `<data-dir>/reports/<UTC-timestamp>-audit.md` — one file per run — and present it
+Persist it to `<data-dir>/reports/<UTC-timestamp>-audit.md`, one file per run, and present it
 to the operator. When `context-guard` is installed its zone vocabulary may frame the headline;
 otherwise use the payload's share of the measured window.
 
@@ -178,10 +178,10 @@ otherwise use the payload's share of the measured window.
   [`reference/engine.md`](reference/engine.md).
 - **A deferred tool is out of the context window but still in every request.** Do not present the
   deferred bucket as already-saved weight.
-- **`System tools` deltas are valid only between runs with identical skill listings** — the engine
+- **`System tools` deltas are valid only between runs with identical skill listings.** The engine
   enforces this via the listing signature; relay its verdict rather than overriding it.
 - **Zero is a finding.** A lever that measures zero here is reported as measuring zero here, at
-  this version — not as broken, and not silently dropped.
+  this version, not as broken, and not silently dropped.
 
 ## Gotchas
 
@@ -189,29 +189,29 @@ Observed failures, each of which produced a confidently wrong number before the 
 
 - **Removing skills makes `System tools` rise.** Listed skill-frontmatter tokens are subtracted
   from that bucket, so a run that changes the skill listing shifts `System tools` with no tool
-  changing state — this once misread a safe-mode run as "safe mode loads deferred tools". The
+  changing state. This once misread a safe-mode run as "safe mode loads deferred tools". The
   signature check exists because of it; never hand-compare two snapshots the engine marked
   incomparable.
 - **Unredirected stdin prepends a warning line** to headless output, which breaks naive parsing.
   The engine redirects and strips; if you capture `/context` by hand for `parse-context`, redirect
   stdin or expect the leading line.
-- **Two CLI installs on one machine answer differently** — category lists differ across versions.
+- **Two CLI installs on one machine answer differently.** Category lists differ across versions.
   The stamp is the guard; when the operator's interactive `claude` is not the binary on PATH, ask
   which to pin with `--binary`.
 - **The measured machine's numbers are not this repo's research numbers.** Never quote a figure
-  from any document — including this plugin's own development history — as if it were the
+  from any document, including this plugin's own development history, as if it were the
   consumer's; the drift is the whole reason the engine exists.
 
 ## Report-only by default; the fix path is an explicit override
 
-Bare invocation is the audit — it changes no configuration. When a measured result suggests a
-trim, print the exact config the operator would apply (for persistent denies: a
-`permissions.deny` entry — there is no `disallowedTools` settings key) and let them apply it,
-with the ledger loop verifying the result.
+Bare invocation is the audit. It changes no configuration. When a measured result suggests a
+trim, print the exact config the operator would apply and let them apply it, with the ledger
+loop verifying the result. For persistent denies, print a `permissions.deny` entry. There is
+no `disallowedTools` settings key.
 
 ### Fix path (`fix` in the arguments only)
 
-The guided walkthrough runs only when the operator explicitly asked for `fix` — the verb
+The guided walkthrough runs only when the operator explicitly asked for `fix`, the verb
 contract's mutation override. Per lever, in the report's ranked order, offer only
 `recommendable-on-fit` catalogue rows whose conditions this audit resolved by measurement;
 everything else stays report material even here.
@@ -221,14 +221,14 @@ Write posture splits by scope, and the split is not negotiable:
 - **Project scope** (`.claude/settings.json`, `.claude/settings.local.json`): may be edited, one
   lever at a time, after the operator approves the exact diff shown in advance. The plugin's
   PreToolUse checkpoint returns `permissionDecision: "ask"` for any settings-surface write, so
-  even in auto mode the write prompts rather than sliding through — **a checkpoint, not a
+  even in auto mode the write prompts rather than sliding through. **A checkpoint, not a
   guarantee**: a `PermissionRequest` hook can still allow it and `disableAllHooks` removes
   non-managed hooks. Measured at v2.1.232 in headless mode, the `ask` fires and blocks even
   under `bypassPermissions` (surfacing as a tool error carrying the reason); interactive
   `bypassPermissions` behavior is unmeasured. Say so when describing the protection.
 - **User-global** (`~/.claude/settings.json`): **never written by this skill.** Print the exact
   edit, fully resolved and paste-ready; applying it is the operator's. "Protected path" is not a
-  human-confirmation guarantee — in auto mode a write there routes to the classifier, which can
+  human-confirmation guarantee. In auto mode a write there routes to the classifier, which can
   approve with no human involved. Print-only is the posture precisely because the prompt cannot
   be relied on.
 - **Managed policy**: read-only by construction; never targeted, never suggested as a write.
@@ -238,4 +238,4 @@ Write posture splits by scope, and the split is not negotiable:
 The loop per applied lever: approve → apply (project scope) or print (everywhere else) →
 re-measure → `compare --lever "<lever>" --emitted-config "<exact text>"` → `ledger --append` →
 report the measured delta, zero included. Never apply a second lever before the first one's
-delta is measured — un-attributed multi-lever jumps are how false folklore starts.
+delta is measured. Un-attributed multi-lever jumps are how false folklore starts.

--- a/plugins/context-budget/skills/setup/SKILL.md
+++ b/plugins/context-budget/skills/setup/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: "Verify context-budget's external prerequisites on this machine — `node`, which both the always-on settings-write checkpoint hook and the measurement engine depend on; the Claude Code CLI the engine measures against; and the optional Agent SDK that enables exact mode — and report the effective settings-write-ask toggle. Use when: 'set up context-budget', 'configure context-budget', 'is context-budget working', 'why did the settings-write ask not prompt', 'why is the audit not exact', or an audit run reported a missing prerequisite. Actions: check (read-only verification, default) | apply (point at each remediation; installs nothing). Re-runnable and safe."
+description: "Verify context-budget's external prerequisites on this machine: `node`, which both the always-on settings-write checkpoint hook and the measurement engine depend on; the Claude Code CLI the engine measures against; and the optional Agent SDK that enables exact mode. Then report the effective settings-write-ask toggle. Use when: 'set up context-budget', 'configure context-budget', 'is context-budget working', 'why did the settings-write ask not prompt', 'why is the audit not exact', or an audit run reported a missing prerequisite. Actions: check (read-only verification, default) | apply (point at each remediation; installs nothing). Re-runnable and safe."
 argument-hint: "check | apply"
 user-invocable: true
 disable-model-invocation: true
@@ -9,16 +9,16 @@ disable-model-invocation: true
 
 Thin check-centric setup per the uniform setup contract (`docs/PLUGIN-PHILOSOPHY.md`
 "Setup is explicit and repeatable" in the marketplace repository): `check` inspects and reports,
-`apply` points at what it found. The warrant is criterion (b), external prerequisites — `node`,
+`apply` points at what it found. The warrant is criterion (b), external prerequisites: `node`,
 the Claude Code CLI
 the engine pins and measures against, and the optional `@anthropic-ai/claude-agent-sdk` that
-enables exact mode — none of which a native configuration prompt can see, and each of which setup
+enables exact mode, none of which a native configuration prompt can see, and each of which setup
 can only verify. The `settings_write_ask_enabled` option is a native `userConfig` toggle whose only
 stored home is the `pluginConfigs` this contract forbids setup to write, so this
 setup is check-only: `apply` installs nothing, writes nothing, and is idempotent by construction.
 
 Action routing: no argument or `check` runs the check; `apply` runs the check first, then points at
-each remediation. Both are non-interactive — never prompt when the action is given.
+each remediation. Both are non-interactive. Never prompt when the action is given.
 
 ## `check` (read-only)
 
@@ -26,35 +26,35 @@ The audit skill and its engine are the single source of truth for what this plug
 [`${CLAUDE_PLUGIN_ROOT}/skills/audit/SKILL.md`](../audit/SKILL.md) § Prerequisites and the header of
 `${CLAUDE_PLUGIN_ROOT}/skills/audit/scripts/measure.mjs`.
 
-**Read it first** — probe what it actually does, don't recite this file. Then run each probe via
+**Read it first**. Probe what it actually does, don't recite this file. Then run each probe via
 Bash and report a PASS/FAIL/INFO table with one remediation line per FAIL. Do not modify anything.
 
 Install nothing.
 
-1. **`node` on `PATH`** — `command -v node`, and report the resolved path and version. This is the
+1. **`node` on `PATH`**. `command -v node`, and report the resolved path and version. This is the
    plugin's one hard prerequisite, and it carries *two* dependents. Report both:
    - The measurement engine is a Node script, so without `node` `/context-budget:audit` cannot
      produce a number and correctly stops rather than estimating.
    - The PreToolUse checkpoint in `${CLAUDE_PLUGIN_ROOT}/hooks/hooks.json` registers in **exec
-     form** — `"command": "node"` with the script in `args` — so Claude Code resolves the bare name
+     form**, `"command": "node"` with the script in `args`, so Claude Code resolves the bare name
      `node` on `PATH` in the hook's own environment. A hook that fails to launch is non-blocking,
      so an unresolvable `node` means the checkpoint produces no `ask` and says nothing about it.
      That silent gap is exactly what a native configuration prompt cannot tell you: the option can
      read `true` while the hook it gates never runs.
 
-   FAIL when absent. The checkpoint is a checkpoint either way, never a guarantee — a
+   FAIL when absent. The checkpoint is a checkpoint either way, never a guarantee. A
    `PermissionRequest` hook can allow the call and `disableAllHooks` removes non-managed hooks.
-2. **The Claude Code CLI** — `command -v claude` and its `--version`. The engine measures a pinned
+2. **The Claude Code CLI**. `command -v claude` and its `--version`. The engine measures a pinned
    binary. PASS when one resolves; report the absolute path and version, because that stamp is what
-   makes a report a claim. INFO when two installs are present — the audit asks which to pin. FAIL
+   makes a report a claim. INFO when two installs are present. The audit asks which to pin. FAIL
    when none resolves *and* the operator has no `--binary` path to name, since the engine then has
    nothing to measure.
-3. **`@anthropic-ai/claude-agent-sdk`** (optional) — probe whether it resolves under
+3. **`@anthropic-ai/claude-agent-sdk`** (optional). Probe whether it resolves under
    `${CLAUDE_PLUGIN_DATA}/sdk`. Present: INFO, exact mode is available. Absent: INFO, not a
-   defect — the engine degrades to parsing headless `/context` output (display-rounded, resting on
+   defect. The engine degrades to parsing headless `/context` output (display-rounded, resting on
    an undocumented surface, and the record carries both caveats), and to a structured error rather
    than a wrong number when neither mode works.
-4. **Settings-write-ask toggle** — report the effective `${user_config.settings_write_ask_enabled}`
+4. **Settings-write-ask toggle**. Report the effective `${user_config.settings_write_ask_enabled}`
    (an unexpanded token or an empty value means the manifest default `true`). INFO. The rendered
    value is injected when this skill loads, so a change made now is observed only in a **fresh
    session**; say so rather than re-reading it mid-session. When it reads `false`, note that the
@@ -65,14 +65,14 @@ Install nothing.
 
 Run `check`, then point at each resolution. Every prerequisite here is a system tool or an operator
 install, and the one option lives in Claude Code's native configuration surface, so `apply` writes
-nothing and installs nothing — re-running it after everything passes changes nothing and reports
+nothing and installs nothing. Re-running it after everything passes changes nothing and reports
 "already configured":
 
 - **Missing `node`:** the platform's own install channel (<https://nodejs.org/en/download>). This
   plugin never downloads a runtime. On Windows, confirm the hook's environment resolves the same
   `node` this check did.
 - **Missing CLI:** install the Claude Code CLI, or run the audit with an explicit `--binary` path.
-- **Exact mode wanted:** print this one-time install, marked as the operator's — it needs network
+- **Exact mode wanted:** print this one-time install, marked as the operator's. It needs network
   access, so this skill offers it and never runs it:
 
   ```shell
@@ -80,24 +80,24 @@ nothing and installs nothing — re-running it after everything passes changes n
   ```
 
 - **Toggle off (or on):** direct to `/plugin configure context-budget@<marketplace>` (interactive,
-  any time). Headless: rerun the install with the new value —
+  any time). Headless: rerun the install with the new value:
   `claude plugin install context-budget@<marketplace> -s <scope> --config settings_write_ask_enabled=true`
   (repeatable per key). Against an already-installed plugin it
-  prints `already installed` **and still writes the value** — verified on Claude Code 2.1.240 (a
+  prints `already installed` **and still writes the value**, verified on Claude Code 2.1.240 (a
   non-sensitive option at `user` scope: a non-default value written to an installed plugin, then
   restored). The short-circuit is about the install, not the config write. Re-verify before relying
-  on it outside those conditions — a `sensitive` option, or `project`/`local` scope, were not
+  on it outside those conditions. A `sensitive` option, or `project`/`local` scope, were not
   covered. Do **not** uninstall to reconfigure: uninstalling drops this plugin's entire stored
   `pluginConfigs` entry, resetting every option in the README's Options reference table to its
   manifest default. `-s` defaults to `user`, so pass the scope `claude plugin list` reports for this
   plugin, and run from that project's directory for a `project`/`local` scope, or the write lands at
   a scope that does not load. This skill never writes user settings or `pluginConfigs`. Afterwards
-  rerun `check` **in a fresh session** — the rendered token is injected at skill load — and report
+  rerun `check` **in a fresh session**. The rendered token is injected at skill load. Report
   the observed effective value; never claim an unobserved change.
 
 ## What this skill does NOT do
 
-- Run a measurement, attribution, or ledger operation — that is `/context-budget:audit`.
-- Install `node`, the CLI, or the Agent SDK, during either `check` or `apply` — guidance only.
+- Run a measurement, attribution, or ledger operation. That is `/context-budget:audit`.
+- Install `node`, the CLI, or the Agent SDK, during either `check` or `apply`. Guidance only.
 - Write the plugin cache, Claude Code user settings, or `pluginConfigs`. Nor any other Claude Code
   settings surface.


### PR DESCRIPTION
No linked issue

## Summary

#2891 instruction-surface de-slop cluster: purge em dashes from the `context-budget` plugin README and every SKILL.md.

## Fix

Rewrote `plugins/context-budget/README.md` and every `plugins/context-budget/**/SKILL.md` under `/ai-slop:audit fix` semantics (periods, commas, or a restructured sentence; never parentheses, en dashes, or a spaced hyphen as a stand-in). Meaning-preserving grammar pass after the mechanical replace. Version-only bump in `plugin.json`. New changelog heading only. The generated options block is ignore-fenced because `scripts/sync-plugin-options-docs.py` still emits em dashes from its shared template.

## Verification

- Detector (`HOME` + `CLAUDE_PROJECT_DIR` isolated so `rule-em-dash` is enabled): 0 `rule-em-dash` findings on rewritten instruction surfaces
- `CHECK_SKILL_SKIP_MARKDOWNLINT=1 bash scripts/check-changed-skills.sh origin/main`: 0 failed; quoted trigger phrases vs origin/main preserved
- `python3 scripts/sync-plugin-options-docs.py --check` up to date
- `scripts/check-changelog-parity.sh --check-bump origin/main` passes
- `node scripts/generate-cheatsheet.mjs --check` in sync

## Related

Refs #2891

#2891 stays open.