### PR TITLE
docs(tdd): de-slop instruction surfaces (0.4.3)

### DIFF
--- a/plugins/tdd/.claude-plugin/plugin.json
+++ b/plugins/tdd/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "tdd",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "A TDD knowledge base distilled from cover-to-cover readings of Kent Beck's Test-Driven Development: By Example and Vladimir Khorikov's Unit Testing: Principles, Practices, and Patterns — fourteen author-attributed reference files behind a routing table plus a no-load quick decision guide, answering the WHY behind test design decisions.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/tdd/CHANGELOG.md
+++ b/plugins/tdd/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to the `tdd` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.4.3]
+
+### Changed
+
+- **Instruction-surface de-slop (#2891, tdd cluster).** Rewrote this plugin's `README.md` and every
+  `SKILL.md` to drop leftover body-prose em dashes under the repo's zero-tolerance house policy, using
+  `/ai-slop:audit fix` semantics: periods or commas, or a restructured sentence, never
+  parentheses, en dashes, or a spaced hyphen as a stand-in. Meaning stays; only the mark
+  and the sentence break change. YAML frontmatter is unchanged so the cheatsheet stays valid.
+
 ## [0.4.2]
 
 ### Changed

--- a/plugins/tdd/README.md
+++ b/plugins/tdd/README.md
@@ -1,7 +1,7 @@
 # tdd
 
 A Claude Code plugin that ships a TDD knowledge base as an on-demand knowledge
-skill — distilled from cover-to-cover readings of Kent Beck's *Test-Driven
+skill, distilled from cover-to-cover readings of Kent Beck's *Test-Driven
 Development: By Example* (2003) and Vladimir Khorikov's *Unit Testing:
 Principles, Practices, and Patterns* (2020). It answers the WHY behind test
 design decisions: when to mock, what makes a good test, classical vs London
@@ -13,20 +13,20 @@ automatically when you ask a test design question.
 
 ## What it provides
 
-- **Routing table** — a hub SKILL.md routes each question to one of fourteen
+- **Routing table.** A hub SKILL.md routes each question to one of fourteen
   author-attributed reference files (Beck methodology, Khorikov four pillars,
   test doubles, testable architecture, integration testing, anti-patterns,
   worked examples, and more), so only the relevant slice loads.
-- **Quick decision guide** — one-line answers to the twelve most common test
+- **Quick decision guide.** One-line answers to the twelve most common test
   design questions, with no reference file load needed.
-- **Author attribution throughout** — shared concepts carry attributed
+- **Author attribution throughout.** Shared concepts carry attributed
   sections with synthesis where the authors overlap; single-author concepts
   are named `{concept}-{author}.md`.
 
 ## Scope boundary
 
 This skill is **knowledge** (WHY behind testing decisions), not **workflow**
-(HOW to run tests). It never runs, scaffolds, or filters tests — your
+(HOW to run tests). It never runs, scaffolds, or filters tests. Your
 project's own test tooling and conventions own that; this skill informs the
 design decisions those workflows execute.
 

--- a/plugins/tdd/skills/principles/SKILL.md
+++ b/plugins/tdd/skills/principles/SKILL.md
@@ -44,7 +44,7 @@ Load the most relevant file first. Load a second only if the first doesn't fully
 - "Is this code testable?" → Check the 2x2 matrix. High complexity + many collaborators = split it (Humble Object)
 - "Should I introduce an interface?" → Only for unmanaged deps you need to mock. Concrete classes for managed deps. Never for in-process deps
 - "Should I test this precondition?" → Yes if it has domain significance (e.g., non-negative employees). No if it's purely technical (array length check)
-- "Should I test this read operation?" → Higher threshold than writes. Writes corrupt data — always test. Reads: only the most complex/important ones
+- "Should I test this read operation?" → Higher threshold than writes. Writes corrupt data, so always test. Reads: only the most complex/important ones
 - "Domain event or direct call?" → Use domain events when the domain model needs to trigger external notifications without depending on out-of-process deps
 - "Why is my test brittle?" → It's probably coupled to implementation details. Check: are you asserting on observable behavior or internal structure?
 
@@ -52,14 +52,14 @@ Load the most relevant file first. Load a second only if the first doesn't fully
 
 - **Beck**: Kent Beck, *Test-Driven Development: By Example* (2003)
 - **Khorikov**: Vladimir Khorikov, *Unit Testing: Principles, Practices, and Patterns* (2020)
-- **Ousterhout** (secondary, cross-referenced only): John Ousterhout, *A Philosophy of Software Design* — cited in one editorial-synthesis section of [test-doubles.md](reference/test-doubles.md)
-- **Mutation-testing literature** (secondary, cross-referenced only): the primary sources on mutation testing — cited in one clearly-labeled editorial note in each of [code-coverage-khorikov.md](reference/code-coverage-khorikov.md) and [four-pillars-khorikov.md](reference/four-pillars-khorikov.md), where a claim of Khorikov's has a measurable partial exception he does not cover. Both notes are marked as outside his text and leave his claim standing. The material itself is owned by `/mutation-testing:principles` when the `mutation-testing` plugin is installed; without it, each note carries its own one-line fallback.
+- **Ousterhout** (secondary, cross-referenced only): John Ousterhout, *A Philosophy of Software Design*, cited in one editorial-synthesis section of [test-doubles.md](reference/test-doubles.md)
+- **Mutation-testing literature** (secondary, cross-referenced only): the primary sources on mutation testing, cited in one clearly-labeled editorial note in each of [code-coverage-khorikov.md](reference/code-coverage-khorikov.md) and [four-pillars-khorikov.md](reference/four-pillars-khorikov.md), where a claim of Khorikov's has a measurable partial exception he does not cover. Both notes are marked as outside his text and leave his claim standing. The material itself is owned by `/mutation-testing:principles` when the `mutation-testing` plugin is installed; without it, each note carries its own one-line fallback.
 
 ## Naming convention
 
-- `{concept}.md` — shared across authors, with attributed sections inside
-- `{concept}-{author}.md` — only one author covers it substantively
+- `{concept}.md` is shared across authors, with attributed sections inside
+- `{concept}-{author}.md` is used when only one author covers it substantively
 
 ## Scope boundary
 
-This skill is **knowledge** (WHY behind testing decisions), not **workflow** (HOW to run tests). For running, filtering, or scaffolding tests, use your project's own test tooling, conventions, and workflow skills — this skill informs the design decisions those workflows execute.
+This skill is **knowledge** (WHY behind testing decisions), not **workflow** (HOW to run tests). For running, filtering, or scaffolding tests, use your project's own test tooling, conventions, and workflow skills. This skill informs the design decisions those workflows execute.


### PR DESCRIPTION
No linked issue

## Summary

#2891 leftover instruction-surface de-slop cluster: rewrite remaining body-prose em dashes in the `tdd` plugin README and every SKILL.md.

Refs #2891

## Fix

Rewrote leftover body-prose em dashes in `plugins/tdd/README.md` and `plugins/tdd/skills/principles/SKILL.md` under `/ai-slop:audit fix` semantics (periods, commas, or a restructured sentence; never parentheses, en dashes, or a spaced hyphen as a stand-in). Meaning-preserving grammar pass after the mechanical replace. Version-only bump in `plugin.json`. New changelog heading only. YAML frontmatter description left unchanged so the cheatsheet and trigger phrases stay valid.

## Verification

- Detector (`HOME` + `CLAUDE_PROJECT_DIR` isolated so `rule-em-dash` is enabled): 0 body-prose `rule-em-dash` findings; 1 leftover in YAML `description` frontmatter, kept so the cheatsheet stays valid
- `CHECK_SKILL_SKIP_MARKDOWNLINT=1 bash scripts/check-changed-skills.sh origin/main`: 0 failed; all 16 quoted trigger phrases vs origin/main preserved
- `python3 scripts/sync-plugin-options-docs.py --check` up to date
- `scripts/check-changelog-parity.sh --check-bump origin/main` passes
- `node scripts/generate-cheatsheet.mjs --check` in sync

## Related

Refs #2891

#2891 stays open.