### PR TITLE
docs(mcp-tools): de-slop instruction surfaces (0.3.2)

### DIFF
--- a/plugins/mcp-tools/.claude-plugin/plugin.json
+++ b/plugins/mcp-tools/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "mcp-tools",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Audits MCP server tool definitions against MCP-specification, Anthropic tool-design, and Claude-Code client criteria and reports a per-tool PASS/WARN/FAIL scorecard covering description, parameters, naming, and annotations. Language-agnostic — Python (mcp), TypeScript, and .NET.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/mcp-tools/CHANGELOG.md
+++ b/plugins/mcp-tools/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to the `mcp-tools` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.3.2]
+
+### Changed
+
+- **Instruction-surface de-slop (#2891, mcp-tools cluster).** Rewrote this plugin's `README.md` and every
+  `SKILL.md` to drop em dashes under the repo's zero-tolerance house policy, using
+  `/ai-slop:audit fix` semantics: periods or commas, or a restructured sentence, never
+  parentheses, en dashes, or a spaced hyphen as a stand-in. Meaning stays; only the mark
+  and the sentence break change. Official page titles in the three authority links keep
+  their em dashes so the cited titles stay verbatim.
+
 ## [0.3.1]
 
 ### Changed

--- a/plugins/mcp-tools/README.md
+++ b/plugins/mcp-tools/README.md
@@ -13,16 +13,16 @@ The criteria come from three upstream authorities, cited so the current text alw
 
 19 criteria (C1-C19) across seven categories, each tagged by authority (SPEC-MUST / SPEC-SHOULD /
 SPEC-OPTIONAL / ANTHROPIC / OPINION) so you can tell a protocol requirement from a style preference.
-OPINION is the skill's own judgment — including the criteria built on Claude-Code-specific client
+OPINION is the skill's own judgment, including the criteria built on Claude-Code-specific client
 behavior, which the Claude Code page documents rather than mandates:
 
-- **Description** — states what / when / returns, fits the client size budget (2KB in Claude Code, for tool descriptions and server instructions alike), leaks no implementation detail.
-- **Parameters** — every parameter described, guidance and format examples, documented optional defaults.
-- **Naming** — valid name charset/length (spec), outcome-driven, service-namespaced.
-- **Annotations** — `readOnlyHint`, `destructiveHint`, `idempotentHint`. These are OPTIONAL in the spec, so a missing annotation is WARN, never FAIL.
-- **Granularity** — workflow-shaped consolidation, not one tool per raw API call.
-- **Schema** — callable from the schema alone, with a valid `inputSchema`.
-- **Claude Code `_meta` annotations** — `anthropic/maxResultSizeChars`, `anthropic/requiresUserInteraction`, `anthropic/alwaysLoad`. Missing is at most an info advisory; a declared value Claude Code ignores or caps is the defect.
+- **Description**. States what / when / returns, fits the client size budget (2KB in Claude Code, for tool descriptions and server instructions alike), leaks no implementation detail.
+- **Parameters**. Every parameter described, guidance and format examples, documented optional defaults.
+- **Naming**. Valid name charset/length (spec), outcome-driven, service-namespaced.
+- **Annotations**. `readOnlyHint`, `destructiveHint`, `idempotentHint`. These are OPTIONAL in the spec, so a missing annotation is WARN, never FAIL.
+- **Granularity**. Workflow-shaped consolidation, not one tool per raw API call.
+- **Schema**. Callable from the schema alone, with a valid `inputSchema`.
+- **Claude Code `_meta` annotations**. `anthropic/maxResultSizeChars`, `anthropic/requiresUserInteraction`, `anthropic/alwaysLoad`. Missing is at most an info advisory; a declared value Claude Code ignores or caps is the defect.
 
 Language-agnostic: it discovers tools in Python (`mcp`), TypeScript (`@modelcontextprotocol/sdk`), and
 .NET (`ModelContextProtocol`) by the SDKs' own tool markers.
@@ -38,13 +38,13 @@ Claude can also invoke it automatically when you ask to "audit MCP tools" or "ch
 
 ## What it does NOT do
 
-- Does not modify tool definitions — it reports; you apply the fixes.
-- Does not test tool functionality — use the MCP Inspector for that.
-- Does not evaluate MCP resources — only tools.
+- Does not modify tool definitions. It reports; you apply the fixes.
+- Does not test tool functionality. Use the MCP Inspector for that.
+- Does not evaluate MCP resources. Only tools.
 
 ## Requirements
 
-- **Bash + coreutils** for the audit's inline mechanics — on native Windows,
+- **Bash + coreutils** for the audit's inline mechanics. On native Windows,
   install
   [Git for Windows](https://code.claude.com/docs/en/setup#set-up-on-windows)
   so they run under Git Bash.
@@ -60,7 +60,7 @@ Claude can also invoke it automatically when you ask to "audit MCP tools" or "ch
 
 ## Configuration
 
-This plugin has no `userConfig`. It reads your project's tool source directly and writes nothing — the
+This plugin has no `userConfig`. It reads your project's tool source directly and writes nothing. The
 scorecard is returned in the response.
 
 ## License

--- a/plugins/mcp-tools/skills/audit/SKILL.md
+++ b/plugins/mcp-tools/skills/audit/SKILL.md
@@ -1,6 +1,6 @@
 ---
-description: "Audit MCP server tool definitions against design quality criteria. Use when: 'audit MCP tools', 'check MCP tool descriptions', 'review MCP server quality', 'tool annotations', 'readOnlyHint missing', 'parameter descriptions missing', 'check the _meta annotations', 'maxResultSizeChars', 'requiresUserInteraction', 'alwaysLoad', 'are my server instructions too long', 'mcp audit', or before shipping MCP server changes. Optional path argument targets a single server directory; omit to audit the whole project. Produces per-tool PASS/WARN/FAIL scorecard covering description completeness, parameters, naming, annotations, and the Claude Code `_meta` annotations, plus a server-level result for the server `instructions` size budget. Language-agnostic — Python (`mcp`), TypeScript, .NET. Not for: MCP server configuration or connection issues."
-argument-hint: "[path] — a directory to scope the audit to (e.g. a single server dir), or omit for the whole project"
+description: "Audit MCP server tool definitions against design quality criteria. Use when: 'audit MCP tools', 'check MCP tool descriptions', 'review MCP server quality', 'tool annotations', 'readOnlyHint missing', 'parameter descriptions missing', 'check the _meta annotations', 'maxResultSizeChars', 'requiresUserInteraction', 'alwaysLoad', 'are my server instructions too long', 'mcp audit', or before shipping MCP server changes. Optional path argument targets a single server directory; omit to audit the whole project. Produces per-tool PASS/WARN/FAIL scorecard covering description completeness, parameters, naming, annotations, and the Claude Code `_meta` annotations, plus a server-level result for the server `instructions` size budget. Language-agnostic: Python (`mcp`), TypeScript, .NET. Not for: MCP server configuration or connection issues."
+argument-hint: "[path]. A directory to scope the audit to (e.g. a single server dir), or omit for the whole project"
 user-invocable: true
 disable-model-invocation: false
 metadata:
@@ -13,9 +13,9 @@ metadata:
 Evaluate MCP server tool definitions against design quality criteria drawn from three upstream
 authorities, cited (not recapped) so the current text always governs:
 
-- [MCP specification 2025-11-25 — Tools](https://modelcontextprotocol.io/specification/2025-11-25/server/tools) — the normative protocol (MUST / SHOULD / OPTIONAL requirements for names, schemas, annotations).
-- [Anthropic — Writing effective tools for AI agents](https://www.anthropic.com/engineering/writing-tools-for-agents) — engineering guidance for descriptions, parameters, namespacing, and workflow-shaped granularity.
-- [Claude Code — Connect Claude Code to tools via MCP](https://code.claude.com/docs/en/mcp) — Claude-Code-specific client behavior: `_meta` annotations and truncation limits.
+- [MCP specification 2025-11-25 — Tools](https://modelcontextprotocol.io/specification/2025-11-25/server/tools). The normative protocol (MUST / SHOULD / OPTIONAL requirements for names, schemas, annotations).
+- [Anthropic — Writing effective tools for AI agents](https://www.anthropic.com/engineering/writing-tools-for-agents). Engineering guidance for descriptions, parameters, namespacing, and workflow-shaped granularity.
+- [Claude Code — Connect Claude Code to tools via MCP](https://code.claude.com/docs/en/mcp). Claude-Code-specific client behavior: `_meta` annotations and truncation limits.
 
 Produces a per-tool scorecard with actionable findings. Catches description gaps, missing annotations,
 and naming issues before they degrade LLM tool selection accuracy.
@@ -32,8 +32,8 @@ how servers are grouped.
 
 Parse `$ARGUMENTS`:
 
-- **`<path>`** — audit a single scope. A directory to narrow the scan to (typically one server's directory).
-- ***(empty)*** — audit every tool discovered under the project root.
+- **`<path>`**. Audit a single scope. A directory to narrow the scan to (typically one server's directory).
+- ***(empty)***. Audit every tool discovered under the project root.
 
 ## Track progress
 
@@ -51,26 +51,26 @@ phases and tick each as it completes. Phase 2 may run subagent fan-out for ≥5 
 
 Read each `Tool file:` from Phase 1. Per the language rules in
 [reference/server-discovery.md](reference/server-discovery.md), extract descriptions, parameters,
-wire-level annotations (C12-C14), and the tool's `_meta` object (C17-C19) — the last via
+wire-level annotations (C12-C14), and the tool's `_meta` object (C17-C19). The last via
 **meta-extraction**, recording each key's JSON type and not merely its presence, because C18 turns on
 it. Load the detailed checklist from [reference/checklist.md](reference/checklist.md).
 
-Once per server, also resolve its `instructions` field — see **Server instructions** in
-[reference/server-discovery.md](reference/server-discovery.md) — and evaluate C4's per-server clause
+Once per server, also resolve its `instructions` field. See **Server instructions** in
+[reference/server-discovery.md](reference/server-discovery.md) and evaluate C4's per-server clause
 against it. Phase 1's records are per-tool, so this is the only step that reaches it; its result lands
 in the server-level row of the Phase 3 report, not in any tool's table.
 
 Evaluate every criterion in the checklist against each tool, and C4's per-server clause once per
 server. Record each result as:
 
-- **PASS** — criterion met
-- **WARN** — criterion partially met or could be improved
-- **FAIL** — criterion not met
-- **info** — an optimization opportunity rather than a defect; the severity `reference/checklist.md`
+- **PASS**. Criterion met
+- **WARN**. Criterion partially met or could be improved
+- **FAIL**. Criterion not met
+- **info**. An optimization opportunity rather than a defect; the severity `reference/checklist.md`
   assigns to C8, C11, C14, and by default to C17-C19
-- **n/a** — the criterion has no subject here, so it cannot pass: a server whose construction site
+- **n/a**. The criterion has no subject here, so it cannot pass: a server whose construction site
   declares no `instructions` gives C4's per-server clause nothing to size
-- **undetermined** — the subject was not reachable in the scanned scope (no server construction site
+- **undetermined**. The subject was not reachable in the scanned scope (no server construction site
   found), which is not the same as its being absent
 
 ### Phase 3: Report
@@ -114,17 +114,17 @@ Server-level criteria — the outcomes that belong to the server, not to any one
 (repeat for each tool)
 ```
 
-**Prioritize FAIL items** — highest-value improvements. WARN items are suggestions and info items are
-optimizations. The `Overall` line and the summary table count every outcome recorded for a server —
-its tools' criterion rows and its server-level rows — across the four severity buckets. `n/a` and
+**Prioritize FAIL items**. Highest-value improvements. WARN items are suggestions and info items are
+optimizations. The `Overall` line and the summary table count every outcome recorded for a server:
+its tools' criterion rows and its server-level rows, across the four severity buckets. `n/a` and
 `undetermined` are not severities: they record that a criterion had no subject, or none reachable, so
 they appear only in the server-level criterion table and never count as a pass. A missing annotation
-is never FAIL — annotations are
+is never FAIL. Annotations are
 OPTIONAL in the spec (C12-C14) or Claude-Code-specific advisories (C17-C19); only a declared value
 Claude Code silently ignores can FAIL (C18).
 
 ## What this skill does NOT do
 
-- Does not modify tool definitions — it reports. Use findings to guide manual improvements.
-- Does not test tool functionality — use MCP Inspector for that.
-- Does not evaluate MCP resources — only tools.
+- Does not modify tool definitions. It reports. Use findings to guide manual improvements.
+- Does not test tool functionality. Use MCP Inspector for that.
+- Does not evaluate MCP resources. Only tools.


### PR DESCRIPTION
No linked issue

## Summary

Refs #2891. Instruction-surface de-slop shard for the `mcp-tools` plugin only. Other plugins stay on main.

## Fix

Rewrote `plugins/mcp-tools/README.md` and every `plugins/mcp-tools/**/SKILL.md` under `/ai-slop:audit fix` semantics (periods, commas, or a restructured sentence; never parentheses, en dashes, or a spaced hyphen as a stand-in). Meaning-preserving grammar pass after the mechanical replace. Version-only bump in `plugin.json`. New changelog heading only. Official page titles in the three authority links keep their em dashes so the cited titles stay verbatim. The fenced report template keeps its `n/a` cells and example em dashes. `docs/SKILL-CHEAT-SHEET.md` was not edited.

## Verification

- Detector (`HOME` + `CLAUDE_PROJECT_DIR` isolated so `rule-em-dash` is enabled): 6 remaining `rule-em-dash` findings, all official page titles in the three authority links (quoted protocol). Fenced report-template em dashes are stripped by the detector.
- `CHECK_SKILL_SKIP_MARKDOWNLINT=1 bash scripts/check-changed-skills.sh origin/main`: 0 failed; quoted trigger phrases vs origin/main preserved
- `python3 scripts/sync-plugin-options-docs.py --check` up to date
- `scripts/check-changelog-parity.sh --check-bump origin/main` passes
- `node scripts/generate-cheatsheet.mjs --check` in sync

## Related

Refs #2891