### PR TITLE
docs(domain-driven-design): de-slop instruction surfaces (0.3.1)

### DIFF
--- a/plugins/domain-driven-design/.claude-plugin/plugin.json
+++ b/plugins/domain-driven-design/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "domain-driven-design",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Domain-driven-design practice skills. Today: actively maintains a consuming project's ubiquitous-language glossary — resolves ambiguous or overloaded terms, records canonical language and rejected synonyms, sharpens what-it-IS definitions, and routes entries to already-known bounded contexts without discovering boundaries.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/domain-driven-design/CHANGELOG.md
+++ b/plugins/domain-driven-design/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to the `domain-driven-design` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.3.1]
+
+### Changed
+
+- **Instruction-surface punctuation.** Replaced em dashes in the plugin README
+  with periods. YAML frontmatter and the `plugin.json` description are
+  unchanged. No behavior change.
+
 ## [0.3.0]
 
 ### Removed

--- a/plugins/domain-driven-design/README.md
+++ b/plugins/domain-driven-design/README.md
@@ -1,16 +1,17 @@
 # domain-driven-design
 
-A Claude Code plugin owning **DDD practice skills** — the stewardship disciplines of
-domain-driven design, independent of any one planning or workshop workflow.
+A Claude Code plugin owning **DDD practice skills**. It holds the stewardship
+disciplines of domain-driven design, independent of any one planning or workshop
+workflow.
 
 | Skill | What it does |
 |---|---|
-| `/domain-driven-design:curate-language` | Actively maintains the consuming project's ubiquitous-language glossary: resolves ambiguous or overloaded terms, records canonical language and rejected synonyms, and routes entries to already-known bounded contexts — never discovering boundaries itself. |
+| `/domain-driven-design:curate-language` | Actively maintains the consuming project's ubiquitous-language glossary: resolves ambiguous or overloaded terms, records canonical language and rejected synonyms, and routes entries to already-known bounded contexts. It never discovers boundaries itself. |
 
 Deferred: `context-mapping` and `aggregate-design` join this plugin when those
 practices materialize as skills.
 
-Bounded-context **discovery** is out of scope here — workshop-driven discovery lives in
+Bounded-context **discovery** is out of scope here. Workshop-driven discovery lives in
 the standalone `event-storming` plugin, which `curate-language` soft-routes to when
 boundaries are missing.
 
@@ -18,7 +19,7 @@ boundaries are missing.
 
 - **Reads your conventions, assumes none.** Glossary filename, location, shape, and
   context map come from the consuming project; where none exist, creation is lazy and
-  discovery-first — never a prescribed universal filename.
+  discovery-first. It never prescribes a universal filename.
 - **No `userConfig`, no persistent state, no network.**
 
 ## Install


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
No linked issue

## Summary

#2891 instruction-surface de-slop shard: purge em dashes from the `domain-driven-design` plugin README.

Refs #2891

## Fix

Rewrote `plugins/domain-driven-design/README.md` under `/ai-slop:audit fix` semantics (periods; never parentheses, en dashes, or a spaced hyphen as a stand-in). YAML frontmatter `summary` and the `plugin.json` description left unchanged so the cheatsheet stays valid. Version-only bump in `plugin.json`. New changelog heading only. `SKILL.md` body was already clean.

## Verification

- Isolated detector (`HOME` + `CLAUDE_PROJECT_DIR` empty so `rule-em-dash` is enabled): README has 0 `rule-em-dash` findings. One remaining finding is the YAML `summary` leftover, deferred to the later frontmatter + cheat-sheet pass.
- `scripts/check-changed-skills.sh origin/main`: no changed skills (README-only).
- `python3 scripts/sync-plugin-options-docs.py --check` up to date
- `scripts/check-changelog-parity.sh --check-bump origin/main` passes
- `node scripts/generate-cheatsheet.mjs --check` in sync

## Related

Refs #2891

#2891 stays open.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-363de5b1-6044-4e78-99f7-867a293bcfcf?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-363de5b1-6044-4e78-99f7-867a293bcfcf&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

