### PR TITLE
docs(typos-format): de-slop instruction surfaces (0.6.28)

### DIFF
--- a/plugins/typos-format/.claude-plugin/plugin.json
+++ b/plugins/typos-format/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "typos-format",
-  "version": "0.6.27",
+  "version": "0.6.28",
   "description": "Spell-check on edit via typos-cli, unconditionally — report-only by default, honoring the consuming repo's own typos configuration when one is present.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/typos-format/CHANGELOG.md
+++ b/plugins/typos-format/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to the `typos-format` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.6.28]
+
+### Changed
+
+- **Instruction-surface de-slop (#2891, typos-format cluster).** Rewrote this plugin's `README.md` and every
+  `SKILL.md` to drop em dashes under the repo's zero-tolerance house policy, using
+  `/ai-slop:audit fix` semantics: periods or commas, or a restructured sentence, never
+  parentheses, en dashes, or a spaced hyphen as a stand-in. Meaning stays; only the mark
+  and the sentence break change. The generated options block is ignore-fenced because
+  `scripts/sync-plugin-options-docs.py` still emits em dashes from its shared template.
+
 ## [0.6.27]
 
 ### Fixed
@@ -50,17 +61,6 @@ All notable changes to the `typos-format` plugin are documented here. Format fol
   demoted to a file pointer *after* write mode had already rewritten the file, which is the
   outcome the ceiling exists to prevent
   ([#3133](https://github.com/melodic-software/claude-code-plugins/issues/3133)).
-
-## [0.6.28]
-
-### Changed
-
-- **Instruction-surface de-slop (#2891, typos-format cluster).** Rewrote this plugin's `README.md` and every
-  `SKILL.md` to drop em dashes under the repo's zero-tolerance house policy, using
-  `/ai-slop:audit fix` semantics: periods or commas, or a restructured sentence, never
-  parentheses, en dashes, or a spaced hyphen as a stand-in. Meaning stays; only the mark
-  and the sentence break change. The generated options block is ignore-fenced because
-  `scripts/sync-plugin-options-docs.py` still emits em dashes from its shared template.
 
 ## [0.6.24]
 

--- a/plugins/typos-format/CHANGELOG.md
+++ b/plugins/typos-format/CHANGELOG.md
@@ -51,6 +51,17 @@ All notable changes to the `typos-format` plugin are documented here. Format fol
   outcome the ceiling exists to prevent
   ([#3133](https://github.com/melodic-software/claude-code-plugins/issues/3133)).
 
+## [0.6.28]
+
+### Changed
+
+- **Instruction-surface de-slop (#2891, typos-format cluster).** Rewrote this plugin's `README.md` and every
+  `SKILL.md` to drop em dashes under the repo's zero-tolerance house policy, using
+  `/ai-slop:audit fix` semantics: periods or commas, or a restructured sentence, never
+  parentheses, en dashes, or a spaced hyphen as a stand-in. Meaning stays; only the mark
+  and the sentence break change. The generated options block is ignore-fenced because
+  `scripts/sync-plugin-options-docs.py` still emits em dashes from its shared template.
+
 ## [0.6.24]
 
 ### Changed

--- a/plugins/typos-format/README.md
+++ b/plugins/typos-format/README.md
@@ -1,17 +1,20 @@
 # typos-format
 
 A Claude Code plugin that spell-checks the moment you edit any file. On every
-`Write` or `Edit` it runs [typos](https://github.com/crate-ci/typos) and
+`Write`, `Edit`, or `NotebookEdit` it runs [typos](https://github.com/crate-ci/typos) and
 surfaces findings back to Claude as advisory context, including remediation
 guidance for allowlisting a false positive. It is **report-only by default**;
 with the `typos_format_write_changes` opt-in it applies typos' safe
 corrections in place and reports every correction it applied.
 
-It ships no rules of its own and runs unconditionally, using typos' built-in
-spelling dictionary. If your repository has its own typos configuration
-(`typos.toml`, `_typos.toml`, `.typos.toml`, `Cargo.toml` with
+It ships one fleet-wide protection of its own: a bundled
+`config/default-typos.toml` injected via `typos -c` so write mode cannot
+silently corrupt git SHAs. Otherwise it runs unconditionally on typos'
+built-in spelling dictionary. If your repository has its own typos
+configuration (`typos.toml`, `_typos.toml`, `.typos.toml`, `Cargo.toml` with
 `[workspace.metadata.typos]`/`[package.metadata.typos]`, or `pyproject.toml`
-with `[tool.typos]`), typos discovers and honors it automatically. No
+with `[tool.typos]`), typos discovers it from the target path and merges
+`extend-*` keys with the bundled file rather than replacing them. No
 opt-in required.
 
 ## Behavior

--- a/plugins/typos-format/README.md
+++ b/plugins/typos-format/README.md
@@ -1,21 +1,17 @@
 # typos-format
 
 A Claude Code plugin that spell-checks the moment you edit any file. On every
-`Write`, `Edit`, or `NotebookEdit` it runs
-[typos](https://github.com/crate-ci/typos) and
-surfaces findings back to Claude as advisory context — including remediation
+`Write` or `Edit` it runs [typos](https://github.com/crate-ci/typos) and
+surfaces findings back to Claude as advisory context, including remediation
 guidance for allowlisting a false positive. It is **report-only by default**;
 with the `typos_format_write_changes` opt-in it applies typos' safe
 corrections in place and reports every correction it applied.
 
-It ships one fleet-wide protection of its own — a bundled
-`config/default-typos.toml` injected via `typos -c` so write mode cannot
-silently corrupt git SHAs — and otherwise runs unconditionally on typos'
-built-in spelling dictionary. If your repository has its own typos
-configuration (`typos.toml`, `_typos.toml`, `.typos.toml`, `Cargo.toml` with
+It ships no rules of its own and runs unconditionally, using typos' built-in
+spelling dictionary. If your repository has its own typos configuration
+(`typos.toml`, `_typos.toml`, `.typos.toml`, `Cargo.toml` with
 `[workspace.metadata.typos]`/`[package.metadata.typos]`, or `pyproject.toml`
-with `[tool.typos]`), typos discovers it from the target path and merges
-`extend-*` keys with the bundled file rather than replacing them — no
+with `[tool.typos]`), typos discovers and honors it automatically. No
 opt-in required.
 
 ## Behavior
@@ -24,11 +20,11 @@ opt-in required.
   dictionary and needs no configuration to be useful, so this hook never gates
   on a consumer typos config existing. When a config IS present, typos' own
   file-anchored discovery still finds and applies it (allowlist/exclude), in
-  its documented precedence order — this plugin never re-implements that walk.
+  its documented precedence order. This plugin never re-implements that walk.
 - **Scan is language-agnostic; write is extension-scoped.** The read-only scan
   runs on any edited file (unlike sibling formatter plugins). Opt-in write mode
   only calls `--write-changes` for an explicit allowlist of source, prose, and
-  hand-edited config extensions — unknown extensions, extensionless paths, and
+  hand-edited config extensions. Unknown extensions, extensionless paths, and
   fixture/lock/binary-adjacent types stay report-only even when
   `typos_format_write_changes` is on (#2650).
 - **Report-only by default.** A dictionary autocorrect is a content mutation
@@ -37,19 +33,19 @@ opt-in required.
   the box the hook reports findings and never modifies a file.
 - **Fix in place is an opt-in, then an allowlist.** With
   `typos_format_write_changes` set to `true`, `typos --write-changes` applies
-  every correction it has confidence in — but only when the edited path's
-  extension is on the write allowlist. Residual findings — an entry with no
-  known correction (e.g. a blank-correction `extend-words` entry marking a
-  term "disallowed"), or one with more than one candidate correction — surface
-  as advisory context, never auto-applied.
+  every correction it has confidence in, but only when the edited path's
+  extension is on the write allowlist. Residual findings surface as advisory
+  context, never auto-applied: an entry with no known correction (e.g. a
+  blank-correction `extend-words` entry marking a term "disallowed"), or one
+  with more than one candidate correction.
 - **Every applied rewrite is disclosed.** A correction changes the content of
-  your file, so the hook reports each one it applied — the word, its
-  replacement, and the line — to Claude *and* to you, capped at ten per run
+  your file, so the hook reports each one it applied, the word, its
+  replacement, and the line, to Claude *and* to you, capped at ten per run
   with a count of the remainder. Nothing this hook writes is silent.
 - **Remediation guidance included.** Both an applied rewrite and a residual
   finding carry the fix: add the term to `extend-words` / `extend-identifiers`
   (or an `extend-ignore-re` pattern) in your typos config if it's intentional.
-  This matters most on the *applied* path — the dictionary has no memory of
+  This matters most on the *applied* path. The dictionary has no memory of
   your repair, so a word you correct by hand is rewritten again on the next
   edit until the allowlist entry exists.
 - **Respects your excludes.** The hook passes `--force-exclude`, so a path
@@ -74,13 +70,13 @@ make; the residual overlap class is tracked fleet-wide in #875.
 
 ## Requirements
 
-- **Bash** — the hook is a Bash script. On native Windows, install
+- **Bash.** The hook is a Bash script. On native Windows, install
   [Git for Windows](https://code.claude.com/docs/en/setup#set-up-on-windows) so
   Claude Code can run it under Git Bash.
-- **jq** on `PATH` — parses the hook payload. Absent: the hook skips with a
+- **jq** on `PATH`. Parses the hook payload. Absent: the hook skips with a
   visible once-per-session notice. [Install jq](https://jqlang.org/download/).
 - **typos** on `PATH`. Unlike Ruff or markdownlint-cli2, typos has no
-  per-repo dependency-manager convention — it is a standalone Rust binary,
+  per-repo dependency-manager convention. It is a standalone Rust binary,
   installed at the machine level (cargo, Homebrew, Conda, pacman, or a
   pre-built binary). typos is never downloaded on the fly; if it is not
   present, the hook skips with a visible once-per-session notice.
@@ -101,7 +97,7 @@ Then verify prerequisites with `/typos-format:setup check`.
 
 ## Configuration
 
-The rules themselves are never configured here — they come from the typos
+The rules themselves are never configured here. They come from the typos
 config already in your repository, which the plugin reads automatically. To
 change the rules (allowlist a false positive, ignore a pattern), edit that
 file.
@@ -110,7 +106,7 @@ Two `userConfig` options tune the hook itself:
 
 | Option | Default | Effect |
 |--------|---------|--------|
-| `typos_format_enabled` | `true` | Kill switch — set `false` for a clean no-op. |
+| `typos_format_enabled` | `true` | Kill switch. Set `false` for a clean no-op. |
 | `typos_format_write_changes` | `false` | Set `true` to apply corrections in place for write-allowlisted extensions (accepting last-writer-wins with any sibling formatter hook on the same file). Default is report-only: findings are reported, no file is modified. Denied extensions stay report-only even when this is on. |
 
 Set them interactively with `/plugin configure typos-format@<marketplace>`, or headless on the
@@ -120,6 +116,7 @@ install command:
 claude plugin install typos-format@<marketplace> --config typos_format_enabled=false
 ```
 
+<!-- ai-slop-ignore-start: generated options block; source is plugin.json + scripts/sync-plugin-options-docs.py -->
 <!-- BEGIN GENERATED: plugin options — edit plugin.json, then run scripts/sync-plugin-options-docs.py -->
 
 ### Options reference
@@ -193,6 +190,7 @@ hands a configured value to a hook process; the value comes from the routes abov
 - [Manage installed plugins](https://code.claude.com/docs/en/discover-plugins#manage-installed-plugins) — enabling, disabling, `/plugin list`
 
 <!-- END GENERATED: plugin options -->
+<!-- ai-slop-ignore-end -->
 
 ## License
 

--- a/plugins/typos-format/skills/setup/SKILL.md
+++ b/plugins/typos-format/skills/setup/SKILL.md
@@ -9,17 +9,17 @@ disable-model-invocation: true
 
 Thin check-centric setup per the uniform setup contract (`docs/PLUGIN-PHILOSOPHY.md`
 "Setup is explicit and repeatable" in the marketplace repository): `check` inspects and
-reports, `apply` resolves. This plugin owns no consumer-project configuration — rules come from
-the repository's own typos config, and the only tunables are the native `userConfig` options
-(the on/off toggle and the write-mode switch). Unlike sibling formatter plugins (Ruff,
-markdownlint-cli2), typos has no per-repo dependency-manager install path — it is a standalone
-Rust binary installed at the machine level (cargo, Homebrew, Conda, pacman, or a pre-built
-binary), never as a project dependency. `apply` is therefore guidance-only: it never installs
-anything, matching the hook's own PATH-only resolution and the plugin philosophy's
-never-download-silently rule.
+reports, `apply` resolves. This plugin owns no consumer-project configuration. Rules come
+from the repository's own typos config, and the only tunables are the native `userConfig`
+options (the on/off toggle and the write-mode switch). Unlike sibling formatter plugins
+(Ruff, markdownlint-cli2), typos has no per-repo dependency-manager install path. It is a
+standalone Rust binary installed at the machine level (cargo, Homebrew, Conda, pacman, or
+a pre-built binary), never as a project dependency. `apply` is therefore guidance-only: it
+never installs anything, matching the hook's own PATH-only resolution and the plugin
+philosophy's never-download-silently rule.
 
 Action routing: no argument or `check` runs the check; `apply` runs the check first, then
-prints remediation guidance for each FAIL. Both are non-interactive — never prompt when the
+prints remediation guidance for each FAIL. Both are non-interactive. Never prompt when the
 action is given.
 
 ## `check` (read-only)
@@ -27,65 +27,63 @@ action is given.
 The hook script (`${CLAUDE_PLUGIN_ROOT}/hooks/typos-format.sh`) is the single source of truth
 for what it requires and how it resolves things.
 
-**Read it first** — probe what it actually does, don't recite this file. Then run each probe via
+**Read it first.** Probe what it actually does, don't recite this file. Then run each probe via
 Bash and report a PASS/FAIL/INFO table with one remediation line per FAIL. Do not modify anything.
 
 When the plugin's toggle is disabled, every prerequisite absence downgrades from FAIL to
-INFO — the hook exits through its enabled-gate before probing anything, so a deliberately
+INFO. The hook exits through its enabled-gate before probing anything, so a deliberately
 disabled plugin is not broken. Report the probes informationally and note that re-enabling
 restores the FAIL semantics.
 
-1. **Bash version** — check against the hook's documented floor (README Requirements),
+1. **Bash version.** Check against the hook's documented floor (README Requirements),
    noting any features the hook degrades without (telemetry's `EPOCHREALTIME`, Bash 5.0+).
-2. **`jq`** — `command -v jq`. FAIL if absent: the hook then skips with a visible
+2. **`jq`.** `command -v jq`. FAIL if absent: the hook then skips with a visible
    once-per-session notice instead of running.
-3. **typos binary** — `command -v typos` (the hook resolves PATH only — no `.venv`-style
+3. **typos binary.** `command -v typos` (the hook resolves PATH only, with no `.venv`-style
    per-repo convention). Report the resolved path and `typos --version` output when found.
    FAIL when absent; the hook then emits a visible once-per-session skip notice instead of
    running.
-4. **Consumer typos config (informational only)** — the hook runs unconditionally and never
+4. **Consumer typos config (informational only).** The hook runs unconditionally and never
    gates on a config existing; typos resolves its own governing config (if any) directly from
-   the file path it is given. The hook also injects its bundled
-   `config/default-typos.toml` via `typos -c` (SHA `extend-ignore-re`); `extend-*` keys
-   merge with the discovered file rather than replacing it. Report whether a `typos.toml`,
-   `_typos.toml`, `.typos.toml`, a `Cargo.toml` with `[workspace.metadata.typos]`/
-   `[package.metadata.typos]`, or a `pyproject.toml` with `[tool.typos]` governs the repo,
-   purely as INFO — its presence or absence never changes whether the hook runs.
-5. **Hook toggle** — report the effective `typos_format_enabled` value:
+   the file path it is given. Report whether a `typos.toml`, `_typos.toml`, `.typos.toml`, a
+   `Cargo.toml` with `[workspace.metadata.typos]`/`[package.metadata.typos]`, or a
+   `pyproject.toml` with `[tool.typos]` governs the repo, purely as INFO. Its presence or
+   absence never changes whether the hook runs.
+5. **Hook toggle.** Report the effective `typos_format_enabled` value:
    `${user_config.typos_format_enabled}` (unexpanded or empty means default `true`).
-6. **Write mode** — report the effective `typos_format_write_changes` value:
+6. **Write mode.** Report the effective `typos_format_write_changes` value:
    `${user_config.typos_format_write_changes}` (unexpanded or empty means the shipped default
-   `false`, and only the literal `true` enables writes — any other value stays report-only).
+   `false`, and only the literal `true` enables writes. Any other value stays report-only).
    Report-only is therefore what a default installation does: the hook still runs, still
-   reports findings, and never modifies a file. Report that as **INFO, not PASS** — every
+   reports findings, and never modifies a file. Report that as **INFO, not PASS**. Every
    prerequisite can pass while the one behavior the consumer came here for was never turned
    on, and the commonest reason to invoke this skill is that spell-fixing is not happening.
    Name the remediation in the same line rather than leaving the reader to infer it.
-7. **Hook registration** — INFO: confirm the plugin is enabled for this project
+7. **Hook registration.** INFO: confirm the plugin is enabled for this project
    (`/plugin` → Installed) rather than parsing settings files.
 
 ## `apply` (idempotent)
 
-Run `check`, then for each FAIL print remediation guidance — never install anything. There is
+Run `check`, then for each FAIL print remediation guidance. Never install anything. There is
 no `apply install-typos`-style write path (unlike `ruff-format`/`markdown-format`): typos has
 no clean per-repo dependency-manager story, so the only responsible action is pointing at the
-official install methods (`https://github.com/crate-ci/typos#install` — cargo, Homebrew,
+official install methods (`https://github.com/crate-ci/typos#install`: cargo, Homebrew,
 Conda, pacman, or a pre-built binary; pick the platform-appropriate one to surface) and letting
 the consumer choose how to install it at the machine level.
 
-After the consumer installs `typos` themselves, re-run `check` and report its actual result —
-never claim resolved without re-verifying. For everything else `apply` only points:
+After the consumer installs `typos` themselves, re-run `check` and report its actual result.
+Never claim resolved without re-verifying. For everything else `apply` only points:
 
 - missing `jq` / Bash: platform install instructions from the README Requirements section;
   this skill never installs system packages.
 - toggle off: direct to `/plugin configure typos-format` (interactive, any
-  time). Headless: rerun the install with the new value —
+  time). Headless: rerun the install with the new value,
   `claude plugin install typos-format@<marketplace> -s <scope> --config typos_format_enabled=true`
   (repeatable per key). Against an already-installed plugin it prints `already installed` **and
-  still writes the value** — verified on Claude Code 2.1.240 (a non-sensitive option at `user`
+  still writes the value**, verified on Claude Code 2.1.240 (a non-sensitive option at `user`
   scope: a non-default value written to an installed plugin, then restored). The short-circuit is
   about the install, not the config write. Re-verify before relying on it outside those
-  conditions — a `sensitive` option, or `project`/`local` scope, were not covered. Do **not**
+  conditions. A `sensitive` option, or `project`/`local` scope, were not covered. Do **not**
   uninstall to reconfigure: uninstalling drops this plugin's entire stored `pluginConfigs` entry,
   resetting every option in the README's Options reference table to its manifest default. `-s`
   defaults to `user`, so pass the scope `claude plugin list` reports for this plugin, and run from
@@ -94,26 +92,26 @@ never claim resolved without re-verifying. For everything else `apply` only poin
   Afterwards, keep the two claims apart. The write is issued and the stored value is what you
   passed; the RUNNING session's behavior is not. The rendered `${user_config.*}` is injected at
   skill load and each hook receives its `CLAUDE_PLUGIN_OPTION_*` from an environment fixed at
-  session start, so a same-session `check` still reports the OLD value — reporting that as a
+  session start, so a same-session `check` still reports the OLD value. Reporting that as a
   failed write would be wrong. Verify the effective value by rerunning `check` in a **fresh
   session**, and never claim an unobserved change.
 - report-only mode (`typos_format_write_changes` unset, or set to anything but `true`): the
-  hook is working as shipped — writes were never turned on — so this is a configuration
+  hook is working as shipped. Writes were never turned on, so this is a configuration
   answer, not a repair. Say so, then offer the same `/plugin configure typos-format` route
   (or the headless install rerun above, with `--config typos_format_write_changes=true`),
   and state what turning it on accepts: last-writer-wins ordering against any
-  sibling hook that rewrites the same file. For the opposite case — writes already on and a
-  few corrections unwanted — the fit is allow-listing those words in the repository's typos
+  sibling hook that rewrites the same file. For the opposite case, writes already on and a
+  few corrections unwanted, the fit is allow-listing those words in the repository's typos
   config, not switching the whole hook back to report-only.
 - no typos config: offer to create a minimal `_typos.toml` in the repository root only when
-  explicitly asked — the plugin imposes no rules of its own.
+  explicitly asked. The plugin imposes no rules of its own.
 
 Re-running `apply` after everything passes changes nothing and reports "already configured".
 
 ## What this skill does NOT do
 
-- Run the spell-checker — editing any file exercises the hook end-to-end.
+- Run the spell-checker. Editing any file exercises the hook end-to-end.
 - Write the plugin cache, Claude Code user settings, or `pluginConfigs`.
-- Install `typos` — installation is always the consumer's own choice and command, at the
+- Install `typos`. Installation is always the consumer's own choice and command, at the
   machine level, never a project dependency this skill records.
 - Download or execute tools during `check` or `apply`.

--- a/plugins/typos-format/skills/setup/SKILL.md
+++ b/plugins/typos-format/skills/setup/SKILL.md
@@ -45,7 +45,9 @@ restores the FAIL semantics.
    running.
 4. **Consumer typos config (informational only).** The hook runs unconditionally and never
    gates on a config existing; typos resolves its own governing config (if any) directly from
-   the file path it is given. Report whether a `typos.toml`, `_typos.toml`, `.typos.toml`, a
+   the file path it is given. The hook also injects its bundled `config/default-typos.toml`
+   via `typos -c` (SHA `extend-ignore-re`); `extend-*` keys merge with the discovered file
+   rather than replacing it. Report whether a `typos.toml`, `_typos.toml`, `.typos.toml`, a
    `Cargo.toml` with `[workspace.metadata.typos]`/`[package.metadata.typos]`, or a
    `pyproject.toml` with `[tool.typos]` governs the repo, purely as INFO. Its presence or
    absence never changes whether the hook runs.


### PR DESCRIPTION
No linked issue

## Summary

#2891 instruction-surface de-slop cluster: purge em dashes from the `typos-format` plugin README and every SKILL.md.

Refs #2891

## Fix

Rewrote `plugins/typos-format/README.md` and every `plugins/typos-format/**/SKILL.md` under `/ai-slop:audit fix` semantics (periods, commas, or a restructured sentence; never parentheses, en dashes, or a spaced hyphen as a stand-in). Meaning-preserving grammar pass after the mechanical replace. Version-only bump in `plugin.json`. New changelog heading only. YAML frontmatter description/summary left unchanged so the cheatsheet stays valid. The generated options block is ignore-fenced because `scripts/sync-plugin-options-docs.py` still emits em dashes from its shared template.

## Verification

- Detector (`HOME` + `CLAUDE_PROJECT_DIR` isolated so `rule-em-dash` is enabled): 0 `rule-em-dash` findings outside the ignore-fenced generated-options span
- `CHECK_SKILL_SKIP_MARKDOWNLINT=1 bash scripts/check-changed-skills.sh origin/main`: 0 failed; quoted trigger phrases vs origin/main preserved
- `python3 scripts/sync-plugin-options-docs.py --check` up to date
- `scripts/check-changelog-parity.sh --check-bump origin/main` passes
- `node scripts/generate-cheatsheet.mjs --check` in sync

## Related

Refs #2891

#2891 stays open.