### PR TITLE
docs(architecture): de-slop instruction surfaces (0.6.4)

### DIFF
--- a/plugins/architecture/.claude-plugin/plugin.json
+++ b/plugins/architecture/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "architecture",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "Scans an existing codebase for module-level architecture friction — shallow modules, seam leaks, and locality gaps — using Ousterhout's deep-module lens, presents candidates as a self-contained HTML report, and runs an interview loop on the selected candidate before handing off for planning.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/architecture/CHANGELOG.md
+++ b/plugins/architecture/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to the `architecture` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.6.4]
+
+### Changed
+
+- **Instruction-surface de-slop (#2891, architecture cluster).** Rewrote this plugin's `README.md` and every
+  `SKILL.md` to drop em dashes under the repo's zero-tolerance house policy, using
+  `/ai-slop:audit fix` semantics: periods or commas, or a restructured sentence, never
+  parentheses, en dashes, or a spaced hyphen as a stand-in. Meaning stays; only the mark
+  and the sentence break change.
+
 ## [0.6.3]
 
 ### Changed

--- a/plugins/architecture/README.md
+++ b/plugins/architecture/README.md
@@ -6,7 +6,7 @@ discovery, distinct from reviewing a diff or planning new work: it hunts for
 shallow modules, seam leaks, and locality gaps in code that already exists.
 
 The first (and default) lens implements John Ousterhout's **deep-module**
-concept from *A Philosophy of Software Design* — a module is *shallow* when its
+concept from *A Philosophy of Software Design*. A module is *shallow* when its
 interface is nearly as complex as its implementation, and *deep* when a small
 interface hides large behavior. Deepening shallow modules improves both
 testability and AI/agent-navigability: a small interface lets a reader grasp a
@@ -16,16 +16,16 @@ module's purpose without traversing the whole import graph.
 
 1. **Explore for friction.** Walks the codebase (via a read-only exploration
    subagent), reads the project's glossary and architecture decision records if
-   present, and applies the *deletion test* to anything suspected shallow —
-   would deleting it concentrate complexity, or merely move it?
+   present, and applies the *deletion test* to anything suspected shallow.
+   Would deleting it concentrate complexity, or merely move it?
 2. **Present candidates.** Writes a self-contained HTML report (inline styles and
    inline SVG only, no remote fetch) to the OS temp directory, one card per
    candidate with a before/after diagram, a recommendation badge, and a
    dependency-category badge. Alongside it, writes a durable machine-readable
    candidate list that survives the session.
 3. **Interview the selected candidate.** Once you pick one, walks the decision tree
-   — constraints, dependencies, the shape of the deepened module, what sits
-   behind the seam, which tests survive — and records the agreed shape for a
+   covering constraints, dependencies, the shape of the deepened module, what sits
+   behind the seam, and which tests survive, then records the agreed shape for a
    planning step to consume. When you want alternatives, a *Design-It-Twice*
    branch frames the problem space, fans out parallel subagents that each design
    the interface under a deliberately different constraint, compares the results
@@ -46,8 +46,8 @@ scan", "make this more testable", "module seams", "locality".
 ## Persistence
 
 The durable candidate list lands in the memory tier of the marketplace
-topic-docs convention — `<memory_dir>/<topic-slug>/deepening-candidates-<timestamp>.md`,
-default `.work/<topic-slug>/` — which is never committed (the memory root
+topic-docs convention: `<memory_dir>/<topic-slug>/deepening-candidates-<timestamp>.md`,
+default `.work/<topic-slug>/`. That path is never committed (the memory root
 self-ignores), so scan output cannot leak into your git history. Resolution
 honors your repo's `.claude/topic-docs.yaml` or declared working-docs
 convention first (see `reference/topic-docs.md`); the skill reports the path

--- a/plugins/architecture/skills/improve/SKILL.md
+++ b/plugins/architecture/skills/improve/SKILL.md
@@ -23,9 +23,9 @@ Arguments: `$ARGUMENTS`
 
 Improvement is distinct from review and planning. Review evaluates a DIFF against criteria (reactive). Planning designs NEW work (forward-looking). This skill scans EXISTING code for friction and proposes candidates for improvement (proactive).
 
-The scan-present-pick process generalizes across improvement **lenses**. Each lens (action) brings its own analysis method and vocabulary via an `actions/<lens>.md` playbook plus a `research/<lens>/` reference set, loaded only when that lens runs. The first lens, `deepening`, implements Ousterhout's deep-module concept — finding shallow modules (interface nearly as complex as implementation) and proposing how to deepen them. The aim is **testability and AI/agent-navigability (AX)**: a deep module's small interface lets a reader — human or agent — grasp its purpose without traversing the whole import graph.
+The scan-present-pick process generalizes across improvement **lenses**. Each lens (action) brings its own analysis method and vocabulary via an `actions/<lens>.md` playbook plus a `research/<lens>/` reference set, loaded only when that lens runs. The first lens, `deepening`, implements Ousterhout's deep-module concept: finding shallow modules (interface nearly as complex as implementation) and proposing how to deepen them. The aim is **testability and AI/agent-navigability (AX)**: a deep module's small interface lets a reader, human or agent, grasp its purpose without traversing the whole import graph.
 
-This finds existing friction — it does not plan new work, apply mechanical code-level tidyings, enforce rules on a diff, or review changes before a PR. Those are separate concerns handled by planning, tidying, rule-enforcement, and review tools respectively (see "Composition").
+This finds existing friction. It does not plan new work, apply mechanical code-level tidyings, enforce rules on a diff, or review changes before a PR. Those are separate concerns handled by planning, tidying, rule-enforcement, and review tools respectively (see "Composition").
 
 ## Actions
 
@@ -34,28 +34,28 @@ This finds existing friction — it does not plan new work, apply mechanical cod
 | *(empty)* | Defaults to `deepening` | Runs the deepening lens |
 | `deepening` | **Deepening (Ousterhout)** | Shallow→deep module scan → HTML report → interview loop (with a Design-It-Twice branch for parallel interface exploration) → hand off an agreed candidate for planning. Full process: `actions/deepening.md` |
 
-One lens per invocation — lenses don't chain implicitly. Read the action's playbook for its full process.
+One lens per invocation. Lenses don't chain implicitly. Read the action's playbook for its full process.
 
 ### Adding a lens
 
-A new improvement lens (e.g. `coupling`, `testability`, dependency-direction review) is a pure ADD — never edit an existing lens's contract to add one (open for extension, closed for modification):
+A new improvement lens (e.g. `coupling`, `testability`, dependency-direction review) is a pure ADD. Never edit an existing lens's contract to add one (open for extension, closed for modification):
 
-- `actions/<lens>.md` — the lens playbook (phases, gates, output shape)
-- `research/<lens>/` — reference for that lens, loaded only when its action runs (per-action progressive disclosure)
+- `actions/<lens>.md`. The lens playbook (phases, gates, output shape)
+- `research/<lens>/`. Reference for that lens, loaded only when its action runs (per-action progressive disclosure)
 - one row in the Actions table above
 
 ## What this skill does NOT do
 
-- **Does not plan implementation** — produces candidates + agreed shape; a planning step plans the work
-- **Does not enforce rules** — a rule-enforcement reviewer does that reactively on a diff
-- **Does not apply mechanical tidyings** — code-level tidyings (rename, extract, inline) are a separate, smaller-grained concern
-- **Does not review a diff** — pre-merge review tools do that
-- **Does not write code** — discovery and design skill only
-- **Does not brainstorm a rough problem** — this skill hunts architecture friction on its own lenses; open-ended "how could we approach X" divergence is a brainstorming concern
+- **Does not plan implementation.** Produces candidates + agreed shape; a planning step plans the work
+- **Does not enforce rules.** A rule-enforcement reviewer does that reactively on a diff
+- **Does not apply mechanical tidyings.** Code-level tidyings (rename, extract, inline) are a separate, smaller-grained concern
+- **Does not review a diff.** Pre-merge review tools do that
+- **Does not write code.** Discovery and design skill only
+- **Does not brainstorm a rough problem.** This skill hunts architecture friction on its own lenses; open-ended "how could we approach X" divergence is a brainstorming concern
 
 ## Composition
 
-Graceful degradation — where a named step below is not available in the consuming project, inline the equivalent work in this session instead of blocking on it.
+Graceful degradation: where a named step below is not available in the consuming project, inline the equivalent work in this session instead of blocking on it.
 
 | When | Then | How |
 |------|------|-----|
@@ -66,7 +66,7 @@ Graceful degradation — where a named step below is not available in the consum
 
 ## Gotchas
 
-Observed failure history — patterns that have actually bitten. Add here when a new one surfaces.
+Observed failure history: patterns that have actually bitten. Add here when a new one surfaces.
 
-- **The durable candidate artifact is a per-project memory-tier file, never `${CLAUDE_PLUGIN_DATA}`.** Even resolved it points at a plugin-global dir with no project dimension that collides candidates across projects, and uninstalling from the last remaining scope deletes the directory — the documented use is deps/caches/generated code, not per-project artifacts. The artifact resolves through the marketplace topic-docs convention (the plugin's topic-docs [binding](../../reference/topic-docs.md)) — memory tier, default `.work/<topic-slug>/`. A `${CLAUDE_PROJECT_DIR}/.claude/...` path is also wrong: `.claude/` generated output is reserved for observability, and an unignored artifact there leaks scan output into git.
-- **Scan-agent claims are shipped only after Phase 1.5 reproduction.** Explore agents have a demonstrated error rate: a real run reported a service "registered but never composed — a bug in the seam" that one grep disproved (it *is* consumed, via a different consumer, with tests). Any candidate headed for a `Strong` badge and any runtime-bug / dead-code claim is reproduced against the actual code before it reaches the user-facing report — the report lends every claim its authority, so an unreproduced overstatement is cheap to make and expensive to reputation.
+- **The durable candidate artifact is a per-project memory-tier file, never `${CLAUDE_PLUGIN_DATA}`.** Even resolved it points at a plugin-global dir with no project dimension that collides candidates across projects, and uninstalling from the last remaining scope deletes the directory. The documented use is deps/caches/generated code, not per-project artifacts. The artifact resolves through the marketplace topic-docs convention (the plugin's topic-docs [binding](../../reference/topic-docs.md)): memory tier, default `.work/<topic-slug>/`. A `${CLAUDE_PROJECT_DIR}/.claude/...` path is also wrong: `.claude/` generated output is reserved for observability, and an unignored artifact there leaks scan output into git.
+- **Scan-agent claims are shipped only after Phase 1.5 reproduction.** Explore agents have a demonstrated error rate: a real run reported a service "registered but never composed — a bug in the seam" that one grep disproved (it *is* consumed, via a different consumer, with tests). Any candidate headed for a `Strong` badge and any runtime-bug / dead-code claim is reproduced against the actual code before it reaches the user-facing report. The report lends every claim its authority, so an unreproduced overstatement is cheap to make and expensive to reputation.


### PR DESCRIPTION
No linked issue

## Summary

Refs #2891. Instruction-surface de-slop shard for the `architecture` plugin only. Other plugins stay on main.

## Fix

Rewrote `plugins/architecture/README.md` and every `plugins/architecture/**/SKILL.md` under `/ai-slop:audit fix` semantics (periods, commas, or a restructured sentence; never parentheses, en dashes, or a spaced hyphen as a stand-in). YAML frontmatter left unchanged. Version-only bump in `plugin.json`. New changelog heading only. One quoted scan-agent claim keeps its em dash. No generated options block. `docs/SKILL-CHEAT-SHEET.md` was not edited.

## Verification

- Detector (`HOME` + `CLAUDE_PROJECT_DIR` isolated so `rule-em-dash` is enabled): 0 body-prose `rule-em-dash` findings outside leftovers. Leftovers: YAML `description` frontmatter, plus the quoted scan-agent claim `registered but never composed — a bug in the seam`
- `CHECK_SKILL_SKIP_MARKDOWNLINT=1 bash scripts/check-changed-skills.sh origin/main`: 0 failed; quoted trigger phrases vs origin/main preserved
- `python3 scripts/sync-plugin-options-docs.py --check` up to date
- `scripts/check-changelog-parity.sh --check-bump origin/main` passes
- `node scripts/generate-cheatsheet.mjs --check` in sync

## Related

Refs #2891