### PR TITLE
docs(claude-memory): de-slop instruction surfaces (0.11.3)

### DIFF
--- a/plugins/claude-memory/.claude-plugin/plugin.json
+++ b/plugins/claude-memory/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "claude-memory",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "description": "Keeps a repo's Claude Code memory layer healthy and under your control, against criteria derived from official Claude Code documentation. The audit skill checks the instruction/memory layer (CLAUDE.md, CLAUDE.local.md, .claude/rules/, auto-memory) with a deterministic script-backed spine plus judgment-tier checks. The stateless skill inspects, disables, and (confirm-gated) purges Claude-written auto memory across all settings scopes.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/claude-memory/CHANGELOG.md
+++ b/plugins/claude-memory/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to the `claude-memory` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.11.3]
+
+### Changed
+
+- **Instruction-surface de-slop (#2891, claude-memory cluster).** Rewrote this plugin's `README.md` and every
+  `SKILL.md` to drop em dashes under the repo's zero-tolerance house policy, using
+  `/ai-slop:audit fix` semantics: periods or commas, or a restructured sentence, never
+  parentheses, en dashes, or a spaced hyphen as a stand-in. Meaning stays; only the mark
+  and the sentence break change.
+
 ## [0.11.2]
 
 ### Fixed

--- a/plugins/claude-memory/README.md
+++ b/plugins/claude-memory/README.md
@@ -21,7 +21,7 @@ Audits the files you write that shape Claude's behavior against a codified check
 official Claude Code documentation (line budgets, deletion test, content placement, consistency,
 currency, auto-memory index integrity). A deterministic spine (script-backed checks for the MEMORY.md
 index and orphan always-loaded rules) yields identical findings on identical repo state; judgment-tier
-checks apply fixed criteria with model reading. Reports persist to the plugin's data directory — they
+checks apply fixed criteria with model reading. Reports persist to the plugin's data directory. They
 audit contributor-personal auto-memory, so they never land in the repo.
 
 Scope covers **both** layers that load every session: the project's `CLAUDE.md` / `CLAUDE.local.md` /
@@ -38,7 +38,7 @@ project-scoped criteria skip personal files instead of reporting a repo-scoped f
 
 ### stateless
 
-Inspects and disables Claude Code **auto memory** — the notes Claude writes for itself per repo at
+Inspects and disables Claude Code **auto memory**, the notes Claude writes for itself per repo at
 `~/.claude/projects/<project>/memory/` (relocatable via `autoMemoryDirectory`). Scope is auto-memory
 only: the instruction layer (`CLAUDE.md`, `.claude/rules/`) belongs to `audit`, and transcripts /
 history are out of scope (Claude Code auto-cleans those via `cleanupPeriodDays`).
@@ -49,11 +49,12 @@ history are out of scope (Claude Code auto-cleans those via `cleanupPeriodDays`)
 /claude-memory:stateless purge     # DESTRUCTIVE — delete auto-memory files after a confirmation gate
 ```
 
-`disable` sets both the env var (authoritative — it overrides `autoMemoryEnabled` per the env-vars
-doc) and the setting (persistent fallback); `purge` reads `autoMemoryDirectory` at every settings
+`disable` sets both the env var and the setting. The env var is authoritative and overrides
+`autoMemoryEnabled` per the env-vars doc; the setting is the persistent fallback. `purge` reads
+`autoMemoryDirectory` at every settings
 scope before it enumerates what to delete, shows a manifest, and deletes only after explicit
 confirmation. Claude Desktop / claude.ai
-account memory is a separate server-side store — the skill gives direction to the app's Settings →
+account memory is a separate server-side store. The skill gives direction to the app's Settings →
 Memory controls rather than deleting it locally.
 
 ## Consumer conventions
@@ -73,11 +74,11 @@ doc-derived checks. Nothing project-specific is baked into the plugin.
 
 ## Configuration
 
-No `userConfig`. State: `audit` reports persist under the plugin's `${CLAUDE_PLUGIN_DATA}` directory —
-they are contributor-local because they cover per-contributor auto-memory, so they never land in the
+No `userConfig`. State: `audit` reports persist under the plugin's `${CLAUDE_PLUGIN_DATA}` directory.
+They are contributor-local because they cover per-contributor auto-memory, so they never land in the
 consuming repo. Side effects: `stateless disable` edits a `settings.json` you choose (setting
 `autoMemoryEnabled` and an `env` var, then flagging a dotfile-manager backfill if the file is tracked);
-`stateless purge` deletes auto-memory `*.md` files after a confirmation gate — both act only on the
+`stateless purge` deletes auto-memory `*.md` files after a confirmation gate. Both act only on the
 scope you confirm. Network: the `audit update` action fetches official docs pages (read-only). Scripts
 require `git` and standard shell utilities.
 

--- a/plugins/claude-memory/skills/audit/SKILL.md
+++ b/plugins/claude-memory/skills/audit/SKILL.md
@@ -1,6 +1,6 @@
 ---
-description: "Audit the Claude Code instruction/memory layer — CLAUDE.md, CLAUDE.local.md, .claude/rules/, and auto-memory — against a codified checklist derived from official Claude Code documentation. Use when: 'audit CLAUDE.md', 'memory health', 'audit rules', 'is my CLAUDE.md too long', 'prune instructions', after CLAUDE.md/rules changes or a Claude Code upgrade; actions: audit (default), fix, update, report."
-argument-hint: "[audit|fix|update|report] — default: audit"
+description: "Audit the Claude Code instruction/memory layer covering CLAUDE.md, CLAUDE.local.md, .claude/rules/, and auto-memory against a codified checklist derived from official Claude Code documentation. Use when: 'audit CLAUDE.md', 'memory health', 'audit rules', 'is my CLAUDE.md too long', 'prune instructions', after CLAUDE.md/rules changes or a Claude Code upgrade; actions: audit (default), fix, update, report."
+argument-hint: "[audit|fix|update|report]. Default: audit"
 user-invocable: true
 disable-model-invocation: false
 shell: bash
@@ -23,7 +23,7 @@ MEMORY.md index issues (M2): !`bash "${CLAUDE_PLUGIN_ROOT}/skills/audit/scripts/
 # Memory Health
 
 Deterministic health check for the Claude Code instruction/memory layer. Audits files YOU write that
-shape Claude's behavior — not the entire context window (MCP tools, agents, and skills are covered by
+shape Claude's behavior, not the entire context window (MCP tools, agents, and skills are covered by
 the `audit` and `automation-gaps` skills in the `claude-config` plugin).
 
 ## Scope
@@ -36,12 +36,12 @@ the `audit` and `automation-gaps` skills in the `claude-config` plugin).
 | **User instructions** | `${CLAUDE_CONFIG_DIR:-~/.claude}/CLAUDE.md` | Every session, full, in **every** project | Yes |
 | **User rules** | `${CLAUDE_CONFIG_DIR:-~/.claude}/rules/**/*.md` | Same as project rules, in every project | Yes |
 | Auto-memory | `~/.claude/projects/<project>/memory/` | First 200 lines / 25KB of MEMORY.md | Yes |
-| Settings, hooks, MCP, agents, skills | Various | Various | No — use `claude-config`'s `audit` / `automation-gaps` |
+| Settings, hooks, MCP, agents, skills | Various | Various | No. Use `claude-config`'s `audit` / `automation-gaps` |
 
 The two user-scope rows are in scope because they load in every session regardless of where it starts.
 Discovery tags every file with its scope so project-scoped criteria (C9) skip personal files rather
 than reporting a repo-scoped finding against one. **C6 Consistency** owns instruction-content
-conflicts across that discover-instruction-surfaces population — including **user↔project** pairs.
+conflicts across that discover-instruction-surfaces population, including **user↔project** pairs.
 `claude-config:audit-instructions` I15 owns memory-layer precedence adjudication and every conflict
 pair with an anchor outside that population (nested `CLAUDE.md`, auto-memory, settings, hooks,
 skills, agents, output styles).
@@ -50,9 +50,10 @@ skills, agents, output styles).
 
 This audit owns instruction-layer **health**: structure, size, placement, and index integrity of
 the memory files against the codified checklist. Whether an instruction's *content* is still
-needed by the current model — prior-model workarounds, over-prescriptive scaffolding, bare
-prohibitions without rationale, reasoning-echo directives, stale example scaffolding — is the
-model-era fit question, owned by the `claude-config` plugin's `audit-instructions` skill. When
+needed by the current model is the model-era fit question, owned by the `claude-config` plugin's
+`audit-instructions` skill. Prior-model workarounds, over-prescriptive scaffolding, bare
+prohibitions without rationale, reasoning-echo directives, and stale example scaffolding fall
+there. When
 that plugin is installed, route such findings to `/claude-config:audit-instructions`, invoked via
 the Skill tool, rather than
 judging them against this checklist; when it is not installed, keep each as a criteria-free
@@ -74,7 +75,7 @@ The checklist at [reference/criteria.md](reference/criteria.md) is codified, not
 Its **deterministic spine** (C1 line budget, M1 index size, the script-backed M2 index integrity and
 RD1 orphan-rule checks) yields byte-identical findings on the same repo state; its **judgment tier**
 (C2-C9, R1-R4, M3-M4) applies fixed criteria with model reading, so findings vary in wording though
-not in criteria — label those "judgment candidate" in the report. Criteria derive from official Claude
+not in criteria. Label those "judgment candidate" in the report. Criteria derive from official Claude
 Code documentation (sourced quotes in [reference/official-guidance.md](reference/official-guidance.md));
 refresh both via the `update` action.
 
@@ -90,7 +91,7 @@ Load [context/update.md](context/update.md) for the research-and-refresh workflo
 
 Load [context/fix.md](context/fix.md) for the fix-with-approval workflow.
 
-## Report location — derive it before writing or reading
+## Derive the report location before writing or reading
 
 Every action that touches the report uses **one** path, resolved here: `audit` writes it, `report`
 serves it, `fix` acts on it.
@@ -105,19 +106,19 @@ ${CLAUDE_PLUGIN_DATA}/audit/<state-key>/last-audit.md
 bash "${CLAUDE_PLUGIN_ROOT}/lib/state-key.sh"
 ```
 
-It prints `<repo-identity>/<worktree-discriminator>` — the scheme `claude-config:audit-pass` defines
+It prints `<repo-identity>/<worktree-discriminator>`, the scheme `claude-config:audit-pass` defines
 and `audit-prompting-postures` already uses, adopted here rather than reinvented. Run it and use the
 result: the key comes from a command this run actually executes, not from a token read out of a file.
 Pass `--explain` when the report should say which rung produced its key.
 
 **Why the key exists.** `${CLAUDE_PLUGIN_DATA}` resolves to `~/.claude/plugins/data/{id}/`, keyed to
-the plugin identifier and nothing else — no project, checkout, worktree, or session segment
+the plugin identifier and nothing else. No project, checkout, worktree, or session segment
 ([plugins reference](https://code.claude.com/docs/en/plugins-reference), § Persistent data directory).
 A fixed `audit/last-audit.md` is therefore **one file per machine**. Losing reports is the smaller
 half; the larger half is the read. `report` mode would serve whatever that file currently holds and
 `fix` mode would act on it, so on a machine with two repositories, project B can be shown project A's
 findings and offered edits derived from another repository's memory layer. That is a wrong answer
-served, not merely an artifact lost — which is why an append-only history does not close it and the
+served, not merely an artifact lost, which is why an append-only history does not close it and the
 *path* has to carry project identity.
 
 **Never serve a report you cannot attribute.** If nothing exists at the derived path, say that no
@@ -127,12 +128,12 @@ location.
 **The pre-rename `health/` directory and any unkeyed `audit/last-audit.md` are unattributable.** This
 skill was once named `health`, and both older layouts wrote a machine-global file with no project
 segment, so nothing records which repository produced it. It cannot be adopted into a project's key
-without inventing that attribution — and inventing it is exactly the defect the key exists to remove.
+without inventing that attribution, and inventing it is exactly the defect the key exists to remove.
 Where such a file is present, name its path to the user as a leftover they may delete, and run the
 audit rather than reading it.
 
 **Audit output is contributor-local by design.** Reports audit a contributor's personal auto-memory
-(`~/.claude/projects/<project>/memory/`), which varies per team member — so they persist in the
+(`~/.claude/projects/<project>/memory/`), which varies per team member, so they persist in the
 plugin's own data directory, never in the consuming repo.
 
 **A rolling latest is a separate decision from keying, and this skill keeps one on purpose.**
@@ -151,13 +152,13 @@ never-serve-what-you-cannot-attribute rule above rather than reaching for anothe
 This skill ships the doc-derived checklist only. A consuming repo that layers its own
 instruction-hygiene conventions (e.g. a team-shared-first codification policy, an always-loaded
 context-budget policy, or an exemption from the 200-line CLAUDE.md target for repos that deliberately
-run a large rules layer) declares them in its own `CLAUDE.md` / `.claude/rules/` — read those files
+run a large rules layer) declares them in its own `CLAUDE.md` / `.claude/rules/`. Read those files
 during the audit and apply any additional criteria or documented exemptions they define, reporting
 such findings under a `REPO` check-ID so they stay distinct from the doc-derived checks.
 
 ## Complementary workflows
 
 If the `claude-md-management` plugin is installed, its `claude-md-improver` skill audits CLAUDE.md
-structure and content quality (complementary to this health check — run this audit FIRST to identify
-issues), and `revise-claude-md` captures session learnings after a fix pass. Absent that plugin, the
+structure and content quality, complementary to this health check. Run this audit FIRST to identify
+issues. `revise-claude-md` captures session learnings after a fix pass. Absent that plugin, the
 fix mode here stands on its own.

--- a/plugins/claude-memory/skills/stateless/SKILL.md
+++ b/plugins/claude-memory/skills/stateless/SKILL.md
@@ -1,6 +1,6 @@
 ---
-description: "Inspect and turn off Claude Code's auto memory — the notes Claude writes itself per repo under ~/.claude/projects/<project>/memory/. Use when: 'make Claude stateless', 'stop Claude remembering', 'disable auto memory', 'turn off auto-memory', 'purge/clear/delete auto memory', 'wipe what Claude saved about this repo', 'does Claude have saved memories'. Actions: status (default — memory + settings across all scopes), disable (autoMemoryEnabled:false + CLAUDE_CODE_DISABLE_AUTO_MEMORY), purge (destructive delete, confirm-gated). Auto-memory only — not CLAUDE.md/rules (use /claude-memory:audit) and not transcripts/history."
-argument-hint: "[status|disable|purge] — default: status"
+description: "Inspect and turn off Claude Code's auto memory, the notes Claude writes itself per repo under ~/.claude/projects/<project>/memory/. Use when: 'make Claude stateless', 'stop Claude remembering', 'disable auto memory', 'turn off auto-memory', 'purge/clear/delete auto memory', 'wipe what Claude saved about this repo', 'does Claude have saved memories'. Actions: status (default, memory + settings across all scopes), disable (autoMemoryEnabled:false + CLAUDE_CODE_DISABLE_AUTO_MEMORY), purge (destructive delete, confirm-gated). Auto-memory only, not CLAUDE.md/rules (use /claude-memory:audit) and not transcripts/history."
+argument-hint: "[status|disable|purge]. Default: status"
 user-invocable: true
 disable-model-invocation: false
 shell: bash
@@ -17,10 +17,10 @@ bash "${CLAUDE_PLUGIN_ROOT}/skills/stateless/scripts/scope-report.sh" || echo "(
 
 # Stateless
 
-Inspect and disable Claude Code **auto memory** — the store Claude writes for itself, one
+Inspect and disable Claude Code **auto memory**, the store Claude writes for itself, one
 directory per repo (`~/.claude/projects/<project>/memory/`, relocatable via
 `autoMemoryDirectory`). Governs auto-memory only. Not in scope: CLAUDE.md / CLAUDE.local.md /
-`.claude/rules/` (use `/claude-memory:audit`), transcripts, history, or shell snapshots — for the
+`.claude/rules/` (use `/claude-memory:audit`), transcripts, history, or shell snapshots. For the
 official full per-project wipe, use `claude project purge` (Claude Code v2.1.124+). What it does
 and does not delete is quoted verbatim in
 [reference/official-guidance.md](reference/official-guidance.md); the deletion plan and flags live
@@ -33,16 +33,16 @@ re-fetch the source pages listed there if a fact is load-bearing before you act.
 
 | Entity | Location | This skill |
 |--------|----------|-----------|
-| Auto-memory store | `~/.claude/projects/<project>/memory/` (or `autoMemoryDirectory`) | Yes — status / disable / purge |
-| `autoMemoryEnabled` setting | any settings scope | Yes — reads & writes |
-| `CLAUDE_CODE_DISABLE_AUTO_MEMORY` | OS env or settings `env` block | Yes — reads & writes |
-| CLAUDE.md / `.claude/rules/` | repo + user | No — use `/claude-memory:audit` |
-| CLAUDE.local.md | repo only — no user-scope equivalent | No — use `/claude-memory:audit` |
-| Transcripts | `~/.claude/projects/<project>/` | No — auto-cleaned by `cleanupPeriodDays`; `claude project purge` (v2.1.124+) deletes this project's now |
-| Prompt history | `~/.claude/history.jsonl` | No — persists indefinitely, not swept by `cleanupPeriodDays`; `claude project purge` filters this project's lines |
-| Session files | `~/.claude/sessions/` | No — one file per running session, cleared when the session exits rather than age-swept; not in `claude project purge`'s deletion list |
-| Shell snapshots / backups | `~/.claude/shell-snapshots/`, `~/.claude/backups/` | No — swept by `cleanupPeriodDays`, but not project-scoped, so `claude project purge` leaves them untouched |
-| Claude Desktop / claude.ai memory | server-side account | Direction only — [context/desktop.md](context/desktop.md) |
+| Auto-memory store | `~/.claude/projects/<project>/memory/` (or `autoMemoryDirectory`) | Yes. Status / disable / purge |
+| `autoMemoryEnabled` setting | any settings scope | Yes. Reads and writes |
+| `CLAUDE_CODE_DISABLE_AUTO_MEMORY` | OS env or settings `env` block | Yes. Reads and writes |
+| CLAUDE.md / `.claude/rules/` | repo + user | No. Use `/claude-memory:audit` |
+| CLAUDE.local.md | repo only, no user-scope equivalent | No. Use `/claude-memory:audit` |
+| Transcripts | `~/.claude/projects/<project>/` | No. Auto-cleaned by `cleanupPeriodDays`; `claude project purge` (v2.1.124+) deletes this project's now |
+| Prompt history | `~/.claude/history.jsonl` | No. Persists indefinitely, not swept by `cleanupPeriodDays`; `claude project purge` filters this project's lines |
+| Session files | `~/.claude/sessions/` | No. One file per running session, cleared when the session exits rather than age-swept; not in `claude project purge`'s deletion list |
+| Shell snapshots / backups | `~/.claude/shell-snapshots/`, `~/.claude/backups/` | No. Swept by `cleanupPeriodDays`, but not project-scoped, so `claude project purge` leaves them untouched |
+| Claude Desktop / claude.ai memory | server-side account | Direction only. See [context/desktop.md](context/desktop.md) |
 
 ## Argument parsing
 
@@ -50,7 +50,7 @@ re-fetch the source pages listed there if a fact is load-bearing before you act.
 |----------|--------|
 | *(none)* or `status` | Report the auto-memory posture: effective enabled/disabled state, where the store lives, what it holds. Read-only. |
 | `status all` | Machine-wide: the `status` report plus a table of EVERY per-project memory store (`scripts/enumerate-all-projects.sh`). Read-only. |
-| `disable` | Turn auto memory off durably (`autoMemoryEnabled: false` + `CLAUDE_CODE_DISABLE_AUTO_MEMORY`). Edits settings — confirm scope first. |
+| `disable` | Turn auto memory off durably (`autoMemoryEnabled: false` + `CLAUDE_CODE_DISABLE_AUTO_MEMORY`). Edits settings. Confirm scope first. |
 | `purge` | **Destructive.** Delete the auto-memory files. Reads `autoMemoryDirectory` at every scope first, shows a manifest, offers an opt-in pre-delete backup, and deletes only after explicit confirmation. |
 | `purge all` | **Destructive, machine-wide.** Same flow with every per-project store as the candidate set, one combined manifest, and ONE combined gate stating the total count and every directory. |
 
@@ -59,7 +59,7 @@ re-fetch the source pages listed there if a fact is load-bearing before you act.
 `CLAUDE_CODE_DISABLE_AUTO_MEMORY` **overrides** `autoMemoryEnabled`: per the env-vars doc, `=1`
 disables and `=0` forces auto memory *on* even when `autoMemoryEnabled: false` would disable
 it. When the env var is unset, `autoMemoryEnabled` (by settings precedence) governs. So a set
-env var of `0` alongside `autoMemoryEnabled: false` means auto memory is effectively **on** —
+env var of `0` alongside `autoMemoryEnabled: false` means auto memory is effectively **on**.
 `status` must report the env var as authoritative whenever it is set. `disable` sets the env
 var to `1` (the authoritative lever) and `autoMemoryEnabled: false` together. See the
 reference file's "Precedence: the env var overrides the setting (VERIFIED)".
@@ -71,7 +71,7 @@ reference file's "Precedence: the env var overrides the setting (VERIFIED)".
 - **purge**: load [context/purge.md](context/purge.md).
 
 For the Claude Desktop / claude.ai account store (server-side, not local files), load
-[context/desktop.md](context/desktop.md) — relevant to `status` and `purge` whenever the user
+[context/desktop.md](context/desktop.md). Relevant to `status` and `purge` whenever the user
 wants to be stateless everywhere, not just in this repo.
 
 ## Gotchas
@@ -79,23 +79,23 @@ wants to be stateless everywhere, not just in this repo.
 - **Precedence**: `CLAUDE_CODE_DISABLE_AUTO_MEMORY` overrides `autoMemoryEnabled` (`=0` forces
   on even against `autoMemoryEnabled: false`). A set env var is authoritative in `status`. (See above.)
 - **`autoMemoryDirectory` relocates the store** and is read from *any* scope. The snapshot
-  prints the slug-derived default only — `purge` and `status` must read the override at every
+  prints the slug-derived default only. `purge` and `status` must read the override at every
   scope or they act on the wrong directory.
 - **`CLAUDE_CONFIG_DIR` relocates the whole config root**: when set, the user `settings.json`
   *and* the `projects/<project>/memory/` tree live under it, not `~/.claude`. All scope and
   memory-dir resolution honors `${CLAUDE_CONFIG_DIR:-~/.claude}` (scripts + workflows); the
   snapshot reports the resolved root, and `purge`'s relocation check treats it as expected.
 - **Windows managed policy** can live in the registry (`HKLM`/`HKCU\SOFTWARE\Policies\ClaudeCode`),
-  not a file. `scope-report.sh` can't read it — report managed scope as unread, don't assume empty.
+  not a file. `scope-report.sh` can't read it. Report managed scope as unread, don't assume empty.
 - **`disable` applies next session**, not immediately: the setting and `env` block are read at
   startup. Tell the user to restart / start a new session.
 - **Tracked `settings.json`**: a live edit to a dotfile-manager-tracked settings file must be
   backfilled to the source; never run an `apply` that could revert the edit.
-- **Desktop / claude.ai memory is server-side** — `purge` cannot delete it; give direction only.
+- **Desktop / claude.ai memory is server-side**. `purge` cannot delete it; give direction only.
 
 ## Repo-agnostic contract
 
-Discover the consumer's state at runtime — never hardcode a machine's paths or current
+Discover the consumer's state at runtime. Never hardcode a machine's paths or current
 posture. Settings scopes, the memory directory, and the env var are read fresh from the
 snapshot above and the workflow scripts. The bundled `scope-report.sh` reuses the plugin's
 single-source memory-dir resolver (`skills/audit/scripts/resolve-memory-dir.sh`) rather than


### PR DESCRIPTION
No linked issue

## Summary

Refs #2891. Instruction-surface de-slop shard for the `claude-memory` plugin only. Other plugins stay on main.

## Fix

Rewrote `plugins/claude-memory/README.md` and every `plugins/claude-memory/**/SKILL.md` under `/ai-slop:audit fix` semantics (periods, commas, or a restructured sentence; never parentheses, en dashes, or a spaced hyphen as a stand-in). Meaning-preserving grammar pass after the mechanical replace. Version-only bump in `plugin.json`. New changelog heading only. Fenced shell comments and the `!` snapshot fallback template keep their em dashes. `docs/SKILL-CHEAT-SHEET.md` was not edited.

## Verification

- Detector (`HOME` + `CLAUDE_PROJECT_DIR` isolated so `rule-em-dash` is enabled): 0 `rule-em-dash` findings on rewritten instruction surfaces. Remaining em dashes are inside fenced templates, which the detector strips.
- `CHECK_SKILL_SKIP_MARKDOWNLINT=1 bash scripts/check-changed-skills.sh origin/main`: 0 failed; quoted trigger phrases vs origin/main preserved
- `python3 scripts/sync-plugin-options-docs.py --check` up to date
- `scripts/check-changelog-parity.sh --check-bump origin/main` passes
- `node scripts/generate-cheatsheet.mjs --check` in sync

## Related

Refs #2891