### PR TITLE
docs(event-storming): de-slop instruction surfaces (0.6.4)

### DIFF
--- a/plugins/event-storming/.claude-plugin/plugin.json
+++ b/plugins/event-storming/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "event-storming",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "EventStorming for domain discovery \u2014 a methodology skill (Big Picture / Process Modeling / Design-Level facilitation reference, notation, patterns) and a simulation skill (agentic multi-persona workshops that produce a structured-markdown model by default; a live Miro-board rendering path is available when the first-party miro plugin is enabled).",
   "author": {
     "name": "Melodic Software",

--- a/plugins/event-storming/CHANGELOG.md
+++ b/plugins/event-storming/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to the `event-storming` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.6.4]
+
+### Changed
+
+- **Instruction-surface de-slop (#2891, event-storming cluster).** Rewrote this plugin's `README.md` and every
+  `SKILL.md` to drop em dashes under the repo's zero-tolerance house policy, using
+  `/ai-slop:audit fix` semantics: periods or commas, or a restructured sentence, never
+  parentheses, en dashes, or a spaced hyphen as a stand-in. Meaning stays; only the mark
+  and the sentence break change. Quoted AskUserQuestion protocol and cited Brandolini
+  Phase headings keep their original punctuation.
+
 ## [0.6.3]
 
 ### Changed

--- a/plugins/event-storming/README.md
+++ b/plugins/event-storming/README.md
@@ -1,6 +1,6 @@
 # event-storming
 
-A Claude Code plugin for **EventStorming** — Alberto Brandolini's workshop format for collaborative
+A Claude Code plugin for **EventStorming**, Alberto Brandolini's workshop format for collaborative
 domain discovery. It helps you explore a business domain, discover bounded contexts, and bridge the
 resulting model to DDD tactical design.
 
@@ -9,14 +9,14 @@ agentic workshop:
 
 | Skill | Invoke | Does |
 |---|---|---|
-| `methodology` | `/event-storming:methodology [--big-picture\|--process\|--design-level\|--patterns\|--glossary\|--notation\|--remote]` | Facilitation knowledge and reference across the three formats — notation, building blocks, patterns/anti-patterns, remote adaptations. No args runs an interactive discovery flow. |
+| `methodology` | `/event-storming:methodology [--big-picture\|--process\|--design-level\|--patterns\|--glossary\|--notation\|--remote]` | Facilitation knowledge and reference across the three formats: notation, building blocks, patterns/anti-patterns, remote adaptations. No args runs an interactive discovery flow. |
 | `simulation` | `/event-storming:simulation [--simulate\|--process-model\|--design-level\|--evaluate\|--retrospective\|--induction\|--value\|--crc\|--ux\|--discover-bcs] [domain]` | An agentic, multi-persona EventStorming workshop that produces a structured-markdown model by default, plus per-run scoring and bounded-context discovery. A live Miro-board rendering path is available when the first-party `miro` plugin is enabled (see Requirements). |
 
 ## When to use which
 
-- **methodology** is pure reference — you are facilitating (or learning) EventStorming yourself and
+- **methodology** is pure reference. You are facilitating or learning EventStorming yourself and
   want the format guidance, notation, and patterns at hand. It needs no external tools.
-- **simulation** *runs* the workshop for you: it spins up 4–7 siloed personas, plays every Big
+- **simulation** *runs* the workshop for you: it spins up 4 to 7 siloed personas, plays every Big
   Picture phase in order, discovers bounded contexts, and lets you drill into Process Modeling and
   Design-Level per context. By default it emits the model as structured markdown (event timeline,
   persona roster, bounded-context tables); with the first-party `miro` plugin enabled it renders
@@ -33,8 +33,8 @@ Each skill auto-invokes on its own trigger phrases, or you can call it directly.
 
 ## Requirements
 
-- **methodology** — none beyond Claude Code.
-- **simulation** — no hard dependency. It runs out of the box in **structured-markdown mode** (the
+- **methodology.** None beyond Claude Code.
+- **simulation.** No hard dependency. It runs out of the box in **structured-markdown mode** (the
   agentic workshop, emitting the model as an event timeline, persona roster, and bounded-context
   tables). Two optional surfaces enhance it, neither bundled:
   - The first-party **`miro` plugin** for the live-board rendering path.
@@ -42,15 +42,15 @@ Each skill auto-invokes on its own trigger phrases, or you can call it directly.
 
 Both optional surfaces degrade gracefully:
 
-- **Miro** — the live-board path uses the first-party **`miro` plugin**: a bundled local-stdio MCP
+- **Miro.** The live-board path uses the first-party **`miro` plugin**: a bundled local-stdio MCP
   server that a fresh consumer must **install from an available marketplace and then enable**
   (select the `miro` plugin in `/plugin`, then enable it) with a Miro API token stored by Claude
   Code's secure credential mechanism. Its tools are namespaced `mcp__plugin_miro_miro__*`. With the plugin absent (or its
   tools unavailable), `simulation` detects it at preflight and runs in structured-markdown mode
   instead of failing. Miro's official hosted server (`mcp.miro.com`) was evaluated and **rejected**
-  as the target (no board-delete tool for teardown; third-party remote egress) — trust record in the
+  as the target (no board-delete tool for teardown; third-party remote egress). Trust record in the
   marketplace repo's MCP decision table (`docs/MIGRATION-PLAYBOOK.md`).
-- **Web research absent** — the skills use the Perplexity MCP tools if present, otherwise Claude
+- **Web research absent.** The skills use the Perplexity MCP tools if present, otherwise Claude
   Code's built-in `WebSearch` / `WebFetch`; with no research surface at all they ask you for the
   domain context rather than guessing.
 

--- a/plugins/event-storming/skills/methodology/SKILL.md
+++ b/plugins/event-storming/skills/methodology/SKILL.md
@@ -34,11 +34,11 @@ To *run* an agentic AI-driven workshop (multi-persona simulation on Miro) rather
 
 ## Interactive Discovery (no args)
 
-When invoked with no arguments, help the user figure out what they need. Don't dump information — ask questions.
+When invoked with no arguments, help the user figure out what they need. Don't dump information. Ask questions.
 
 ### Step 1: Check for existing boards
 
-**Miro availability gate:** this step needs a Miro MCP server. If Miro tools are unavailable in the session (no `miro_list_boards` tool), skip board discovery entirely and go straight to Step 2 — do not error. Reference-only guidance (every `--<format>` action) works with no Miro at all.
+**Miro availability gate:** this step needs a Miro MCP server. If Miro tools are unavailable in the session (no `miro_list_boards` tool), skip board discovery entirely and go straight to Step 2. Do not error. Reference-only guidance (every `--<format>` action) works with no Miro at all.
 
 When Miro IS available, query it for recent boards: `miro_list_boards`. Look for boards with EventStorming-related names (containing "Big Picture", "Process Model", "Design-Level", "EventStorming", or domain-specific names from prior sessions). Sort by last modified.
 
@@ -54,7 +54,7 @@ If recent boards exist, present them:
 > 2. Start a new EventStorming session
 > 3. Just learn about EventStorming (reference mode)"
 
-If the user picks an existing board, read it via `miro_list_board_items` (full pagination) to understand what's there — what format was used, what phase it's in, what building blocks are present. Then suggest next steps:
+If the user picks an existing board, read it via `miro_list_board_items` (full pagination) to understand what's there: what format was used, what phase it's in, what building blocks are present. Then suggest next steps:
 
 - If it's a Big Picture with no PM/DL follow-up → suggest `/event-storming:simulation --process-model` or `/event-storming:simulation --value` on the winning problem
 - If it's a Big Picture with PM done → suggest `/event-storming:simulation --design-level` or `/event-storming:simulation --crc`
@@ -82,7 +82,7 @@ Based on their choice, ask:
 >
 > Examples: e-commerce, conference organization, healthcare scheduling, insurance claims, logistics..."
 
-Then do 3+ web-research searches for domain context before proceeding — use the Perplexity MCP tools if present, otherwise the built-in `WebSearch`/`WebFetch`. If no web-research surface is available, ask the user for the domain context instead of guessing.
+Then do 3+ web-research searches for domain context before proceeding. Use the Perplexity MCP tools if present, otherwise the built-in `WebSearch`/`WebFetch`. If no web-research surface is available, ask the user for the domain context instead of guessing.
 
 ### Step 4: Recommend and execute
 
@@ -107,11 +107,11 @@ EventStorming is a flexible workshop format for collaborative exploration of com
 
 **Three main formats, increasing in precision:**
 
-1. **Big Picture** — Explore the entire business domain with all stakeholders. Discover bounded contexts, hotspots, and key business events. The broadest format.
-2. **Process Modeling** — Zoom into a specific business process. Model the flow with events, commands, policies, read models, and external systems. A cooperative game.
-3. **Design-Level** — Zoom into software design. Discover aggregates, define command/event contracts, and bridge to implementation. The most precise format.
+1. **Big Picture.** Explore the entire business domain with all stakeholders. Discover bounded contexts, hotspots, and key business events. The broadest format.
+2. **Process Modeling.** Zoom into a specific business process. Model the flow with events, commands, policies, read models, and external systems. A cooperative game.
+3. **Design-Level.** Zoom into software design. Discover aggregates, define command/event contracts, and bridge to implementation. The most precise format.
 
-**Core principle:** EventStorming is not about the stickies — it is about the conversations the stickies trigger. The real value is shared understanding, not the artifact.
+**Core principle:** EventStorming is not about the stickies. It is about the conversations the stickies trigger. The real value is shared understanding, not the artifact.
 
 ### Source authority hierarchy
 
@@ -122,7 +122,7 @@ Brandolini's book (*Introducing EventStorming*, Leanpub) is the **canonical sour
 3. **When sources conflict, Brandolini wins**
 4. **When Brandolini is silent** (e.g., Design-Level at ~10% written), secondary sources fill the gap with clear attribution
 
-This matters because secondary authors publish their *interpretations* of how to facilitate Brandolini's method — often good interpretations, but not Brandolini's prescribed sequence.
+This matters because secondary authors publish their *interpretations* of how to facilitate Brandolini's method. Often good interpretations, but not Brandolini's prescribed sequence.
 
 ---
 
@@ -132,7 +132,7 @@ This matters because secondary authors publish their *interpretations* of how to
 |-------|---------|-------------|
 | **Orange** | Domain Event | Something that happened (past tense). The fundamental building block |
 | **Blue** | Command / Action | An intention or decision that triggers an event |
-| **Lilac/Purple** | Policy | Reactive logic — "whenever X happens, do Y". Connects events to commands |
+| **Lilac/Purple** | Policy | Reactive logic: "whenever X happens, do Y". Connects events to commands |
 | **Yellow (small)** | Actor / Person | A human role that issues commands |
 | **Yellow (large)** | Read Model | Information a person needs to make a decision |
 | **Pink/Red** | External System | A system outside the current domain boundary |
@@ -177,13 +177,13 @@ Load these based on what the user needs:
 ## Applying EventStorming to Your Codebase
 
 EventStorming output (sticky notes on a wall) bridges to code via DDD tactical patterns. Each
-sticky-note color maps to a concrete code element in a DDD codebase — commands, domain events,
+sticky-note color maps to a concrete code element in a DDD codebase: commands, domain events,
 aggregates, read models, policies. See `reference/design-level.md` ("Relationship to Your
 Architecture") for the sticky-color-to-tactical-pattern mapping and how to translate it to the
 building blocks your own stack uses.
 
 EventStorming directly informs bounded context discovery, domain event design, aggregate
-boundaries, command/query separation, policy identification, and hot-spot tracking — see
+boundaries, command/query separation, policy identification, and hot-spot tracking. See
 `reference/design-level.md` for the concrete code mapping.
 
 When using this skill for domain modeling, read the consuming project's own architecture and
@@ -195,8 +195,8 @@ patterns onto that stack's building blocks rather than assuming a particular fra
 When the user wants shareable artifacts from EventStorming output, and the `document-skills` plugin
 (or equivalent document tooling) is available in the session, hand off to it:
 
-- **Board results slides** — `document-skills:pptx` for Big Picture results, Process Model swimlanes
-- **Workshop guide** — `document-skills:docx` for participant materials and facilitation notes
-- **Stakeholder report** — `document-skills:pdf` for comprehensive modeling report
+- **Board results slides.** `document-skills:pptx` for Big Picture results, Process Model swimlanes
+- **Workshop guide.** `document-skills:docx` for participant materials and facilitation notes
+- **Stakeholder report.** `document-skills:pdf` for comprehensive modeling report
 
 If no document tooling is present, emit the artifact as markdown instead.

--- a/plugins/event-storming/skills/simulation/SKILL.md
+++ b/plugins/event-storming/skills/simulation/SKILL.md
@@ -20,12 +20,12 @@ Parse `$ARGUMENTS` for a simulation mode:
 - `--process-model [board-url-or-bc-name]`: Run Process Modeling only, against an existing Big Picture board. Reads the BP board to extract the winning problem / selected BC, then executes PM with the 3-pass technique. Use when the user wants to deep-dive a specific BC without re-running Big Picture.
 - `--design-level [board-url-or-bc-name]`: Run Design-Level only, against an existing Process Modeling board. Reads the PM board to extract the process model, then executes DL with Blank Aggregates technique. Use when the user wants to go from PM → DL on a specific bounded context.
 - `--evaluate`: Run the iteration workflow against existing boards. Loads `iteration-workflow.md` and `simulation-evaluation.md`. Executes: SCORE → COMPARE → DIFF → FIX → VERIFY → CODIFY. Requires existing boards (reads the run-state store, `${CLAUDE_PLUGIN_DATA}/history.jsonl`, for board URLs).
-- `--retrospective [domain]`: Run Big Picture as an organization retrospective — exploring an existing business process to find improvement opportunities. Frames exploration as "what ACTUALLY happens?" vs the official version. Same phases as `--simulate` but with a focus on problems/opportunities in existing flows rather than new product discovery. (Book Ch. 1 story 4, Ch. 10)
+- `--retrospective [domain]`: Run Big Picture as an organization retrospective, exploring an existing business process to find improvement opportunities. Frames exploration as "what ACTUALLY happens?" vs the official version. Same phases as `--simulate` but with a focus on problems/opportunities in existing flows rather than new product discovery. (Book Ch. 1 story 4, Ch. 10)
 - `--induction [domain]`: Run Big Picture as a new hire onboarding exercise. The New Hire persona leads (models based on guessing/assumptions), senior personas correct and explain. Implements Brandolini's "give newcomers the leading role" (Ch. 10). Produces a learning-oriented model, not a definitive one.
 - `--value [domain]`: Run standalone Value Exploration against an existing Big Picture board. Executes all 5 sub-rounds: Financial value → Non-financial currencies → Contrasting perspectives → Diverging perspectives (customer segments) → Explore Purpose. (Book Ch. 5)
 - `--crc [board-url]`: Run Event-Driven CRC Cards validation against an existing Design-Level board. Assigns each aggregate to a separate agent, passes command/event cards between them with "tell don't ask" constraint. Validates interaction patterns work. (Book Ch. 22)
-- `--ux [domain]`: Run UX-Driven EventStorming — Process Modeling with a user journey focus. Follows the customer/user through the process, evaluating emotional experience, friction points, and "flawless execution" at each step. Uses standard PM color grammar plus emotional annotations. (Book preface + Brandolini's "Transactions Redefined" talk)
-- `--discover-bcs [board-url]`: Run Bounded Context discovery against an existing Big Picture board. Reads ALL board items via MCP, applies Brandolini's 6 heuristics (Ch. 6) mechanically against the data, and produces a structured BC analysis with heuristic evidence. Can be run at any time against any completed BP board — results are reproducible. See "Bounded Context Discovery Protocol" below.
+- `--ux [domain]`: Run UX-Driven EventStorming, Process Modeling with a user journey focus. Follows the customer/user through the process, evaluating emotional experience, friction points, and "flawless execution" at each step. Uses standard PM color grammar plus emotional annotations. (Book preface + Brandolini's "Transactions Redefined" talk)
+- `--discover-bcs [board-url]`: Run Bounded Context discovery against an existing Big Picture board. Reads ALL board items via MCP, applies Brandolini's 6 heuristics (Ch. 6) mechanically against the data, and produces a structured BC analysis with heuristic evidence. Can be run at any time against any completed BP board. Results are reproducible. See "Bounded Context Discovery Protocol" below.
 
 If no simulation mode is specified, ask whether to run a full `--simulate` cycle (defaulting the domain to "Developer Conference") or to read facilitation reference instead (`/event-storming:methodology`).
 
@@ -35,8 +35,8 @@ For facilitation knowledge, format guidance, notation, and the no-args interacti
 
 ## Miro availability & graceful degradation
 
-This skill drives an EventStorming model onto a **Miro board** via the first-party **`miro` plugin**
-— a bundled local-stdio MCP server, enabled separately (`event-storming` does not bundle it). The
+This skill drives an EventStorming model onto a **Miro board** via the first-party **`miro` plugin**,
+a bundled local-stdio MCP server, enabled separately (`event-storming` does not bundle it). The
 plugin exposes its tools under the **`mcp__plugin_miro_miro__`** prefix, so before any mode runs
 check whether e.g. `mcp__plugin_miro_miro__miro_list_boards` / `mcp__plugin_miro_miro__miro_create_board`
 are callable. A bare `miro_*` name does not resolve for a plugin-bundled server, so the gate must
@@ -47,21 +47,21 @@ plugin's tool under the `mcp__plugin_miro_miro__` prefix.
 - **Miro absent** → do NOT fail. Tell the user the `miro` plugin isn't enabled, then offer two paths
   and let them choose:
   1. **Structured-markdown mode (default, recommended):** run the same agentic multi-persona
-     workshop, but emit the model as structured markdown instead of board stickies — an ordered
+     workshop, but emit the model as structured markdown instead of board stickies: an ordered
      event timeline, a persona roster, bounded-context tables, and hot-spot / opportunity lists.
      Every phase that would place stickies instead appends to the markdown artifact. The
      facilitation logic, personas, phase ordering, and rubric scoring are identical; only the
      rendering surface changes. Persist the artifact under `${CLAUDE_PLUGIN_DATA}/sessions/`.
-  2. **Install + enable the `miro` plugin, then retry:** a fresh user has only `event-storming` — the
+  2. **Install + enable the `miro` plugin, then retry:** a fresh user has only `event-storming`. The
      `miro` plugin must be installed from an available marketplace first, then enabled through
      the `/plugin` interface with a Miro API token (stored by Claude Code's secure credential
      mechanism). Do not assume a marketplace name. Stop until its tools are available. Full setup:
      `reference/miro-integration.md`.
 
 Modes that read an *existing* board (`--process-model`, `--design-level`, `--evaluate`, `--crc`,
-`--discover-bcs` with a board URL) require Miro — if it's absent, say so and offer path 2, since
+`--discover-bcs` with a board URL) require Miro. If it's absent, say so and offer path 2, since
 there is no board to read. One check precedes that gate: for a BC-name input, `--design-level`
-resolves its prerequisite first — the run-state store lookup (`${CLAUDE_PLUGIN_DATA}/history.jsonl`)
+resolves its prerequisite first. The run-state store lookup (`${CLAUDE_PLUGIN_DATA}/history.jsonl`)
 needs no Miro, so a missing Process Modeling board is surfaced as the missing prerequisite (offer
 `--process-model` first) before any Miro gating.
 
@@ -71,19 +71,19 @@ needs no Miro, so a missing Process Modeling board is surfaced as the missing pr
 
 **Required reading before execution:**
 
-1. `@./reference/agentic-simulation.md` — execution guide: personas, round-based orchestration (every Big Picture phase, in order), board setup, session lifecycle
-2. `@./reference/simulation-evaluation.md` — phase-by-phase rubric, chapter index, pre-flight checklist
-3. `@./reference/iteration-workflow.md` — the meta-process for evaluation
-4. Prior-run state under `${CLAUDE_PLUGIN_DATA}/` (see "Cross-run state" below) — previous-version metrics for comparison, if any
+1. `@./reference/agentic-simulation.md`. Execution guide: personas, round-based orchestration (every Big Picture phase, in order), board setup, session lifecycle
+2. `@./reference/simulation-evaluation.md`. Phase-by-phase rubric, chapter index, pre-flight checklist
+3. `@./reference/iteration-workflow.md`. The meta-process for evaluation
+4. Prior-run state under `${CLAUDE_PLUGIN_DATA}/` (see "Cross-run state" below). Previous-version metrics for comparison, if any
 
 **Flow:**
 
-1. **Setup** — MCP preflight (Miro availability per "Miro availability & graceful degradation" above), domain research (3+ web-research searches — Perplexity MCP if present, else `WebSearch`; default domain "Developer Conference"), persona setup (4-7 personas, three-zone DEEP/GREY/PRETEND knowledge, 5 shared focal moments). Session lifecycle (ID, dirs, teardown) and preflight detail: `@./reference/agentic-simulation.md` "Session lifecycle".
-2. **Big Picture** (always first) — run every workshop phase in order (Chaotic Exploration → Enforce Timeline → People & Systems → Explicit Walk-through → Reverse Narrative → [optional] Add the Money / Value Exploration → Problems & Opportunities → Arrow Voting → Wrapping Up) per `@./reference/agentic-simulation.md` "Round-Based Orchestration", taking a visual-verification screenshot at each transition; then run the post-workshop visual check (Ch. 9) and score against the Big Picture rubric.
-3. **Post-workshop analysis + interactive progression** — run bounded-context discovery (architect's homework, not a workshop phase — see `--discover-bcs` below), present the arrow-voting winner and discovered BCs, then use AskUserQuestion to let the user pick the next BC to Process Model, then Design-Level, repeating per BC. **Never auto-advance formats — the user chooses each step.**
-4. **Evaluation & codification** — score all boards against the full rubric, compare against the `${CLAUDE_PLUGIN_DATA}/history.jsonl` baselines, run the retrospective protocol (`@./reference/simulation-evaluation.md`), update the run-state store with version metrics / board URLs / findings, present the version comparison, and clean up old boards with user approval.
+1. **Setup.** MCP preflight (Miro availability per "Miro availability & graceful degradation" above), domain research (3+ web-research searches. Perplexity MCP if present, else `WebSearch`; default domain "Developer Conference"), persona setup (4-7 personas, three-zone DEEP/GREY/PRETEND knowledge, 5 shared focal moments). Session lifecycle (ID, dirs, teardown) and preflight detail: `@./reference/agentic-simulation.md` "Session lifecycle".
+2. **Big Picture** (always first). Run every workshop phase in order (Chaotic Exploration → Enforce Timeline → People & Systems → Explicit Walk-through → Reverse Narrative → [optional] Add the Money / Value Exploration → Problems & Opportunities → Arrow Voting → Wrapping Up) per `@./reference/agentic-simulation.md` "Round-Based Orchestration", taking a visual-verification screenshot at each transition; then run the post-workshop visual check (Ch. 9) and score against the Big Picture rubric.
+3. **Post-workshop analysis + interactive progression.** Run bounded-context discovery (architect's homework, not a workshop phase. See `--discover-bcs` below), present the arrow-voting winner and discovered BCs, then use AskUserQuestion to let the user pick the next BC to Process Model, then Design-Level, repeating per BC. **Never auto-advance formats. The user chooses each step.**
+4. **Evaluation & codification.** Score all boards against the full rubric, compare against the `${CLAUDE_PLUGIN_DATA}/history.jsonl` baselines, run the retrospective protocol (`@./reference/simulation-evaluation.md`), update the run-state store with version metrics / board URLs / findings, present the version comparison, and clean up old boards with user approval.
 
-Throughout, maintain an **exploration map** (Big Picture URL, all BCs explored + unexplored, per-BC Process Modeling and Design-Level board URLs) on the Big Picture board as a cyan sticky and in the run-state store (`${CLAUDE_PLUGIN_DATA}/history.jsonl`) — layout detail in `@./reference/agentic-simulation.md`.
+Throughout, maintain an **exploration map** (Big Picture URL, all BCs explored + unexplored, per-BC Process Modeling and Design-Level board URLs) on the Big Picture board as a cyan sticky and in the run-state store (`${CLAUDE_PLUGIN_DATA}/history.jsonl`). Layout detail in `@./reference/agentic-simulation.md`.
 
 ## Running a Deep Dive (`--process-model` or `--design-level`)
 
@@ -101,7 +101,7 @@ When invoked with `--process-model` or `--design-level`, run a single format aga
 **`--design-level [board-url-or-bc-name]`:**
 
 1. Read the run-state store (`${CLAUDE_PLUGIN_DATA}/history.jsonl`) for the Process Modeling board URL for the specified BC
-2. If no prior Process Modeling board exists for the BC, surface the missing prerequisite and offer to run `--process-model` first — never fabricate a process model or aggregates from scratch
+2. If no prior Process Modeling board exists for the BC, surface the missing prerequisite and offer to run `--process-model` first. Never fabricate a process model or aggregates from scratch
 3. Extract the process model (events, commands, policies)
 4. Execute Design-Level with Blank Aggregates technique
 5. Score against DL rubric
@@ -115,21 +115,21 @@ When invoked with `--evaluate`, run the iteration workflow against existing boar
 
 ## Bounded Context Discovery Protocol (`--discover-bcs`)
 
-When invoked with `--discover-bcs [board-url]`, run Brandolini's 6 heuristics (Ch. 6) against an existing Big Picture board. This is the architect's post-workshop homework — reproducible and evidence-based. The board data can arrive two ways: a board URL (live Miro read — requires Miro per the availability gate) or a directly-supplied board export (a structured-markdown board dump), which substitutes for the live read and needs no Miro.
+When invoked with `--discover-bcs [board-url]`, run Brandolini's 6 heuristics (Ch. 6) against an existing Big Picture board. This is the architect's post-workshop homework. Reproducible and evidence-based. The board data can arrive two ways: a board URL (live Miro read. Requires Miro per the availability gate) or a directly-supplied board export (a structured-markdown board dump), which substitutes for the live read and needs no Miro.
 
 **Prerequisites:** A completed Big Picture board with People & Systems and Walk-through phases done. The more phases completed, the richer the signals.
 
 **Execution sequence:**
 
-1. **Read ALL board items** — via `miro_list_board_items` (full pagination) for a live board, or by parsing the supplied board export when one was provided instead of a URL. Parse into structured data: events by persona, people, external systems, hot spots, pivotal events.
+1. **Read ALL board items** via `miro_list_board_items` (full pagination) for a live board, or by parsing the supplied board export when one was provided instead of a URL. Parse into structured data: events by persona, people, external systems, hot spots, pivotal events.
 
-2. **Apply Brandolini's 6 boundary heuristics mechanically** against the parsed data — canonical definitions in `/event-storming:methodology --big-picture` "Heuristics for Discovering Boundaries". Board-data signals: pivotal-event stickies (`dark_blue` / `--- PIVOTAL ---`) mark business-phase boundaries (H1); persona y-offset rows reveal parallel swimlanes (H2); per-persona event density per timeline zone assigns ownership (H3/H4); `[DIVERGENCE]` / hot-spot markers and same-noun-different-meaning phrasings signal boundaries (H5/H6). Use short BC names (2-3 words).
+2. **Apply Brandolini's 6 boundary heuristics mechanically** against the parsed data. Canonical definitions in `/event-storming:methodology --big-picture` "Heuristics for Discovering Boundaries". Board-data signals: pivotal-event stickies (`dark_blue` / `--- PIVOTAL ---`) mark business-phase boundaries (H1); persona y-offset rows reveal parallel swimlanes (H2); per-persona event density per timeline zone assigns ownership (H3/H4); `[DIVERGENCE]` / hot-spot markers and same-noun-different-meaning phrasings signal boundaries (H5/H6). Use short BC names (2-3 words).
 
-3. **Produce the BC analysis output** — a table of `# | BC Name (2-3 words) | Key Events | Primary Personas | Heuristic Evidence`, where the evidence column cites which heuristic fired (e.g. `H1: phase X→Y; H5: "Budget Approved" divergence; H6: "Ticket" means different things`).
+3. **Produce the BC analysis output**, a table of `# | BC Name (2-3 words) | Key Events | Primary Personas | Heuristic Evidence`, where the evidence column cites which heuristic fired (e.g. `H1: phase X→Y; H5: "Budget Approved" divergence; H6: "Ticket" means different things`).
 
-4. **Place BC labels** on the board as cyan stickies at y=7100 (the canonical BC Labels row — bottom of board, below all other content per the Big Picture Y-Coordinate Table in `@./reference/miro-integration.md`), with `[BC]` prefix. Live-board path only — when working from a supplied export there is no board to write; the step 3 table is the complete deliverable.
+4. **Place BC labels** on the board as cyan stickies at y=7100 (the canonical BC Labels row. Bottom of board, below all other content per the Big Picture Y-Coordinate Table in `@./reference/miro-integration.md`), with `[BC]` prefix. Live-board path only. When working from a supplied export there is no board to write; the step 3 table is the complete deliverable.
 
-5. **Cross-reference with arrow voting winner** — which BC does the winner scope to? Mark it as the recommended next exploration target.
+5. **Cross-reference with arrow voting winner.** Which BC does the winner scope to? Mark it as the recommended next exploration target.
 
 **Reproducibility guarantee:** Running `--discover-bcs` against the same board state should produce the same BCs, because the heuristics are applied mechanically against data, not subjectively. The evidence column provides traceability.
 
@@ -161,7 +161,7 @@ Load these based on the mode being run:
 
 ## Cross-run state
 
-Persist all generated state — session archives, board URLs, version metrics, run findings — under
+Persist all generated state, session archives, board URLs, version metrics, run findings, under
 `${CLAUDE_PLUGIN_DATA}/` (the per-plugin directory that survives updates). Session archives go to
 `${CLAUDE_PLUGIN_DATA}/sessions/<session-id>/`; comparison baselines (prior-version metrics) to a
 JSON/JSONL file such as `${CLAUDE_PLUGIN_DATA}/history.jsonl`. Never write generated state inside


### PR DESCRIPTION
No linked issue

## Summary

#2891 instruction-surface de-slop cluster: purge em dashes from the `event-storming` plugin README and every SKILL.md.

Refs #2891

## Fix

Rewrote `plugins/event-storming/README.md` and every `plugins/event-storming/**/SKILL.md` under `/ai-slop:audit fix` semantics (periods, commas, or a restructured sentence; never parentheses, en dashes, or a spaced hyphen as a stand-in). Meaning-preserving grammar pass after the mechanical replace. Version-only bump in `plugin.json`. New changelog heading only. YAML frontmatter description/summary left unchanged so the cheatsheet stays valid. Quoted AskUserQuestion protocol and cited Brandolini Phase headings keep their original punctuation.

## Verification

- Detector (`HOME` + `CLAUDE_PROJECT_DIR` isolated so `rule-em-dash` is enabled): 0 body-prose `rule-em-dash` findings outside YAML frontmatter and quoted AskUserQuestion protocol
- `CHECK_SKILL_SKIP_MARKDOWNLINT=1 bash scripts/check-changed-skills.sh origin/main`: 0 failed; quoted trigger phrases vs origin/main preserved
- `python3 scripts/sync-plugin-options-docs.py --check` up to date
- `scripts/check-changelog-parity.sh --check-bump origin/main` passes
- `node scripts/generate-cheatsheet.mjs --check` in sync

## Related

Refs #2891

#2891 stays open.