### PR TITLE
docs(bash-format): de-slop instruction surfaces (0.7.23)

### DIFF
--- a/plugins/bash-format/.claude-plugin/plugin.json
+++ b/plugins/bash-format/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "bash-format",
-  "version": "0.7.22",
+  "version": "0.7.23",
   "description": "Auto-format and lint shell scripts on edit via shfmt + ShellCheck, using the consuming repo's own .editorconfig and .shellcheckrc.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/bash-format/CHANGELOG.md
+++ b/plugins/bash-format/CHANGELOG.md
@@ -3,17 +3,6 @@
 All notable changes to the `bash-format` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
-## [0.7.22]
-
-### Fixed
-
-- **Vendored `hook-utils.sh` skip latch (#3128).** The shared notice latch now
-  keys on session and agent (a subagent gets its own first notice), stores a
-  skip count in the marker (independent of `HOOK_TELEMETRY_SINK`), and emits a
-  one-line re-notice every 8 skips instead of going silent after the first.
-  The first `PATH probed:` dump omits other plugins' bin dirs. Copies stay
-  byte-identical via `scripts/sync-hook-utils.sh`.
-
 ## [0.7.23]
 
 ### Changed
@@ -24,6 +13,17 @@ All notable changes to the `bash-format` plugin are documented here. Format foll
   parentheses, en dashes, or a spaced hyphen as a stand-in. Meaning stays; only the mark
   and the sentence break change. The generated options block is ignore-fenced because
   `scripts/sync-plugin-options-docs.py` still emits em dashes from its shared template.
+
+## [0.7.22]
+
+### Fixed
+
+- **Vendored `hook-utils.sh` skip latch (#3128).** The shared notice latch now
+  keys on session and agent (a subagent gets its own first notice), stores a
+  skip count in the marker (independent of `HOOK_TELEMETRY_SINK`), and emits a
+  one-line re-notice every 8 skips instead of going silent after the first.
+  The first `PATH probed:` dump omits other plugins' bin dirs. Copies stay
+  byte-identical via `scripts/sync-hook-utils.sh`.
 
 ## [0.7.21]
 

--- a/plugins/bash-format/CHANGELOG.md
+++ b/plugins/bash-format/CHANGELOG.md
@@ -14,6 +14,17 @@ All notable changes to the `bash-format` plugin are documented here. Format foll
   The first `PATH probed:` dump omits other plugins' bin dirs. Copies stay
   byte-identical via `scripts/sync-hook-utils.sh`.
 
+## [0.7.23]
+
+### Changed
+
+- **Instruction-surface de-slop (#2891, bash-format cluster).** Rewrote this plugin's `README.md` and every
+  `SKILL.md` to drop em dashes under the repo's zero-tolerance house policy, using
+  `/ai-slop:audit fix` semantics: periods or commas, or a restructured sentence, never
+  parentheses, en dashes, or a spaced hyphen as a stand-in. Meaning stays; only the mark
+  and the sentence break change. The generated options block is ignore-fenced because
+  `scripts/sync-plugin-options-docs.py` still emits em dashes from its shared template.
+
 ## [0.7.21]
 
 ### Changed

--- a/plugins/bash-format/README.md
+++ b/plugins/bash-format/README.md
@@ -6,7 +6,7 @@ them. On every `Write` or `Edit` of a `.sh` or `.bash` file it runs
 [shfmt](https://github.com/mvdan/sh), surfacing findings back to Claude as
 advisory context.
 
-It uses **your repository's own configuration** — `.shellcheckrc` for linting
+It uses **your repository's own configuration**, `.shellcheckrc` for linting
 and `.editorconfig` for formatting. It ships no rules of its own.
 
 ## Behavior
@@ -14,7 +14,7 @@ and `.editorconfig` for formatting. It ships no rules of its own.
 - **Lint on edit (always).** ShellCheck (`warning` severity and above) runs on
   every edit. It is non-mutating; it only reports.
 - **Format on edit (opt-in).** `shfmt` runs **only when an `.editorconfig`
-  section names shell files** — a shell glob such as `[*.sh]`, `[*.bash]`, or
+  section names shell files**: a shell glob such as `[*.sh]`, `[*.bash]`, or
   `[*.{sh,bash}]` (including path-prefixed forms like `[**/*.sh]`), found by
   walking up from the file to the repository root. A bare `[*]` catch-all is
   **not** an opt-in: most repos only set line-ending / charset properties there,
@@ -30,19 +30,19 @@ and `.editorconfig` for formatting. It ships no rules of its own.
   your hard gate.
 - **Config from the consumer.** ShellCheck discovers `.shellcheckrc` by walking
   up from the file's directory; shfmt reads `.editorconfig` the same way. No
-  working-directory assumptions — the tools are anchored to the edited file.
-- **Scope: files inside the current project — when `CLAUDE_PROJECT_DIR` is set.**
+  working-directory assumptions. The tools are anchored to the edited file.
+- **Scope: files inside the current project, when `CLAUDE_PROJECT_DIR` is set.**
   With `CLAUDE_PROJECT_DIR` set, the hook acts only on shell files under it
-  (symlink-resolved): a `.sh`/`.bash` file written *outside* the project — e.g. to
-  a temp or scratchpad directory — is silently skipped (no lint, no format, no
+  (symlink-resolved): a `.sh`/`.bash` file written *outside* the project, e.g. to
+  a temp or scratchpad directory, is silently skipped (no lint, no format, no
   notice), deliberate defense-in-depth scoping inherited from the shared hook
   library. The OS temp tree (`TMPDIR`/`TMP`/`TEMP` and the POSIX defaults) is
-  outside the project even when it sits *under* `CLAUDE_PROJECT_DIR` — the shape a
+  outside the project even when it sits *under* `CLAUDE_PROJECT_DIR`, the shape a
   home-directory project dir takes, where Claude Code's own session scratchpad
   would otherwise prefix-match as project content. The one exception is a project
   root that itself lives under temp (a fixture checkout built with `mktemp -d`),
   whose files are project content. Membership recognizes Windows 8.3 short-name
-  spellings (`KYLESE~1`) of in-project paths — a per-volume concern: only volumes
+  spellings (`KYLESE~1`) of in-project paths, a per-volume concern: only volumes
   with 8.3 generation enabled produce such paths. If `CLAUDE_PROJECT_DIR` is **unset** (e.g. some
   headless `-p` sessions), the membership check is skipped and any existing edited
   file is processed. Either way, to lint a file the hook skipped, run `shellcheck`
@@ -50,17 +50,17 @@ and `.editorconfig` for formatting. It ships no rules of its own.
 
 ## Requirements
 
-- **Bash** — the hook is a Bash script. On native Windows, install
+- **Bash.** The hook is a Bash script. On native Windows, install
   [Git for Windows](https://code.claude.com/docs/en/setup#set-up-on-windows) so
   Claude Code can run it under Git Bash.
-- **jq** on `PATH` — parses the hook payload. Absent: the hook skips with a
+- **jq** on `PATH`. Parses the hook payload. Absent: the hook skips with a
   visible once-per-session notice. [Install jq](https://jqlang.org/download/).
 - **ShellCheck** on `PATH` for the lint pass. Absent: the lint pass skips with
   a visible once-per-session notice.
 - **shfmt** on `PATH` for the format pass (and an `.editorconfig` in your repo
   to opt in). Absent while the repo opts in: the format pass skips with a
   visible once-per-session notice. Without the `.editorconfig` opt-in the
-  format pass stays quiet — the repo chose not to format.
+  format pass stays quiet. The repo chose not to format.
 
 Each pass is independent: when a tool is absent its pass is skipped (visibly)
 and the other still runs.
@@ -97,6 +97,7 @@ install command:
 claude plugin install bash-format@<marketplace> --config bash_format_enabled=false
 ```
 
+<!-- ai-slop-ignore-start: generated options block; source is plugin.json + scripts/sync-plugin-options-docs.py -->
 <!-- BEGIN GENERATED: plugin options — edit plugin.json, then run scripts/sync-plugin-options-docs.py -->
 
 ### Options reference
@@ -169,6 +170,7 @@ hands a configured value to a hook process; the value comes from the routes abov
 - [Manage installed plugins](https://code.claude.com/docs/en/discover-plugins#manage-installed-plugins) — enabling, disabling, `/plugin list`
 
 <!-- END GENERATED: plugin options -->
+<!-- ai-slop-ignore-end -->
 
 ## License
 

--- a/plugins/bash-format/skills/setup/SKILL.md
+++ b/plugins/bash-format/skills/setup/SKILL.md
@@ -9,83 +9,83 @@ disable-model-invocation: true
 
 Thin check-centric setup per the uniform setup contract (`docs/PLUGIN-PHILOSOPHY.md`
 "Setup is explicit and repeatable" in the marketplace repository): `check` inspects and
-reports, `apply` resolves. This plugin owns no consumer-project configuration — linting rules
-come from the repository's own `.shellcheckrc`, formatting from its `.editorconfig`, and the
-only tunable is the native `userConfig` toggle. Every prerequisite is a `PATH` binary the
-plugin never bundles, and the plugin never installs system packages, so `apply` is
-guidance-only with **no write path** — it never modifies the repository, user settings, or the
-plugin cache.
+reports, `apply` resolves. This plugin owns no consumer-project configuration. Linting
+rules come from the repository's own `.shellcheckrc`, formatting from its `.editorconfig`,
+and the only tunable is the native `userConfig` toggle. Every prerequisite is a `PATH`
+binary the plugin never bundles, and the plugin never installs system packages, so `apply`
+is guidance-only with **no write path**. It never modifies the repository, user settings, or
+the plugin cache.
 
 Action routing: no argument or `check` runs the check; `apply` runs the check first, then
-offers remediation guidance. Both are non-interactive — never prompt when the action is given.
+offers remediation guidance. Both are non-interactive. Never prompt when the action is given.
 
 ## `check` (read-only)
 
 The hook script (`${CLAUDE_PLUGIN_ROOT}/hooks/bash-format.sh`) is the single source of truth
 for what it requires and how it resolves things.
 
-**Read it first** — probe what it actually does, don't recite this file. Then run each probe via
+**Read it first.** Probe what it actually does, don't recite this file. Then run each probe via
 Bash and report a PASS/FAIL/INFO table with one remediation line per FAIL. Do not modify anything.
 
 The lint pass and the format pass are independent; report each separately.
 
 When the plugin's toggle is disabled, every prerequisite absence downgrades from FAIL to
-INFO — the hook exits through its enabled-gate before probing anything, so a deliberately
+INFO. The hook exits through its enabled-gate before probing anything, so a deliberately
 disabled plugin is not broken. Report the probes informationally and note that re-enabling
 restores the FAIL semantics.
 
-1. **Bash version** — check against the hook's documented floor (README Requirements),
+1. **Bash version.** Check against the hook's documented floor (README Requirements),
    noting any features the hook degrades without (for example telemetry's `EPOCHREALTIME`,
    a Bash 5.0+ builtin).
-2. **`jq`** — `command -v jq`. FAIL if absent: the hook then skips with a visible
+2. **`jq`.** `command -v jq`. FAIL if absent: the hook then skips with a visible
    once-per-session notice instead of running either pass.
-3. **`shellcheck`** (lint pass) — `command -v shellcheck`. FAIL if absent: the lint pass
+3. **`shellcheck`** (lint pass). `command -v shellcheck`. FAIL if absent: the lint pass
    skips with a visible once-per-session notice.
-4. **`shfmt`** (format pass) — `command -v shfmt`. Its FAIL/INFO status depends on the
+4. **`shfmt`** (format pass). `command -v shfmt`. Its FAIL/INFO status depends on the
    `.editorconfig` opt-in below, because the format pass runs **only when the repo has opted
    in**:
    - opted in AND `shfmt` absent → FAIL: the format pass skips with a visible once-per-session
      notice.
    - not opted in → INFO regardless of `shfmt`: the format pass stays quiet by design (the
      repo chose not to format), so a missing `shfmt` is not a defect here.
-5. **`.editorconfig` shell opt-in** — mirror the hook's opt-in logic
+5. **`.editorconfig` shell opt-in.** Mirror the hook's opt-in logic
    (`shell_editorconfig_opt_in` / `section_applies_to_shell`), not merely "does an
-   `.editorconfig` exist". The opt-in is an EditorConfig **section that names shell files**
-   — a shell glob such as `[*.sh]`, `[*.bash]`, or `[*.{sh,bash}]` (including path-prefixed
-   forms like `[**/*.sh]`) — discovered by walking up from the file's directory to the repo
+   `.editorconfig` exist". The opt-in is an EditorConfig **section that names shell files**:
+   a shell glob such as `[*.sh]`, `[*.bash]`, or `[*.{sh,bash}]` (including path-prefixed
+   forms like `[**/*.sh]`), discovered by walking up from the file's directory to the repo
    root and stopping at a `root = true` config. A bare `[*]` catch-all does NOT count (most
    repos only set line-ending / charset properties there). Path-only sections like
    `[scripts/**]` do NOT count either. Report as INFO: whether a governing shell section
    exists and therefore whether the format pass is active. If none exists, INFO-note the
    consequence per the hook's logic: shell files are left unformatted rather than rewritten
    to shfmt's built-in defaults.
-6. **`.shellcheckrc`** — INFO: ShellCheck auto-discovers `.shellcheckrc` by walking up from
+6. **`.shellcheckrc`.** INFO: ShellCheck auto-discovers `.shellcheckrc` by walking up from
    the file's directory. Report whether one exists; its absence is not a FAIL (ShellCheck
    applies its own defaults).
-7. **Hook toggle** — report the effective `bash_format_enabled` value:
+7. **Hook toggle.** Report the effective `bash_format_enabled` value:
    `${user_config.bash_format_enabled}` (unexpanded or empty means default `true`; any value
    other than `true` disables the hook).
-8. **Hook registration** — INFO: confirm the plugin is enabled for this project
+8. **Hook registration.** INFO: confirm the plugin is enabled for this project
    (`/plugin` → Installed) rather than parsing settings files.
-9. **Project scope** — INFO: when `CLAUDE_PROJECT_DIR` is set, the hook acts only
+9. **Project scope.** INFO: when `CLAUDE_PROJECT_DIR` is set, the hook acts only
    on shell files inside it (symlink-resolved membership guard in the shared hook
-   library, aware of Windows 8.3 short-name spellings of in-project paths — a
+   library, aware of Windows 8.3 short-name spellings of in-project paths, a
    per-volume property; only volumes with 8.3 generation enabled produce them);
    a `.sh`/`.bash` file written *outside* the project (temp/scratchpad
-   dirs) is silently skipped — no lint, no format, no notice. The OS temp tree
+   dirs) is silently skipped. No lint, no format, no notice. The OS temp tree
    counts as outside even when it sits under `CLAUDE_PROJECT_DIR`, unless the
    project root itself lives under temp. When
    `CLAUDE_PROJECT_DIR` is **unset** (e.g. some headless `-p` sessions) the guard
    is skipped and any existing edited file is processed. Report this so a green
    `check` is not read as "every shell edit anywhere is covered".
 
-When every probe passes, report the result **with the scope caveat** (item 9) —
-never an unqualified "fully operational", which would imply out-of-project shell
+When every probe passes, report the result **with the scope caveat** (item 9).
+Never an unqualified "fully operational", which would imply out-of-project shell
 edits are covered when they are deliberately skipped.
 
 ## `apply` (idempotent)
 
-Run `check`, then for each FAIL point at the resolution — this skill installs nothing:
+Run `check`, then for each FAIL point at the resolution. This skill installs nothing:
 
 - missing `shellcheck`: install guidance from the README Requirements section
   (the [ShellCheck install guide](https://github.com/koalaman/shellcheck#installing)); this
@@ -95,17 +95,17 @@ Run `check`, then for each FAIL point at the resolution — this skill installs 
 - missing `jq` / Bash: platform install instructions from the README Requirements section.
 - no shell `.editorconfig` opt-in (and formatting is wanted): explain that adding a governing
   shell section (`[*.sh]`, `[*.bash]`, or `[*.{sh,bash}]`) to an `.editorconfig` opts the
-  repo in — a bare `[*]` is not enough — but this skill does not write it. `.editorconfig` is
+  repo in. A bare `[*]` is not enough, but this skill does not write it. `.editorconfig` is
   cross-cutting (it governs every editor and tool in the repo), so the choice and the edit
   belong to the consumer.
 - toggle off: direct to `/plugin configure bash-format` (interactive, any
-  time). Headless: rerun the install with the new value —
+  time). Headless: rerun the install with the new value,
   `claude plugin install bash-format@<marketplace> -s <scope> --config bash_format_enabled=true`
   (repeatable per key). Against an already-installed plugin it prints `already installed` **and
-  still writes the value** — verified on Claude Code 2.1.240 (a non-sensitive option at `user`
+  still writes the value**, verified on Claude Code 2.1.240 (a non-sensitive option at `user`
   scope: a non-default value written to an installed plugin, then restored). The short-circuit is
   about the install, not the config write. Re-verify before relying on it outside those
-  conditions — a `sensitive` option, or `project`/`local` scope, were not covered. Do **not**
+  conditions. A `sensitive` option, or `project`/`local` scope, were not covered. Do **not**
   uninstall to reconfigure: uninstalling drops this plugin's entire stored `pluginConfigs` entry,
   resetting every option in the README's Options reference table to its manifest default. `-s`
   defaults to `user`, so pass the scope `claude plugin list` reports for this plugin, and run from
@@ -114,21 +114,21 @@ Run `check`, then for each FAIL point at the resolution — this skill installs 
   Afterwards, keep the two claims apart. The write is issued and the stored value is what you
   passed; the RUNNING session's behavior is not. The rendered `${user_config.*}` is injected at
   skill load and each hook receives its `CLAUDE_PLUGIN_OPTION_*` from an environment fixed at
-  session start, so a same-session `check` still reports the OLD value — reporting that as a
+  session start, so a same-session `check` still reports the OLD value. Reporting that as a
   failed write would be wrong. Verify the effective value by rerunning `check` in a **fresh
   session**, and never claim an unobserved change.
 
 After pointing at a remediation, re-run the relevant `check` probe and report its actual
-result — never claim resolved on the reader's report that they installed something.
+result. Never claim resolved on the reader's report that they installed something.
 
 Re-running `apply` after everything passes changes nothing and reports "already configured".
 
 ## What this skill does NOT do
 
-- Run the linter or formatter — editing any `.sh` or `.bash` file exercises the hook
+- Run the linter or formatter. Editing any `.sh` or `.bash` file exercises the hook
   end-to-end.
 - Write the plugin cache, Claude Code user settings, or `pluginConfigs`. Nor the repository,
-  including `.editorconfig` / `.shellcheckrc` — every prerequisite is a `PATH` binary or the
+  including `.editorconfig` / `.shellcheckrc`. Every prerequisite is a `PATH` binary or the
   native toggle, so remediation is guidance only.
 - Download or execute tools during `check` beyond the read-only `command -v` presence probes.
 
@@ -143,7 +143,7 @@ Re-running `apply` after everything passes changes nothing and reports "already 
 - **`check` PASS ≠ every shell edit is covered.** When `CLAUDE_PROJECT_DIR` is set
   the hook is project-scoped (probe 9): shell files written outside it are silently
   skipped, so a fully green `check` still does not cover out-of-project edits. (When
-  `CLAUDE_PROJECT_DIR` is unset the scoping does not apply — see probe 9.)
+  `CLAUDE_PROJECT_DIR` is unset the scoping does not apply. See probe 9.)
 - **`shfmt` FAIL is opt-in-conditional.** A missing `shfmt` is only a FAIL when an
   `.editorconfig` section governs shell files; without that opt-in it is INFO, not
   a defect. Resolve the `.editorconfig` opt-in state before calling `shfmt` a failure.


### PR DESCRIPTION
No linked issue

## Summary

#2891 instruction-surface de-slop cluster: purge em dashes from the `bash-format` plugin README and every SKILL.md.

Refs #2891

## Fix

Rewrote `plugins/bash-format/README.md` and every `plugins/bash-format/**/SKILL.md` under `/ai-slop:audit fix` semantics (periods, commas, or a restructured sentence; never parentheses, en dashes, or a spaced hyphen as a stand-in). Meaning-preserving grammar pass after the mechanical replace. Version-only bump in `plugin.json`. New changelog heading only. YAML frontmatter description/summary left unchanged so the cheatsheet stays valid. The generated options block is ignore-fenced because `scripts/sync-plugin-options-docs.py` still emits em dashes from its shared template.

## Verification

- Detector (`HOME` + `CLAUDE_PROJECT_DIR` isolated so `rule-em-dash` is enabled): 0 `rule-em-dash` findings outside the ignore-fenced generated-options span
- `CHECK_SKILL_SKIP_MARKDOWNLINT=1 bash scripts/check-changed-skills.sh origin/main`: 0 failed; quoted trigger phrases vs origin/main preserved
- `python3 scripts/sync-plugin-options-docs.py --check` up to date
- `scripts/check-changelog-parity.sh --check-bump origin/main` passes
- `node scripts/generate-cheatsheet.mjs --check` in sync

## Related

Refs #2891

#2891 stays open.