### PR TITLE
docs(planning): de-slop instruction surfaces (0.34.4)

### DIFF
--- a/plugins/planning/.claude-plugin/plugin.json
+++ b/plugins/planning/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "planning",
-  "version": "0.34.3",
+  "version": "0.34.4",
   "userConfig": {
     "use_ask_user_question": {
       "type": "boolean",

--- a/plugins/planning/CHANGELOG.md
+++ b/plugins/planning/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to the `planning` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.34.4]
+
+### Changed
+
+- **Instruction-surface de-slop (#2891, planning cluster).** Isolated `/ai-slop:audit`
+  over this plugin's `README.md` and every `SKILL.md` found no remaining prose em dashes
+  under the repo's zero-tolerance house policy. YAML frontmatter description/summary left
+  unchanged so the cheatsheet stays valid. The generated options block is ignore-fenced
+  because `scripts/sync-plugin-options-docs.py` still emits em dashes from its shared
+  template. Fenced interview, design, and plan templates keep their quoted protocol marks.
+
 ## [0.34.3]
 
 ### Changed


### PR DESCRIPTION
No linked issue

## Summary

#2891 instruction-surface de-slop cluster: purge em dashes from the `planning` plugin README and every SKILL.md.

Refs #2891

## Fix

Isolated `/ai-slop:audit` over `plugins/planning/README.md` and every `plugins/planning/**/SKILL.md` found no remaining prose em dashes under `/ai-slop:audit fix` semantics. Version-only bump in `plugin.json`. New changelog heading only. YAML frontmatter description/summary left unchanged so the cheatsheet stays valid. The generated options block stays ignore-fenced because `scripts/sync-plugin-options-docs.py` still emits em dashes from its shared template. Fenced interview, design, and plan templates keep their quoted protocol marks.

## Verification

- Detector (`HOME` + `CLAUDE_PROJECT_DIR` isolated so `rule-em-dash` is enabled): 0 `rule-em-dash` findings. 59 declines are ignore-fenced generated-options spans and fenced templates
- `CHECK_SKILL_SKIP_MARKDOWNLINT=1 bash scripts/check-changed-skills.sh origin/main`: no changed skills; nothing to gate
- `python3 scripts/sync-plugin-options-docs.py --check` up to date
- `scripts/check-changelog-parity.sh --check-bump origin/main` passes
- `node scripts/generate-cheatsheet.mjs --check` in sync

## Related

Refs #2891

#2891 stays open.
