### PR TITLE
fix(scripts): iterate cross-plugin cluster paths without word-splitting them

### DIFF
--- a/scripts/check-cross-plugin-source-drift.sh
+++ b/scripts/check-cross-plugin-source-drift.sh
@@ -125,7 +125,7 @@ if [[ "$mode" == "discover" ]]; then
   # (#3376). Two hazards, one of them latent in each direction: an unquoted
   # `$(...)` here word-split every key on IFS whitespace and glob-expanded the
   # results against the working directory, so a cluster path with a space
-  # mis-iterated silently; and `printf '%s\n'` with NO arguments still prints
+  # iterated wrongly and silently; and `printf '%s\n'` with NO arguments prints
   # one blank line, which `mapfile -t` would turn into a single empty key on a
   # tree that has no clusters at all. An empty array iterates zero times and
   # feeds `sort` nothing, which is the answer both cases want.

--- a/scripts/check-cross-plugin-source-drift.sh
+++ b/scripts/check-cross-plugin-source-drift.sh
@@ -56,7 +56,12 @@ for plugin_dir in plugins/*/; do
       continue
     fi
     rel="${full#"$plugin_dir"}"
-    cluster_entries["$rel"]+="${plugin}:${full} "
+    # NEWLINE-delimited, not space-delimited (#3376). `find -print0` already
+    # hands us paths containing spaces intact; joining the accumulator on a
+    # space would throw that away again the moment load_cluster split it back
+    # apart, turning one entry into two bogus ones and feeding sha256sum a
+    # truncated path. A newline is the one separator no path here can contain.
+    cluster_entries["$rel"]+="${plugin}:${full}"$'\n'
   done < <(find "$plugin_dir" -type f -print0)
 done
 
@@ -66,8 +71,7 @@ done
 # the arrays and put a function call where .shellcheckrc's SC2310 warns about
 # set -e suppression.
 load_cluster() {
-  # shellcheck disable=SC2206
-  entries=(${cluster_entries[$1]})
+  mapfile -t entries < <(printf '%s' "${cluster_entries[$1]}")
   plugins_list=()
   local entry
   for entry in "${entries[@]}"; do
@@ -117,7 +121,18 @@ discover | --check) ;;
 esac
 
 if [[ "$mode" == "discover" ]]; then
-  for rel in $(printf '%s\n' "${!cluster_status[@]}" | sort); do
+  # Feed `sort` from a loop rather than `printf '%s\n' "${!cluster_status[@]}"`
+  # (#3376). Two hazards, one of them latent in each direction: an unquoted
+  # `$(...)` here word-split every key on IFS whitespace and glob-expanded the
+  # results against the working directory, so a cluster path with a space
+  # mis-iterated silently; and `printf '%s\n'` with NO arguments still prints
+  # one blank line, which `mapfile -t` would turn into a single empty key on a
+  # tree that has no clusters at all. An empty array iterates zero times and
+  # feeds `sort` nothing, which is the answer both cases want.
+  mapfile -t sorted_rels < <(
+    for rel in "${!cluster_status[@]}"; do printf '%s\n' "$rel"; done | sort
+  )
+  for rel in "${sorted_rels[@]}"; do
     load_cluster "$rel"
     reg=""
     [[ -n "${registered[$rel]:-}" ]] && reg=" [registered]"

--- a/scripts/check-cross-plugin-source-drift.test.sh
+++ b/scripts/check-cross-plugin-source-drift.test.sh
@@ -147,6 +147,58 @@ else
 fi
 rm -rf "$f"
 
+# --- a cluster path containing a space iterates ONCE, not once per word ----
+#
+# Pre-#3376 discover mode iterated an UNQUOTED command substitution, so every
+# cluster key was word-split on IFS whitespace and glob-expanded against the
+# working directory; and the cluster accumulator was space-joined, so
+# load_cluster split each entry's path apart again and handed sha256sum a
+# truncated name, which is fatal under this script's `set -e`. A space-bearing
+# path therefore mis-iterated with no error signal, in the one mode whose whole
+# job is showing a human the cluster inventory.
+f="$(new_fixture)"
+plugin_file "$f" alpha "hooks/shared file.sh" "same"
+plugin_file "$f" beta "hooks/shared file.sh" "same"
+registry "$f" "hooks/shared file.sh"
+if out="$(run_discover "$f" 2>&1)"; then
+  hits="$(grep -c 'shared file\.sh' <<<"$out" || true)"
+  if [[ "$hits" == "1" ]] &&
+    grep -q 'IDENTICAL.*hooks/shared file\.sh  (plugins: alpha beta) \[registered\]' <<<"$out"; then
+    ok "discover lists a space-bearing cluster path exactly once, naming both plugins"
+  else
+    fail "expected ONE IDENTICAL line for 'hooks/shared file.sh' naming alpha and beta (saw $hits), got: $out"
+  fi
+else
+  fail "discover should exit 0 on a space-bearing cluster path, got: $out"
+fi
+if out="$(run_check "$f" 2>&1)"; then
+  ok "--check accepts a registered identical space-bearing cluster"
+else
+  fail "--check should pass for a registered identical space-bearing cluster, got: $out"
+fi
+rm -rf "$f"
+
+# --- discover on a tree with NO clusters at all ----------------------------
+#
+# The empty-array edge the #3376 fix has to get right, and the one the obvious
+# rewrite gets wrong: `printf '%s\n'` with no arguments still prints one blank
+# line, so `mapfile -t < <(printf '%s\n' "${!cluster_status[@]}" | sort)` hands
+# the loop a single EMPTY key, which dies on `${cluster_entries[]}` under
+# `set -u`. The old unquoted `$(...)` was accidentally safe here, so a fix that
+# only addressed word-splitting would trade one silent bug for a loud one.
+f="$(new_fixture)"
+plugin_file "$f" alpha hooks/only-here.sh "content"
+if out="$(run_discover "$f" 2>&1)"; then
+  if [[ -z "$out" ]]; then
+    ok "discover on a cluster-free tree exits 0 and prints nothing"
+  else
+    fail "discover on a cluster-free tree should print nothing, got: $out"
+  fi
+else
+  fail "discover on a cluster-free tree should exit 0, got: $out"
+fi
+rm -rf "$f"
+
 # --- production registry: every cluster documents its enforcement path (#2404) -
 REGISTRY="$SELF_DIR/cross-plugin-source-registry.txt"
 if [[ ! -f "$REGISTRY" ]]; then

--- a/scripts/check-cross-plugin-source-drift.test.sh
+++ b/scripts/check-cross-plugin-source-drift.test.sh
@@ -154,7 +154,7 @@ rm -rf "$f"
 # working directory; and the cluster accumulator was space-joined, so
 # load_cluster split each entry's path apart again and handed sha256sum a
 # truncated name, which is fatal under this script's `set -e`. A space-bearing
-# path therefore mis-iterated with no error signal, in the one mode whose whole
+# path therefore iterated wrongly with no error signal, in the one mode whose
 # job is showing a human the cluster inventory.
 f="$(new_fixture)"
 plugin_file "$f" alpha "hooks/shared file.sh" "same"


### PR DESCRIPTION
## Summary

`scripts/check-cross-plugin-source-drift.sh` discover mode iterated its cluster
keys through an unquoted command substitution:

```bash
for rel in $(printf '%s\n' "${!cluster_status[@]}" | sort); do
```

That word-splits every key on IFS whitespace and then glob-expands each
resulting word. A cluster rel path containing a space became several bogus
iterations; one containing `*`, `?` or `[` could expand against the working
directory. Discover mode is the surface a human reads to inspect cluster
status, so the cost was wrong output with no error signal at all.

Today's registered cluster paths are all safe, so the defect was latent.

## Fix

Two sites, because the issue's stated one-line fix does not actually hold.

1. `cluster_entries` was a **space-joined** accumulator
   (`+="${plugin}:${full} "`), and `load_cluster` split it back apart with an
   unquoted array assignment. `find -print0` hands the loop space-bearing paths
   intact, and that pair threw the information away again: one entry became
   two, and `sha256sum` was handed a truncated path. Under this script's
   `set -e` that aborts the whole run. The accumulator is now newline-delimited
   and read back with `mapfile` -- the one separator a path under `plugins/`
   cannot contain. The obsolete `# shellcheck disable=SC2206` goes with it.

2. The discover loop now sorts into an array. It feeds `sort` from a loop
   rather than `printf '%s\n' "${!cluster_status[@]}"`, and that detail is
   load-bearing: `printf '%s\n'` with **no arguments** still prints one blank
   line, so the obvious `mapfile -t sorted < <(printf ... | sort)` rewrite
   yields a single EMPTY key on a tree with no clusters and dies on
   `${cluster_entries[]}` under `set -u`. The old unquoted `$(...)` was
   accidentally safe there, so that rewrite would have traded a silent bug for
   a loud one. A loop over an empty array iterates zero times and feeds `sort`
   nothing, which is the answer both cases want.

## Verification

Two new cases in `scripts/check-cross-plugin-source-drift.test.sh`:

- a cluster rel path containing a space, asserting discover emits exactly ONE
  line for it and that the line names both plugins (proving `load_cluster` did
  not split the entry either), plus `--check` still accepting it as registered;
- discover on a tree with no clusters at all, which is the regression the fix
  itself could have shipped and which no existing case covered (the nearest,
  "a file carried by only one plugin", runs `--check`, not discover).

Results:

- With the fix: `PASS=12 FAIL=0`.
- With `check-cross-plugin-source-drift.sh` reverted to `HEAD`, both space
  cases fail with exactly the predicted truncation:
  `sha256sum: plugins/alpha/hooks/shared: No such file or directory`
  (`PASS=10 FAIL=2`). The cluster-free case passes pre-fix by design.
- `scripts/affected-tests.sh --explain` maps both changed files to
  `scripts/check-cross-plugin-source-drift.test.sh` and nothing else;
  `--run` is green (`All 1 selected suites passed or were skipped.`).
- Real-tree behavior unchanged: discover output is **byte-identical** before
  and after (`diff -u` clean over all 20 cluster lines), and `--check` still
  reports `No unregistered or drifted cross-plugin source clusters found.`
- `shellcheck --rcfile .shellcheckrc`, `shfmt -d`, and
  `scripts/check-shell-portability.sh --paths` on both files: clean.

Not covered by a test: a cluster path containing a literal `*`, `?` or `[`.
NTFS cannot hold such a filename, so a fixture for it would be Linux-only and
would fail the Windows CI lane. The glob half of the hazard is removed by the
same change (no unquoted expansion survives), and the space case exercises the
identical code path.

## Related

Closes #3376

Found by the batch-simplify sweep on `claude/code-tidying-batch-simplify-s7ljbi`
and deliberately left unfixed there because that sweep was behavior-preserving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
