### PR TITLE
docs(wizard): de-slop instruction surfaces (0.2.2)

### DIFF
--- a/plugins/wizard/.claude-plugin/plugin.json
+++ b/plugins/wizard/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "wizard",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Generate an interactive bash wizard that walks a human, step by step, through the manual procedures an agent cannot perform — provisioning infrastructure or credentials, setting CI secrets, clicking through third-party dashboards, one-off migrations and cutovers. One skill, generate (/wizard:generate): the agent scopes the stages from the repo (reading key NAMES only from a live .env, never values), authors them onto a fixed hardened library (TTY-only fail-closed prompts, https-only URL opening, hidden secret entry, single-quoted 0600 .env upserts with a gitignore check, repo-confirmed gh secret/variable writes over stdin, names-only summary), prints the full STAGES block for explicit human approval BEFORE the script is made executable, and never runs the wizard itself — the human does, in their own terminal. Ephemeral by default: built for one run, committed only when the setup path should live in the repo. The generated script requires bash (Windows: Git Bash or WSL); gh is optional — CI-secret stages degrade to a visible warning plus a closing-summary entry when it is absent.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/wizard/CHANGELOG.md
+++ b/plugins/wizard/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to the `wizard` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.2.2]
+
+### Changed
+
+- **Instruction-surface de-slop (#2891, wizard cluster).** Rewrote this plugin's `README.md`
+  and every `SKILL.md` to drop em dashes under the repo's zero-tolerance house policy, using
+  `/ai-slop:audit fix` semantics: periods or commas, or a restructured sentence, never
+  parentheses, en dashes, or a spaced hyphen as a stand-in. Meaning stays; only the mark
+  and the sentence break change. YAML frontmatter description/summary left unchanged so
+  the cheatsheet stays valid. No generated options block.
+
 ## [0.2.1]
 
 ### Added

--- a/plugins/wizard/README.md
+++ b/plugins/wizard/README.md
@@ -1,6 +1,6 @@
 # wizard
 
-A Claude Code plugin that generates **interactive bash wizards** — scripts that
+A Claude Code plugin that generates **interactive bash wizards**, scripts that
 walk a human, step by step, through the manual procedures an agent cannot
 perform: provisioning infrastructure or credentials, setting CI secrets,
 clicking through an unfamiliar third-party dashboard, or sequencing a one-off
@@ -12,8 +12,8 @@ and confirms at every stage.
 |---|---|
 | `/wizard:generate` | Scope the manual procedure from the repo, author its stages onto the fixed hardened template, verify statically, and hand off to the human after explicit approval |
 
-The skill is model-invoked: when the agent hits a step only a human can take —
-a key it can't mint, a dashboard it can't click — it can reach for this instead
+The skill is model-invoked: when the agent hits a step only a human can take,
+a key it can't mint, a dashboard it can't click, it can reach for this instead
 of dumping numbered instructions into the chat. It is fenced the other way too:
 it never fires for steps the agent can perform itself.
 
@@ -45,9 +45,9 @@ it never fires for steps the agent can perform itself.
 
 ## Prerequisites
 
-- **bash** — to run the generated script. On Windows the supported path is Git
+- **bash**, to run the generated script. On Windows the supported path is Git
   Bash or WSL. (Generating a wizard needs nothing beyond the agent itself.)
-- **`gh` (GitHub CLI), optional** — only for stages that write GitHub Actions
+- **`gh` (GitHub CLI), optional**. Only for stages that write GitHub Actions
   secrets or variables. When `gh` is missing or unauthenticated those stages
   warn visibly and land in the closing to-do summary instead of failing the
   run. Wizards whose values live only in `.env` never touch `gh`.
@@ -56,14 +56,14 @@ it never fires for steps the agent can perform itself.
 
 A wizard is built for one run: save it to a scratch or `scripts/` path, run it,
 delete it. Commit it only when it is a repeatable setup path the next person on
-the repo will also need — then link it from the README so they run the script
+the repo will also need. Then link it from the README so they run the script
 instead of re-asking an agent.
 
 ## Setup skill assessment
 
 This plugin ships no `setup` skill, per the philosophy's criteria: it has (a) no
 consumer-project configuration surface, (b) no external prerequisite for its own
-operation — `bash` and `gh` are prerequisites of the *generated artifact's run*,
+operation. `bash` and `gh` are prerequisites of the *generated artifact's run*,
 declared above and at the point of use in the generated script itself, which
-degrades visibly when `gh` is absent — and (c) no `userConfig` at all. Setup
+degrades visibly when `gh` is absent, and (c) no `userConfig` at all. Setup
 would be blanket ceremony with nothing to check or apply.

--- a/plugins/wizard/skills/generate/SKILL.md
+++ b/plugins/wizard/skills/generate/SKILL.md
@@ -14,21 +14,21 @@ opens each URL, says exactly what to click and copy, captures the values, writes
 them where they belong (`.env`, CI secrets), confirms at every stage, and shows
 how many stages are left.
 
-The UX and the security hardening are already solved by [template.sh](template.sh) —
-stage-by-stage progress, fail-closed TTY-only prompts, https-only URL opening
+The UX and the security hardening are already solved by [template.sh](template.sh).
+Stage-by-stage progress, fail-closed TTY-only prompts, https-only URL opening
 (cross-platform incl. WSL and Git Bash), hidden secret entry, quoted `0600`
 `.env` upserts with a gitignore check, repo-confirmed `gh secret`/`gh variable`
 writes over stdin, and a closing names-only summary. **Your job is only to scope
 the procedure and author its stages.** The library above the `STAGES` marker is
-identical in every wizard; that consistency is the point — never hand-edit it.
+identical in every wizard; that consistency is the point. Never hand-edit it.
 
-A wizard is ephemeral by default — built for one run, saved to a scratch or
+A wizard is ephemeral by default. It is built for one run, saved to a scratch or
 `scripts/` path, deleted when the job's done. Commit it only when the user wants
 a repeatable setup path that should live in the repo.
 
 The generated script requires bash; on Windows the supported path is Git Bash or
 WSL. `gh` (authenticated) is needed only by stages that write CI secrets or
-variables — when it's absent those stages warn and land in the closing summary
+variables. When it's absent those stages warn and land in the closing summary
 instead of failing the run.
 
 ## Process
@@ -36,58 +36,58 @@ instead of failing the run.
 ### 1. Scope the procedure
 
 Work out every manual step the human must take and every value that gets
-captured along the way. Read the repo first — don't ask cold:
+captured along the way. Read the repo first. Don't ask cold:
 
 - For setup: read `.env.example`, `README`, `docker-compose*`, framework config,
   and `.github/workflows/*` fully (every `secrets.*` / `vars.*` reference is a
   value the wizard must produce). From a **live** `.env`, take **key names
-  only** — e.g. `grep -oE '^[A-Za-z_][A-Za-z0-9_]*=' .env` — never values.
+  only**, e.g. `grep -oE '^[A-Za-z_][A-Za-z0-9_]*=' .env`. Never values.
 - For a migration or transition: the current state, the target state, and the
   irreversible actions between them.
 
 Be honest about what reaches the model if the user asks: values the wizard
-captures at runtime never reach the model — the human runs the script and it
+captures at runtime never reach the model. The human runs the script and it
 writes captures straight to `.env` or `gh`. Authoring-time reads are names-only
 by the rule above. A value the user pastes into the chat, though, is in context
 like any other pasted text.
 
 Then show the user the ordered list of stages and the values each produces, and
-confirm — they may add, drop, or reorder.
+confirm. They may add, drop, or reorder.
 
 **Done when:** every stage is named in order, and for each captured value you
 know (a) where the human gets it, (b) where it's written (`.env`, a CI secret,
-both, or nowhere — some stages are pure actions), and (c) whether it's secret
+both, or nowhere; some stages are pure actions), and (c) whether it's secret
 (hidden entry) or public.
 
 ### 2. Map each stage's journey
 
 For each stage, write the precise path a human follows: which URL to open, what
-to do there, where a value is shown, which variable it fills — e.g. "Dashboard →
+to do there, where a value is shown, which variable it fills, e.g. "Dashboard →
 Developers → API keys → Reveal test key → copy". Where you don't actually know
-the current UI or the exact command, say so and ask the user or check the docs —
-never invent steps that may not exist.
+the current UI or the exact command, say so and ask the user or check the docs.
+Never invent steps that may not exist.
 
 **Done when:** every stage traces to concrete instructions a stranger could follow.
 
 ### 3. Author the wizard
 
 Copy [template.sh](template.sh) to the target path. Replace the example stage
-with one `stage` per step, in dependency order. Use the library helpers —
+with one `stage` per step, in dependency order. Use the library helpers:
 `stage`, `say`/`step`/`note`/`warn`, `open_url`, `ask`/`ask_secret`,
-`write_env`, `set_secret`/`set_var`, `pause`/`confirm` — and set `TOTAL_STAGES`
+`write_env`, `set_secret`/`set_var`, `pause`/`confirm`. Then set `TOTAL_STAGES`
 to the number of stages you wrote.
 
 Hold the bar the template sets: open the URL (https only) before asking for its
 value, use `ask_secret` for anything secret, `write_env` every persisted value,
 `set_secret` only the values CI actually needs, and `confirm` before any
 irreversible action. Each `stage` clears the screen so only the current step is
-visible — keep a stage to one focused task so nothing the human needs scrolls
+visible. Keep a stage to one focused task so nothing the human needs scrolls
 away. Don't touch the library above the marker.
 
 ### 4. Verify and hand off
 
 1. `bash -n <script>`; run `shellcheck` if available. Fix what they find.
-2. Trace it statically — never run it end-to-end yourself: it opens browsers and
+2. Trace it statically. Never run it end-to-end yourself: it opens browsers and
    blocks on human input, and the agent-never-executes line is the security
    model. Dispatch a fresh-context subagent to do the trace: hand it the script
    and the step-1 value list (artifact only, not your reasoning), and have it
@@ -95,7 +95,7 @@ away. Don't touch the library above the marker.
    <!-- portability-ok: matching set_secret names to CI secrets.* references applies only when the consumer's declared CI-secret destination is GitHub Actions -->
    that every `set_secret`/`set_var` name exactly matches a `secrets.*`/`vars.*`
    reference in CI, and that nothing above the `STAGES` marker was edited.
-3. **Stop the line — human approval gate.** Print the full `STAGES` block
+3. **Stop the line. Human approval gate.** Print the full `STAGES` block
    (everything below the marker) to the user and get their explicit approval.
    Do NOT `chmod +x` the script, and do NOT tell the user to run it, until they
    have read the stages and approved them. This is a hard ordering, not a
@@ -107,12 +107,12 @@ away. Don't touch the library above the marker.
 
 ## Gotchas
 
-- **No back button.** A wrong answer means Ctrl-C and re-run — cheap by design:
+- **No back button.** A wrong answer means Ctrl-C and re-run. Cheap by design:
   values already in `.env` are offered back as defaults, so the human presses
   Enter through the stages they got right.
 - **TTY required.** The script refuses to start without `/dev/tty`, so it will
   not run piped, in CI, or driven by pasted input. That is deliberate.
 - **Arrow keys** work in `ask` prompts (readline) but not in `ask_secret`
-  (hidden entry has no line editing) — backspace works in both.
+  (hidden entry has no line editing). Backspace works in both.
 - **`gh` absence is not an error.** CI-secret stages degrade to a warning plus a
   closing-summary entry telling the human what to set by hand.


### PR DESCRIPTION
No linked issue

## Summary

#2891 instruction-surface de-slop cluster: purge em dashes from the `wizard` plugin README and every SKILL.md.

Refs #2891

## Fix

Rewrote `plugins/wizard/README.md` and every `plugins/wizard/**/SKILL.md` under `/ai-slop:audit fix` semantics (periods, commas, or a restructured sentence; never parentheses, en dashes, or a spaced hyphen as a stand-in). Meaning-preserving grammar pass after the mechanical replace. Version-only bump in `plugin.json`. New changelog heading only. YAML frontmatter description/summary left unchanged so the cheatsheet stays valid. No generated options block.

## Verification

- Detector (`HOME` + `CLAUDE_PROJECT_DIR` isolated so `rule-em-dash` is enabled): 0 `rule-em-dash` findings and 0 declines
- `CHECK_SKILL_SKIP_MARKDOWNLINT=1 bash scripts/check-changed-skills.sh origin/main`: 0 failed; quoted trigger phrases vs origin/main preserved
- `python3 scripts/sync-plugin-options-docs.py --check` up to date
- `scripts/check-changelog-parity.sh --check-bump origin/main` passes
- `node scripts/generate-cheatsheet.mjs --check` in sync

## Related

Refs #2891

#2891 stays open.
