### PR TITLE
fix(go-format): capture the telemetry run's own stdout in the leak assertion

### DIFF
--- a/plugins/go-format/.claude-plugin/plugin.json
+++ b/plugins/go-format/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "go-format",
-  "version": "0.3.24",
+  "version": "0.3.25",
   "description": "Auto-fix Go formatting and import management on edit via goimports — runs unconditionally (no consumer-config gate), skipping generated files.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/go-format/CHANGELOG.md
+++ b/plugins/go-format/CHANGELOG.md
@@ -3,6 +3,19 @@
 All notable changes to the `go-format` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.3.25]
+
+### Fixed
+
+- **Telemetry stdout-leak assertion was vacuous (#3367).** `go-format.test.sh` claimed the
+  telemetry envelope "never leaked into hook's own stdout", but it grepped `$OUT` — last
+  assigned by the kill-switch case, whose own assertion proves that capture is EMPTY. The
+  telemetry run itself discarded its stdout, so the assertion checked output that run never
+  produced and passed unconditionally. It now captures the telemetry run's own stdout and
+  greps that, with a preceding guard asserting the capture is non-empty so an empty capture
+  can never make the check vacuous again. Verified by mutation: with an envelope echoed onto
+  the hook's stdout the old assertion still passed (46/0) and the new one fails.
+
 ## [0.3.24]
 
 ### Changed

--- a/plugins/go-format/hooks/go-format.test.sh
+++ b/plugins/go-format/hooks/go-format.test.sh
@@ -340,7 +340,11 @@ fi
 printf 'package main\n\nfunc main() {\n\tfmt.Println("hi"\n}\n' >"$REPO/tel.go"
 TEL="$(mktemp)"
 SINK="$(make_sink "cat >\"$TEL\"")"
-run_hook_env "$REPO/tel.go" PATH="$(dirname "$REAL_GOIMPORTS"):$PATH" CLAUDE_PLUGIN_OPTION_GO_FORMAT_ENABLED=true HOOK_TELEMETRY_SINK="$SINK" >/dev/null
+# Capture THIS run's stdout (#3367). Discarding it and grepping a `$OUT` last
+# assigned by an earlier case made the stdout-leak assertion below vacuous: it
+# checked output the telemetry run never produced, so it would have kept
+# passing had the hook started printing the envelope.
+TEL_OUT=$(run_hook_env "$REPO/tel.go" PATH="$(dirname "$REAL_GOIMPORTS"):$PATH" CLAUDE_PLUGIN_OPTION_GO_FORMAT_ENABLED=true HOOK_TELEMETRY_SINK="$SINK")
 wait_for_sink "$TEL"
 if [[ -s "$TEL" ]]; then
   ok "telemetry/stub-sink: envelope received"
@@ -359,7 +363,15 @@ if [[ -s "$TEL" ]]; then
   FREL=$(jq -r '.data.file' "$TEL")
   if [[ -n "$FREL" && "$FREL" != /* && "$FREL" != ?:* ]]; then ok "envelope: data.file repo-relative ($FREL)"; else fail "envelope: data.file not repo-relative: $FREL"; fi
   if jq -e '.duration_ms | type == "number" and . >= 0 and floor == .' "$TEL" >/dev/null 2>&1; then ok "envelope: duration_ms non-negative int"; else fail "envelope: duration_ms invalid ($(jq .duration_ms "$TEL"))"; fi
-  if ! printf '%s' "$OUT" | grep -q schema_version 2>/dev/null; then ok "envelope: never leaked into hook's own stdout"; else fail "envelope leaked into stdout"; fi
+  # Staleness guard: the fixture is a syntax-error file, so THIS run must have
+  # put its advisory additionalContext JSON on stdout. An empty capture means
+  # the assertion below is grepping nothing and proves nothing.
+  if [[ -n "$TEL_OUT" ]]; then
+    ok "envelope: telemetry run's own stdout captured (leak assertion has something to check)"
+  else
+    fail "envelope: telemetry run produced no stdout — leak assertion would be vacuous"
+  fi
+  if ! printf '%s' "$TEL_OUT" | grep -q schema_version 2>/dev/null; then ok "envelope: never leaked into hook's own stdout"; else fail "envelope leaked into stdout: $TEL_OUT"; fi
 else
   fail "telemetry/stub-sink: no envelope written"
 fi


### PR DESCRIPTION
## Summary

`plugins/go-format/hooks/go-format.test.sh` asserted that the telemetry envelope never
reaches the hook's own stdout, but the assertion checked a variable the telemetry run never
wrote. It passed unconditionally and would have kept passing if the hook started printing the
envelope, leaving the stdout-parity contract unguarded while appearing tested.

`$OUT` was last assigned at line 320 by the kill-switch case — whose own assertion (`-z "$OUT"`)
proves that capture is EMPTY. The telemetry run at line 343 discarded its stdout with
`>/dev/null` and assigned nothing, so line 362's `printf '%s' "$OUT" | grep -q schema_version`
grepped an empty string.

## Fix

- Capture the telemetry run's own stdout into `TEL_OUT` (drop the `>/dev/null`) and grep that.
- Add a staleness guard asserting `TEL_OUT` is non-empty BEFORE the leak check. The fixture is a
  syntax-error file, so that run must put its advisory `additionalContext` JSON on stdout
  (Case 7 already proves this shape). An empty capture now fails loudly instead of silently
  making the leak assertion vacuous.

Test-only change; the hook itself is untouched.

## Verification

Windows 11, Git Bash, `goimports` on PATH (`C:\Users\KyleSexton\go\bin\goimports.exe`).

- Baseline, unmodified suite and hook: `PASS=46 FAIL=0`.
- **Mutation check** (the acceptance criterion). Temporarily appended
  `echo '{"schema_version":"1.0","MUTATION":"leak"}'` to the hook's `emit_tel`, then ran both
  suites against that leaking hook:
  - Pre-fix suite (`git show HEAD:...go-format.test.sh`): `PASS=46 FAIL=0` — the assertion is
    vacuous, exactly as reported.
  - Fixed suite: `FAIL: envelope leaked into stdout: ... {"schema_version":"1.0","MUTATION":"leak"}`,
    `PASS=46 FAIL=1`.
  - Mutation reverted (`git checkout plugins/go-format/hooks/go-format.sh`); the fixed suite is
    green again.
- `bash plugins/go-format/hooks/go-format.test.sh` (post-fix, unmutated hook): `PASS=47 FAIL=0`
  (46 before, plus the new staleness guard).
- `scripts/affected-tests.sh --run` over this PR's three paths: selects
  `plugins/go-format/hooks/go-format.test.sh`; the manifest and CHANGELOG are recorded in
  `scripts/affected-tests-no-suite.txt`.

## Related

Closes #3367
