### PR TITLE
docs(eol-normalizer): de-slop instruction surfaces (0.6.21)

### DIFF
--- a/plugins/eol-normalizer/.claude-plugin/plugin.json
+++ b/plugins/eol-normalizer/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "eol-normalizer",
-  "version": "0.6.20",
+  "version": "0.6.21",
   "description": "Normalize a written file's working-tree line endings to its .gitattributes eol value on edit — symmetric CRLF/LF driven by git check-attr, advisory and never blocking.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/eol-normalizer/CHANGELOG.md
+++ b/plugins/eol-normalizer/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to the `eol-normalizer` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.6.21]
+
+### Changed
+
+- **Instruction-surface de-slop (#2891, eol-normalizer cluster).** Rewrote this plugin's `README.md` and every
+  `SKILL.md` to drop em dashes under the repo's zero-tolerance house policy, using
+  `/ai-slop:audit fix` semantics: periods or commas, or a restructured sentence, never
+  parentheses, en dashes, or a spaced hyphen as a stand-in. Meaning stays; only the mark
+  and the sentence break change. The generated options block is ignore-fenced because
+  `scripts/sync-plugin-options-docs.py` still emits em dashes from its shared template.
+
 ## [0.6.20]
 
 ### Fixed

--- a/plugins/eol-normalizer/README.md
+++ b/plugins/eol-normalizer/README.md
@@ -4,9 +4,9 @@ A Claude Code plugin that normalizes a file's working-tree line endings the
 moment you edit it. On every `Write` or `Edit` it resolves the file's
 `.gitattributes` `eol=` value via
 [`git check-attr`](https://git-scm.com/docs/git-check-attr) and rewrites the
-file's line endings to match — symmetric CRLF↔LF, idempotent, best-effort.
+file's line endings to match. Symmetric CRLF↔LF, idempotent, best-effort.
 
-It uses **your repository's own `.gitattributes`** — it ships no policy and
+It uses **your repository's own `.gitattributes`**. It ships no policy and
 imposes no rules of its own.
 
 ## Behavior
@@ -14,16 +14,16 @@ imposes no rules of its own.
 - **LF arm (every OS).** A file resolving to `eol=lf` is normalized CRLF→LF.
 - **CRLF arm (every OS).** A file resolving to `eol=crlf` is normalized
   LF→CRLF. The hook compensates for tool writes that bypass git's checkout
-  smudge, and such writes happen on any platform — an LF write to an
+  smudge, and such writes happen on any platform. An LF write to an
   `eol=crlf` path violates the repo's policy on Linux/macOS just as much as on
   Windows.
 - **Binary guard.** `eol` alone is not proof of text: under a broad
   `* text=auto eol=lf` rule, the `eol` attribute resolves to `lf` for binaries
-  too. The hook mirrors gitattributes semantics — explicit `text` is trusted,
+  too. The hook mirrors gitattributes semantics. Explicit `text` is trusted,
   `-text` skips, and `text=auto` content-sniffs (NUL scan of the first 8000
-  bytes, git's own detection window) — so binary files are never rewritten.
+  bytes, git's own detection window), so binary files are never rewritten.
 - **Unspecified → no-op.** A path with no `eol=` attribute is left untouched.
-  There is no hardcoded extension list — resolution is entirely
+  There is no hardcoded extension list. Resolution is entirely
   `.gitattributes`-driven, so narrow rules (a single `eol=lf` path) correctly
   win over broad ones (`*.txt eol=crlf`).
 - **Advisory, never blocking.** The hook always exits `0`. Make a commit hook or
@@ -31,14 +31,14 @@ imposes no rules of its own.
 
 ## Requirements
 
-- **Bash** — the hook is a Bash script. On native Windows, install
+- **Bash.** The hook is a Bash script. On native Windows, install
   [Git for Windows](https://code.claude.com/docs/en/setup#set-up-on-windows) so
   Claude Code can run it under Git Bash.
-- **jq** on `PATH` — parses the hook payload. Absent: the hook skips with a
+- **jq** on `PATH`. Parses the hook payload. Absent: the hook skips with a
   visible once-per-session notice. [Install jq](https://jqlang.org/download/).
-- **git** on `PATH` — the attribute resolution (`git check-attr`) and repo-root
+- **git** on `PATH`. The attribute resolution (`git check-attr`) and repo-root
   detection depend on it. Without a git repository the hook is a quiet no-op
-  (nothing to normalize against — not a missing prerequisite).
+  (nothing to normalize against, not a missing prerequisite).
 
 Rewriting uses `perl` when present, falling back to `tr`/`awk` otherwise, so no
 extra tooling is required.
@@ -59,7 +59,7 @@ Then verify prerequisites with `/eol-normalizer:setup check`.
 ## Configuration
 
 The normalization policy itself is your repository's `.gitattributes`, which the
-hook reads automatically — to change which files normalize to which endings,
+hook reads automatically. To change which files normalize to which endings,
 edit your `.gitattributes`. One `userConfig` option tunes the hook's own
 behavior:
 
@@ -74,6 +74,7 @@ the install command:
 claude plugin install eol-normalizer@<marketplace> --config eol_normalizer_enabled=false
 ```
 
+<!-- ai-slop-ignore-start: generated options block; source is plugin.json + scripts/sync-plugin-options-docs.py -->
 <!-- BEGIN GENERATED: plugin options — edit plugin.json, then run scripts/sync-plugin-options-docs.py -->
 
 ### Options reference
@@ -146,6 +147,7 @@ hands a configured value to a hook process; the value comes from the routes abov
 - [Manage installed plugins](https://code.claude.com/docs/en/discover-plugins#manage-installed-plugins) — enabling, disabling, `/plugin list`
 
 <!-- END GENERATED: plugin options -->
+<!-- ai-slop-ignore-end -->
 
 ## License
 

--- a/plugins/eol-normalizer/skills/setup/SKILL.md
+++ b/plugins/eol-normalizer/skills/setup/SKILL.md
@@ -9,13 +9,13 @@ disable-model-invocation: true
 
 Thin check-centric setup per the uniform setup contract (`docs/PLUGIN-PHILOSOPHY.md`
 "Setup is explicit and repeatable" in the marketplace repository): `check` inspects and
-reports, `apply` resolves. This plugin owns no consumer-project configuration — the
+reports, `apply` resolves. This plugin owns no consumer-project configuration. The
 normalization policy is the repository's own `.gitattributes`, and the only tunable is the
 native `userConfig` toggle. Every prerequisite is a system tool (Bash, jq, git), so `apply`
 is pure guidance and writes nothing.
 
 Action routing: no argument or `check` runs the check; `apply` runs the check first, then
-points at each remediation. Both are non-interactive — never prompt when the action is given.
+points at each remediation. Both are non-interactive. Never prompt when the action is given.
 
 ## `check` (read-only)
 
@@ -26,54 +26,54 @@ that sourced library is where the real resolution lives (the `git check-attr` ca
 anchoring, and the NUL-byte binary guard), so the sourced files are in scope and the entry script
 alone will not tell you what runs.
 
-**Read it first** — probe what it actually does, don't recite this file. Then run each probe via
+**Read it first.** Probe what it actually does, don't recite this file. Then run each probe via
 Bash and report a PASS/FAIL/INFO table with one remediation line per FAIL. Do not modify anything.
 
 When the plugin's toggle is disabled, every prerequisite absence downgrades from FAIL to
-INFO — the hook exits through its enabled-gate before probing anything, so a deliberately
+INFO. The hook exits through its enabled-gate before probing anything, so a deliberately
 disabled plugin is not broken. Report the probes informationally and note that re-enabling
 restores the FAIL semantics.
 
-1. **Bash version** — check against the hook's documented floor (README Requirements),
+1. **Bash version.** Check against the hook's documented floor (README Requirements),
    noting any features the hook degrades without (for example telemetry's `EPOCHREALTIME`,
    Bash 5.0+).
-2. **`jq`** — `command -v jq`. FAIL if absent: the hook then skips with a visible
+2. **`jq`.** `command -v jq`. FAIL if absent: the hook then skips with a visible
    once-per-session notice instead of normalizing.
-3. **`git`** — `command -v git`. FAIL if absent: unlike jq, the hook emits NO visible notice
-   when git is missing — `git check-attr` and repo-root resolution silently fail and the
+3. **`git`.** `command -v git`. FAIL if absent: unlike jq, the hook emits NO visible notice
+   when git is missing. `git check-attr` and repo-root resolution silently fail and the
    hook no-ops, so this probe is the only visibility. Distinguish the two non-failure cases
-   the hook treats differently: git present but the path is not inside a git repository →
-   INFO (not applicable — nothing to normalize against, per the README), and git present
-   inside a repo but no `eol=` rule governs any path → INFO (inert by design, the opt-in
-   analog: resolution is entirely `.gitattributes`-driven).
-4. **Consumer `.gitattributes` `eol=` policy** — using the hook's own resolver
+   the hook treats differently. Git present but the path is not inside a git repository →
+   INFO, not applicable: nothing to normalize against, per the README. Git present
+   inside a repo but no `eol=` rule governs any path → INFO, inert by design, the opt-in
+   analog: resolution is entirely `.gitattributes`-driven.
+4. **Consumer `.gitattributes` `eol=` policy.** Using the hook's own resolver
    (`git check-attr eol` anchored at the repo root), confirm whether any `eol=lf`/`eol=crlf`
    rule governs paths the hook would touch. `check-attr` answers for ANY candidate path,
-   tracked or not — the hook normalizes a first write to a brand-new file the same as an
-   edit to a tracked one — so probe representative candidate paths (or report the declared
+   tracked or not. The hook normalizes a first write to a brand-new file the same as an
+   edit to a tracked one, so probe representative candidate paths (or report the declared
    patterns), never a tracked-files listing that would miss untracked matches. Report what
-   governs, or INFO that none does — absence is the opt-out by design, so the plugin is
+   governs, or INFO that none does. Absence is the opt-out by design, so the plugin is
    inert (INFO, not FAIL), matching the README's "ships no policy of its own" stance.
-5. **Hook toggle** — report the effective `eol_normalizer_enabled` value:
+5. **Hook toggle.** Report the effective `eol_normalizer_enabled` value:
    `${user_config.eol_normalizer_enabled}` (unexpanded or empty means default `true`).
-6. **Hook registration** — INFO: confirm the plugin is enabled for this project
+6. **Hook registration.** INFO: confirm the plugin is enabled for this project
    (`/plugin` → Installed) rather than parsing settings files.
 
 ## `apply` (idempotent)
 
 Run `check`, then for each FAIL point at the resolution. Every prerequisite here is a system
-tool, so `apply` installs nothing and writes nothing — it only points:
+tool, so `apply` installs nothing and writes nothing. It only points:
 
 - missing `jq` / Bash / git: platform install instructions from the README Requirements
   section; this skill never installs system packages.
 - toggle off: direct to `/plugin configure eol-normalizer` (interactive, any
-  time). Headless: rerun the install with the new value —
+  time). Headless: rerun the install with the new value,
   `claude plugin install eol-normalizer@<marketplace> -s <scope> --config eol_normalizer_enabled=true`
   (repeatable per key). Against an already-installed plugin it prints `already installed` **and
-  still writes the value** — verified on Claude Code 2.1.240 (a non-sensitive option at `user`
+  still writes the value**, verified on Claude Code 2.1.240 (a non-sensitive option at `user`
   scope: a non-default value written to an installed plugin, then restored). The short-circuit is
   about the install, not the config write. Re-verify before relying on it outside those
-  conditions — a `sensitive` option, or `project`/`local` scope, were not covered. Do **not**
+  conditions. A `sensitive` option, or `project`/`local` scope, were not covered. Do **not**
   uninstall to reconfigure: uninstalling drops this plugin's entire stored `pluginConfigs` entry,
   resetting every option in the README's Options reference table to its manifest default. `-s`
   defaults to `user`, so pass the scope `claude plugin list` reports for this plugin, and run from
@@ -82,7 +82,7 @@ tool, so `apply` installs nothing and writes nothing — it only points:
   Afterwards, keep the two claims apart. The write is issued and the stored value is what you
   passed; the RUNNING session's behavior is not. The rendered `${user_config.*}` is injected at
   skill load and each hook receives its `CLAUDE_PLUGIN_OPTION_*` from an environment fixed at
-  session start, so a same-session `check` still reports the OLD value — reporting that as a
+  session start, so a same-session `check` still reports the OLD value. Reporting that as a
   failed write would be wrong. Verify the effective value by rerunning `check` in a **fresh
   session**, and never claim an unobserved change.
 - no `eol=` policy: this is the opt-out, not a defect. Point at the repository's own
@@ -94,7 +94,7 @@ Re-running `apply` after everything passes changes nothing and reports "already 
 
 ## What this skill does NOT do
 
-- Normalize any file — editing a file exercises the hook end-to-end.
+- Normalize any file. Editing a file exercises the hook end-to-end.
 - Write the plugin cache, Claude Code user settings, or `pluginConfigs`. Nor `.gitattributes`.
-- Install any tool, during either `check` or `apply` — all prerequisites are system tools
+- Install any tool, during either `check` or `apply`. All prerequisites are system tools
   resolved with guidance only.


### PR DESCRIPTION
No linked issue

## Summary

Refs #2891. Instruction-surface de-slop shard for the `eol-normalizer` plugin only. Other plugins stay on main.

## Fix

Rewrote `plugins/eol-normalizer/README.md` and every `plugins/eol-normalizer/**/SKILL.md` under `/ai-slop:audit fix` semantics (periods, commas, or a restructured sentence; never parentheses, en dashes, or a spaced hyphen as a stand-in). YAML frontmatter left unchanged. Version-only bump in `plugin.json`. New changelog heading only. The generated options block is ignore-fenced because `scripts/sync-plugin-options-docs.py` still emits em dashes from its shared template. `eol-normalizer` 0.6.21.

## Verification

- Detector (`HOME` + `CLAUDE_PROJECT_DIR` isolated so `rule-em-dash` is enabled): 0 `rule-em-dash` findings on rewritten prose. Leftovers are the ignore-fenced generated-options span, plus version-only `plugin.json` description text and historical CHANGELOG entries that this shard did not rewrite
- `CHECK_SKILL_SKIP_MARKDOWNLINT=1 bash scripts/check-changed-skills.sh origin/main`: 0 failed; quoted trigger phrases vs origin/main preserved
- `python3 scripts/sync-plugin-options-docs.py --check` up to date
- `scripts/check-changelog-parity.sh --check-bump origin/main` passes
- `node scripts/generate-cheatsheet.mjs --check` in sync

## Related

Refs #2891