### PR TITLE
fix(knowledge): make recover-watch-bootstrap's usage branch reachable and its downsample warn honest

### DIFF
--- a/plugins/knowledge/.claude-plugin/plugin.json
+++ b/plugins/knowledge/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "knowledge",
-  "version": "0.13.14",
+  "version": "0.13.15",
   "description": "Ingest external knowledge into durable, synthesized artifacts. Ships a book-distillation pipeline (PDF/EPUB into concept-organized, author-attributed skill reference files), a video-digest pipeline (watch a single public video from YouTube or X, formerly Twitter: transcript, link harvest, and repo-applicability synthesis), a course-digest pipeline (extract and synthesize online video courses \u2014 Dometrain, Teachable \u2014 into repo-applicable recommendations), a docpage-digest pipeline (single online documentation page into a verified knowledge slice with dual verification \u2014 one cross-vendor verifier \u2014 and an interview handoff), and a map-corpus pipeline (multi-resource corpus into a classified link map, deterministic node manifests, gate-verified relevance inventory, and an approved queue of docpage-digest runs), plus a re-runnable setup action; a configurable library directory governs where synthesized artifacts land in the consuming repo.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/knowledge/CHANGELOG.md
+++ b/plugins/knowledge/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to the `knowledge` plugin are recorded here. The `version` i
 `.claude-plugin/plugin.json` is the delivery vehicle — a consumer receives a change
 only after that version increases.
 
+## [0.13.15]
+
+### Fixed
+
+- **`recover-watch-bootstrap` crashed instead of printing its usage line (#3365).** The CLI ran
+  `path.resolve(argv[2])` through `path.resolve(argv[5])` BEFORE the presence check, so a
+  missing argument threw `TypeError: The "paths[0]" argument must be of type string` first and
+  the usage branch (and its `return 1`) was unreachable. Callers got a stack trace. Arguments
+  are now validated before resolution, so a short invocation prints the usage line and returns
+  1.
+- **The downsample WARN reported the same count on both sides (#3365).** `selection` was
+  reassigned with the downsampled array before the log interpolated
+  `selection.selected.length`, so a 50-frame selection cut to 16 logged
+  `downsampled 16 → 16 frames` and hid every dropped frame. The stratified downsample moved to
+  an exported `downsampleSelectedFrames` helper that captures the pre-downsample count, and the
+  WARN now names the true before count, the after count, and how many frames were dropped.
+
 ## [0.13.14]
 
 ### Changed

--- a/plugins/knowledge/skills/video-digest/extraction/watch/recover-watch-bootstrap.js
+++ b/plugins/knowledge/skills/video-digest/extraction/watch/recover-watch-bootstrap.js
@@ -133,21 +133,56 @@ export function resolveWorkArtifacts(workDir) {
   };
 }
 
+export const RECOVER_USAGE =
+  "Usage: node watch/recover-watch-bootstrap.js <slice-dir> <workDir> <framesDir> <contactSheetsDir>";
+
+/**
+ * Stratified downsample of a frame selection to the frame count the contact
+ * sheets already on disk can hold.
+ *
+ * Split out so the WARN reports the count it downsampled FROM: reassigning
+ * `selection` before reading `selection.selected.length` printed the
+ * post-downsample count on both sides of the arrow, so the log claimed
+ * "N → N" and hid how many frames were dropped.
+ *
+ * @param {import('../watching/models.js').SelectedFrame[]} selected
+ * @param {number} targetFrameCount
+ * @returns {{ selected: import('../watching/models.js').SelectedFrame[], droppedCount: number, warning: string|null }}
+ */
+export function downsampleSelectedFrames(selected, targetFrameCount) {
+  const beforeCount = selected.length;
+  if (beforeCount <= targetFrameCount) {
+    return { selected, droppedCount: 0, warning: null };
+  }
+  const step = beforeCount / targetFrameCount;
+  const downsampled = [];
+  for (let i = 0; i < targetFrameCount; i++) {
+    downsampled.push(selected[Math.floor(i * step)]);
+  }
+  return {
+    selected: downsampled,
+    droppedCount: beforeCount - downsampled.length,
+    warning: `WARN: downsampled ${beforeCount} → ${downsampled.length} frames (stratified, ${beforeCount - downsampled.length} dropped)`,
+  };
+}
+
 /**
  * @param {string[]} argv
  */
 export async function recoverWatchBootstrapCli(argv) {
-  const sliceDir = path.resolve(argv[2]);
-  const workDir = path.resolve(argv[3]);
-  const framesDir = path.resolve(argv[4]);
-  const contactSheetsDir = path.resolve(argv[5]);
-
-  if (!sliceDir || !workDir || !framesDir || !contactSheetsDir) {
-    writeStderr(
-      "Usage: node watch/recover-watch-bootstrap.js <slice-dir> <workDir> <framesDir> <contactSheetsDir>",
-    );
+  // Validate BEFORE resolving: `path.resolve(undefined)` throws a TypeError,
+  // so resolving first made this usage branch unreachable and turned a bad
+  // invocation into a stack trace.
+  const [sliceDirArg, workDirArg, framesDirArg, contactSheetsDirArg] = argv.slice(2, 6);
+  if (!sliceDirArg || !workDirArg || !framesDirArg || !contactSheetsDirArg) {
+    writeStderr(RECOVER_USAGE);
     return 1;
   }
+
+  const sliceDir = path.resolve(sliceDirArg);
+  const workDir = path.resolve(workDirArg);
+  const framesDir = path.resolve(framesDirArg);
+  const contactSheetsDir = path.resolve(contactSheetsDirArg);
 
   const sourceUrl = await resolveRecoverySourceUrl(sliceDir);
   if (!sourceUrl) {
@@ -196,20 +231,14 @@ export async function recoverWatchBootstrapCli(argv) {
   const expectedSheetCount = sheetFiles.length;
   const expectedFrameCount = expectedSheetCount * 16;
 
-  if (selection.selected.length > expectedFrameCount) {
-    const step = selection.selected.length / expectedFrameCount;
-    const downsampled = [];
-    for (let i = 0; i < expectedFrameCount; i++) {
-      downsampled.push(selection.selected[Math.floor(i * step)]);
-    }
+  const downsample = downsampleSelectedFrames(selection.selected, expectedFrameCount);
+  if (downsample.warning) {
     selection = {
       ...selection,
-      selected: downsampled,
+      selected: downsample.selected,
       candidateCount: merged.length,
     };
-    writeStderr(
-      `WARN: downsampled ${selection.selected.length} → ${expectedFrameCount} frames (stratified) to match ${expectedSheetCount} contact sheets`,
-    );
+    writeStderr(`${downsample.warning} to match ${expectedSheetCount} contact sheets`);
   }
 
   const batches = batchFramesForContactSheets(selection.selected, 16);

--- a/plugins/knowledge/skills/video-digest/extraction/watch/recover-watch-bootstrap.test.js
+++ b/plugins/knowledge/skills/video-digest/extraction/watch/recover-watch-bootstrap.test.js
@@ -4,7 +4,12 @@ import path from "node:path";
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { recoverWatchBootstrapCli, resolveRecoverySourceUrl } from "./recover-watch-bootstrap.js";
+import {
+  downsampleSelectedFrames,
+  RECOVER_USAGE,
+  recoverWatchBootstrapCli,
+  resolveRecoverySourceUrl,
+} from "./recover-watch-bootstrap.js";
 import { createWatchState, writeWatchState } from "./watch-state.js";
 
 const captured = vi.hoisted(() => ({ stderr: /** @type {string[]} */ ([]) }));
@@ -57,5 +62,66 @@ describe("recovery source-URL resolution", () => {
 
     expect(code).toBe(1);
     expect(captured.stderr.join("\n")).toContain("no sourceUrl");
+  });
+});
+
+describe("recovery CLI argument validation", () => {
+  beforeEach(() => {
+    captured.stderr.length = 0;
+  });
+
+  // Regression (#3365): `path.resolve(argv[2..5])` ran BEFORE the presence
+  // check, so a missing argument threw `TypeError` and the usage branch was
+  // unreachable. A bad invocation must print the usage line and return 1.
+  it.each([
+    ["no arguments", []],
+    ["only slice-dir", ["slice"]],
+    ["only slice-dir and workDir", ["slice", "work"]],
+    ["missing contactSheetsDir", ["slice", "work", "frames"]],
+    ["empty contactSheetsDir", ["slice", "work", "frames", ""]],
+  ])("prints usage and returns 1 with %s", async (_label, args) => {
+    const code = await recoverWatchBootstrapCli(["node", "recover-watch-bootstrap.js", ...args]);
+
+    expect(code).toBe(1);
+    expect(captured.stderr.join("\n")).toContain(RECOVER_USAGE);
+  });
+});
+
+describe("stratified downsample reporting", () => {
+  // Regression (#3365): the WARN interpolated `selection.selected.length`
+  // AFTER `selection` was reassigned to the downsampled array, so it printed
+  // "N → N" and hid every dropped frame.
+  it("reports the pre-downsample count, not the post-downsample count", () => {
+    const selected = Array.from({ length: 50 }, (_, i) => ({ path: `f${i}.png` }));
+
+    const result = downsampleSelectedFrames(selected, 16);
+
+    expect(result.selected).toHaveLength(16);
+    expect(result.droppedCount).toBe(34);
+    expect(result.warning).toContain("downsampled 50 → 16 frames");
+    expect(result.warning).not.toContain("16 → 16");
+  });
+
+  it("keeps the selection and stays silent when it already fits", () => {
+    const selected = Array.from({ length: 12 }, (_, i) => ({ path: `f${i}.png` }));
+
+    const result = downsampleSelectedFrames(selected, 16);
+
+    expect(result.selected).toBe(selected);
+    expect(result.droppedCount).toBe(0);
+    expect(result.warning).toBeNull();
+  });
+
+  it("samples across the whole selection rather than truncating the tail", () => {
+    const selected = Array.from({ length: 8 }, (_, i) => ({ path: `f${i}.png` }));
+
+    const result = downsampleSelectedFrames(selected, 4);
+
+    expect(result.selected.map((f) => f.path)).toEqual([
+      "f0.png",
+      "f2.png",
+      "f4.png",
+      "f6.png",
+    ]);
   });
 });


### PR DESCRIPTION
## Summary

Two confirmed defects in
`plugins/knowledge/skills/video-digest/extraction/watch/recover-watch-bootstrap.js`.

**1. The usage branch was unreachable.** `recoverWatchBootstrapCli` ran `path.resolve(argv[2])`
through `path.resolve(argv[5])` before the `if (!sliceDir || ...)` check, so a missing argument
threw first and the usage message plus its `return 1` could never execute:

```
$ node -e 'require("node:path").resolve(undefined)'
TypeError: The "paths[0]" argument must be of type string. Received undefined
```

**2. The downsample WARN lied about how many frames it dropped.** `selection` was reassigned
with `selected: downsampled` before the log interpolated `selection.selected.length`, so both
sides of the arrow printed the post-downsample count. Reproducing the pre-fix expression on a
50-frame selection cut to 16:

```
DEFECT2 pre-fix WARN: downsampled 16 -> 16 frames
```

The dropped count is precisely what someone debugging a frame/contact-sheet mismatch is looking
for, and it was the one number the line could not show.

## Fix

- Destructure `argv.slice(2, 6)` and validate presence BEFORE resolving. The usage line and
  exit code 1 are now reachable; `RECOVER_USAGE` is exported so the test asserts the same
  string the CLI prints rather than a copy of it.
- Extract the stratified downsample into an exported `downsampleSelectedFrames(selected,
  targetFrameCount)` that captures the pre-downsample count and returns
  `{ selected, droppedCount, warning }`. The WARN now reads
  `downsampled 50 → 16 frames (stratified, 34 dropped) to match N contact sheets`.
  Extraction is what makes the branch testable: it sits mid-CLI behind a real `ffprobe` spawn and
  a full temp-dir fixture, so the exported helper is the only reachable seam. `resolveWorkArtifacts`
  and `resolveRecoverySourceUrl` are already exported and imported by the sibling suite, so this
  follows the file's existing shape.

Behavior is otherwise preserved, including the `expectedFrameCount === 0` edge (no sheets on
disk still yields an empty selection and a warning, as before).

## Verification

`npx vitest run watch/recover-watch-bootstrap.test.js` from
`plugins/knowledge/skills/video-digest/extraction`: **11 passed** (3 pre-existing, 8 new).

New coverage in the existing suite:

- Five parametrized bad invocations (no args, one, two, three, and an empty fourth) each assert
  `code === 1` and that stderr carries `RECOVER_USAGE`. Every one of these threw `TypeError`
  before the fix.
- `downsampleSelectedFrames(50 frames, 16)` asserts `droppedCount === 34`, that the warning
  contains `downsampled 50 → 16 frames`, and explicitly that it does NOT contain `16 → 16` —
  the exact pre-fix string.
- The already-fits case returns the same array identity with no warning.
- The sampling is stratified, not a tail truncation (`8 -> 4` yields `f0, f2, f4, f6`).

`scripts/affected-tests.sh --run --explain` on this branch: see the comment below for the exact
output. Only `*.test.sh` is executed by `--run`, so the vitest suite was run directly, as above.

## Related

Closes #3365
