### PR TITLE
fix(powershell-format): release the _ps_before snapshot and disclose a rewrite on the tool-break arm

### DIFF
--- a/plugins/powershell-format/.claude-plugin/plugin.json
+++ b/plugins/powershell-format/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "powershell-format",
-  "version": "0.7.24",
+  "version": "0.7.25",
   "description": "Auto-format and lint PowerShell on edit via PSScriptAnalyzer, only when a PSScriptAnalyzerSettings.psd1 governs the repo — using the consuming repo's own analyzer settings.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/powershell-format/CHANGELOG.md
+++ b/plugins/powershell-format/CHANGELOG.md
@@ -7,6 +7,14 @@ All notable changes to the `powershell-format` plugin are documented here. Forma
 
 ### Fixed
 
+- **The findings and tool-break arms emitted two JSON documents on stdout (#3366).** The hook
+  output contract is ONE JSON document for the whole of stdout, but an arm carrying both
+  `additionalContext` and a rewrite disclosure printed `hook::ctx_flush`'s object and then the
+  disclosure's, producing an invalid response in which either channel could be lost. The
+  disclosure helper splits into `take_ps_rewrite_disclosure` (release the snapshot, record the
+  text) and its emitting wrapper, so arms 1 and the tool-break catch-all now compose both
+  channels through `hook::emit_channels`. Arms 0, 3, 5, and 6 keep the wrapper and are unchanged.
+
 - **`_ps_before` snapshot leaked on the trust-gate and tool-break arms (#3366).** The hook copies
   the target file to an `mktemp` snapshot so a formatter rewrite can be disclosed. Arms 3 and 5
   release it and the disclosure helper releases it on the arms that call it, but the trust-gate

--- a/plugins/powershell-format/CHANGELOG.md
+++ b/plugins/powershell-format/CHANGELOG.md
@@ -3,6 +3,23 @@
 All notable changes to the `powershell-format` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.7.25]
+
+### Fixed
+
+- **`_ps_before` snapshot leaked on the trust-gate and tool-break arms (#3366).** The hook copies
+  the target file to an `mktemp` snapshot so a formatter rewrite can be disclosed. Arms 3 and 5
+  release it and the disclosure helper releases it on the arms that call it, but the trust-gate
+  arm (`6)`) and the tool-break catch-all (`*)`) returned without either, leaking one temp file
+  per gated run. Both now release it.
+- **A formatter rewrite went undisclosed when pwsh broke (#3366).** `Invoke-Formatter` writes the
+  reformatted file back before `Invoke-ScriptAnalyzer` runs, and both sit inside the same
+  try/catch that raises exit 4, so a rewrite can already be on disk when pwsh throws. The
+  tool-break arm exited 0 without calling `maybe_disclose_ps_rewrite`, silently violating the
+  hook's rewrite-disclosure contract; it now discloses. The trust-gate arm owes no disclosure:
+  every `exit 6` is raised by the gate, which runs before `Invoke-Formatter`, so no rewrite can
+  have landed there.
+
 ## [0.7.24]
 
 ### Changed

--- a/plugins/powershell-format/hooks/powershell-format.sh
+++ b/plugins/powershell-format/hooks/powershell-format.sh
@@ -755,6 +755,11 @@ case $PWSH_EXIT in
     hook::emit_skip_notice PostToolUse \
       "powershell-format trust gate: PSScriptAnalyzer run skipped — $SETTINGS_REL declares CustomRulePath (analysis would load and execute repository-supplied rule modules) or cannot be verified code-free. $APPROVE_HINT"
   fi
+  # No disclosure decision is owed here: every `exit 6` in the pwsh block above
+  # is raised by the trust gate, which runs BEFORE Invoke-Formatter, so no
+  # rewrite can have landed. Only the snapshot needs releasing — same as arms
+  # 3 and 5, which also precede the formatter.
+  rm -f "$_ps_before"
   emit_skipped
   ;;
 *)
@@ -770,6 +775,11 @@ case $PWSH_EXIT in
   done <<<"$PSSA_OUTPUT"
   hook::ctx_flush PostToolUse
   emit_tel "skipped" '[]'
+  # Invoke-Formatter writes back BEFORE Invoke-ScriptAnalyzer runs, and both sit
+  # inside the same try/catch that raises exit 4 — so a rewrite can already be on
+  # disk when pwsh breaks. Disclose it (the helper also releases the snapshot on
+  # both the changed and unchanged paths) rather than exiting on a silent rewrite.
+  maybe_disclose_ps_rewrite
   exit 0
   ;;
 esac

--- a/plugins/powershell-format/hooks/powershell-format.sh
+++ b/plugins/powershell-format/hooks/powershell-format.sh
@@ -212,13 +212,28 @@ if _ps_before=$(mktemp 2>/dev/null); then
   cp "$FILE" "$_ps_before" 2>/dev/null || _ps_before=""
 fi
 
-maybe_disclose_ps_rewrite() {
+# Release the snapshot and record the disclosure text (empty when nothing was
+# rewritten) in PS_REWRITE_MESSAGE. Split from the emitting wrapper because an
+# arm that ALSO carries additionalContext must compose both channels into ONE
+# document: Claude Code parses the hook's whole stdout as a single JSON doc, so
+# a second printed object is an invalid response and either message can be lost.
+# Idempotent — a second call finds `_ps_before` empty and resets the message.
+PS_REWRITE_MESSAGE=""
+take_ps_rewrite_disclosure() {
+  PS_REWRITE_MESSAGE=""
   [[ -n "$_ps_before" ]] || return 0
   if ! cmp -s "$_ps_before" "$FILE" 2>/dev/null; then
-    hook::emit_system_message "powershell-format: reformatted $(basename "$FILE") via Invoke-Formatter (structural layout only)."
+    PS_REWRITE_MESSAGE="powershell-format: reformatted $(basename "$FILE") via Invoke-Formatter (structural layout only)."
   fi
   rm -f "$_ps_before"
   _ps_before=""
+}
+
+# Disclosure for an arm that carries no additionalContext of its own.
+maybe_disclose_ps_rewrite() {
+  take_ps_rewrite_disclosure
+  [[ -n "$PS_REWRITE_MESSAGE" ]] || return 0
+  hook::emit_system_message "$PS_REWRITE_MESSAGE"
 }
 
 # Single pwsh invocation — probe the module, gate code-loading settings, format
@@ -665,22 +680,24 @@ case $PWSH_EXIT in
   # Findings — advisory context, exit 0. Status "ok": the analyzer RAN and
   # produced a judgment (findings live in data.findings), mirroring the sibling
   # formatter plugins where status reflects whether the tool ran, not clean-ness.
-  hook::ctx_reset
-  hook::ctx_append "powershell-format: $(basename "$FILE") has PSScriptAnalyzer findings (advisory):"
+  PS_CTX="powershell-format: $(basename "$FILE") has PSScriptAnalyzer findings (advisory):"
   findings_raw=""
   while IFS= read -r line; do
     [[ -n "$line" ]] || continue
-    hook::ctx_append "  $line"
+    PS_CTX+=$'\n'"  $line"
     findings_raw+="$line"$'\n'
   done <<<"$PSSA_OUTPUT"
-  hook::ctx_flush PostToolUse
 
   FINDINGS_JSON='[]'
   if [[ -n "$findings_raw" ]]; then
     FINDINGS_JSON=$(printf '%s' "$findings_raw" | jq -R . | jq -s . 2>/dev/null) || FINDINGS_JSON='[]'
   fi
   emit_tel "ok" "$FINDINGS_JSON"
-  maybe_disclose_ps_rewrite
+  # Findings AND a rewrite disclosure compose into one document. Emitting the
+  # context and the systemMessage as two objects would break the single-JSON-doc
+  # stdout contract, which is what hook::emit_channels exists to prevent.
+  take_ps_rewrite_disclosure
+  hook::emit_channels PostToolUse "$PS_CTX" "$PS_REWRITE_MESSAGE"
   exit 0
   ;;
 3)
@@ -767,19 +784,19 @@ case $PWSH_EXIT in
   # judgment was made. Surface via additionalContext (NOT stderr — an advisory
   # hook's exit-0 stderr can trip a false "Hook Error" label). Record as
   # "skipped" (the analyzer never ran to judgment).
-  hook::ctx_reset
-  hook::ctx_append "powershell-format: pwsh failed for $(basename "$FILE") (no diagnostics; tool break, not a finding):"
+  PS_CTX="powershell-format: pwsh failed for $(basename "$FILE") (no diagnostics; tool break, not a finding):"
   while IFS= read -r line; do
     [[ -n "$line" ]] || continue
-    hook::ctx_append "  $line"
+    PS_CTX+=$'\n'"  $line"
   done <<<"$PSSA_OUTPUT"
-  hook::ctx_flush PostToolUse
   emit_tel "skipped" '[]'
   # Invoke-Formatter writes back BEFORE Invoke-ScriptAnalyzer runs, and both sit
   # inside the same try/catch that raises exit 4 — so a rewrite can already be on
-  # disk when pwsh breaks. Disclose it (the helper also releases the snapshot on
-  # both the changed and unchanged paths) rather than exiting on a silent rewrite.
-  maybe_disclose_ps_rewrite
+  # disk when pwsh breaks. Take the disclosure (which also releases the snapshot
+  # on the changed and unchanged paths alike) and emit it WITH the tool-break
+  # context as one document, rather than exiting on a silent rewrite.
+  take_ps_rewrite_disclosure
+  hook::emit_channels PostToolUse "$PS_CTX" "$PS_REWRITE_MESSAGE"
   exit 0
   ;;
 esac

--- a/plugins/powershell-format/hooks/powershell-format.test.sh
+++ b/plugins/powershell-format/hooks/powershell-format.test.sh
@@ -762,6 +762,111 @@ else
 fi
 
 # ============================================================================
+# Snapshot release + rewrite disclosure on the non-formatting arms (#3366)
+# ============================================================================
+# The hook copies the target file to an `_ps_before` mktemp snapshot so a
+# formatter rewrite can be disclosed on the user channel. Every exit arm owes
+# that snapshot a release. The trust-gate (pwsh exit 6) and tool-break
+# (catch-all) arms used to return without one, leaking one temp file per gated
+# run; the tool-break arm also skipped maybe_disclose_ps_rewrite, so a rewrite
+# Invoke-Formatter had already written back before the analyzer threw went
+# undisclosed.
+#
+# Each run gets its own TMPDIR so "left nothing behind" is a strict emptiness
+# check, and HOOK_TELEMETRY_SINK stays unwired so hook-utils' own envelope
+# mktemp never lands in the scratch. The stub pwsh counts the scratch's entries
+# WHILE it runs: that live probe is what keeps the post-run emptiness assertion
+# from being vacuous — a scratch the hook's mktemp never used would read as
+# "empty" too, and the assertion would pass over a leak elsewhere.
+ARM_REPO="$WORK/arm-cleanup"
+new_repo "$ARM_REPO"
+ARM_FILE="$ARM_REPO/arm.ps1"
+
+# run_arm <label> <stub-body> -> ARM_OUT (hook stdout), ARM_RC, ARM_DURING
+# (scratch entries while pwsh ran), ARM_LEFT (scratch entries after the hook
+# exited), ARM_FILE reset to its pre-run content first.
+run_arm() {
+  local label="$1" stub="$2" scratch probe
+  scratch="$WORK/scratch-$label"
+  probe="$WORK/probe-$label"
+  rm -rf "$scratch"
+  mkdir -p "$scratch"
+  rm -f "$probe"
+  printf "%s\n" "Get-ChildItem -Path '.'" >"$ARM_FILE"
+  make_stub_pwsh "ls -A \"\$TMPDIR\" 2>/dev/null | wc -l >\"$probe\"
+$stub"
+  # `-u` must precede every NAME=VALUE: env stops parsing options at the first
+  # operand, so a trailing `-u FOO` is taken as the command to run (exit 127).
+  ARM_OUT=$(run_hook_env "$ARM_FILE" \
+    -u HOOK_TELEMETRY_SINK \
+    CLAUDE_PLUGIN_OPTION_POWERSHELL_FORMAT_ENABLED=true \
+    CLAUDE_PLUGIN_DATA="$WORK/arm-data-$label" \
+    TMPDIR="$scratch" \
+    PATH="$STUB_BIN:$PATH")
+  ARM_RC=$?
+  ARM_DURING="$(tr -cd '0-9' <"$probe" 2>/dev/null)"
+  ARM_LEFT="$(ls -A "$scratch" 2>/dev/null | wc -l | tr -cd '0-9')"
+}
+
+# --- Trust-gate arm (pwsh exit 6) -> snapshot released -----------------------
+run_arm gate 'echo "PSSA_TRUST NOSTORE"; exit 6'
+if [[ "${ARM_DURING:-0}" -ge 1 ]]; then
+  ok "trust-gate arm: hook's snapshot mktemp lands in the isolated TMPDIR (leak check is discriminating)"
+else
+  fail "trust-gate arm: nothing in the isolated TMPDIR during the run — leak check would be vacuous"
+fi
+if [[ $ARM_RC -eq 0 && "${ARM_LEFT:-1}" -eq 0 ]]; then
+  ok "trust-gate arm (pwsh exit 6) -> _ps_before snapshot released, nothing left in TMPDIR"
+else
+  fail "trust-gate arm leaked $ARM_LEFT temp file(s) (rc=$ARM_RC out=$ARM_OUT)"
+fi
+
+# --- Tool-break arm (pwsh exit 4) -> snapshot released AND rewrite disclosed --
+# The stub rewrites the file before throwing, standing in for Invoke-Formatter
+# writing back (line 631 of the pwsh block) and Invoke-ScriptAnalyzer then
+# throwing inside the same try/catch (exit 4).
+run_arm break "printf '# rewritten by the formatter\\n' >>\"$ARM_FILE\"
+echo 'boom: analyzer threw' >&2
+exit 4"
+if [[ "${ARM_DURING:-0}" -ge 1 ]]; then
+  ok "tool-break arm: hook's snapshot mktemp lands in the isolated TMPDIR (leak check is discriminating)"
+else
+  fail "tool-break arm: nothing in the isolated TMPDIR during the run — leak check would be vacuous"
+fi
+if [[ $ARM_RC -eq 0 && "${ARM_LEFT:-1}" -eq 0 ]]; then
+  ok "tool-break arm (pwsh exit 4) -> _ps_before snapshot released, nothing left in TMPDIR"
+else
+  fail "tool-break arm leaked $ARM_LEFT temp file(s) (rc=$ARM_RC out=$ARM_OUT)"
+fi
+# Substring match rather than has_format_disclosure: this arm emits the
+# tool-break additionalContext document and the disclosure document separately
+# (the same shape arm 1 already has), so jq cannot read the pair as one object.
+if printf '%s' "$ARM_OUT" | grep -q 'reformatted arm.ps1 via Invoke-Formatter'; then
+  ok "tool-break arm -> a rewrite that landed before pwsh threw is disclosed"
+else
+  fail "tool-break arm -> rewrite went undisclosed: $ARM_OUT"
+fi
+if printf '%s' "$ARM_OUT" | grep -qi 'tool break'; then
+  ok "tool-break arm -> still surfaces the advisory tool-break context alongside the disclosure"
+else
+  fail "tool-break arm -> tool-break context lost: $ARM_OUT"
+fi
+
+# --- Tool-break arm with NO rewrite -> silent, still no leak ------------------
+run_arm quiet "echo 'boom: analyzer threw' >&2; exit 4"
+if [[ "${ARM_LEFT:-1}" -eq 0 ]]; then
+  ok "tool-break arm without a rewrite -> snapshot still released"
+else
+  fail "tool-break arm without a rewrite leaked $ARM_LEFT temp file(s)"
+fi
+if printf '%s' "$ARM_OUT" | grep -q 'reformatted'; then
+  fail "tool-break arm disclosed a rewrite that never happened: $ARM_OUT"
+else
+  ok "tool-break arm without a rewrite -> no disclosure (no-op paths stay silent)"
+fi
+rm -f "$STUB_BIN/pwsh"
+
+# ============================================================================
 # Telemetry
 # ============================================================================
 

--- a/plugins/powershell-format/hooks/powershell-format.test.sh
+++ b/plugins/powershell-format/hooks/powershell-format.test.sh
@@ -230,7 +230,7 @@ run_arm() {
   mkdir -p "$scratch"
   rm -f "$probe"
   printf "%s\n" "Get-ChildItem -Path '.'" >"$ARM_FILE"
-  make_stub_pwsh "ls -A \"\$TMPDIR\" 2>/dev/null | wc -l >\"$probe\"
+  make_stub_pwsh "find \"\$TMPDIR\" -mindepth 1 2>/dev/null | wc -l >\"$probe\"
 $stub"
   # `-u` must precede every NAME=VALUE: env stops parsing options at the first
   # operand, so a trailing `-u FOO` is taken as the command to run (exit 127).
@@ -242,7 +242,7 @@ $stub"
     PATH="$STUB_BIN:$PATH")
   ARM_RC=$?
   ARM_DURING="$(tr -cd '0-9' <"$probe" 2>/dev/null)"
-  ARM_LEFT="$(ls -A "$scratch" 2>/dev/null | wc -l | tr -cd '0-9')"
+  ARM_LEFT="$(find "$scratch" -mindepth 1 2>/dev/null | wc -l | tr -cd '0-9')"
 }
 
 # Trust-gate arm (pwsh exit 6) -> snapshot released.

--- a/plugins/powershell-format/hooks/powershell-format.test.sh
+++ b/plugins/powershell-format/hooks/powershell-format.test.sh
@@ -195,6 +195,120 @@ if printf '%s' "$OUT" | jq -e '.hookSpecificOutput.additionalContext' >/dev/null
 else
   fail "tool break -> no additionalContext JSON: $OUT"
 fi
+# --- Snapshot release + rewrite disclosure on the non-formatting arms (#3366) -
+# The hook copies the target file to an `_ps_before` mktemp snapshot so a
+# formatter rewrite can be disclosed on the user channel. Every exit arm owes
+# that snapshot a release. The trust-gate (pwsh exit 6) and tool-break
+# (catch-all) arms used to return without one, leaking one temp file per gated
+# run; the tool-break arm also skipped the disclosure, so a rewrite
+# Invoke-Formatter had already written back before the analyzer threw went
+# unnamed.
+#
+# These live ABOVE the real-pwsh prerequisite gate on purpose: they drive the
+# arms through the stub pwsh, so they need neither a real pwsh nor the
+# PSScriptAnalyzer module, and placing them below would silently skip this
+# regression coverage on exactly the pwsh-less hosts CI runs on.
+#
+# Each run gets its own TMPDIR so "left nothing behind" is a strict emptiness
+# check, and HOOK_TELEMETRY_SINK stays unwired so hook-utils' own envelope
+# mktemp never lands in the scratch. The stub pwsh counts the scratch's entries
+# WHILE it runs: that live probe is what keeps the post-run emptiness assertion
+# from being vacuous — a scratch the hook's mktemp never used would read as
+# "empty" too, and the assertion would pass over a leak elsewhere.
+ARM_REPO="$WORK/arm-cleanup"
+new_repo "$ARM_REPO"
+ARM_FILE="$ARM_REPO/arm.ps1"
+
+# run_arm <label> <stub-body> -> ARM_OUT (hook stdout), ARM_RC, ARM_DURING
+# (scratch entries while pwsh ran), ARM_LEFT (scratch entries after the hook
+# exited), ARM_FILE reset to its pre-run content first.
+run_arm() {
+  local label="$1" stub="$2" scratch probe
+  scratch="$WORK/scratch-$label"
+  probe="$WORK/probe-$label"
+  rm -rf "$scratch"
+  mkdir -p "$scratch"
+  rm -f "$probe"
+  printf "%s\n" "Get-ChildItem -Path '.'" >"$ARM_FILE"
+  make_stub_pwsh "ls -A \"\$TMPDIR\" 2>/dev/null | wc -l >\"$probe\"
+$stub"
+  # `-u` must precede every NAME=VALUE: env stops parsing options at the first
+  # operand, so a trailing `-u FOO` is taken as the command to run (exit 127).
+  ARM_OUT=$(run_hook_env "$ARM_FILE" \
+    -u HOOK_TELEMETRY_SINK \
+    CLAUDE_PLUGIN_OPTION_POWERSHELL_FORMAT_ENABLED=true \
+    CLAUDE_PLUGIN_DATA="$WORK/arm-data-$label" \
+    TMPDIR="$scratch" \
+    PATH="$STUB_BIN:$PATH")
+  ARM_RC=$?
+  ARM_DURING="$(tr -cd '0-9' <"$probe" 2>/dev/null)"
+  ARM_LEFT="$(ls -A "$scratch" 2>/dev/null | wc -l | tr -cd '0-9')"
+}
+
+# Trust-gate arm (pwsh exit 6) -> snapshot released.
+run_arm gate 'echo "PSSA_TRUST NOSTORE"; exit 6'
+if [[ "${ARM_DURING:-0}" -ge 1 ]]; then
+  ok "trust-gate arm: hook's snapshot mktemp lands in the isolated TMPDIR (leak check is discriminating)"
+else
+  fail "trust-gate arm: nothing in the isolated TMPDIR during the run — leak check would be vacuous"
+fi
+if [[ $ARM_RC -eq 0 && "${ARM_LEFT:-1}" -eq 0 ]]; then
+  ok "trust-gate arm (pwsh exit 6) -> _ps_before snapshot released, nothing left in TMPDIR"
+else
+  fail "trust-gate arm leaked $ARM_LEFT temp file(s) (rc=$ARM_RC out=$ARM_OUT)"
+fi
+
+# Tool-break arm (pwsh exit 4) -> snapshot released AND rewrite disclosed. The
+# stub rewrites the file before throwing, standing in for Invoke-Formatter
+# writing back and Invoke-ScriptAnalyzer then throwing inside the same
+# try/catch (exit 4).
+run_arm break "printf '# rewritten by the formatter\\n' >>\"$ARM_FILE\"
+echo 'boom: analyzer threw' >&2
+exit 4"
+if [[ "${ARM_DURING:-0}" -ge 1 ]]; then
+  ok "tool-break arm: hook's snapshot mktemp lands in the isolated TMPDIR (leak check is discriminating)"
+else
+  fail "tool-break arm: nothing in the isolated TMPDIR during the run — leak check would be vacuous"
+fi
+if [[ $ARM_RC -eq 0 && "${ARM_LEFT:-1}" -eq 0 ]]; then
+  ok "tool-break arm (pwsh exit 4) -> _ps_before snapshot released, nothing left in TMPDIR"
+else
+  fail "tool-break arm leaked $ARM_LEFT temp file(s) (rc=$ARM_RC out=$ARM_OUT)"
+fi
+# The hook output contract is ONE JSON document for the whole of stdout, so the
+# tool-break context and the disclosure must compose rather than print twice.
+# `jq -s length` counts the documents on stdout, which is what makes the two
+# assertions below meaningful: on a two-document response `jq -e` would be
+# reading whichever object came last, not the response as a reader sees it.
+if [[ "$(printf '%s' "$ARM_OUT" | jq -s 'length' 2>/dev/null)" == "1" ]]; then
+  ok "tool-break arm -> context and disclosure compose into ONE JSON document"
+else
+  fail "tool-break arm -> stdout is not a single JSON document: $ARM_OUT"
+fi
+if has_format_disclosure "$ARM_OUT"; then
+  ok "tool-break arm -> a rewrite that landed before pwsh threw is disclosed"
+else
+  fail "tool-break arm -> rewrite went undisclosed: $ARM_OUT"
+fi
+if printf '%s' "$ARM_OUT" | jq -e '.hookSpecificOutput.additionalContext | contains("tool break")' >/dev/null 2>&1; then
+  ok "tool-break arm -> still surfaces the advisory tool-break context alongside the disclosure"
+else
+  fail "tool-break arm -> tool-break context lost: $ARM_OUT"
+fi
+
+# Tool-break arm with NO rewrite -> silent, still no leak.
+run_arm quiet "echo 'boom: analyzer threw' >&2; exit 4"
+if [[ "${ARM_LEFT:-1}" -eq 0 ]]; then
+  ok "tool-break arm without a rewrite -> snapshot still released"
+else
+  fail "tool-break arm without a rewrite leaked $ARM_LEFT temp file(s)"
+fi
+if printf '%s' "$ARM_OUT" | grep -q 'reformatted'; then
+  fail "tool-break arm disclosed a rewrite that never happened: $ARM_OUT"
+else
+  ok "tool-break arm without a rewrite -> no disclosure (no-op paths stay silent)"
+fi
+
 rm -f "$STUB_BIN/pwsh"
 
 # --- settings walk-up bounded by CLAUDE_PROJECT_DIR ceiling ------------------
@@ -303,6 +417,35 @@ if printf '%s' "$OUT" | jq -e '.hookSpecificOutput.additionalContext' >/dev/null
   fi
 else
   fail "lint finding -> no additionalContext JSON: $OUT"
+fi
+
+# --- Case 4b: findings AND a formatter rewrite compose into ONE document -----
+# Arm 1 carries both channels at once. The hook output contract is a single
+# JSON document for the whole of stdout, so a run that both reformats and
+# reports findings must compose them rather than print two objects (#3366).
+# The fixture pairs a lowercase alias (PSUseCorrectCasing rewrites it) with a
+# global var (PSAvoidGlobalVars survives the formatter as a finding), and the
+# last assertion proves the rewrite actually happened — without it the
+# composition check would pass on a run that had nothing to compose.
+# SC2016: literal PowerShell variable syntax — single quotes are intentional.
+# shellcheck disable=SC2016
+printf '%s\n%s\n' "get-childitem -Path '.'" '$global:both = 1' >"$REPO/lib/both.ps1"
+OUT=$(run_hook "$REPO/lib/both.ps1")
+if [[ "$(printf '%s' "$OUT" | jq -s 'length' 2>/dev/null)" == "1" ]]; then
+  ok "findings + rewrite -> ONE JSON document on stdout"
+else
+  fail "findings + rewrite -> stdout is not a single JSON document: $OUT"
+fi
+if has_format_disclosure "$OUT" &&
+  printf '%s' "$OUT" | jq -e '.hookSpecificOutput.additionalContext | contains("PSAvoidGlobalVars")' >/dev/null 2>&1; then
+  ok "findings + rewrite -> both channels survive composition"
+else
+  fail "findings + rewrite -> a channel was lost: $OUT"
+fi
+if grep -q 'Get-ChildItem' "$REPO/lib/both.ps1"; then
+  ok "findings + rewrite -> the formatter did rewrite (fixture is discriminating)"
+else
+  fail "findings + rewrite -> no rewrite happened, so the composition check proves nothing: $(cat "$REPO/lib/both.ps1")"
 fi
 
 # --- Case 5: .psm1 and .psd1 extensions match --------------------------------
@@ -760,111 +903,6 @@ if printf '%s' "$OUT_GATE_6" | jq -e '.systemMessage | contains("trust gate")' >
 else
   fail "escaped CustomRulePath key evaded the gate: $OUT_GATE_6"
 fi
-
-# ============================================================================
-# Snapshot release + rewrite disclosure on the non-formatting arms (#3366)
-# ============================================================================
-# The hook copies the target file to an `_ps_before` mktemp snapshot so a
-# formatter rewrite can be disclosed on the user channel. Every exit arm owes
-# that snapshot a release. The trust-gate (pwsh exit 6) and tool-break
-# (catch-all) arms used to return without one, leaking one temp file per gated
-# run; the tool-break arm also skipped maybe_disclose_ps_rewrite, so a rewrite
-# Invoke-Formatter had already written back before the analyzer threw went
-# undisclosed.
-#
-# Each run gets its own TMPDIR so "left nothing behind" is a strict emptiness
-# check, and HOOK_TELEMETRY_SINK stays unwired so hook-utils' own envelope
-# mktemp never lands in the scratch. The stub pwsh counts the scratch's entries
-# WHILE it runs: that live probe is what keeps the post-run emptiness assertion
-# from being vacuous — a scratch the hook's mktemp never used would read as
-# "empty" too, and the assertion would pass over a leak elsewhere.
-ARM_REPO="$WORK/arm-cleanup"
-new_repo "$ARM_REPO"
-ARM_FILE="$ARM_REPO/arm.ps1"
-
-# run_arm <label> <stub-body> -> ARM_OUT (hook stdout), ARM_RC, ARM_DURING
-# (scratch entries while pwsh ran), ARM_LEFT (scratch entries after the hook
-# exited), ARM_FILE reset to its pre-run content first.
-run_arm() {
-  local label="$1" stub="$2" scratch probe
-  scratch="$WORK/scratch-$label"
-  probe="$WORK/probe-$label"
-  rm -rf "$scratch"
-  mkdir -p "$scratch"
-  rm -f "$probe"
-  printf "%s\n" "Get-ChildItem -Path '.'" >"$ARM_FILE"
-  make_stub_pwsh "ls -A \"\$TMPDIR\" 2>/dev/null | wc -l >\"$probe\"
-$stub"
-  # `-u` must precede every NAME=VALUE: env stops parsing options at the first
-  # operand, so a trailing `-u FOO` is taken as the command to run (exit 127).
-  ARM_OUT=$(run_hook_env "$ARM_FILE" \
-    -u HOOK_TELEMETRY_SINK \
-    CLAUDE_PLUGIN_OPTION_POWERSHELL_FORMAT_ENABLED=true \
-    CLAUDE_PLUGIN_DATA="$WORK/arm-data-$label" \
-    TMPDIR="$scratch" \
-    PATH="$STUB_BIN:$PATH")
-  ARM_RC=$?
-  ARM_DURING="$(tr -cd '0-9' <"$probe" 2>/dev/null)"
-  ARM_LEFT="$(ls -A "$scratch" 2>/dev/null | wc -l | tr -cd '0-9')"
-}
-
-# --- Trust-gate arm (pwsh exit 6) -> snapshot released -----------------------
-run_arm gate 'echo "PSSA_TRUST NOSTORE"; exit 6'
-if [[ "${ARM_DURING:-0}" -ge 1 ]]; then
-  ok "trust-gate arm: hook's snapshot mktemp lands in the isolated TMPDIR (leak check is discriminating)"
-else
-  fail "trust-gate arm: nothing in the isolated TMPDIR during the run — leak check would be vacuous"
-fi
-if [[ $ARM_RC -eq 0 && "${ARM_LEFT:-1}" -eq 0 ]]; then
-  ok "trust-gate arm (pwsh exit 6) -> _ps_before snapshot released, nothing left in TMPDIR"
-else
-  fail "trust-gate arm leaked $ARM_LEFT temp file(s) (rc=$ARM_RC out=$ARM_OUT)"
-fi
-
-# --- Tool-break arm (pwsh exit 4) -> snapshot released AND rewrite disclosed --
-# The stub rewrites the file before throwing, standing in for Invoke-Formatter
-# writing back (line 631 of the pwsh block) and Invoke-ScriptAnalyzer then
-# throwing inside the same try/catch (exit 4).
-run_arm break "printf '# rewritten by the formatter\\n' >>\"$ARM_FILE\"
-echo 'boom: analyzer threw' >&2
-exit 4"
-if [[ "${ARM_DURING:-0}" -ge 1 ]]; then
-  ok "tool-break arm: hook's snapshot mktemp lands in the isolated TMPDIR (leak check is discriminating)"
-else
-  fail "tool-break arm: nothing in the isolated TMPDIR during the run — leak check would be vacuous"
-fi
-if [[ $ARM_RC -eq 0 && "${ARM_LEFT:-1}" -eq 0 ]]; then
-  ok "tool-break arm (pwsh exit 4) -> _ps_before snapshot released, nothing left in TMPDIR"
-else
-  fail "tool-break arm leaked $ARM_LEFT temp file(s) (rc=$ARM_RC out=$ARM_OUT)"
-fi
-# Substring match rather than has_format_disclosure: this arm emits the
-# tool-break additionalContext document and the disclosure document separately
-# (the same shape arm 1 already has), so jq cannot read the pair as one object.
-if printf '%s' "$ARM_OUT" | grep -q 'reformatted arm.ps1 via Invoke-Formatter'; then
-  ok "tool-break arm -> a rewrite that landed before pwsh threw is disclosed"
-else
-  fail "tool-break arm -> rewrite went undisclosed: $ARM_OUT"
-fi
-if printf '%s' "$ARM_OUT" | grep -qi 'tool break'; then
-  ok "tool-break arm -> still surfaces the advisory tool-break context alongside the disclosure"
-else
-  fail "tool-break arm -> tool-break context lost: $ARM_OUT"
-fi
-
-# --- Tool-break arm with NO rewrite -> silent, still no leak ------------------
-run_arm quiet "echo 'boom: analyzer threw' >&2; exit 4"
-if [[ "${ARM_LEFT:-1}" -eq 0 ]]; then
-  ok "tool-break arm without a rewrite -> snapshot still released"
-else
-  fail "tool-break arm without a rewrite leaked $ARM_LEFT temp file(s)"
-fi
-if printf '%s' "$ARM_OUT" | grep -q 'reformatted'; then
-  fail "tool-break arm disclosed a rewrite that never happened: $ARM_OUT"
-else
-  ok "tool-break arm without a rewrite -> no disclosure (no-op paths stay silent)"
-fi
-rm -f "$STUB_BIN/pwsh"
 
 # ============================================================================
 # Telemetry


### PR DESCRIPTION
## Summary

`plugins/powershell-format/hooks/powershell-format.sh` snapshots the target file to an `mktemp`
copy (`_ps_before`) so `maybe_disclose_ps_rewrite` can name a formatter rewrite on the user
channel. Arms 3 and 5 `rm -f` it, and the disclosure helper releases it on the arms that call it.
Two arms did neither:

- the trust-gate arm `6)` reached `emit_skipped` without releasing it, leaking one temp file per
  gated run;
- the tool-break catch-all `*)` exited 0 without releasing it AND without calling
  `maybe_disclose_ps_rewrite`, so besides the leak a rewrite that had already landed went
  undisclosed.

The second one is the more serious of the two. `Invoke-Formatter` writes the reformatted file
back at line 631, `Invoke-ScriptAnalyzer` runs at line 640, and both sit inside the same
`try`/`catch` that raises `exit 4`. So on a tool break the file on disk can already differ from
what the user wrote, and the hook said nothing.

Reproduced against the pre-fix hook with a stub `pwsh` and an isolated `TMPDIR` (see Verification
for the harness):

```
--- gate:  rc=0 during=1 left=1          <- snapshot leaked
--- break: rc=0 during=1 left=1          <- snapshot leaked
    out={... "tool break, not a finding" ...}   <- no "reformatted" disclosure
```

## Fix

- `maybe_disclose_ps_rewrite` splits into `take_ps_rewrite_disclosure` (release the snapshot,
  record the text in `PS_REWRITE_MESSAGE`) and the emitting wrapper. An arm that also carries
  `additionalContext` can then compose both channels through `hook::emit_channels` instead of
  printing a second JSON object. Arms 0/3/5/6 keep the wrapper and are unchanged in behavior.
- Arm `*)`: build the tool-break context in a variable, take the disclosure, and emit both as
  ONE document. That releases the snapshot on the changed and unchanged paths alike, so it
  satisfies the disclosure and the cleanup criteria together.
- Arm `1)` (findings) gets the same composition. It already printed `hook::ctx_flush`'s document
  followed by the disclosure's, so a run that both reformatted and reported findings emitted two
  objects. That is a pre-existing violation of the same contract, in the same file, and closing
  it is two lines given the split above; leaving it would have left the fix half-applied.
- Arm `6)`: `rm -f "$_ps_before"`, exactly parallel to arms 3 and 5.

**No disclosure call on arm 6, and that is deliberate rather than an omission.** The issue raised
it as an open question ("a rewrite disclosure decision may also be warranted"). Every `exit 6` in
the pwsh block is raised by the trust gate at lines 269-591; `Invoke-Formatter` is at line 622. No
rewrite can have landed on that path, so the snapshot is provably identical to the file and only
needs releasing. A comment on the arm records that reasoning so a future reader does not read the
asymmetry as a second bug.

No `EXIT` trap. The issue floated one as a hardening idea; a trap spanning this hook's many `exit
0` arms, `emit_skipped`, and its subshells is materially more blast radius than the two lines the
acceptance criteria ask for. Left as a follow-up rather than smuggled in here.

## Verification

Windows 11, Git Bash, pwsh 7.6.5, PSScriptAnalyzer present.

New cases in `powershell-format.test.sh`, driven through the suite's existing stub-`pwsh`
mechanism (`make_stub_pwsh`), each with its own `TMPDIR` so "left nothing behind" is a strict
emptiness check, and with `HOOK_TELEMETRY_SINK` unwired so hook-utils' own envelope `mktemp`
cannot land in the scratch. They sit ABOVE the real-`pwsh` prerequisite gate, because they need
neither a real `pwsh` nor PSScriptAnalyzer and would otherwise be skipped on exactly the
`pwsh`-less hosts where this regression coverage matters:

- trust-gate arm (`exit 6`): scratch empty after the run.
- tool-break arm (`exit 4` after the stub rewrites the file): scratch empty; stdout is exactly
  ONE JSON document (`jq -s length == 1`); it carries both the disclosure and the tool-break
  `additionalContext`.
- tool-break arm with no rewrite: scratch empty, and NO disclosure (no-op paths stay silent).
- Case 4b, arm 1 with a real `pwsh`: a fixture pairing a lowercase alias with a global var
  produces a rewrite AND a finding; stdout is one document carrying both channels, and a third
  assertion confirms the formatter actually rewrote, so the composition check cannot pass on a
  run with nothing to compose.

**The emptiness assertions are not vacuous, and the suite proves it rather than asserting it.**
The stub `pwsh` counts the scratch's entries while it is running, and each arm asserts that count
is at least 1 before asserting the post-run count is 0. Without that live probe, a scratch the
hook's `mktemp` never used would read as "empty" and the check would pass over a leak somewhere
else.

Pre-fix reproduction used a standalone replica of `run_arm` against a `git stash`-ed-out hook (the
full suite is ~12 minutes on this box, so the arms were iterated in isolation first): both arms
reported `left=1` and the tool-break arm emitted no disclosure, as quoted above. The numbers in
this section come from the real suite run, not the replica.

Full suite: `bash plugins/powershell-format/hooks/powershell-format.test.sh` -> `PASS=86 FAIL=0`
(74 on `main`; 12 new assertions).

Repo gates, all green: `scripts/affected-tests.sh --run` (selects this suite),
`scripts/check-changelog-parity.sh --check` and `--check-bump origin/main`,
`scripts/validate-plugins.sh`, `scripts/check-shell-portability.sh --paths` over both touched
shell files.

One unrelated note: the `env` invocation in the new helper puts `-u HOOK_TELEMETRY_SINK` before
every `NAME=VALUE`, because `env` stops parsing options at the first operand and a trailing `-u
FOO` is taken as the command to run (exit 127). Caught while building these cases.

## Related

Closes #3366
