### PR TITLE
fix(scripts): validate the precompute gate's base ref in the parent shell

### DIFF
--- a/scripts/check-skill-precompute-compose.sh
+++ b/scripts/check-skill-precompute-compose.sh
@@ -90,6 +90,24 @@ scan_skill() {
   return 0
 }
 
+# Validate the base ref HERE, in the parent shell, and not inside the
+# process substitution below (#3377). An `exit 2` in there terminates only
+# the subshell: `mapfile`'s own status reflects the read, process-substitution
+# exit codes are not propagated, and the parent saw nothing but an empty
+# `targets` -- so a typo'd branch or a shallow clone missing the ref scanned
+# zero files and exited 0. The error text reached stderr, but the exit code CI
+# gates on said success, which is a silent pass in exactly the case this
+# validation was written to catch.
+case "$first" in
+--all | --paths) ;;
+*)
+  if ! git rev-parse --verify --quiet "${first}^{commit}" >/dev/null; then
+    printf 'Error: base ref %s is not a valid commit\n' "$first" >&2
+    exit 2
+  fi
+  ;;
+esac
+
 mapfile -t targets < <(
   case "$first" in
   --all)
@@ -99,12 +117,7 @@ mapfile -t targets < <(
     printf '%s\n' "${rest[@]}"
     ;;
   *)
-    base="$first"
-    if ! git rev-parse --verify --quiet "${base}^{commit}" >/dev/null; then
-      printf 'Error: base ref %s is not a valid commit\n' "$base" >&2
-      exit 2
-    fi
-    git diff --name-only "$base" -- 'plugins/' |
+    git diff --name-only "$first" -- 'plugins/' |
       sed -nE 's#^(plugins/[^/]+/skills/[^/]+)/SKILL\.md$#\1/SKILL.md#p' |
       sort -u
     ;;

--- a/scripts/check-skill-precompute-compose.test.sh
+++ b/scripts/check-skill-precompute-compose.test.sh
@@ -187,4 +187,43 @@ else
 fi
 rm -rf "$f"
 
+# --- an invalid base ref exits 2, not a silent "nothing to gate" (#3377) -----
+#
+# Target discovery runs inside `mapfile -t targets < <( ... )`, and the
+# base-ref branch's `exit 2` terminated only that process-substitution
+# subshell. `mapfile`'s own status reflects the READ, and a process
+# substitution's exit code is not propagated, so the parent saw nothing but an
+# empty `targets`, scanned zero files and exited 0. A typo'd branch or a
+# shallow clone missing the ref therefore read as "nothing to gate": the error
+# text went to stderr, but the exit code CI gates on said success, in exactly
+# the case this validation exists to catch.
+f="$(new_git_fixture)"
+skill_md "$f" $'---\ndescription: test\n---\n\n## Body\n\nNo precompute here.\n'
+git_test_config "$f" add -A >/dev/null
+git_test_config "$f" commit -qm base >/dev/null
+out="$(run_check "$f" no-such-ref-deadbeef 2>&1)" && rc=0 || rc=$?
+if [[ "$rc" -eq 2 ]] && echo "$out" | grep -q 'not a valid commit'; then
+  ok "an invalid base ref exits 2"
+elif [[ "$rc" -eq 0 ]]; then
+  fail "an invalid base ref passed SILENTLY (rc=0), the #3377 shape: $out"
+else
+  fail "an invalid base ref should exit 2 (rc=$rc): $out"
+fi
+rm -rf "$f"
+
+# --- --all still scans the tree, and is never base-ref validated -------------
+#
+# The #3377 fix hoists `git rev-parse` into the parent, so the mode dispatch
+# that keeps --all and --paths out of that check is now load-bearing: a fixture
+# with no git repository at all must still scan.
+f="$(new_fixture)"
+skill_md "$f" $'---\ndescription: test\n---\n\n## Pre-computed context\n\nA: !`git branch --show-current`\nB: !`git status --porcelain`\n\n## Body\n'
+out="$(run_check "$f" --all 2>&1)" && rc=0 || rc=$?
+if [[ "$rc" -eq 0 ]] && echo "$out" | grep -q '1 skill(s) scanned, 1 violation'; then
+  ok "--all scans the tree with no base-ref validation"
+else
+  fail "--all should scan the fixture and report its violation (rc=$rc): $out"
+fi
+rm -rf "$f"
+
 test_harness::report


### PR DESCRIPTION
## Summary

`scripts/check-skill-precompute-compose.sh <base-ref>` treated an invalid base
ref as a clean pass.

Target discovery ran inside `mapfile -t targets < <( ... )`. The base-ref
branch validated the ref and, on failure, printed an error and ran `exit 2` --
but that exit terminated only the process-substitution subshell. `mapfile`'s
own status reflects the read, and a process substitution's exit code is not
propagated, so the parent saw nothing but an empty `targets`, scanned zero
files, printed `No skill SKILL.md files in scope — nothing to gate.` and
exited 0.

A typo'd branch or a shallow clone missing the ref therefore read as "nothing
to gate". The error text did reach stderr, but the exit code CI gates on said
success: a silent pass in exactly the situation the validation exists to catch.

Reproduced on `main`:

```
$ bash scripts/check-skill-precompute-compose.sh no-such-ref-xyz
No skill SKILL.md files in scope — nothing to gate.
rc=0
```

## Fix

`git rev-parse --verify` is hoisted into the parent shell, ahead of the
`mapfile`, so its `exit 2` is the script's exit 2. The `cd` at the top of the
script already put us at the repo root, so nothing about the check moves. The
now-redundant `base="$first"` indirection goes with it, and the mode dispatch
keeps `--all` and `--paths` out of the check.

After:

```
$ bash scripts/check-skill-precompute-compose.sh no-such-ref-xyz
Error: base ref no-such-ref-xyz is not a valid commit
rc=2
```

One deliberate behavior change beyond the issue: a bare `--` is let through by
the argument parser as `first` and was never a working paths separator. It
previously printed the same "not a valid commit" error and exited 0; it now
exits 2 with it. That is the same correction, applied to the same wrong exit
code.

## Verification

Two new cases in `scripts/check-skill-precompute-compose.test.sh`:

- an invalid base ref against a git fixture that has a real commit (so the
  failure is unambiguously about the bogus ref, not an empty HEAD), asserting
  rc 2 and naming rc 0 explicitly as the #3377 shape;
- `--all` against a fixture with no git repository at all, which pins the mode
  dispatch that the hoisted validation now depends on.

Results:

- With the fix: `PASS=13 FAIL=0`.
- With `check-skill-precompute-compose.sh` reverted to `HEAD`, the base-ref
  case fails with
  `FAIL: an invalid base ref passed SILENTLY (rc=0), the #3377 shape`
  (`PASS=12 FAIL=1`). The `--all` case passes pre-fix by design.
- `scripts/affected-tests.sh --run` on both changed files selects
  `scripts/check-skill-precompute-compose.test.sh` and nothing else, and is
  green (`All 1 selected suites passed or were skipped.`).
- Modes unchanged on the real tree: a valid base ref (`HEAD`) still exits 0,
  and the existing suite's `--paths`, `--strict --paths`, bare base-ref,
  `--strict <base-ref>`, no-args, `--help`, `-h` and `--strict`-alone cases all
  still pass.
- CI invokes this gate as `--all` (`ci.yml:1493`), which never reaches the
  validation, so no CI lane changes behavior.
- `shellcheck --rcfile .shellcheckrc` and
  `scripts/check-shell-portability.sh --paths` on both files: clean. (`shfmt -d`
  reports one pre-existing diff at `--strict) STRICT=1; shift ;;`, untouched
  here and unrelated to this change; shfmt is not a CI gate.)

## Related

Closes #3377

Found by the batch-simplify sweep on `claude/code-tidying-batch-simplify-s7ljbi`
and deliberately left unfixed there because that sweep was behavior-preserving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
