### PR TITLE
docs(powershell-format): de-slop instruction surfaces (0.7.23)

### DIFF
--- a/plugins/powershell-format/.claude-plugin/plugin.json
+++ b/plugins/powershell-format/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "powershell-format",
-  "version": "0.7.22",
+  "version": "0.7.23",
   "description": "Auto-format and lint PowerShell on edit via PSScriptAnalyzer, only when a PSScriptAnalyzerSettings.psd1 governs the repo — using the consuming repo's own analyzer settings.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/powershell-format/CHANGELOG.md
+++ b/plugins/powershell-format/CHANGELOG.md
@@ -3,17 +3,6 @@
 All notable changes to the `powershell-format` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
-## [0.7.22]
-
-### Fixed
-
-- **Vendored `hook-utils.sh` skip latch (#3128).** The shared notice latch now
-  keys on session and agent (a subagent gets its own first notice), stores a
-  skip count in the marker (independent of `HOOK_TELEMETRY_SINK`), and emits a
-  one-line re-notice every 8 skips instead of going silent after the first.
-  The first `PATH probed:` dump omits other plugins' bin dirs. Copies stay
-  byte-identical via `scripts/sync-hook-utils.sh`.
-
 ## [0.7.23]
 
 ### Changed
@@ -24,6 +13,17 @@ All notable changes to the `powershell-format` plugin are documented here. Forma
   parentheses, en dashes, or a spaced hyphen as a stand-in. Meaning stays; only the mark
   and the sentence break change. The generated options block is ignore-fenced because
   `scripts/sync-plugin-options-docs.py` still emits em dashes from its shared template.
+
+## [0.7.22]
+
+### Fixed
+
+- **Vendored `hook-utils.sh` skip latch (#3128).** The shared notice latch now
+  keys on session and agent (a subagent gets its own first notice), stores a
+  skip count in the marker (independent of `HOOK_TELEMETRY_SINK`), and emits a
+  one-line re-notice every 8 skips instead of going silent after the first.
+  The first `PATH probed:` dump omits other plugins' bin dirs. Copies stay
+  byte-identical via `scripts/sync-hook-utils.sh`.
 
 ## [0.7.21]
 

--- a/plugins/powershell-format/CHANGELOG.md
+++ b/plugins/powershell-format/CHANGELOG.md
@@ -14,6 +14,17 @@ All notable changes to the `powershell-format` plugin are documented here. Forma
   The first `PATH probed:` dump omits other plugins' bin dirs. Copies stay
   byte-identical via `scripts/sync-hook-utils.sh`.
 
+## [0.7.23]
+
+### Changed
+
+- **Instruction-surface de-slop (#2891, powershell-format cluster).** Rewrote this plugin's `README.md` and every
+  `SKILL.md` to drop em dashes under the repo's zero-tolerance house policy, using
+  `/ai-slop:audit fix` semantics: periods or commas, or a restructured sentence, never
+  parentheses, en dashes, or a spaced hyphen as a stand-in. Meaning stays; only the mark
+  and the sentence break change. The generated options block is ignore-fenced because
+  `scripts/sync-plugin-options-docs.py` still emits em dashes from its shared template.
+
 ## [0.7.21]
 
 ### Changed

--- a/plugins/powershell-format/README.md
+++ b/plugins/powershell-format/README.md
@@ -14,13 +14,13 @@ and runs only when your repo has opted into a `PSScriptAnalyzerSettings.psd1`.
 - **Opt-in on a settings file.** PSScriptAnalyzer runs **only when a
   `PSScriptAnalyzerSettings.psd1` governs the edited file**, found by walking up
   from the file to the repository root and stopping at the closest one. Unlike
-  some formatters, PSScriptAnalyzer does not auto-discover its settings —
-  `Invoke-Formatter` and `Invoke-ScriptAnalyzer` take an explicit settings path —
+  some formatters, PSScriptAnalyzer does not auto-discover its settings.
+  `Invoke-Formatter` and `Invoke-ScriptAnalyzer` take an explicit settings path,
   so the hook both gates on that file and passes it through. A repo without a
   settings file is left untouched rather than formatted and linted with
   PSScriptAnalyzer's built-in defaults, so the plugin never imposes a style you
   did not choose. A settings file that declares `CustomRulePath` is additionally
-  gated on explicit approval — see [Trust model](#trust-model).
+  gated on explicit approval. See [Trust model](#trust-model).
 - **Format on edit.** `Invoke-Formatter` applies your settings' formatting rules
   (indentation, alias expansion, brace placement, and so on) in place.
 - **Findings are advisory.** Semantic diagnostics your settings enable (for
@@ -29,8 +29,8 @@ and runs only when your repo has opted into a `PSScriptAnalyzerSettings.psd1`.
   via `additionalContext`; they never reject the edit. Make a commit hook or CI
   your hard gate.
 - **Graceful degrade.** If PowerShell (`pwsh`) is not installed, or the
-  PSScriptAnalyzer module is not available, the hook is a clean silent no-op —
-  no error spam. `pwsh` is resolved from `PATH` and is never downloaded.
+  PSScriptAnalyzer module is not available, the hook is a clean silent no-op.
+  No error spam. `pwsh` is resolved from `PATH` and is never downloaded.
 
 ## Trust model
 
@@ -43,16 +43,16 @@ analyzer under such a settings file without an explicit approval: it skips the
 format/lint run and reports a visible trust-gate notice (once per session, on
 both the agent and user channels) naming the settings file and the approval
 marker to create. To approve, review the settings file and every rule module it
-references — treat them with the same trust you give your build and CI
-configuration — then create the marker directory using the exact `mkdir -p`
+references. Treat them with the same trust you give your build and CI
+configuration, then create the marker directory using the exact `mkdir -p`
 command the notice carries. The marker lives under
 `${CLAUDE_PLUGIN_DATA}/trust-approvals` and is content-addressed over the
 repository, the settings file, every file reachable under each declared
 `CustomRulePath` entry (recursively for directories), and every repository
 file those files reference by string literal (transitively, bounded), so a
 change to the settings, to any referenced rule module, or to a file a rule
-module loads — including a branch switch that swaps module bytes under an
-unchanged settings file — revokes the approval and re-gates the run. Detection uses PowerShell's restricted data-file parser,
+module loads, including a branch switch that swaps module bytes under an
+unchanged settings file, revokes the approval and re-gates the run. Detection uses PowerShell's restricted data-file parser,
 not a textual scan; a settings file that parser cannot read is treated as
 code-loading and stays gated, a `CustomRulePath` entry that does not resolve
 to hashable content leaves the state unverifiable with no approval route, and
@@ -65,19 +65,19 @@ directory outside the project.
 
 ## Requirements
 
-- **Bash** — the hook is a Bash script. On native Windows, install
+- **Bash.** The hook is a Bash script. On native Windows, install
   [Git for Windows](https://code.claude.com/docs/en/setup#set-up-on-windows) so
   Claude Code can run it under Git Bash.
-- **jq** on `PATH` — parses the hook payload. Absent: the hook skips with a
+- **jq** on `PATH`. Parses the hook payload. Absent: the hook skips with a
   visible once-per-session notice. [Install jq](https://jqlang.org/download/).
-- **PowerShell 7+** (`pwsh`) on `PATH` — the hook probes `pwsh` only; legacy
+- **PowerShell 7+** (`pwsh`) on `PATH`. The hook probes `pwsh` only; legacy
   Windows PowerShell 5.1 (`powershell.exe`) is not used. If absent, the hook
   stays quiet by design: a machine without PowerShell is treated as
   not-applicable, not as a missing prerequisite.
 - The **PSScriptAnalyzer** module installed
   (`Install-Module PSScriptAnalyzer`). If absent, the hook stays quiet (same
   not-applicable classification).
-- A **`PSScriptAnalyzerSettings.psd1`** in your repo — the opt-in.
+- A **`PSScriptAnalyzerSettings.psd1`** in your repo. That file is the opt-in.
 
 The hook itself runs on Bash 3.2+. Telemetry timing uses `EPOCHREALTIME`
 (Bash 5.0+); on older bash the telemetry envelope is skipped while formatting and
@@ -111,6 +111,7 @@ on the install command:
 claude plugin install powershell-format@<marketplace> --config powershell_format_enabled=false
 ```
 
+<!-- ai-slop-ignore-start: generated options block; source is plugin.json + scripts/sync-plugin-options-docs.py -->
 <!-- BEGIN GENERATED: plugin options — edit plugin.json, then run scripts/sync-plugin-options-docs.py -->
 
 ### Options reference
@@ -183,6 +184,7 @@ hands a configured value to a hook process; the value comes from the routes abov
 - [Manage installed plugins](https://code.claude.com/docs/en/discover-plugins#manage-installed-plugins) — enabling, disabling, `/plugin list`
 
 <!-- END GENERATED: plugin options -->
+<!-- ai-slop-ignore-end -->
 
 ## License
 

--- a/plugins/powershell-format/skills/setup/SKILL.md
+++ b/plugins/powershell-format/skills/setup/SKILL.md
@@ -9,90 +9,90 @@ disable-model-invocation: true
 
 Thin check-centric setup per the uniform setup contract (`docs/PLUGIN-PHILOSOPHY.md`
 "Setup is explicit and repeatable" in the marketplace repository): `check` inspects and
-reports, `apply` resolves. This plugin owns no consumer-project configuration — formatting
+reports, `apply` resolves. This plugin owns no consumer-project configuration. Formatting
 and linting rules come from the repository's own `PSScriptAnalyzerSettings.psd1`, and the
 only tunable is the native `userConfig` toggle. The `pwsh` runtime and the PSScriptAnalyzer
 module are resolved from the environment (never bundled, never downloaded), and the plugin
-installs nothing, so `apply` is guidance-only with **no write path** — it never modifies
+installs nothing, so `apply` is guidance-only with **no write path**. It never modifies
 the repository, user settings, or the plugin cache.
 
 Note the deliberate asymmetry vs the sibling formatter plugins: only `jq` absence is a
-prerequisite defect here. A machine without PowerShell — or without the PSScriptAnalyzer
-module, or a repo without a settings file — is treated as **not-applicable, not missing**: the
+prerequisite defect here. A machine without PowerShell, or without the PSScriptAnalyzer
+module, or a repo without a settings file, is treated as **not-applicable, not missing**: the
 hook stays quiet by design, so `check` reports these as INFO, never FAIL.
 
 Action routing: no argument or `check` runs the check; `apply` runs the check first, then
-offers remediation guidance. Both are non-interactive — never prompt when the action is given.
+offers remediation guidance. Both are non-interactive. Never prompt when the action is given.
 
 ## `check` (read-only)
 
 The hook script (`${CLAUDE_PLUGIN_ROOT}/hooks/powershell-format.sh`) is the single source of
 truth for what it requires and how it resolves things.
 
-**Read it first** — probe what it actually does, don't recite this file. Then run each probe via
+**Read it first.** Probe what it actually does, don't recite this file. Then run each probe via
 Bash and report a PASS/FAIL/INFO table with one remediation line per FAIL. Do not modify anything.
 
 When the plugin's toggle is disabled, every prerequisite absence downgrades from FAIL to
-INFO — the hook exits through its enabled-gate before probing anything, so a deliberately
+INFO. The hook exits through its enabled-gate before probing anything, so a deliberately
 disabled plugin is not broken. Report the probes informationally and note that re-enabling
 restores the FAIL semantics.
 
-1. **Bash version** — check against the hook's documented floor (README Requirements),
+1. **Bash version.** Check against the hook's documented floor (README Requirements),
    noting any features the hook degrades without (for example telemetry's `EPOCHREALTIME`,
    a Bash 5.0+ builtin).
-2. **`jq`** — `command -v jq`. FAIL if absent: the hook then skips with a visible
+2. **`jq`.** `command -v jq`. FAIL if absent: the hook then skips with a visible
    once-per-session notice instead of running. This is the only FAIL-class prerequisite.
-3. **`pwsh` (PowerShell 7+)** — probe read-only:
+3. **`pwsh` (PowerShell 7+).** Probe read-only:
    `pwsh -NoProfile -NonInteractive -Command '$PSVersionTable.PSVersion.ToString()'`. INFO,
    not FAIL: the hook probes `pwsh` only (never legacy `powershell.exe`) and stays quiet when
-   it is absent — a machine without PowerShell is not-applicable by design. Report the version
+   it is absent. A machine without PowerShell is not-applicable by design. Report the version
    when present.
-4. **PSScriptAnalyzer module** — probe **only when `pwsh` resolved** (chain behind step 3 so
+4. **PSScriptAnalyzer module.** Probe **only when `pwsh` resolved** (chain behind step 3 so
    the probe never errors on a pwsh-less box):
    `pwsh -NoProfile -NonInteractive -Command 'if (Get-Module -ListAvailable -Name PSScriptAnalyzer) { "present" } else { "absent" }'`.
    INFO, not FAIL: absent → the hook is a clean quiet no-op (same not-applicable
-   classification). This probe is read-only — `Get-Module -ListAvailable` inspects, it does
+   classification). This probe is read-only. `Get-Module -ListAvailable` inspects, it does
    not format, lint, or mutate.
-5. **`PSScriptAnalyzerSettings.psd1` opt-in** — INFO: the hook runs **only when a
+5. **`PSScriptAnalyzerSettings.psd1` opt-in.** INFO: the hook runs **only when a
    `PSScriptAnalyzerSettings.psd1` governs the edited file** (walking up from the file to the
    repo root, bounded by `CLAUDE_PROJECT_DIR` when set, stopping at the closest one). Absence
-   is the opt-out and is **by design, not a defect** — the plugin is inert until a repo adopts
+   is the opt-out and is **by design, not a defect**. The plugin is inert until a repo adopts
    a settings file. Report whether one exists and its location. When one exists, surface the
-   README **Trust model**: the settings file is executed-adjacent configuration — a
+   README **Trust model**: the settings file is executed-adjacent configuration. A
    `CustomRulePath` it declares would load and run repository-supplied rule modules during
    analysis, so the hook gates such a settings state on an explicit per-content trust
    approval (marker under `${CLAUDE_PLUGIN_DATA}/trust-approvals`; any settings change
    revokes it). It carries the same trust as build/CI configuration.
-6. **Hook toggle** — report the effective `powershell_format_enabled` value:
+6. **Hook toggle.** Report the effective `powershell_format_enabled` value:
    `${user_config.powershell_format_enabled}` (unexpanded or empty means default `true`; any
    value other than `true` disables the hook).
-7. **Hook registration** — INFO: confirm the plugin is enabled for this project
+7. **Hook registration.** INFO: confirm the plugin is enabled for this project
    (`/plugin` → Installed) rather than parsing settings files.
 
 ## `apply` (idempotent)
 
-Run `check`, then for each finding point at the resolution — this skill installs nothing:
+Run `check`, then for each finding point at the resolution. This skill installs nothing:
 
 - missing `jq` / Bash: platform install instructions from the README Requirements section;
   this skill never installs system packages.
 - `pwsh` absent (and PowerShell support is wanted): point at installing
   [PowerShell 7+](https://learn.microsoft.com/powershell/scripting/install/installing-powershell);
   this skill never installs it. If PowerShell is genuinely not applicable on this machine,
-  leaving it absent is a valid end state — the hook stays quiet.
+  leaving it absent is a valid end state. The hook stays quiet.
 - PSScriptAnalyzer module absent: `Install-Module PSScriptAnalyzer` is **user-scope guidance
-  only** — state the command for the reader to run; this skill never runs it.
+  only**. State the command for the reader to run; this skill never runs it.
 - no `PSScriptAnalyzerSettings.psd1` (and linting/formatting is wanted): explain that adding a
-  settings file at or below the project root opts the repo in — but this skill does not write
+  settings file at or below the project root opts the repo in, but this skill does not write
   it. The settings file is the executed-adjacent trust boundary above; the choice and the edit
   belong to the consumer.
 - toggle off: direct to `/plugin configure powershell-format` (interactive, any
-  time). Headless: rerun the install with the new value —
+  time). Headless: rerun the install with the new value,
   `claude plugin install powershell-format@<marketplace> -s <scope> --config powershell_format_enabled=true`
   (repeatable per key). Against an already-installed plugin it prints `already installed` **and
-  still writes the value** — verified on Claude Code 2.1.240 (a non-sensitive option at `user`
+  still writes the value**, verified on Claude Code 2.1.240 (a non-sensitive option at `user`
   scope: a non-default value written to an installed plugin, then restored). The short-circuit is
   about the install, not the config write. Re-verify before relying on it outside those
-  conditions — a `sensitive` option, or `project`/`local` scope, were not covered. Do **not**
+  conditions. A `sensitive` option, or `project`/`local` scope, were not covered. Do **not**
   uninstall to reconfigure: uninstalling drops this plugin's entire stored `pluginConfigs` entry,
   resetting every option in the README's Options reference table to its manifest default. `-s`
   defaults to `user`, so pass the scope `claude plugin list` reports for this plugin, and run from
@@ -101,21 +101,21 @@ Run `check`, then for each finding point at the resolution — this skill instal
   Afterwards, keep the two claims apart. The write is issued and the stored value is what you
   passed; the RUNNING session's behavior is not. The rendered `${user_config.*}` is injected at
   skill load and each hook receives its `CLAUDE_PLUGIN_OPTION_*` from an environment fixed at
-  session start, so a same-session `check` still reports the OLD value — reporting that as a
+  session start, so a same-session `check` still reports the OLD value. Reporting that as a
   failed write would be wrong. Verify the effective value by rerunning `check` in a **fresh
   session**, and never claim an unobserved change.
 
 After pointing at a remediation, re-run the relevant `check` probe and report its actual
-result — never claim resolved on the reader's report that they installed something.
+result. Never claim resolved on the reader's report that they installed something.
 
 Re-running `apply` after everything passes changes nothing and reports "already configured".
 
 ## What this skill does NOT do
 
-- Run the formatter or linter — editing any `.ps1`, `.psm1`, or `.psd1` file exercises the
+- Run the formatter or linter. Editing any `.ps1`, `.psm1`, or `.psd1` file exercises the
   hook end-to-end. The `check` pwsh probes are read-only capability checks; they never format,
   lint, or mutate any file.
 - Write the plugin cache, Claude Code user settings, or `pluginConfigs`. Nor the repository,
-  including `PSScriptAnalyzerSettings.psd1` — the `pwsh` runtime and the PSScriptAnalyzer module
+  including `PSScriptAnalyzerSettings.psd1`. The `pwsh` runtime and the PSScriptAnalyzer module
   are resolved from the environment, never installed, so remediation is guidance only.
 - Download tools during `check` beyond the read-only presence and version probes.


### PR DESCRIPTION
No linked issue

## Summary

#2891 instruction-surface de-slop cluster: purge em dashes from the `powershell-format` plugin README and every SKILL.md.

Refs #2891

## Fix

Rewrote `plugins/powershell-format/README.md` and every `plugins/powershell-format/**/SKILL.md` under `/ai-slop:audit fix` semantics (periods, commas, or a restructured sentence; never parentheses, en dashes, or a spaced hyphen as a stand-in). Meaning-preserving grammar pass after the mechanical replace. Version-only bump in `plugin.json`. New changelog heading only. YAML frontmatter description/summary left unchanged so the cheatsheet stays valid. The generated options block is ignore-fenced because `scripts/sync-plugin-options-docs.py` still emits em dashes from its shared template.

## Verification

- Detector (`HOME` + `CLAUDE_PROJECT_DIR` isolated so `rule-em-dash` is enabled): 0 `rule-em-dash` findings outside the ignore-fenced generated-options span
- `CHECK_SKILL_SKIP_MARKDOWNLINT=1 bash scripts/check-changed-skills.sh origin/main`: 0 failed; quoted trigger phrases vs origin/main preserved
- `python3 scripts/sync-plugin-options-docs.py --check` up to date
- `scripts/check-changelog-parity.sh --check-bump origin/main` passes
- `node scripts/generate-cheatsheet.mjs --check` in sync

## Related

Refs #2891

#2891 stays open.