### PR TITLE
docs(actionlint): de-slop instruction surfaces (0.8.21)

### DIFF
--- a/plugins/actionlint/.claude-plugin/plugin.json
+++ b/plugins/actionlint/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "actionlint",
-  "version": "0.8.20",
+  "version": "0.8.21",
   "description": "Lint GitHub Actions workflow files on edit via actionlint, surfacing findings as advisory context.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/actionlint/CHANGELOG.md
+++ b/plugins/actionlint/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to the `actionlint` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.8.21]
+
+### Changed
+
+- **Instruction-surface de-slop (#2891, actionlint cluster).** Rewrote this plugin's `README.md` and every
+  `SKILL.md` to drop em dashes under the repo's zero-tolerance house policy, using
+  `/ai-slop:audit fix` semantics: periods or commas, or a restructured sentence, never
+  parentheses, en dashes, or a spaced hyphen as a stand-in. Meaning stays; only the mark
+  and the sentence break change. The generated options block is ignore-fenced because
+  `scripts/sync-plugin-options-docs.py` still emits em dashes from its shared template.
+
 ## [0.8.20]
 
 ### Fixed

--- a/plugins/actionlint/README.md
+++ b/plugins/actionlint/README.md
@@ -5,7 +5,7 @@ edit them. On every `Write` or `Edit` of a file under `.github/workflows/`
 (`*.yml` or `*.yaml`) it runs [actionlint](https://github.com/rhysd/actionlint)
 and surfaces any findings back to Claude as advisory context.
 
-It ships no rules of its own and no binary — it runs the `actionlint` already on
+It ships no rules of its own and no binary. It runs the `actionlint` already on
 your `PATH`.
 
 ## Behavior
@@ -19,22 +19,22 @@ your `PATH`.
   `.github/workflows/*.yaml` are linted. Other YAML is left alone.
 - **External run-block linters disabled (`-shellcheck= -pyflakes=`).**
   actionlint's embedded-bash ShellCheck and `shell: python` pyflakes
-  integrations are turned off. Each spawns a subprocess per `run:` block —
+  integrations are turned off. Each spawns a subprocess per `run:` block.
   ShellCheck deadlocks on large blocks under the Windows subprocess IPC path in
   actionlint 1.7.x, and either adds latency unsuited to an edit-time hook.
   Native workflow diagnostics are unaffected; run the full integrations in CI.
 - **Graceful degrade.** When `actionlint` (or `jq`) is not on `PATH` the hook
-  skips and says so — a once-per-session notice to both Claude
+  skips and says so, a once-per-session notice to both Claude
   (`additionalContext`) and you (`systemMessage`), never a silent no-op.
 
 ## Requirements
 
-- **Bash** — the hook is a Bash script. On native Windows, install
+- **Bash.** The hook is a Bash script. On native Windows, install
   [Git for Windows](https://code.claude.com/docs/en/setup#set-up-on-windows) so
   Claude Code can run it under Git Bash.
-- **jq** on `PATH` — parses the hook payload. Absent: the hook skips with a
+- **jq** on `PATH`. Parses the hook payload. Absent: the hook skips with a
   visible once-per-session notice. [Install jq](https://jqlang.org/download/).
-- **actionlint** on `PATH` — the linter itself. Absent: workflow lint skips
+- **actionlint** on `PATH`. The linter itself. Absent: workflow lint skips
   with a visible once-per-session notice. See the
   [actionlint install guide](https://github.com/rhysd/actionlint/blob/main/docs/install.md).
 
@@ -52,9 +52,9 @@ Then verify prerequisites with `/actionlint:setup check`.
 actionlint auto-discovers its own `.github/actionlint.yaml` config from your
 repository when present. Two `userConfig` options tune the hook itself:
 
-- **`actionlint_enabled`** (boolean, default `true`) — kill switch for the
+- **`actionlint_enabled`** (boolean, default `true`). Kill switch for the
   actionlint-check hook.
-- **`stdin_read_timeout`** (number, default `2`, minimum `1`) — **idle** bound in
+- **`stdin_read_timeout`** (number, default `2`, minimum `1`). **Idle** bound in
   seconds on reading the hook payload from stdin. Any byte arriving resets it, so
   a large or slowly-delivered payload is never cut off while it is still coming;
   it fires only once the pipe has gone silent for that long, and this hook then
@@ -63,9 +63,9 @@ repository when present. Two `userConfig` options tune the hook itself:
   configured interval of it; where fractional timeouts are unavailable (Bash 3.2,
   the macOS system shell) it is read as one window and a producer that sends
   bytes then goes silent can take up to two intervals. A producer that keeps
-  emitting is bounded by Claude Code's own hook timeout, not by this value. A
-  setting this shell's `read -t` will not accept — or `0` — falls back to the
-  default.
+  emitting is bounded by Claude Code's own hook timeout, not by this value. If
+  this shell's `read -t` will not accept the setting, or the setting is `0`, the
+  hook falls back to the default.
 
 Configure interactively with `/plugin configure actionlint@<marketplace>` or headless at
 install time:
@@ -74,6 +74,7 @@ install time:
 claude plugin install actionlint@<marketplace> --config actionlint_enabled=false
 ```
 
+<!-- ai-slop-ignore-start: generated options block; source is plugin.json + scripts/sync-plugin-options-docs.py -->
 <!-- BEGIN GENERATED: plugin options — edit plugin.json, then run scripts/sync-plugin-options-docs.py -->
 
 ### Options reference
@@ -147,6 +148,7 @@ hands a configured value to a hook process; the value comes from the routes abov
 - [Manage installed plugins](https://code.claude.com/docs/en/discover-plugins#manage-installed-plugins) — enabling, disabling, `/plugin list`
 
 <!-- END GENERATED: plugin options -->
+<!-- ai-slop-ignore-end -->
 
 ## License
 

--- a/plugins/actionlint/skills/setup/SKILL.md
+++ b/plugins/actionlint/skills/setup/SKILL.md
@@ -9,68 +9,68 @@ disable-model-invocation: true
 
 Thin check-centric setup per the uniform setup contract (`docs/PLUGIN-PHILOSOPHY.md`
 "Setup is explicit and repeatable" in the marketplace repository): `check` inspects and
-reports, `apply` resolves. This plugin owns no consumer-project configuration — actionlint
+reports, `apply` resolves. This plugin owns no consumer-project configuration. actionlint
 auto-discovers its own optional config from the repository, and the tunables are the native
 `userConfig` options (the `actionlint_enabled` toggle and `stdin_read_timeout`). Every
 prerequisite is a `PATH` binary the plugin never bundles, and the plugin never installs
-system packages, so `apply` is guidance-only with **no write path** — it never modifies the
+system packages, so `apply` is guidance-only with **no write path**. It never modifies the
 repository, user settings, or the plugin cache.
 
 Action routing: no argument or `check` runs the check; `apply` runs the check first, then
-offers remediation guidance. Both are non-interactive — never prompt when the action is given.
+offers remediation guidance. Both are non-interactive. Never prompt when the action is given.
 
 ## `check` (read-only)
 
 The hook script (`${CLAUDE_PLUGIN_ROOT}/hooks/actionlint-check.sh`) is the single source of
 truth for what it requires and how it resolves things.
 
-**Read it first** — probe what it actually does, don't recite this file. Then run each probe via
+**Read it first.** Probe what it actually does, don't recite this file. Then run each probe via
 Bash and report a PASS/FAIL/INFO table with one remediation line per FAIL. Do not modify anything.
 
 When the plugin's toggle is disabled, every prerequisite absence downgrades from FAIL to
-INFO — the hook exits through its enabled-gate before probing anything, so a deliberately
+INFO. The hook exits through its enabled-gate before probing anything, so a deliberately
 disabled plugin is not broken. Report the probes informationally and note that re-enabling
 restores the FAIL semantics.
 
-1. **Bash version** — check against the hook's documented floor (README Requirements),
+1. **Bash version.** Check against the hook's documented floor (README Requirements),
    noting any features the hook degrades without (for example telemetry's `EPOCHREALTIME`,
    a Bash 5.0+ builtin).
-2. **`jq`** — `command -v jq`. FAIL if absent: the hook then skips with a visible
+2. **`jq`.** `command -v jq`. FAIL if absent: the hook then skips with a visible
    once-per-session notice instead of linting.
-3. **`actionlint`** — `command -v actionlint`. FAIL if absent: the hook skips workflow lint
+3. **`actionlint`.** `command -v actionlint`. FAIL if absent: the hook skips workflow lint
    with a visible once-per-session notice (it ships no binary of its own).
-4. **actionlint config** — INFO: actionlint auto-discovers an optional
-   `.github/actionlint.yaml` from the repository when present. It is not required — actionlint
+4. **actionlint config.** INFO: actionlint auto-discovers an optional
+   `.github/actionlint.yaml` from the repository when present. It is not required. actionlint
    runs with its built-in defaults without one. Report whether one exists for the reader's
    awareness; its absence is not a FAIL.
-5. **Hook toggle** — report the effective `actionlint_enabled` value:
+5. **Hook toggle.** Report the effective `actionlint_enabled` value:
    `${user_config.actionlint_enabled}` (unexpanded or empty means default `true`; any value
    other than `true` disables the hook).
-5b. **Stdin read timeout** — INFO: report the effective `stdin_read_timeout` value:
+5b. **Stdin read timeout.** INFO: report the effective `stdin_read_timeout` value:
    `${user_config.stdin_read_timeout}` (unexpanded or empty means default `2` seconds,
-   minimum `1`). It is an IDLE bound — any byte arriving resets it, so it fires only once
+   minimum `1`). It is an IDLE bound. Any byte arriving resets it, so it fires only once
    the pipe has gone silent for that long, at which point this hook fails open. A value
    `read -t` will not accept, or `0`, falls back to the default.
-6. **Hook registration** — INFO: confirm the plugin is enabled for this project
+6. **Hook registration.** INFO: confirm the plugin is enabled for this project
    (`/plugin` → Installed) rather than parsing settings files.
 
 ## `apply` (idempotent)
 
-Run `check`, then for each FAIL point at the resolution — this skill installs nothing:
+Run `check`, then for each FAIL point at the resolution. This skill installs nothing:
 
 - missing `actionlint`: platform install guidance from the README Requirements section
   (the [actionlint install guide](https://github.com/rhysd/actionlint/blob/main/docs/install.md)).
 - missing `jq` / Bash: platform install instructions from the README Requirements section.
 - toggle off: direct to `/plugin configure actionlint` (interactive, any
-  time). Headless: rerun the install with the new value —
+  time). Headless: rerun the install with the new value,
   `claude plugin install actionlint@<marketplace> -s <scope> --config actionlint_enabled=true`
   (repeatable per key). The official docs document `--config` only as a `claude plugin install`
   flag and say nothing about an already-installed plugin, so this rests on observation, not
   documentation: against an already-installed plugin the command prints `already installed`
-  **and still writes the value** — verified on Claude Code 2.1.240 (a non-sensitive option at
+  **and still writes the value**, verified on Claude Code 2.1.240 (a non-sensitive option at
   `user` scope: a non-default value written to an installed plugin, then restored). The
   short-circuit is about the install, not the config write. Re-verify before relying on it
-  outside those conditions — a `sensitive` option, or `project`/`local` scope, were not covered.
+  outside those conditions. A `sensitive` option, or `project`/`local` scope, were not covered.
   Do **not** uninstall to reconfigure: uninstalling drops this plugin's entire stored
   `pluginConfigs` entry, resetting every option in the README's Options reference table to its
   manifest default. `-s` defaults to `user`, so pass the scope `claude plugin list` reports for
@@ -80,12 +80,12 @@ Run `check`, then for each FAIL point at the resolution — this skill installs 
   Afterwards, keep the two claims apart. The write is issued and the stored value is what you
   passed; the RUNNING session's behavior is not. The rendered `${user_config.*}` is injected at
   skill load and each hook receives its `CLAUDE_PLUGIN_OPTION_*` from an environment fixed at
-  session start, so a same-session `check` still reports the OLD value — reporting that as a
+  session start, so a same-session `check` still reports the OLD value. Reporting that as a
   failed write would be wrong. Verify the effective value by rerunning `check` in a **fresh
   session**, and never claim an unobserved change.
 
 After pointing at a remediation, re-run the relevant `check` probe and report its actual
-result — never claim resolved on the reader's report that they installed something.
+result. Never claim resolved on the reader's report that they installed something.
 
 Re-running `apply` after everything passes changes nothing and reports "already configured".
 
@@ -93,7 +93,7 @@ Re-running `apply` after everything passes changes nothing and reports "already 
 
 - **A userConfig knob is reachable natively only if the manifest declares it.** Per current
   docs, `claude plugin install --config <key=value>` sets options "declared in the plugin's
-  manifest" — an undeclared key silently cannot be set through native config surfaces (a raw
+  manifest". An undeclared key silently cannot be set through native config surfaces (a raw
   settings `env` block still works). That is why `stdin_read_timeout` is declared in this
   plugin's manifest even though the shared hook lib supplies its default; hook plugins reusing
   the shared lib should declare it too (claude-ops set the precedent).
@@ -103,19 +103,19 @@ Re-running `apply` after everything passes changes nothing and reports "already 
   stamped rather than cited: on Claude Code 2.1.240 the command printed `already installed`
   and still wrote the value, for a non-sensitive option at `user` scope. Re-verify if the CLI's
   plugin surface changes, and do not extend the observation to a `sensitive` option or to
-  `project`/`local` scope — neither was covered.
+  `project`/`local` scope. Neither was covered.
 - **`-shellcheck=` / `-pyflakes=` are deliberate, and the deadlock claim is a local
   observation.** The hook disables actionlint's external run-block linters primarily for
   edit-time latency; the additional "ShellCheck deadlocks on large blocks under the Windows
-  subprocess IPC path in actionlint 1.7.x" rationale is the hook author's own reproduction —
-  no matching upstream rhysd/actionlint issue as of 2026-07-23. The latency rationale alone
+  subprocess IPC path in actionlint 1.7.x" rationale is the hook author's own reproduction.
+  No matching upstream rhysd/actionlint issue as of 2026-07-23. The latency rationale alone
   justifies the flags for an advisory edit-time hook; deep run-block linting belongs in a
   commit hook or CI.
 
 ## What this skill does NOT do
 
-- Run the linter — editing any `.github/workflows/*.yml` or `*.yaml` file exercises the hook
+- Run the linter. Editing any `.github/workflows/*.yml` or `*.yaml` file exercises the hook
   end-to-end.
-- Write the plugin cache, Claude Code user settings, or `pluginConfigs`. Nor the repository —
-  every prerequisite is a `PATH` binary or the native toggle, so remediation is guidance only.
+- Write the plugin cache, Claude Code user settings, or `pluginConfigs`. Nor the repository.
+  Every prerequisite is a `PATH` binary or the native toggle, so remediation is guidance only.
 - Download or execute tools during `check` beyond the read-only `command -v` presence probes.


### PR DESCRIPTION
No linked issue

## Summary

Refs #2891. Instruction-surface de-slop shard for the `actionlint` plugin only. Other plugins stay on main.

## Fix

Rewrote `plugins/actionlint/README.md` and every `plugins/actionlint/**/SKILL.md` under `/ai-slop:audit fix` semantics (periods, commas, or a restructured sentence; never parentheses, en dashes, or a spaced hyphen as a stand-in). YAML frontmatter left unchanged. Version-only bump in `plugin.json`. New changelog heading only. The generated options block is ignore-fenced because `scripts/sync-plugin-options-docs.py` still emits em dashes from its shared template. `actionlint` 0.8.21.

## Verification

- Detector (`HOME` + `CLAUDE_PROJECT_DIR` isolated so `rule-em-dash` is enabled): 0 `rule-em-dash` findings on rewritten prose. Leftovers are the ignore-fenced generated-options span, plus version-only `plugin.json` description text and historical CHANGELOG entries that this shard did not rewrite
- `CHECK_SKILL_SKIP_MARKDOWNLINT=1 bash scripts/check-changed-skills.sh origin/main`: 0 failed; quoted trigger phrases vs origin/main preserved
- `python3 scripts/sync-plugin-options-docs.py --check` up to date
- `scripts/check-changelog-parity.sh --check-bump origin/main` passes
- `node scripts/generate-cheatsheet.mjs --check` in sync

## Related

Refs #2891