### PR TITLE
docs(markdown-format): de-slop instruction surfaces (0.11.31)

### DIFF
--- a/plugins/markdown-format/.claude-plugin/plugin.json
+++ b/plugins/markdown-format/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "markdown-format",
-  "version": "0.11.30",
+  "version": "0.11.31",
   "description": "Auto-format and lint Markdown on edit via markdownlint-cli2 — only in repos that carry their own markdownlint config.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/markdown-format/CHANGELOG.md
+++ b/plugins/markdown-format/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to the `markdown-format` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.11.31]
+
+### Changed
+
+- **Instruction-surface de-slop (#2891, markdown-format cluster).** Rewrote this plugin's `README.md` and every
+  `SKILL.md` to drop em dashes under the repo's zero-tolerance house policy, using
+  `/ai-slop:audit fix` semantics: periods or commas, or a restructured sentence, never
+  parentheses, en dashes, or a spaced hyphen as a stand-in. Meaning stays; only the mark
+  and the sentence break change. The generated options block is ignore-fenced because
+  `scripts/sync-plugin-options-docs.py` still emits em dashes from its shared template.
+
 ## [0.11.30]
 
 ### Fixed

--- a/plugins/markdown-format/README.md
+++ b/plugins/markdown-format/README.md
@@ -6,7 +6,7 @@ On every `Write` or `Edit` of a `.md` or `.mdc` file it runs
 the file's repository root, applying every auto-fixable rule and surfacing the
 residual (unfixable) findings back to Claude as advisory context.
 
-It uses **your repository's own markdownlint configuration** — it ships none and
+It uses **your repository's own markdownlint configuration**. It ships none and
 imposes no rules of its own. A repository with no discoverable markdownlint
 config has chosen no Markdown style, so the hook does not run there at all
 (#1809): carrying a config **is** the opt-in.
@@ -16,21 +16,21 @@ config has chosen no Markdown style, so the hook does not run there at all
 - **Markdown paths only at launch.** `hooks.json` registers the handler on
   `Write|Edit` but each copy carries `if: Edit(*.md)` or `if: Edit(*.mdc)`.
   `Edit(path)` is the permission-rule form that covers Write; a `Write(path)`
-  rule is never matched. A `.txt` Write therefore never starts the process —
-  it does not reach the script's in-script extension skip, and it cannot
+  rule is never matched. A `.txt` Write therefore never starts the process.
+  It does not reach the script's in-script extension skip, and it cannot
   produce a `hook_non_blocking_error` for work this hook does not do (#2867).
   The script still checks the extension itself, because an `if` filter is one
   rule per handler and fails open on an unparsable payload.
 - **Config opt-in.** The hook runs only when a markdownlint config file that
   `markdownlint-cli2` would discover automatically (`.markdownlint-cli2.jsonc`,
-  `.markdownlint.json`, … — any of the ten documented names) exists between the
+  `.markdownlint.json`, …, any of the ten documented names) exists between the
   edited file's directory and the repository root. Without one, neither `--fix`
-  rewrites nor default-rule findings are imposed — the same doctrine as
+  rewrites nor default-rule findings are imposed, the same doctrine as
   `bash-format`'s shfmt gate. A `package.json` `markdownlint-cli2` property
   does not open the gate: markdownlint-cli2 honors it only under an explicit
   `--config` flag, not by discovery.
-- **Gitignored paths are out of scope.** A file git excludes — a scratch tier
-  such as `.work/**`, build output, a vendored tree — is neither rewritten nor
+- **Gitignored paths are out of scope.** A file git excludes, a scratch tier
+  such as `.work/**`, build output, or a vendored tree, is neither rewritten nor
   reported on. Your ignore rules already say which paths are not part of the
   reviewable artifact, so the hook reads them rather than asking for a second
   declaration. The verdict comes from `git check-ignore`, so it is git's full
@@ -42,11 +42,11 @@ config has chosen no Markdown style, so the hook does not run there at all
   markdownlint-cli2 applies its own `ignores` / `gitignore` config downstream, so
   a path your markdownlint config also excludes stays untouched even with the
   option on. When the verdict cannot be determined (no `git` on
-  `PATH`, no working tree, `git check-ignore` erroring), the hook lints — a
+  `PATH`, no working tree, `git check-ignore` erroring), the hook lints. A
   scope check that failed closed would disable the plugin invisibly.
 - **Auto-fix on edit.** Fixable violations (final newline, list-marker style,
   trailing spaces, …) are corrected in place, and the count of fixes written is
-  reported to Claude and to you — a run that changed your file never passes
+  reported to Claude and to you. A run that changed your file never passes
   unannounced. `markdownlint-cli2` reports no per-fix detail, so neither can
   this hook; the count is what there is.
 - **Advisory, never blocking.** The hook always exits `0`. Unfixable findings are
@@ -60,10 +60,10 @@ config has chosen no Markdown style, so the hook does not run there at all
   that rule once in your markdownlint config, not to re-read it on every edit.
 - **Config from the consumer.** `markdownlint-cli2` discovers config
   (`.markdownlint-cli2.jsonc`, `.markdownlint.json`, …) per edited file, from
-  the file's directory up through its parents — so a nested config governs its
+  the file's directory up through its parents, so a nested config governs its
   subtree. The hook `cd`s to the repository root before linting so that
   discovery caps at the root regardless of the session's working directory.
-  A configuration that can execute code is gated on explicit approval — see
+  A configuration that can execute code is gated on explicit approval. See
   [Configuration trust boundary](#configuration-trust-boundary).
 
 ## Known limitation
@@ -93,8 +93,8 @@ The hook requires the following tools:
 Missing prerequisites do not block an edit. Following Claude Code's
 [PostToolUse contract](https://code.claude.com/docs/en/hooks#posttooluse-decision-control),
 the hook exits `0` and reports a once-per-session notice to both Claude
-(`additionalContext`) and you (`systemMessage`). Only the notice latches —
-the binary probe re-runs on every Markdown edit and recovers mid-session when
+(`additionalContext`) and you (`systemMessage`). Only the notice latches.
+The binary probe re-runs on every Markdown edit and recovers mid-session when
 the tool becomes resolvable. A missing-`markdownlint-cli2` notice includes a
 `PATH probed:` line naming the plausible directories the hook process actually
 searched (Claude Code plugin-bin entries collapse to a count). When
@@ -117,7 +117,7 @@ unchanged finding set is reported in full each time.
 ### Configuration trust boundary
 
 `markdownlint-cli2` supports executable `.cjs`/`.mjs` configuration and can
-load custom rules, Markdown-it plugins, and output formatters — running it
+load custom rules, Markdown-it plugins, and output formatters. Running it
 under such configuration executes code the repository supplies. The hook
 therefore never runs the linter under a code-loading configuration without an
 explicit approval: it skips the lint run and reports a visible trust-gate
@@ -128,14 +128,14 @@ exact `mkdir -p` command the notice carries. The marker lives under
 `${CLAUDE_PLUGIN_DATA}/trust-approvals` and is content-addressed over the
 repository, its risky configuration files, and every repository file those
 files' string literals resolve to (transitively, bounded), so a change to the
-configuration or to a referenced repository module — including a branch switch
-that swaps module bytes under an unchanged config — revokes the approval and
+configuration or to a referenced repository module, including a branch switch
+that swaps module bytes under an unchanged config, revokes the approval and
 re-gates the run. When `CLAUDE_PLUGIN_DATA` is unavailable, the module scan
 overflows its bound, or the configuration contains constructs that defeat
 textual verification (string escapes or tags able to hide a module-loading
 key), the gate fails closed and the lint run stays skipped. Declarative
-rule-only JSONC/YAML configuration is unaffected and lints immediately —
-prefer it when executable configuration is unnecessary.
+rule-only JSONC/YAML configuration is unaffected and lints immediately.
+Prefer it when executable configuration is unnecessary.
 
 ## Install
 
@@ -152,15 +152,15 @@ repository's own package manager.
 
 ## Configuration
 
-The rules themselves are never configured here — the plugin's only rule source is
+The rules themselves are never configured here. The plugin's only rule source is
 the markdownlint config already in your repository, which it reads automatically.
 To change the rules, edit your repo's markdownlint config.
 
 Which paths are in scope is also not configured here: the hook asks
-`git check-ignore` and leaves the paths git excludes alone — that means your
+`git check-ignore` and leaves the paths git excludes alone. That means your
 `.gitignore` files, `$GIT_DIR/info/exclude`, and your global `core.excludesFile`
 together. To exempt a path that git tracks, use `markdownlint-cli2`'s own
-`ignores` (or `gitignore`) key in a `.markdownlint-cli2.*` config — the hook
+`ignores` (or `gitignore`) key in a `.markdownlint-cli2.*` config. The hook
 passes the edited file to
 `markdownlint-cli2`, which applies those itself (verified against
 markdownlint-cli2 v0.23.2; the tool's documentation does not state the behavior
@@ -181,6 +181,7 @@ the install command:
 claude plugin install markdown-format@<marketplace> --config markdown_format_enabled=false
 ```
 
+<!-- ai-slop-ignore-start: generated options block; source is plugin.json + scripts/sync-plugin-options-docs.py -->
 <!-- BEGIN GENERATED: plugin options — edit plugin.json, then run scripts/sync-plugin-options-docs.py -->
 
 ### Options reference
@@ -255,6 +256,7 @@ hands a configured value to a hook process; the value comes from the routes abov
 - [Manage installed plugins](https://code.claude.com/docs/en/discover-plugins#manage-installed-plugins) — enabling, disabling, `/plugin list`
 
 <!-- END GENERATED: plugin options -->
+<!-- ai-slop-ignore-end -->
 
 ## License
 

--- a/plugins/markdown-format/skills/setup/SKILL.md
+++ b/plugins/markdown-format/skills/setup/SKILL.md
@@ -9,70 +9,71 @@ disable-model-invocation: true
 
 Thin check-centric setup per the uniform setup contract (`docs/PLUGIN-PHILOSOPHY.md`
 "Setup is explicit and repeatable" in the marketplace repository): `check` inspects and
-reports, `apply` resolves. This plugin owns no consumer-project configuration — rules
+reports, `apply` resolves. This plugin owns no consumer-project configuration. Rules
 come from the repository's own markdownlint config, and the only tunable is the native
-`userConfig` toggle — so `apply` is guidance-and-verify, with exactly one write path:
+`userConfig` toggle, so `apply` is guidance-and-verify, with exactly one write path:
 the explicitly invoked `apply install-lint` dependency install described below.
 
 Action routing: no argument or `check` runs the check; `apply` runs the check first, then
 remediation; `apply install-lint` additionally authorizes the consumer-repo dependency
-install described below. All are non-interactive — never prompt when the action is given.
+install described below. All are non-interactive. Never prompt when the action is given.
 
 ## `check` (read-only)
 
 The hook script (`${CLAUDE_PLUGIN_ROOT}/hooks/markdown-format.sh`) is the single source of
 truth for what it requires and how it resolves things.
 
-**Read it first** — probe what it actually does, don't recite this file. Then run each probe via
+**Read it first.** Probe what it actually does, don't recite this file. Then run each probe via
 Bash and report a PASS/FAIL/INFO table with one remediation line per FAIL. Do not modify anything.
 
 When the plugin's toggle is disabled, every prerequisite absence downgrades from FAIL to
-INFO — the hook exits through its enabled-gate before probing anything, so a deliberately
+INFO. The hook exits through its enabled-gate before probing anything, so a deliberately
 disabled plugin is not broken. Report the probes informationally and note that re-enabling
 restores the FAIL semantics.
 
-1. **Bash version** — check against the hook's documented floor (README Requirements),
+1. **Bash version.** Check against the hook's documented floor (README Requirements),
    noting any features the hook degrades without (for example telemetry's Bash builtin).
-2. **`jq`** — `command -v jq`. FAIL if absent *and* the repository opted in per item 4: the
+2. **`jq`.** `command -v jq`. FAIL if absent *and* the repository opted in per item 4: the
    hook then skips with a visible once-per-session notice instead of formatting. Without
    that opt-in the hook decides the opt-in first and emits nothing at all, so report jq's
-   absence as INFO there — the missing config, not jq, is why nothing happens.
-3. **`markdownlint-cli2`** — resolve it exactly the way the hook's resolution code does
+   absence as INFO there. The missing config, not jq, is why nothing happens.
+3. **`markdownlint-cli2`.** Resolve it exactly the way the hook's resolution code does
    (its sanctioned lookup paths, including its symlink/escape validation of a repo-local
    shim). A binary or shim the hook would reject must not PASS here. Then confirm the
-   resolved tool actually executes — run it with `--version` (a repo shim can resolve yet
+   resolved tool actually executes. Run it with `--version` (a repo shim can resolve yet
    still be broken: missing Node interpreter, dangling target); resolution without
    successful execution is FAIL, with the execution error in the remediation line. FAIL
    when nothing the hook would accept resolves.
-4. **Consumer markdownlint config — the opt-in** — this is what activates the hook, not a
+4. **Consumer markdownlint config, the opt-in.** This is what activates the hook, not a
    style detail. Mirror its walk: from an edited file's directory up to the repo root, so
    nested configs apply to nested files and the opt-in is per-path (a root config covers
    the tree; a `docs/` config covers only `docs/`). Where that walk finds nothing the hook
-   exits silently — no `--fix`, no findings, and no notice of any kind, not even a missing
+   exits silently: no `--fix`, no findings, and no notice of any kind, not even a missing
    prerequisite. Search the whole tree (skip `node_modules`), report the root config the
    cascade discovers, list nested configs with their directory scope, and surface the
    README's configuration trust boundary for every config the hook's own risk collection
    (`collect_risky_configs`) would flag. For a path no config governs, report the hook as
-   **INFO — inactive, not PASS**: nothing is broken, the repository simply never opted in,
+   **INFO, inactive, not PASS**: nothing is broken, the repository simply never opted in,
    and that is the whole reason formatting is not happening. Name the remediation in the
    same line rather than leaving the reader to infer it. Never report markdownlint's own
-   default rules as the fallback — an unconfigured repo gets no rules, not the defaults.
-5. **Path scope — the repository's `.gitignore`** — INFO: the hook leaves a gitignored
+   default rules as the fallback. An unconfigured repo gets no rules, not the defaults.
+5. **Path scope, the repository's `.gitignore`.** INFO: the hook leaves a gitignored
    file alone, neither rewriting nor reporting on it, because a path the repository
    excludes is not part of the reviewable artifact. List the ignored Markdown the
-   repository carries as out of scope — `git ls-files --others --ignored
-   --exclude-standard -- '*.md' '*.mdc'` — and note that a tracked file is never treated
+   repository carries as out of scope with
+   `git ls-files --others --ignored --exclude-standard -- '*.md' '*.mdc'`,
+   and note that a tracked file is never treated
    as ignored even when a pattern matches it. Report the effective
    `${user_config.markdown_format_lint_gitignored}` value (unexpanded or empty means
    default `false`, i.e. gitignored files are skipped); `true` restores linting there.
-6. **Hook toggle** — report the effective `markdown_format_enabled` value:
+6. **Hook toggle.** Report the effective `markdown_format_enabled` value:
    `${user_config.markdown_format_enabled}` (unexpanded or empty means default `true`).
-7. **Hook registration** — INFO: confirm the plugin is enabled for this project
+7. **Hook registration.** INFO: confirm the plugin is enabled for this project
    (`/plugin` → Installed) rather than parsing settings files.
 
 ## `apply` (idempotent)
 
-Run `check`, then for each FAIL offer the resolution — never install anything without the
+Run `check`, then for each FAIL offer the resolution. Never install anything without the
 consumer's explicit go-ahead in the invocation. `apply install-lint` adds
 `markdownlint-cli2` as a dev dependency in the consumer repository **using the
 repository's own package manager**, resolved in order: lockfile (`pnpm-lock.yaml` →
@@ -80,8 +81,8 @@ repository's own package manager**, resolved in order: lockfile (`pnpm-lock.yaml
 `package-lock.json` or `npm-shrinkwrap.json` → `npm install --save-dev`), then the
 `package.json` `"packageManager"` field when no lockfile exists, then npm only when
 neither signal is present. With no `package.json`, an ambiguous multi-lockfile state, or a lockfile that
-contradicts `packageManager`, stop with manager-specific guidance instead of guessing —
-never introduce a competing lockfile. The change is stated before running. For a Yarn repository, don't infer the linker — ask
+contradicts `packageManager`, stop with manager-specific guidance instead of guessing.
+Never introduce a competing lockfile. The change is stated before running. For a Yarn repository, don't infer the linker. Ask
 the repo's own Yarn: run `yarn config get nodeLinker` in the repo. `pnp` (Berry's default
 when unset) → skip the install and give guidance, because Plug'n'Play generates a loader file,
 not the `node_modules/.bin` shim the hook resolves; install `markdownlint-cli2` on
@@ -89,19 +90,19 @@ not the `node_modules/.bin` shim the hook resolves; install `markdownlint-cli2` 
 setting and always materializes `node_modules`) → install. The
 verify-after-remediation rule below is the backstop when an install still yields no
 usable shim. After ANY remediation, re-run the
-relevant `check` probe and report its actual result — never claim resolved on the
+relevant `check` probe and report its actual result. Never claim resolved on the
 install command's exit code alone. For everything else `apply` only points:
 
 - missing `jq` / Bash: platform install instructions from the README Requirements section;
   this skill never installs system packages.
 - toggle off: direct to `/plugin configure markdown-format` (interactive, any
-  time). Headless: rerun the install with the new value —
+  time). Headless: rerun the install with the new value,
   `claude plugin install markdown-format@<marketplace> -s <scope> --config markdown_format_enabled=true`
   (repeatable per key). Against an already-installed plugin it prints `already installed` **and
-  still writes the value** — verified on Claude Code 2.1.240 (a non-sensitive option at `user`
+  still writes the value**, verified on Claude Code 2.1.240 (a non-sensitive option at `user`
   scope: a non-default value written to an installed plugin, then restored). The short-circuit is
   about the install, not the config write. Re-verify before relying on it outside those
-  conditions — a `sensitive` option, or `project`/`local` scope, were not covered. Do **not**
+  conditions. A `sensitive` option, or `project`/`local` scope, were not covered. Do **not**
   uninstall to reconfigure: uninstalling drops this plugin's entire stored `pluginConfigs` entry,
   resetting every option in the README's Options reference table to its manifest default. `-s`
   defaults to `user`, so pass the scope `claude plugin list` reports for this plugin, and run from
@@ -110,20 +111,20 @@ install command's exit code alone. For everything else `apply` only points:
   Afterwards, keep the two claims apart. The write is issued and the stored value is what you
   passed; the RUNNING session's behavior is not. The rendered `${user_config.*}` is injected at
   skill load and each hook receives its `CLAUDE_PLUGIN_OPTION_*` from an environment fixed at
-  session start, so a same-session `check` still reports the OLD value — reporting that as a
+  session start, so a same-session `check` still reports the OLD value. Reporting that as a
   failed write would be wrong. Verify the effective value by rerunning `check` in a **fresh
   session**, and never claim an unobserved change.
 - no markdownlint config: this is why the hook does nothing here, so lead with it rather
   than leaving it as a footnote under the passing prerequisites. Then offer to create a
-  minimal `.markdownlint-cli2.jsonc` in the repository root only when explicitly asked —
-  the plugin imposes no rules of its own, and which rules a repository adopts is its own
+  minimal `.markdownlint-cli2.jsonc` in the repository root only when explicitly asked.
+  The plugin imposes no rules of its own, and which rules a repository adopts is its own
   decision, never this skill's.
 
 Re-running `apply` after everything passes changes nothing and reports "already configured".
 
 ## What this skill does NOT do
 
-- Run the formatter — editing any `.md` file exercises the hook end-to-end. The only
+- Run the formatter. Editing any `.md` file exercises the hook end-to-end. The only
   execution `check` performs is the harmless `--version` liveness probe of the resolved
   linter; it never lints, fixes, or touches repository content.
 - Write the plugin cache, Claude Code user settings, or `pluginConfigs`.


### PR DESCRIPTION
No linked issue

## Summary

#2891 instruction-surface de-slop cluster: purge em dashes from the `markdown-format` plugin README and every SKILL.md.

Refs #2891

## Fix

Rewrote `plugins/markdown-format/README.md` and every `plugins/markdown-format/**/SKILL.md` under `/ai-slop:audit fix` semantics (periods, commas, or a restructured sentence; never parentheses, en dashes, or a spaced hyphen as a stand-in). Meaning-preserving grammar pass after the mechanical replace. Version-only bump in `plugin.json`. New changelog heading only. YAML frontmatter description/summary left unchanged so the cheatsheet stays valid. The generated options block is ignore-fenced because `scripts/sync-plugin-options-docs.py` still emits em dashes from its shared template.

## Verification

- Detector (`HOME` + `CLAUDE_PROJECT_DIR` isolated so `rule-em-dash` is enabled): 0 `rule-em-dash` findings outside the ignore-fenced generated-options span
- `CHECK_SKILL_SKIP_MARKDOWNLINT=1 bash scripts/check-changed-skills.sh origin/main`: 0 failed; quoted trigger phrases vs origin/main preserved
- `python3 scripts/sync-plugin-options-docs.py --check` up to date
- `scripts/check-changelog-parity.sh --check-bump origin/main` passes
- `node scripts/generate-cheatsheet.mjs --check` in sync

## Related

Refs #2891

#2891 stays open.