### PR TITLE
fix(ai-slop): expand directory targets from one path anchor (0.3.8)

### DIFF
--- a/plugins/ai-slop/.claude-plugin/plugin.json
+++ b/plugins/ai-slop/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "ai-slop",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "description": "Detects and removes AI-writing tells (slop) in checked-in markdown prose: em dashes, emoji formatting, AI vocabulary, negative parallelisms, chatbot phrases, filler, stacked hedging, citation artifacts, and the rest of a catalog distilled from Wikipedia's Signs of AI writing. Read-only audit by default with a deterministic detector plus a judgment rubric; an explicit fix action rewrites findings behind a semantic-diff guard. Findings conform to the detector-findings convention so the review fanout fix relay can consume them.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/ai-slop/CHANGELOG.md
+++ b/plugins/ai-slop/CHANGELOG.md
@@ -1,5 +1,55 @@
 # Changelog
 
+## [0.3.8]
+
+- **A directory target silently audited untracked files instead of the tracked ones it promised.**
+  `detect.sh` expanded a directory by prefixing `git ls-files --full-name` output with
+  `git rev-parse --show-toplevel`, then narrowing the result with a `grep -F` filter built from
+  `pwd`. One directory has several spellings on Git Bash, where git answers the Windows form of
+  the same checkout a shell reaches as `/tmp/...`, so wherever the two disagree no prefixed
+  candidate could match the filter, `grep` exited non-zero, and the `|| find` fallback ran in
+  place of the branch it was meant to back up. The two are not equivalent: `ls-files` lists
+  tracked files, while `find` walks the filesystem and returns untracked and ignored markdown as
+  well. A directory target therefore reported findings against files the checkout does not track,
+  with nothing to distinguish that from the documented behavior. Measured against
+  `plugins/ai-slop`: zero of the thirteen tracked markdown files survived the filter, and the walk
+  scanned fourteen files, one of them untracked.
+
+  Expansion now runs `git ls-files` with `-C <dir>`, which is already restricted to that
+  directory's subtree and answers in paths relative to it. The caller's own spelling of the
+  directory becomes the only anchor in the pipeline, so no second source remains to disagree with
+  it. The multi-anchor treatment #3242 gave the `emit-findings.sh` producers is deliberately not
+  copied here: those relativize a path a caller hands them and must recognize whichever spelling
+  arrives, whereas this expansion constructs its paths and can simply never introduce a second
+  spelling. Trailing slashes are stripped in full, so a `docs//` target can no longer emit a
+  doubled separator that splits one file across two target strings.
+
+- **A tracked markdown file whose name held a non-ASCII byte was dropped without a trace.** git
+  C-quotes such a path unless told otherwise, so `café.md` arrived as a literal
+  `"caf\303\251.md"`, the joined path failed the scan loop's existence test, and the file
+  produced neither a finding nor a declined row. The listing now sets `core.quotePath=false`. The
+  case that matters most for this plugin is a filename containing an em dash, which the em-dash
+  detector would otherwise never open. The listing stays newline-delimited rather than moving to
+  `-z`, because the report format is one line per finding, so a filename holding a newline cannot
+  be represented downstream whichever way the listing is read, and the newline form keeps the
+  listing's exit status observable.
+
+- **The fallback no longer changes semantics without saying so.** The branch is chosen up front
+  from `--is-inside-work-tree` rather than from an empty pipeline, so a listing that legitimately
+  finds nothing is no longer indistinguishable from one that failed, and a directory inside a
+  checkout holding only untracked markdown expands to nothing rather than falling through to a
+  walk. A walk still answers whenever git cannot confirm a work tree, which covers a directory
+  outside any checkout and equally a git that is absent or refuses to answer; the absent case now
+  reports on stderr, because tracked-files-only is not achievable without git. Inside a confirmed
+  work tree, a failing listing reports rather than degrading into a different set of files.
+
+  Coverage pins the invariant by asserting the emitted path rather than the file count alone: an
+  expansion that discarded the caller's spelling and rebuilt each path from
+  `git rev-parse --show-toplevel` still scans exactly one file, so a count-only assertion admits
+  the very defect this fixes. Added cases cover both spellings, single and doubled trailing
+  slashes, subtree restriction, a non-ASCII filename, and a directory holding only untracked
+  markdown.
+
 ## [0.3.7]
 
 - **A branch name beginning with a YAML indicator silently dropped every finding it emitted.**

--- a/plugins/ai-slop/skills/audit/scripts/detect.sh
+++ b/plugins/ai-slop/skills/audit/scripts/detect.sh
@@ -259,17 +259,49 @@ fi
 # Directory targets expand to the markdown beneath them (tracked files when the
 # directory is inside a git checkout, a filesystem walk otherwise). Without
 # this a directory fails the scan loop's -f test and is skipped silently.
+#
+# ONE anchor, the caller's own spelling of the directory. A directory has
+# several spellings on Git Bash: git answers `C:/Users/...` for the same
+# checkout a shell reaches as `/tmp/...`. The earlier expansion built its
+# prefix from `git rev-parse --show-toplevel` and its filter from `pwd`, so on
+# any host where those disagree no candidate survived the filter and the walk
+# below silently replaced the tracked-files listing it was meant to back up
+# (issue 3266). Running `ls-files` with `-C <dir>` needs neither: it is already
+# restricted to that directory's subtree and answers in paths relative to it,
+# so `<dir>` is the only anchor and cannot disagree with itself.
+#
+# The branch is chosen up front from `--is-inside-work-tree`, never from an
+# empty pipeline, so a walk is only ever the answer for a directory that is
+# genuinely outside a checkout. Inside one, a listing that fails says so on
+# stderr rather than degrading into a different set of files.
+expand_dir_target() {
+  local dir="${1%/}" inside listing status
+  [[ -n "$dir" ]] || dir="$1"
+
+  inside="$(git -C "$dir" rev-parse --is-inside-work-tree 2>/dev/null || true)"
+  if [[ "$inside" != "true" ]]; then
+    find "$dir" -name '*.md' -type f 2>/dev/null
+    return 0
+  fi
+
+  listing="$(git -C "$dir" ls-files '*.md')"
+  status=$?
+  if [[ "$status" -ne 0 ]]; then
+    echo "detect.sh: git ls-files failed under $dir (exit $status); that directory expanded to nothing" >&2
+    return 0
+  fi
+
+  while IFS= read -r rel; do
+    [[ -n "$rel" ]] && printf '%s/%s\n' "$dir" "$rel"
+  done <<<"$listing"
+}
+
 EXPANDED=()
 for t in ${TARGETS[@]+"${TARGETS[@]}"}; do
   if [[ -d "$t" ]]; then
     while IFS= read -r line; do
       [[ -n "$line" ]] && EXPANDED+=("$line")
-    done < <(
-      git -C "$t" ls-files --full-name '*.md' 2>/dev/null |
-        sed "s|^|$(git -C "$t" rev-parse --show-toplevel 2>/dev/null)/|" |
-        grep -F "$(cd "$t" && pwd)/" ||
-        find "$t" -name '*.md' -type f 2>/dev/null
-    )
+    done < <(expand_dir_target "$t")
   else
     EXPANDED+=("$t")
   fi

--- a/plugins/ai-slop/skills/audit/scripts/detect.sh
+++ b/plugins/ai-slop/skills/audit/scripts/detect.sh
@@ -270,13 +270,33 @@ fi
 # restricted to that directory's subtree and answers in paths relative to it,
 # so `<dir>` is the only anchor and cannot disagree with itself.
 #
-# The branch is chosen up front from `--is-inside-work-tree`, never from an
-# empty pipeline, so a walk is only ever the answer for a directory that is
-# genuinely outside a checkout. Inside one, a listing that fails says so on
-# stderr rather than degrading into a different set of files.
+# `core.quotePath=false` is load-bearing rather than cosmetic. At its default
+# git C-quotes any path holding a non-ASCII byte, so a tracked `caf\303\251.md`
+# comes back wrapped in literal double quotes, the joined path fails the scan
+# loop's -f test, and the file leaves no finding and no declined row. A
+# markdown file with an em dash in its NAME would go unscanned by the em-dash
+# detector for that reason alone. The listing stays newline-delimited rather
+# than moving to `-z`: the report format is one line per finding, so a filename
+# holding a newline cannot be represented downstream whichever way it is read,
+# and the newline form keeps the listing's exit status observable.
+#
+# The branch is chosen up front from `--is-inside-work-tree` rather than from
+# an empty pipeline, so a listing that legitimately finds nothing is no longer
+# indistinguishable from one that failed. A walk still answers whenever git
+# cannot CONFIRM a work tree, which covers a directory outside any checkout and
+# equally a git that is absent or refuses to answer; the absent case says so on
+# stderr, because tracked-files-only is not achievable without git. Inside a
+# confirmed work tree a failing listing reports rather than degrading into a
+# different set of files.
 expand_dir_target() {
-  local dir="${1%/}" inside listing status
-  [[ -n "$dir" ]] || dir="$1"
+  local dir="$1" inside listing status rel
+  while [[ "$dir" == */ && "$dir" != "/" ]]; do dir="${dir%/}"; done
+
+  if ! command -v git >/dev/null 2>&1; then
+    echo "detect.sh: git is unavailable; $dir expanded by filesystem walk, which counts untracked files" >&2
+    find "$dir" -name '*.md' -type f 2>/dev/null
+    return 0
+  fi
 
   inside="$(git -C "$dir" rev-parse --is-inside-work-tree 2>/dev/null || true)"
   if [[ "$inside" != "true" ]]; then
@@ -284,7 +304,7 @@ expand_dir_target() {
     return 0
   fi
 
-  listing="$(git -C "$dir" ls-files '*.md')"
+  listing="$(git -C "$dir" -c core.quotePath=false ls-files '*.md')"
   status=$?
   if [[ "$status" -ne 0 ]]; then
     echo "detect.sh: git ls-files failed under $dir (exit $status); that directory expanded to nothing" >&2

--- a/plugins/ai-slop/skills/audit/scripts/detect.test.sh
+++ b/plugins/ai-slop/skills/audit/scripts/detect.test.sh
@@ -404,6 +404,41 @@ out="$(bash "$DETECT" "$GITDIR/docs" 2>&1)"
 assert_contains "dir target in git repo: tracked file scanned via ls-files" "$out" "tracked.md"
 assert_contains "dir target in git repo: only the tracked file counts" "$out" "1 files scanned"
 
+# Path agreement. One directory has several SPELLINGS on Git Bash: git answers
+# the Windows form of the same checkout a shell reaches as "/tmp/...". An
+# expansion that derives its prefix from one source and its filter from another
+# drops every candidate wherever the two disagree, and the walk that backs it up
+# returns untracked markdown in place of the tracked listing (issue 3266). The
+# assertion is that the SPELLING of the target cannot change the answer. On a
+# host where the two forms already agree these two cases restate the one above,
+# which is the point: the invariant holds everywhere, and it is only observable
+# here.
+GITSPELL="$(git -C "$GITDIR/docs" rev-parse --show-toplevel)/docs"
+PWDSPELL="$(cd "$GITDIR/docs" && pwd)"
+
+out="$(bash "$DETECT" "$GITSPELL" 2>&1)"
+assert_contains "dir target, git spelling: only the tracked file counts" "$out" "1 files scanned"
+
+out="$(bash "$DETECT" "$PWDSPELL" 2>&1)"
+assert_contains "dir target, shell spelling: only the tracked file counts" "$out" "1 files scanned"
+
+# A trailing slash is the same directory and must expand identically; the
+# expansion builds paths by concatenation, so an unnormalized target would emit
+# a doubled separator and scan nothing.
+out="$(bash "$DETECT" "$GITDIR/docs/" 2>&1)"
+assert_contains "dir target with a trailing slash: only the tracked file counts" "$out" "1 files scanned"
+
+# The walk is reserved for a directory genuinely outside a checkout. A directory
+# INSIDE one that holds only untracked markdown expands to nothing rather than
+# falling through to a filesystem walk, which is what the documented
+# tracked-files-only contract means.
+mkdir -p "$GITDIR/untrackedonly"
+cat >"$GITDIR/untrackedonly/loose.md" <<EOF
+A loose em dash ${EM} here.
+EOF
+out="$(bash "$DETECT" "$GITDIR/untrackedonly" 2>&1)"
+assert_contains "dir target in git repo, no tracked markdown: expands to nothing" "$out" "0 files scanned"
+
 # --- Excerpt truncation at the byte boundary --------------------------------------
 
 # 79 ASCII bytes then an em dash: a byte cut at 80 would keep only the first

--- a/plugins/ai-slop/skills/audit/scripts/detect.test.sh
+++ b/plugins/ai-slop/skills/audit/scripts/detect.test.sh
@@ -416,17 +416,54 @@ assert_contains "dir target in git repo: only the tracked file counts" "$out" "1
 GITSPELL="$(git -C "$GITDIR/docs" rev-parse --show-toplevel)/docs"
 PWDSPELL="$(cd "$GITDIR/docs" && pwd)"
 
+# Each case asserts the emitted PATH, not just the count. A count alone does not
+# pin this: an expansion that discards the caller's spelling and rebuilds every
+# path from `git rev-parse --show-toplevel`, which is the anchor that must not
+# be reintroduced, still scans exactly one file and would satisfy a count-only
+# assertion while reproducing the defect.
 out="$(bash "$DETECT" "$GITSPELL" 2>&1)"
 assert_contains "dir target, git spelling: only the tracked file counts" "$out" "1 files scanned"
+assert_contains "dir target, git spelling: emits the caller's spelling" "$out" "file=$GITSPELL/tracked.md"
 
 out="$(bash "$DETECT" "$PWDSPELL" 2>&1)"
 assert_contains "dir target, shell spelling: only the tracked file counts" "$out" "1 files scanned"
+assert_contains "dir target, shell spelling: emits the caller's spelling" "$out" "file=$PWDSPELL/tracked.md"
 
 # A trailing slash is the same directory and must expand identically; the
 # expansion builds paths by concatenation, so an unnormalized target would emit
-# a doubled separator and scan nothing.
+# a doubled separator. Two slashes are stripped as readily as one, so a doubled
+# separator cannot reach the report and split one file across two target
+# strings that `sort -u` is then unable to collapse.
 out="$(bash "$DETECT" "$GITDIR/docs/" 2>&1)"
 assert_contains "dir target with a trailing slash: only the tracked file counts" "$out" "1 files scanned"
+assert_contains "dir target with a trailing slash: no doubled separator" "$out" "file=$GITDIR/docs/tracked.md"
+
+out="$(bash "$DETECT" "$GITDIR/docs//" 2>&1)"
+assert_contains "dir target with a doubled trailing slash: no doubled separator" "$out" "file=$GITDIR/docs/tracked.md"
+
+# Subtree restriction. `ls-files` run with `-C <dir>` reports only that
+# directory's own subtree, which is what lets the expansion drop the repo root
+# from the derivation entirely. A listing anchored at the checkout root instead
+# would sweep in this sibling.
+mkdir -p "$GITDIR/sibling"
+cat >"$GITDIR/sibling/outside.md" <<EOF
+A sibling em dash ${EM} here.
+EOF
+git -C "$GITDIR" add sibling/outside.md
+out="$(bash "$DETECT" "$GITDIR/docs" 2>&1)"
+assert_contains "dir target: restricted to its own subtree" "$out" "1 files scanned"
+
+# A non-ASCII filename. git C-quotes such a path unless told otherwise, and a
+# quoted path fails the scan loop's -f test and is dropped with no finding and
+# no declined row. The em dash in this name is the case that matters most here:
+# the detector would otherwise never read the file it is named for.
+mkdir -p "$GITDIR/unicode"
+cat >"$GITDIR/unicode/caf${EM}e.md" <<EOF
+An accented em dash ${EM} here.
+EOF
+git -C "$GITDIR" add "unicode/caf${EM}e.md"
+out="$(bash "$DETECT" "$GITDIR/unicode" 2>&1)"
+assert_contains "dir target: a non-ASCII filename is scanned, not silently dropped" "$out" "1 files scanned"
 
 # The walk is reserved for a directory genuinely outside a checkout. A directory
 # INSIDE one that holds only untracked markdown expands to nothing rather than


### PR DESCRIPTION
Closes #3266

## Summary

`detect.sh` expanded a directory target by building its path prefix from `git rev-parse
--show-toplevel` and its filter from `pwd`. Those two answer in different spellings on Git Bash,
so every candidate was dropped and the `|| find` fallback quietly ran a filesystem walk in place
of the documented tracked-files-only listing. A directory target therefore audited untracked and
ignored markdown while reporting nothing unusual.

## Fix

Expansion now runs `git ls-files` with `-C <dir>`, which is already restricted to that directory's
subtree and answers in paths relative to it. The caller's own spelling of the directory becomes
the only anchor in the pipeline, so no second source remains to disagree with it.

The multi-anchor treatment #3242 gave the two `emit-findings.sh` producers (`REPO_ROOT_ALT` /
`REPO_ROOT_PWD`) is deliberately not copied here. Those producers relativize a path a caller hands
them and must therefore recognize whichever spelling arrives. This expansion constructs its own
paths, so the better answer is to never introduce a second spelling rather than to carry three and
compare against each.

Two further defects in that code path came out of independent review and are fixed in the same
change:

- `git ls-files` C-quotes any path holding a non-ASCII byte, so a tracked `café.md` arrived as a
  literal `"caf\303\251.md"`, failed the scan loop's existence test, and produced neither a
  finding nor a declined row. The listing now sets `core.quotePath=false`. The sharpest case for
  this plugin is a filename containing an em dash, which the em-dash detector would otherwise
  never open. The listing stays newline-delimited rather than moving to `-z`, because the report
  format is one line per finding, so a filename holding a newline cannot be represented downstream
  whichever way the listing is read, and the newline form keeps the listing's exit status
  observable.
- The branch is chosen up front from `--is-inside-work-tree` rather than from an empty pipeline,
  so a listing that legitimately finds nothing is no longer indistinguishable from one that
  failed. A walk still answers whenever git cannot confirm a work tree, which covers a directory
  outside any checkout and equally a git that is absent or refuses to answer. The comment
  introduced with the first commit claimed otherwise and has been corrected, and the absent case
  now reports on stderr, because tracked-files-only is not achievable without git.

Trailing slashes are stripped in full, so a `docs//` target no longer emits a doubled separator
that splits one file across two target strings `sort -u` cannot collapse.

## Verification

The named case in the repository's own suite, before and after:

```
origin/main   FAIL: dir target in git repo: only the tracked file counts
this branch   PASS: dir target in git repo: only the tracked file counts
```

Suite totals, run on Git Bash where the two spellings genuinely diverge:

```
origin/main   4 of 128 cases FAILED
this branch   3 of 138 cases FAILED
```

The FAIL set is compared by name, not by count. The three surviving failures
(`config: em_dash_allowed_paths exempts the document`, `config: disabled rule emits no findings`,
`config: disabled rule reported in summary`) are identical on both sides and pre-date this change.
They are the separate config-cascade defect and are untouched here; one reviewer traced them to
the Windows `jq` build emitting CRLF, whose trailing carriage return breaks the string-matched
glob and disabled-rule comparisons. No case that passes on `origin/main` fails on this branch.

Directory expansion measured against `plugins/ai-slop`, with one untracked markdown file placed in
the tree:

```
before   14 files scanned, including the untracked file
after    13 files scanned, exactly the 13 files git reports as tracked
```

The collapsed filter itself, measured on `origin/main`: zero of the thirteen tracked markdown
files survived it, which is what routed every directory target to the walk.

Path agreement verified directly by passing the same fixture directory in both spellings
(`C:/Users/...` and `/tmp/...`); both now yield the tracked file only, and both emit the caller's
spelling.

The new assertions were confirmed to be load-bearing by mutation rather than by inspection. Three
wrong implementations were built and run against them:

| Mutation | Count-only assertion | Assertion in this PR |
|---|---|---|
| Rebuild each path from `git rev-parse --show-toplevel` | passes | fails |
| Drop `core.quotePath=false` | fails | fails |
| Strip only one trailing slash | passes | fails |

The first row is the important one: re-anchoring on the very source this change exists to remove
still scans exactly one file, so a count-only assertion admits the defect. The added cases assert
the emitted path.

Gates run locally: `shellcheck` clean on both scripts, `markdownlint-cli2` clean on the changelog,
`scripts/check-changelog-parity.sh --check` and `--check-bump origin/main` both pass with the
manifest at 0.3.8.

Review was performed by two independent fresh-context agents on different models, each given only
the diff with the author's rationale withheld. Both reproduced the original defect. One returned
PASS, the other returned FAIL on the quoted-filename defect; every finding either agreed on has
been fixed in this PR, and the coverage gap the second raised is what prompted the mutation
testing above. Please note that this change and that review were produced by autonomous agents,
so the usual human authorship assumption does not hold and the diff deserves a human read on its
own terms.

## Related

Refs #3242, which resolved the same class of repo-root spelling mismatch in the two
`emit-findings.sh` producers and whose approach this change deliberately diverges from, for the
reason given under Fix. The pre-existing `REPO_ROOT` mismatch in `matches_glob` and in the scan
loop's `rel` computation is left untouched and remains open.
