### PR TITLE
docs(ai-briefing): de-slop instruction surfaces (0.7.8)

### DIFF
--- a/plugins/ai-briefing/.claude-plugin/plugin.json
+++ b/plugins/ai-briefing/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "ai-briefing",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "description": "Build source-backed AI-industry briefings from official vendor publications, configured RSS/Atom feeds, GitHub releases, reputable secondary reporting, and user-supplied URLs. Deduplicate, rank, and present results as markdown or optional HTML/PPTX decks, with repository-owned profile, audience, and brand configuration. Automated X/Twitter collection is disabled; Playwright is used only for deterministic local rendering.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/ai-briefing/CHANGELOG.md
+++ b/plugins/ai-briefing/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to the `ai-briefing` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.7.8]
+
+### Changed
+
+- **Instruction-surface de-slop (#2891, ai-briefing cluster).** Rewrote this plugin's `README.md` and every
+  `SKILL.md` to drop em dashes under the repo's zero-tolerance house policy, using
+  `/ai-slop:audit fix` semantics: periods or commas, or a restructured sentence, never
+  parentheses, en dashes, or a spaced hyphen as a stand-in. Meaning stays; only the mark
+  and the sentence break change.
+  The generated options block is ignore-fenced because
+  `scripts/sync-plugin-options-docs.py` still emits em dashes from its shared template.
+
 ## [0.7.7]
 
 ### Changed

--- a/plugins/ai-briefing/README.md
+++ b/plugins/ai-briefing/README.md
@@ -25,8 +25,8 @@ and presents the result as markdown or an optional HTML/PPTX deck.
 
 The presentation pipeline follows Playwright's current supported environment matrix
 (verified 2026-07-18 against
-[Playwright system requirements](https://playwright.dev/docs/intro#system-requirements) —
-re-check that page before installing, the matrix moves with Playwright releases):
+[Playwright system requirements](https://playwright.dev/docs/intro#system-requirements).
+Re-check that page before installing. The matrix moves with Playwright releases):
 
 - the latest Node.js 22.x, 24.x, or 26.x release, with npm;
 - Windows 11+ or Windows Server 2019+;
@@ -38,7 +38,7 @@ Setup preflights Node, npm, and the OS family. On Linux, Playwright's documented
 Unsupported or missing prerequisites are reported before the existing runtime is changed.
 
 The `setup apply install-build-deps` install step is a POSIX-shell script: it requires
-Bash — on native Windows that is Git Bash (its platform gate accepts
+Bash. On native Windows that is Git Bash (its platform gate accepts
 `MINGW*`/`MSYS*`/`CYGWIN*`; install
 [Git for Windows](https://code.claude.com/docs/en/setup#set-up-on-windows)).
 The build pipeline itself is portable Node and has no shell requirement.
@@ -80,6 +80,7 @@ Machine-local state and generated artifacts live under `${CLAUDE_PLUGIN_DATA}`, 
 profile. Tracked source, audience, and brand configuration always stays in the consumer
 repository.
 
+<!-- ai-slop-ignore-start: generated options block; source is plugin.json + scripts/sync-plugin-options-docs.py -->
 <!-- BEGIN GENERATED: plugin options — edit plugin.json, then run scripts/sync-plugin-options-docs.py -->
 
 ### Options reference
@@ -152,3 +153,4 @@ hands a configured value to a hook process; the value comes from the routes abov
 - [Manage installed plugins](https://code.claude.com/docs/en/discover-plugins#manage-installed-plugins) — enabling, disabling, `/plugin list`
 
 <!-- END GENERATED: plugin options -->
+<!-- ai-slop-ignore-end -->

--- a/plugins/ai-briefing/skills/generate/SKILL.md
+++ b/plugins/ai-briefing/skills/generate/SKILL.md
@@ -139,6 +139,6 @@ under `.claude/ai-briefing/[<profile>/]` in the consumer repository.
 
 ## References
 
-- `references/audience-defaults.md` — default ranking lens and profile overlay.
-- `references/build-pipeline.md` — deterministic HTML/PDF/PPTX generation and validation.
-- `references/slide-generation.md` — slide structure and optional build prerequisites.
+- `references/audience-defaults.md`. Default ranking lens and profile overlay.
+- `references/build-pipeline.md`. Deterministic HTML/PDF/PPTX generation and validation.
+- `references/slide-generation.md`. Slide structure and optional build prerequisites.

--- a/plugins/ai-briefing/skills/setup/SKILL.md
+++ b/plugins/ai-briefing/skills/setup/SKILL.md
@@ -21,13 +21,13 @@ Check-centric per the uniform setup contract (`docs/PLUGIN-PHILOSOPHY.md`
 "Setup is explicit and repeatable" in the marketplace repository): `check` inspects and
 reports, `apply` scaffolds the profile, and the build-toolchain install is a distinct
 opt-in subaction rather than fused behind a flag. Tracked profile configuration belongs in
-the consuming repository — never in `${CLAUDE_PLUGIN_DATA}`, which is reserved for
+the consuming repository, never in `${CLAUDE_PLUGIN_DATA}`, which is reserved for
 machine-local state and generated artifacts.
 
 Action routing: no argument or `check` runs the check; `apply` runs the check first, then
 scaffolds; `apply install-build-deps` additionally authorizes the build-toolchain install
 below. `--profile <name>` selects the profile for either action and wins over the configured
-active profile. All actions are non-interactive when the profile is unambiguous — never
+active profile. All actions are non-interactive when the profile is unambiguous. Never
 prompt when the action and profile are given.
 
 ## Profile contents
@@ -51,17 +51,17 @@ anything.
    rendered `${user_config.active_profile}` value when non-empty, else the root `default`
    profile. A per-run `--profile` wins. Require a 1-63 character lowercase-kebab slug and
    reject reserved Windows device names. Report the resolved profile path, which of the three
-   sources supplied it, and — when the resolved value came from `${user_config.active_profile}` or
-   the configured value is wrong for this repository — the reconfiguration route:
+   sources supplied it. When the resolved value came from `${user_config.active_profile}` or
+   the configured value is wrong for this repository, also report the reconfiguration route:
    - **Interactive, any time:** `/plugin configure ai-briefing@<marketplace>`. The recommended
      route; this skill never writes `pluginConfigs`.
-   - **Headless:** rerun the install with the new value — `claude plugin install
+   - **Headless:** rerun the install with the new value. `claude plugin install
      ai-briefing@<marketplace> -s <scope> --config active_profile=<name>` (repeatable per key).
      Against an already-installed plugin it prints `already installed` **and still writes the
-     value** — verified on Claude Code 2.1.240 (a non-sensitive option at `user` scope: a
+     value**. Verified on Claude Code 2.1.240 (a non-sensitive option at `user` scope: a
      non-default value written to an installed plugin, then restored). The short-circuit is about
-     the install, not the config write. Re-verify before relying on it outside those conditions —
-     a `sensitive` option, or `project`/`local` scope, were not covered. Do **not** uninstall to
+     the install, not the config write. Re-verify before relying on it outside those conditions.
+     A `sensitive` option, or `project`/`local` scope, were not covered. Do **not** uninstall to
      reconfigure: uninstalling drops this plugin's entire stored `pluginConfigs` entry, resetting
      every option in the README's Options reference table to its manifest default. `-s` defaults
      to `user`, so pass the scope `claude plugin list` reports for this plugin, and run from that
@@ -70,26 +70,26 @@ anything.
      Afterwards, keep the two claims apart. The write is issued and the stored value is what you
      passed; the RUNNING session's behavior is not. The rendered `${user_config.*}` is injected at
      skill load and each hook receives its `CLAUDE_PLUGIN_OPTION_*` from an environment fixed at
-     session start, so a same-session `check` still reports the OLD value — reporting that as a
+     session start, so a same-session `check` still reports the OLD value. Reporting that as a
      failed write would be wrong. Verify the effective value by rerunning `check` in a **fresh
      session**, and never claim an unobserved change.
    - **Neither, for a one-off:** a per-run `--profile <name>` selects a different profile without
      touching stored config.
-2. **`sources.md`** — FAIL if the resolved profile has no `sources.md`: `/ai-briefing:generate`
+2. **`sources.md`.** FAIL if the resolved profile has no `sources.md`: `/ai-briefing:generate`
    has no authorized sources to collect from. Remediation: `apply`.
-3. **Optional overlays** — INFO: report whether `audience.md` and declarative `brand.json`
+3. **Optional overlays.** INFO: report whether `audience.md` and declarative `brand.json`
    exist; their absence is expected and never a FAIL.
-4. **Build toolchain** — INFO unless the consumer intends `--format html`/`--format slides`.
+4. **Build toolchain.** INFO unless the consumer intends `--format html`/`--format slides`.
    Report whether the locked runtime at `${CLAUDE_PLUGIN_DATA}/runtime/build` exists and its
    `.version` matches the plugin's `plugin.json` version (a mismatch means a rebuild is due).
    Read-only: never launch a browser here. Missing or stale is INFO with remediation
-   `apply install-build-deps`, because the toolchain is opt-in — markdown output needs none
+   `apply install-build-deps`, because the toolchain is opt-in. Markdown output needs none
    of it.
-5. **Build preflight** — INFO: report `node --version`, `npm --version`, and the OS family
+5. **Build preflight.** INFO: report `node --version`, `npm --version`, and the OS family
    against Playwright's current supported environment matrix. The README's matrix is a dated
    snapshot (verified against
    [Playwright system requirements](https://playwright.dev/docs/intro#system-requirements));
-   the linked page is authoritative — re-check it before installing.
+   the linked page is authoritative. Re-check it before installing.
 
 ## `apply` (idempotent)
 
@@ -106,7 +106,7 @@ nothing and reports "already configured".
    the files the consumer requests. Keep local logo assets beside `brand.json`. Recommend a
    project ignore convention such as `.claude/ai-briefing/**/*.local.*` for personal overlays
    while keeping shared profile files tracked.
-3. **`apply install-build-deps` — install the optional build toolchain.** Parse the subaction
+3. **`apply install-build-deps` installs the optional build toolchain.** Parse the subaction
    before invoking a shell and never interpolate raw arguments into a command. Without it,
    skip this step and change no existing runtime. With it, build and validate a temporary
    locked runtime first, then replace the current runtime with same-filesystem renames. A
@@ -183,11 +183,11 @@ nothing and reports "already configured".
    operating-system packages. Other supported platforms install the browser shell and rely
    on their platform prerequisites. Supported OS and Node targets are whatever
    [Playwright's system requirements](https://playwright.dev/docs/intro#system-requirements)
-   currently list (the README's matrix is a dated snapshot of that page — the link is
+   currently list (the README's matrix is a dated snapshot of that page. The link is
    authoritative). The launch probe runs before the runtime swap.
 
-   After the install, re-run the `check` build-toolchain probe and report its actual result —
-   never claim the toolchain is ready on the swap's exit code alone.
+   After the install, re-run the `check` build-toolchain probe and report its actual result.
+   Never claim the toolchain is ready on the swap's exit code alone.
 
 4. **Confirm.** Report the profile path, whether `sources.md` was created or preserved, which
    optional overlays were created, and whether build dependencies were installed or


### PR DESCRIPTION
No linked issue

## Summary

Refs #2891. Instruction-surface de-slop shard for the `ai-briefing` plugin only. Other plugins stay on main.

## Fix

Rewrote `plugins/ai-briefing/README.md` and every `plugins/ai-briefing/**/SKILL.md` under `/ai-slop:audit fix` semantics (periods, commas, or a restructured sentence; never parentheses, en dashes, or a spaced hyphen as a stand-in). YAML frontmatter left unchanged. Version-only bump in `plugin.json`. New changelog heading only. The generated options block is ignore-fenced because `scripts/sync-plugin-options-docs.py` still emits em dashes from its shared template. `docs/SKILL-CHEAT-SHEET.md` was not edited.

## Verification

- Detector (`HOME` + `CLAUDE_PROJECT_DIR` isolated so `rule-em-dash` is enabled): 0 body-prose `rule-em-dash` findings; 1 leftover in YAML `description` frontmatter, kept so the cheatsheet stays valid; 58 declined generated-options spans
- `CHECK_SKILL_SKIP_MARKDOWNLINT=1 bash scripts/check-changed-skills.sh origin/main`: 0 failed; quoted trigger phrases vs origin/main preserved
- `python3 scripts/sync-plugin-options-docs.py --check` up to date
- `scripts/check-changelog-parity.sh --check-bump origin/main` passes
- `node scripts/generate-cheatsheet.mjs --check` in sync

## Related

Refs #2891