### PR TITLE
docs(adhd): de-slop instruction surfaces (0.4.2)

### DIFF
--- a/docs/SKILL-CHEAT-SHEET.md
+++ b/docs/SKILL-CHEAT-SHEET.md
@@ -142,7 +142,7 @@ owned by [docs/CATALOG-TAXONOMY.md](CATALOG-TAXONOMY.md).
 | Skill | Plugin | What it does |
 | --- | --- | --- |
 | [`/adhd:clarify`](../plugins/adhd/skills/clarify/SKILL.md) | `adhd` | Reshape a dense, decision-heavy message into clear one-decision-at-a-time chunks, losing nothing |
-| [`/adhd:shape`](../plugins/adhd/skills/shape/SKILL.md) | `adhd` | Set a standing action-first output posture — lead with the next action, cut preamble |
+| [`/adhd:shape`](../plugins/adhd/skills/shape/SKILL.md) | `adhd` | Set a standing action-first output posture. Lead with the next action, cut preamble |
 | [`/ai-slop:audit`](../plugins/ai-slop/skills/audit/SKILL.md) | `ai-slop` | Detect and remove AI-writing tells from markdown prose |
 | [`/claude-config:audit`](../plugins/claude-config/skills/audit/SKILL.md) | `claude-config` | Audit settings, hooks, permissions, and MCP config for drift against current official docs |
 | [`/claude-config:audit-automation-gaps`](../plugins/claude-config/skills/audit-automation-gaps/SKILL.md) | `claude-config` | Audit the repo's automation landscape for hook, MCP, skill, and subagent gaps worth adding |

--- a/plugins/adhd/.claude-plugin/plugin.json
+++ b/plugins/adhd/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "adhd",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Shape and restructure the assistant's output for a reader with ADHD — action-first, low-friction, and digestible. adhd:shape is a standing session posture: lead with the concrete next action, number multi-step work, restate state across turns, cap and rank lists, give concrete time estimates, make wins visible, and cut preamble, recap, and closers. adhd:clarify is a one-shot reshape of a dense, decision-heavy artifact already on screen — chunk it one-decision-at-a-time, define the session's own jargon, and surface exactly what you must decide, faithfully (operative terms quoted verbatim, no altitude loss), rendered as an HTML decision table for big content. Reauthored in part from ayghri/i-have-adhd (MIT). Deliberately mutually exclusive with terse-for-tokens output shapers like caveman — opposite objectives.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/adhd/CHANGELOG.md
+++ b/plugins/adhd/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to the `adhd` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.4.2]
+
+### Changed
+
+- **Instruction-surface de-slop (#2891, adhd cluster).** Rewrote this plugin's `README.md` and every
+  `SKILL.md` to drop em dashes under the repo's zero-tolerance house policy, using
+  `/ai-slop:audit fix` semantics: periods or commas, or a restructured sentence, never
+  parentheses, en dashes, or a spaced hyphen as a stand-in. Meaning stays; only the mark
+  and the sentence break change. The generated options block is ignore-fenced because
+  `scripts/sync-plugin-options-docs.py` still emits em dashes from its shared template.
+
 ## [0.4.1]
 
 ### Changed

--- a/plugins/adhd/README.md
+++ b/plugins/adhd/README.md
@@ -1,18 +1,18 @@
 # adhd
 
 A Claude Code plugin that shapes and restructures the assistant's output for a
-reader with ADHD — and anyone who wants action-first, low-friction, digestible
+reader with ADHD, and anyone who wants action-first, low-friction, digestible
 responses. Two skills, one concern: arrange output so an ADHD brain can act on
 it. `shape` sets a standing house style; `clarify` rescues one specific artifact.
 
 | Skill | What it does |
 |---|---|
 | `/adhd:shape` | Shape responses to lead with the next action, number multi-step work, restate state, cap and rank lists, estimate time concretely, make wins visible, and cut preamble, recap, and closers |
-| `/adhd:clarify` | Faithfully restructure a dense, decision-heavy message already on screen — chunk it one-decision-at-a-time, define the session's jargon, and surface what you must decide; renders an HTML decision table for big content |
+| `/adhd:clarify` | Faithfully restructure a dense, decision-heavy message already on screen. Chunk it one-decision-at-a-time, define the session's jargon, and surface what you must decide; renders an HTML decision table for big content |
 
 ## What it does
 
-### `/adhd:shape` — set the house style
+### `/adhd:shape`, set the house style
 
 The skill re-anchors ten output rules grounded in five facts about how an ADHD
 brain reads: working memory is small, knowing is not doing, starting is the
@@ -27,19 +27,19 @@ full-length, a destructive action gets a confirmation first (safety over
 brevity), a debug spiral pauses to name the wrong assumption, and a genuinely
 ambiguous request earns one clarifying question.
 
-### `/adhd:clarify` — rescue one dense artifact
+### `/adhd:clarify`, rescue one dense artifact
 
 Where `shape` governs how the assistant writes going forward, `clarify` acts once
 on something already on screen: a wall-of-text interview round, a jargon-thick
 design memo, a recommendation you have to re-read three times. It restructures
-that exact artifact — one decision per chunk, a glossary of the session's own
-shorthand, and the actual choices pulled to the surface — **faithfully**. The
+that exact artifact. One decision per chunk, a glossary of the session's own
+shorthand, and the actual choices pulled to the surface, **faithfully**. The
 move is restructure, never simplify: precision and reading level stay fixed;
 only the arrangement changes (lowering the altitude is `education:explain`'s job,
 a deliberately disjoint concern). Four hard fidelity rules keep a clarification of
 a decision document from corrupting the decisions: operative terms quoted verbatim,
 original item numbers kept as back-links, omissions named explicitly, and a
-closing line that the clarification is a lens — final answers are validated against the
+closing line that the clarification is a lens. Final answers are validated against the
 original text. For big or decision-dense content it renders an HTML decision
 table (item, recommendation, alternative, and what you're deciding, with rows
 numbered so a terminal answer maps back), honoring the Artifact tool contract and
@@ -48,13 +48,13 @@ Artifact surface is unavailable.
 
 ## Triggering: on-demand, session-standing once invoked
 
-The skill is on-demand by design — it does **not** auto-fire on every message.
+The skill is on-demand by design. It does **not** auto-fire on every message.
 It surfaces when you ask for it in plain language ("ADHD-friendly",
 "action-first", "give me the structured version", "cut the preamble") or when
 you invoke `/adhd:shape` directly.
 
 Once invoked, `shape`'s rules persist as a **standing instruction for the rest of
-the session** — invoke it once at the start of a session and every following
+the session**. Invoke it once at the start of a session and every following
 response is shaped, no need to repeat it. Invoke it whenever you want that
 output shape; skip it when you don't. Turn it off mid-session with **"stop
 shaping"** or **"normal output"**.
@@ -69,7 +69,7 @@ a plain-language cue ("make this clear", "clarify this", "help me digest this",
 acts on one artifact, and changes nothing about how later responses are written.
 Its triggers are kept disjoint from `education:explain`'s comprehension cues ("I
 don't get it", "ELI5", "explain simply") so the two auto-firing skills route on
-intent — restructure faithfully vs drop the altitude — rather than colliding on
+intent, restructure faithfully vs drop the altitude, rather than colliding on
 their shared "previous response" default target.
 
 ### Deferred: deterministic zero-invocation always-on
@@ -80,11 +80,11 @@ deliberate non-goal for this version, recorded here so it is not re-litigated:
 - **Why it is not a `userConfig` switch.** A `userConfig` boolean substitutes
   only into an already-invoked skill's *body*; it cannot flip frontmatter or
   cause a skill to auto-invoke. So no config toggle can, by itself, turn on
-  always-on — a switch that cannot act would be a dead knob.
+  always-on. A switch that cannot act would be a dead knob.
 - **The only mechanism that delivers it is a hook.** Deterministic
   every-session arming needs a `SessionStart` (or `UserPromptSubmit`) hook that
   injects the rules as additional context. That is a code-execution trust
-  surface, adopted only on demonstrated need — and the session-standing
+  surface, adopted only on demonstrated need, and the session-standing
   behavior above already covers the common case (invoke once, shaped for the
   rest of the session).
 - **Trigger to build it.** Demonstrated demand for zero-invocation auto-arm.
@@ -95,7 +95,7 @@ deliberate non-goal for this version, recorded here so it is not re-litigated:
 
 Do **not** run this alongside a token-minimizing output shaper such as
 [caveman](https://github.com/JuliusBrussee/caveman) at the same time. They pull
-in opposite directions on the same axis — the shape of the assistant's output:
+in opposite directions on the same axis, the shape of the assistant's output:
 
 | | `adhd:shape` | caveman |
 |---|---|---|
@@ -104,7 +104,7 @@ in opposite directions on the same axis — the shape of the assistant's output:
 
 Two output-shape disciplines active at once produce a contradictory,
 unpredictable mix. Pick one for a given session. (There is no runtime coupling
-between the plugins to enforce this — it is a usage guideline.)
+between the plugins to enforce this. It is a usage guideline.)
 
 ## Install
 
@@ -115,13 +115,13 @@ between the plugins to enforce this — it is a usage guideline.)
 
 ## Configuration
 
-None. The plugin is zero-config and zero-prerequisite — no `userConfig`, no
+None. The plugin is zero-config and zero-prerequisite. No `userConfig`, no
 setup skill, no external tools. Enable it and invoke `/adhd:shape` or
 `/adhd:clarify`.
 
 ## Attribution
 
-`/adhd:shape` is reauthored — not forked — from
+`/adhd:shape` is reauthored, not forked, from
 [ayghri/i-have-adhd](https://github.com/ayghri/i-have-adhd) (MIT): the ten
 rules' substance is preserved, the wrapper is adapted to this marketplace's
 discovery discipline (no auto-fire-on-any-message), and the prose is

--- a/plugins/adhd/skills/clarify/SKILL.md
+++ b/plugins/adhd/skills/clarify/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: "Faithfully clarify a dense, decision-heavy message so you can act on it — chunk it into one-decision-at-a-time, define the session's own jargon, and surface exactly what you must decide, with operative terms quoted verbatim and no loss of precision. Decision-dense content gets an HTML decision table with numbered rows. Use when: 'make this clear', 'clarify this', 'help me digest this', 'break this down', 'I can't parse this', 'what am I actually deciding here', 'this is a wall of text'. Empty argument targets the previous assistant response. This changes STRUCTURE, not altitude — a lossy plain-language / ELI5 drop is education:explain (if installed) instead. Sibling to adhd:shape, a standing session-wide posture; this is a one-shot reshape of one artifact."
+description: "Faithfully clarify a dense, decision-heavy message so you can act on it. Chunk it into one-decision-at-a-time, define the session's own jargon, and surface exactly what you must decide, with operative terms quoted verbatim and no loss of precision. Decision-dense content gets an HTML decision table with numbered rows. Use when: 'make this clear', 'clarify this', 'help me digest this', 'break this down', 'I can't parse this', 'what am I actually deciding here', 'this is a wall of text'. Empty argument targets the previous assistant response. This changes STRUCTURE, not altitude. A lossy plain-language / ELI5 drop is education:explain (if installed) instead. Sibling to adhd:shape, a standing session-wide posture; this is a one-shot reshape of one artifact."
 argument-hint: "[artifact to clarify] (empty = the previous assistant response)"
 user-invocable: true
 disable-model-invocation: false
@@ -10,40 +10,40 @@ metadata:
 
 # Clarify a dense artifact into something you can act on
 
-You were just handed a wall of text — an interview round with seven
+You were just handed a wall of text, an interview round with seven
 cross-referenced questions, a design memo thick with session jargon. This skill
 takes **that exact artifact** and makes it clear enough to act on: one decision
 at a time, jargon defined, and the actual choices pulled to the surface.
 
 The move is **clarify by restructuring, never by simplifying**. The content stays
 at full precision and full reading level; only its *arrangement* changes. Lowering
-the altitude — plain words, an analogy, ELI5 — is a different job (see
-[Boundaries](#boundaries)). A clarification that loses or softens a decision is
+the altitude is a different job (see
+[Boundaries](#boundaries)). That means plain words, an analogy, ELI5. A clarification that loses or softens a decision is
 worse than the wall of text, so the fidelity rules below are hard, not aspirational.
 
 ## The core move
 
 1. **Identify the target.** With an argument, that is the thing. Empty
    argument → the **previous assistant response** (see [Empty
-   argument](#empty-argument--anaphora-default)).
-2. **Ground it, don't recall it.** Re-read the actual artifact this turn — the
+   argument](#empty-argument-anaphora-default)).
+2. **Ground it, don't recall it.** Re-read the actual artifact this turn, the
    message just sent, in full. Working from your memory of it instead of its text
    is how operative terms drift.
-3. **Restructure faithfully** — chunk, define jargon, surface decisions
+3. **Restructure faithfully**. Chunk, define jargon, surface decisions
    (below), under the fidelity rules.
-4. **Choose the medium** — artifact, local file, or terminal — per
+4. **Choose the medium**. Artifact, local file, or terminal, per
    [Rendering](#rendering-artifact-forward).
 
-## Empty argument — anaphora default
+## Empty argument, anaphora default
 
-With no argument, the target is the **assistant's own previous response** — the
+With no argument, the target is the **assistant's own previous response**, the
 thing the reader is reacting to. "Make this clear" needs no topic named:
 re-read that prior message and clarify it. When there is **no prior assistant
-message** — a cold start where the reader opens with "make this clear" and
-nothing has been said — do not invent a target: ask what to clarify.
+message**, a cold start where the reader opens with "make this clear" and
+nothing has been said, do not invent a target: ask what to clarify.
 
 **Trivial-target escape hatch.** When the resolved target holds fewer than ~2
-decisions — a short answer, a status line, anything with nothing to untangle —
+decisions, a short answer, a status line, anything with nothing to untangle,
 do **not** run the full table/glossary apparatus on it. Say in one line that
 the target has nothing dense to clarify, and ask what the reader actually
 wanted clarified. A three-line response restructured into a one-row decision
@@ -52,7 +52,7 @@ table is ceremony, not clarity.
 **Conflicting-shaper note.** If a terse-for-tokens output shaper (e.g. caveman
 hooks) is active in the session context, say so before rendering: this skill's
 faithful, structure-adding output directly contradicts a strip-words directive,
-and the two cannot both govern the same response. Advisory only — name the
+and the two cannot both govern the same response. Advisory only. Name the
 source and let the user pick.
 
 ## Fidelity rules (hard)
@@ -62,25 +62,26 @@ four rules are non-negotiable, because a restructure that corrupts a decision
 defeats the purpose:
 
 1. **Quote operative terms verbatim.** The load-bearing words of every
-   recommendation — the chosen option, the number, the named file, the
-   condition, the verb that decides — are **copied, never paraphrased**. Restate
+   recommendation, the chosen option, the number, the named file, the
+   condition, the verb that decides, are **copied, never paraphrased**. Restate
    surrounding framing in your own words if it helps; never the terms the reader
    will act on. "Go with option B, patch bump, gated behind `--force`" survives
    into the clarified version character-for-character.
 2. **Keep the original numbers as back-links.** Every chunk carries the
    original item's own identifier (Q9, Round 4 · P15b, §3) so the reader can jump
    back to the source. This is separate from any numbering this skill adds for
-   itself (see [Rendering](#rendering-artifact-forward)) — never collapse the two.
+   itself (see [Rendering](#rendering-artifact-forward)). Never collapse the two.
    When the original carries **no identifiers** (a dense prose memo with no Q-numbers
    or section marks), synthesize a locator and say you did: a sequential marker
-   ("¶2", "Para 3") or the chunk's quoted opening phrase — never leave a chunk
+   ("¶2", "Para 3") or the chunk's quoted opening phrase. Never leave a chunk
    with no way back to its source passage.
 3. **List omissions explicitly.** Anything in the original you did not carry
-   forward — a caveat, a fifth option, a dependency — is named in a short "Left
-   out" note, not silently dropped. The reader decides whether an omission
+   forward is named in a short "Left
+   out" note, not silently dropped. That includes a caveat, a fifth option, a
+   dependency. The reader decides whether an omission
    mattered; you do not get to decide it for them by hiding it.
-4. **State that it is a lens.** Close with one line: this is a clarification —
-   validate final answers against the original text, not against this
+4. **State that it is a lens.** Close with one line: this is a clarification.
+   Validate final answers against the original text, not against this
    restructuring.
 
 ## Restructure moves
@@ -94,24 +95,24 @@ before the one that depends on it, and say so when it does.
 
 ### Define the session's own jargon
 
-A dense artifact leans on shorthand coined earlier in the session — "the lane,"
+A dense artifact leans on shorthand coined earlier in the session, such as "the lane,"
 "gate vacuity," "managed components," "P15b." Collect every such term and define
 it once, in plain words, in a short glossary the reader can see while reading the
 chunks (not one they must remember from earlier). Define the shorthand; do
-**not** simplify the concept it names — the definition is a pointer to the term,
+**not** simplify the concept it names. The definition is a pointer to the term,
 at the same altitude.
 
 ### Surface what must be decided
 
 For each chunk, make the actual choice unmissable: the recommendation (verbatim),
 the alternative it was chosen over (verbatim, if the original named one), and, in
-one sentence, **what the reader is actually deciding** — the crux, not a
+one sentence, **what the reader is actually deciding**, the crux, not a
 restatement of the option. If the original only recommends with no alternative,
 say so rather than inventing one.
 
 ## Rendering: artifact-forward
 
-Decision-dense content wants a table, not a paragraph — a table is the part a
+Decision-dense content wants a table, not a paragraph. A table is the part a
 plain reply cannot do well. Pick the medium by what the session can render and
 how heavy the content is:
 
@@ -121,18 +122,18 @@ how heavy the content is:
 | Big / decision-dense | No artifact surface (e.g. plain terminal), file writing useful | **Local HTML file** under plugin data / temp, hand back the path |
 | Small (1–2 decisions), or no useful file surface | either | **Structured terminal markdown** |
 
-The Artifact rendering surface is a claude.ai-hosted capability — present in some
+The Artifact rendering surface is a claude.ai-hosted capability, present in some
 sessions and absent in others. Detect it: if the Artifact tool is available, that
 is the top rung; otherwise degrade down the ladder. Never claim a decision table
 was rendered when only prose was produced.
 
-Write any local HTML file to the **ephemeral tier** — one file created through
-the platform's temp API — and hand back that path. A clarified view is
+Write any local HTML file to the **ephemeral tier**, one file created through
+the platform's temp API, and hand back that path. A clarified view is
 transient generated state, so it never lands in the consumer's repository tree.
 Do **not** delete the file before returning: the path is the delivery
 mechanism, so it must still be readable when the reader opens it. It outlives
 this invocation, and nothing documented reclaims the OS temp tree on a
-schedule — so write one file per run and never an accumulating tree. Resolve
+schedule, so write one file per run and never an accumulating tree. Resolve
 that one path deterministically: never
 branch on whether the harness injected a scratchpad path or set
 `CLAUDE_JOB_DIR`, and never depend on the session scratchpad, which is an
@@ -144,8 +145,8 @@ plugin's directory when the token travels through another skill's arguments).
 If no writable temp location nor the Artifact surface is available, drop to the
 terminal-markdown rung rather than writing into the repo.
 
-The fidelity rules hold in **every** medium — verbatim terms, original-number
-back-links, omissions, lens line — table or prose.
+The fidelity rules hold in **every** medium. Verbatim terms, original-number
+back-links, omissions, lens line, table or prose.
 
 ### The decision table
 
@@ -156,15 +157,15 @@ Whichever medium, the decision table has numbered rows and these columns:
 | 1 | Q9 | *(verbatim operative terms)* | *(verbatim, or "none offered")* | the crux in one sentence |
 | 2 | Q10 | *(verbatim)* | *(verbatim)* | … |
 
-- The **`#` column is the table's own row number** (this skill's) — its job is
+- The **`#` column is the table's own row number** (this skill's). Its job is
   answer-mapping, so the reader can reply "row 2: take the alternative" and you
   know exactly which original item that resolves.
-- The **`Item` column is the original identifier** (Q9, §3, Round 4 · P15b) — the
+- The **`Item` column is the original identifier** (Q9, §3, Round 4 · P15b), the
   back-link to the source. Two numbering systems, kept distinct.
 - **Recommendation and Alternative cells carry the verbatim operative terms.** A
   cell is where paraphrase and truncation creep in; resist both. If a
   recommendation is too long for a cell, quote its operative clause verbatim and
-  link the row to the fuller original by its `Item` number — never a lossy summary.
+  link the row to the fuller original by its `Item` number. Never a lossy summary.
 - **Escape copied text before it becomes HTML.** In the artifact and local-file
   media, treat every copied term as text content and HTML-escape it. Operative
   terms often contain code-like characters (`<dialog>`, `A && B`, `--force`); left
@@ -177,19 +178,19 @@ Whichever medium, the decision table has numbered rows and these columns:
 ### Honoring the Artifact contract
 
 When you publish an artifact, honor the Artifact tool contract. **Load the
-`artifact-design` skill for the design fundamentals when it is available** — it
+`artifact-design` skill for the design fundamentals when it is available**. It
 ships with the artifact surface, so it is normally present on the publish rung;
 if it is not, meet the contract's essentials directly rather than skipping them:
 a self-contained page (no external hosts), theme-aware, a title and one-line
-description, a favicon. Either way, the decision table is the page's spine — keep
-the treatment utilitarian, not a flashy hero — and this static table needs no
+description, a favicon. Either way, the decision table is the page's spine. Keep
+the treatment utilitarian, not a flashy hero, and this static table needs no
 runtime capabilities. In the terminal, give a one-line summary and the artifact
 link (or the local file path); don't reprint the whole table twice.
 
 ## Boundaries
 
-**vs `education:explain` — structure, not altitude.** `explain` drops the
-*altitude*: plain words, a concrete analogy, ELI5 — it trades precision for
+**vs `education:explain`, structure, not altitude.** `explain` drops the
+*altitude*: plain words, a concrete analogy, ELI5. It trades precision for
 accessibility, and it climbs back up only on request. This skill holds altitude
 **fixed** and changes *arrangement*: same precision, same reading level, made
 clear by reorganizing. The routing rule: "I don't get it / explain simply / what
@@ -199,15 +200,15 @@ genuinely needs the concept made simpler, hand off by invoking `/education:expla
 `education` plugin is installed); otherwise a faithful restructure is this skill's
 job.
 
-**vs `adhd:shape` — one-shot, not standing.** `shape` is a **standing** posture:
+**vs `adhd:shape`, one-shot, not standing.** `shape` is a **standing** posture:
 invoke it once and every response for the rest of the session is shaped. This is
-a **one-shot** reshape of **one** artifact already on screen — it does not change
+a **one-shot** reshape of **one** artifact already on screen. It does not change
 how future responses are written. Use `shape` to set the house style; use this to
 rescue a specific wall of text. Two interaction rules when both are active:
 the decision table is **exempt from shape's five-item list cap** (fidelity
 forbids dropping decisions, and fidelity wins over shaping); and when the
 target is shape-formatted output, judge by the target's **actual decision
-density, never its provenance** — an already action-shaped, low-density
+density, never its provenance**. An already action-shaped, low-density
 response has nothing left to restructure (take the trivial-target escape
 hatch), but a dense multi-decision artifact still gets the full faithful
 restructure even though shape produced it (shape's explain override emits

--- a/plugins/adhd/skills/shape/SKILL.md
+++ b/plugins/adhd/skills/shape/SKILL.md
@@ -1,35 +1,35 @@
 ---
-description: "Shape the assistant's output for a reader with ADHD — and anyone who wants action-first, low-friction responses. Lead with the concrete next action, number multi-step work, restate state across turns, cap and rank lists, give concrete time estimates, make wins visible, and cut preamble, recap, and closers. Use when: 'ADHD-friendly', 'action-first', 'give me the structured version', 'lead with what to do', 'cut the preamble', or when the user invokes it to set that output shape for the session. Once invoked, applies to every response for the rest of the session. This is a STANDING posture over future responses; to reshape one dense message already on screen (chunk it one-decision-at-a-time, define its jargon, surface the decisions) without changing the session style, that is the one-shot sibling adhd:clarify. Skip when the user wants a full narrative explanation (it stays long) or a destructive action needs confirmation (safety wins over brevity)."
+description: "Shape the assistant's output for a reader with ADHD, and anyone who wants action-first, low-friction responses. Lead with the concrete next action, number multi-step work, restate state across turns, cap and rank lists, give concrete time estimates, make wins visible, and cut preamble, recap, and closers. Use when: 'ADHD-friendly', 'action-first', 'give me the structured version', 'lead with what to do', 'cut the preamble', or when the user invokes it to set that output shape for the session. Once invoked, applies to every response for the rest of the session. This is a STANDING posture over future responses; to reshape one dense message already on screen (chunk it one-decision-at-a-time, define its jargon, surface the decisions) without changing the session style, that is the one-shot sibling adhd:clarify. Skip when the user wants a full narrative explanation (it stays long) or a destructive action needs confirmation (safety wins over brevity)."
 user-invocable: true
 disable-model-invocation: false
 metadata:
   workflow-stage: anytime
-  summary: Set a standing action-first output posture — lead with the next action, cut preamble
+  summary: Set a standing action-first output posture. Lead with the next action, cut preamble
 ---
 
 # Shape output for an ADHD reader
 
 Once invoked, this is a standing instruction: shape **every** response for the
 rest of this session in the form below, not just the next one. The reader has
-ADHD. The output is not merely short — it is arranged so an ADHD brain can act
+ADHD. The output is not merely short. It is arranged so an ADHD brain can act
 on it.
 
 ## Before applying: conflicting-shaper check
 
-Scan the session context for another active output-shaping discipline —
+Scan the session context for another active output-shaping discipline:
 hook-injected instructions from a terse-for-tokens shaper (e.g. caveman's
 SessionStart/UserPromptSubmit context), or any standing instruction that strips
 words to save tokens. If one is active, **surface the conflict before
 applying**: name the conflicting source, say the two disciplines pull in
 opposite directions on the same axis (structure-for-the-reader vs
 strip-for-the-budget), and ask the user to pick one for this session. Do not
-silently apply both — the mix is contradictory and unpredictable. This is an
+silently apply both. The mix is contradictory and unpredictable. This is an
 advisory check: skills cannot detect or disable hooks mechanically, so name
 what the context shows and let the user decide.
 
 ## Turning it off
 
-The posture ends when the user says so — "stop shaping" or "normal output"
+The posture ends when the user says so. "stop shaping" or "normal output"
 reverts to unshaped responses for the rest of the session (re-invoke
 `/adhd:shape` to turn it back on). Treat close variants ("drop the ADHD
 format") the same way.
@@ -51,7 +51,7 @@ format") the same way.
 
 ### 1. Lead with the next action
 
-The first line is a thing the reader can do — not context, not a plan, the
+The first line is a thing the reader can do. Not context, not a plan, the
 action. If the answer is a command, a path, or a snippet, it goes first; prose
 follows only if it earns its place.
 
@@ -77,7 +77,7 @@ item hides a second "and then."
 If anything stays open, name exactly **one** thing the reader can do in under
 two minutes. "Open the file" counts.
 
-- Weak: "Hope that helps — let me know if you want to dig deeper."
+- Weak: "Hope that helps. Let me know if you want to dig deeper."
 - Strong: "Next: run `npm test` and paste the first failing line."
 
 ### 4. Suppress tangents
@@ -87,18 +87,18 @@ own question.
 
 - Weak: "Here's the fix. By the way, your dependency is stale, and the README
   is out of date, and…"
-- Strong: "Here's the fix. Separately: a dependency is stale — want that next?"
+- Strong: "Here's the fix. Separately: a dependency is stale. Want that next?"
 
 ### 5. Restate state every turn
 
 The reader cannot carry "we're on step 3 of 5" between messages. Say it again.
 
 - Weak: "Done. Ready for the next part?"
-- Strong: "Step 3 of 5 done: schema updated. Next: backfill the new column —
-  run the script?"
+- Strong: "Step 3 of 5 done: schema updated. Next: backfill the new column.
+  Run the script?"
 
 The boundary against rule 10's "no recap": restating state is the
-**last-completed step plus the next step, once** — never a running list of
+**last-completed step plus the next step, once**, never a running list of
 everything done so far. "Step 3 of 5 done: X. Next: Y" passes; "I've now done
 X, Y, and Z" is the forbidden recap.
 
@@ -122,7 +122,7 @@ Show what works now, concretely. Do not bury the win in a recap.
 No "Uh oh," no "Oh no," no "There seems to be a problem." Name the cause and
 the fix.
 
-- Weak: "Uh oh, the test is failing — there seems to be an issue…"
+- Weak: "Uh oh, the test is failing. There seems to be an issue…"
 - Strong: "Test fails at `auth.spec.ts:42`: expected 200, got 401. Cause:
   missing auth header. Fix: add `Authorization: Bearer ${token}`."
 
@@ -131,7 +131,7 @@ the fix.
 Past five, split into "do now" vs "later," or "must" vs "nice to have." Five
 ranked items beat ten unranked.
 
-Exception: a `/adhd:clarify` decision table is **exempt** from this cap — its
+Exception: a `/adhd:clarify` decision table is **exempt** from this cap. Its
 fidelity rules forbid dropping or compressing any decision, and fidelity wins
 over shaping. A 7-decision table renders all 7 rows.
 
@@ -147,7 +147,7 @@ Start with the answer. Stop when the answer is done.
 
 ## When to override these defaults
 
-Drop the brevity rules — never the flat, preamble-free tone — when:
+Drop the brevity rules, never the flat, preamble-free tone, when:
 
 1. **The user asks to "explain" or "walk me through."** Explain in full; let the
    body run as long as the topic needs. Still no preamble, still no closer; add
@@ -180,7 +180,7 @@ Observed failures from a live audit of this skill (adhd@0.2.0, 2026-07-23):
 - **Applied silently alongside an active conflicting shaper.** With caveman's
   hooks injecting terse-for-tokens instructions, invoking this skill produced
   the exact "contradictory, unpredictable mix" the README warns about, with no
-  conflict flagged — the warning lived only in README/plugin.json, layers the
+  conflict flagged. The warning lived only in README/plugin.json, layers the
   model never reads at invocation time. The conflicting-shaper check above is
   the fix; it is advisory by necessity (no documented skill-to-hook detection
   mechanism exists).
@@ -189,7 +189,7 @@ Observed failures from a live audit of this skill (adhd@0.2.0, 2026-07-23):
   summarized/compacted, the rules can drop out of context. Re-invoke
   `/adhd:shape` after a compaction if responses stop being shaped.
 - **Rules 5 vs 10 read as contradictory without the boundary test.** "Restate
-  state every turn" vs "no recap" — the explicit test now lives in rule 5
+  state every turn" vs "no recap". The explicit test now lives in rule 5
   (last-completed step + next step only; never a running done-list).
 
 ## Attribution


### PR DESCRIPTION
No linked issue

## Summary

#2891 instruction-surface de-slop cluster: purge em dashes from the `adhd` plugin README and every SKILL.md.

## Fix

Rewrote `plugins/adhd/README.md` and every `plugins/adhd/**/SKILL.md` under `/ai-slop:audit fix` semantics (periods, commas, or a restructured sentence; never parentheses, en dashes, or a spaced hyphen as a stand-in). A self-audit repaired wrap leftovers, split asides, and heading-anchor leftovers the mechanical pass left as fragments. `adhd` 0.4.2. Changing `skills/shape/SKILL.md`'s `metadata.summary` required regenerating `docs/SKILL-CHEAT-SHEET.md` so the cheat-sheet `--check` gate stays green.

## Verification

- Detector: 0 `rule-em-dash` findings outside ignore-fenced generated-options spans (and required trigger strings that must keep em dashes)
- `CHECK_SKILL_SKIP_MARKDOWNLINT=1 bash scripts/check-changed-skills.sh origin/main`: 0 failed; quoted trigger phrases vs origin/main preserved
- `python3 scripts/sync-plugin-options-docs.py --check` up to date
- `scripts/check-changelog-parity.sh --check-bump origin/main` passes
- `node scripts/generate-cheatsheet.mjs --check` in sync after regenerating the one `adhd:shape` summary line

## Related

Refs #2891

#2891 stays open.