### PR TITLE
docs(ruff-format): de-slop instruction surfaces (0.6.23)

### DIFF
--- a/plugins/ruff-format/.claude-plugin/plugin.json
+++ b/plugins/ruff-format/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "ruff-format",
-  "version": "0.6.22",
+  "version": "0.6.23",
   "description": "Auto-format and lint Python on edit via Ruff, only when a Ruff config governs the repo — using the consuming repo's own Ruff config.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/ruff-format/CHANGELOG.md
+++ b/plugins/ruff-format/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to the `ruff-format` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.6.23]
+
+### Changed
+
+- **Instruction-surface de-slop (#2891, ruff-format cluster).** Rewrote this plugin's `README.md` and every
+  `SKILL.md` to drop em dashes under the repo's zero-tolerance house policy, using
+  `/ai-slop:audit fix` semantics: periods or commas, or a restructured sentence, never
+  parentheses, en dashes, or a spaced hyphen as a stand-in. Meaning stays; only the mark
+  and the sentence break change. The generated options block is ignore-fenced because
+  `scripts/sync-plugin-options-docs.py` still emits em dashes from its shared template.
+
 ## [0.6.22]
 
 ### Fixed

--- a/plugins/ruff-format/README.md
+++ b/plugins/ruff-format/README.md
@@ -13,20 +13,20 @@ own and runs only when your repo has opted into Ruff.
 
 - **Opt-in on a Ruff config.** Ruff runs **only when a `.ruff.toml`,
   `ruff.toml`, or `pyproject.toml` with a `[tool.ruff]` section governs the
-  edited file**, found by walking up from the file to the repository root — the
+  edited file**, found by walking up from the file to the repository root, the
   same discovery Ruff itself uses (a `pyproject.toml` without `[tool.ruff]` is
   ignored, exactly as Ruff ignores it). A repo without a Ruff config is left
   untouched rather than rewritten to Ruff's built-in defaults, so the plugin
   never imposes a style you did not choose. **Known limitation:** a
   `pyproject.toml` that expresses this as a bare `[tool]` header with an inline
   table (`[tool]` + `ruff = { ... }`) is not recognized, even though Ruff
-  itself honors that form — such a repo is treated as un-configured and the
+  itself honors that form. Such a repo is treated as un-configured and the
   hook skips (fails safe: a missed opt-in, never a wrong edit).
 - **Fix + format on edit.** `ruff check --fix` applies safe fixes (never
   `--unsafe-fixes`) and `ruff format` formats in place. Residual diagnostics
   are reported but not auto-applied.
 - **Just-added imports are protected.** The hook passes `--unfixable F401`, so
-  an unused import is *reported* but never auto-deleted — during iterative
+  an unused import is *reported* but never auto-deleted. During iterative
   editing an import often lands one edit before the code that uses it. This
   extends your config's own `unfixable` list; it does not replace it.
 - **Syntax errors are version-aware.** Ruff's parser checks syntax against your
@@ -43,12 +43,12 @@ own and runs only when your repo has opted into Ruff.
 
 ## Requirements
 
-- **Bash** — the hook is a Bash script. On native Windows, install
+- **Bash.** The hook is a Bash script. On native Windows, install
   [Git for Windows](https://code.claude.com/docs/en/setup#set-up-on-windows) so
   Claude Code can run it under Git Bash.
-- **jq** on `PATH` — parses the hook payload. Absent: the hook skips with a
+- **jq** on `PATH`. Parses the hook payload. Absent: the hook skips with a
   visible once-per-session notice. [Install jq](https://jqlang.org/download/).
-- **Ruff** available to the repo — installed in the repo's `.venv` (the hook
+- **Ruff** available to the repo. Installed in the repo's `.venv` (the hook
   resolves `.venv/bin/ruff`, or `.venv/Scripts/ruff.exe` on Windows, walking up
   from the edited file) or on `PATH`. Ruff is never downloaded on the fly; if
   it is not present while a Ruff config governs the repo, the hook skips with a
@@ -58,7 +58,7 @@ own and runs only when your repo has opted into Ruff.
   absent, in which case the run is reported as a tool break rather than a
   finding.
 - A **Ruff config** (`.ruff.toml`, `ruff.toml`, or `pyproject.toml` with
-  `[tool.ruff]`) in the repo — the opt-in.
+  `[tool.ruff]`) in the repo, the opt-in.
 
 The hook itself runs on Bash 3.2+. Telemetry timing uses `EPOCHREALTIME`
 (Bash 5.0+); on older bash the telemetry envelope is skipped while formatting
@@ -75,7 +75,7 @@ Then verify prerequisites with `/ruff-format:setup check`.
 
 ## Configuration
 
-The rules themselves are never configured here — they come from the Ruff config
+The rules themselves are never configured here. They come from the Ruff config
 already in your repository, which the plugin reads automatically. To change the
 rules, edit that file.
 
@@ -83,7 +83,7 @@ One `userConfig` option tunes the hook itself:
 
 | Option | Default | Effect |
 |--------|---------|--------|
-| `ruff_format_enabled` | `true` | Kill switch — set `false` for a clean no-op. |
+| `ruff_format_enabled` | `true` | Kill switch. Set `false` for a clean no-op. |
 
 Set it interactively with `/plugin configure ruff-format@<marketplace>`, or headless on the
 install command:
@@ -92,6 +92,7 @@ install command:
 claude plugin install ruff-format@<marketplace> --config ruff_format_enabled=false
 ```
 
+<!-- ai-slop-ignore-start: generated options block; source is plugin.json + scripts/sync-plugin-options-docs.py -->
 <!-- BEGIN GENERATED: plugin options — edit plugin.json, then run scripts/sync-plugin-options-docs.py -->
 
 ### Options reference
@@ -164,6 +165,7 @@ hands a configured value to a hook process; the value comes from the routes abov
 - [Manage installed plugins](https://code.claude.com/docs/en/discover-plugins#manage-installed-plugins) — enabling, disabling, `/plugin list`
 
 <!-- END GENERATED: plugin options -->
+<!-- ai-slop-ignore-end -->
 
 ## License
 

--- a/plugins/ruff-format/skills/setup/SKILL.md
+++ b/plugins/ruff-format/skills/setup/SKILL.md
@@ -9,80 +9,80 @@ disable-model-invocation: true
 
 Thin check-centric setup per the uniform setup contract (`docs/PLUGIN-PHILOSOPHY.md`
 "Setup is explicit and repeatable" in the marketplace repository): `check` inspects and
-reports, `apply` resolves. This plugin owns no consumer-project configuration — rules come
+reports, `apply` resolves. This plugin owns no consumer-project configuration. Rules come
 from the repository's own Ruff config, and the only tunable is the native `userConfig`
-toggle — so `apply` is guidance-and-verify, with exactly one write path: the explicitly
+toggle, so `apply` is guidance-and-verify, with exactly one write path: the explicitly
 invoked `apply install-ruff` install into the repo's existing managed environment
 described below.
 
 Action routing: no argument or `check` runs the check; `apply` runs the check first, then
 remediation; `apply install-ruff` additionally authorizes the consumer-repo install
-described below. All are non-interactive — never prompt when the action is given.
+described below. All are non-interactive. Never prompt when the action is given.
 
 ## `check` (read-only)
 
 The hook script (`${CLAUDE_PLUGIN_ROOT}/hooks/ruff-format.sh`) is the single source of
 truth for what it requires and how it resolves things.
 
-**Read it first** — probe what it actually does, don't recite this file. Then run each probe via
+**Read it first.** Probe what it actually does, don't recite this file. Then run each probe via
 Bash and report a PASS/FAIL/INFO table with one remediation line per FAIL. Do not modify anything.
 
 When the plugin's toggle is disabled, every prerequisite absence downgrades from FAIL to
-INFO — the hook exits through its enabled-gate before probing anything, so a deliberately
+INFO. The hook exits through its enabled-gate before probing anything, so a deliberately
 disabled plugin is not broken. Report the probes informationally and note that re-enabling
 restores the FAIL semantics.
 
-1. **Bash version** — check against the hook's documented floor (README Requirements),
+1. **Bash version.** Check against the hook's documented floor (README Requirements),
    noting any features the hook degrades without (for example telemetry's `EPOCHREALTIME`,
    Bash 5.0+).
-2. **`jq`** — `command -v jq`. FAIL if absent: the hook then skips with a visible
+2. **`jq`.** `command -v jq`. FAIL if absent: the hook then skips with a visible
    once-per-session notice instead of formatting.
-3. **Ruff binary** — resolve it exactly the way the hook's resolution code does: its
+3. **Ruff binary.** Resolve it exactly the way the hook's resolution code does: its
    repo-managed virtual-environment walk (the exact `.venv` interpreter paths it tests for
    the current platform, walking up from the edited file toward the repo root) and then
-   `PATH`. Test only what the hook tests — a binary the hook would not accept must not PASS
+   `PATH`. Test only what the hook tests. A binary the hook would not accept must not PASS
    here. FAIL when nothing the hook would resolve is present while a Ruff config governs the
    repo; the hook then emits a visible once-per-session skip notice instead of formatting.
-4. **Consumer Ruff config** — mirror the hook's opt-in walk: it stops at the FIRST
+4. **Consumer Ruff config.** Mirror the hook's opt-in walk: it stops at the FIRST
    (closest) governing config found walking from the edited file's directory up to the repo
    root, honoring Ruff's own same-directory precedence and counting a `pyproject.toml` only
    when it carries a `[tool.ruff]` section or any `[tool.ruff.*]` subtable such as
-   `[tool.ruff.lint]` (read the hook for the exact names and the section test — its test is
-   the authority). Report the governing config the walk discovers, or INFO that none exists —
-   absence is the opt-out by design, so the plugin is inert (INFO, not FAIL), matching the
+   `[tool.ruff.lint]`. Read the hook for the exact names and the section test; its test is
+   the authority. Report the governing config the walk discovers, or INFO that none exists.
+   Absence is the opt-out by design, so the plugin is inert (INFO, not FAIL), matching the
    README's "ships no rules of its own" stance.
-5. **Hook toggle** — report the effective `ruff_format_enabled` value:
+5. **Hook toggle.** Report the effective `ruff_format_enabled` value:
    `${user_config.ruff_format_enabled}` (unexpanded or empty means default `true`).
-6. **Hook registration** — INFO: confirm the plugin is enabled for this project
+6. **Hook registration.** INFO: confirm the plugin is enabled for this project
    (`/plugin` → Installed) rather than parsing settings files.
 
 ## `apply` (idempotent)
 
-Run `check`, then for each FAIL offer the resolution — never install anything without the
+Run `check`, then for each FAIL offer the resolution. Never install anything without the
 consumer's explicit go-ahead in the invocation. `apply install-ruff` installs Ruff **only
 into a managed Python environment the repo already uses**, never by creating one and never
 globally, mirroring how the hook resolves the binary. Resolve the target from what the repo
 already declares:
 
-Principles, in order — they decide every case, whatever the tool:
+Principles, in order. They decide every case, whatever the tool:
 
-1. **Identify the repo's dependency manager from its own markers** — a lockfile or a
+1. **Identify the repo's dependency manager from its own markers.** A lockfile or a
    `pyproject.toml` tool section (uv, Poetry, Pipenv, PDM, Hatch, …). Recognize the tool
    from what the repo declares; don't assume from an enumerated list.
 2. **Record through the manager, never around it.** A managed project gets Ruff via that
    tool's own dev-dependency add command (e.g. `uv add --dev ruff`,
    `poetry add --group dev ruff`, `pipenv install --dev ruff`, `pdm add -d ruff`) so the
-   manifest and lockfile record it — a bare `pip install` into its environment is state
+   manifest and lockfile record it. A bare `pip install` into its environment is state
    the tool's next sync or clean silently removes.
 3. **Never create or mutate an environment.** When no environment exists yet, use the
-   tool's record-only mode when it has one (e.g. `uv add --dev ruff --no-sync` — plain
+   tool's record-only mode when it has one (e.g. `uv add --dev ruff --no-sync`. Plain
    `uv add` syncs and would create `.venv`) and hand the sync/install step to the
    consumer as their own command; when the tool's add command cannot avoid
-   creating/instantiating an environment, don't run it — give it as guidance instead.
+   creating/instantiating an environment, don't run it. Give it as guidance instead.
 4. **Only where the hook resolves.** The hook resolves repo-ancestor `.venv` interpreters
    or `PATH`, nothing else. Tools that default their environment to a cache directory
    (Poetry, Pipenv, and any similar) must have an in-project environment confirmed first
-   (the tool's own config/env answers — e.g. `poetry config virtualenvs.in-project`,
+   (the tool's own config/env answers, e.g. `poetry config virtualenvs.in-project`,
    `PIPENV_VENV_IN_PROJECT`); otherwise guide (enable in-project mode + recreate, or put
    `ruff` on `PATH`) rather than installing somewhere the hook never looks.
 5. **Bare `pip install` only into a plain existing `.venv`** with no manager markers of
@@ -92,20 +92,20 @@ Principles, in order — they decide every case, whatever the tool:
    (`https://docs.astral.sh/ruff/installation/`), matching the hook's own skip-notice
    text.
 
-After ANY remediation, re-run the relevant `check` probe and report its actual result —
-never claim resolved on the install command's exit code alone. For everything else `apply`
+After ANY remediation, re-run the relevant `check` probe and report its actual result.
+Never claim resolved on the install command's exit code alone. For everything else `apply`
 only points:
 
 - missing `jq` / Bash: platform install instructions from the README Requirements section;
   this skill never installs system packages.
 - toggle off: direct to `/plugin configure ruff-format` (interactive, any
-  time). Headless: rerun the install with the new value —
+  time). Headless: rerun the install with the new value,
   `claude plugin install ruff-format@<marketplace> -s <scope> --config ruff_format_enabled=true`
   (repeatable per key). Against an already-installed plugin it prints `already installed` **and
-  still writes the value** — verified on Claude Code 2.1.240 (a non-sensitive option at `user`
+  still writes the value**, verified on Claude Code 2.1.240 (a non-sensitive option at `user`
   scope: a non-default value written to an installed plugin, then restored). The short-circuit is
   about the install, not the config write. Re-verify before relying on it outside those
-  conditions — a `sensitive` option, or `project`/`local` scope, were not covered. Do **not**
+  conditions. A `sensitive` option, or `project`/`local` scope, were not covered. Do **not**
   uninstall to reconfigure: uninstalling drops this plugin's entire stored `pluginConfigs` entry,
   resetting every option in the README's Options reference table to its manifest default. `-s`
   defaults to `user`, so pass the scope `claude plugin list` reports for this plugin, and run from
@@ -114,17 +114,17 @@ only points:
   Afterwards, keep the two claims apart. The write is issued and the stored value is what you
   passed; the RUNNING session's behavior is not. The rendered `${user_config.*}` is injected at
   skill load and each hook receives its `CLAUDE_PLUGIN_OPTION_*` from an environment fixed at
-  session start, so a same-session `check` still reports the OLD value — reporting that as a
+  session start, so a same-session `check` still reports the OLD value. Reporting that as a
   failed write would be wrong. Verify the effective value by rerunning `check` in a **fresh
   session**, and never claim an unobserved change.
 - no Ruff config: offer to create a minimal Ruff config in the repository root only when
-  explicitly asked — the plugin imposes no rules of its own.
+  explicitly asked. The plugin imposes no rules of its own.
 
 Re-running `apply` after everything passes changes nothing and reports "already configured".
 
 ## What this skill does NOT do
 
-- Run the formatter — editing any `.py`/`.pyi` file exercises the hook end-to-end.
+- Run the formatter. Editing any `.py`/`.pyi` file exercises the hook end-to-end.
 - Write the plugin cache, Claude Code user settings, or `pluginConfigs`.
 - Create a virtual environment, install Ruff globally, or install outside a managed
   environment the repo already uses.


### PR DESCRIPTION
No linked issue

## Summary

Refs #2891. Instruction-surface de-slop shard for the `ruff-format` plugin only. Other plugins stay on main.

## Fix

Rewrote `plugins/ruff-format/README.md` and every `plugins/ruff-format/**/SKILL.md` under `/ai-slop:audit fix` semantics (periods, commas, or a restructured sentence; never parentheses, en dashes, or a spaced hyphen as a stand-in). YAML frontmatter left unchanged. Version-only bump in `plugin.json`. New changelog heading only. The generated options block is ignore-fenced because `scripts/sync-plugin-options-docs.py` still emits em dashes from its shared template. `ruff-format` 0.6.23.

## Verification

- Detector (`HOME` + `CLAUDE_PROJECT_DIR` isolated so `rule-em-dash` is enabled): 0 `rule-em-dash` findings on rewritten prose. Leftovers are the ignore-fenced generated-options span, plus version-only `plugin.json` description text and historical CHANGELOG entries that this shard did not rewrite
- `CHECK_SKILL_SKIP_MARKDOWNLINT=1 bash scripts/check-changed-skills.sh origin/main`: 0 failed; quoted trigger phrases vs origin/main preserved
- `python3 scripts/sync-plugin-options-docs.py --check` up to date
- `scripts/check-changelog-parity.sh --check-bump origin/main` passes
- `node scripts/generate-cheatsheet.mjs --check` in sync

## Related

Refs #2891