### PR TITLE
docs(biome-format): de-slop instruction surfaces (0.6.22)

### DIFF
--- a/plugins/biome-format/.claude-plugin/plugin.json
+++ b/plugins/biome-format/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "biome-format",
-  "version": "0.6.21",
+  "version": "0.6.22",
   "description": "Auto-format and lint JS/TS/JSX/JSON on edit via Biome, only when a biome.json governs the repo — using the consuming repo's own Biome config.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/biome-format/CHANGELOG.md
+++ b/plugins/biome-format/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to the `biome-format` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.6.22]
+
+### Changed
+
+- **Instruction-surface de-slop (#2891, biome-format cluster).** Rewrote this plugin's `README.md` and every
+  `SKILL.md` to drop em dashes under the repo's zero-tolerance house policy, using
+  `/ai-slop:audit fix` semantics: periods or commas, or a restructured sentence, never
+  parentheses, en dashes, or a spaced hyphen as a stand-in. Meaning stays; only the mark
+  and the sentence break change. The generated options block is ignore-fenced because
+  `scripts/sync-plugin-options-docs.py` still emits em dashes from its shared template.
+
 ## [0.6.21]
 
 ### Fixed

--- a/plugins/biome-format/README.md
+++ b/plugins/biome-format/README.md
@@ -3,8 +3,8 @@
 A Claude Code plugin that formats and lints JavaScript, TypeScript, JSX, and
 JSON the moment you edit them. On every `Write` or `Edit` of a `.ts`, `.tsx`,
 `.js`, `.jsx`, `.mjs`, `.cjs`, `.mts`, `.cts`, `.json`, or `.jsonc` file it runs
-[Biome](https://biomejs.dev/)'s `check --write` — applying safe fixes,
-formatting, and import sorting — then surfaces any residual findings back to
+[Biome](https://biomejs.dev/)'s `check --write`, applying safe fixes,
+formatting, and import sorting, then surfaces any residual findings back to
 Claude as advisory context.
 
 It uses **your repository's own `biome.json`**. It ships no rules of its own and
@@ -21,9 +21,9 @@ runs only when your repo has opted into Biome.
   onward, so honoring them here would risk reformatting with built-in defaults on
   an older Biome. Use a canonical `biome.json` / `biome.jsonc`.)
 - **Format + lint on edit.** `biome check --write` applies safe fixes,
-  formatting, and import sorting in place. Residual diagnostics — errors and,
-  because the hook passes `--error-on-warnings`, warnings — are reported but not
-  auto-applied (unsafe fixes are never forced).
+  formatting, and import sorting in place. Residual diagnostics are reported
+  but not auto-applied. That includes errors and, because the hook passes
+  `--error-on-warnings`, warnings. Unsafe fixes are never forced.
 - **Respects your ignores.** Biome honors your config's `files.includes` ignore
   rules even for the single edited file. A path your config excludes (for
   generated or vendored code) is left untouched, with no advisory noise.
@@ -37,12 +37,12 @@ runs only when your repo has opted into Biome.
 
 ## Requirements
 
-- **Bash** — the hook is a Bash script. On native Windows, install
+- **Bash.** The hook is a Bash script. On native Windows, install
   [Git for Windows](https://code.claude.com/docs/en/setup#set-up-on-windows) so
   Claude Code can run it under Git Bash.
-- **jq** on `PATH` — parses the hook payload. Absent: the hook skips with a
+- **jq** on `PATH`. Parses the hook payload. Absent: the hook skips with a
   visible once-per-session notice. [Install jq](https://jqlang.org/download/).
-- **Biome** available to the repo — installed in the repo's `node_modules`
+- **Biome** available to the repo. Installed in the repo's `node_modules`
   (the hook runs `node_modules/.bin/biome`) or on `PATH`. Biome is never
   downloaded on the fly; if it is not present while a Biome config governs the
   repo, the hook skips with a visible once-per-session notice.
@@ -50,7 +50,7 @@ runs only when your repo has opted into Biome.
   `check --write --error-on-warnings --reporter=github`, and on much older
   releases those flags may be absent, in which case the run is reported as a
   tool break rather than a finding.
-- A **`biome.json`** or **`biome.jsonc`** in the repo — the opt-in.
+- A **`biome.json`** or **`biome.jsonc`** in the repo, the opt-in.
 
 The hook itself runs on Bash 3.2+. Telemetry timing uses `EPOCHREALTIME`
 (Bash 5.0+); on older bash the telemetry envelope is skipped while formatting and
@@ -83,6 +83,7 @@ install command:
 claude plugin install biome-format@<marketplace> --config biome_format_enabled=false
 ```
 
+<!-- ai-slop-ignore-start: generated options block; source is plugin.json + scripts/sync-plugin-options-docs.py -->
 <!-- BEGIN GENERATED: plugin options — edit plugin.json, then run scripts/sync-plugin-options-docs.py -->
 
 ### Options reference
@@ -155,6 +156,7 @@ hands a configured value to a hook process; the value comes from the routes abov
 - [Manage installed plugins](https://code.claude.com/docs/en/discover-plugins#manage-installed-plugins) — enabling, disabling, `/plugin list`
 
 <!-- END GENERATED: plugin options -->
+<!-- ai-slop-ignore-end -->
 
 ## License
 

--- a/plugins/biome-format/skills/setup/SKILL.md
+++ b/plugins/biome-format/skills/setup/SKILL.md
@@ -9,54 +9,54 @@ disable-model-invocation: true
 
 Thin check-centric setup per the uniform setup contract (`docs/PLUGIN-PHILOSOPHY.md`
 "Setup is explicit and repeatable" in the marketplace repository): `check` inspects and
-reports, `apply` resolves. This plugin owns no consumer-project configuration — rules come
+reports, `apply` resolves. This plugin owns no consumer-project configuration. Rules come
 from the repository's own Biome config, and the only tunable is the native `userConfig`
-toggle — so `apply` is guidance-and-verify, with exactly one write path: the explicitly
+toggle, so `apply` is guidance-and-verify, with exactly one write path: the explicitly
 invoked `apply install-biome` dependency install described below.
 
 Action routing: no argument or `check` runs the check; `apply` runs the check first, then
 remediation; `apply install-biome` additionally authorizes the consumer-repo dependency
-install described below. All are non-interactive — never prompt when the action is given.
+install described below. All are non-interactive. Never prompt when the action is given.
 
 ## `check` (read-only)
 
 The hook script (`${CLAUDE_PLUGIN_ROOT}/hooks/biome-format.sh`) is the single source of
 truth for what it requires and how it resolves things.
 
-**Read it first** — probe what it actually does, don't recite this file. Then run each probe via
+**Read it first.** Probe what it actually does, don't recite this file. Then run each probe via
 Bash and report a PASS/FAIL/INFO table with one remediation line per FAIL. Do not modify anything.
 
 When the plugin's toggle is disabled, every prerequisite absence downgrades from FAIL to
-INFO — the hook exits through its enabled-gate before probing anything, so a deliberately
+INFO. The hook exits through its enabled-gate before probing anything, so a deliberately
 disabled plugin is not broken. Report the probes informationally and note that re-enabling
 restores the FAIL semantics.
 
-1. **Bash version** — check against the hook's documented floor (README Requirements),
+1. **Bash version.** Check against the hook's documented floor (README Requirements),
    noting any features the hook degrades without (for example telemetry's `EPOCHREALTIME`,
    Bash 5.0+).
-2. **`jq`** — `command -v jq`. FAIL if absent: the hook then skips with a visible
+2. **`jq`.** `command -v jq`. FAIL if absent: the hook then skips with a visible
    once-per-session notice instead of formatting.
-3. **Biome binary** — resolve it exactly the way the hook's resolution code does: its
+3. **Biome binary.** Resolve it exactly the way the hook's resolution code does: its
    repo-local install walk (the `node_modules/.bin` path it tests, walking up from the
-   edited file toward the repo root) and then `PATH`. Test only what the hook tests — a
+   edited file toward the repo root) and then `PATH`. Test only what the hook tests. A
    binary the hook would not accept must not PASS here. FAIL when nothing the hook would
    resolve is present while a Biome config governs the repo; the hook then emits a visible
    once-per-session skip notice instead of formatting.
-4. **Consumer Biome config** — mirror the hook's opt-in walk: it records the topmost
+4. **Consumer Biome config.** Mirror the hook's opt-in walk: it records the topmost
    governing config found walking from the edited file's directory up to the repo root, and
-   deliberately accepts only the config names the hook treats as the opt-in (read the hook —
-   the hidden dotted variants are intentionally excluded). Report the governing config the
-   walk discovers, or INFO that none exists — absence is the opt-out by design, so the
+   deliberately accepts only the config names the hook treats as the opt-in. Read the hook:
+   the hidden dotted variants are intentionally excluded. Report the governing config the
+   walk discovers, or INFO that none exists. Absence is the opt-out by design, so the
    plugin is inert (INFO, not FAIL), matching the README's "ships no rules of its own"
    stance.
-5. **Hook toggle** — report the effective `biome_format_enabled` value:
+5. **Hook toggle.** Report the effective `biome_format_enabled` value:
    `${user_config.biome_format_enabled}` (unexpanded or empty means default `true`).
-6. **Hook registration** — INFO: confirm the plugin is enabled for this project
+6. **Hook registration.** INFO: confirm the plugin is enabled for this project
    (`/plugin` → Installed) rather than parsing settings files.
 
 ## `apply` (idempotent)
 
-Run `check`, then for each FAIL offer the resolution — never install anything without the
+Run `check`, then for each FAIL offer the resolution. Never install anything without the
 consumer's explicit go-ahead in the invocation. `apply install-biome` adds
 `@biomejs/biome` as a dev dependency in the consumer repository **using the repository's
 own package manager**, resolved in order: lockfile (`pnpm-lock.yaml` → `pnpm add -D`,
@@ -64,27 +64,27 @@ own package manager**, resolved in order: lockfile (`pnpm-lock.yaml` → `pnpm a
 `npm install --save-dev`), then the `package.json` `"packageManager"` field when no
 lockfile exists, then npm only when neither signal is present. With no `package.json`, an
 ambiguous multi-lockfile state, or a lockfile that contradicts `packageManager`, stop with
-manager-specific guidance instead of guessing — never introduce a competing lockfile. The
-change is stated before running. For a Yarn repository, don't infer the linker — ask the
+manager-specific guidance instead of guessing. Never introduce a competing lockfile. The
+change is stated before running. For a Yarn repository, don't infer the linker. Ask the
 repo's own Yarn: run `yarn config get nodeLinker` in the repo. `pnp` (Berry's default when
 unset) → skip the install and give guidance, because Plug'n'Play generates a loader file,
 not the `node_modules/.bin` shim the hook resolves; install `@biomejs/biome` on `PATH` or
 switch the linker. `node-modules`/`pnpm`, or Yarn Classic (which has no such setting and
 always materializes `node_modules`) → install. The verify-after-remediation rule below is
 the backstop when an install still yields no usable shim. After ANY remediation, re-run the
-relevant `check` probe and report its actual result — never claim resolved on the install
+relevant `check` probe and report its actual result. Never claim resolved on the install
 command's exit code alone. For everything else `apply` only points:
 
 - missing `jq` / Bash: platform install instructions from the README Requirements section;
   this skill never installs system packages.
 - toggle off: direct to `/plugin configure biome-format` (interactive, any
-  time). Headless: rerun the install with the new value —
+  time). Headless: rerun the install with the new value,
   `claude plugin install biome-format@<marketplace> -s <scope> --config biome_format_enabled=true`
   (repeatable per key). Against an already-installed plugin it prints `already installed` **and
-  still writes the value** — verified on Claude Code 2.1.240 (a non-sensitive option at `user`
+  still writes the value**, verified on Claude Code 2.1.240 (a non-sensitive option at `user`
   scope: a non-default value written to an installed plugin, then restored). The short-circuit is
   about the install, not the config write. Re-verify before relying on it outside those
-  conditions — a `sensitive` option, or `project`/`local` scope, were not covered. Do **not**
+  conditions. A `sensitive` option, or `project`/`local` scope, were not covered. Do **not**
   uninstall to reconfigure: uninstalling drops this plugin's entire stored `pluginConfigs` entry,
   resetting every option in the README's Options reference table to its manifest default. `-s`
   defaults to `user`, so pass the scope `claude plugin list` reports for this plugin, and run from
@@ -93,17 +93,17 @@ command's exit code alone. For everything else `apply` only points:
   Afterwards, keep the two claims apart. The write is issued and the stored value is what you
   passed; the RUNNING session's behavior is not. The rendered `${user_config.*}` is injected at
   skill load and each hook receives its `CLAUDE_PLUGIN_OPTION_*` from an environment fixed at
-  session start, so a same-session `check` still reports the OLD value — reporting that as a
+  session start, so a same-session `check` still reports the OLD value. Reporting that as a
   failed write would be wrong. Verify the effective value by rerunning `check` in a **fresh
   session**, and never claim an unobserved change.
 - no Biome config: offer to create a minimal `biome.json` in the repository root only when
-  explicitly asked — the plugin imposes no rules of its own.
+  explicitly asked. The plugin imposes no rules of its own.
 
 Re-running `apply` after everything passes changes nothing and reports "already configured".
 
 ## What this skill does NOT do
 
-- Run the formatter — editing any supported file exercises the hook end-to-end.
+- Run the formatter. Editing any supported file exercises the hook end-to-end.
 - Write the plugin cache, Claude Code user settings, or `pluginConfigs`.
 - Download or execute tools during `check`; network use happens only in an explicitly
   requested `apply install-biome` inside the consumer repository.


### PR DESCRIPTION
No linked issue

## Summary

Refs #2891. Instruction-surface de-slop shard for the `biome-format` plugin only. Other plugins stay on main.

## Fix

Rewrote `plugins/biome-format/README.md` and every `plugins/biome-format/**/SKILL.md` under `/ai-slop:audit fix` semantics (periods, commas, or a restructured sentence; never parentheses, en dashes, or a spaced hyphen as a stand-in). YAML frontmatter left unchanged. Version-only bump in `plugin.json`. New changelog heading only. The generated options block is ignore-fenced because `scripts/sync-plugin-options-docs.py` still emits em dashes from its shared template. `biome-format` 0.6.22.

## Verification

- Detector (`HOME` + `CLAUDE_PROJECT_DIR` isolated so `rule-em-dash` is enabled): 0 `rule-em-dash` findings on rewritten prose. Leftovers are the ignore-fenced generated-options span, plus version-only `plugin.json` description text and historical CHANGELOG entries that this shard did not rewrite
- `CHECK_SKILL_SKIP_MARKDOWNLINT=1 bash scripts/check-changed-skills.sh origin/main`: 0 failed; quoted trigger phrases vs origin/main preserved
- `python3 scripts/sync-plugin-options-docs.py --check` up to date
- `scripts/check-changelog-parity.sh --check-bump origin/main` passes
- `node scripts/generate-cheatsheet.mjs --check` in sync

## Related

Refs #2891