### PR TITLE
docs(computer-use): de-slop instruction surfaces (0.1.1)

### DIFF
--- a/plugins/computer-use/.claude-plugin/plugin.json
+++ b/plugins/computer-use/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "computer-use",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Operating knowledge for Claude Code's built-in computer-use MCP server — the desktop screen-control surface. `/computer-use:diagnose` resolves a symptom to a cause instead of retrying: why every screenshot is downscaled to a fixed pixel budget and why zoom (not a bigger display) is the way back to detail, how to read a capture or input failure, and the per-OS quirks that make a synthesized key or menu behave unlike a human's. `/computer-use:setup` verifies the prerequisites the surface cannot verify for itself and reports the environment settings that end a session mid-run.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/computer-use/CHANGELOG.md
+++ b/plugins/computer-use/CHANGELOG.md
@@ -12,7 +12,8 @@ All notable changes to the `computer-use` plugin are documented here. Format fol
   `/ai-slop:audit fix` semantics: periods or commas, or a restructured sentence, never
   parentheses, en dashes, or a spaced hyphen as a stand-in. Meaning stays; only the mark
   and the sentence break change.
-  One quoted remediation protocol string keeps its em dash.
+  One quoted remediation protocol string keeps its em dash. The setup skill now
+  ships warranted `evals/evals.json` because a SKILL.md edit requires it.
 
 ## [0.1.0]
 

--- a/plugins/computer-use/CHANGELOG.md
+++ b/plugins/computer-use/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to the `computer-use` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.1.1]
+
+### Changed
+
+- **Instruction-surface de-slop (#2891, computer-use cluster).** Rewrote this plugin's `README.md` and every
+  `SKILL.md` to drop em dashes under the repo's zero-tolerance house policy, using
+  `/ai-slop:audit fix` semantics: periods or commas, or a restructured sentence, never
+  parentheses, en dashes, or a spaced hyphen as a stand-in. Meaning stays; only the mark
+  and the sentence break change.
+  One quoted remediation protocol string keeps its em dash.
+
 ## [0.1.0]
 
 ### Added

--- a/plugins/computer-use/README.md
+++ b/plugins/computer-use/README.md
@@ -1,17 +1,17 @@
 # computer-use
 
 A Claude Code plugin carrying the operating knowledge for the built-in **computer-use** MCP
-server — the desktop screen-control surface. Two skills, one concern: making a screen-control
+server, the desktop screen-control surface. Two skills, one concern: making a screen-control
 session succeed, and making its failures legible.
 
 | Skill | What it does |
 |---|---|
-| `/computer-use:diagnose` | Symptom-to-cause for a screen-control session — the screenshot pixel budget and when `zoom` recovers detail, the ladders for capture and input failures, and the per-OS quirks that make synthesized input behave unlike a human's. A symptom guide answers the common cases with no file load. |
+| `/computer-use:diagnose` | Symptom-to-cause for a screen-control session. Covers the screenshot pixel budget and when `zoom` recovers detail, the ladders for capture and input failures, and the per-OS quirks that make synthesized input behave unlike a human's. A symptom guide answers the common cases with no file load. |
 | `/computer-use:setup` | Read-only preflight. Confirms the surface and tool availability, then reports the screensaver, display-sleep, and lock timeouts that end a session mid-run regardless of how busy Claude is. Check-only: every prerequisite is external or a system setting this plugin must not write. |
 
 ## Why this exists
 
-The computer-use tool descriptions already document the mechanics — the actions, the allowlist
+The computer-use tool descriptions already document the mechanics: the actions, the allowlist
 gate, the permission tiers, the ladder that prefers a dedicated MCP over Chrome over screen
 control. **This plugin restates none of that**, on purpose: a standing instruction that repeats
 what the surface already says is a per-session tax for zero gain.
@@ -21,11 +21,11 @@ documented upstream:
 
 - **The idle timer does not see Claude.** Synthesized input does not reset the OS idle timer, so
   a long session hits the screensaver or display-sleep timeout no matter how much Claude is
-  clicking — and cannot recover itself once it does. Measured, not inferred.
+  clicking, and cannot recover itself once it does. Measured, not inferred.
 - **Screenshot quality is a fixed pixel budget, not a scale factor**, so the intuitive fixes
   (smaller monitor, lower resolution) do not work and one non-obvious one (`zoom`, which
   re-captures at full resolution) does.
-- **Capture and input failures are environment state**, not tool defects — and each has a
+- **Capture and input failures are environment state**, not tool defects, and each has a
   distinct signature worth reading rather than retrying past.
 
 ## Works on any machine
@@ -53,10 +53,10 @@ the other.
 
 - **No system-setting changes.** Power, screensaver, and lock policy are reported with their
   measured values and handed to the operator. The plugin never writes them.
-- **No `apply` action.** There is nothing it could conformingly write — the check-only carve-out
+- **No `apply` action.** There is nothing it could conformingly write. The check-only carve-out
   applies, so `setup` verifies and reports and stops.
-- **No mechanism claims it cannot support.** Where a behavior is reproducible but unexplained —
-  Windows shell menus ignoring a synthesized Escape — the plugin says exactly that and ships the
+- **No mechanism claims it cannot support.** Where a behavior is reproducible but unexplained,
+  such as Windows shell menus ignoring a synthesized Escape, the plugin says exactly that and ships the
   rule anyway.
 
 ## Prerequisites

--- a/plugins/computer-use/skills/diagnose/SKILL.md
+++ b/plugins/computer-use/skills/diagnose/SKILL.md
@@ -12,7 +12,7 @@ metadata:
 ## Purpose
 
 Claude Code ships computer use as a built-in MCP server whose tool descriptions already cover
-the mechanics — actions, the allowlist gate, permission tiers, the ladder that prefers a
+the mechanics: actions, the allowlist gate, permission tiers, the ladder that prefers a
 dedicated MCP over Chrome over screen control. **This skill does not restate any of that.**
 
 It carries only what the surface does *not* tell you and the model cannot derive: the shape of
@@ -26,8 +26,8 @@ Parse `$ARGUMENTS`. Each value names one reference spoke; there are exactly thre
 | Argument | Loads |
 |---|---|
 | *(none)* | Nothing. Answer from the symptom guide below, and load a spoke only if the symptom needs it. |
-| `screenshots` | [reference/screenshots-and-zoom.md](reference/screenshots-and-zoom.md) — pixel budget, `zoom`, resolution guidance |
-| `failures` | [reference/failure-diagnostics.md](reference/failure-diagnostics.md) — the idle timer, capture and input ladders, probes |
+| `screenshots` | [reference/screenshots-and-zoom.md](reference/screenshots-and-zoom.md). Pixel budget, `zoom`, resolution guidance |
+| `failures` | [reference/failure-diagnostics.md](reference/failure-diagnostics.md). The idle timer, capture and input ladders, probes |
 | `quirks` | The per-OS file for the machine you are on (see below) |
 
 ## Symptom guide (no file load needed)
@@ -35,7 +35,7 @@ Parse `$ARGUMENTS`. Each value names one reference spoke; there are exactly thre
 | Situation | Answer |
 |---|---|
 | Screenshot looks low-resolution | Expected. Fixed pixel budget, no setting. Use `zoom`. → [screenshots-and-zoom.md](reference/screenshots-and-zoom.md) |
-| Small text unreadable after downscale | `zoom` the region — it re-captures at full resolution. Do **not** lower display resolution. |
+| Small text unreadable after downscale | `zoom` the region. It re-captures at full resolution. Do **not** lower display resolution. |
 | `empty capture (0x0)` | Environment, not a tool bug. Walk the ladder → [failure-diagnostics.md](reference/failure-diagnostics.md) |
 | Input returns a UIPI error | An elevated or secure-desktop process holds the foreground. Not recoverable by retrying. |
 | "not in the allowed applications and is currently in front" | A background app stole focus. Retry with `screenshot` as the batch's first action. |
@@ -49,14 +49,14 @@ Load only the file for the machine you are on:
 | Platform | File |
 |---|---|
 | Windows | [reference/windows-quirks.md](reference/windows-quirks.md) |
-| macOS | not yet written — see the honest-gap note below |
+| macOS | not yet written. See the honest-gap note below |
 
 **Verification gap (declared, not hidden).** Every empirical claim in this plugin was measured
 on Windows 11 with the Claude Desktop surface. macOS is supported by the platform and by this
 plugin's platform-neutral content, but no macOS quirks file ships because none has been
 verified. A macOS user gets the platform-neutral material and no fabricated specifics.
 
-## Surfaces differ — know which one you are on
+## Surfaces differ. Know which one you are on
 
 Computer use is not one thing, and guidance written for one surface is wrong on the other
 (verified 2026-08-10 against [computer use from the
@@ -74,13 +74,13 @@ before applying any surface-specific advice.
 ## Gotchas
 
 - **The screenshot budget is not a scale factor.** Two machines with different displays land at
-  the same megapixel count, not the same ratio — which is why "just use a smaller monitor" does
+  the same megapixel count, not the same ratio, which is why "just use a smaller monitor" does
   not produce a sharper screenshot. See the reference file before advising anyone on resolution.
 - **`zoom` re-captures; it does not crop.** It therefore fails when capture is failing, and it
   recovers genuine detail when capture is healthy. Both follow from the same fact.
 - **A tool error naming an unexpected app is the safety gate working**, not a defect. Nothing was
   typed into the wrong window. Re-screenshot and retry rather than escalating.
-- **On a multi-monitor machine, a launched app can be missing for two opposite reasons** — it
+- **On a multi-monitor machine, a launched app can be missing for two opposite reasons.** It
   opened on a display you are not capturing, or you are pinned to the display it did not open
   on. Chasing the first creates the second; reset to `auto` before sweeping.
 - **Elevated processes cannot be driven at all.** UIPI blocks synthesized input from a

--- a/plugins/computer-use/skills/setup/SKILL.md
+++ b/plugins/computer-use/skills/setup/SKILL.md
@@ -20,7 +20,7 @@ Non-interactive: never prompt. Run the probes, print the table, stop.
 ## `check` (read-only)
 
 Read [`../diagnose/reference/failure-diagnostics.md`](../diagnose/reference/failure-diagnostics.md)
-first — it owns the probe commands and the reasoning behind them. Do not restate them here;
+first. It owns the probe commands and the reasoning behind them. Do not restate them here;
 run them and report. Emit a PASS / FAIL / INFO table with one remediation line per non-PASS.
 
 ### 1. Surface and platform
@@ -35,7 +35,7 @@ Report the surface as INFO. It is context for everything below, not a pass/fail.
 
 ### 2. Tool availability
 
-Confirm the computer-use tools are actually reachable in this session — call
+Confirm the computer-use tools are actually reachable in this session. Call
 `list_granted_applications`, which is read-only and has no side effects. It returns the
 allowlist and the active grant flags.
 
@@ -43,7 +43,7 @@ allowlist and the active grant flags.
 - Tools absent → FAIL. Remediation: enable the `computer-use` MCP server for this project, and
   confirm the plan supports it (research preview, Pro or Max; not Team or Enterprise).
 
-Do **not** call `request_access` during a check — that raises a consent dialog, which is not
+Do **not** call `request_access` during a check. That raises a consent dialog, which is not
 read-only behavior.
 
 ### 3. Session-killing timeouts (the one that actually bites)
@@ -56,14 +56,14 @@ numbers**:
 - display-off timeout;
 - sleep timeout.
 
-Probe **runtime state before configuration** — a registry or defaults read says a screensaver is
-configured, not that one is on screen now — and report both.
+Probe **runtime state before configuration**. A registry or defaults read says a screensaver is
+configured, not that one is on screen now. Report both.
 
 **Platform coverage is uneven, and the check must say so rather than skip.** The diagnostics
 reference ships verified probe commands for Windows only. On macOS, no verified probe set ships:
 report this step as INFO-unverified, name the three settings the operator must read from System
 Settings themselves (screensaver idle delay, display sleep, require-password-on-wake), and state
-that the hazard is unchanged — synthesized input does not reset the idle timer on any platform.
+that the hazard is unchanged. Synthesized input does not reset the idle timer on any platform.
 Never silently omit the step, and never substitute an unverified command as though it were
 checked.
 
@@ -75,7 +75,7 @@ Remediation is always advisory, phrased as the operator's decision: *"Screensave
 minutes and this run will exceed that — raise or disable it for the duration."* Never change a
 power, screensaver, or lock setting; state the setting and the value and let the operator act.
 
-Note the three settings are independent — "display never sleeps" says nothing about the
+Note the three settings are independent. "Display never sleeps" says nothing about the
 screensaver, and the screensaver is the more common culprit.
 
 ### 4. Multi-monitor state
@@ -88,7 +88,7 @@ class of confusion, and knowing it up front is cheaper than diagnosing it later.
 
 If any known focus-stealing utility is running (peripheral suites, overlays, launchers), report
 it as INFO with the retry pattern from the diagnostics reference. This is a nuisance, not a
-blocker — the allowlist gate catches it safely every time.
+blocker. The allowlist gate catches it safely every time.
 
 ## Reporting
 
@@ -105,9 +105,9 @@ action rather than listing everything at once.
   display sleep, and lock are three independent settings; the screensaver has its own timeout
   and is the more common cause of a dead session. Probe all three or the check is misleading.
 - **`powercfg /requests` needs an elevated prompt.** From an ordinary session it exits non-zero
-  with a permissions message — report that the probe was unavailable rather than reporting that
+  with a permissions message. Report that the probe was unavailable rather than reporting that
   nothing holds a power request.
 - **A timeout is only a FAIL relative to the run.** There is no universally correct value; grade
   against the expected unattended duration or the check produces noise on short tasks.
 - **Never remediate the settings this skill reports.** Power, screensaver, and lock policy are
-  system settings — report the measured value and the recommendation, and let the operator act.
+  system settings. Report the measured value and the recommendation, and let the operator act.

--- a/plugins/computer-use/skills/setup/evals/evals.json
+++ b/plugins/computer-use/skills/setup/evals/evals.json
@@ -5,12 +5,13 @@
       "id": 1,
       "name": "default-check-is-read-only-and-reports-timeouts",
       "prompt": "/computer-use:setup",
-      "expected_output": "Runs the check-only preflight: determines the surface, confirms computer-use tools via list_granted_applications, probes screensaver, display-sleep, and lock timeouts, and reports a PASS/FAIL/INFO table with one remediation line each. Does not write system settings and does not call request_access.",
+      "expected_output": "Runs the check-only preflight: determines the surface, confirms computer-use tools via list_granted_applications, probes screensaver timeout and lock-on-resume, display-off timeout, and sleep timeout, and reports a PASS/FAIL/INFO table with one remediation line each. Does not write system settings and does not call request_access.",
       "files": [],
       "expectations": [
         "Treats bare invocation as check, the only action",
         "Calls list_granted_applications rather than request_access",
-        "Reports screensaver, display-sleep, and lock timeouts as independent settings",
+        "Reports screensaver timeout and lock-on-resume, display-off timeout, and sleep timeout as independent settings",
+        "Does NOT treat lock-on-resume as a substitute for the sleep timeout",
         "Does NOT change power, screensaver, or lock settings"
       ]
     },

--- a/plugins/computer-use/skills/setup/evals/evals.json
+++ b/plugins/computer-use/skills/setup/evals/evals.json
@@ -1,0 +1,42 @@
+{
+  "skill_name": "setup",
+  "evals": [
+    {
+      "id": 1,
+      "name": "default-check-is-read-only-and-reports-timeouts",
+      "prompt": "/computer-use:setup",
+      "expected_output": "Runs the check-only preflight: determines the surface, confirms computer-use tools via list_granted_applications, probes screensaver, display-sleep, and lock timeouts, and reports a PASS/FAIL/INFO table with one remediation line each. Does not write system settings and does not call request_access.",
+      "files": [],
+      "expectations": [
+        "Treats bare invocation as check, the only action",
+        "Calls list_granted_applications rather than request_access",
+        "Reports screensaver, display-sleep, and lock timeouts as independent settings",
+        "Does NOT change power, screensaver, or lock settings"
+      ]
+    },
+    {
+      "id": 2,
+      "name": "refuses-apply-and-hands-settings-to-the-operator",
+      "prompt": "/computer-use:setup apply\n\nTurn off my screensaver so long runs stop dying.",
+      "expected_output": "Stays check-only. There is nothing apply could write. Reports the measured timeout values and leaves the change as the operator's decision.",
+      "files": [],
+      "expectations": [
+        "Does not invent or run an apply write path",
+        "Does NOT modify screensaver, power, or lock settings",
+        "Reports measured values so the operator can act"
+      ]
+    },
+    {
+      "id": 3,
+      "name": "macos-unverified-probes-are-named-not-skipped",
+      "prompt": "/computer-use:setup\n\nI am on macOS. Is computer use ready for a 40-minute unattended run?",
+      "expected_output": "Reports the timeout step as INFO-unverified because no verified macOS probe set ships, names the three settings the operator must read from System Settings, and states that synthesized input still does not reset the idle timer.",
+      "files": [],
+      "expectations": [
+        "Does not silently omit the timeout step on macOS",
+        "Does not substitute an unverified probe command as if it were checked",
+        "States that synthesized input does not reset the idle timer on any platform"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
No linked issue

## Summary

Refs #2891. Instruction-surface de-slop shard for the `computer-use` plugin only. Other plugins stay on main.

## Fix

Rewrote `plugins/computer-use/README.md` and every `plugins/computer-use/**/SKILL.md` under `/ai-slop:audit fix` semantics (periods, commas, or a restructured sentence; never parentheses, en dashes, or a spaced hyphen as a stand-in). YAML frontmatter left unchanged. Version-only bump in `plugin.json`. New changelog heading only. The quoted remediation protocol string keeps its em dash. The setup skill now ships warranted `evals/evals.json` because a SKILL.md edit requires it. No generated options block. `docs/SKILL-CHEAT-SHEET.md` was not edited.

## Verification

- Detector (`HOME` + `CLAUDE_PROJECT_DIR` isolated so `rule-em-dash` is enabled): 0 body-prose `rule-em-dash` findings outside leftovers. Leftovers: YAML `description` and `argument-hint` frontmatter, plus the quoted remediation protocol string
- `CHECK_SKILL_SKIP_MARKDOWNLINT=1 bash scripts/check-changed-skills.sh origin/main`: 0 failed; quoted trigger phrases vs origin/main preserved
- `python3 scripts/sync-plugin-options-docs.py --check` up to date
- `scripts/check-changelog-parity.sh --check-bump origin/main` passes
- `node scripts/generate-cheatsheet.mjs --check` in sync
- `bash plugins/skill-quality/scripts/check-evals-quality.sh plugins/computer-use/skills/setup/evals/evals.json` PASS

## Related

Refs #2891