### PR TITLE
fix(scripts): fail a bare read_list --comments with rc 2 instead of looping

### DIFF
--- a/scripts/lib/read-list.sh
+++ b/scripts/lib/read-list.sh
@@ -67,7 +67,14 @@ read_list::into() {
     case "$1" in
     --comments)
       _rl_mode="${2-}"
-      shift 2 || true
+      # Shift only what is actually there. `shift 2` with `--comments` as the
+      # LAST argument shifts nothing and returns non-zero, and the `|| true`
+      # this replaces swallowed that: `$#` stayed at 1 and the loop reprocessed
+      # `--comments` forever (#3363) instead of ever reaching the rc-2 branch
+      # below. Draining to `$# == 0` lets a bare `--comments` fall through to
+      # the existing "mode is required" error, the same answer `--comments ''`
+      # already gave.
+      shift $(($# > 1 ? 2 : 1))
       ;;
     *)
       printf 'read-list: unknown option %s\n' "$1" >&2

--- a/scripts/lib/read-list.test.sh
+++ b/scripts/lib/read-list.test.sh
@@ -105,20 +105,45 @@ fi
 # same rc-2 answer, and must reach it AT ALL. The pre-#3363 arm consumed its
 # value with `shift 2 || true`; as the last argument that shifted nothing and
 # returned non-zero, `|| true` hid the failure, `$#` stayed at 1, and the option
-# loop reprocessed `--comments` forever. `timeout` is the load-bearing part of
-# this assertion: without it a regression does not FAIL this suite, it HANGS it,
-# which in CI is an unbounded stall rather than a red test.
+# loop reprocessed `--comments` forever.
+#
+# The WATCHDOG is the load-bearing part of this assertion, not decoration:
+# without a bound, a regression does not FAIL this suite, it HANGS it, and an
+# unbounded stall in CI is worse than a red test. It is hand-rolled from
+# `kill`/`wait` rather than written as `timeout 5` because GNU coreutils
+# `timeout` is absent from a stock macOS userland, which
+# scripts/check-shell-portability.sh names as the platform no runner here
+# covers: on a developer's Mac that invocation would return 127 and fail a
+# correct library. `sleep`, `kill` and `wait` are POSIX, so this bounds the
+# probe everywhere. A killed probe reports 128+SIGKILL, never 2.
 missing_value_rc=0
 # shellcheck disable=SC2016  # $1/$2 are the inner `bash -c` positionals, deliberately unexpanded here
-timeout 5 bash -c '
+bash -c '
   . "$1"
   declare -a probe=()
   read_list::into probe "$2" --comments
-' _ "$SELF_DIR/read-list.sh" "$f" 2>/dev/null || missing_value_rc=$?
+' _ "$SELF_DIR/read-list.sh" "$f" 2>/dev/null &
+probe_pid=$!
+# SIGKILL on the watchdog SHELL, and no `wait` for it. SIGTERM would be
+# deferred until its foreground `sleep` returned, costing the suite the full
+# five seconds on the HAPPY path; SIGKILL cannot be deferred. Killing the shell
+# rather than letting it fire against an already-reaped pid is also what keeps
+# this free of a pid-reuse hazard: the orphaned `sleep` has nothing left to run
+# the kill.
+# The `>/dev/null 2>&1` is not cosmetic. Without it the orphaned `sleep`
+# inherits this suite's stdout, and anything reading the suite through a pipe
+# blocks for the full five seconds waiting for that last writer to close.
+(
+  sleep 5
+  kill -9 "$probe_pid" 2>/dev/null
+) >/dev/null 2>&1 &
+watchdog_pid=$!
+wait "$probe_pid" || missing_value_rc=$?
+kill -9 "$watchdog_pid" 2>/dev/null
 if [[ "$missing_value_rc" -eq 2 ]]; then
   ok "a bare --comments (no mode value) returns 2 promptly"
-elif [[ "$missing_value_rc" -eq 124 ]]; then
-  fail "a bare --comments HUNG (timed out) instead of returning 2 (#3363)"
+elif [[ "$missing_value_rc" -ge 128 ]]; then
+  fail "a bare --comments HUNG (watchdog killed it, rc=$missing_value_rc) instead of returning 2 (#3363)"
 else
   fail "a bare --comments returned $missing_value_rc, want 2"
 fi

--- a/scripts/lib/read-list.test.sh
+++ b/scripts/lib/read-list.test.sh
@@ -100,6 +100,28 @@ if read_list::into entries "$f" --bogus 2>/dev/null; then
 else
   ok "an unknown option is rejected"
 fi
+
+# A BARE `--comments` (the flag present, its mode value missing) must reach the
+# same rc-2 answer, and must reach it AT ALL. The pre-#3363 arm consumed its
+# value with `shift 2 || true`; as the last argument that shifted nothing and
+# returned non-zero, `|| true` hid the failure, `$#` stayed at 1, and the option
+# loop reprocessed `--comments` forever. `timeout` is the load-bearing part of
+# this assertion: without it a regression does not FAIL this suite, it HANGS it,
+# which in CI is an unbounded stall rather than a red test.
+missing_value_rc=0
+# shellcheck disable=SC2016  # $1/$2 are the inner `bash -c` positionals, deliberately unexpanded here
+timeout 5 bash -c '
+  . "$1"
+  declare -a probe=()
+  read_list::into probe "$2" --comments
+' _ "$SELF_DIR/read-list.sh" "$f" 2>/dev/null || missing_value_rc=$?
+if [[ "$missing_value_rc" -eq 2 ]]; then
+  ok "a bare --comments (no mode value) returns 2 promptly"
+elif [[ "$missing_value_rc" -eq 124 ]]; then
+  fail "a bare --comments HUNG (timed out) instead of returning 2 (#3363)"
+else
+  fail "a bare --comments returned $missing_value_rc, want 2"
+fi
 rm -f "$f"
 
 # --- an unreadable file is loud, never an empty list -----------------------


### PR DESCRIPTION
## Summary

`read_list::into <arr> <file> --comments` with the mode value missing hung
forever instead of returning the rc 2 the function already had a branch for.

The option loop's `--comments` arm consumed its value with `shift 2 || true`
(`scripts/lib/read-list.sh:70`). When `--comments` is the last positional,
bash's `shift 2` with only one positional left shifts *nothing* and returns
non-zero; `|| true` swallowed that failure, so `$#` stayed at 1 and
`while (($# > 0))` reprocessed `--comments` indefinitely. The rc-2
"mode is required" branch below it was unreachable on that path.

No in-repo caller hits this today. The cost of leaving it was that any future
caller which forgot the mode value got a silent, unbounded stall in a hook or
in CI rather than a usage error.

## Fix

`scripts/lib/read-list.sh` shifts only what is actually present:

```bash
shift $(($# > 1 ? 2 : 1))
```

The loop now drains to `$# == 0`, and a bare `--comments` falls through to the
existing `--comments is required (inline|leading); there is no default` error
with rc 2, which is the same answer `--comments ''` already gave. Deliberately
reusing that branch rather than adding a second message: the two inputs are the
same mistake and should not diverge in wording.

## Verification

New case in `scripts/lib/read-list.test.sh` runs the missing-value invocation
under a **bound** and asserts rc 2. The bound is the load-bearing part: without
it a regression does not *fail* this suite, it *hangs* it, and an unbounded
stall in CI is worse than a red test.

The bound is a hand-rolled `sleep`/`kill`/`wait` watchdog rather than
`timeout 5`. GNU coreutils `timeout` is absent from a stock macOS userland, and
`scripts/check-shell-portability.sh:2-12` names macOS as exactly the platform
no runner here covers, so a `timeout`-based test would return 127 and fail a
correct library on a developer's Mac with CI none the wiser. (Raised by
chatgpt-codex-connector on the first push; fixed in cab587f5.) Three details in
the watchdog are load-bearing and commented at their lines: the watchdog shell
is SIGKILLed (SIGTERM is deferred until its foreground `sleep` returns, costing
five seconds on the *happy* path), it is killed rather than left to fire at an
already-reaped pid (no pid-reuse window), and its output goes to `/dev/null`
(otherwise the orphaned `sleep` holds the suite's stdout open and any reader
consuming it through a pipe blocks five seconds -- measured: 7.2s before the
redirect, 0.27s after).

- With the fix: `PASS=30 FAIL=0`, 0.27s piped.
- Proven to fail pre-fix: with `scripts/lib/read-list.sh` reverted to `main`,
  the suite reports
  `FAIL: a bare --comments HUNG (watchdog killed it, rc=137) instead of returning 2 (#3363)`
  (`PASS=29 FAIL=1`), bounded at 5.3s.
- `scripts/affected-tests.sh --explain scripts/lib/read-list.sh
  scripts/lib/read-list.test.sh` maps both files to suites (no unmapped file).
  Every suite that sources or names `read-list.sh` was run green:
  `read-list` 30/0, `affected-tests` 47/0, `check-changelog-parity` 84/0,
  `check-docs-only` 21/0, `check-hook-userconfig-argv` 17/0,
  `check-orphaned-fixtures` 13/0, `check-skill-portability` 92/0,
  `check-shell-portability` 336/0.
- `scripts/check-shell-portability.sh --paths` on both changed files: clean.
- `shellcheck --rcfile .shellcheckrc` and `shfmt -d` on both files: clean.

## Related

Closes #3363

Found by the batch-simplify sweep on `claude/code-tidying-batch-simplify-s7ljbi`
and deliberately left unfixed there because that sweep was behavior-preserving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
