### PR TITLE
docs(context7): de-slop instruction surfaces (0.5.3)

### DIFF
--- a/plugins/context7/.claude-plugin/plugin.json
+++ b/plugins/context7/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "context7",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Looks up current library documentation, API references, and code examples via Context7 (ctx7 CLI or the Context7 MCP server) with a two-step resolve-then-query workflow: a lookup skill (default lookup plus an upstream drift-check action) and a setup skill for CLI install, auth, and MCP configuration.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/context7/CHANGELOG.md
+++ b/plugins/context7/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to the `context7` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.5.3]
+
+### Changed
+
+- **Instruction-surface de-slop (#2891, context7 cluster).** Rewrote this plugin's `README.md` and every
+  `SKILL.md` to drop em dashes under the repo's zero-tolerance house policy, using
+  `/ai-slop:audit fix` semantics: periods or commas, or a restructured sentence, never
+  parentheses, en dashes, or a spaced hyphen as a stand-in. Meaning stays; only the mark
+  and the sentence break change. Vendored `skills/lookup/vendor/**/SKILL.md` is left
+  untouched: it is detector-excluded upstream baseline, not a rewrite target.
+
 ## [0.5.2]
 
 ### Changed

--- a/plugins/context7/README.md
+++ b/plugins/context7/README.md
@@ -1,7 +1,7 @@
 # context7
 
 A Claude Code plugin for looking up **current library documentation, API
-references, and code examples** via [Context7](https://context7.com) — so
+references, and code examples** via [Context7](https://context7.com), so
 answers about libraries, frameworks, SDKs, and cloud services come from live
 docs instead of stale training data.
 
@@ -16,7 +16,7 @@ a question names a library); configure the environment with `/context7:setup`:
 
 ## Skills
 
-- **`/context7:lookup <library> <query>`** (default) — the two-step Context7
+- **`/context7:lookup <library> <query>`** (default). The two-step Context7
   workflow: resolve the library name to a `/org/project` ID, then query its
   docs. Works through the `ctx7` CLI, or through the Context7 MCP server when
   the consuming project has one configured (same backend, ~1.8× more content
@@ -25,7 +25,7 @@ a question names a library); configure the environment with `/context7:setup`:
   latest npm release (`--fix` upgrades it) and diffs Upstash's upstream
   reference skills against the plugin's bundled `vendor/` baselines, reporting
   anything new for manual review. It never auto-rewrites the skill.
-- **`/context7:setup`** — idempotent verification and configuration. `check`
+- **`/context7:setup`**. Idempotent verification and configuration. `check`
   (default) reports the `ctx7` CLI, `CONTEXT7_API_KEY` auth, and Context7 MCP
   server state read-only; `apply` resolves what it found (auth and MCP guidance);
   `apply install-cli` installs/upgrades the `ctx7` CLI. Also covers the Windows
@@ -33,10 +33,10 @@ a question names a library); configure the environment with `/context7:setup`:
 
 ## Requirements
 
-- **`ctx7` CLI** (`npm install -g ctx7@latest`) for the CLI path — or a
+- **`ctx7` CLI** (`npm install -g ctx7@latest`) for the CLI path, or a
   Context7 MCP server configured in the consuming project for the MCP path.
   Either alone is enough; the skill picks whichever is available.
-- **`CONTEXT7_API_KEY`** (optional) — anonymous usage works at low rates; an
+- **`CONTEXT7_API_KEY`** (optional). Anonymous usage works at low rates; an
   API key raises limits. Set it as an environment variable; never commit it.
 
 ## Install
@@ -48,25 +48,25 @@ a question names a library); configure the environment with `/context7:setup`:
 
 ## Configuration
 
-This plugin has no `userConfig` and ships **no MCP server** — it never opens a
+This plugin has no `userConfig` and ships **no MCP server**. It never opens a
 network surface by itself beyond the lookups you ask for. Two optional
 consumer-side settings:
 
-- `CONTEXT7_API_KEY` environment variable — higher rate limits for both CLI
+- `CONTEXT7_API_KEY` environment variable. Higher rate limits for both CLI
   and MCP paths.
-- A `context7` entry in your own MCP configuration if you want the MCP path —
-  the skill documents the exact snippet and degrades cleanly to the CLI when
+- A `context7` entry in your own MCP configuration if you want the MCP path.
+  The skill documents the exact snippet and degrades cleanly to the CLI when
   it is absent.
 
 ## Data egress note
 
 Lookup queries (your library question text) are sent to the Context7 backend
 (`context7.com` / `mcp.context7.com`). Don't put secrets in queries. The
-`ctx7` CLI also sends anonymous usage telemetry by default — set
+`ctx7` CLI also sends anonymous usage telemetry by default. Set
 `CTX7_TELEMETRY_DISABLED=1` to opt out. The `update` action additionally
 fetches two public files from `raw.githubusercontent.com` (Upstash's
-reference skills) and reads the npm registry for the latest `ctx7` version —
-read-only, nothing uploaded.
+reference skills) and reads the npm registry for the latest `ctx7` version.
+Read-only, nothing uploaded.
 
 ## License
 

--- a/plugins/context7/skills/lookup/SKILL.md
+++ b/plugins/context7/skills/lookup/SKILL.md
@@ -1,6 +1,6 @@
 ---
-description: "Look up current library documentation, API references, and code examples via Context7 (ctx7 CLI or the Context7 MCP server — same backend). Use when: 'look up the docs for X', 'what's the API for X', 'how do I configure X', 'latest docs for X', 'check context7 for X', 'how do I migrate to X v2', or whenever a question names a library, framework, SDK, CLI tool, or cloud service — including API syntax, configuration, setup, and version-migration questions. Actions: lookup <library> <query> (default) | update (CLI upgrade + upstream drift check). For CLI/MCP setup, auth, and Windows gotchas, run /context7:setup."
-argument-hint: "[lookup <library> <query> | update] (default: lookup — e.g., /context7:lookup react \"useEffect cleanup\")"
+description: "Look up current library documentation, API references, and code examples via Context7 (ctx7 CLI or the Context7 MCP server, same backend). Use when: 'look up the docs for X', 'what's the API for X', 'how do I configure X', 'latest docs for X', 'check context7 for X', 'how do I migrate to X v2', or whenever a question names a library, framework, SDK, CLI tool, or cloud service, including API syntax, configuration, setup, and version-migration questions. Actions: lookup <library> <query> (default) | update (CLI upgrade + upstream drift check). For CLI/MCP setup, auth, and Windows gotchas, run /context7:setup."
+argument-hint: "[lookup <library> <query> | update] (default: lookup, e.g., /context7:lookup react \"useEffect cleanup\")"
 user-invocable: true
 disable-model-invocation: false
 allowed-tools:
@@ -17,13 +17,13 @@ shell: bash
 
 Installed CLI version: !`ctx7 --version 2>/dev/null || echo "not installed (run: npm install -g ctx7@latest)"`
 
-MCP availability: check your own tool list — if `mcp__context7__resolve-library-id` / `mcp__context7__query-docs` are present, the MCP path is configured.
+MCP availability: check your own tool list. If `mcp__context7__resolve-library-id` / `mcp__context7__query-docs` are present, the MCP path is configured.
 
 ## Purpose
 
 A primary source of up-to-date library documentation. Two equivalent interfaces: CLI (`ctx7`) via npm, and the Context7 HTTP MCP server (`mcp__context7__*`) when the consuming project has it configured. Both read the same backend. Pick by workflow (see [When to use CLI vs MCP](#when-to-use-cli-vs-mcp)).
 
-**Philosophy**: training data is stale by the time you use it. Library APIs, framework defaults, best practices change. Before claiming how a library works, verify against Context7 — even for libraries you "know."
+**Philosophy**: training data is stale by the time you use it. Library APIs, framework defaults, best practices change. Before claiming how a library works, verify against Context7, even for libraries you "know."
 
 ## Actions
 
@@ -34,7 +34,7 @@ A primary source of up-to-date library documentation. Two equivalent interfaces:
 
 If the argument is bare (no action keyword), treat as `lookup`.
 
-First-time setup — CLI install, `CONTEXT7_API_KEY` auth, optional MCP server wiring, and the Windows Git Bash gotcha — lives in its own skill: run `/context7:setup`.
+First-time setup covers CLI install, `CONTEXT7_API_KEY` auth, optional MCP server wiring, and the Windows Git Bash gotcha. It lives in its own skill: run `/context7:setup`.
 
 ## Lookup (happy path)
 
@@ -54,15 +54,15 @@ mcp__context7__resolve-library-id(libraryName: "...", query: "...")
 mcp__context7__query-docs(libraryId: "/org/project", query: "...")
 ```
 
-You MUST call `library` / `resolve-library-id` first to get a valid ID, UNLESS the user provides one in `/org/project` format. One concept per query — when a question spans several independent topics, run a separate lookup per topic. Do not run more than 3 lookup commands per topic — if you cannot find what you need, fall back to training knowledge and tell the user Context7 didn't cover it.
+You MUST call `library` / `resolve-library-id` first to get a valid ID, UNLESS the user provides one in `/org/project` format. One concept per query. When a question spans several independent topics, run a separate lookup per topic. Do not run more than 3 lookup commands per topic. If you cannot find what you need, fall back to training knowledge and tell the user Context7 didn't cover it.
 
-**Do not include sensitive information** (API keys, passwords, credentials) in queries — sent to the Context7 backend.
+**Do not include sensitive information** (API keys, passwords, credentials) in queries. Sent to the Context7 backend.
 
 Details: query-writing, result selection, version-specific IDs, common mistakes → [context/lookup.md](context/lookup.md)
 
 ## When to use CLI vs MCP
 
-Both read the same backend — results equivalent in substance. Pick by workflow.
+Both read the same backend. Results equivalent in substance. Pick by workflow.
 
 | Use the CLI (`ctx7`) when | Use the MCP (`mcp__context7__*`) when |
 |---|---|
@@ -85,20 +85,20 @@ bash "${CLAUDE_PLUGIN_ROOT}/skills/lookup/scripts/update.sh"        # check only
 bash "${CLAUDE_PLUGIN_ROOT}/skills/lookup/scripts/update.sh" --fix  # apply CLI upgrade
 ```
 
-Script (a) reports installed vs latest `ctx7` version, (b) fetches latest upstream `find-docs/SKILL.md` and `context7-cli/SKILL.md` from `upstash/context7`, (c) diffs against the `vendor/` baselines, (d) if different, reports NEW upstream guidance for manual integration into this skill. The script does NOT auto-overwrite this `SKILL.md` — customizations (Windows gotcha, CLI-vs-MCP guidance, action dispatch) must be preserved.
+Script (a) reports installed vs latest `ctx7` version, (b) fetches latest upstream `find-docs/SKILL.md` and `context7-cli/SKILL.md` from `upstash/context7`, (c) diffs against the `vendor/` baselines, (d) if different, reports NEW upstream guidance for manual integration into this skill. The script does NOT auto-overwrite this `SKILL.md`. Customizations (Windows gotcha, CLI-vs-MCP guidance, action dispatch) must be preserved.
 
 Full protocol (merge strategy, what to preserve, maintainer-only baseline refresh) → [context/update.md](context/update.md)
 
 ## What this skill does NOT do
 
-- **Does not replace multi-source research** — use your research workflow for architecture decisions or anything needing cross-referenced sources. This skill is library-doc retrieval only
-- **Does not refactor code** — retrieves docs. User's question shapes what comes back
-- **Does not cache content locally** — docs fetched fresh each call. `vendor/` baseline is verbatim upstream for skill-content drift detection only, not doc retrieval (do NOT read `vendor/` for normal lookup invocations; only when running the `update` action)
-- **Does not auto-overwrite on update** — `update` is advisory. User approves any merge before changes land
+- **Does not replace multi-source research**. Use your research workflow for architecture decisions or anything needing cross-referenced sources. This skill is library-doc retrieval only
+- **Does not refactor code**. Retrieves docs. User's question shapes what comes back
+- **Does not cache content locally**. Docs fetched fresh each call. `vendor/` baseline is verbatim upstream for skill-content drift detection only, not doc retrieval (do NOT read `vendor/` for normal lookup invocations; only when running the `update` action)
+- **Does not auto-overwrite on update**. `update` is advisory. User approves any merge before changes land
 
 ## Gotchas
 
 - **Windows Git Bash**: `ctx7 docs /org/project "..."` gets path-mangled to `C:/Program Files/Git/org/project`. Always prefix with `MSYS_NO_PATHCONV=1`. `ctx7 library` is unaffected. Full detail: [context/cli.md](context/cli.md)
-- **Prefer the `CONTEXT7_API_KEY` env var over `ctx7 login`**: `ctx7 login` triggers browser OAuth and writes a token to `~/.ctx7/` — the env var is simpler and portable across machines. See [context/cli.md](context/cli.md)
+- **Prefer the `CONTEXT7_API_KEY` env var over `ctx7 login`**: `ctx7 login` triggers browser OAuth and writes a token to `~/.ctx7/`. The env var is simpler and portable across machines. See [context/cli.md](context/cli.md)
 - **No content tuning**: CLI has no `--tokens` / `--limit` flag. Default depth is server-controlled. For more content per call, prefer MCP (returns ~1.8× more by default)
 - **Don't run `ctx7 skills install` into `.claude/skills/`**: this plugin owns the Context7 lookup surface. Installing Upstash's `find-docs` skill alongside creates a parallel surface that fragments lookups and drifts independently

--- a/plugins/context7/skills/setup/SKILL.md
+++ b/plugins/context7/skills/setup/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: "Verify or configure Context7 for this plugin's lookups — check the ctx7 CLI, CONTEXT7_API_KEY auth, and the Context7 MCP server, then install/upgrade the CLI on request. Use when: 'set up context7', 'configure context7', 'is context7 working', 'context7 setup', 'install ctx7', 'context7 auth', 'add the Context7 MCP server'. Actions: check (read-only verification, default) | apply (resolve what check found) | apply install-cli (also install/upgrade the ctx7 CLI)."
+description: "Verify or configure Context7 for this plugin's lookups. Check the ctx7 CLI, CONTEXT7_API_KEY auth, and the Context7 MCP server, then install/upgrade the CLI on request. Use when: 'set up context7', 'configure context7', 'is context7 working', 'context7 setup', 'install ctx7', 'context7 auth', 'add the Context7 MCP server'. Actions: check (read-only verification, default) | apply (resolve what check found) | apply install-cli (also install/upgrade the ctx7 CLI)."
 argument-hint: "check | apply [install-cli]"
 user-invocable: true
 disable-model-invocation: true
@@ -15,7 +15,7 @@ Installed CLI version: !`ctx7 --version 2>/dev/null || echo "not installed"`
 
 Latest published CLI version: !`npm view ctx7 version 2>/dev/null || echo "unknown (npm registry unreachable)"`
 
-MCP availability: check your own tool list — if `mcp__context7__resolve-library-id` / `mcp__context7__query-docs` are present, the Context7 MCP server is already configured.
+MCP availability: check your own tool list. If `mcp__context7__resolve-library-id` / `mcp__context7__query-docs` are present, the Context7 MCP server is already configured.
 
 ## Purpose
 
@@ -32,28 +32,28 @@ changes.
 
 Action routing: no argument or `check` runs the check; `apply` runs the check first, then the
 guidance-only remediations (auth, MCP routing); `apply install-cli` additionally authorizes the
-global `ctx7` install/upgrade below. All actions are non-interactive when the action is given —
-never prompt.
+global `ctx7` install/upgrade below. All actions are non-interactive when the action is given.
+Never prompt.
 
 ## `check` (read-only)
 
 Work top-down from the pre-computed context and report a PASS/FAIL/INFO table with one
 remediation line per FAIL. Do not install, edit config, or write anything.
 
-1. **CLI path** — from the pre-computed block: is `ctx7` installed, and does it match the latest
+1. **CLI path**. From the pre-computed block: is `ctx7` installed, and does it match the latest
    published version? A working, current CLI is PASS. Installed-but-behind is INFO with
    remediation `apply install-cli`. Absent is INFO only when the MCP path is live (below);
    otherwise it is a FAIL of the "at least one path works" requirement.
-2. **MCP path** — is the Context7 MCP server present in your tool list? Present is PASS; absent is
-   INFO (the MCP interface is optional — the CLI alone is sufficient).
-3. **At least one path** — FAIL only when neither the CLI nor the MCP server resolves; every
+2. **MCP path**. Is the Context7 MCP server present in your tool list? Present is PASS; absent is
+   INFO. The MCP interface is optional; the CLI alone is sufficient.
+3. **At least one path**. FAIL only when neither the CLI nor the MCP server resolves; every
    lookup would then be blocked. Remediation: `apply install-cli`, or add the MCP server (routed
    in `apply`).
-4. **Auth** — INFO: report whether `CONTEXT7_API_KEY` is present in the environment
-   (`[ -n "$CONTEXT7_API_KEY" ]`). Report presence only — never print or echo the value.
+4. **Auth**. INFO: report whether `CONTEXT7_API_KEY` is present in the environment
+   (`[ -n "$CONTEXT7_API_KEY" ]`). Report presence only. Never print or echo the value.
    Anonymous usage works at low rates, so absence is never a FAIL.
-5. **Windows Git Bash** — INFO: CLI `ctx7 docs /org/project "..."` calls must be prefixed with
-   `MSYS_NO_PATHCONV=1` (a no-op on macOS/Linux — safe to always include), or the `/org/project`
+5. **Windows Git Bash**. INFO: CLI `ctx7 docs /org/project "..."` calls must be prefixed with
+   `MSYS_NO_PATHCONV=1` (a no-op on macOS/Linux, so it is safe to always include), or the `/org/project`
    ID gets path-mangled. Full explanation:
    `${CLAUDE_PLUGIN_ROOT}/skills/lookup/context/cli.md`.
 
@@ -63,7 +63,7 @@ Run `check`, then resolve each finding. Re-running after both paths are working 
 and reports "already configured". State each change before making it, and re-detect before
 claiming it.
 
-1. **`apply install-cli` — install or upgrade the CLI.** Only with this subaction, and only when
+1. **`apply install-cli` installs or upgrades the CLI.** Only with this subaction, and only when
    `check` found `ctx7` missing or behind latest:
 
    ```bash
@@ -73,9 +73,9 @@ claiming it.
    No global install available? `npx ctx7@latest <command>` works per-invocation. Version floor,
    npx trade-offs, and the full command/flag reference:
    `${CLAUDE_PLUGIN_ROOT}/skills/lookup/context/cli.md`. After installing, re-read the CLI version
-   and report the observed result — never claim upgraded on the install command's exit code alone.
+   and report the observed result. Never claim upgraded on the install command's exit code alone.
 
-2. **Auth (optional, both paths) — guidance only.** For higher limits, direct the user to set
+2. **Auth (optional, both paths). Guidance only.** For higher limits, direct the user to set
    `CONTEXT7_API_KEY` in their own shell profile / secret store:
 
    ```bash
@@ -87,10 +87,10 @@ claiming it.
    in a fresh session; report its presence only and defer verification to that fresh session.
    Rationale and the `ctx7 login` caveat: `${CLAUDE_PLUGIN_ROOT}/skills/lookup/context/cli.md`.
 
-3. **MCP path (optional) — guidance only.** If the user wants the MCP interface (cleaner output,
+3. **MCP path (optional). Guidance only.** If the user wants the MCP interface (cleaner output,
    ~1.8× more content per call, no Windows ceremony), route them to add a `context7` server entry
-   to *their own* MCP configuration. The exact JSON — anonymous and API-key forms, plus the
-   "unset env var breaks config parsing" caveat — lives in
+   to *their own* MCP configuration. The exact JSON, covering anonymous and API-key forms plus the
+   "unset env var breaks config parsing" caveat, lives in
    `${CLAUDE_PLUGIN_ROOT}/skills/lookup/context/mcp.md`. Do not edit their `.mcp.json` for them.
 
 4. **Verify.** Re-read the CLI version and your tool list. Confirm at least one path (CLI or MCP)
@@ -103,11 +103,11 @@ available (CLI, MCP, or both). If nothing needed changing, say the environment w
 
 ## Boundaries
 
-- Do not run `ctx7 setup` or `ctx7 skills install` — this plugin owns the lookup surface; those
+- Do not run `ctx7 setup` or `ctx7 skills install`. This plugin owns the lookup surface; those
   install a parallel skill that fragments and clobbers it (detail in the CLI and update references).
-- Do not run `ctx7 setup --mcp` or edit the consumer's `.mcp.json` without consent — their MCP
+- Do not run `ctx7 setup --mcp` or edit the consumer's `.mcp.json` without consent. Their MCP
   configuration is theirs to curate.
 - Do not write `CONTEXT7_API_KEY` into the repository, Claude Code settings, or any config file, and
   never print its value; the key belongs in the environment or a secret store.
 - Do not write the plugin cache, Claude Code user settings, or `pluginConfigs`.
-- Do not perform library lookups — that is `/context7:lookup`.
+- Do not perform library lookups. That is `/context7:lookup`.


### PR DESCRIPTION
No linked issue

## Summary

Refs #2891. Instruction-surface de-slop shard for the `context7` plugin only. Other plugins stay on main.

## Fix

Rewrote `plugins/context7/README.md` and every `plugins/context7/**/SKILL.md` under `/ai-slop:audit fix` semantics (periods, commas, or a restructured sentence; never parentheses, en dashes, or a spaced hyphen as a stand-in). Meaning-preserving grammar pass after the mechanical replace. Version-only bump in `plugin.json`. New changelog heading only. Vendored `skills/lookup/vendor/**/SKILL.md` is left untouched as detector-excluded upstream baseline. The fenced lookup command comment keeps its em dash. `docs/SKILL-CHEAT-SHEET.md` was not edited.

## Verification

- Detector (`HOME` + `CLAUDE_PROJECT_DIR` isolated so `rule-em-dash` is enabled): 0 `rule-em-dash` findings on rewritten instruction surfaces. Remaining em dashes are inside a fenced template or vendored baseline.
- `CHECK_SKILL_SKIP_MARKDOWNLINT=1 bash scripts/check-changed-skills.sh origin/main`: 0 failed; quoted trigger phrases vs origin/main preserved
- `python3 scripts/sync-plugin-options-docs.py --check` up to date
- `scripts/check-changelog-parity.sh --check-bump origin/main` passes
- `node scripts/generate-cheatsheet.mjs --check` in sync

## Related

Refs #2891