### PR TITLE
docs(claude-ops): fix the repository name in the #3111 changelog link

### DIFF
--- a/plugins/claude-ops/CHANGELOG.md
+++ b/plugins/claude-ops/CHANGELOG.md
@@ -445,7 +445,7 @@ CLI behaviour added or changed below was verified on **Claude Code 2.1.240**.
 - **Docs:** README only. The generated options block's headless route no longer implies
   `--config` applies at install time alone, and now carries the CLI version its claim was
   verified against
-  ([#3111](https://github.com/melodic-software/claude-codeplugins/issues/3111)); two upstream
+  ([#3111](https://github.com/melodic-software/claude-code-plugins/issues/3111)); two upstream
   links that resolved to empty backward-compatibility anchors on the settings page were
   repointed at the headings that hold the content. Emitted by
   `scripts/sync-plugin-options-docs.py`, which regenerates every plugin README from one


### PR DESCRIPTION
## Summary

One-character-class typo in a changelog issue link: `claude-codeplugins` → `claude-code-plugins`.

## Problem

The weekly link-check report (#3340) flagged two errors. `https://github.com/melodic-software/claude-codeplugins/issues/3111` is a real break (the repository name is misspelled, so GitHub answers 404). The other, `https://lib.rs/crates/cargo-udeps` 403, is a bot-block on a live page (200 to a plain fetch) and is excluded at the source in standards#497, which fans out here on the next sync.

## Fix

Correct the repository name in `plugins/claude-ops/CHANGELOG.md`.

## Verification

- `scripts/affected-tests.sh --explain`: the file is a recorded no-suite class (markdown lane covers it).
- `curl -sI https://github.com/melodic-software/claude-code-plugins/issues/3111` → 200.

## Related

- Closes #3340
- standards#497 (lib.rs exclude)
