### PR TITLE
docs(work-items): de-slop instruction surfaces (0.39.23)

### DIFF
--- a/plugins/work-items/.claude-plugin/plugin.json
+++ b/plugins/work-items/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "work-items",
-  "version": "0.39.22",
+  "version": "0.39.23",
   "description": "Manages development work items through a provider-neutral tracker seam that ships with the plugin (bundled dispatcher plus github, local-markdown, jira, gitea, and linear adapters; seam plugin-dir canonical, adapters consumer-local-first): dashboard, taxonomy-labeled creation, a race-safe assignee-plus-lease claim protocol, recurring-schedule checks, TODO scanning, stale-lease auditing, plan decomposition into vertical-slice items, a macro-journey router over spec containers (rollup, per-container execution shape, next-step routing), raw-intake triage (issues and unsolicited PRs through raw, verified, briefed, autonomous-eligible states), plus the two work-items loop lanes of the loop-lane convention: a self-paced autonomous work-loop drain (work-class admission gate, adaptive item cap, PR-only) and an attended attend-queue escalation lane. The re-runnable setup skill binds the provider (.work-item-tracker.json), seeds the recurring-schedule seam (.github/recurring-schedule.json), and remaps canonical role labels.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/work-items/CHANGELOG.md
+++ b/plugins/work-items/CHANGELOG.md
@@ -3,6 +3,19 @@
 All notable changes to the `work-items` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.39.23]
+
+### Changed
+
+- **Instruction-surface de-slop (#2891, work-items cluster).** Re-audited this plugin's
+  `README.md` and every `SKILL.md` under `/ai-slop:audit fix` semantics after later
+  versions landed on the 0.39.13 shard. Prose stays em-dash-free. Leftovers that must
+  keep the mark: the quoted auto-invocation trigger (`the spec changed — redo the tickets`)
+  so skill-quality does not treat the rewrite as a dropped trigger; quoted claim/lease
+  and triage protocol strings; fenced templates; and the ignore-fenced generated options
+  block, because `scripts/sync-plugin-options-docs.py` still emits em dashes from its
+  shared template.
+
 ## [0.39.22]
 
 ### Fixed


### PR DESCRIPTION
No linked issue

## Summary

Refs #2891. Instruction-surface de-slop shard for the `work-items` plugin only. Other plugins stay on main.

## Fix

Re-audited `plugins/work-items/README.md` and every `plugins/work-items/**/SKILL.md` under `/ai-slop:audit fix` semantics after later versions landed on the 0.39.13 shard. Instruction-surface prose is already em-dash-free. The generated options block stays ignore-fenced because `scripts/sync-plugin-options-docs.py` still emits em dashes from its shared template. Quoted claim/lease and triage protocol strings, fenced templates, and the required auto-invocation trigger (`the spec changed — redo the tickets`) keep their em dashes so skill-quality does not treat a rewrite as a dropped trigger. `work-items` 0.39.23. Adapter READMEs under `tools/work-item-tracker/**` and `docs/SKILL-CHEAT-SHEET.md` were not edited.

## Verification

- Detector (rule-em-dash enabled, isolated config): 1 remaining `rule-em-dash` (the required `decompose` trigger phrase), 65 declined (generated-options fence plus fenced/inline-code protocol spans)
- `CHECK_SKILL_SKIP_MARKDOWNLINT=1 bash scripts/check-changed-skills.sh origin/main`: no changed skills
- `python3 scripts/sync-plugin-options-docs.py --check` up to date
- `scripts/check-changelog-parity.sh --check-bump origin/main` passes
- `node scripts/generate-cheatsheet.mjs --check` in sync

## Related

Refs #2891