### PR TITLE
docs(desktop-notification): de-slop instruction surfaces (0.6.20)

### DIFF
--- a/plugins/desktop-notification/.claude-plugin/plugin.json
+++ b/plugins/desktop-notification/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "desktop-notification",
-  "version": "0.6.19",
+  "version": "0.6.20",
   "description": "Alert you when Claude Code needs input — an audible terminal bell, an OSC 9 terminal notification, and an OS-native toast (macOS/Linux) on permission and idle prompts.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/desktop-notification/CHANGELOG.md
+++ b/plugins/desktop-notification/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to the `desktop-notification` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.6.20]
+
+### Changed
+
+- **Instruction-surface de-slop (#2891, desktop-notification cluster).** Rewrote this plugin's `README.md` and every
+  `SKILL.md` to drop em dashes under the repo's zero-tolerance house policy, using
+  `/ai-slop:audit fix` semantics: periods or commas, or a restructured sentence, never
+  parentheses, en dashes, or a spaced hyphen as a stand-in. Meaning stays; only the mark
+  and the sentence break change. The generated options block is ignore-fenced because
+  `scripts/sync-plugin-options-docs.py` still emits em dashes from its shared template.
+
 ## [0.6.19]
 
 ### Fixed

--- a/plugins/desktop-notification/README.md
+++ b/plugins/desktop-notification/README.md
@@ -3,7 +3,7 @@
 A Claude Code plugin that alerts you the moment Claude needs your input. On a
 `permission_prompt` or `idle_prompt` notification it emits up to three additive,
 independently-toggleable channels: an audible terminal bell, an OSC 9 terminal
-notification, and — on macOS and Linux — an OS-native desktop toast.
+notification, and, on macOS and Linux, an OS-native desktop toast.
 
 ## Behavior
 
@@ -27,9 +27,9 @@ channel semantics per the [hooks reference](https://code.claude.com/docs/en/hook
 
 | OS | Tool | Requirement |
 |---|---|---|
-| macOS | [`osascript … display notification`](https://code-maven.com/display-notification-from-the-mac-command-line) | Built-in — no dependency. First run prompts to allow notifications for the terminal app. |
+| macOS | [`osascript … display notification`](https://code-maven.com/display-notification-from-the-mac-command-line) | Built-in. No dependency. First run prompts to allow notifications for the terminal app. |
 | Linux | [`notify-send`](https://man.archlinux.org/man/notify-send.1.en) (libnotify) | Install `libnotify-bin` (Debian/Ubuntu) or `libnotify` (Fedora). Absent → the `os_toast` channel is a silent no-op. |
-| Windows / other | none | No OS-toast branch: a fire-and-forget hook process leaves no live activator host for a WinRT toast to render into, so it would never reliably surface. The `terminal_notify` channel (OSC 9) carries Windows attention — [Windows Terminal handles OSC 9](https://code.claude.com/docs/en/hooks). |
+| Windows / other | none | No OS-toast branch: a fire-and-forget hook process leaves no live activator host for a WinRT toast to render into, so it would never reliably surface. The `terminal_notify` channel (OSC 9) carries Windows attention. [Windows Terminal handles OSC 9](https://code.claude.com/docs/en/hooks). |
 
 The OS toast body includes the current git branch when the project is a git
 repository (e.g. `Waiting for your input — feat/my-branch`); outside a repo it is
@@ -37,9 +37,9 @@ just the message.
 
 ## Requirements
 
-The hook runs on Bash 3.2+ (Git Bash on native Windows — install
-[Git for Windows](https://code.claude.com/docs/en/setup#set-up-on-windows)) and
-needs [`jq`](https://jqlang.github.io/jq/) on `PATH`; without jq, notifications
+The hook runs on Bash 3.2+. On native Windows, install
+[Git for Windows](https://code.claude.com/docs/en/setup#set-up-on-windows) so Git Bash is
+available. It needs [`jq`](https://jqlang.github.io/jq/) on `PATH`; without jq, notifications
 are disabled with a visible once-per-session notice. macOS needs nothing
 further; Linux needs `libnotify` only for the `os_toast` channel; Windows needs
 nothing (terminal channels only). Telemetry
@@ -85,10 +85,11 @@ desktop-notification@<marketplace>` or `--config desktop_notification_enabled=fa
 ## Telemetry (opt-in)
 
 When the consumer sets `HOOK_TELEMETRY_SINK` to an executable, the hook emits one
-[telemetry envelope](../../docs/conventions/hook-telemetry/README.md) per run —
+[telemetry envelope](../../docs/conventions/hook-telemetry/README.md) per run.
 `hook: "desktop-notification"`, `hook_event: "Notification"`, and a `data` payload
 of `notification_type` plus the `channels` that fired. Unset → exact no-op.
 
+<!-- ai-slop-ignore-start: generated options block; source is plugin.json + scripts/sync-plugin-options-docs.py -->
 <!-- BEGIN GENERATED: plugin options — edit plugin.json, then run scripts/sync-plugin-options-docs.py -->
 
 ### Options reference
@@ -164,6 +165,7 @@ hands a configured value to a hook process; the value comes from the routes abov
 - [Manage installed plugins](https://code.claude.com/docs/en/discover-plugins#manage-installed-plugins) — enabling, disabling, `/plugin list`
 
 <!-- END GENERATED: plugin options -->
+<!-- ai-slop-ignore-end -->
 
 ## License
 

--- a/plugins/desktop-notification/skills/setup/SKILL.md
+++ b/plugins/desktop-notification/skills/setup/SKILL.md
@@ -9,13 +9,13 @@ disable-model-invocation: true
 
 Thin check-centric setup per the uniform setup contract (`docs/PLUGIN-PHILOSOPHY.md`
 "Setup is explicit and repeatable" in the marketplace repository): `check` inspects and
-reports, `apply` resolves. This plugin owns no consumer-project configuration — the only
+reports, `apply` resolves. This plugin owns no consumer-project configuration. The only
 tunables are the four native `userConfig` toggles (master + one per channel), and every
 remaining prerequisite is a system tool or an OS package. So `apply` is pure
 guidance-and-verify with **no write path**: it installs nothing and edits nothing.
 
 Action routing: no argument or `check` runs the check; `apply` runs the check first, then
-offers the resolution for each finding. Both are non-interactive — never prompt when the
+offers the resolution for each finding. Both are non-interactive. Never prompt when the
 action is given.
 
 ## `check` (read-only)
@@ -24,59 +24,59 @@ The hook script and the shared library it sources are the single source of truth
 plugin requires and how it degrades: `${CLAUDE_PLUGIN_ROOT}/hooks/desktop-notification.sh` and
 `${CLAUDE_PLUGIN_ROOT}/hooks/hook-utils.sh`.
 
-**Read it first** — probe what it actually does, don't recite this file. Then run each probe via
+**Read it first**. Probe what it actually does, don't recite this file. Then run each probe via
 Bash and report a PASS/FAIL/INFO table with one remediation line per FAIL. Do not modify anything.
 
 When the plugin's toggle is disabled, every prerequisite absence downgrades from FAIL to
-INFO — the hook exits through its enabled-gate before probing anything, so a deliberately
+INFO. The hook exits through its enabled-gate before probing anything, so a deliberately
 disabled plugin is not broken. Report the probes informationally and note that re-enabling
 restores the FAIL semantics.
 
-1. **Bash version** — check `${BASH_VERSION}` against the hook's documented floor (README
+1. **Bash version**. Check `${BASH_VERSION}` against the hook's documented floor (README
    Requirements: Bash 3.2+). INFO when below 5.0: `EPOCHREALTIME` is unset there, so the
-   opt-in telemetry envelope is skipped while notifications still fire — a degrade, not a
+   opt-in telemetry envelope is skipped while notifications still fire, a degrade, not a
    failure.
-2. **`jq`** — `command -v jq`. FAIL if absent: without it the hook can neither classify the
+2. **`jq`**. `command -v jq`. FAIL if absent: without it the hook can neither classify the
    notification nor emit its terminal sequence, so it surfaces a once-per-session
    `systemMessage` notice and drops every notification for the session.
-3. **Per-OS `os_toast` dependency** — detect the current OS family with `uname -s` and probe
+3. **Per-OS `os_toast` dependency**. Detect the current OS family with `uname -s` and probe
    ONLY that family's requirement (the hook's `case "$(uname -s)"` does exactly this):
-   - **Linux** — `command -v notify-send` (libnotify). FAIL only if the `os_toast` channel is
+   - **Linux**. `command -v notify-send` (libnotify). FAIL only if the `os_toast` channel is
      enabled and it is absent; otherwise INFO. Absent → the `os_toast` channel is a
      documented silent no-op; remediation is the README's install hint (`libnotify-bin` on
      Debian/Ubuntu, `libnotify` on Fedora). The terminal channels are unaffected.
-   - **macOS (Darwin)** — INFO: `osascript` is built-in, no dependency. Note the first toast
+   - **macOS (Darwin)**. INFO: `osascript` is built-in, no dependency. Note the first toast
      prompts to allow notifications for the terminal app.
-   - **Windows / other** — INFO: the hook has no `os_toast` branch on this platform (a
+   - **Windows / other**. INFO: the hook has no `os_toast` branch on this platform (a
      fire-and-forget process leaves no live activator host for a WinRT toast). The
      `terminal_notify` OSC 9 channel carries attention here; nothing to install.
-4. **Channel toggles** — report the effective value of all four native booleans (unexpanded
+4. **Channel toggles**. Report the effective value of all four native booleans (unexpanded
    or empty means the default `true`): master `${user_config.desktop_notification_enabled}`,
    `${user_config.desktop_notification_bell_enabled}`,
    `${user_config.desktop_notification_terminal_notify_enabled}`, and
    `${user_config.desktop_notification_os_toast_enabled}`. Call out when the master toggle is
    off (the whole hook is muted) or when the only channel that would fire on this OS is
    disabled.
-5. **Hook registration** — INFO: confirm the plugin is enabled for this project
+5. **Hook registration**. INFO: confirm the plugin is enabled for this project
    (`/plugin` → Installed) rather than parsing settings files.
 
 ## `apply` (idempotent)
 
-Run `check`, then for each FAIL or actionable INFO offer the resolution — this skill installs
+Run `check`, then for each FAIL or actionable INFO offer the resolution. This skill installs
 nothing and writes nothing, so every remediation is a pointer the user acts on:
 
-- **missing `jq` / old Bash** — the platform install instructions from the README Requirements
+- **missing `jq` / old Bash**. The platform install instructions from the README Requirements
   section. This skill never installs system packages.
-- **missing `notify-send`** (Linux, `os_toast` enabled) — `sudo apt install libnotify-bin`
+- **missing `notify-send`** (Linux, `os_toast` enabled). `sudo apt install libnotify-bin`
   (Debian/Ubuntu) or `sudo dnf install libnotify` (Fedora), per the README's per-OS table.
-  Guidance only — the user runs it.
-- **a toggle is off** — direct to `/plugin configure desktop-notification` (interactive,
-  any time). Headless: rerun the install with the new value —
+  Guidance only. The user runs it.
+- **a toggle is off**. Direct to `/plugin configure desktop-notification` (interactive,
+  any time). Headless: rerun the install with the new value.
   `claude plugin install desktop-notification@<marketplace> -s <scope> --config <key>=true`.
-  Against an already-installed plugin it prints `already installed` **and still writes the value**
-  — verified on Claude Code 2.1.240 (a non-sensitive option at `user` scope: a non-default value
+  Against an already-installed plugin it prints `already installed` **and still writes the value**.
+  Verified on Claude Code 2.1.240 (a non-sensitive option at `user` scope: a non-default value
   written to an installed plugin, then restored). The short-circuit is about the install, not the
-  config write. Re-verify before relying on it outside those conditions — a `sensitive` option, or
+  config write. Re-verify before relying on it outside those conditions. A `sensitive` option, or
   `project`/`local` scope, were not covered. Do **not** uninstall to reconfigure: uninstalling
   drops this plugin's entire stored `pluginConfigs` entry, resetting every option in the README's
   Options reference table to its manifest default, not only the toggle being flipped. `-s`
@@ -87,18 +87,18 @@ nothing and writes nothing, so every remediation is a pointer the user acts on:
   Afterwards, keep the two claims apart. The write is issued and the stored value is what you
   passed; the RUNNING session's behavior is not. The rendered `${user_config.*}` is injected at
   skill load and each hook receives its `CLAUDE_PLUGIN_OPTION_*` from an environment fixed at
-  session start, so a same-session `check` still reports the OLD value — reporting that as a
+  session start, so a same-session `check` still reports the OLD value. Reporting that as a
   failed write would be wrong. Verify the effective value by rerunning `check` in a **fresh
   session**, and never claim an unobserved change.
 
 After the user reports acting on any system-tool remediation, re-run the relevant `check`
-probe and report its actual result — never claim resolved on the user's say-so alone.
+probe and report its actual result. Never claim resolved on the user's say-so alone.
 Re-running `apply` when everything already passes changes nothing and reports "already
 configured".
 
 ## What this skill does NOT do
 
-- Install `jq`, `libnotify`, or any system package — `apply` is guidance-and-verify with no
+- Install `jq`, `libnotify`, or any system package. `apply` is guidance-and-verify with no
   write path.
-- Fire a notification — a `permission_prompt` or `idle_prompt` exercises the hook end-to-end.
+- Fire a notification. A `permission_prompt` or `idle_prompt` exercises the hook end-to-end.
 - Write the plugin cache, Claude Code user settings, or `pluginConfigs`. Nor the hook scripts.


### PR DESCRIPTION
No linked issue

## Summary

Refs #2891. Instruction-surface de-slop shard for the `desktop-notification` plugin only. Other plugins stay on main.

## Fix

Rewrote `plugins/desktop-notification/README.md` and every `plugins/desktop-notification/**/SKILL.md` under `/ai-slop:audit fix` semantics (periods, commas, or a restructured sentence; never parentheses, en dashes, or a spaced hyphen as a stand-in). Meaning-preserving grammar pass after the mechanical replace. Version-only bump in `plugin.json`. New changelog heading only. The generated options block is ignore-fenced because `scripts/sync-plugin-options-docs.py` still emits em dashes from its shared template. The quoted toast-body protocol string keeps its em dash. `docs/SKILL-CHEAT-SHEET.md` was not edited.

## Verification

- Detector (`HOME` + `CLAUDE_PROJECT_DIR` isolated so `rule-em-dash` is enabled): 0 `rule-em-dash` findings outside ignore-fenced generated-options spans (61 declined). The toast-body example is an inline-code protocol string.
- `CHECK_SKILL_SKIP_MARKDOWNLINT=1 bash scripts/check-changed-skills.sh origin/main`: 0 failed; quoted trigger phrases vs origin/main preserved
- `python3 scripts/sync-plugin-options-docs.py --check` up to date
- `scripts/check-changelog-parity.sh --check-bump origin/main` passes
- `node scripts/generate-cheatsheet.mjs --check` in sync

## Related

Refs #2891