### PR TITLE
fix(ai-briefing): anchor the slides window parse so an ascii arrow cannot split a timestamp

### DIFF
--- a/plugins/ai-briefing/.claude-plugin/plugin.json
+++ b/plugins/ai-briefing/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "ai-briefing",
-  "version": "0.7.12",
+  "version": "0.7.13",
   "description": "Build source-backed AI-industry briefings from official vendor publications, configured RSS/Atom feeds, GitHub releases, reputable secondary reporting, and user-supplied URLs. Deduplicate, rank, and present results as markdown or optional HTML/PPTX decks, with repository-owned profile, audience, and brand configuration. Automated X/Twitter collection is disabled; Playwright is used only for deterministic local rendering.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/ai-briefing/CHANGELOG.md
+++ b/plugins/ai-briefing/CHANGELOG.md
@@ -3,6 +3,21 @@
 All notable changes to the `ai-briefing` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.7.13]
+
+### Fixed
+
+- **ASCII `->` window headers rendered a nonsense date range on the slides (#3364).**
+  `emit-slides-data.js` parsed the briefing header window with
+  `([0-9T:Z\-]+)\s*[→-]+\s*([0-9T:Z\-]+)`. That separator class matches `-` but not `>`, so
+  on the ASCII spelling the engine backtracked and satisfied the split INSIDE the first
+  timestamp: `2026-04-24T19:00:00Z -> 2026-05-05T20:30:00Z` parsed as `2026-04` and
+  `24T19:00:00Z`, and `formatWindow` rendered garbage. The parse now anchors each endpoint on
+  a full `YYYY-MM-DD` shape, which makes the mid-timestamp split structurally impossible
+  rather than dependent on backtracking order, and accepts `→`, `->`, an en/em dash, and a
+  bare hyphen as separators. Parsing and rendering moved to `lib/window.js` so they are unit
+  testable; `emit-slides-data.js` runs `main()` on import and could not be exercised directly.
+
 ## [0.7.12]
 
 ### Changed

--- a/plugins/ai-briefing/skills/generate/output/build/emit-slides-data.js
+++ b/plugins/ai-briefing/skills/generate/output/build/emit-slides-data.js
@@ -14,6 +14,7 @@ import { validateDeck } from "./lib/schema.js";
 import { brand as DEFAULT_BRAND, theme as DEFAULT_THEME } from "./brand.js";
 import { resolveBrand } from "./lib/brand-overlay.js";
 import { buildOutDir, configDir, meetingsDir, slidesDataPath, stateRoot } from "./lib/paths.js";
+import { formatWindow, parseWindowRange } from "./lib/window.js";
 
 const PROVIDER_LOGOS = {
   anthropic: "assets/logo-anthropic.svg",
@@ -51,14 +52,6 @@ async function readState() {
   } catch {
     return null;
   }
-}
-
-function formatWindow(openIso, closeIso) {
-  const a = new Date(openIso);
-  const b = new Date(closeIso);
-  const days = Math.round((b - a) / (1000 * 60 * 60 * 24));
-  const fmt = (d) => d.toISOString().slice(0, 10);
-  return `${fmt(a)} to ${fmt(b)} (~${days} days)`;
 }
 
 function asJsLiteral(v) {
@@ -133,8 +126,8 @@ async function main() {
   let windowStr;
   if (briefing.meta.window) {
     // briefing.meta.window e.g. "2026-04-24T19:00:00Z → 2026-05-05T20:30:00Z (~11 days)"
-    const m = briefing.meta.window.match(/([0-9T:Z\-]+)\s*[→-]+\s*([0-9T:Z\-]+)/);
-    if (m) windowStr = formatWindow(m[1], m[2]);
+    const range = parseWindowRange(briefing.meta.window);
+    if (range) windowStr = formatWindow(range.open, range.close);
     else windowStr = briefing.meta.window;
   } else if (state?.current_meeting_window?.opened_date) {
     windowStr = formatWindow(state.current_meeting_window.opened_date, new Date().toISOString());

--- a/plugins/ai-briefing/skills/generate/output/build/lib/window.js
+++ b/plugins/ai-briefing/skills/generate/output/build/lib/window.js
@@ -1,0 +1,47 @@
+// Briefing-header window parsing and rendering.
+//
+// The `Window:` line in a briefing's header carries two ISO instants joined by
+// an arrow. Authors spell that arrow either as a Unicode arrow (`→`) or as the
+// ASCII digraph (`->`), so both must parse to the SAME pair of timestamps.
+
+/**
+ * A full ISO instant as briefings write it: a calendar date, optionally
+ * followed by a time. Anchoring on the `YYYY-MM-DD` shape is what makes the
+ * split structurally impossible — a looser class like `[0-9T:Z-]+` lets the
+ * engine backtrack and satisfy the first group with just `2026`, leaving the
+ * `-` of `04-24` to serve as the separator (#3364).
+ */
+const ISO_INSTANT = "\\d{4}-\\d{2}-\\d{2}(?:T\\d{2}:\\d{2}(?::\\d{2})?(?:Z|[+-]\\d{2}:?\\d{2})?)?";
+
+/**
+ * Separator spellings, longest first so `->` is never consumed as a bare `-`
+ * that then strands the `>`.
+ */
+const SEPARATOR = "(?:-+>|→|[–—]|-)";
+
+const WINDOW_RANGE = new RegExp(`(${ISO_INSTANT})\\s*${SEPARATOR}\\s*(${ISO_INSTANT})`);
+
+/**
+ * Parse a briefing header window into its two endpoints.
+ *
+ * @param {string} windowStr e.g. "2026-04-24T19:00:00Z → 2026-05-05T20:30:00Z (~11 days)"
+ * @returns {{ open: string, close: string } | null} null when no range is present
+ */
+export function parseWindowRange(windowStr) {
+  if (typeof windowStr !== "string") return null;
+  const m = windowStr.match(WINDOW_RANGE);
+  return m ? { open: m[1], close: m[2] } : null;
+}
+
+/**
+ * @param {string} openIso
+ * @param {string} closeIso
+ * @returns {string} "YYYY-MM-DD to YYYY-MM-DD (~N days)"
+ */
+export function formatWindow(openIso, closeIso) {
+  const a = new Date(openIso);
+  const b = new Date(closeIso);
+  const days = Math.round((b - a) / (1000 * 60 * 60 * 24));
+  const fmt = (d) => d.toISOString().slice(0, 10);
+  return `${fmt(a)} to ${fmt(b)} (~${days} days)`;
+}

--- a/plugins/ai-briefing/skills/generate/output/build/test/window.test.js
+++ b/plugins/ai-briefing/skills/generate/output/build/test/window.test.js
@@ -1,0 +1,57 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { formatWindow, parseWindowRange } from "../lib/window.js";
+
+const OPEN = "2026-04-24T19:00:00Z";
+const CLOSE = "2026-05-05T20:30:00Z";
+
+test("parses the Unicode-arrow window header", () => {
+  assert.deepEqual(parseWindowRange(`${OPEN} → ${CLOSE} (~11 days)`), {
+    open: OPEN,
+    close: CLOSE,
+  });
+});
+
+// Regression (#3364): the old `([0-9T:Z-]+)\s*[→-]+\s*([0-9T:Z-]+)` could not
+// place the `>` of an ASCII arrow, so it backtracked and split INSIDE the first
+// timestamp — yielding open="2026", close="04-24T19:00:00Z" and a nonsense
+// rendered window. Both spellings must yield the same full pair.
+test("parses the ASCII-arrow window header into the same full timestamps", () => {
+  assert.deepEqual(parseWindowRange(`${OPEN} -> ${CLOSE} (~11 days)`), {
+    open: OPEN,
+    close: CLOSE,
+  });
+});
+
+test("both separator spellings render an identical window string", () => {
+  const unicode = parseWindowRange(`${OPEN} → ${CLOSE} (~11 days)`);
+  const ascii = parseWindowRange(`${OPEN} -> ${CLOSE} (~11 days)`);
+  assert.equal(
+    formatWindow(ascii.open, ascii.close),
+    formatWindow(unicode.open, unicode.close),
+  );
+  assert.equal(formatWindow(ascii.open, ascii.close), "2026-04-24 to 2026-05-05 (~11 days)");
+});
+
+test("accepts a bare hyphen and an en/em dash between full timestamps", () => {
+  for (const sep of ["-", "–", "—", "-->"]) {
+    assert.deepEqual(
+      parseWindowRange(`${OPEN} ${sep} ${CLOSE}`),
+      { open: OPEN, close: CLOSE },
+      `separator ${sep} must not split a timestamp`,
+    );
+  }
+});
+
+test("accepts date-only endpoints", () => {
+  assert.deepEqual(parseWindowRange("2026-04-24 -> 2026-05-05"), {
+    open: "2026-04-24",
+    close: "2026-05-05",
+  });
+});
+
+test("returns null when the header carries no range", () => {
+  assert.equal(parseWindowRange("rolling window"), null);
+  assert.equal(parseWindowRange(undefined), null);
+});


### PR DESCRIPTION
## Summary

Any briefing whose header spells the window separator as the ASCII arrow (`->`) rendered a
nonsense date range on the slides. `emit-slides-data.js:136` parsed the window with
`([0-9T:Z\-]+)\s*[→-]+\s*([0-9T:Z\-]+)`: the capture classes include `-`, and the separator
class matches `-` but not `>`, so the engine could not place the `>` and backtracked until the
split landed inside the first timestamp. `formatWindow` was then handed a garbage pair.

Reproduced against the pre-fix regex:

```
$ node -e 'console.log("2026-04-24T19:00:00Z -> 2026-05-05T20:30:00Z (~11 days)".match(/([0-9T:Z\-]+)\s*[→-]+\s*([0-9T:Z\-]+)/).slice(1,3))'
[ '2026-04', '24T19:00:00Z' ]
```

## Fix

`plugins/ai-briefing/skills/generate/output/build/lib/window.js` (new) owns the parse:

- Each endpoint is anchored on a full `YYYY-MM-DD[Thh:mm[:ss][Z|±hh:mm]]` shape. This is the
  load-bearing half: `2026` alone can no longer satisfy the first group, so a mid-timestamp
  split is structurally impossible rather than merely disfavored by backtracking order.
- The separator alternation accepts `→`, `->` (and `-->`), an en/em dash, and a bare hyphen,
  longest first so `->` is never consumed as a `-` that strands the `>`.
- `parseWindowRange` returns `{ open, close }` or `null`; `formatWindow` moved alongside it.

Extraction to `lib/` is not cosmetic: `emit-slides-data.js` calls `main()` at import
(`main().catch(...)` on its last line), so nothing defined in it can be exercised from a test.
Every sibling suite in `build/test/` imports from `../lib/`, so this follows the existing shape.

`emit-slides-data.js` now calls `parseWindowRange` and keeps its `else windowStr =
briefing.meta.window` fallback unchanged.

## Verification

- New `build/test/window.test.js` (Node's built-in runner, matching the sibling suites):
  `node --test test/window.test.js` -> `pass 6, fail 0`. It covers the Unicode form, the ASCII
  form, that both spellings render an identical window string
  (`2026-04-24 to 2026-05-05 (~11 days)`), bare-hyphen/en-dash/em-dash/`-->` separators,
  date-only endpoints, and the no-range and non-string cases returning `null`.
- The ASCII case is a true regression test: it asserts the full pair
  `{2026-04-24T19:00:00Z, 2026-05-05T20:30:00Z}`, which the pre-fix regex returned as
  `2026-04` / `24T19:00:00Z` (shown above).
- `scripts/affected-tests.sh` over this PR's paths: the Node suites are selected and reported
  `NOT RUN` by design (only `*.test.sh` is executed by `--run`), so they were run directly with
  `node --test` as above.

## Related

Closes #3364
