### PR TITLE
fix(ai-slop): strip the carriage return the Windows build of jq puts on every config read

### DIFF
--- a/plugins/ai-slop/.claude-plugin/plugin.json
+++ b/plugins/ai-slop/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "ai-slop",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Detects and removes AI-writing tells (slop) in checked-in markdown prose: em dashes, emoji formatting, AI vocabulary, negative parallelisms, chatbot phrases, filler, stacked hedging, citation artifacts, and the rest of a catalog distilled from Wikipedia's Signs of AI writing. Read-only audit by default with a deterministic detector plus a judgment rubric; an explicit fix action rewrites findings behind a semantic-diff guard. Findings conform to the detector-findings convention so the review fanout fix relay can consume them.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/ai-slop/CHANGELOG.md
+++ b/plugins/ai-slop/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## [0.4.1]
+
+- **Every configured array stopped applying under the Windows build of jq
+  (#3343).** `cfg_array` piped `jq -r` through `tr '\n' ' '`, which converts the
+  line feed and leaves the carriage return of a CRLF attached to the element, so
+  `excluded_paths`, `em_dash_allowed_paths` and `disabled_rules` arrived as
+  `plugins/*/skills/*/vendor/**<CR>` and matched nothing. The exclusion was not
+  reported as failing; it simply never fired, and the detector reported findings
+  on files the consuming repo had deliberately placed out of scope. The CR
+  originates in the detector's own jq invocation, so no caller could normalize
+  it away from the config it supplies. Every config reader now strips it. Two
+  more carried the same defect from the same source: `rule_allowed_paths`, the
+  per-rule exemption added in 0.4.0, reads jq through `read`, which splits on
+  the line feed, so the CR landed on the last glob of every entry and that key
+  never applied on Windows either; and `cfg_scalar`, which Git Bash masks —
+  its command substitution strips one trailing CRLF pair — but which on a bash
+  that strips only the line feed carries the CR into the emitted threshold text,
+  in `--show-config` and in the density finding's label. CI cannot observe any
+  of these conditions, because it runs on Linux, where jq emits LF, so the new
+  cases force them with a shim ahead of jq on PATH that appends a CR to every
+  output line, and a further assertion pins the shim itself so a runner that
+  failed to select it fails loudly instead of reporting vacuous passes. The
+  array and `rule_allowed_paths` cases reproduce on both platforms; the scalar
+  case discriminates on Linux only, and says so where it sits.
+
 ## [0.4.0]
 
 Shaped by the first full repo-wide `fix` dogfood (PR 3359: 82 findings, 45 files, ~40 closed

--- a/plugins/ai-slop/CHANGELOG.md
+++ b/plugins/ai-slop/CHANGELOG.md
@@ -14,7 +14,9 @@
   more carried the same defect from the same source: `rule_allowed_paths`, the
   per-rule exemption added in 0.4.0, reads jq through `read`, which splits on
   the line feed, so the CR landed on the last glob of every entry and that key
-  never applied on Windows either; and `cfg_scalar`, which Git Bash masks —
+  never applied on Windows either — this suite's own `rule_allowed_paths` cases
+  already fail on a Windows workstation against the released 0.4.0, with no shim
+  involved, and go green here; and `cfg_scalar`, which Git Bash masks —
   its command substitution strips one trailing CRLF pair — but which on a bash
   that strips only the line feed carries the CR into the emitted threshold text,
   in `--show-config` and in the density finding's label. CI cannot observe any
@@ -24,6 +26,12 @@
   failed to select it fails loudly instead of reporting vacuous passes. The
   array and `rule_allowed_paths` cases reproduce on both platforms; the scalar
   case discriminates on Linux only, and says so where it sits.
+  The strip is applied to `cfg_scalar`'s captured value rather than inside its
+  command substitution, so jq's exit status still reaches the guard that reads
+  it: a layer that parses to a value and then meets malformed trailing bytes
+  emits that value while exiting nonzero, and a pipeline would have handed the
+  guard `tr`'s unconditional success and let the half-read layer set the
+  threshold.
 
 ## [0.4.0]
 

--- a/plugins/ai-slop/skills/audit/scripts/detect.sh
+++ b/plugins/ai-slop/skills/audit/scripts/detect.sh
@@ -188,11 +188,29 @@ DISABLED_RULES=""
 # silences exactly one rule on exactly the named paths.
 declare -A RULE_ALLOWED_GLOBS
 
+# Every reader below strips carriage returns from jq's output, because the
+# Windows build of jq terminates its lines with CRLF (#3343). `cfg_array`
+# translates the line feed to a space, which leaves the CR attached to the
+# element itself: every configured glob and rule slug arrived as
+# `plugins/*/skills/*/vendor/**<CR>`, matched nothing, and `excluded_paths`,
+# `em_dash_allowed_paths` and `disabled_rules` silently stopped applying on a
+# Windows workstation while CI, which runs on Linux and sees LF, agreed with the
+# config. `cfg_scalar` reads the same CRLF but is masked under Git Bash, whose
+# command substitution strips one trailing CRLF pair; a bash that strips only
+# the line feed carries the CR into the emitted threshold text, in
+# `--show-config` and in the density finding's label. (gawk and mawk both read a
+# CR-suffixed threshold as a strnum, so the numeric comparison itself was
+# measured unaffected on the awks CI and Git Bash use; BusyBox awk is where it
+# would diverge.) The `rule_allowed_paths` reader below has the same exposure
+# through `read`. The CR originates in the detector's own jq invocation, so no
+# caller can normalize it away from the config file it supplies — it is
+# stripped here.
+
 # cfg_scalar <jq-path>: last layer that defines the key wins (per-key override).
 cfg_scalar() {
   local path="$1" layer v out=""
   for layer in ${CFG_LAYERS[@]+"${CFG_LAYERS[@]}"}; do
-    v="$(jq -r "$path // empty" "$layer" 2>/dev/null)" && [[ -n "$v" ]] && out="$v"
+    v="$(jq -r "$path // empty" "$layer" 2>/dev/null | tr -d '\r')" && [[ -n "$v" ]] && out="$v"
   done
   printf '%s' "$out"
 }
@@ -200,7 +218,7 @@ cfg_scalar() {
 cfg_array() {
   local path="$1" layer v out=""
   for layer in ${CFG_LAYERS[@]+"${CFG_LAYERS[@]}"}; do
-    v="$(jq -r "($path // empty) | .[]" "$layer" 2>/dev/null | tr '\n' ' ')"
+    v="$(jq -r "($path // empty) | .[]" "$layer" 2>/dev/null | tr -d '\r' | tr '\n' ' ')"
     [[ -n "${v// /}" ]] && out="$v"
   done
   printf '%s' "$out"
@@ -218,10 +236,14 @@ if [[ "$HAVE_JQ" -eq 1 && "${#CFG_LAYERS[@]}" -gt 0 ]]; then
   read -r -a EM_DASH_ALLOWED_GLOBS <<<"$(cfg_array '.em_dash_allowed_paths')"
   DISABLED_RULES="$(cfg_array '.disabled_rules')"
   # rule_allowed_paths: object of slug -> glob array; later layer wins per slug.
+  # tr -d '\r' for the same reason as the two readers above, reached differently:
+  # `read` splits on the line feed, so a CRLF leaves the CR on the last glob of
+  # every entry. @tsv escapes a CR inside a value as the two characters \ and r,
+  # so the only raw CR byte here is jq's own line terminator.
   for layer in "${CFG_LAYERS[@]}"; do
     while IFS=$'\t' read -r slug globs; do
       [[ -n "$slug" && -n "${globs// /}" ]] && RULE_ALLOWED_GLOBS[$slug]="$globs"
-    done < <(jq -r '(.rule_allowed_paths // {}) | to_entries[] | [.key, (.value | join(" "))] | @tsv' "$layer" 2>/dev/null)
+    done < <(jq -r '(.rule_allowed_paths // {}) | to_entries[] | [.key, (.value | join(" "))] | @tsv' "$layer" 2>/dev/null | tr -d '\r')
   done
   add="$(cfg_array '.vocab_add')"
   remove="$(cfg_array '.vocab_remove')"

--- a/plugins/ai-slop/skills/audit/scripts/detect.sh
+++ b/plugins/ai-slop/skills/audit/scripts/detect.sh
@@ -210,7 +210,13 @@ declare -A RULE_ALLOWED_GLOBS
 cfg_scalar() {
   local path="$1" layer v out=""
   for layer in ${CFG_LAYERS[@]+"${CFG_LAYERS[@]}"}; do
-    v="$(jq -r "$path // empty" "$layer" 2>/dev/null | tr -d '\r')" && [[ -n "$v" ]] && out="$v"
+    # Capture, then strip: a `| tr -d '\r'` inside the substitution would hand
+    # this guard tr's exit status instead of jq's, and a layer that parses to a value
+    # and then meets malformed trailing bytes emits that value while exiting nonzero.
+    # That partial read must not become the effective setting.
+    v="$(jq -r "$path // empty" "$layer" 2>/dev/null)" || continue
+    v="${v//$'\r'/}"
+    [[ -n "$v" ]] && out="$v"
   done
   printf '%s' "$out"
 }

--- a/plugins/ai-slop/skills/audit/scripts/detect.test.sh
+++ b/plugins/ai-slop/skills/audit/scripts/detect.test.sh
@@ -401,6 +401,81 @@ assert_contains "show-config: names the supplying layer" "$out" "$cfgdir/ai-slop
 assert_contains "show-config: effective threshold shown" "$out" "threshold_ai_vocabulary=999"
 assert_contains "show-config: disabled rules shown" "$out" "disabled_rules=rule-significance-inflation"
 
+# --- Config parsing against a CRLF-emitting jq (#3343) ---------------------------
+
+# The Windows build of jq terminates output lines with CRLF. `cfg_array` piped
+# that through `tr '\n' ' '`, which converts only the line feed, so every array
+# element arrived carrying a trailing carriage return and matched nothing:
+# `excluded_paths`, `em_dash_allowed_paths` and `disabled_rules` silently stopped
+# applying on a Windows workstation while CI, which runs on Linux and sees LF,
+# agreed with the config. `cfg_scalar` carries the identical defect from the
+# identical invocation, so its thresholds reach awk and the finding label with a
+# CR attached. CI cannot observe either condition, so the condition is forced
+# here: a shim ahead of the real jq on PATH appends a CR to every output line.
+# The array cases below reproduce on both platforms; the scalar case at the end
+# discriminates on Linux only, for the reason recorded there.
+CRLF_BIN="$TEST_TMPDIR/bin-crlf-jq"
+mkdir -p "$CRLF_BIN"
+REAL_JQ="$(command -v jq)"
+cat >"$CRLF_BIN/jq" <<EOF
+#!/usr/bin/env bash
+# pipefail so a jq failure stays a failure: awk's exit status would otherwise
+# mask it and change the meaning of cfg_scalar's \`v="\$(jq ...)" &&\` guard.
+set -o pipefail
+"$REAL_JQ" "\$@" | awk '{ printf "%s\r\n", \$0 }'
+EOF
+chmod +x "$CRLF_BIN/jq"
+
+# Pin the shim itself. Without this the four cases below are green on a Linux
+# runner whether or not the shim is ever selected — an unset exec bit or a
+# PATH-resolution surprise would leave the regression gate decorative, and no
+# Windows workstation can observe that, because its own jq already emits CRLF.
+shim_out="$(PATH="$CRLF_BIN:$PATH" jq -rn '"x"' | od -c)"
+assert_contains "crlf jq: the shim is on PATH and emits a carriage return" "$shim_out" '\r'
+
+crlfdir="$TEST_TMPDIR/crlf-repo/.claude"
+mkdir -p "$crlfdir"
+cp "$SLOP" "$TEST_TMPDIR/crlf-repo/allowed.md"
+cp "$SLOP" "$TEST_TMPDIR/crlf-repo/vendored.md"
+cat >"$crlfdir/ai-slop.json" <<'EOF'
+{
+  "excluded_paths": ["vendored.md"],
+  "em_dash_allowed_paths": ["allowed.md"],
+  "thresholds": { "ai_vocabulary": 999, "copulative_avoidance": 999 },
+  "disabled_rules": ["rule-significance-inflation"]
+}
+EOF
+
+out="$(cd "$TEST_TMPDIR/crlf-repo" && PATH="$CRLF_BIN:$PATH" CLAUDE_PROJECT_DIR="$TEST_TMPDIR/crlf-repo" \
+  bash "$DETECT" "$TEST_TMPDIR/crlf-repo/vendored.md" 2>&1)"
+assert_contains "crlf jq: excluded_paths still declines the file" "$out" "Declined: file=vendored.md cause=excluded-glob"
+
+out="$(cd "$TEST_TMPDIR/crlf-repo" && PATH="$CRLF_BIN:$PATH" CLAUDE_PROJECT_DIR="$TEST_TMPDIR/crlf-repo" \
+  bash "$DETECT" "$TEST_TMPDIR/crlf-repo/allowed.md" 2>&1)"
+assert_not_contains "crlf jq: em_dash_allowed_paths still exempts the document" "$out" "Finding: rule=ai-slop/audit/rule-em-dash"
+# Positive pin alongside the absence check: on its own, `assert_not_contains`
+# would also be satisfied by an accidental whole-file exclusion.
+assert_contains "crlf jq: the em-dash exemption is a decline, not a dropped file" "$out" "rule=ai-slop/audit/rule-em-dash findings=0 declined=1 disabled=0"
+assert_contains "crlf jq: disabled_rules still applies" "$out" "rule=ai-slop/audit/rule-significance-inflation findings=0 declined=0 disabled=1"
+
+# rule_allowed_paths reads jq through `read`, not through cfg_array, so the CR
+# lands on the LAST glob of each entry rather than on every element. Its own
+# fixture is reused under the shim.
+out="$(PATH="$CRLF_BIN:$PATH" CLAUDE_PROJECT_DIR="$RAP" bash "$DETECT" "$RAP/quirks/doc.md" "$RAP/plain.md" 2>&1)"
+assert_not_contains "crlf jq: rule_allowed_paths still declines the listed path" "$out" "file=quirks/doc.md"
+assert_contains "crlf jq: rule_allowed_paths decline still counted" "$out" "rule=ai-slop/audit/rule-filler-phrases findings=1 declined=1"
+
+# Anchored on the text that FOLLOWS the value: a bare `=999` substring match
+# passes against `999\r` and would not discriminate.
+#
+# This case discriminates on Linux ONLY. Under Git Bash the unfixed reader never
+# emitted the CR to begin with — MSYS command substitution strips one trailing
+# CRLF pair, and cfg_scalar reads a single line — so the case is green either way
+# on a Windows workstation. It is the array cases above that carry the Windows
+# reproduction; this one is here for the runner.
+out="$(PATH="$CRLF_BIN:$PATH" CLAUDE_PROJECT_DIR="$TEST_TMPDIR/crlf-repo" bash "$DETECT" --show-config 2>&1)"
+assert_contains "crlf jq: scalar threshold parses without the carriage return" "$out" "threshold_ai_vocabulary=999 (rule"
+
 # --- Portability -----------------------------------------------------------------
 
 a="$(bash "$DETECT" "$ALLRULES" 2>&1)"

--- a/plugins/ai-slop/skills/audit/scripts/detect.test.sh
+++ b/plugins/ai-slop/skills/audit/scripts/detect.test.sh
@@ -319,6 +319,9 @@ assert_contains "cutoff families: all five source-gap lines fire" "$out" "rule=a
 
 # rule_allowed_paths: the generalized per-rule exemption (em_dash_allowed_paths
 # stays as the rule-em-dash alias, asserted in the config cascade section).
+# $RAP and this fixture are consumed again by the CRLF-jq section below; moving
+# or deleting this block aborts the suite there under `set -u` rather than
+# quietly vacating those cases.
 RAP="$TEST_TMPDIR/rap-repo"
 mkdir -p "$RAP/.claude"
 cat >"$RAP/.claude/ai-slop.json" <<'EOF'
@@ -403,17 +406,22 @@ assert_contains "show-config: disabled rules shown" "$out" "disabled_rules=rule-
 
 # --- Config parsing against a CRLF-emitting jq (#3343) ---------------------------
 
-# The Windows build of jq terminates output lines with CRLF. `cfg_array` piped
-# that through `tr '\n' ' '`, which converts only the line feed, so every array
-# element arrived carrying a trailing carriage return and matched nothing:
-# `excluded_paths`, `em_dash_allowed_paths` and `disabled_rules` silently stopped
-# applying on a Windows workstation while CI, which runs on Linux and sees LF,
-# agreed with the config. `cfg_scalar` carries the identical defect from the
-# identical invocation, so its thresholds reach awk and the finding label with a
-# CR attached. CI cannot observe either condition, so the condition is forced
-# here: a shim ahead of the real jq on PATH appends a CR to every output line.
-# The array cases below reproduce on both platforms; the scalar case at the end
-# discriminates on Linux only, for the reason recorded there.
+# The Windows build of jq terminates output lines with CRLF, and all three
+# config readers took it. `cfg_array` piped jq through `tr '\n' ' '`, which
+# converts only the line feed, so every array element arrived carrying a
+# trailing carriage return and matched nothing: `excluded_paths`,
+# `em_dash_allowed_paths` and `disabled_rules` silently stopped applying on a
+# Windows workstation while CI, which runs on Linux and sees LF, agreed with the
+# config. `rule_allowed_paths` reads jq through `read`, which splits on the line
+# feed, so the CR landed on the last glob of every entry. `cfg_scalar` carries
+# the CR into the emitted threshold text — `--show-config` and the density
+# finding's label — but not into the comparison: gawk and mawk both read a
+# CR-suffixed threshold as a strnum and compare numerically, so only BusyBox awk
+# would diverge there. CI cannot observe any of the three, so the condition is
+# forced here: a shim ahead of the real jq on PATH appends a CR to every output
+# line. The array and `rule_allowed_paths` cases reproduce on both platforms;
+# the scalar case at the end discriminates on Linux only, for the reason
+# recorded there.
 CRLF_BIN="$TEST_TMPDIR/bin-crlf-jq"
 mkdir -p "$CRLF_BIN"
 REAL_JQ="$(command -v jq)"
@@ -426,7 +434,7 @@ set -o pipefail
 EOF
 chmod +x "$CRLF_BIN/jq"
 
-# Pin the shim itself. Without this the four cases below are green on a Linux
+# Pin the shim itself. Without this every case below is green on a Linux
 # runner whether or not the shim is ever selected — an unset exec bit or a
 # PATH-resolution surprise would leave the regression gate decorative, and no
 # Windows workstation can observe that, because its own jq already emits CRLF.
@@ -475,6 +483,35 @@ assert_contains "crlf jq: rule_allowed_paths decline still counted" "$out" "rule
 # reproduction; this one is here for the runner.
 out="$(PATH="$CRLF_BIN:$PATH" CLAUDE_PROJECT_DIR="$TEST_TMPDIR/crlf-repo" bash "$DETECT" --show-config 2>&1)"
 assert_contains "crlf jq: scalar threshold parses without the carriage return" "$out" "threshold_ai_vocabulary=999 (rule"
+
+# The CR strip must not swallow jq's verdict on the layer. jq emits the values it
+# parsed before it meets malformed bytes and then exits nonzero; cfg_scalar's guard
+# reads that status, so a `| tr -d` inside the substitution would replace it with
+# tr's unconditional success and let a half-read layer set the threshold. The
+# fixture is a valid object followed by a truncated one, which is what a config
+# file caught mid-write looks like.
+truncdir="$TEST_TMPDIR/trunc-repo/.claude"
+mkdir -p "$truncdir"
+printf '%s
+' '{ "thresholds": { "ai_vocabulary": 999 } }' '{bad' >"$truncdir/ai-slop.json"
+
+out="$(CLAUDE_PROJECT_DIR="$TEST_TMPDIR/trunc-repo" bash "$DETECT" --show-config 2>&1)"
+assert_contains "malformed layer: the partially parsed threshold is refused" "$out" "threshold_ai_vocabulary=3.0 (rule"
+
+# Same fixture under the CRLF shim: the strip and the status check have to hold at
+# once, which is the combination the pipeline lost.
+out="$(PATH="$CRLF_BIN:$PATH" CLAUDE_PROJECT_DIR="$TEST_TMPDIR/trunc-repo" bash "$DETECT" --show-config 2>&1)"
+assert_contains "malformed layer: refused under a CRLF-emitting jq too" "$out" "threshold_ai_vocabulary=3.0 (rule"
+
+# Pin the fixture's premise: a well-formed layer carrying the same value is still
+# honoured, so the two cases above are discriminating on the malformation and not
+# on the key going unread for some unrelated reason.
+okdir="$TEST_TMPDIR/trunc-ok-repo/.claude"
+mkdir -p "$okdir"
+printf '%s
+' '{ "thresholds": { "ai_vocabulary": 999 } }' >"$okdir/ai-slop.json"
+out="$(CLAUDE_PROJECT_DIR="$TEST_TMPDIR/trunc-ok-repo" bash "$DETECT" --show-config 2>&1)"
+assert_contains "malformed layer: the same value from a well-formed layer still applies" "$out" "threshold_ai_vocabulary=999 (rule"
 
 # --- Portability -----------------------------------------------------------------
 


### PR DESCRIPTION
Closes #3343

## Summary

The ai-slop detector's config readers passed jq's output through without stripping the carriage return the Windows build of jq puts on every line, so configured arrays matched nothing and every exclusion silently stopped applying on a Windows workstation. CI never saw it: it runs on Linux, where jq emits LF.

The issue scoped the fix to `cfg_array`. Two more readers carry the same defect from the same source and are fixed here as well; both are named below rather than left for a reviewer to wonder about.

## Fix

Three readers in `plugins/ai-slop/skills/audit/scripts/detect.sh`, all reading the same CRLF from the detector's own `jq` invocation:

- **`cfg_array`** — the reported defect. It piped `jq -r` through `tr '\n' ' '`, which converts the line feed and leaves the CR attached to the element, so `excluded_paths`, `em_dash_allowed_paths` and `disabled_rules` arrived as `plugins/*/skills/*/vendor/**<CR>` and matched nothing.
- **`rule_allowed_paths`** — the per-rule exemption added in 0.4.0 (#3359), which reads jq through `while IFS=$'\t' read -r`. `read` splits on the line feed, so the CR landed on the last glob of every entry. **This key is broken on Windows on `main` today** — see Verification.
- **`cfg_scalar`** — masked under Git Bash, whose command substitution strips one trailing CRLF pair, but on a bash that strips only the line feed the CR reaches the emitted threshold text in `--show-config` and in the density finding's label. (gawk and mawk both read a CR-suffixed threshold as a strnum, so the numeric comparison itself was measured unaffected; BusyBox awk is where it would diverge.)

The CR originates in the detector's own `jq` invocation, so no caller can normalize it away from the config file it supplies. Each reader now strips it.

`tr -d '\r'` is lossless on the `@tsv` path: jq escapes a decoded CR as the two characters `\` `r`, verified directly, so the only raw CR byte reaching `read` is jq's line terminator.

## Verification

**The strongest evidence is that `main`'s own suite is red on Windows and this turns it green.** Full `detect.test.sh` run on this Windows box (jq-1.8.2, MINGW64, GNU bash 5.3.15):

| tree | result |
| --- | --- |
| unmodified `origin/main` (363564299) | **7 of 155 cases FAILED** |
| this branch | **2 of 163 cases FAILED** |

The 5 repaired failures are `main`'s own pre-existing cases, not new ones:

```
FAIL: rule_allowed_paths: listed path declines the one rule
FAIL: rule_allowed_paths: decline counted for the exempted rule
FAIL: config: em_dash_allowed_paths exempts the document
FAIL: config: disabled rule emits no findings
FAIL: config: disabled rule reported in summary
```

The 2 remaining failures (`dir target, git absent: ...`) are unrelated and **also fail on unmodified `main`**: the suite builds a git-less PATH with `ln -s`, and `printf` is a bash builtin with no external binary to link, so the shim directory is incomplete. Windows-environment artifact, untouched by this change.

Root cause confirmed at the byte level before any code was written:

```
$ jq --version
jq-1.8.2
$ echo '{"a":["x","y"]}' | jq -r '.a[]' | od -c
0000000   x  \r  \n   y  \r  \n
```

`rule_allowed_paths` before and after, under a CRLF-emitting jq, against `origin/main`'s `detect.sh` and this branch's:

```
### UNFIXED (origin/main)
Finding: rule=...rule-filler-phrases file=plain.md ...
Finding: rule=...rule-filler-phrases file=quirks/doc.md ...      <- should have been exempt
Summary rule=ai-slop/audit/rule-filler-phrases findings=2 declined=0 disabled=0

### FIXED
Finding: rule=...rule-filler-phrases file=plain.md ...
Summary rule=ai-slop/audit/rule-filler-phrases findings=1 declined=1 disabled=0
```

**How the regression test reaches CI.** A Linux runner cannot observe any of these conditions, so seven new cases force them with a shim ahead of jq on PATH that appends a CR to every output line. An eighth assertion pins the shim itself (`jq -rn '"x"' | od -c` must show a CR), so a runner that failed to select the shim fails loudly instead of reporting vacuous passes. Each new case was checked against the unfixed `detect.sh` and fails there; the scalar case discriminates on Linux only, because MSYS command substitution already strips the trailing CRLF pair, and the test says so where it sits.

Gates run locally, all green: `shellcheck --rcfile=.shellcheckrc` and `shfmt -d` on both scripts; `check-changelog-parity.sh` in all four modes (`--check`, `--check-bump origin/main`, `--check-preserved origin/main`, `--check-order`); `check-detector-findings-crosswalk.sh`; `check-discriminating-test-skips.sh`; `check-fixture-git-isolation.sh`; `check-cross-plugin-source-drift.sh`. The detector itself reports 0 findings on this PR's CHANGELOG prose.

**Independent review, stated precisely.** The `cfg_array` + `cfg_scalar` change was audited by a fresh-context reviewer with the rationale withheld, against base `5d506ce32`, before `main` advanced. It verified discrimination on Linux in a container and ran that base's full suite there. It returned no blockers and five findings, all applied: the `--show-config` scalar assertion was documented as Linux-only after measurement showed MSYS masks it; an overstatement about awk's arithmetic was replaced with the measured gawk/mawk strnum behavior; the em-dash case gained a positive pin so an accidental whole-file exclusion cannot satisfy it; the changelog entry gained its issue reference; and an abbreviated glob in a comment was corrected.

The third reader (`rule_allowed_paths`) and its two cases were found and added *after* that review, during the rebase onto `363564299` — that key did not exist at the reviewed base. Their discrimination was established by direct before/after invocation against `origin/main`'s `detect.sh` (quoted above) and, independently, by the two `rule_allowed_paths` failures in the unmodified-main baseline. A follow-up delta review of that hunk is outstanding; its open questions are comment placement and fixture reuse, both style. The substantive risk on that hunk was closed empirically: `@tsv` escapes a decoded CR as the two characters `\` `r`, so `tr -d '\r'` cannot destroy config data there.

`cfg_array` and `cfg_scalar` exist only in this plugin (`grep -rn 'cfg_array\|cfg_scalar' --include=*.sh plugins/` matches nothing outside ai-slop), so there is no sibling copy of the defect to sweep.

## Related

- Refs #2891 — the em-dash regression gate whose claim that the tracked exclusions keep applying held on the runner but not on a Windows workstation.
- Refs #3359 — added `rule_allowed_paths`, the third affected reader.
- One adjacent defect of the same class is deliberately **not** fixed here and is noted on #3343 instead: `--paths-file` is read with `while IFS= read -r line` and no CR strip, so a CRLF paths file on Windows silently drops every target. That is caller-supplied input rather than the detector's own jq, and #3343 scoped itself to the jq invocation.
