### PR TITLE
test(scripts): disown the read-list watchdog so Git Bash stays quiet

### DIFF
--- a/scripts/lib/read-list.test.sh
+++ b/scripts/lib/read-list.test.sh
@@ -138,6 +138,12 @@ probe_pid=$!
   kill -9 "$probe_pid" 2>/dev/null
 ) >/dev/null 2>&1 &
 watchdog_pid=$!
+# `disown` drops the watchdog from the job table so bash does not announce its
+# death. Measured on Git Bash (MSYS2), which prints
+# `<script>: line N: <pid> Killed  ( sleep 5; ... )` to the suite's stderr
+# without it, on the PASSING path; Linux bash stays quiet either way. The
+# probe's own kill IS still announced, but only where this case already FAILs.
+disown "$watchdog_pid" 2>/dev/null
 wait "$probe_pid" || missing_value_rc=$?
 kill -9 "$watchdog_pid" 2>/dev/null
 if [[ "$missing_value_rc" -eq 2 ]]; then


### PR DESCRIPTION
## Summary

Follow-up to #3390, which merged while this was in flight.

That PR bounded the `read_list::into` hang probe with a hand-rolled watchdog,
and SIGKILLs the watchdog shell on the **passing** path. Git Bash (MSYS2)
announces that kill to the suite's stderr:

```
scripts/lib/read-list.test.sh: line 141: 963299 Killed    ( sleep 5; kill -9 "$probe_pid" 2> /dev/null )
```

Linux bash stays quiet either way, and CI runs `scripts/lib/read-list.test.sh`
only on `ubuntu-24.04` (`ci.yml:1234`, the `plugin-gate` job). So the noise is
invisible to every lane and visible to every contributor who develops on
Windows, which is why it survived the original PR's Linux-only verification.

## Fix

`disown "$watchdog_pid"` drops the watchdog from the job table before it is
killed. Bash only announces jobs it is tracking, so the notice goes away
without changing the kill, the bound, or the assertion.

The probe's own kill is still announced, deliberately. It only fires on the
path where this case is already reporting `FAIL ... rc=137`, and there a line
naming the killed process reads as diagnosis rather than noise.

## Verification

- Git Bash (MSYS2), the platform that showed the defect: `PASS=30 FAIL=0` with
  stderr **empty**, both piped and unpiped. Before this change the same
  invocation put the `Killed` line on stderr.
- Linux: `PASS=30 FAIL=0` in 0.28s, stderr empty. Unchanged from #3390.
- Assertion still bites: against `main`'s pre-#3390 library the case reports
  `FAIL: a bare --comments HUNG (watchdog killed it, rc=137)` / `PASS=29 FAIL=1`.
- `shellcheck --rcfile .shellcheckrc`, `shfmt -d`, and
  `scripts/check-shell-portability.sh --paths`: clean.
- `scripts/affected-tests.sh` maps the file to its own suite (R1 self).

## Related

Follows up #3390 / #3363. No linked issue: this is a same-day repair of a
cross-platform defect in code that PR just landed, caught by re-running its
suite on Git Bash rather than only on Linux.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
