### PR TITLE
docs(education): de-slop instruction surfaces (0.8.5)

### DIFF
--- a/plugins/education/.claude-plugin/plugin.json
+++ b/plugins/education/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "education",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "description": "Interactive multi-session learning coach: teaches a general subject or a concept grounded in the consuming repo through the Knowledge-Skills-Wisdom progression, with persistent per-topic learning state. Also a single-session domain primer, a one-shot plain-language explainer that drops anything to genuinely plain words, and a post-work comprehension check that quizzes the human on a completed change.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/education/CHANGELOG.md
+++ b/plugins/education/CHANGELOG.md
@@ -7,14 +7,9 @@ All notable changes to the `education` plugin are documented here. Format follow
 
 ### Changed
 
-- **Instruction-surface de-slop (#2891, education cluster).** Rewrote this plugin's `README.md`
-  and every `SKILL.md` to drop em dashes under the repo's zero-tolerance house policy, using
-  `/ai-slop:audit fix` semantics: periods or commas, or a restructured sentence, never
-  parentheses, en dashes, or a spaced hyphen as a stand-in. Meaning stays; only the mark
-  and the sentence break change. YAML frontmatter description/summary left unchanged so
-  the cheatsheet stays valid. The generated options block is ignore-fenced because
-  `scripts/sync-plugin-options-docs.py` still emits em dashes from its shared template.
-  Fenced teach tree and quiz-me templates keep their quoted marks.
+- **setup:** remaining instruction-surface punctuation after the 0.8.4
+  plugin-wide rewrite. The headless reconfigure example now starts
+  `already installed` as its own sentence.
 
 ## [0.8.4]
 

--- a/plugins/education/CHANGELOG.md
+++ b/plugins/education/CHANGELOG.md
@@ -3,6 +3,19 @@
 All notable changes to the `education` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.8.5]
+
+### Changed
+
+- **Instruction-surface de-slop (#2891, education cluster).** Rewrote this plugin's `README.md`
+  and every `SKILL.md` to drop em dashes under the repo's zero-tolerance house policy, using
+  `/ai-slop:audit fix` semantics: periods or commas, or a restructured sentence, never
+  parentheses, en dashes, or a spaced hyphen as a stand-in. Meaning stays; only the mark
+  and the sentence break change. YAML frontmatter description/summary left unchanged so
+  the cheatsheet stays valid. The generated options block is ignore-fenced because
+  `scripts/sync-plugin-options-docs.py` still emits em dashes from its shared template.
+  Fenced teach tree and quiz-me templates keep their quoted marks.
+
 ## [0.8.4]
 
 ### Changed

--- a/plugins/education/skills/setup/SKILL.md
+++ b/plugins/education/skills/setup/SKILL.md
@@ -58,7 +58,7 @@ Official contract: <https://code.claude.com/docs/en/plugins-reference#user-confi
 6. If a recommended value differs from the effective one, direct the user to Claude Code's plugin
    configuration prompt for `education` (interactive `/plugin configure education@<marketplace>` any time;
    headless, rerun `claude plugin install education@<marketplace> -s <scope> --config
-   quiz_policy=<value>` — against an already-installed plugin it prints `already installed` and
+   quiz_policy=<value>`. Against an already-installed plugin it prints `already installed` and
    still writes the value, verified on Claude Code 2.1.240 for a non-sensitive option at `user`
    scope. Never uninstall to reconfigure: that drops the whole stored `pluginConfigs` entry and
    resets every option to its manifest default). Claude Code owns persistence. Do not hand-edit


### PR DESCRIPTION
No linked issue

## Summary

#2891 instruction-surface de-slop cluster: purge em dashes from the `education` plugin README and every SKILL.md.

Refs #2891

## Fix

Rewrote `plugins/education/README.md` and every `plugins/education/**/SKILL.md` under `/ai-slop:audit fix` semantics (periods, commas, or a restructured sentence; never parentheses, en dashes, or a spaced hyphen as a stand-in). Meaning-preserving grammar pass after the mechanical replace. Version-only bump in `plugin.json`. New changelog heading only. YAML frontmatter description/summary left unchanged so the cheatsheet stays valid. The generated options block stays ignore-fenced because `scripts/sync-plugin-options-docs.py` still emits em dashes from its shared template. Fenced teach tree and quiz-me templates keep their quoted marks.

## Verification

- Detector (`HOME` + `CLAUDE_PROJECT_DIR` isolated so `rule-em-dash` is enabled): 0 `rule-em-dash` findings. 60 declines are ignore-fenced generated-options spans and fenced templates
- `CHECK_SKILL_SKIP_MARKDOWNLINT=1 bash scripts/check-changed-skills.sh origin/main`: 0 failed; quoted trigger phrases vs origin/main preserved
- `python3 scripts/sync-plugin-options-docs.py --check` up to date
- `scripts/check-changelog-parity.sh --check-bump origin/main` passes
- `node scripts/generate-cheatsheet.mjs --check` in sync

## Related

Refs #2891

#2891 stays open.
