### PR TITLE
docs(go-format): de-slop instruction surfaces (0.3.23)

### DIFF
--- a/plugins/go-format/.claude-plugin/plugin.json
+++ b/plugins/go-format/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "go-format",
-  "version": "0.3.22",
+  "version": "0.3.23",
   "description": "Auto-fix Go formatting and import management on edit via goimports — runs unconditionally (no consumer-config gate), skipping generated files.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/go-format/CHANGELOG.md
+++ b/plugins/go-format/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to the `go-format` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.3.23]
+
+### Changed
+
+- **Instruction-surface de-slop (#2891, go-format cluster).** Rewrote this plugin's `README.md` and every
+  `SKILL.md` to drop em dashes under the repo's zero-tolerance house policy, using
+  `/ai-slop:audit fix` semantics: periods or commas, or a restructured sentence, never
+  parentheses, en dashes, or a spaced hyphen as a stand-in. Meaning stays; only the mark
+  and the sentence break change. The generated options block is ignore-fenced because
+  `scripts/sync-plugin-options-docs.py` still emits em dashes from its shared template.
+
 ## [0.3.22]
 
 ### Fixed

--- a/plugins/go-format/README.md
+++ b/plugins/go-format/README.md
@@ -4,17 +4,17 @@ A Claude Code plugin that formats Go files and manages their imports the
 moment you edit them. On every `Write` or `Edit` of a `.go` file it runs
 [goimports](https://pkg.go.dev/golang.org/x/tools/cmd/goimports)'s `-w`,
 which adds missing imports, removes unused ones, and applies `gofmt`-
-equivalent formatting — then surfaces any syntax error goimports can't parse
+equivalent formatting, then surfaces any syntax error goimports can't parse
 back to Claude as advisory context.
 
 ## Behavior
 
-- **Unconditional — no consumer-config opt-in gate.** Unlike sibling
+- **Unconditional, no consumer-config opt-in gate.** Unlike sibling
   formatter plugins (`ruff-format`, `typos-format`), this hook runs on every
   edited `.go` file regardless of repository configuration. `goimports`'
   own docs describe it as "a replacement for your editor's gofmt-on-save
   hook" and it has no meaningful config-divergence axis when left
-  unconfigured — running it does not impose a style choice a repo hasn't
+  unconfigured. Running it does not impose a style choice a repo hasn't
   made, the same reasoning that makes `gofmt` itself safe to run
   unconditionally.
 - **Extension-scoped.** Only `.go` files trigger the hook (like
@@ -22,18 +22,18 @@ back to Claude as advisory context.
   language-agnostic scope).
 - **Skips generated files.** A file whose leading comment/blank-line block
   contains Go's canonical `// Code generated ... DO NOT EDIT.` marker is
-  left untouched — this includes files where a copyright/license header
+  left untouched. This includes files where a copyright/license header
   (a `//` or `/* */` block) precedes the marker, common for
   `addlicense`/`goheader` output. `goimports` itself has no awareness of
   that convention, so this hook adds the guard itself.
-- **Fix in place.** Formatting and import changes are applied silently — no
+- **Fix in place.** Formatting and import changes are applied silently. No
   advisory noise on a successful fix, the same posture as a successful
   `ruff-format`/`typos-format` autofix pass.
 - **Groups local imports using your module's own path.** When a `go`
   toolchain is on `PATH`, the hook resolves the edited file's own module
   path (`go list -m`) and passes it as goimports' `-local` grouping prefix,
   so your package's own internal imports stay in their own group instead of
-  being collapsed into the third-party group — matching goimports' own
+  being collapsed into the third-party group, matching goimports' own
   `-local` convention without adding any new consumer config. Falls back to
   goimports' plain default grouping when `go` is absent or the file isn't
   in a resolvable module.
@@ -46,13 +46,13 @@ back to Claude as advisory context.
 
 ## Requirements
 
-- **Bash** — the hook is a Bash script. On native Windows, install
+- **Bash.** The hook is a Bash script. On native Windows, install
   [Git for Windows](https://code.claude.com/docs/en/setup#set-up-on-windows) so
   Claude Code can run it under Git Bash.
-- **jq** on `PATH` — parses the hook payload. Absent: the hook skips with a
+- **jq** on `PATH`. Parses the hook payload. Absent: the hook skips with a
   visible once-per-session notice. [Install jq](https://jqlang.org/download/).
 - **goimports** on `PATH`. Like `typos-format`, `goimports` has no
-  per-repo dependency-manager convention — it is conventionally
+  per-repo dependency-manager convention. It is conventionally
   `go install`ed to the machine-global `$GOPATH/bin`. It is never
   downloaded on the fly; if it is not present, the hook skips with a
   visible once-per-session notice.
@@ -78,12 +78,12 @@ Then verify prerequisites with `/go-format:setup check`.
 
 ## Configuration
 
-There are no rules to configure — `goimports` runs with no consumer-config
+There are no rules to configure. `goimports` runs with no consumer-config
 surface to read. One `userConfig` option tunes the hook itself:
 
 | Option | Default | Effect |
 |--------|---------|--------|
-| `go_format_enabled` | `true` | Kill switch — set `false` for a clean no-op. |
+| `go_format_enabled` | `true` | Kill switch. Set `false` for a clean no-op. |
 
 Set it interactively with `/plugin configure go-format@<marketplace>`, or headless on the
 install command:
@@ -92,6 +92,7 @@ install command:
 claude plugin install go-format@<marketplace> --config go_format_enabled=false
 ```
 
+<!-- ai-slop-ignore-start: generated options block; source is plugin.json + scripts/sync-plugin-options-docs.py -->
 <!-- BEGIN GENERATED: plugin options — edit plugin.json, then run scripts/sync-plugin-options-docs.py -->
 
 ### Options reference
@@ -164,6 +165,7 @@ hands a configured value to a hook process; the value comes from the routes abov
 - [Manage installed plugins](https://code.claude.com/docs/en/discover-plugins#manage-installed-plugins) — enabling, disabling, `/plugin list`
 
 <!-- END GENERATED: plugin options -->
+<!-- ai-slop-ignore-end -->
 
 ## License
 

--- a/plugins/go-format/skills/setup/SKILL.md
+++ b/plugins/go-format/skills/setup/SKILL.md
@@ -9,16 +9,16 @@ disable-model-invocation: true
 
 Thin check-centric setup per the uniform setup contract (`docs/PLUGIN-PHILOSOPHY.md`
 "Setup is explicit and repeatable" in the marketplace repository): `check` inspects and
-reports, `apply` resolves. This plugin owns no consumer-project configuration — it runs
+reports, `apply` resolves. This plugin owns no consumer-project configuration. It runs
 unconditionally (no consumer-config opt-in gate, unlike sibling formatter plugins Ruff/typos),
 so the only tunable is the native `userConfig` toggle. Like `typos-format`, `goimports` has no
-per-repo dependency-manager install path in the way Ruff's `.venv` does — it is conventionally
+per-repo dependency-manager install path in the way Ruff's `.venv` does. It is conventionally
 `go install`ed to the machine-global `$GOPATH/bin`, never as a project dependency. `apply` is
 therefore guidance-only: it never installs anything, matching the hook's own PATH-only
 resolution and the plugin philosophy's never-download-silently rule.
 
 Action routing: no argument or `check` runs the check; `apply` runs the check first, then
-prints remediation guidance for each FAIL. Both are non-interactive — never prompt when the
+prints remediation guidance for each FAIL. Both are non-interactive. Never prompt when the
 action is given.
 
 ## `check` (read-only)
@@ -26,53 +26,53 @@ action is given.
 The hook script (`${CLAUDE_PLUGIN_ROOT}/hooks/go-format.sh`) is the single source of truth for
 what it requires and how it resolves things.
 
-**Read it first** — probe what it actually does, don't recite this file. Then run each probe via
+**Read it first.** Probe what it actually does, don't recite this file. Then run each probe via
 Bash and report a PASS/FAIL/INFO table with one remediation line per FAIL. Do not modify anything.
 
 When the plugin's toggle is disabled, every prerequisite absence downgrades from FAIL to
-INFO — the hook exits through its enabled-gate before probing anything, so a deliberately
+INFO. The hook exits through its enabled-gate before probing anything, so a deliberately
 disabled plugin is not broken. Report the probes informationally and note that re-enabling
 restores the FAIL semantics.
 
-1. **Bash version** — check against the hook's documented floor (README Requirements),
+1. **Bash version.** Check against the hook's documented floor (README Requirements),
    noting any features the hook degrades without (telemetry's `EPOCHREALTIME`, Bash 5.0+).
-2. **`jq`** — `command -v jq`. FAIL if absent: the hook then skips with a visible
+2. **`jq`.** `command -v jq`. FAIL if absent: the hook then skips with a visible
    once-per-session notice instead of formatting.
-3. **`goimports` binary** — `command -v goimports` (the hook resolves PATH only — no
+3. **`goimports` binary.** `command -v goimports` (the hook resolves PATH only, no
    `.venv`-style per-repo convention). Report the resolved path and `goimports -h`'s first line
    when found (goimports has no `--version` flag; the help header is the closest signal). FAIL
-   when absent — the hook then emits a visible once-per-session skip notice instead of running.
-4. **Hook toggle** — report the effective `go_format_enabled` value:
+   when absent. The hook then emits a visible once-per-session skip notice instead of running.
+4. **Hook toggle.** Report the effective `go_format_enabled` value:
    `${user_config.go_format_enabled}` (unexpanded or empty means default `true`).
-5. **Hook registration** — INFO: confirm the plugin is enabled for this project
+5. **Hook registration.** INFO: confirm the plugin is enabled for this project
    (`/plugin` → Installed) rather than parsing settings files.
 
-There is no consumer-config probe (unlike `typos-format`'s config-walk check) — this hook runs
+There is no consumer-config probe (unlike `typos-format`'s config-walk check). This hook runs
 unconditionally by design; report that plainly as INFO, not as a gap.
 
 ## `apply` (idempotent)
 
-Run `check`, then for each FAIL print remediation guidance — never install anything. There is
+Run `check`, then for each FAIL print remediation guidance. Never install anything. There is
 no `apply install-goimports`-style write path: `go install golang.org/x/tools/cmd/goimports@latest`
 writes to the machine-global `$GOPATH/bin` (not project-scoped) and `@latest` is not
 idempotent-pinned, so the only responsible action is pointing at the command and letting the
 consumer run it themselves.
 
 After the consumer installs `goimports` themselves, re-run `check` and report its actual
-result — never claim resolved without re-verifying. For everything else `apply` only points:
+result. Never claim resolved without re-verifying. For everything else `apply` only points:
 
 - missing `goimports`: `go install golang.org/x/tools/cmd/goimports@latest` (requires a Go
   toolchain: https://go.dev/dl/).
 - missing `jq` / Bash: platform install instructions from the README Requirements section;
   this skill never installs system packages.
 - toggle off: direct to `/plugin configure go-format` (interactive, any
-  time). Headless: rerun the install with the new value —
+  time). Headless: rerun the install with the new value,
   `claude plugin install go-format@<marketplace> -s <scope> --config go_format_enabled=true`
   (repeatable per key). Against an already-installed plugin it prints `already installed` **and
-  still writes the value** — verified on Claude Code 2.1.240 (a non-sensitive option at `user`
+  still writes the value**, verified on Claude Code 2.1.240 (a non-sensitive option at `user`
   scope: a non-default value written to an installed plugin, then restored). The short-circuit is
   about the install, not the config write. Re-verify before relying on it outside those
-  conditions — a `sensitive` option, or `project`/`local` scope, were not covered. Do **not**
+  conditions. A `sensitive` option, or `project`/`local` scope, were not covered. Do **not**
   uninstall to reconfigure: uninstalling drops this plugin's entire stored `pluginConfigs` entry,
   resetting every option in the README's Options reference table to its manifest default. `-s`
   defaults to `user`, so pass the scope `claude plugin list` reports for this plugin, and run from
@@ -81,7 +81,7 @@ result — never claim resolved without re-verifying. For everything else `apply
   Afterwards, keep the two claims apart. The write is issued and the stored value is what you
   passed; the RUNNING session's behavior is not. The rendered `${user_config.*}` is injected at
   skill load and each hook receives its `CLAUDE_PLUGIN_OPTION_*` from an environment fixed at
-  session start, so a same-session `check` still reports the OLD value — reporting that as a
+  session start, so a same-session `check` still reports the OLD value. Reporting that as a
   failed write would be wrong. Verify the effective value by rerunning `check` in a **fresh
   session**, and never claim an unobserved change.
 
@@ -89,8 +89,8 @@ Re-running `apply` after everything passes changes nothing and reports "already 
 
 ## What this skill does NOT do
 
-- Run the formatter — editing any `.go` file exercises the hook end-to-end.
+- Run the formatter. Editing any `.go` file exercises the hook end-to-end.
 - Write the plugin cache, Claude Code user settings, or `pluginConfigs`.
-- Install `goimports` — installation is always the consumer's own choice and command, at the
+- Install `goimports`. Installation is always the consumer's own choice and command, at the
   machine level, never a project dependency this skill records.
 - Download or execute tools during `check` or `apply`.


### PR DESCRIPTION
No linked issue

## Summary

Refs #2891. Instruction-surface de-slop shard for the `go-format` plugin only. Other plugins stay on main.

## Fix

Rewrote `plugins/go-format/README.md` and every `plugins/go-format/**/SKILL.md` under `/ai-slop:audit fix` semantics (periods, commas, or a restructured sentence; never parentheses, en dashes, or a spaced hyphen as a stand-in). YAML frontmatter left unchanged. Version-only bump in `plugin.json`. New changelog heading only. The generated options block is ignore-fenced because `scripts/sync-plugin-options-docs.py` still emits em dashes from its shared template. `go-format` 0.3.23.

## Verification

- Detector (`HOME` + `CLAUDE_PROJECT_DIR` isolated so `rule-em-dash` is enabled): 0 `rule-em-dash` findings on rewritten prose. Leftovers are the ignore-fenced generated-options span, plus version-only `plugin.json` description text and historical CHANGELOG entries that this shard did not rewrite
- `CHECK_SKILL_SKIP_MARKDOWNLINT=1 bash scripts/check-changed-skills.sh origin/main`: 0 failed; quoted trigger phrases vs origin/main preserved
- `python3 scripts/sync-plugin-options-docs.py --check` up to date
- `scripts/check-changelog-parity.sh --check-bump origin/main` passes
- `node scripts/generate-cheatsheet.mjs --check` in sync

## Related

Refs #2891