### PR TITLE
docs(miro): de-slop instruction surfaces (0.3.7)

### DIFF
--- a/plugins/miro/.claude-plugin/plugin.json
+++ b/plugins/miro/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "miro",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "Miro board management over the Model Context Protocol: create and manage boards, sticky notes, shapes, frames, connectors, and tags for EventStorming, brainstorming, and diagramming. Bundles a local stdio MCP server (single self-contained Node artifact); installs disabled — opt in and supply a Miro API token.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/miro/CHANGELOG.md
+++ b/plugins/miro/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to the `miro` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.3.7]
+
+### Changed
+
+- **Instruction-surface de-slop (#2891, miro cluster).** Rewrote this plugin's `README.md` and every
+  `SKILL.md` to drop em dashes under the repo's zero-tolerance house policy, using
+  `/ai-slop:audit fix` semantics: periods or commas, or a restructured sentence, never
+  parentheses, en dashes, or a spaced hyphen as a stand-in. Meaning stays; only the mark
+  and the sentence break change.
+  The generated options block is ignore-fenced because
+  `scripts/sync-plugin-options-docs.py` still emits em dashes from its shared template.
+
 ## [0.3.6]
 
 ### Changed

--- a/plugins/miro/README.md
+++ b/plugins/miro/README.md
@@ -12,13 +12,13 @@ spawn bug, [anthropics/claude-code#58510](https://github.com/anthropics/claude-c
 
 ## Enabling and configuration
 
-The plugin **installs disabled** (`defaultEnabled: false`) — a bundled MCP server that
+The plugin **installs disabled** (`defaultEnabled: false`). A bundled MCP server that
 connects to an external, credentialed service is opt-in, not on by default. Enable it
 with `claude plugin enable miro` or the `/plugin` interface, and provide a token:
 
 | Option | Storage | Purpose |
 |---|---|---|
-| `miro_api_token` | Claude Code secure credential storage (never `settings.json`) | Miro REST API token. Required — the server exits at startup without it. |
+| `miro_api_token` | Claude Code secure credential storage (never `settings.json`) | Miro REST API token. Required. The server exits at startup without it. |
 
 Get a token from <https://miro.com/app/settings/user-profile/apps>. Claude Code prompts
 for it at enable time (masked input). Sensitive values use the macOS Keychain, or
@@ -34,7 +34,7 @@ token and never invokes a mutating Miro tool.
 
 Once set, a sensitive `userConfig` value has no dedicated reconfigure entry in the `/plugin`
 detail view, and the `/mcp` server menu's "Clear authentication" applies to OAuth-based servers
-only — it is not the rotation path for a token supplied through `userConfig` (the bundled stdio
+only. It is not the rotation path for a token supplied through `userConfig` (the bundled stdio
 server receives `miro_api_token` as its `MIRO_API_TOKEN` environment variable, never through an
 OAuth flow). To change or clear the token at any time, run:
 
@@ -43,14 +43,14 @@ OAuth flow). To change or clear the token at any time, run:
 ```
 
 That reopens the same configuration screen shown at first enable, letting you overwrite or blank
-the stored token. Prefer it regardless — it masks input, where a token passed on the command line
+the stored token. Prefer it regardless. It masks input, where a token passed on the command line
 lands in shell history and the process table.
 
-The older claim here — that `--config` is ignored once the plugin is installed — was never
+The older claim here, that `--config` is ignored once the plugin is installed, was never
 version-stamped, and on Claude Code 2.1.240 a plain `claude plugin install … --config` was
 observed to write the value of an already-installed plugin for a **non-sensitive** option at
 `user` scope. Whether that holds for a `sensitive` option such as `miro_api_token` has not been
-verified, so do not rely on it for a credential — and do not uninstall to rotate: that drops this
+verified, so do not rely on it for a credential. Do not uninstall to rotate: that drops this
 plugin's entire stored `pluginConfigs` entry, resetting every option in the Options reference
 table below to its manifest default.
 
@@ -63,12 +63,12 @@ tags, connectors, bulk create, and overlap detection. Read-only tools annotate
 ## Architecture
 
 Stdio MCP server ([`@modelcontextprotocol/sdk`](https://github.com/modelcontextprotocol/typescript-sdk))
-on Node ≥ 24 — cross-platform, no per-OS path divergence at the stdio boundary. Tool
+on Node ≥ 24. Cross-platform, no per-OS path divergence at the stdio boundary. Tool
 definitions are thin wrappers over the [`@mirohq/miro-api`](https://www.npmjs.com/package/@mirohq/miro-api)
 client; the request/response and error-shaping logic lives in `src/`.
 
 The TypeScript in `src/` is the single source of truth. `dist/index.min.js` is generated
-build output — an [esbuild](https://esbuild.github.io/) single-file bundle of the
+build output: an [esbuild](https://esbuild.github.io/) single-file bundle of the
 source and all runtime dependencies. Plugin install runs no build step, so the bundle
 is committed; CI rebuilds it from source with the pinned toolchain and fails on any
 drift, so the committed artifact is always exactly what the source produces.
@@ -88,6 +88,7 @@ npm run verify-bundle # fail if dist/index.min.js drifts from src/
 After editing `src/`, run `npm run bundle` and commit the regenerated `dist/index.min.js`
 alongside the source change.
 
+<!-- ai-slop-ignore-start: generated options block; source is plugin.json + scripts/sync-plugin-options-docs.py -->
 <!-- BEGIN GENERATED: plugin options — edit plugin.json, then run scripts/sync-plugin-options-docs.py -->
 
 ### Options reference
@@ -155,3 +156,4 @@ hands a configured value to a hook process; the value comes from the routes abov
 - [Manage installed plugins](https://code.claude.com/docs/en/discover-plugins#manage-installed-plugins) — enabling, disabling, `/plugin list`
 
 <!-- END GENERATED: plugin options -->
+<!-- ai-slop-ignore-end -->

--- a/plugins/miro/skills/setup/SKILL.md
+++ b/plugins/miro/skills/setup/SKILL.md
@@ -13,7 +13,7 @@ the required `miro_api_token` when the plugin is enabled and owns its secure cre
 
 Check-only per the uniform setup contract's userConfig-only carve-out: this plugin's entire
 configuration surface is the native sensitive `userConfig` token, so `check` (default and only
-action) verifies and reports, and reconfiguration routes through Claude Code's native flow — an
+action) verifies and reports, and reconfiguration routes through Claude Code's native flow. An
 `apply` here would have nothing to write except the credential storage and `pluginConfigs` setup
 must never touch. Non-interactive: the optional API probe runs only when `verify-api` is passed,
 never from an in-flow question.
@@ -37,7 +37,7 @@ Official contracts:
    After configuration, require `/reload-plugins` or a new session before rechecking tool availability.
 4. When the scoped Miro tools are present, report that the server started and the token was supplied;
    do not claim that the token has valid API access merely from tool discovery.
-5. Optional credential check — only when the invocation passed `verify-api` (the explicit opt-in;
+5. Optional credential check, only when the invocation passed `verify-api` (the explicit opt-in;
    never offer it as an in-flow question): call the read-only `miro_list_boards` tool with
    `limit: 1`. Never create, update, or delete a board during setup.
    - Success verifies API access; report only the count returned, not board names, IDs, or URLs.
@@ -47,7 +47,7 @@ Official contracts:
 
 ## Headless installation
 
-For a non-interactive install — CI, a fleet bootstrap, a scripted machine setup — seed the token
+For a non-interactive install, CI, a fleet bootstrap, or a scripted machine setup, seed the token
 on the initial install instead of the interactive `/plugin` prompt. Three steps, all required:
 
 ```shell
@@ -58,7 +58,7 @@ claude plugin enable miro -s <scope>
 
 Both placeholders are bootstrap inputs, not lookups: before the first install there is no record
 to read them from. `<marketplace>` is the name the catalog registers under when it is added, and
-`<scope>` is the scope the bootstrap chooses — `user`, `project`, or `local`; `marketplace add`
+`<scope>` is the scope the bootstrap chooses: `user`, `project`, or `local`. `marketplace add`
 and `install` default to `user` when the flag is omitted, while `enable` auto-detects. Carry the
 same `<scope>` through all three. Note the asymmetry: `marketplace add` spells it `--scope` only,
 while `install` and `enable` also accept the `-s` short form. Registering at `user` while
@@ -67,29 +67,29 @@ settings, so a fresh clone or CI agent carries the enabled plugin with no regist
 to resolve it from.
 
 **The enable step is not optional.** This plugin ships `defaultEnabled: false`, so it installs
-DISABLED — the install seeds the token but leaves the MCP server, and therefore every `miro` tool,
+DISABLED. The install seeds the token but leaves the MCP server, and therefore every `miro` tool,
 unavailable until it is enabled ([Default enablement](https://code.claude.com/docs/en/plugins-reference#default-enablement),
 which also notes `claude plugin enable` auto-detects the scope when `-s` is omitted; passing it
 explicitly keeps the sequence deterministic in CI). A bootstrap that stops after `install` looks
 successful and delivers no tools.
 
 **Rotating or clearing the token:** `/plugin configure miro@<marketplace>` (interactive, any
-time) is the recommended rotation path regardless — it masks input, unlike anything passed on the
+time) is the recommended rotation path regardless. It masks input, unlike anything passed on the
 command line (see the security note below).
 
-The older claim here — that `--config` is ignored once the plugin is installed — was never
+The older claim here, that `--config` is ignored once the plugin is installed, was never
 version-stamped, and on Claude Code 2.1.240 a plain `claude plugin install … --config` was
 observed to write the value of an already-installed plugin for a **non-sensitive** option at
 `user` scope. Whether that holds for a `sensitive` option such as `miro_api_token` has not been
 verified, so do not rely on it for a credential. Do **not** uninstall to rotate either:
 uninstalling drops this plugin's entire stored `pluginConfigs` entry, resetting every option in
 the README's Options reference table to its manifest default, and it can drop the
-`enabledPlugins` entry as well — a `defaultEnabled: false` plugin reinstalls DISABLED, so a
+`enabledPlugins` entry as well. A `defaultEnabled: false` plugin reinstalls DISABLED, so a
 rotation that ends at `install` completes with no tools available.
 
 **Security note:** passing the token as a CLI argument records it in shell history
 (`.bash_history`, `.zsh_history`) and briefly exposes it in the process table
-(`/proc/<pid>/cmdline`, `ps aux`) while the command runs — unlike the interactive `/plugin`
+(`/proc/<pid>/cmdline`, `ps aux`) while the command runs, unlike the interactive `/plugin`
 prompt, which masks input and touches neither surface. In CI/CD, route the value through your
 secrets manager rather than inlining it literally.
 


### PR DESCRIPTION
No linked issue

## Summary

Refs #2891. Instruction-surface de-slop shard for the `miro` plugin only. Other plugins stay on main.

## Fix

Rewrote `plugins/miro/README.md` and every `plugins/miro/**/SKILL.md` under `/ai-slop:audit fix` semantics (periods, commas, or a restructured sentence; never parentheses, en dashes, or a spaced hyphen as a stand-in). YAML frontmatter left unchanged. Version-only bump in `plugin.json`. New changelog heading only. The generated options block is ignore-fenced because `scripts/sync-plugin-options-docs.py` still emits em dashes from its shared template. `docs/SKILL-CHEAT-SHEET.md` was not edited.

## Verification

- Detector (`HOME` + `CLAUDE_PROJECT_DIR` isolated so `rule-em-dash` is enabled): 0 body-prose `rule-em-dash` findings; 1 leftover in YAML `description` frontmatter, kept so the cheatsheet stays valid; 53 declined generated-options spans
- `CHECK_SKILL_SKIP_MARKDOWNLINT=1 bash scripts/check-changed-skills.sh origin/main`: 0 failed; quoted trigger phrases vs origin/main preserved
- `python3 scripts/sync-plugin-options-docs.py --check` up to date
- `scripts/check-changelog-parity.sh --check-bump origin/main` passes
- `node scripts/generate-cheatsheet.mjs --check` in sync

## Related

Refs #2891