### PR TITLE
docs(repo-fleet-hygiene): de-slop instruction surfaces (0.23.10)

### DIFF
--- a/plugins/repo-fleet-hygiene/.claude-plugin/plugin.json
+++ b/plugins/repo-fleet-hygiene/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "repo-fleet-hygiene",
-  "version": "0.23.9",
+  "version": "0.23.10",
   "description": "Cross-repository Git/GitHub fleet discovery, evidence rollup, and a gated apply verb that executes a prior fleet action plan behind one confirmation. Audit stays read-only and confidence-tiered; apply mutates only with --apply plus interactive confirmation or --yes.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/repo-fleet-hygiene/CHANGELOG.md
+++ b/plugins/repo-fleet-hygiene/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to `repo-fleet-hygiene` are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.23.10]
+
+### Changed
+
+- **Instruction-surface de-slop (#2891, repo-fleet-hygiene cluster).** Rewrote this plugin's
+  `README.md` and every `SKILL.md` to drop em dashes under the repo's zero-tolerance house
+  policy, using `/ai-slop:audit fix` semantics: periods or commas, or a restructured sentence,
+  never parentheses, en dashes, or a spaced hyphen as a stand-in. Meaning stays; only the mark
+  and the sentence break change.
+
 ## [0.23.9]
 
 ### Changed

--- a/plugins/repo-fleet-hygiene/README.md
+++ b/plugins/repo-fleet-hygiene/README.md
@@ -9,7 +9,7 @@ The currently shipped audit reports:
 
 - local branches whose matching GitHub pull request is merged;
 - remote-tracking heads that still exist on origin after a GitHub merge (where
-  `delete_branch_on_merge` is not enabled or was blocked — enabling that setting is complementary,
+  `delete_branch_on_merge` is not enabled or was blocked. Enabling that setting is complementary,
   not a substitute for this visibility, and this plugin never changes repository settings);
 - merged-PR, missing, prunable, or administratively mismatched worktree registrations;
 - linked worktrees that do not conform to the configured worktree root (or placement when unset); and
@@ -33,7 +33,7 @@ The epic's fleet architecture is intentionally split from the current implementa
 | Capability | Owner | Availability in this release |
 |---|---|---|
 | Bounded repository discovery (bare path, drive root, `--root`, `--repo`, config rungs) and canonical-checkout resolution | `repo-fleet-hygiene` | Shipped |
-| Machine-wide discovery with no argument (ghq / configured roots / agent state / bounded sweep ladder) | `repo-fleet-hygiene` | Not shipped — remaining contract work (not an open issue); a no-scope run fails with remedies rather than guessing a root |
+| Machine-wide discovery with no argument (ghq / configured roots / agent state / bounded sweep ladder) | `repo-fleet-hygiene` | Not shipped. Remaining contract work, not an open issue; a no-scope run fails with remedies rather than guessing a root |
 | Cross-repository GitHub merge and repository-identity evidence | `repo-fleet-hygiene` | Shipped |
 | Per-repository worktree status, stranded-work classification, and cleanup | `/source-control:worktree` | Delegated; fleet-local reclaimability was retired in [#2605](https://github.com/melodic-software/claude-code-plugins/issues/2605) |
 | Per-repository branch, cache, build, and deletion triage | `/repo-hygiene:clean` | Delegated |
@@ -64,7 +64,7 @@ Audit the current project repository explicitly (no fleet config required):
 ```
 
 A bare `/repo-fleet-hygiene:audit` with neither CLI scope nor `fleet.root` / `fleet.repo` in a
-resolved config hard-fails and names remedies — it does not audit the session project directory.
+resolved config hard-fails and names remedies. It does not audit the session project directory.
 
 Audit one or more repository-tree roots:
 
@@ -103,7 +103,7 @@ The apply verb:
 2. owns batched `merged-local-branch` deletion (repo-hygiene branch deletion stays interactive) and
    cleans merged/prunable/missing worktrees in the plan's declared order;
 3. shows one fleet plan and requires one explicit confirmation (or `--yes`) before any mutation; and
-4. re-derives mutable branch/worktree OIDs at execution time — tip drift skips fail-closed.
+4. re-derives mutable branch/worktree OIDs at execution time. Tip drift skips fail-closed.
 
 Audit remains read-only. A `HIGH` finding is never itself permission to delete; only `:apply
 --apply` after confirmation (or `--yes`) mutates. Do not add an execute flag to `audit-fleet.sh`.
@@ -159,11 +159,11 @@ successfully audited.
 
 ## What this does not answer
 
-"Can I delete this repository safely?" is deletion triage — an inventory of dirty files, stashes,
-and unpushed branches — and belongs to `/repo-hygiene:clean` (its scan/stash/git tiers), which owns
+"Can I delete this repository safely?" is deletion triage, an inventory of dirty files, stashes,
+and unpushed branches, and belongs to `/repo-hygiene:clean` (its scan/stash/git tiers), which owns
 per-repository disposability analysis. This audit is a read-only cross-repository evidence REPORT;
 it names candidates and hands off. Linked unlocked worktrees are named in `worktree-status-handoff`
-for `/source-control:worktree status` stranded-work classification — this audit does not emit a
+for `/source-control:worktree status` stranded-work classification. This audit does not emit a
 `git status`-based reclaimability substitute.
 
 ## Requirements

--- a/plugins/repo-fleet-hygiene/skills/apply/SKILL.md
+++ b/plugins/repo-fleet-hygiene/skills/apply/SKILL.md
@@ -25,7 +25,7 @@ explicit `--apply`, then interactive confirmation **or** `--yes` for non-interac
 ## Non-negotiable boundary
 
 - Never run without `--plan-file` pointing at a prior audit plan (`schema_version: 1`).
-- Never treat plan tips as authorization — re-derive every mutable OID immediately before delete.
+- Never treat plan tips as authorization. Re-derive every mutable OID immediately before delete.
 - Skip fail-closed on OID drift, missing plan OID, protected/current/worktree-attached branches,
   locked or stranded worktrees, or unknown operations.
 - Own batched `merged-local-branch` deletion here (repo-hygiene branch deletion stays interactive /
@@ -61,7 +61,7 @@ One gate covers every repository and every operation in the plan.
 
 ## What this skill does NOT do
 
-- Re-run fleet discovery or GitHub evidence collection — that is `/repo-fleet-hygiene:audit`.
+- Re-run fleet discovery or GitHub evidence collection. That is `/repo-fleet-hygiene:audit`.
 - Add execution flags to `audit-fleet.sh`.
 - Batch-delete via `/repo-hygiene:clean git` (that skill refuses to batch branch deletion).
 - Remove stranded/dirty/locked worktrees, or act on tip-drift / manual-review findings.

--- a/plugins/repo-fleet-hygiene/skills/audit/SKILL.md
+++ b/plugins/repo-fleet-hygiene/skills/audit/SKILL.md
@@ -29,7 +29,7 @@ the compact machine-readable rollup and action-plan artifact from
 
 Never run or suggest running inline from this skill: `git fetch`, `git worktree prune`,
 `git worktree repair`, `git worktree remove`, `git branch -d/-D`, `git remote set-url`, or any
-filesystem deletion. The bundled script has no mutation mode — `--apply-plan` is a read-only
+filesystem deletion. The bundled script has no mutation mode. `--apply-plan` is a read-only
 dry-run approval artifact over a prior plan file. A report may name a command/tool as a future
 handoff; the fleet action plan lists those invocations once per repository behind one confirmation
 gate. Actual fleet mutation belongs to `/repo-fleet-hygiene:apply`, not this skill.
@@ -46,7 +46,7 @@ Parse `$ARGUMENTS` as opaque arguments for the bundled script. Supported flags:
 - `--canonical <github.com/owner/repo=path>`: invocation-specific canonical checkout override
   (repeatable; explicit wins over config).
 - `--skip <name>`: discovery directory-name skip (repeatable). Explicit `--skip` / `fleet.skip`
-  entries **replace** the default skip list rather than appending — otherwise shrinking is
+  entries **replace** the default skip list rather than appending. Otherwise shrinking is
   impossible. Default (neither CLI nor config): `node_modules`, `vendor`, `.venv`. To extend, pass
   those three defaults plus your names; to shrink (e.g. reach a repo under `vendor/`), omit names
   you want walked. CLI and config compose additively with each other like other scope inputs.
@@ -54,29 +54,29 @@ Parse `$ARGUMENTS` as opaque arguments for the bundled script. Supported flags:
   stay skipped unconditionally even when an explicit list omits them.
 - `--max-depth <1..12>`: discovery bound; explicit wins over config/default `5`.
 - `--project-dir <dir>`: the session's project directory, used for the project-scoped config rung.
-  It is **not** a scope fallback — a run with no scope fails rather than auditing it.
+  It is **not** a scope fallback. A run with no scope fails rather than auditing it.
 - `--detail`: emit collapsed per-target evidence after the rollup (default is rollup + action plan
   only).
 - `--plan-file <path>`: write the machine-readable action-plan JSON to this path (otherwise a temp
   file is created and named in the report).
-- `--apply-plan <path>`: standalone read-only mode — render the ordered dry-run approval artifact
+- `--apply-plan <path>`: standalone read-only mode. Render the ordered dry-run approval artifact
   for a previously written plan (cannot combine with discovery flags).
 
 Always pass `--project-dir "${CLAUDE_PROJECT_DIR}"` on audit runs (not on `--apply-plan`). That
 variable is substituted in this markdown content and in `allowed-tools` Bash rules, but it is
-**not** present in the Bash tool's environment, so the script cannot read it for itself — passing
+**not** present in the Bash tool's environment, so the script cannot read it for itself. Passing
 it in is what makes the project rung below reachable at all.
 
-If no scope resolves — no bare path, no `--root`, no `--repo`, and no config-supplied
-`fleet.root`/`fleet.repo` — the run **stops** and names the ways to supply scope plus
+If no scope resolves, no bare path, no `--root`, no `--repo`, and no config-supplied
+`fleet.root`/`fleet.repo`, the run **stops** and names the ways to supply scope plus
 `/repo-fleet-hygiene:setup apply`. Pass that guidance through rather than re-deriving a root
 yourself. The project directory is **not** a fallback scope: auditing the session's incidental
 working directory was removed because it silently audited whatever tree the shell happened to sit
 in. Config
-resolution is the script's own ladder — do not pre-resolve or pass a probed path yourself:
+resolution is the script's own ladder. Do not pre-resolve or pass a probed path yourself:
 explicit `--config` wins, else the script probes
 `<project-dir>/.claude/repo-fleet-hygiene.conf` (project-scoped), else
-`~/.claude/repo-fleet-hygiene.conf` (user-global — a machine-scoped fleet config placed there is
+`~/.claude/repo-fleet-hygiene.conf` (user-global, a machine-scoped fleet config placed there is
 recorded user intent, not a guessed root). The report header names the consumed config and its
 source, or states that none was consumed. Never guess a broader machine root from the current
 path beyond that ladder.
@@ -85,7 +85,7 @@ Config-supplied scope is **additive** to CLI-supplied scope: a `--repo X` run st
 configured root. The header's `Scope:` line names each contributing rung and its entry count, so
 report that line rather than assuming the arguments were the whole scope.
 
-Before execution, reject any arguments outside this grammar — noting that a bare positional path
+Before execution, reject any arguments outside this grammar, noting that a bare positional path
 **is** in the grammar, so `/repo-fleet-hygiene:audit D:` and
 `/repo-fleet-hygiene:audit /path/to/tree` are valid invocations to pass through, not arguments to
 refuse. What stays rejected is an unrecognized flag: anything beginning with `-` that is not listed
@@ -111,7 +111,7 @@ The bundled collector is authoritative for classifications. Preserve its evidenc
    the linked root, so a sibling worktree reached first by discovery would otherwise become the
    path every handoff points at. When a supplied or discovered path resolves to a different main
    worktree, the header states the substitution on one `Resolved to main worktree:` line per
-   repository, naming every path that resolved into it — relay it, because the operator named one
+   repository, naming every path that resolved into it. Relay it, because the operator named one
    path and the report is about another. The report always shows
    discovered and canonical paths. An
    override target with a missing/non-GitHub remote, or a different identity that cannot be proven to
@@ -119,30 +119,30 @@ The bundled collector is authoritative for classifications. Preserve its evidenc
 2. **GitHub identity:** read the selected fetch remote with `git remote get-url`; accept only
    `github.com/owner/repo`; query `GET /repos/{owner}/{repo}`. If returned `full_name` differs, report
    `HIGH` transfer/rename evidence and **continue** branch/worktree analysis against that resolved
-   identity — a moved remote is not a reason to skip local classification or merge evidence. A
+   identity. A moved remote is not a reason to skip local classification or merge evidence. A
    404/403/network error is `UNKNOWN`, never "deleted" or "moved". A 404/403 on an identity listed
-   in `fleet.ackUnavailable` is demoted to `ACKNOWLEDGED` — still reported, never suppressed; acks
+   in `fleet.ackUnavailable` is demoted to `ACKNOWLEDGED`, still reported, never suppressed; acks
    never touch non-404/403 failures or successful-response evidence.
 3. **Merged branch:** one aliased `gh api graphql` query per repository page of local branches
    (up to `MERGED_PR_GRAPHQL_ALIAS_PAGE` `headRefName` aliases per call, `first:1`,
-   `states:[MERGED]`). GraphQL's `headRefName` argument is an **exact** match — never the search
+   `states:[MERGED]`). GraphQL's `headRefName` argument is an **exact** match, never the search
    API's prefix-matching `head:` qualifier, so `feature/auth` and `feature/auth-v2` never conflate.
    Measured rate cost stays 1 per call (nodeCount equals the alias count); that stays well under
    GitHub's documented 500,000-node ceiling and 5,000-point/hour primary limit. This retires the REST
    `merged-pr-window-truncated` disclosure and the privacy-gated per-branch `--head` fallback:
    every non-default local branch the operator asked about is queried by exact name, including
    heads GitHub auto-deleted and a later fetch pruned. Fail closed when `gh`/GraphQL is
-   unavailable — emit `github-pr-evidence-unavailable` and never infer unmerged from a missing
+   unavailable. Emit `github-pr-evidence-unavailable` and never infer unmerged from a missing
    row after a failed page. Identical branch names in another repository are unrelated. `HIGH`
    requires the PR `headRefOid` to equal the current local tip. Tip drift is `MEDIUM` manual
-   review. Git ancestry without GitHub evidence is `LOW` and never called merged-by-PR — and
+   review. Git ancestry without GitHub evidence is `LOW` and never called merged-by-PR, and
    under squash merges that ancestry predicate is near-inert, so on a squash-merging fleet
    GitHub evidence is effectively the only merge evidence.
 4. **Merged remote branch:** after local classification, the same merged-PR rows are matched
    against each remote-tracking tip under the selected remote. When `headRefOid` equals that tip
    and the branch is not the default, probe live existence with
    `git ls-remote --heads <remote> refs/heads/<branch>`. A matching tip → `HIGH`
-   `merged-remote-branch` (remote head still present after merge — unset or blocked
+   `merged-remote-branch` (remote head still present after merge, unset or blocked
    `delete_branch_on_merge`). ls-remote failure → `MEDIUM` cached observation (may be stale after a
    prune-less fetch). Empty ls-remote → no finding (head already gone upstream). Remote-only heads
    (local already deleted) are included. The handoff is an optional `git push --delete --dry-run`
@@ -155,7 +155,7 @@ The bundled collector is authoritative for classifications. Preserve its evidenc
    the canonical checkout's expected common dir. A mismatch is `HIGH` evidence of an administrative
    linkage problem but **manual review only**. Missing/prunable registrations never trigger pruning.
    Linked, unlocked registrations with reliable admin emit one `MEDIUM` `worktree-status-handoff`
-   per repository naming those paths — disposability (stranded / unknown / safe) is owned by
+   per repository naming those paths. Disposability (stranded / unknown / safe) is owned by
    `/source-control:worktree status`, and this collector emits no `git status`-based substitute
    verdict. Separately, every linked worktree that passes existence and root-verifiability checks
    is classified against the configured worktree root (`melodic.worktreeroot` when present on the
@@ -176,7 +176,7 @@ The bundled collector is authoritative for classifications. Preserve its evidenc
    empty/failed inventory never means no branches are attached.
 6. **Protection:** current/default/worktree-attached branches are never emitted as standalone branch
    cleanup candidates. A merged worktree is routed to worktree dry-run first. `merged-remote-branch`
-   is independent of local attachment — it describes the remote ref.
+   is independent of local attachment. It describes the remote ref.
 
 Every emitted finding kind, both confidence axes, and the merge-strategy and
 `gc.worktreePruneExpire` dependencies the tiers rest on:
@@ -190,10 +190,10 @@ read-only enforcement model and its threat assumptions:
 Default output is screen-scale:
 
 1. Fleet header (config, scope, discovery counts).
-2. **Repository rollup** — one row per repository with `CLEAN` / `N candidates` /
+2. **Repository rollup**. One row per repository with `CLEAN` / `N candidates` /
    `BLOCKED (evidence gap)`, plus counts by finding kind. Fleet-level findings (stale config,
    duplicate checkouts) get their own row. A fleet verdict summarizes blocked vs candidate vs clean.
-3. **Fleet action plan** — recommended skill invocations **once per repository** (not once per
+3. **Fleet action plan**. Recommended skill invocations **once per repository** (not once per
    finding), ordered so branch cleanups precede worktree cleanups, behind **one** confirmation gate.
 4. Path to the machine-readable action-plan JSON (and the `--apply-plan` dry-run invocation).
 
@@ -204,7 +204,7 @@ same-named branches across repositories.
 `ACKNOWLEDGED` remains a prominence demotion, not a fifth confidence tier: the evidence stays exactly
 as weak as the `UNKNOWN` it came from. A rollup `CLEAN` verdict means no actionable cleanup-plan
 candidates (the kinds that produce skill invocations) and no UNKNOWN evidence gap for that
-repository — not "GitHub was unreachable so nothing was wrong." Manual-review HIGH/MEDIUM findings
+repository, not "GitHub was unreachable so nothing was wrong." Manual-review HIGH/MEDIUM findings
 (for example `locked-worktree` or `merged-pr-tip-drift`) remain in kind counts but do not inflate
 `N candidates` when the action plan correctly lists `Actions: none`.
 
@@ -249,7 +249,7 @@ Related fleet contracts that remain separate:
 - Invalid config SYNTAX, invalid override, or an invalid CLI-supplied `--repo`/`--root` path: report
   the exact invalid input and stop; never silently fall back.
 - No scope given and the project directory is not a Git working tree: stop, and relay the script's
-  remedy block verbatim — the operator did not choose that path, so the rejection alone is not
+  remedy block verbatim. The operator did not choose that path, so the rejection alone is not
   actionable.
 - A config-sourced `fleet.repo`/`fleet.root` path that is missing or not a Git working tree degrades
   per-entry, not per-run: the entry becomes an `UNKNOWN` `stale-config-entry` finding and the rest of
@@ -284,12 +284,12 @@ Related fleet contracts that remain separate:
 | Finding | Handoff (not executed here) |
 |---|---|
 | `merged-local-branch` | Run `/repo-hygiene:clean git` in the named canonical repository |
-| `merged-remote-branch` | Optional preview only: `git push --delete --dry-run <remote> <branch>` in the canonical repository (never executed here). Enabling GitHub `delete_branch_on_merge` is complementary and owned by the repository's settings automation — this audit does not change it |
+| `merged-remote-branch` | Optional preview only: `git push --delete --dry-run <remote> <branch>` in the canonical repository (never executed here). Enabling GitHub `delete_branch_on_merge` is complementary and owned by the repository's settings automation. This audit does not change it |
 | `merged-worktree`, `prunable-worktree`, `missing-worktree` | Run `/source-control:worktree cleanup --dry-run` in the canonical repository |
-| `worktree-status-handoff` | Run `/source-control:worktree status` in the canonical repository (stranded-work axis); use cleanup `--dry-run` only after Work is safe. If `source-control` is not installed, name the listed worktree targets and the missing collaborator — emit no porcelain-based substitute verdict |
+| `worktree-status-handoff` | Run `/source-control:worktree status` in the canonical repository (stranded-work axis); use cleanup `--dry-run` only after Work is safe. If `source-control` is not installed, name the listed worktree targets and the missing collaborator. Emit no porcelain-based substitute verdict |
 | `worktree-admin-mismatch` | Manual inspection; `git worktree repair` is an option only after validating which administrative directory is authoritative |
 | `worktree-not-a-root` | Manual inspection of the registered path; a `git -C` probe of it describes the CONTAINING repository, so no cleanup handoff is safe until the path is resolved |
-| `worktree-root-unverifiable` | Manual inspection of the registered path. Root-ness is unproven here rather than disproven — the probe itself failed — so infer nothing about the path in either direction |
+| `worktree-root-unverifiable` | Manual inspection of the registered path. Root-ness is unproven here rather than disproven. The probe itself failed, so infer nothing about the path in either direction |
 | `worktree-nested-in-repository` | Recreate at an external root with `/source-control:worktree create`, then remove the nested one |
 | `worktree-outside-configured-root` | Recreate at the expected location named in evidence with `/source-control:worktree create`, then remove the misplaced one |
 | `worktree-wrong-layout` | Recreate at the expected `<owner>-<repo>-<slug>` path under the configured root, then remove the wrong-layout one |

--- a/plugins/repo-fleet-hygiene/skills/setup/SKILL.md
+++ b/plugins/repo-fleet-hygiene/skills/setup/SKILL.md
@@ -13,7 +13,7 @@ edits Claude Code settings, `pluginConfigs`, Git remotes, branches, worktrees, o
 The config file itself is optional to *create*, but a no-argument `/repo-fleet-hygiene:audit` now
 requires scope from somewhere: CLI bare path / `--root` / `--repo`, or `fleet.root` / `fleet.repo`
 entries in a consumed config. Absence of every config on the ladder is therefore INFO for `check`
-(nothing to validate yet) and a hard failure for a subsequent no-argument audit — not a silent
+(nothing to validate yet) and a hard failure for a subsequent no-argument audit, not a silent
 default to the current project. Check-centric per the uniform setup contract
 (`docs/PLUGIN-PHILOSOPHY.md` "Setup is explicit and repeatable" in the marketplace repository):
 `check` inspects read-only; `apply` creates or updates the file, then re-runs `check`. No argument
@@ -23,7 +23,7 @@ the arguments fully specify the change, `apply` proceeds without prompting.
 Default config path: `${CLAUDE_PROJECT_DIR}/.claude/repo-fleet-hygiene.conf`. An explicit `--config`
 may choose another path. Resolve relative roots/repos/canonical paths from the config file directory.
 
-**Scoping rule (state it in `check`/`apply` output):** the audit consumes config through a ladder —
+**Scoping rule (state it in `check`/`apply` output):** the audit consumes config through a ladder:
 explicit `--config`, else the project-scoped default above, else the user-global
 `~/.claude/repo-fleet-hygiene.conf`. A project-scoped config is therefore consumed only when the
 audit runs with that same project directory; a fleet config meant to apply from every project
@@ -40,7 +40,7 @@ check | apply [--config <path>] [--root <dir>]... [--repo <dir>]...
 
 `--max-depth` writes `[fleet] maxDepth`; `--skip` writes repeatable `[fleet] skip` entries. This
 skill owns the config file that carries both. Explicit `fleet.skip` entries **replace** the audit's
-default discovery skip list (they do not append) — say that when writing them, because "extend" is
+default discovery skip list (they do not append). Say that when writing them, because "extend" is
 the naive reading. To extend without shrinking, write the three replaceable defaults
 (`node_modules`, `vendor`, `.venv`) plus the extra names. `.`, `..`, and `.git` stay skipped
 unconditionally and do not need to be written.
@@ -48,25 +48,25 @@ unconditionally and do not need to be written.
 ## `check` (read-only)
 
 The config file and the grammar below are the source of truth. Probe, report a PASS/FAIL/INFO table
-with one remediation line per FAIL, and modify nothing. Do NOT run the collector — that is
+with one remediation line per FAIL, and modify nothing. Do NOT run the collector. That is
 `/repo-fleet-hygiene:audit`; `check` only validates the configuration the audit would consume, using
 `git config --file` and read-only filesystem probes.
 
-1. **Config presence** — resolve the config path (`--config` or the default). Absent → INFO naming
+1. **Config presence**. Resolve the config path (`--config` or the default). Absent → INFO naming
    the full ladder: the audit next probes the user-global `~/.claude/repo-fleet-hygiene.conf` (report
    whether one exists there) and otherwise defaults to the current project; `apply` scaffolds a
    config only if the user wants bounded roots or overrides.
-2. **Parse validity** — present config: `git config --file "<path>" --list >/dev/null`. A non-zero exit
+2. **Parse validity**. Present config: `git config --file "<path>" --list >/dev/null`. A non-zero exit
    is FAIL with the parse error in the remediation line. Never `source` the file.
-3. **Entry resolution** — for each `[fleet] root`/`repo` and each `[canonical …] path`, resolve it from
+3. **Entry resolution**. For each `[fleet] root`/`repo` and each `[canonical …] path`, resolve it from
    the config directory and confirm the directory exists and (for roots/repos) `git rev-parse` succeeds
    read-only. A referenced path that does not resolve is FAIL, naming the entry.
-4. **`maxDepth`** — present and outside `1..12` is FAIL; absent is INFO (the audit's own default applies).
-5. **Canonical identity** — INFO for each `[canonical "github.com/owner/repository"]` entry: report the
+4. **`maxDepth`**. Present and outside `1..12` is FAIL; absent is INFO (the audit's own default applies).
+5. **Canonical identity**. INFO for each `[canonical "github.com/owner/repository"]` entry: report the
    normalized key. Flag as FAIL only a key that is not a normalizable `github.com/owner/repository`.
-6. **Acknowledged identities** — INFO listing each `fleet.ackUnavailable` entry (normalized). FAIL any
+6. **Acknowledged identities**. INFO listing each `fleet.ackUnavailable` entry (normalized). FAIL any
    value that is not a normalizable `github.com/owner/repository`.
-7. **Discovery skip names** — INFO listing each `fleet.skip` entry. FAIL any value that is empty or
+7. **Discovery skip names**. INFO listing each `fleet.skip` entry. FAIL any value that is empty or
    contains a path separator (must be a bare directory name). Remind that any present `fleet.skip`
    **replaces** the audit default skip list rather than appending.
 
@@ -80,14 +80,14 @@ Run `check`, then create or update the config from the supplied arguments.
    Validate `--max-depth` as an integer in `1..12` and write it as `[fleet] maxDepth`; this skill
    owns the file that carries it, so it must be settable here rather than by hand-editing.
    Validate each `--ack-unavailable` value as a normalizable `github.com/owner/repository`
-   (no filesystem probe — the identity is expected to be inaccessible); write it as a repeatable
+   (no filesystem probe, the identity is expected to be inaccessible); write it as a repeatable
    `[fleet] ackUnavailable` entry, deduplicating case-insensitively against entries already
-   present. Like roots/repos, apply is additive — removing an acknowledgment is a manual edit of
+   present. Like roots/repos, apply is additive. Removing an acknowledgment is a manual edit of
    the consumer's own config file.
    Validate each `--skip` value as a bare directory name (reject empty and any path separator);
    write it as a repeatable `[fleet] skip` entry, deduplicating exact matches against entries
    already present. State the replace semantics when writing: any `fleet.skip` present replaces the
-   audit's default skip list (`node_modules`, `vendor`, `.venv`) rather than appending — to
+   audit's default skip list (`node_modules`, `vendor`, `.venv`) rather than appending. To
    extend, include those three defaults plus the new names. `.`, `..`, and `.git` stay skipped
    unconditionally. Removing a skip entry is a manual edit.
 2. If the config exists, read it with `git config --file <path> --list --show-origin`. Preserve every
@@ -106,31 +106,31 @@ Run `check`, then create or update the config from the supplied arguments.
 4. Write/update with an ordinary file edit, not `git config --file ... --add`: the file may be tracked
    and the user must see a deterministic diff. Preserve comments and unrelated sections. Prefer a
    path relative to the config file's directory for any root/repository/canonical target expressible
-   that way — the grammar resolves relative paths from that directory and both forms audit
+   that way. The grammar resolves relative paths from that directory and both forms audit
    identically, while some consumer environments run a write-time path-portability guard that rejects
    absolute paths in tracked config. "Expressible that way" is the real constraint: on Windows, no
    relative path exists between two volumes, so a fleet root on `D:` with a config on `C:` has only
    the absolute form. Write the absolute path, and say in the report that the relative form was
-   unavailable because the target is on another volume — otherwise the guard's rejection reads as a
+   unavailable because the target is on another volume. Otherwise the guard's rejection reads as a
    consumer mistake. This preference is prose guidance followed by the model, not a property a
    deterministic component enforces; treat it as a default to justify departing from, not a
    guarantee.
-5. Verify after remediation — re-run every `check` probe against the written file (never claim success on
+5. Verify after remediation. Re-run every `check` probe against the written file (never claim success on
    the edit alone). Config-only, exactly as `check` defines them:
 
-   - **Parse validity** — `git config --file "<config-path>" --list >/dev/null`
-   - **Entry resolution** — for each `[fleet] root`/`repo` and each `[canonical …] path`, resolve from
+   - **Parse validity**. `git config --file "<config-path>" --list >/dev/null`
+   - **Entry resolution**. For each `[fleet] root`/`repo` and each `[canonical …] path`, resolve from
      the config directory and confirm the directory exists and (for roots/repos) `git rev-parse` succeeds
      read-only
-   - **`maxDepth`** — when present, confirm it is an integer in `1..12`
-   - **Canonical identity** and **acknowledged identities** — confirm each key/value normalizes to
+   - **`maxDepth`**. When present, confirm it is an integer in `1..12`
+   - **Canonical identity** and **acknowledged identities**. Confirm each key/value normalizes to
      `github.com/owner/repository`
-   - **Discovery skip names** — when present, confirm each `fleet.skip` value is a bare directory
+   - **Discovery skip names**. When present, confirm each `fleet.skip` value is a bare directory
      name (non-empty, no path separator)
 
    Do **not** invoke the collector to verify a write. It is the full fleet walk this skill says it
-   never runs — per-repository network queries across every configured root, minutes on a real fleet
-   — and it proves nothing about the file that the `check` probes do not already prove. If the user
+   never runs: per-repository network queries across every configured root, minutes on a real fleet,
+   and it proves nothing about the file that the `check` probes do not already prove. If the user
    explicitly wants an end-to-end run, say that it is a real audit and hand off by invoking
    `/repo-fleet-hygiene:audit` via the Skill tool.
 
@@ -154,29 +154,29 @@ Re-running `apply` with the same arguments after everything resolves changes not
 ```
 
 `ackUnavailable` demotes a 404/403 `github-identity-unavailable` finding for that identity from
-`UNKNOWN` to `ACKNOWLEDGED` in the audit report — still reported, never suppressed, and never
+`UNKNOWN` to `ACKNOWLEDGED` in the audit report, still reported, never suppressed, and never
 affecting non-404/403 failures or successful-response evidence. Use it for foreseeable 404s:
 upstream repositories made private or deleted, or repositories owned by a different GitHub account
 than the authenticated `gh` login.
 
 `skip` replaces the audit's default discovery skip list (`node_modules`, `vendor`, `.venv`)
-whenever any entry is present. It does **not** append — a lone `skip = third_party` means only
+whenever any entry is present. It does **not** append. A lone `skip = third_party` means only
 `third_party` is skipped (plus unconditional `.` / `..` / `.git`). To extend the defaults, write
 those three plus the extra names. CLI `--skip` and config `fleet.skip` compose additively with each
 other the same way other scope inputs do.
 
 Resolution priority is explicit audit CLI override, canonical config entry, then the discovered
 checkout's own **main worktree** (the first record of `git worktree list --porcelain`). A canonical
-override is therefore not needed merely to steer the audit away from a linked worktree — the audit
+override is therefore not needed merely to steer the audit away from a linked worktree. The audit
 resolves that itself. Never add one because two directory names look similar; verify the normalized
 GitHub remote identity on both sides first.
 
 ## What this skill does NOT do
 
-- Run a fleet audit — that is `/repo-fleet-hygiene:audit`. `check` validates config only; it never
+- Run a fleet audit. That is `/repo-fleet-hygiene:audit`. `check` validates config only; it never
   walks the fleet.
 - Write the plugin cache, Claude Code user settings, or `pluginConfigs`. Nor any machine-local
-  state — the config is the consumer's own tracked file.
+  state. The config is the consumer's own tracked file.
 - Touch Git remotes, branches, or worktrees.
 
 ## Gotchas
@@ -184,15 +184,15 @@ GitHub remote identity on both sides first.
 - **Absolute paths in tracked config can be rejected by consumer write guards.** A root, repository, or
   canonical target written as an absolute path may trip a consumer's write-time path-portability guard;
   the same target written relative to the config file's directory passes and resolves identically, so
-  `apply` prefers the relative form — except across Windows volumes, where no relative form exists and
+  `apply` prefers the relative form, except across Windows volumes, where no relative form exists and
   the absolute path is the only honest option. When that happens, write the absolute path, say in the
   report that no relative path exists between volumes, and name the consumer's remedies if the guard
   still rejects the write: colocate the config with the fleet root on one volume, exempt this file or
-  path from the guard, or keep a user-global config outside the guard's scan — do not fabricate a
+  path from the guard, or keep a user-global config outside the guard's scan. Do not fabricate a
   relative path or leave the consumer to conclude they misconfigured something.
 - **A project-scoped config is consumed only from its own project.** Per the Scoping rule above, a
   config meant to apply from every project belongs at the user-global
-  `~/.claude/repo-fleet-hygiene.conf`, not a per-project path — otherwise the audit silently narrows to
+  `~/.claude/repo-fleet-hygiene.conf`, not a per-project path. Otherwise the audit silently narrows to
   the project it was authored in. Two cases collapse this warning, and `check` should say which one
   applies rather than repeating a caution that cannot bite: when the project directory *is* the home
   directory both rungs name the same file, and when no project directory reaches the audit (the


### PR DESCRIPTION
No linked issue

## Summary

Refs #2891. Instruction-surface de-slop shard for the `repo-fleet-hygiene` plugin only. Other plugins stay on main.

## Fix

Rewrote `plugins/repo-fleet-hygiene/README.md` and every `plugins/repo-fleet-hygiene/**/SKILL.md` under `/ai-slop:audit fix` semantics (periods, commas, or a restructured sentence; never parentheses, en dashes, or a spaced hyphen as a stand-in). YAML frontmatter `description`/`summary` left unchanged. Version-only bump in `plugin.json`. New changelog heading only. No generated options block.

## Verification

- Detector (`HOME` + `CLAUDE_PROJECT_DIR` isolated so `rule-em-dash` is enabled): 0 `rule-em-dash` findings on rewritten prose. Leftovers are YAML `description` lines left unchanged, plus fenced templates / quoted protocol / N/A cells the detector already strips
- `CHECK_SKILL_SKIP_MARKDOWNLINT=1 bash scripts/check-changed-skills.sh origin/main`: 0 failed; quoted trigger phrases vs origin/main preserved
- `python3 scripts/sync-plugin-options-docs.py --check` up to date
- `scripts/check-changelog-parity.sh --check-bump origin/main` passes
- `node scripts/generate-cheatsheet.mjs --check` in sync

## Related

Refs #2891