### PR TITLE
fix(machine-health): repair nvidia-smi flags and the approved_by separator

### DIFF
--- a/plugins/machine-health/.claude-plugin/plugin.json
+++ b/plugins/machine-health/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "machine-health",
-  "version": "0.11.9",
+  "version": "0.11.10",
   "description": "Workstation health audit: OS-specific checks (disk, OS updates, security posture, CISA KEV correlation) run from a versioned catalog with trend-aware severity, approval-gated remediations, and dated markdown reports. Windows fully implemented; macOS/Linux scaffolded (report UNKNOWN and stop). Machine state persists in the plugin data directory; the report directory and check catalog are configurable.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/machine-health/CHANGELOG.md
+++ b/plugins/machine-health/CHANGELOG.md
@@ -3,6 +3,26 @@
 All notable changes to the `machine-health` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.11.10]
+
+### Fixed
+
+- **`Get-GpuDriverInfo` asks `nvidia-smi` for the fields it meant to ask for.** The query and
+  format flags were written bare with a space after each comma
+  (`--query-gpu=name, driver_version`), which PowerShell's argument-mode comma operator turns
+  into an array that spreads into four separate argv entries. `nvidia-smi` rejected them
+  (`Option driver_version is not recognized`, exit 2), so the NVIDIA branch silently produced
+  nothing on real hardware while the suite's argument-agnostic mocks stayed green. Both flags
+  are now single quoted tokens, and the suite gained a shadowing `nvidia-smi` stub that
+  captures and asserts the exact argument vector.
+- **`approved_by` records one backslash between host and user, not two.** The TODO.md migration
+  built the identity as `"$env:COMPUTERNAME\\$env:USERNAME"`; PowerShell double-quoted strings
+  do not treat `\` as an escape, so every migrated approval persisted a literal `HOST\\user`.
+  The field is free-form audit metadata (`catalog/schemas/approvals.schema.json`) and no code
+  path compares it — `Test-ApprovalGranted` reads only `approved` — so previously persisted
+  values need no migration; the one-shot TODO.md path writes only when `approvals.json` is
+  absent, which further bounds the reach.
+
 ## [0.11.9]
 
 ### Changed

--- a/plugins/machine-health/skills/audit/scripts/windows/lib/Get-ApprovalState.ps1
+++ b/plugins/machine-health/skills/audit/scripts/windows/lib/Get-ApprovalState.ps1
@@ -65,7 +65,9 @@ function Read-ApprovalsFromTodo {
     if ($migrations.Count -eq 0) { return $null }
 
     $stamp = (Get-Date).ToString('o')
-    $approvedBy = "$env:COMPUTERNAME\\$env:USERNAME"
+    # One backslash, not two: PowerShell double-quoted strings do not treat `\`
+    # as an escape character, so `\\` here would persist a literal `HOST\\user`.
+    $approvedBy = "$env:COMPUTERNAME\$env:USERNAME"
     $rem = [ordered]@{}
     foreach ($id in $migrations.Keys) {
         $rem[$id] = [pscustomobject]@{

--- a/plugins/machine-health/skills/audit/scripts/windows/lib/Get-GpuDriverInfo.ps1
+++ b/plugins/machine-health/skills/audit/scripts/windows/lib/Get-GpuDriverInfo.ps1
@@ -30,8 +30,13 @@ function Get-GpuDriverInfo {
     $nvCmd = Get-Command nvidia-smi -ErrorAction SilentlyContinue
     if ($nvCmd) {
         try {
-            $raw = & nvidia-smi --query-gpu=name, driver_version `
-                --format=csv, noheader 2>$null
+            # Each flag is ONE token, and the quoting is load-bearing. Written
+            # bare with a space after the comma, PowerShell's argument-mode
+            # comma operator builds an array that spreads into four separate
+            # argv entries, and nvidia-smi rejects the flags ("Option
+            # driver_version is not recognized", exit 2).
+            $raw = & nvidia-smi '--query-gpu=name,driver_version' `
+                '--format=csv,noheader' 2>$null
             if ($LASTEXITCODE -eq 0 -and $raw) {
                 foreach ($line in ($raw -split "`r?`n")) {
                     $parts = $line -split ',' | ForEach-Object { $_.Trim() }

--- a/plugins/machine-health/skills/audit/tests/windows/lib/Get-ApprovalState.Tests.ps1
+++ b/plugins/machine-health/skills/audit/tests/windows/lib/Get-ApprovalState.Tests.ps1
@@ -132,6 +132,22 @@ Describe 'Get-ApprovalState' -Tag 'lib' {
             $state.remediations.'clear-temp-files'.approved_at | Should -Match '^\d{4}-\d{2}-\d{2}T'
         }
 
+        It 'separates host and user in approved_by with exactly one backslash' {
+            # #3369: the interpolation used "$env:COMPUTERNAME\\$env:USERNAME".
+            # PowerShell double-quoted strings do not treat backslash as an
+            # escape, so that emitted a LITERAL doubled separator. Counted
+            # rather than compared against a rebuilt expected value: rebuilding
+            # it with the same expression would pass while both sides are wrong.
+            Set-Content -LiteralPath $script:todoPath `
+                -Value '- [x] Clear-TempFiles' -Encoding utf8
+
+            $state = Get-ApprovalState -StateDir $script:stateDir -TodoPath $script:todoPath
+
+            $approvedBy = $state.remediations.'clear-temp-files'.approved_by
+            @($approvedBy.ToCharArray() | Where-Object { $_ -eq '\' }).Count | Should -Be 1
+            $approvedBy | Should -Not -BeLike '*\\*'
+        }
+
         It 'does NOT overwrite an existing approvals.json with a migration' {
             New-Item -ItemType Directory -Path $script:stateDir -Force | Out-Null
             $existing = '{"schema_version":"1.0","remediations":{"clear-temp-files":{"approved":false}}}'

--- a/plugins/machine-health/skills/audit/tests/windows/lib/Get-GpuDriverInfo.Tests.ps1
+++ b/plugins/machine-health/skills/audit/tests/windows/lib/Get-GpuDriverInfo.Tests.ps1
@@ -6,60 +6,128 @@ BeforeAll {
     $script:SkillRoot = Split-Path -Parent $script:TestsRoot
     $script:LibPath = Join-Path $script:SkillRoot 'scripts\windows\lib\Get-GpuDriverInfo.ps1'
     . $script:LibPath
+
+    # A shadowing FUNCTION, not a Pester Mock: nvidia-smi is an Application, so
+    # it cannot be mocked on a machine that does not have it installed (most CI
+    # runners), and argument capture through an Application mock is unreliable
+    # where it is installed. PowerShell resolves functions ahead of
+    # applications, so this intercepts the lib's `& nvidia-smi` either way.
+    #
+    # A function does not set $LASTEXITCODE, and the lib gates on it, so the
+    # stub sets it explicitly rather than inheriting whatever stale value the
+    # caller's scope happens to hold.
+    function nvidia-smi {
+        [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseApprovedVerbs', '',
+            Justification = 'Deliberately shadows the nvidia-smi executable under test.')]
+        param([Parameter(ValueFromRemainingArguments = $true)] [object[]] $Arguments)
+        # Flattened through the pipeline so a nested array — which is what
+        # PowerShell's argument-mode comma operator builds, and what a native
+        # command would spread into separate argv entries — is captured the way
+        # nvidia-smi would have received it, rather than as one joined string.
+        $global:NvidiaSmiCapturedArgs = @($Arguments | ForEach-Object { $_ })
+        $global:LASTEXITCODE = 0
+        $global:NvidiaSmiStdout
+    }
 }
 
 Describe 'Get-GpuDriverInfo' -Tag 'lib' {
-    BeforeEach {
-        # Make nvidia-smi appear absent so every test exercises the
-        # Win32_VideoController fallback path in isolation.
-        Mock Get-Command {
-            param($Name) if ($Name -eq 'nvidia-smi') { $null }
+    Context 'Win32_VideoController fallback' {
+        BeforeEach {
+            # Make nvidia-smi appear absent so every test exercises the
+            # Win32_VideoController fallback path in isolation.
+            Mock Get-Command {
+                param($Name) if ($Name -eq 'nvidia-smi') { $null }
+            }
+        }
+
+        It 'returns an empty array when no GPUs are enumerable' {
+            Mock Get-CimInstance { throw 'No WMI' } -ParameterFilter {
+                $ClassName -eq 'Win32_VideoController'
+            }
+            $result = @(Get-GpuDriverInfo)
+            $result.Count | Should -Be 0
+        }
+
+        It 'maps Intel GPU from Win32_VideoController' {
+            Mock Get-CimInstance {
+                @([pscustomobject]@{
+                        Name          = 'Intel(R) UHD Graphics 630'
+                        DriverVersion = '31.0.101.2111'
+                        DriverDate    = (Get-Date '2024-06-15')
+                    })
+            } -ParameterFilter { $ClassName -eq 'Win32_VideoController' }
+            $result = @(Get-GpuDriverInfo)
+            $result.Count | Should -Be 1
+            $result[0].vendor | Should -Be 'Intel'
+            $result[0].source | Should -Be 'Win32_VideoController'
+        }
+
+        It 'maps AMD GPU from Win32_VideoController' {
+            Mock Get-CimInstance {
+                @([pscustomobject]@{
+                        Name          = 'AMD Radeon RX 7900 XTX'
+                        DriverVersion = '24.10.1'
+                        DriverDate    = (Get-Date '2024-10-20')
+                    })
+            } -ParameterFilter { $ClassName -eq 'Win32_VideoController' }
+            $result = @(Get-GpuDriverInfo)
+            $result[0].vendor | Should -Be 'AMD'
+        }
+
+        It 'skips NVIDIA entries from Win32_VideoController (already covered by nvidia-smi path)' {
+            Mock Get-CimInstance {
+                @([pscustomobject]@{
+                        Name          = 'NVIDIA GeForce RTX 4090'
+                        DriverVersion = '551.23'
+                        DriverDate    = (Get-Date '2024-11-01')
+                    })
+            } -ParameterFilter { $ClassName -eq 'Win32_VideoController' }
+            $result = @(Get-GpuDriverInfo)
+            $result.Count | Should -Be 0
         }
     }
 
-    It 'returns an empty array when no GPUs are enumerable' {
-        Mock Get-CimInstance { throw 'No WMI' } -ParameterFilter {
-            $ClassName -eq 'Win32_VideoController'
+    Context 'nvidia-smi invocation' {
+        BeforeEach {
+            $global:NvidiaSmiCapturedArgs = $null
+            $global:NvidiaSmiStdout = 'NVIDIA GeForce RTX 4090, 551.23'
+            # Truthy: the lib only tests whether the command resolved. Faked so
+            # the branch is reachable on hosts without the NVIDIA toolkit.
+            Mock Get-Command { [pscustomobject]@{ Name = 'nvidia-smi' } } `
+                -ParameterFilter { $Name -eq 'nvidia-smi' }
+            Mock Get-CimInstance { @() } -ParameterFilter {
+                $ClassName -eq 'Win32_VideoController'
+            }
         }
-        $result = @(Get-GpuDriverInfo)
-        $result.Count | Should -Be 0
-    }
 
-    It 'maps Intel GPU from Win32_VideoController' {
-        Mock Get-CimInstance {
-            @([pscustomobject]@{
-                    Name          = 'Intel(R) UHD Graphics 630'
-                    DriverVersion = '31.0.101.2111'
-                    DriverDate    = (Get-Date '2024-06-15')
-                })
-        } -ParameterFilter { $ClassName -eq 'Win32_VideoController' }
-        $result = @(Get-GpuDriverInfo)
-        $result.Count | Should -Be 1
-        $result[0].vendor | Should -Be 'Intel'
-        $result[0].source | Should -Be 'Win32_VideoController'
-    }
+        AfterEach {
+            Remove-Variable -Name NvidiaSmiCapturedArgs, NvidiaSmiStdout `
+                -Scope Global -ErrorAction SilentlyContinue
+        }
 
-    It 'maps AMD GPU from Win32_VideoController' {
-        Mock Get-CimInstance {
-            @([pscustomobject]@{
-                    Name          = 'AMD Radeon RX 7900 XTX'
-                    DriverVersion = '24.10.1'
-                    DriverDate    = (Get-Date '2024-10-20')
-                })
-        } -ParameterFilter { $ClassName -eq 'Win32_VideoController' }
-        $result = @(Get-GpuDriverInfo)
-        $result[0].vendor | Should -Be 'AMD'
-    }
+        It 'passes --query-gpu and --format as two intact arguments' {
+            # #3370: the invocation was written with a space after each comma
+            # (`--query-gpu=name, driver_version`). PowerShell parses that in
+            # argument mode as an ARRAY, which flattens into four separate
+            # native arguments, so nvidia-smi rejected the flags and the NVIDIA
+            # branch returned nothing on real hardware. Asserting on the arg
+            # shape is the only discriminating check here: the stub owns both
+            # the exit code and stdout.
+            $null = Get-GpuDriverInfo
 
-    It 'skips NVIDIA entries from Win32_VideoController (already covered by nvidia-smi path)' {
-        Mock Get-CimInstance {
-            @([pscustomobject]@{
-                    Name          = 'NVIDIA GeForce RTX 4090'
-                    DriverVersion = '551.23'
-                    DriverDate    = (Get-Date '2024-11-01')
-                })
-        } -ParameterFilter { $ClassName -eq 'Win32_VideoController' }
-        $result = @(Get-GpuDriverInfo)
-        $result.Count | Should -Be 0
+            $captured = @($global:NvidiaSmiCapturedArgs)
+            $captured.Count | Should -Be 2
+            $captured[0] | Should -BeExactly '--query-gpu=name,driver_version'
+            $captured[1] | Should -BeExactly '--format=csv,noheader'
+        }
+
+        It 'maps the nvidia-smi CSV row onto an NVIDIA record' {
+            $result = @(Get-GpuDriverInfo)
+            $result.Count | Should -Be 1
+            $result[0].vendor | Should -Be 'NVIDIA'
+            $result[0].model | Should -Be 'NVIDIA GeForce RTX 4090'
+            $result[0].driver_version | Should -Be '551.23'
+            $result[0].source | Should -Be 'nvidia-smi'
+        }
     }
 }


### PR DESCRIPTION
## Summary

Two independent defects in the `machine-health` audit skill's Windows lib, both surfaced by the
batch-simplify sweep and deliberately left for a behavior-changing PR. Neither was caught by the
existing Pester suite, because in each case the suite asserted around the defect rather than on it.

Plugin version 0.11.9 -> 0.11.10 with a `### Fixed` changelog entry.

## Fix

**#3370 — `Get-GpuDriverInfo` nvidia-smi argument list.** The invocation was written bare with a
space after each comma:

```powershell
$raw = & nvidia-smi --query-gpu=name, driver_version `
    --format=csv, noheader 2>$null
```

PowerShell's argument-mode comma operator builds an array from `a, b`, and a native command
spreads that array into separate argv entries — so nvidia-smi received four arguments instead of
two. Reproduced directly on this machine (RTX 3000 Ada, driver 596.86):

```text
ERROR: Option driver_version is not recognized. Please run 'nvidia-smi -h' for help.
EXIT=2
```

Both flags are now single quoted tokens (`'--query-gpu=name,driver_version'`,
`'--format=csv,noheader'`), with a comment naming the parsing rule so the quoting is not tidied
away again.

**#3369 — `approved_by` double backslash.** `Read-ApprovalsFromTodo` built the approver identity
as `"$env:COMPUTERNAME\\$env:USERNAME"`. PowerShell double-quoted strings do not treat `\` as an
escape character, so `\\` is two literal separators and every migrated approval persisted
`HOST\\user`. Now one backslash.

On the issue's second acceptance box (migrate or waive previously persisted values): **waived,
with evidence.** `approved_by` is declared free-form in
`catalog/schemas/approvals.schema.json` ("Free-form identifier for audit (hostname, username, or
note)") and carries no pattern constraint. `git grep approved_by` returns the writer, the schema,
one doc example, and the tests — no consumer compares it; `Test-ApprovalGranted` reads only
`approved`. The migration is additionally one-shot and fires only when `approvals.json` is absent,
which bounds the reach to hosts that upgraded through the legacy TODO.md path and never re-wrote
the file.

## Verification

Both regression tests were confirmed RED against the unfixed source before the fix landed.

**#3370** — `tests/windows/lib/Get-GpuDriverInfo.Tests.ps1` gained a `Context 'nvidia-smi
invocation'`. It installs a shadowing `nvidia-smi` **function** rather than a Pester `Mock`:
nvidia-smi is an Application, so it cannot be mocked on a host that lacks it, and PowerShell
resolves functions ahead of applications on hosts that have it. The stub sets `$LASTEXITCODE`
itself (a function does not, and the lib gates on it) and flattens its captured arguments through
the pipeline so a nested array is recorded the way a native command would have spread it.

- Before the fix: `Expected 2, but got 4.`
- After the fix: 6/6 passing; the second case pins the CSV row -> NVIDIA record mapping.
- Manual spot check (AC3), real hardware, after the fix:

```text
vendor         : NVIDIA
model          : NVIDIA RTX 3000 Ada Generation Laptop GPU
driver_version : 596.86
source         : nvidia-smi
```

**#3369** — `tests/windows/lib/Get-ApprovalState.Tests.ps1` gained `separates host and user in
approved_by with exactly one backslash`. It counts the separators rather than comparing against a
rebuilt `"$env:COMPUTERNAME\$env:USERNAME"`, which would pass while both sides were wrong.

- Before the fix: `Expected 1, but got 2.`
- After the fix: 17/17 passing.

**Gates**

- `scripts/affected-tests.sh --run` — exit 0; 6 Pester suites SELECTED and reported as NOT RUN by
  design (the runner will not guess a non-shell lane). All six run individually and pass:
  `Test-Drivers` 8, `Get-ApprovalState` 17, `Get-ElevationMatrix` 6, `Get-GpuDriverInfo` 6,
  `New-InvalidCatalogEntryResult` 12, `Write-ElevationBanner` 5.
- `scripts/validate-plugins.sh` — passed.
- `scripts/run-plugin-tests.sh` discovers only `plugins/**/*.test.sh` and `machine-health` carries
  none, so it has nothing plugin-specific to say here; it is covered in CI by the `plugin-gate`
  lane, which runs it over the whole corpus and passed.
- `scripts/check-changelog-parity.sh --check` and `--check-bump origin/main` — both passed.
- Full skill suite: 423 passed / 1 failed / 1 skipped. The single failure,
  `Test-EnvironmentHealth` "expands %VAR% before existence and scope checks", is **pre-existing**:
  it fails identically on a stashed (unmodified) tree and is host-environment dependent
  (`'user'` vs `'unknown'`). Not touched by this PR.
- `scripts/check-shell-portability.sh` is not applicable — this change set contains no shell files.

## Related

Closes #3370
Closes #3369
