### PR TITLE
docs(knowledge): de-slop instruction surfaces (0.13.9)

### DIFF
--- a/plugins/knowledge/.claude-plugin/plugin.json
+++ b/plugins/knowledge/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "knowledge",
-  "version": "0.13.8",
+  "version": "0.13.9",
   "description": "Ingest external knowledge into durable, synthesized artifacts. Ships a book-distillation pipeline (PDF/EPUB into concept-organized, author-attributed skill reference files), a video-digest pipeline (watch a single public video from YouTube or X, formerly Twitter: transcript, link harvest, and repo-applicability synthesis), a course-digest pipeline (extract and synthesize online video courses — Dometrain, Teachable — into repo-applicable recommendations), a docpage-digest pipeline (single online documentation page into a verified knowledge slice with dual verification — one cross-vendor verifier — and an interview handoff), and a map-corpus pipeline (multi-resource corpus into a classified link map, deterministic node manifests, gate-verified relevance inventory, and an approved queue of docpage-digest runs), plus a re-runnable setup action; a configurable library directory governs where synthesized artifacts land in the consuming repo.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/knowledge/CHANGELOG.md
+++ b/plugins/knowledge/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to the `knowledge` plugin are recorded here. The `version` i
 `.claude-plugin/plugin.json` is the delivery vehicle — a consumer receives a change
 only after that version increases.
 
+## [0.13.9]
+
+### Changed
+
+- **Instruction-surface de-slop (#2891, knowledge cluster).** Rewrote this plugin's `README.md`
+  and every `SKILL.md` to drop em dashes under the repo's zero-tolerance house policy, using
+  `/ai-slop:audit fix` semantics: periods or commas, or a restructured sentence, never
+  parentheses, en dashes, or a spaced hyphen as a stand-in. Meaning stays; only the mark
+  and the sentence break change. YAML frontmatter description/summary left unchanged so
+  the cheatsheet stays valid. The generated options block is ignore-fenced because
+  `scripts/sync-plugin-options-docs.py` still emits em dashes from its shared template.
+  Precomputed probe echoes and fenced course-digest templates keep their quoted marks.
+
 ## [0.13.8]
 
 ### Fixed

--- a/plugins/knowledge/CHANGELOG.md
+++ b/plugins/knowledge/CHANGELOG.md
@@ -8,14 +8,9 @@ only after that version increases.
 
 ### Changed
 
-- **Instruction-surface de-slop (#2891, knowledge cluster).** Rewrote this plugin's `README.md`
-  and every `SKILL.md` to drop em dashes under the repo's zero-tolerance house policy, using
-  `/ai-slop:audit fix` semantics: periods or commas, or a restructured sentence, never
-  parentheses, en dashes, or a spaced hyphen as a stand-in. Meaning stays; only the mark
-  and the sentence break change. YAML frontmatter description/summary left unchanged so
-  the cheatsheet stays valid. The generated options block is ignore-fenced because
-  `scripts/sync-plugin-options-docs.py` still emits em dashes from its shared template.
-  Precomputed probe echoes and fenced course-digest templates keep their quoted marks.
+- **setup:** remaining instruction-surface punctuation after the 0.13.8
+  plugin-wide rewrite. The OS-level media-tools probe now comma-separates
+  frame extraction from watch/course actions.
 
 ## [0.13.8]
 

--- a/plugins/knowledge/skills/setup/SKILL.md
+++ b/plugins/knowledge/skills/setup/SKILL.md
@@ -49,7 +49,7 @@ config, or install anything.
    or `chromium_headless_shell-*` build (course-digest frame capture). Missing is INFO with
    remediation `apply install-deps`.
 4. **OS-level media tools**. INFO. Probe `yt-dlp --version` (youtube acquisition), `ffmpeg
-   -version` (frame extraction — watch/course actions), and `magick -version` (ImageMagick 7,
+   -version` (frame extraction, watch/course actions), and `magick -version` (ImageMagick 7,
    contact sheets. Watch/course actions). Each absence is INFO with the platform install command
    from the ingest skill's Prerequisites; this skill never installs system packages. `book-distill`
    (PDF) needs none of these.


### PR DESCRIPTION
No linked issue

## Summary

#2891 instruction-surface de-slop cluster: purge em dashes from the `knowledge` plugin README and every SKILL.md.

Refs #2891

## Fix

Rewrote `plugins/knowledge/README.md` and every `plugins/knowledge/**/SKILL.md` under `/ai-slop:audit fix` semantics (periods, commas, or a restructured sentence; never parentheses, en dashes, or a spaced hyphen as a stand-in). Meaning-preserving grammar pass after the mechanical replace. Version-only bump in `plugin.json`. New changelog heading only. YAML frontmatter description/summary left unchanged so the cheatsheet stays valid. The generated options block stays ignore-fenced because `scripts/sync-plugin-options-docs.py` still emits em dashes from its shared template. Precomputed probe echoes and fenced course-digest templates keep their quoted marks.

## Verification

- Detector (`HOME` + `CLAUDE_PROJECT_DIR` isolated so `rule-em-dash` is enabled): 0 `rule-em-dash` findings. 62 declines are ignore-fenced generated-options spans, inline-code probe echoes, and fenced templates
- `CHECK_SKILL_SKIP_MARKDOWNLINT=1 bash scripts/check-changed-skills.sh origin/main`: 0 failed; quoted trigger phrases vs origin/main preserved
- `python3 scripts/sync-plugin-options-docs.py --check` up to date
- `scripts/check-changelog-parity.sh --check-bump origin/main` passes
- `node scripts/generate-cheatsheet.mjs --check` in sync

## Related

Refs #2891

#2891 stays open.
