### PR TITLE
docs(machine-health): de-slop instruction surfaces (0.11.3)

### DIFF
--- a/plugins/machine-health/.claude-plugin/plugin.json
+++ b/plugins/machine-health/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "machine-health",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "description": "Workstation health audit: OS-specific checks (disk, OS updates, security posture, CISA KEV correlation) run from a versioned catalog with trend-aware severity, approval-gated remediations, and dated markdown reports. Windows fully implemented; macOS/Linux scaffolded (report UNKNOWN and stop). Machine state persists in the plugin data directory; the report directory and check catalog are configurable.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/machine-health/CHANGELOG.md
+++ b/plugins/machine-health/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to the `machine-health` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.11.3]
+
+### Changed
+
+- **Instruction-surface de-slop (#2891, machine-health cluster).** Rewrote this plugin's `README.md` and every
+  `SKILL.md` to drop em dashes under the repo's zero-tolerance house policy, using
+  `/ai-slop:audit fix` semantics: periods or commas, or a restructured sentence, never
+  parentheses, en dashes, or a spaced hyphen as a stand-in. Meaning stays; only the mark
+  and the sentence break change. The generated options block is ignore-fenced because
+  `scripts/sync-plugin-options-docs.py` still emits em dashes from its shared template.
+
 ## [0.11.2]
 
 ### Changed

--- a/plugins/machine-health/README.md
+++ b/plugins/machine-health/README.md
@@ -7,13 +7,13 @@ dated markdown report per run. Fail-safe posture throughout: surface issues over
 them, and every finding carries reproduction commands.
 
 Windows is fully implemented (18 checks, PowerShell 7.x). macOS and Linux are scaffolded as
-honest `NOT_IMPLEMENTED` stubs — on those hosts the skill reports UNKNOWN and stops rather than
+honest `NOT_IMPLEMENTED` stubs. On those hosts the skill reports UNKNOWN and stops rather than
 pretending coverage.
 
 | Skill | What it does |
 |---|---|
-| `/machine-health:audit` | Runs the audit — load catalog + machine overlay, dispatch checks under per-check timeouts, apply trend-aware severity, run approved remediations (non-dry runs), render the dated report, append history. |
-| `/machine-health:setup` | Configures this machine. `check` (read-only, default) reports the effective catalog overlay, remediation approvals, and pending proposals against the shipped catalog; `apply` writes the machine-local overlay (disable/deprecate/demote checks, register custom ones) and seeds remediation approvals — interactively, or non-interactively with `disable=`/`deprecate=`/`demote=`/`approve=` arguments. |
+| `/machine-health:audit` | Runs the audit. Load catalog + machine overlay, dispatch checks under per-check timeouts, apply trend-aware severity, run approved remediations (non-dry runs), render the dated report, append history. |
+| `/machine-health:setup` | Configures this machine. `check` (read-only, default) reports the effective catalog overlay, remediation approvals, and pending proposals against the shipped catalog; `apply` writes the machine-local overlay (disable/deprecate/demote checks, register custom ones) and seeds remediation approvals, interactively, or non-interactively with `disable=`/`deprecate=`/`demote=`/`approve=` arguments. |
 
 ## The audit
 
@@ -21,7 +21,7 @@ Each run dispatches the enabled catalog checks (90s per-check timeout, 15m total
 schema-validated JSON results, adjusts severity against the last 8 weeks of history, correlates
 related findings, and renders `reports/health-<UTC-timestamp>.md` with CRIT/WARN/INFO/OK/UNKNOWN
 sections, reproduction commands, and trend deltas. State is append-only (`history.jsonl`);
-elevation is never prompted for — admin-gated checks return UNKNOWN with a `needs_admin` marker.
+elevation is never prompted for. Admin-gated checks return UNKNOWN with a `needs_admin` marker.
 
 Remediations are deliberately narrow (restart a stopped Automatic service, clear aged temp files),
 default to **not approved**, and only run when explicitly approved in the machine's
@@ -56,32 +56,33 @@ run log. No telemetry, no other network calls, no `Invoke-Expression` on externa
 If you previously ran machine-health as an in-repo skill with reports, state, and logs under one
 output base (default `Documents\MachineHealth`):
 
-1. Reports can stay put — set the `report_dir` option to the same folder (or leave unset for the
+1. Reports can stay put. Set the `report_dir` option to the same folder (or leave unset for the
    default, which is that folder).
 2. Move machine state into the plugin data directory so trend history and approvals carry over:
    `<old output base>\state\` → `${CLAUDE_PLUGIN_DATA}\state\` (`history.jsonl`, `latest.json`,
    `approvals.json`). Old logs may stay behind or move to `${CLAUDE_PLUGIN_DATA}\logs\`.
 3. `${CLAUDE_PLUGIN_DATA}` resolves under `~/.claude/plugins/data/`, in a directory named for the
    plugin's install identity (`machine-health-<marketplace>`, or `machine-health-inline` for a
-   `--plugin-dir` session) — not `machine-health`. Run `/machine-health:setup check` to have the
+   `--plugin-dir` session), not `machine-health`. Run `/machine-health:setup check` to have the
    resolved path printed rather than guessing it; a state root guessed wrong splits the overlay from
    the state and logs.
 
 ## Configuration
 
-One plugin option: `report_dir` (directory) — where dated reports land; unset means
+One plugin option: `report_dir` (directory), where dated reports land; unset means
 `Documents\MachineHealth` under the user profile. Everything else is machine-local state managed
 by `/machine-health:setup`. No hooks, no MCP servers.
 
 ## Tests
 
-A Pester 5.7+ suite ships with the plugin (`skills/audit/tests/`). Windows-only — it
+A Pester 5.7+ suite ships with the plugin (`skills/audit/tests/`). Windows-only. It
 mocks Win32/MSFT CIM types that resolve only there:
 
 ```powershell
 pwsh -NoProfile -File plugins/machine-health/skills/audit/scripts/run-tests.ps1
 ```
 
+<!-- ai-slop-ignore-start: generated options block; source is plugin.json + scripts/sync-plugin-options-docs.py -->
 <!-- BEGIN GENERATED: plugin options — edit plugin.json, then run scripts/sync-plugin-options-docs.py -->
 
 ### Options reference
@@ -154,6 +155,7 @@ hands a configured value to a hook process; the value comes from the routes abov
 - [Manage installed plugins](https://code.claude.com/docs/en/discover-plugins#manage-installed-plugins) — enabling, disabling, `/plugin list`
 
 <!-- END GENERATED: plugin options -->
+<!-- ai-slop-ignore-end -->
 
 ## License
 

--- a/plugins/machine-health/skills/audit/SKILL.md
+++ b/plugins/machine-health/skills/audit/SKILL.md
@@ -7,7 +7,7 @@ disable-model-invocation: false
 
 ## Overview
 
-This skill performs a **weekly workstation health audit** with a fail-safe posture: surface issues over silently fixing them. Findings always include reproduction commands so the human can rerun the check outside the skill. Remediations are narrow, logged, and only attempted when the OS-specific `remediation-policy.md` authorizes them. Severity is always trend-aware — a single reading is rarely load-bearing; history is consulted before finalizing severity.
+This skill performs a **weekly workstation health audit** with a fail-safe posture: surface issues over silently fixing them. Findings always include reproduction commands so the human can rerun the check outside the skill. Remediations are narrow, logged, and only attempted when the OS-specific `remediation-policy.md` authorizes them. Severity is always trend-aware. A single reading is rarely load-bearing; history is consulted before finalizing severity.
 
 The skill is stateless about scheduling; a separate routine (e.g., a Monday 08:00 scheduled task, or an ad-hoc `/machine-health:audit` invocation) calls into it.
 
@@ -19,12 +19,12 @@ Two roots, resolved through the plugin's configuration seams:
 
 | Root | Holds | Resolution |
 |---|---|---|
-| **Report root** (`-OutputBase`) | `reports/` — the human-facing dated reports | `${user_config.report_dir}` when set to a non-empty path; if it is empty or still shows an unexpanded `${user_config.report_dir}` token (option unset), default to `$env:USERPROFILE\Documents\MachineHealth` |
-| **State root** (`-StateBase`) | `state/` (history, latest snapshot, approvals), `logs/`, catalog overlay, custom checks, `TODO.md` proposals | `${CLAUDE_PLUGIN_DATA}` — the per-plugin data directory that survives plugin updates — passed explicitly when the token expands. If it is unexpanded, do **not** fall through to the orchestrator's environment ladder: the harness sets `CLAUDE_PLUGIN_DATA` per plugin, and a subprocess inherits whichever plugin's value its parent process already carried, so a skill-invoked tool can inherit an unrelated installed plugin's value and write this plugin's `state/`, `logs/`, and catalog overlay into that plugin's directory. Pass `-StateBase <report-root>` explicitly instead — colocating state with the reports is wrong-but-visible, where the inherited variable is wrong-and-silent — and report that the plugin-specific root could not be resolved. Never substitute a literal path: the directory under `~/.claude/plugins/data/` is named for the plugin's install identity, not the plugin, so a guessed path names a different directory and splits state from the overlay |
+| **Report root** (`-OutputBase`) | `reports/`, the human-facing dated reports | `${user_config.report_dir}` when set to a non-empty path; if it is empty or still shows an unexpanded `${user_config.report_dir}` token (option unset), default to `$env:USERPROFILE\Documents\MachineHealth` |
+| **State root** (`-StateBase`) | `state/` (history, latest snapshot, approvals), `logs/`, catalog overlay, custom checks, `TODO.md` proposals | `${CLAUDE_PLUGIN_DATA}`, the per-plugin data directory that survives plugin updates, passed explicitly when the token expands. If it is unexpanded, do **not** fall through to the orchestrator's environment ladder: the harness sets `CLAUDE_PLUGIN_DATA` per plugin, and a subprocess inherits whichever plugin's value its parent process already carried, so a skill-invoked tool can inherit an unrelated installed plugin's value and write this plugin's `state/`, `logs/`, and catalog overlay into that plugin's directory. Pass `-StateBase <report-root>` explicitly instead. Colocating state with the reports is wrong-but-visible, where the inherited variable is wrong-and-silent. Report that the plugin-specific root could not be resolved. Never substitute a literal path: the directory under `~/.claude/plugins/data/` is named for the plugin's install identity, not the plugin, so a guessed path names a different directory and splits state from the overlay |
 
-Pass both explicitly to the orchestrator (`-OutputBase <report-root> -StateBase <state-root>`). Never write generated state into the plugin's own install directory — a plugin update replaces it.
+Pass both explicitly to the orchestrator (`-OutputBase <report-root> -StateBase <state-root>`). Never write generated state into the plugin's own install directory. A plugin update replaces it.
 
-Other runtime parameters the caller passes (via slash-command arguments, scheduled task arguments, or environment variables — the orchestrator accepts them as parameters):
+Other runtime parameters the caller passes (via slash-command arguments, scheduled task arguments, or environment variables; the orchestrator accepts them as parameters):
 
 | Parameter | Default | Meaning |
 |---|---|---|
@@ -60,34 +60,34 @@ Routing table:
 | Detected OS | Orchestrator | Status |
 |---|---|---|
 | Windows | `scripts/windows/Invoke-MachineHealthCheck.ps1` | Implemented |
-| macOS | `scripts/macos/NOT_IMPLEMENTED.md` | Stub — report UNKNOWN and stop |
-| Linux | `scripts/linux/NOT_IMPLEMENTED.md` | Stub — report UNKNOWN and stop |
+| macOS | `scripts/macos/NOT_IMPLEMENTED.md` | Stub. Report UNKNOWN and stop |
+| Linux | `scripts/linux/NOT_IMPLEMENTED.md` | Stub. Report UNKNOWN and stop |
 
 ## High-level procedure
 
-1. **Verify preconditions.** PowerShell 7.4+ (enforced by the orchestrator's `#Requires`; individual checks that need a still-newer cmdlet return UNKNOWN rather than aborting). The report and state roots are writable. Record elevation state via `scripts/<os>/lib/Test-IsElevated.ps1` — never prompt for UAC.
+1. **Verify preconditions.** PowerShell 7.4+ (enforced by the orchestrator's `#Requires`; individual checks that need a still-newer cmdlet return UNKNOWN rather than aborting). The report and state roots are writable. Record elevation state via `scripts/<os>/lib/Test-IsElevated.ps1`. Never prompt for UAC.
 2. **Load and filter the catalog.** The orchestrator reads the shipped `catalog/checks.jsonc`, merges the machine-local overlay at `<StateBase>/catalog/checks.local.jsonc` when present (see `references/shared/catalog-overlay.md`), and keeps entries whose `os` list contains the current OS and where `enabled: true` and `deprecated: false`.
-3. **Load trend context.** Read the tail of `<StateBase>/state/history.jsonl` (last 8 weeks) for each check. Pass the slice to each check script over stdin so checks can annotate deltas — but checks remain stateless themselves.
-4. **Invoke the OS orchestrator.** Pass `OutputBase`, `StateBase`, and `RunMode`. The orchestrator dispatches checks under per-check 90s timeouts, collects JSON results, applies trend-aware severity adjustments, and — on non-dry runs — dispatches authorized remediations with before/after logging.
-5. **Receive the structured result.** Run discovery per `references/shared/discovery-guide.md` — propose 1–3 OS-appropriate new checks. Straightforward read-only ones may be implemented as custom checks (script under `<StateBase>/scripts/<os>/checks/`, registered in the catalog overlay); anything needing new permissions or remediation lands in `<StateBase>/TODO.md` for human approval. Checks broadly useful to every consumer are best contributed to the plugin itself.
+3. **Load trend context.** Read the tail of `<StateBase>/state/history.jsonl` (last 8 weeks) for each check. Pass the slice to each check script over stdin so checks can annotate deltas, but checks remain stateless themselves.
+4. **Invoke the OS orchestrator.** Pass `OutputBase`, `StateBase`, and `RunMode`. The orchestrator dispatches checks under per-check 90s timeouts, collects JSON results, applies trend-aware severity adjustments, and, on non-dry runs, dispatches authorized remediations with before/after logging.
+5. **Receive the structured result.** Run discovery per `references/shared/discovery-guide.md`. Propose 1–3 OS-appropriate new checks. Straightforward read-only ones may be implemented as custom checks (script under `<StateBase>/scripts/<os>/checks/`, registered in the catalog overlay); anything needing new permissions or remediation lands in `<StateBase>/TODO.md` for human approval. Checks broadly useful to every consumer are best contributed to the plugin itself.
 6. **Render the markdown report** from `references/shared/report-template.md` into `<OutputBase>/reports/health-<UTC-timestamp>.md` (one file per run, so a same-day rerun does not overwrite the earlier report).
 
-   When the severity spread or trend deltas would read better visually, also generate a self-contained static HTML view of that report (color-coded CRIT/WARN/UNKNOWN, no remote fetch) — the markdown `.md` report stays the durable record.
-7. **Update state.** Write `<StateBase>/state/latest.json`. Append one compact line to `<StateBase>/state/history.jsonl` — the trend source of truth.
-8. **Verify and summarize.** Confirm the report exists. Print CRIT/WARN counts + report path to session output. A clean run may still include `UNKNOWN` findings — call those out too.
+   When the severity spread or trend deltas would read better visually, also generate a self-contained static HTML view of that report (color-coded CRIT/WARN/UNKNOWN, no remote fetch). The markdown `.md` report stays the durable record.
+7. **Update state.** Write `<StateBase>/state/latest.json`. Append one compact line to `<StateBase>/state/history.jsonl`, the trend source of truth.
+8. **Verify and summarize.** Confirm the report exists. Print CRIT/WARN counts + report path to session output. A clean run may still include `UNKNOWN` findings. Call those out too.
 
 ## Guardrails
 
 - **Max total runtime:** 15 minutes. Partial results mark missing checks `UNKNOWN` with reason `"timeout"`.
 - **Per-check timeout:** 90 seconds.
-- **No interactive prompts.** Ever — this runs unattended on a schedule; a stalled prompt would hang the weekly job.
-- **No retry loops on failure.** One attempt per check, one attempt per remediation. `references/shared/remediation-philosophy.md` carries the one-attempt rationale for remediations; checks stay one-attempt for the same reason — a flaky check should read as flaky, not as eventually-fine.
+- **No interactive prompts.** Ever. This runs unattended on a schedule; a stalled prompt would hang the weekly job.
+- **No retry loops on failure.** One attempt per check, one attempt per remediation. `references/shared/remediation-philosophy.md` carries the one-attempt rationale for remediations; checks stay one-attempt for the same reason. A flaky check should read as flaky, not as eventually-fine.
 - **First-run dry mode.** The first ever run (RunMode `first-run`) forces `DryRun = true`. Seeds state, produces the first report, queues remediation approval in `<StateBase>/TODO.md`.
 - **Idempotency.** Two runs back-to-back produce two valid reports and two history entries with no partial state.
-- **Egress allowlist.** Microsoft Update endpoints, winget sources, and the CISA KEV feed are the only permitted outbound URLs — this keeps the skill's network footprint auditable and prevents an unvetted check or remediation from calling an arbitrary host. Every outbound URL is logged to `<StateBase>/logs/run-YYYY-MM-DD.log`.
+- **Egress allowlist.** Microsoft Update endpoints, winget sources, and the CISA KEV feed are the only permitted outbound URLs. This keeps the skill's network footprint auditable and prevents an unvetted check or remediation from calling an arbitrary host. Every outbound URL is logged to `<StateBase>/logs/run-YYYY-MM-DD.log`.
 - **No `Invoke-Expression`** on any data the skill did not author itself in this session. No "run whatever came back" patterns.
 - **Admin is not assumed.** Any check requiring elevation self-checks and returns `UNKNOWN` with `needs_admin: true` rather than prompting UAC.
-- **Defer remediations under user load.** If the interactive session has had input in the last 60 seconds, log a note and run read-only checks only — defer remediations to next run.
+- **Defer remediations under user load.** If the interactive session has had input in the last 60 seconds, log a note and run read-only checks only. Defer remediations to next run.
 - **Never write into the plugin install directory.** All generated state routes to `<StateBase>` / `<OutputBase>`; a plugin update replaces the install.
 
 ## Self-improvement hooks
@@ -95,16 +95,16 @@ Routing table:
 The skill grows itself within narrow, auditable bounds:
 
 - **Write to `<StateBase>/TODO.md`** when discovery proposes a check needing new permissions, network access, or remediation path. Human approval required before it becomes active.
-- **Mark catalog entries `deprecated: true`** (never delete silently) with a `deprecation_reason` when a check has become meaningless for this host — via the catalog overlay (`references/shared/catalog-overlay.md`), never by editing the shipped catalog. Propose removal after 3 consecutive crashes (each increments `crash_count`).
-- **Demote chronically quiet checks** — after 4 consecutive identical outputs, propose demotion to monthly cadence (write to `<StateBase>/TODO.md`; the approved demotion is an overlay `cadence` patch — don't reshuffle cadence on your own).
+- **Mark catalog entries `deprecated: true`** (never delete silently) with a `deprecation_reason` when a check has become meaningless for this host, via the catalog overlay (`references/shared/catalog-overlay.md`), never by editing the shipped catalog. Propose removal after 3 consecutive crashes (each increments `crash_count`).
+- **Demote chronically quiet checks.** After 4 consecutive identical outputs, propose demotion to monthly cadence. Write to `<StateBase>/TODO.md`; the approved demotion is an overlay `cadence` patch. Don't reshuffle cadence on your own.
 - **Refresh the CISA KEV cache** weekly via `scripts/<os>/lib/Get-CisaKevCache.ps1` (the winget-upgrades check does this automatically; the live cache lives under `$env:LOCALAPPDATA\machine-health\cache`, seeded from the shipped `catalog/cisa-kev.json` stub). Skip if younger than 7 days.
-- **Never rewrite history.** `state/history.jsonl` is append-only — it is the trend-detection source of truth, and rewriting an old line corrupts every severity-trend comparison drawn from it. If a historical entry is wrong, add a correction entry; don't edit the old line.
+- **Never rewrite history.** `state/history.jsonl` is append-only. It is the trend-detection source of truth, and rewriting an old line corrupts every severity-trend comparison drawn from it. If a historical entry is wrong, add a correction entry; don't edit the old line.
 
 ## Consumer configuration
 
-- **Report directory** — the `report_dir` plugin option (set at install or via `/plugin configure machine-health@<marketplace>`).
-- **Check catalog** — `/machine-health:setup` interviews and writes the machine-local overlay (disable/deprecate/demote shipped checks, register custom ones).
-- **Remediation approvals** — `<StateBase>/state/approvals.json` per `references/shared/approvals.md`; nothing is approved by default. `/machine-health:setup` can seed it.
+- **Report directory**: the `report_dir` plugin option (set at install or via `/plugin configure machine-health@<marketplace>`).
+- **Check catalog**: `/machine-health:setup` interviews and writes the machine-local overlay (disable/deprecate/demote shipped checks, register custom ones).
+- **Remediation approvals**: `<StateBase>/state/approvals.json` per `references/shared/approvals.md`; nothing is approved by default. `/machine-health:setup` can seed it.
 
 ## Not in scope for this skill
 

--- a/plugins/machine-health/skills/setup/SKILL.md
+++ b/plugins/machine-health/skills/setup/SKILL.md
@@ -11,8 +11,8 @@ Inspect and customize `/machine-health:audit` on this host per the uniform setup
 (`docs/PLUGIN-PHILOSOPHY.md` "Setup is explicit and repeatable" in the marketplace repository):
 `check` reads the effective configuration and reports, `apply` writes it. The machine-local
 surface is the catalog overlay at `<StateBase>/catalog/checks.local.jsonc` and the remediation
-approvals at `<StateBase>/state/approvals.json`. Configuration here is machine-local by design —
-a workstation's check tuning does not belong in any repository. Idempotent: re-running reads the
+approvals at `<StateBase>/state/approvals.json`. Configuration here is machine-local by design.
+A workstation's check tuning does not belong in any repository. Idempotent: re-running reads the
 existing files and offers updates rather than overwriting blind.
 
 Action routing: no argument or `check` runs the check; `apply` runs the check first, then applies
@@ -23,20 +23,20 @@ and always interviews.
 
 ## Resolving the state root
 
-`<StateBase>` is `${CLAUDE_PLUGIN_DATA}` — the per-plugin data directory that survives plugin
+`<StateBase>` is `${CLAUDE_PLUGIN_DATA}`, the per-plugin data directory that survives plugin
 updates. Create it if missing.
 
 **There is no hardcoded fallback path, and inventing one is a defect rather than a safety net.** The
 directory under `~/.claude/plugins/data/` is named for the plugin's *install identity*
 (`<name>-<marketplace>`, or `<name>-inline` for a `--plugin-dir` session), not for the plugin. Any
 literal path written here therefore resolves to a **different** directory than the one this plugin
-actually reads and writes — so the overlay and approvals land in one place while the audit's state
+actually reads and writes. The overlay and approvals land in one place while the audit's state
 and logs live in another, each half looking complete to whoever wrote it, and the operator's
 disabled checks silently stop taking effect.
 
 So when `${CLAUDE_PLUGIN_DATA}` renders as the literal unexpanded token, **stop at step 1 of
 `check`**: report that the skill is running outside plugin context and cannot resolve its state
-root, run no further probe, and write nothing. Continuing would be worse than stopping — with the
+root, run no further probe, and write nothing. Continuing would be worse than stopping. With the
 root unresolved, an absent overlay and an unreadable one are the same observation, so every verdict
 below would assert more than the evidence supports. `apply` refuses outright for the same reason:
 there is no root to write to. (This differs from `/machine-health:audit`, which passes a state root
@@ -47,7 +47,7 @@ overlay directly and has no such rung.)
 `~/.claude/plugins/data/machine-health`, `check` reports a split when it finds one: probe that exact
 legacy path and any `machine-health-*` sibling of the resolved `<StateBase>`, and for each that
 exists and is not `<StateBase>`, name it and list what it holds. Only `<StateBase>` is read.
-Consolidating is the operator's move — moving or deleting the stray root is a decision about their
+Consolidating is the operator's move. Moving or deleting the stray root is a decision about their
 data, and this skill neither relocates nor removes files.
 
 ## `check` (read-only)
@@ -59,47 +59,47 @@ suggested-action line per FAIL; modify nothing. The plugin ships a working zero-
 shipped catalog, no remediations approved), so an absent overlay or absent approvals file is **INFO**
 (default in effect), never FAIL.
 
-1. **State root** — INFO: the resolved `<StateBase>` path, whether it exists yet, and any split root
-   found. FAIL and stop here when the token did not expand (see above) — the remaining probes do not
+1. **State root**. INFO: the resolved `<StateBase>` path, whether it exists yet, and any split root
+   found. FAIL and stop here when the token did not expand (see above). The remaining probes do not
    run.
-2. **Catalog overlay** (`<StateBase>/catalog/checks.local.jsonc`) — INFO when absent (the shipped
+2. **Catalog overlay** (`<StateBase>/catalog/checks.local.jsonc`). INFO when absent (the shipped
    catalog applies unchanged). When present, validate against
    `${CLAUDE_PLUGIN_ROOT}/skills/audit/catalog/schemas/checks.schema.json`: a registered custom check
    is a full `#/$defs/CheckEntry` and must satisfy it outright, while a partial override of a shipped
-   check carries `id` plus only the fields it changes — check those field names and value types
+   check carries `id` plus only the fields it changes. Check those field names and value types
    against `CheckEntry` without applying its `required` list (merge behavior:
    `${CLAUDE_PLUGIN_ROOT}/skills/audit/references/shared/catalog-overlay.md`). Confirm every
-   entry targets a real check — a shipped check id, or a custom check whose `script` path resolves
+   entry targets a real check: a shipped check id, or a custom check whose `script` path resolves
    under `<StateBase>`. FAIL a malformed entry, an entry targeting an unknown check id, or a custom
    entry whose `script` file is missing; report which checks the overlay patches (disabled,
    deprecated, demoted) and any custom checks it registers.
-3. **Remediation approvals** (`<StateBase>/state/approvals.json`) — INFO when absent (no remediation
-   is approved — the safe default; a bare audit mutates nothing). When present: validate against
+3. **Remediation approvals** (`<StateBase>/state/approvals.json`). INFO when absent (no remediation
+   is approved, the safe default; a bare audit mutates nothing). When present: validate against
    `${CLAUDE_PLUGIN_ROOT}/skills/audit/catalog/schemas/approvals.schema.json` (shape and examples in
    `${CLAUDE_PLUGIN_ROOT}/skills/audit/references/shared/approvals.md`) and confirm each approval names a real remediation
    (`restart-stopped-service`, `clear-temp-files`). FAIL a malformed file or an approval for an
    unknown remediation; otherwise report which remediations are approved.
-4. **Pending proposals** (`<StateBase>/TODO.md`) — INFO: count proposals (deprecation, cadence
+4. **Pending proposals** (`<StateBase>/TODO.md`). INFO: count proposals (deprecation, cadence
    demotion, new check) awaiting a decision from a prior audit; the suggested-action line is to run
    `apply` to walk them.
-5. **Report directory** — INFO: the effective location — the `report_dir` plugin option when set,
+5. **Report directory**. INFO: the effective location. The `report_dir` plugin option when set,
    else `$env:USERPROFILE\Documents\MachineHealth`.
 
 ## `apply` (idempotent)
 
 Run `check` first. Then, if the invocation carries write arguments, apply each non-interactively;
-otherwise run the interview. After any write, re-read the target file and confirm the entry landed —
-never report success on the write alone. Only write entries that differ from the shipped catalog, so
+otherwise run the interview. After any write, re-read the target file and confirm the entry landed.
+Never report success on the write alone. Only write entries that differ from the shipped catalog, so
 the overlay stays minimal.
 
 **Non-interactive write paths** (named in the argument-hint; each targets a shipped check or
 remediation, so no interview is needed):
 
-- `disable=<check-id>` — write `"enabled": false` for that check to the overlay.
-- `deprecate=<check-id>` — write `"deprecated": true` plus a `deprecation_reason` (from a
+- `disable=<check-id>`. Write `"enabled": false` for that check to the overlay.
+- `deprecate=<check-id>`. Write `"deprecated": true` plus a `deprecation_reason` (from a
   `reason=<text>` argument when supplied, else a short default) to the overlay.
-- `demote=<check-id>` — write `"cadence": "monthly"` for that check to the overlay.
-- `approve=<remediation-id>` — write the approval to `<StateBase>/state/approvals.json` per
+- `demote=<check-id>`. Write `"cadence": "monthly"` for that check to the overlay.
+- `approve=<remediation-id>`. Write the approval to `<StateBase>/state/approvals.json` per
   `${CLAUDE_PLUGIN_ROOT}/skills/audit/references/shared/approvals.md`. A supplied `approve=` argument IS the explicit user decision;
   never approve a remediation not named in the arguments or the interview.
 
@@ -115,7 +115,7 @@ give, rather than writing a dangling entry.
    `TODO.md`.
 3. **Interview catalog changes** against the merged view: disable (`"enabled": false`), retire
    (`"deprecated": true` + `deprecation_reason`), or demote to monthly (`"cadence": "monthly"`).
-4. **Register custom checks** when the user wants one (always interactive — it authors a script):
+4. **Register custom checks** when the user wants one (always interactive, it authors a script):
    write the script to `<StateBase>/scripts/windows/checks/Test-<Thing>.ps1` (single JSON object per
    `${CLAUDE_PLUGIN_ROOT}/skills/audit/references/shared/output-schema.md`, `-Human` mode included), then add a full schema-valid
    overlay entry with `script` set to `scripts/windows/checks/Test-<Thing>.ps1`. Merge and resolution
@@ -126,8 +126,8 @@ give, rather than writing a dangling entry.
    `${CLAUDE_PLUGIN_ROOT}/skills/audit/references/shared/approvals.md`. Never enable a remediation the user did not explicitly approve.
 6. **Confirm the report directory.** Show where reports land (the `report_dir` plugin option when
    set, else `$env:USERPROFILE\Documents\MachineHealth`); to change it, direct the user to
-   `/plugin configure machine-health@<marketplace>` (interactive, any time) — the option is stored in plugin
-   config, not the overlay. Headless: rerun the install with the new value —
+   `/plugin configure machine-health@<marketplace>` (interactive, any time). The option is stored in plugin
+   config, not the overlay. Headless: rerun the install with the new value,
    `claude plugin install machine-health@<marketplace> -s <scope> --config report_dir=<path>`.
    Against an already-installed plugin it prints `already installed` and still writes the value,
    verified on Claude Code 2.1.240 for a non-sensitive option at `user` scope; a `sensitive`
@@ -140,7 +140,7 @@ give, rather than writing a dangling entry.
    Afterwards, keep the two claims apart. The write is issued and the stored value is what you
    passed; the RUNNING session's behavior is not. The rendered `${user_config.*}` is injected at
    skill load and each hook receives its `CLAUDE_PLUGIN_OPTION_*` from an environment fixed at
-   session start, so a same-session `check` still reports the OLD value — reporting that as a
+   session start, so a same-session `check` still reports the OLD value. Reporting that as a
    failed write would be wrong. Verify the effective value by rerunning `check` in a **fresh
    session**, and never claim an unobserved change.
 
@@ -154,9 +154,9 @@ alone reports the effective configuration and changes nothing.
 
 ## What this skill does NOT do
 
-- Run the audit — that is `/machine-health:audit`.
-- Edit the shipped catalog or anything inside the plugin install directory — a plugin update
+- Run the audit. That is `/machine-health:audit`.
+- Edit the shipped catalog or anything inside the plugin install directory. A plugin update
   replaces it; machine-local changes live only under `<StateBase>`.
-- Approve remediations silently — every approval is an explicit user decision (an `approve=`
+- Approve remediations silently. Every approval is an explicit user decision (an `approve=`
   argument or an interview yes).
 - Write the plugin cache, Claude Code user settings, or `pluginConfigs`.


### PR DESCRIPTION
No linked issue

## Summary

#2891 instruction-surface de-slop cluster: purge em dashes from the `machine-health` plugin README and every SKILL.md.

## Fix

Rewrote `plugins/machine-health/README.md` and every `plugins/machine-health/**/SKILL.md` under `/ai-slop:audit fix` semantics (periods, commas, or a restructured sentence; never parentheses, en dashes, or a spaced hyphen as a stand-in). A self-audit repaired wrap leftovers, split asides, and table cells the mechanical pass left as fragments. Nested tool READMEs under `skills/audit/` were left untouched. The generated options block is ignore-fenced because `scripts/sync-plugin-options-docs.py` still emits em dashes from its shared template. `machine-health` 0.11.3.

## Verification

- Detector: 0 `rule-em-dash` findings outside ignore-fenced generated-options spans (and required trigger strings that must keep em dashes)
- `CHECK_SKILL_SKIP_MARKDOWNLINT=1 bash scripts/check-changed-skills.sh origin/main`: 0 failed; quoted trigger phrases vs origin/main preserved
- `python3 scripts/sync-plugin-options-docs.py --check` up to date
- `scripts/check-changelog-parity.sh --check-bump origin/main` passes
- `node scripts/generate-cheatsheet.mjs --check` in sync

## Related

Refs #2891

#2891 stays open.