### PR TITLE
docs(kindle-dedrm): de-slop instruction surfaces (0.7.4)

### DIFF
--- a/plugins/kindle-dedrm/.claude-plugin/plugin.json
+++ b/plugins/kindle-dedrm/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "kindle-dedrm",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "Manage the Kindle for PC 2.8.0 + Calibre DeDRM workflow for personal-use ebook DRM removal on books you own (Windows only). Action router with setup, sync, update, cleanup, and status, each state mutation paired with a documented compensating reversal.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/kindle-dedrm/CHANGELOG.md
+++ b/plugins/kindle-dedrm/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to the `kindle-dedrm` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.7.4]
+
+### Changed
+
+- **Instruction-surface de-slop (#2891, kindle-dedrm cluster).** Rewrote this plugin's `README.md` and every
+  `SKILL.md` to drop em dashes under the repo's zero-tolerance house policy, using
+  `/ai-slop:audit fix` semantics: periods or commas, or a restructured sentence, never
+  parentheses, en dashes, or a spaced hyphen as a stand-in. Meaning stays; only the mark
+  and the sentence break change. YAML frontmatter description/summary left unchanged so
+  the cheatsheet stays valid.
+
 ## [0.7.3]
 
 ### Changed

--- a/plugins/kindle-dedrm/README.md
+++ b/plugins/kindle-dedrm/README.md
@@ -2,7 +2,7 @@
 
 A Claude Code plugin that manages the fragile, multi-tool workflow for
 removing DRM from Kindle books **you own** so they are readable on non-Kindle
-devices — Kindle for PC 2.8.0 pinned against auto-update, Calibre with the KFX
+devices. Kindle for PC 2.8.0 pinned against auto-update, Calibre with the KFX
 Input and DeDRM plugins, and the Kindle_Key_Finder tool. It captures the
 lifecycle as discrete **reversible actions**, each state mutation paired with a
 documented compensating reversal, and tracks every upstream source that drifts
@@ -10,7 +10,7 @@ independently.
 
 Invoke it with `/kindle-dedrm:manage` and an optional action.
 
-## ⚠️ Personal-use DRM removal — read first
+## ⚠️ Personal-use DRM removal. Read first
 
 This plugin exists to make **books you have purchased and own** readable on your
 own devices. The legality of circumventing technological protection measures
@@ -18,17 +18,17 @@ varies by jurisdiction (in the U.S., see 17 U.S.C. § 1201 and the Librarian of
 Congress's triennial exemptions); **you own the decision** for your own use.
 The plugin never distributes anything: extracted keys, decrypted EPUBs, and the
 scripts stay on your machine, and the hard safety rules forbid sending any of
-them off-machine. It does not touch books you do not own — it only processes
+them off-machine. It does not touch books you do not own. It only processes
 content Kindle has already downloaded into your own `My Kindle Content` folder.
 This is a caution, not legal advice.
 
-## ⚠️ Private marketplace only — carve out before publishing
+## ⚠️ Private marketplace only. Carve out before publishing
 
 `melodic-software/claude-code-plugins` is a **private** marketplace. This plugin
 is intentionally its own unit (not bundled into `knowledge`) because
 plugin-level enablement is all-or-nothing and this carries a different risk
 profile than the other knowledge tooling. **If this marketplace is ever made
-public, carve this plugin out first** — remove its `marketplace.json` entry (or
+public, carve this plugin out first.** Remove its `marketplace.json` entry (or
 relocate it to a separate private marketplace) so a personal-use DRM-removal
 workflow is not published to a general audience.
 
@@ -37,7 +37,7 @@ workflow is not published to a general audience.
 Kindle for PC and the KFXKeyExtractor / KFXArchiver binaries are Windows-only
 (hard-coded memory offsets). The scripts invoke PowerShell and rely on Windows
 environment variables (`%LOCALAPPDATA%`, `%APPDATA%`, `%USERPROFILE%`) via Git
-Bash. There is no macOS or Linux path — the skill states this and does not fake
+Bash. There is no macOS or Linux path. The skill states this and does not fake
 support on other operating systems.
 
 ## Actions
@@ -47,13 +47,13 @@ support on other operating systems.
 | (empty) / `status` | Probe current state and recommend the fitting action, or emit a diagnostic report |
 | `setup` | Delegates to the dedicated **`/kindle-dedrm:setup`** skill (uniform check/apply contract). `check` probes prerequisites + state read-only; `apply` runs first-time provisioning: download + install Kindle for PC 2.8.0, sign-in checkpoint, sync books, install Calibre plugins, run keyfinder, apply firewall block + ICACLS update lock |
 | `sync` | Re-process books purchased after setup: disable firewall, sync in Kindle, delete any staged installer, re-enable firewall, re-run keyfinder |
-| `update` | Drift check (no mutations) against captured upstream baselines — version pins, tutorial URLs, supported-version matrix |
+| `update` | Drift check (no mutations) against captured upstream baselines: version pins, tutorial URLs, supported-version matrix |
 | `cleanup` | Reverse every mutation with per-item confirmation. `--soft` keeps Kindle for PC + Calibre + Library; `--full` also offers to uninstall Kindle for PC and remove Calibre plugins |
 
 Flags: `--dry-run` (preview sync), `--soft` / `--full` (cleanup depth).
 
 Every mutation the plugin makes has an entry in the skill's reversal matrix, and
-the user's decrypted Calibre Library is **never** auto-deleted — those are the
+the user's decrypted Calibre Library is **never** auto-deleted. Those are the
 books the whole workflow exists to produce.
 
 ## How it works
@@ -72,7 +72,7 @@ against.
 
 - **Windows** with Git Bash (for the `.sh` helpers) and PowerShell.
 - **Calibre** installed, plus **Python 3.6+** on PATH (not the WindowsApps stub).
-- **`gh` CLI, authenticated** — the `setup` download step and the
+- **`gh` CLI, authenticated.** The `setup` download step and the
   `check-drift` probe resolve the DeDRM_tools release tag via `gh api`.
   Absent: both fall back to the pinned tag in `references/versions.md`
   (check-drift reports the source unreachable) rather than failing mid-flow.
@@ -88,11 +88,11 @@ against.
 
 ## Configuration
 
-This plugin has no `userConfig`. It is machine-scoped and single-user — every
+This plugin has no `userConfig`. It is machine-scoped and single-user. Every
 path is derived at runtime from the operating system's own environment variables,
 and there is nothing repo- or consumer-specific to configure. `/kindle-dedrm:setup`
-is a prerequisite/state check and a provisioning walkthrough, not a config writer —
-it writes no Claude Code user settings or `pluginConfigs`.
+is a prerequisite/state check and a provisioning walkthrough, not a config writer.
+It writes no Claude Code user settings or `pluginConfigs`.
 
 ## License
 

--- a/plugins/kindle-dedrm/skills/manage/SKILL.md
+++ b/plugins/kindle-dedrm/skills/manage/SKILL.md
@@ -25,8 +25,8 @@ Output reports: Kindle for PC version, firewall rule presence, ICACLS deny prese
 
 | Action | When | What it does |
 |---|---|---|
-| (empty) | Default — auto-detect from status | If pristine → recommend `/kindle-dedrm:setup`. If state OK + user mentioned new books → recommend `sync`. Otherwise emit status report |
-| `setup` | First-time install | Delegates to the dedicated **`/kindle-dedrm:setup`** skill (uniform check/apply contract): provisioning walkthrough — download, install Kindle for PC 2.8.0, sign-in checkpoint, sync books, install Calibre plugins, run keyfinder, apply firewall + ICACLS lockdown |
+| (empty) | Default. Auto-detect from status | If pristine → recommend `/kindle-dedrm:setup`. If state OK + user mentioned new books → recommend `sync`. Otherwise emit status report |
+| `setup` | First-time install | Delegates to the dedicated **`/kindle-dedrm:setup`** skill (uniform check/apply contract): provisioning walkthrough: download, install Kindle for PC 2.8.0, sign-in checkpoint, sync books, install Calibre plugins, run keyfinder, apply firewall + ICACLS lockdown |
 | `sync` | New books purchased after initial setup | Disable firewall, prompt user to sync in Kindle, delete cached installer, re-enable firewall, re-run keyfinder |
 | `update` | Periodic drift check | WebFetch tutorial URLs + gh API for upstream releases, diff against captured baselines in `references/sources.md`, emit drift report. No mutations |
 | `cleanup` | Decommission | Walk through every reversible mutation with per-item Y/N. Default (confirm-each) offers the firewall rule, ICACLS deny, keyfinder, and downloads; `--soft` limits to tools + downloads (keeps the firewall/ICACLS lock and Kindle for PC); `--full` also offers to uninstall Kindle for PC and remove Calibre plugins. The Calibre Library is never offered |
@@ -48,14 +48,14 @@ Apply across every action. Violating any risks losing the working 2.8.0 setup or
 
 First-time provisioning lives in the dedicated **`/kindle-dedrm:setup`** skill, which conforms to the
 uniform check/apply contract: `check` probes prerequisites and current state read-only, `apply` runs the
-full provisioning walkthrough (`references/workflow.md`) — the gated artifact download, install,
+full provisioning walkthrough (`references/workflow.md`). The gated artifact download, install,
 firewall block, ICACLS lock, Calibre plugins, and keyfinder. When this router's smart auto-detect finds
 a pristine machine, recommend `/kindle-dedrm:setup` rather than provisioning inline; the sequence has a
 single owner (`/kindle-dedrm:setup` → `references/workflow.md`).
 
 ## Action: sync
 
-Re-sync new books purchased after initial setup. Idempotent — safe to re-run.
+Re-sync new books purchased after initial setup. Idempotent. Safe to re-run.
 
 ```bash
 # Dry-run preview first
@@ -64,7 +64,7 @@ bash "${CLAUDE_PLUGIN_ROOT}/skills/manage/scripts/sync-prep.sh" --dry-run
 
 Sequence:
 
-1. Verify state via status.sh — abort if firewall rule absent or ICACLS deny missing (run `setup` first).
+1. Verify state via status.sh. Abort if firewall rule absent or ICACLS deny missing (run `setup` first).
 2. **Disable firewall block** (`scripts/firewall.ps1 disable`).
 3. **User opens Kindle for PC, syncs, double-clicks new books, quits Kindle.** Agent cannot drive GUI; pause for user confirmation.
 4. **Delete any newly-staged installer** at `%LOCALAPPDATA%\Amazon\Kindle\updates\*` (`scripts/sync-finalize.sh delete-cache`). ICACLS deny prevents *future* writes but doesn't stop one that lands during the brief firewall-disabled window.
@@ -72,7 +72,7 @@ Sequence:
 6. **Re-run keyfinder** (`~/Tools/Kindle_Key_Finder/Run_keyfinder_admin.vbs`). Saved config auto-loads; tool processes only new books.
 7. **Verify new EPUBs** under Calibre Library.
 
-If user reports a cached installer popped up during step 3, that's expected — Amazon staged 2.9.x. Delete it via step 4 immediately and verify Kindle.exe still reports 2.8.0.70980.
+If user reports a cached installer popped up during step 3, that's expected. Amazon staged 2.9.x. Delete it via step 4 immediately and verify Kindle.exe still reports 2.8.0.70980.
 
 ## Action: update
 
@@ -98,7 +98,7 @@ Output: drift report listing each source's status (`current` / `stale` / `unreac
 When the user accepts a drift recommendation, the re-pin edit is **maintainer work, gated
 on a working-tree checkout**: applying it requires `${CLAUDE_PLUGIN_ROOT}` to be inside a
 git working tree (`git -C "${CLAUDE_PLUGIN_ROOT}" rev-parse --is-inside-work-tree`
-succeeds — a marketplace clone or a `--plugin-dir` load). In installed form
+succeeds, a marketplace clone or a `--plugin-dir` load). In installed form
 `${CLAUDE_PLUGIN_ROOT}` is the read-only plugin cache: **stop** after the drift report and
 direct the change to the plugin's source repository (file an issue or PR there); never
 edit bundled files in the cache. Consumers then receive the re-pin through
@@ -106,7 +106,7 @@ edit bundled files in the cache. Consumers then receive the re-pin through
 
 In a checkout, when the user accepts a drift recommendation:
 
-1. Apply the change to `references/versions.md` (update pin, refresh page summary) — the
+1. Apply the change to `references/versions.md` (update pin, refresh page summary). The
    single source of truth; `check-drift.sh` parses its pins from that file, so no second
    copy needs editing.
 2. Run the affected portion of `setup` (e.g., re-download DeDRM_tools if a new pre-release is selected).
@@ -140,7 +140,7 @@ Reversal matrix (every row maps a mutation made by setup/sync to its compensatin
 | Calibre `dedrm.json` (key store) | `rm "$APPDATA\calibre\plugins\dedrm.json"` | Only on `--full` |
 | Calibre Library books (decrypted EPUBs) | NEVER auto-deleted; user keeps these | Manual only, never offered |
 
-The skill should NEVER offer to delete the user's Calibre Library — those are the decrypted books the entire workflow exists to produce.
+The skill should NEVER offer to delete the user's Calibre Library. Those are the decrypted books the entire workflow exists to produce.
 
 ## What this skill does NOT do
 
@@ -153,11 +153,11 @@ The skill should NEVER offer to delete the user's Calibre Library — those are 
 
 ## Cross-references
 
-- `references/workflow.md` — procedural detail (the long-form version of `setup`)
-- `references/sources.md` — URL inventory + drift baselines + page hashes
-- `references/versions.md` — version pins, SHA256 baselines, supported Kindle/tool matrix
-- `references/troubleshooting.md` — common errors and recovery paths
-- `scripts/` — executable helpers cited above
+- `references/workflow.md`: procedural detail (the long-form version of `setup`)
+- `references/sources.md`: URL inventory + drift baselines + page hashes
+- `references/versions.md`: version pins, SHA256 baselines, supported Kindle/tool matrix
+- `references/troubleshooting.md`: common errors and recovery paths
+- `scripts/`: executable helpers cited above
 
 ## Recheck triggers
 
@@ -168,4 +168,4 @@ The skill should NEVER offer to delete the user's Calibre Library — those are 
 | techy-notes.com tutorial 404s or moves | Pivot to epubor.com tutorial (secondary); update `references/sources.md` |
 | Kindle for PC ships a version > 2.9.1 not in `KFXARCHIVER_TOOL_MAP` | Wait for KFXArchiver update; document in `references/troubleshooting.md` |
 | Calibre's KFX Input plugin renamed in catalog | Update plugin name reference in `references/workflow.md` |
-| User reports a sync that left a 2.9.x cached installer past firewall re-enable | Tighten timing in `scripts/sync-prep.sh` — possibly add an automatic `sync-finalize.sh` invocation when Kindle.exe quits |
+| User reports a sync that left a 2.9.x cached installer past firewall re-enable | Tighten timing in `scripts/sync-prep.sh`. Possibly add an automatic `sync-finalize.sh` invocation when Kindle.exe quits |

--- a/plugins/kindle-dedrm/skills/setup/SKILL.md
+++ b/plugins/kindle-dedrm/skills/setup/SKILL.md
@@ -13,31 +13,31 @@ Verify and provision the first-time DeDRM setup, per the uniform setup contract
 (the router skill's workflow reference), then re-runs `check`. No argument or `check` runs the check;
 `apply` runs the check first, then provisioning; `apply download` runs only the gated
 artifact-download subaction. This plugin has no repo- or consumer-scoped
-configuration and no `userConfig` scalars/toggles — setup writes no Claude Code user settings, no
+configuration and no `userConfig` scalars/toggles. Setup writes no Claude Code user settings, no
 `pluginConfigs`, and nothing into the plugin cache or plugin data directory; it provisions the user's
 machine (installs, firewall rule, ICACLS lock, extracted keys) and every mutation has a compensating
 reversal under `/kindle-dedrm:manage cleanup`.
 
 Scope and the hard safety rules are the router skill's: read
 [`${CLAUDE_PLUGIN_ROOT}/skills/manage/SKILL.md`](${CLAUDE_PLUGIN_ROOT}/skills/manage/SKILL.md)
-"Hard safety rules" before any `apply` — they apply here unchanged (never open Kindle with the firewall
+"Hard safety rules" before any `apply`. They apply here unchanged (never open Kindle with the firewall
 down except during an active sync; never run the cached auto-update installer; never send keys or
 extracted files off the machine).
 
 ## Interactivity
 
-Much of provisioning is irreducibly interactive — the installer's UAC + EULA, the Amazon sign-in race
+Much of provisioning is irreducibly interactive. The installer's UAC + EULA, the Amazon sign-in race
 window, the Calibre plugin GUI loads, and the keyfinder VBS are actions on the user's machine the agent
 physically cannot drive. `apply` keeps these as **user-action hand-offs** (hand the user the exact step,
-wait for confirmation at each CHECKPOINT), not interview prompts — there are no configuration decisions
-to interview for. The parts that genuinely automate — artifact download + SHA verification, the firewall
-rule, the ICACLS lock — run non-interactively.
+wait for confirmation at each CHECKPOINT), not interview prompts. There are no configuration decisions
+to interview for. The parts that genuinely automate, artifact download + SHA verification, the firewall
+rule, the ICACLS lock, run non-interactively.
 
 ## `check` (read-only)
 
 The status script
 (`${CLAUDE_PLUGIN_ROOT}/skills/manage/scripts/status.sh`) is the source of truth for current
-state — run it and read its JSON before reporting. Add the prerequisite probes the pre-flight table in
+state. Run it and read its JSON before reporting. Add the prerequisite probes the pre-flight table in
 the workflow reference (`${CLAUDE_PLUGIN_ROOT}/skills/manage/references/workflow.md`)
 requires. Report a PASS/FAIL/INFO table with one remediation per FAIL; modify
 nothing, download nothing, extract nothing.
@@ -46,57 +46,57 @@ nothing, download nothing, extract nothing.
 bash "${CLAUDE_PLUGIN_ROOT}/skills/manage/scripts/status.sh"
 ```
 
-1. **Hard prerequisites** — FAIL when absent: Calibre installed (any recent version); Python 3.6+ on
+1. **Hard prerequisites.** FAIL when absent: Calibre installed (any recent version); Python 3.6+ on
    PATH and **not** the Windows Store `WindowsApps` stub; `pwsh` available; admin rights available.
    These are true prerequisites, not opt-in state.
-2. **Kindle for PC version** — installed and **not** `2.8.0.70980` is FAIL (the user must uninstall it
-   first — the skill never auto-uninstalls; see
+2. **Kindle for PC version.** Installed and **not** `2.8.0.70980` is FAIL (the user must uninstall it
+   first. The skill never auto-uninstalls; see
    `${CLAUDE_PLUGIN_ROOT}/skills/manage/references/troubleshooting.md`). Absent is INFO (not
-   yet provisioned — `apply` installs it). Exactly `2.8.0.70980` is PASS.
-3. **Provisioning state** — firewall rule, ICACLS deny, `~/Tools/Kindle_Key_Finder`, and the three
+   yet provisioned. `apply` installs it). Exactly `2.8.0.70980` is PASS.
+3. **Provisioning state.** Firewall rule, ICACLS deny, `~/Tools/Kindle_Key_Finder`, and the three
    `~/Downloads` artifacts. Before first setup these are legitimately absent → INFO ("not yet
    provisioned; run `apply`"), not FAIL.
-4. **Cached auto-update installer** — `status.sh`'s `cached_installer` present is FAIL: it is the
+4. **Cached auto-update installer.** `status.sh`'s `cached_installer` present is FAIL: it is the
    auto-update payload that breaks key extraction; remediation is
    `${CLAUDE_PLUGIN_ROOT}/skills/manage/scripts/lock-updates.sh apply` /
    `${CLAUDE_PLUGIN_ROOT}/skills/manage/scripts/sync-finalize.sh delete-cache` (never run it).
-5. **Calibre plugins and books** — INFO: report `calibre_plugins` (KFX Input, DeDRM, `dedrm.json`
-   presence) and the `books` synced/converted counts. Report the key store `dedrm.json` presence-only —
-   never print its contents (it holds extracted keys).
+5. **Calibre plugins and books.** INFO: report `calibre_plugins` (KFX Input, DeDRM, `dedrm.json`
+   presence) and the `books` synced/converted counts. Report the key store `dedrm.json` presence-only.
+   Never print its contents (it holds extracted keys).
 
 ## `apply` (idempotent)
 
 Run `check`, then provision. `apply` walks the full first-time sequence; `apply download` runs only the
 gated download subaction. Every step's exact command, rationale, and verification live in
-[`${CLAUDE_PLUGIN_ROOT}/skills/manage/references/workflow.md`](${CLAUDE_PLUGIN_ROOT}/skills/manage/references/workflow.md) — **follow
-it there; do not restate it here** (that keeps the download flow's pinned-tag fallback and the
+[`${CLAUDE_PLUGIN_ROOT}/skills/manage/references/workflow.md`](${CLAUDE_PLUGIN_ROOT}/skills/manage/references/workflow.md).
+**Follow it there; do not restate it here** (that keeps the download flow's pinned-tag fallback and the
 Key_Finder URL empty-match guard authoritative in one place). Pause at every CHECKPOINT for user
 confirmation.
 
-- **`apply download`** — Step 1 of the workflow reference: download the three artifacts to
+- **`apply download`.** Step 1 of the workflow reference: download the three artifacts to
   `~/Downloads` and SHA256-verify them against the versions reference
   (`${CLAUDE_PLUGIN_ROOT}/skills/manage/references/versions.md`). The DeDRM_tools tag resolves
   dynamically via the authenticated `gh` CLI and **falls back to the pinned tag in the versions
   reference** when `gh` is unavailable or returns nothing; the guard refuses to compose a URL with the
   placeholder still in place. The Key_Finder zip URL resolves from the tutorial article and **stops with
   the mirror-procedure pointer on an empty match**. On a SHA mismatch, stop and re-fetch.
-- **Full `apply`** — Steps 1–9 of the workflow reference: download (as above) → extract → user runs
+- **Full `apply`.** Steps 1-9 of the workflow reference: download (as above) → extract → user runs
   the installer (UAC/EULA hand-off, CHECKPOINT) → sign-in race window (CHECKPOINT) → verify books on
   disk → firewall block (`${CLAUDE_PLUGIN_ROOT}/skills/manage/scripts/firewall.ps1 enable`) →
   delete cached installer + ICACLS deny
   (`${CLAUDE_PLUGIN_ROOT}/skills/manage/scripts/lock-updates.sh apply`) → Calibre plugin loads
   (GUI hand-off, CHECKPOINT) → run keyfinder (VBS hand-off, CHECKPOINT) → verify EPUBs.
-- **Verify after each remediation** — after each automated mutation re-run the relevant `status.sh`
+- **Verify after each remediation.** After each automated mutation re-run the relevant `status.sh`
   probe (firewall rule enabled, ICACLS `LOCK OK`, downloads `3/3`, Kindle version `2.8.0.70980`) and
   report its actual result; never claim a step succeeded on a command's exit code alone.
 
-Re-running `apply` when `check` already passes changes nothing new — the download, extraction, firewall,
-and lock steps are idempotent — and reports "already provisioned".
+Re-running `apply` when `check` already passes changes nothing new. The download, extraction, firewall,
+and lock steps are idempotent, and the skill reports "already provisioned".
 
 ## What this skill does NOT do
 
-- Run `sync`, `update`, `cleanup`, or `status` — those stay on the router skill
+- Run `sync`, `update`, `cleanup`, or `status`. Those stay on the router skill
   (`/kindle-dedrm:manage`); `check` here is the read-only state report, `apply` is first-time provisioning.
 - Write the plugin cache, Claude Code user settings, or `pluginConfigs`. Nor the plugin data directory.
-- Send any script, key, or extracted file off the user's machine — personal-use scope only.
+- Send any script, key, or extracted file off the user's machine. Personal-use scope only.
 - Auto-uninstall a wrong Kindle for PC version or run the cached auto-update installer.


### PR DESCRIPTION
No linked issue

## Summary

#2891 instruction-surface de-slop cluster: purge em dashes from the `kindle-dedrm` plugin README and every SKILL.md.

Refs #2891

## Fix

Rewrote `plugins/kindle-dedrm/README.md` and every `plugins/kindle-dedrm/**/SKILL.md` under `/ai-slop:audit fix` semantics (periods, commas, or a restructured sentence; never parentheses, en dashes, or a spaced hyphen as a stand-in). Meaning-preserving grammar pass after the mechanical replace. Version-only bump in `plugin.json`. New changelog heading only. YAML frontmatter description/summary left unchanged so the cheatsheet stays valid. No generated options block. Two `rule-em-dash` leftovers remain on YAML frontmatter `description` lines in `skills/setup/SKILL.md` and `skills/manage/SKILL.md` so quoted trigger phrases and the cheatsheet stay valid.

## Verification

- Detector (`HOME` + `CLAUDE_PROJECT_DIR` isolated so `rule-em-dash` is enabled): 0 `rule-em-dash` findings outside YAML frontmatter description lines (2 leftovers, justified)
- `CHECK_SKILL_SKIP_MARKDOWNLINT=1 bash scripts/check-changed-skills.sh origin/main`: 0 failed; quoted trigger phrases vs origin/main preserved
- `python3 scripts/sync-plugin-options-docs.py --check` up to date
- `scripts/check-changelog-parity.sh --check-bump origin/main` passes
- `node scripts/generate-cheatsheet.mjs --check` in sync

## Related

Refs #2891

#2891 stays open.