### PR TITLE
fix(provenance): discharge the rubric-v3 re-score, and the answer key it found in the rubric

### DIFF
--- a/plugins/provenance/.claude-plugin/plugin.json
+++ b/plugins/provenance/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "provenance",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "description": "Finds prose in tracked markdown that restates content an external source owns (vendor docs, blogs, articles) without adequate attribution, confirms the source, and refactors the copy into a pointer, a citation, or a dated stamped record. Documentation provenance, not software supply chain. Nomination and judgment are LLM work; the scripts do only reasoning-free work (corpus scoping, breadcrumb extraction, stamp expiry, fingerprint compare of two concrete texts). Read-only audit by default; explicit fix and sweep actions apply dispositions behind a semantic-diff guard and live pointer verification. Findings conform to the detector-findings convention.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/provenance/CHANGELOG.md
+++ b/plugins/provenance/CHANGELOG.md
@@ -109,8 +109,16 @@
   `SC2034` read as a bare year, and `read` matching inside `cache_read_input_tokens`. Both have a
   different root cause (token boundaries, not the month list), and both plausible fixes push toward
   under-reporting: a year-boundary fix shifts `RSTART` into the window machinery two prior commits
-  tuned, and excluding `_` from the keyword boundary would stop matching a real `last_verified_...`
-  stamp.
+  tuned, and excluding `_` from the keyword boundary would stop matching a real stamp that exists
+  today: `plugins/work-items/skills/track/actions/add.md:104` carries `"last_checked":
+  "2026-04-08"`, which parses now and would be lost. That exhibit is named because the first draft
+  of this entry cited an invented one; the verifier checked the repo, found no such token, and
+  supplied the real line. The conclusion held, the evidence for it did not.
+
+  The bare-year bucket needs its own designed pass rather than a boundary tweak bolted onto a
+  word-sense fix. Of its 23 declines, a token-boundary change repairs exactly one: the rest carry
+  years that are already token-boundaried, among them an issue number `#1941` and a glob example
+  `photos [2024/**`.
 
 - **The `not-found` searched-surfaces listing is recorded as prose-only and unenforced.** Three
   separate requirements say a run must list every surface it searched before concluding no source

--- a/plugins/provenance/CHANGELOG.md
+++ b/plugins/provenance/CHANGELOG.md
@@ -88,7 +88,17 @@
   modal verb, and both stamp detectors matched it bare, so prose like "the first read may raise a
   permission prompt" became a stamp candidate whose date could not be parsed and landed in the
   declined bucket — indistinguishable, to a reader adjudicating that bucket, from a real stamp the
-  parser failed on. 17 of the 22 month-name declines in the 2026-08-28 corpus carried the word.
+  parser failed on. **19 of the 24 month-name declines carried the word**, measured over 1,352
+  files at `--as-of 2026-08-28` on this branch's head.
+
+  That figure is tree-dependent and three different numbers for it appeared during this change,
+  which is worth recording rather than tidying away. An earlier draft said 17 of 22, measured
+  correctly against a branch base that was two commits behind `main` and therefore missing merged
+  changelog entries whose own prose contains the modal; repairing the base moved it to 19 of 24.
+  The script comments said 13, which matched no tree. Both are corrected. The lesson is the same
+  one 0.3.2 records about this file: a count taken over a corpus that includes this repository is
+  a reading at a commit, not a constant, and it needs the commit attached or it will not
+  reproduce.
 
   `may` now needs a digit beside it before it counts as a date. Every date form has one, and the
   modal does not. The other eleven months still match bare, because over-reporting into a bucket a

--- a/plugins/provenance/CHANGELOG.md
+++ b/plugins/provenance/CHANGELOG.md
@@ -2,6 +2,70 @@
 
 ## [0.4.0]
 
+### Changed
+
+- **The version-3 re-score is done, and the measurement carries forward unchanged.** Version 3's
+  own rule blocked every precision figure, and with it every class's fix eligibility, on a table
+  pinned to version 2. All ten golden cases were re-judged by a three-judge panel each, thirty
+  judges in independent processes, cases relabelled so no directory name or path reached a judge.
+  Each saw the candidate passage, the fetched source, the whole containing file and the rubric,
+  per the version-3 dispatch; none saw the case's `expected.json`, the fingerprint figures, or
+  another judge's verdict. The deterministic layer was re-run alongside and reproduced every
+  containment, jaccard and matched-span figure the fixtures record.
+
+  Result: **8 tp / 0 fp / 0 fn / 2 tn, precision 1.00, recall 1.00** — the table version 2
+  recorded, now pinned to version 3. Every panel unanimous, **no verdict moved.** `c04` is the
+  only case whose attribution reaches grading, so it is the only one C3's stated scope could have
+  moved, and all three judges took the new test where version 2 left it: the derivation is one
+  lift inside otherwise-original material, so a `See also` bullet two sections below understates
+  its scope and C3 passes.
+
+  **No class becomes fix-eligible, for the reason that was already there.** Every class measures
+  1.00 against the 0.95 bar and every class sits below `min_n_per_class` 10 (n = 2, 5, 1, 2). The
+  re-score lifts the rubric-version block and leaves the class-size one standing, which is what
+  keeps the sweep in #3465 report-only.
+
+### Fixed
+
+- **The rubric carried its own answer key, and every judge read it.** Version 3's version-history
+  paragraph recorded the expected tally, the panel size, and an enumeration of which golden case
+  turns on which criterion, including the one case the scope change exists to restate. The
+  pipeline inlines the whole rubric into every judge prompt at the judgment step, so all thirty
+  judges in the re-score above read the prediction before grading, and that run had to withdraw
+  its claim of a blind panel. Found by that run's own fresh-context verifier, which returned FAIL
+  on the method while confirming the arithmetic.
+
+  The paragraph was written to keep the figures from sitting under a cloud they did not deserve.
+  Putting it in the file judges read at judgment time is what made a blind measurement against
+  that rubric impossible. The prediction and the enumeration are changelog material and now live
+  here; the rubric keeps the criteria, the carve-outs, the scope rule, the worked examples and the
+  tier table, and says explicitly that a judge should be able to read all of it and still not know
+  the answer.
+
+  **The verdict was tested against the leak rather than assumed safe.** `c04` was re-judged by a
+  second three-judge panel against the same rubric with the version-history preamble removed and
+  every criterion, carve-out, scope sentence and worked example intact. All three returned STANDS
+  with C3 PASS on the same scope-mismatch reasoning. The leak did not drive the verdict; the claim
+  that a fully blind panel produced it is still withdrawn.
+
+  **A second leak of the same kind sits in a fixture and is deliberately NOT fixed here.** The
+  `source.md` shared by `c08`, `c09` and `c10` announces itself as "the shared basis for the three
+  adversarial synonym-rotation cases", naming them and asserting the local text is a rotation,
+  which pre-answers C1 and C2 for nine of the thirty judges. That line is inside the text the
+  fingerprint module compares, so removing it moves every containment and matched-span figure
+  those three cases record. **The fix and a re-score are one atomic change**, and splitting them
+  would leave a recorded measurement that no longer reproduces from its own fixtures. It is filed
+  for the round that next re-scores rather than taken now.
+
+  Two smaller limits, recorded rather than worked around. Four case bodies state their own intended
+  answer (`c06` and `c07` open "A hard negative", `c08` and `c10` open "Adversarial case"), and
+  version 3 requires the judge to read the whole containing file, so those judges saw it;
+  withholding it would mean editing a fixture. And `c07`'s `expected.json` explains the case as a
+  C1 failure while also recording that the owned-content carve-out applies, which the rubric's own
+  order of evaluation makes exclusive. All three judges declined it at the carve-out, which is what
+  that order requires. The route differs, the recorded answer does not, and neither the fixture nor
+  the rubric was changed to match the run.
+
 ### Added
 
 - **The evidence-tier contract now covers a vendored-snapshot basis.** Every tier row gated on
@@ -19,8 +83,6 @@
   was fetched and this one was not; the recorded route is what keeps the report honest about the
   difference. The follow-up is human: re-run the candidate when upstream is reachable or the
   snapshot re-syncs, rather than holding the finding open.
-
-### Fixed
 
 - **The modal "may" is no longer read as a month name.** `may` is a month and an ordinary English
   modal verb, and both stamp detectors matched it bare, so prose like "the first read may raise a
@@ -49,8 +111,6 @@
   under-reporting: a year-boundary fix shifts `RSTART` into the window machinery two prior commits
   tuned, and excluding `_` from the keyword boundary would stop matching a real `last_verified_...`
   stamp.
-
-### Changed
 
 - **The `not-found` searched-surfaces listing is recorded as prose-only and unenforced.** Three
   separate requirements say a run must list every surface it searched before concluding no source

--- a/plugins/provenance/CHANGELOG.md
+++ b/plugins/provenance/CHANGELOG.md
@@ -154,7 +154,7 @@
   `Verified this May` as an example of the shape, inside a `verified` keyword window, in a file the
   corpus scans. So from the commit that documents the fix onward the corpus does carry a
   digitless-May stamp — the one written to explain that it carried none. Measured at `a827aa58`:
-  529 / 499 / 30 post-fix against 528 / 499 / 29 pre-fix, an effect of +1 candidate rather than
+  529 / 499 / 30 / 0 post-fix against 528 / 499 / 29 / 0 pre-fix, an effect of +1 candidate rather than
   none.
 
   That is the fourth time on this branch that prose about a detector has moved what the detector

--- a/plugins/provenance/CHANGELOG.md
+++ b/plugins/provenance/CHANGELOG.md
@@ -1,5 +1,74 @@
 # Changelog
 
+## [0.4.0]
+
+### Added
+
+- **The evidence-tier contract now covers a vendored-snapshot basis.** Every tier row gated on
+  either a fetched source or no source at all, and the sweep hit a third case the table could not
+  express: a finding compared against an in-repo copy of upstream, carrying a declared upstream ref
+  and a sync date, reached because every live fetch rung failed. Strong provenance, weak currency.
+  It happened at `plugins/playwright/skills/playwright/reference/test-generation.md:80`, where both
+  candidate upstream URLs returned 404 and only the committed baseline remained.
+
+  Such a finding now caps at `source-fetched-similar`, records `source.route: vendored-snapshot`
+  together with each live fetch that failed and how, and is **never fix-eligible**. The reason is
+  the plugin's whole subject: fix eligibility rests on current upstream state, and a snapshot
+  cannot establish it. Stale evidence licenses no edit. The tier borrow is declared deliberate
+  rather than left to read as accurate, since `source-fetched-similar` is worded for a source that
+  was fetched and this one was not; the recorded route is what keeps the report honest about the
+  difference. The follow-up is human: re-run the candidate when upstream is reachable or the
+  snapshot re-syncs, rather than holding the finding open.
+
+### Fixed
+
+- **The modal "may" is no longer read as a month name.** `may` is a month and an ordinary English
+  modal verb, and both stamp detectors matched it bare, so prose like "the first read may raise a
+  permission prompt" became a stamp candidate whose date could not be parsed and landed in the
+  declined bucket — indistinguishable, to a reader adjudicating that bucket, from a real stamp the
+  parser failed on. 17 of the 22 month-name declines in the 2026-08-28 corpus carried the word.
+
+  `may` now needs a digit beside it before it counts as a date. Every date form has one, and the
+  modal does not. The other eleven months still match bare, because over-reporting into a bucket a
+  human reads is the safe direction and this fix must not trade it for under-reporting.
+
+  Three sites changed, not two: both detectors and **the classifier in `check-stamps.sh`**, which
+  a single-site fix would have missed and which decides the decline reason a human then reads.
+  `check-stamps.sh` and `extract-breadcrumbs.sh` change together and their suites now assert the
+  agreement over a shared fixture, because a previous fix in this area landed in one script and
+  needed a follow-up commit to reach its sibling.
+
+  Over 1,352 files: declines 45 to 28, month-name declines 22 to 5, 17 lines removed and none
+  added. **`parsed` is unchanged at 499 and `findings` unchanged at 0** — the load-bearing numbers,
+  because they say no real stamp was reclassified in either direction and none had been masked. A
+  real `May 2026` stamp is still detected in both month-first and day-first forms.
+
+  Two adjacent false positives are deliberately left in place and recorded rather than fixed:
+  `SC2034` read as a bare year, and `read` matching inside `cache_read_input_tokens`. Both have a
+  different root cause (token boundaries, not the month list), and both plausible fixes push toward
+  under-reporting: a year-boundary fix shifts `RSTART` into the window machinery two prior commits
+  tuned, and excluding `_` from the keyword boundary would stop matching a real `last_verified_...`
+  stamp.
+
+### Changed
+
+- **The `not-found` searched-surfaces listing is recorded as prose-only and unenforced.** Three
+  separate requirements say a run must list every surface it searched before concluding no source
+  exists. Nothing checks that: `emit-findings.sh` projects no `searched` array and no budget block,
+  and the relay boundary withholds `not-found` findings from the file entirely, so a listing that
+  omits a rung is indistinguishable downstream from a complete one. Rather than leave three
+  requirements reading as though something enforced them, the docs now say a run's listing is that
+  run's own claim and never validation evidence that no source exists, and name what an
+  implementing change would need. This repo's house style prefers a recorded limitation to an
+  asserted capability.
+
+- **The fix contract warns that a corpus file can be a generator's rendered output.** The sweep
+  found one whose authoritative home is `docs/native-surfaces/records.json`, outside the markdown
+  corpus, with its rendering marked never-hand-edit. A fix applied to the rendering would edit a
+  file its own header forbids editing, and the next regeneration would overwrite it. Dispositions
+  now say to check the file head for a generated-output marker and route to the human naming the
+  generator's input as the real fix site. No script enforces this check.
+
 ## [0.3.2]
 
 ### Fixed

--- a/plugins/provenance/CHANGELOG.md
+++ b/plugins/provenance/CHANGELOG.md
@@ -117,15 +117,26 @@
   signal that separates these in edited prose. The rule now lives in a named `may_form()` carried
   at all three sites rather than three copied regexes.
 
-  **The case signal was measured on this corpus, not assumed.** Over 1,352 files: 1,458 lines carry
-  a lowercase `may`, overwhelmingly the modal; 24 carry a capital `May`, of which about 17 are month
-  dates and 7 are capitalised modals in table cells and bullets; and 34 carry an ALL-CAPS `MAY`, of
-  which **none is a date** — every one is an RFC-2119 modal. So two costs are accepted knowingly.
+  **The case signal was measured on this corpus, not assumed.** At `3c538bcc`, over 1,352 files:
+  1,458 lines carry a lowercase `may`, overwhelmingly the modal; 24 carry a capital `May`, of which
+  **14 are month dates and 10 are capitalised modals** in table cells, bullets and sentence
+  openings; and 34 carry an ALL-CAPS `MAY`, of which **none is a date** — they are permission
+  modals. So two costs are accepted knowingly.
   A capitalised modal opening a sentence or a cell now reads as a month when a stamp keyword sits
   in its window, which over-reports into a bucket a human adjudicates. And ALL-CAPS defeats case, so
   a digitless `MAY` date stays invisible; buying it back would mean reading `MAY` as a month, which
   on this corpus means 34 false candidates for a form nobody writes. Both are pinned by tests,
   including one named for the over-report so it is not rediscovered as a bug.
+
+  **A third cost is recorded and left rather than chased.** `may_form()` returns on the digit
+  branch, so `RSTART` belongs to that match; when a digit-adjacent `may` sits beyond the window and
+  a capital `May` sits inside it, the caller rejects the out-of-window digit match and never
+  consults the in-window capital. Appending a stray `7 may` to an otherwise valid line therefore
+  removes its candidacy — under-reporting, the direction this fix exists to prevent. No corpus line
+  has that shape. Returning the leftmost of the two matches would fix it; trying the capital branch
+  first only mirrors the bug, so the obvious one-line swap is not a fix. Both scripts inherit it
+  identically, so their cross-script agreement assertion is blind to it, exactly as it was to the
+  original regression. Recorded at the rule so the next reader is warned rather than surprised.
 
   **The suites could not have caught this, which is the part worth keeping.** They assert that both
   scripts return the same count over a shared fixture — an assertion that passes when both are
@@ -134,10 +145,24 @@
   likely. The new cases pin a **non-zero** expected count in both suites, so agreement is now
   backed by a known answer rather than by two implementations nodding at each other.
 
-  Corpus effect of the correction: **none.** Candidates, parsed, declined and findings are all
-  unchanged at 527 / 499 / 28 / 0, because this corpus carries no digitless-May stamp today. The
-  regression was latent here and real in principle; the shapes the reviewers named are ordinary
-  ones this corpus simply does not happen to contain.
+  Corpus effect of the correction, **at `3c538bcc`**: none. Candidates, parsed, declined and
+  findings all unchanged at 527 / 499 / 28 / 0, the two JSON products byte-identical, because the
+  corpus carried no digitless-May stamp at that commit. The regression was latent there and real in
+  principle.
+
+  **It stopped being latent one commit later, and this entry is why.** The paragraph above quotes
+  `Verified this May` as an example of the shape, inside a `verified` keyword window, in a file the
+  corpus scans. So from the commit that documents the fix onward the corpus does carry a
+  digitless-May stamp — the one written to explain that it carried none. Measured at `a827aa58`:
+  529 / 499 / 30 post-fix against 528 / 499 / 29 pre-fix, an effect of +1 candidate rather than
+  none.
+
+  That is the fourth time on this branch that prose about a detector has moved what the detector
+  reports, after the stale Phase 6 baseline, the figures that went stale as the entry describing
+  them was written, and a count that changed when the branch base was repaired. The rule this file
+  keeps relearning is the one it already states: **a count over a corpus that includes this
+  repository is a reading at a commit, and it needs the commit attached or it will not reproduce.**
+  Every figure in this entry now carries one.
 
   Three sites changed, not two: both detectors and **the classifier in `check-stamps.sh`**, which
   a single-site fix would have missed and which decides the decline reason a human then reads.

--- a/plugins/provenance/CHANGELOG.md
+++ b/plugins/provenance/CHANGELOG.md
@@ -100,9 +100,44 @@
   a reading at a commit, not a constant, and it needs the commit attached or it will not
   reproduce.
 
-  `may` now needs a digit beside it before it counts as a date. Every date form has one, and the
-  modal does not. The other eleven months still match bare, because over-reporting into a bucket a
-  human reads is the safe direction and this fix must not trade it for under-reporting.
+  `may` counts as a date when a digit sits beside it — every date form has one and the modal does
+  not — **or** when the original line capitalises it. The other eleven months still match bare,
+  because over-reporting into a bucket a human reads is the safe direction and this fix must not
+  trade it for under-reporting.
+
+  **The first version of this fix did trade it, and three independent reviewers caught that.**
+  Requiring a digit made a digitless stamp vanish: `Verified this May` and `Checked last May
+  against the vendor page` stopped matching anything, and the loss was *upstream* of the declined
+  bucket rather than inside it — `keyword_window()` returned empty, the caller dropped the line
+  before classification, and `is_stamp()` did the same to the inventory. Not declined, not
+  inventoried, gone. `Verified in June` was still declined and still visible, so the same shape got
+  two different treatments purely because of the modal collision.
+
+  The capital `M` is what fixes it. Both scripts lowercase before matching and so discard the one
+  signal that separates these in edited prose. The rule now lives in a named `may_form()` carried
+  at all three sites rather than three copied regexes.
+
+  **The case signal was measured on this corpus, not assumed.** Over 1,352 files: 1,458 lines carry
+  a lowercase `may`, overwhelmingly the modal; 24 carry a capital `May`, of which about 17 are month
+  dates and 7 are capitalised modals in table cells and bullets; and 34 carry an ALL-CAPS `MAY`, of
+  which **none is a date** — every one is an RFC-2119 modal. So two costs are accepted knowingly.
+  A capitalised modal opening a sentence or a cell now reads as a month when a stamp keyword sits
+  in its window, which over-reports into a bucket a human adjudicates. And ALL-CAPS defeats case, so
+  a digitless `MAY` date stays invisible; buying it back would mean reading `MAY` as a month, which
+  on this corpus means 34 false candidates for a form nobody writes. Both are pinned by tests,
+  including one named for the over-report so it is not rediscovered as a bug.
+
+  **The suites could not have caught this, which is the part worth keeping.** They assert that both
+  scripts return the same count over a shared fixture — an assertion that passes when both are
+  equally wrong, which is exactly what happened. A cross-implementation agreement test detects
+  divergence and is blind to a common error, and a shared definition is what makes a common error
+  likely. The new cases pin a **non-zero** expected count in both suites, so agreement is now
+  backed by a known answer rather than by two implementations nodding at each other.
+
+  Corpus effect of the correction: **none.** Candidates, parsed, declined and findings are all
+  unchanged at 527 / 499 / 28 / 0, because this corpus carries no digitless-May stamp today. The
+  regression was latent here and real in principle; the shapes the reviewers named are ordinary
+  ones this corpus simply does not happen to contain.
 
   Three sites changed, not two: both detectors and **the classifier in `check-stamps.sh`**, which
   a single-site fix would have missed and which decides the decline reason a human then reads.

--- a/plugins/provenance/skills/audit/SKILL.md
+++ b/plugins/provenance/skills/audit/SKILL.md
@@ -107,7 +107,10 @@ texts, file composition); every judgment about whether a passage is a copy is mo
 
 9. **Map the tier**, by fixed rule from the evidence, never from a judge's confidence. A
    paraphrase can never be `fingerprint-confirmed`: no lexical evidence is possible for one, and
-   unanimity does not manufacture any. When `accuracy.review_agents` > 0, run the review pass
+   unanimity does not manufacture any. A finding whose only basis is an in-repo vendored
+   snapshot, reached because every live fetch failed, caps at `source-fetched-similar` and is
+   never fix-eligible; the full rule is in
+   [`reference/source-fetch.md`](reference/source-fetch.md). When `accuracy.review_agents` > 0, run the review pass
    over STANDS verdicts; a veto never reassigns a tier, it forces `leave-with-reason`.
 
 10. **Report.** Group by file. Per finding give the tier, the class, the location, the rubric
@@ -192,7 +195,9 @@ fired on an identifier, a test runner exiting non-zero without failing.
   `llm-suspected`, and `not-found` reach the human report only. They have no crosswalk row to
   look a tier up from, and a relay row is an instruction to a remediation surface.
 - **Does not treat a missing source as evidence.** `not-found` names every surface checked and
-  concludes nothing about the passage.
+  concludes nothing about the passage. That listing is a prose obligation on the run: no script
+  field carries it and nothing verifies it is complete, so it is never validation evidence
+  (`reference/source-fetch.md`, "Budgets, caching, and stopping").
 - **Does not assess copyright.** The rubric measures drift risk; findings are editorial and the
   remedies are maintenance remedies. Nothing here is legal advice.
 - **Does not scan** code comments (`code-tidying:audit-comment-residue`), in-repo duplication

--- a/plugins/provenance/skills/audit/reference/dispositions.md
+++ b/plugins/provenance/skills/audit/reference/dispositions.md
@@ -83,6 +83,14 @@ to the human with the guard's own reason.
 4. **Carve-outs re-checked at edit time.** A passage inside a quotation context, a conforming
    stamped record, or a vendored tree is not edited, even if a finding reached this point.
 
+One gap is flagged here rather than guarded: a corpus file can be the rendered output of a
+generator whose source of record lives outside the markdown corpus (a sweep of this marketplace
+repository found one stale string whose authoritative home is `docs/native-surfaces/records.json`,
+with its rendering marked never-hand-edit). A fix applied to such a rendering edits a file its
+own header forbids editing, and the next regeneration overwrites it. Check the file head for a
+generated-output marker before applying any disposition; when one is present, route the finding
+to the human and name the generator's input as the real fix site. No script enforces this check.
+
 ## The demotion path when a pointer later dies
 
 A pointer that was live at edit time can die later. That is a foreseen state with a defined

--- a/plugins/provenance/skills/audit/reference/rubric.md
+++ b/plugins/provenance/skills/audit/reference/rubric.md
@@ -14,13 +14,19 @@ attribute a specific paragraph in the middle of it" cuts against.
 
 That changes what C3 tests, so the measurement version 2 stands on does **not** carry forward.
 **The golden set must be re-scored against version 3 before any precision figure is cited against
-it**, and no class becomes fix-eligible on a measurement pinned to a superseded rubric. Stated so
-the figures are not left under a cloud they do not deserve: **no current golden case appears to
-turn on the scope question** — seven have no attribution anywhere, one is declined at a carve-out
-before grading, one fails C1, and the single case with attribution is a lift inside an otherwise
-original file, which resolves the same way at either scope. The re-score is expected to reproduce
-8 tp / 0 fp / 0 fn / 2 tn. It is still required, because the rule keys on a criterion changing
-rather than on a recorded case flipping.
+it**, and no class becomes fix-eligible on a measurement pinned to a superseded rubric. That
+re-score has since been run and its outcome is in `CHANGELOG.md`.
+
+**Nothing about a measurement's result belongs in this file, and version 3 shipped a paragraph
+that broke that rule.** The pipeline inlines this whole file into every judge prompt at the
+judgment step, so anything recorded here is read by every judge before they grade. Version 3's
+first draft of the paragraph above also carried the expected tally, the panel size, and an
+enumeration of which golden case turns on which criterion, including the one case the scope change
+exists to restate. Thirty judges read it during the re-score, and the run that found this had to
+withdraw its claim of a blind panel. The prediction and the enumeration are changelog material and
+now live there. **Keep this file to the criteria, the carve-outs, the scope rule, the worked
+examples and the tier table: a judge should be able to read all of it and still not know the
+answer.**
 
 **Version 2 was the one exception to the invalidation rule**, kept here because the reasoning is
 the standard the next exception has to meet. It changed no criterion's substance and no carve-out;

--- a/plugins/provenance/skills/audit/reference/source-fetch.md
+++ b/plugins/provenance/skills/audit/reference/source-fetch.md
@@ -74,6 +74,31 @@ the page's own content**, never against the mirror's self-reported sync time, wh
 by the party whose freshness is in question. Corroborate by naming a fact only a sufficiently
 recent sync could carry.
 
+## When every live rung fails and a vendored snapshot exists
+
+A repository can carry an in-repo copy of the upstream under a `vendor/` tree, committed with a
+declared upstream ref and a sync date. When the live fetch fails on every rung (a 404 on the raw
+channel, a dead page, a mirror that cannot be corroborated) and such a snapshot is the only
+available basis, the comparison may run against the snapshot. That evidence is strong on
+provenance and weak on currency: it proves what upstream said at the sync date, not what
+upstream says now, and drift since that date is exactly what this audit exists to find.
+
+The rule, stated so no judge has to improvise it:
+
+- **The finding caps at `source-fetched-similar` and is never fix-eligible**, whatever the
+  fingerprint module reports. `fingerprint-confirmed` requires an identity-checked live fetch
+  because fix eligibility rests on current upstream state, which a snapshot cannot establish.
+  Stale evidence licenses no edit.
+- **Record `source.route: vendored-snapshot`** and name, in the finding: the snapshot path, its
+  declared upstream ref, its sync date, and each live fetch that failed with how it failed. The
+  human report must be able to say the basis was a committed copy, not a live read.
+- **The tier is borrowed knowingly.** `source-fetched-similar` is worded for a fetched source; a
+  snapshot basis is admitted under it as the strongest report-only tier, and the recorded route
+  is what keeps the report honest about the difference. This rule caps the tier and leaves the
+  table in `reference/rubric.md` unchanged.
+- **The follow-up is human.** Recommend re-running the candidate when upstream is reachable
+  again or the snapshot re-syncs; do not hold the finding open waiting for either.
+
 ## A 200 does not mean you got the page you asked for
 
 A fetch can return `200`, the right content type, and a complete untruncated body that is
@@ -118,3 +143,12 @@ Exhausting a budget produces the neutral outcome, not a failure and not a negati
 `source not identified (budget exhausted; searched: ...)`, naming every surface checked. Absence
 of a located source is never evidence that the passage is original. Record the counts in the
 finding's `budget` block so the human report can show what the run spent and where it stopped.
+
+**The searched-surfaces listing is prose-only, and nothing enforces it.** The requirement above,
+and its restatements in `SKILL.md` and `reference/dispositions.md`, binds the run's conduct and
+no schema: `scripts/emit-findings.sh` has no field, count, or budget block for the listing, and
+the relay boundary withholds `not-found` findings from the findings file entirely, so a listing
+that omits a surface is indistinguishable downstream from a complete one. Treat a report's
+listing as the run's own claim, never as validation evidence that no source exists. Making it
+checkable would mean adding a `searched` array to the report sidecar and a schema check in
+`emit-findings.sh`; until such a change lands, this recorded limitation is the contract.

--- a/plugins/provenance/skills/audit/scripts/check-stamps.sh
+++ b/plugins/provenance/skills/audit/scripts/check-stamps.sh
@@ -295,23 +295,64 @@ function reset(name) {
   delete d_line; delete d_reason; delete d_text
 }
 
+# may_form(w, worig): does this window carry the MONTH May rather than the
+# ordinary English modal? "w" is the lowered window and "worig" the same span of
+# the original line, which is where the discriminating signal lives.
+#
+# "may" is split out of the month list because it is also a modal verb. Matched
+# bare, prose like "the first read may raise a permission prompt" became a
+# candidate whose date could not be parsed, so it landed in the declined bucket
+# and a reader could not tell it from a real stamp we failed to parse: 19 of the
+# 24 month-name declines were this word, measured over 1,352 files at --as-of
+# 2026-08-28. That count is tree-dependent and will drift, because the prose in
+# this repo also contains the modal; take it as the shape of the problem, not a
+# constant.
+#
+# Two signals separate the two words, and either one alone is enough:
+#
+#   A digit beside it. Every date form carries one ("may 2026", "may 17",
+#   "17 may") and the modal does not. Case-blind, so it is what an ALL-CAPS
+#   heading falls back on.
+#
+#   A capital M on the original line. In edited prose the month is capitalised
+#   and the modal is not, and the rest of the scan works from a lowered copy
+#   that throws that signal away. This is what admits a digitless month date,
+#   "Verified this May", which the digit rule alone silently dropped: it was a
+#   candidate declining as a month-name form, visible to a human reading the
+#   declined bucket, and it became invisible to both this script and
+#   extract-breadcrumbs.sh. Under-reporting is the one direction this detector
+#   must not move in, and a digitless "Verified in June" still matches bare, so
+#   the same sentence written with May has to behave the same way.
+#
+# Two consequences, both measured over the 1,352-file corpus at 2026-08-28
+# rather than assumed:
+#
+#   A capitalised modal opening a sentence or a markdown table cell ("May the
+#   build stay green", "| May fail on usage limits") reads as a month. Seven of
+#   the 24 capitalised "May" lines in the corpus are that shape. It over-reports
+#   into a bucket a human reads, which is the safe direction.
+#
+#   ALL-CAPS defeats case, so a digitless ALL-CAPS May date stays invisible. All
+#   34 ALL-CAPS "MAY" lines in the corpus are RFC-2119 modals and not one is a
+#   date, so reading that form as a month would cost 34 false candidates to buy a
+#   date form nobody writes.
+#
+# match() leaves RSTART and RLENGTH set globally, so a caller that needs the
+# offset of the accepted match reads them straight after a true return.
+function may_form(w, worig) {
+  if (match(w, /(may[^a-z]*[0-9]|[0-9][^a-z]*may)/)) return 1
+  # No leading boundary, matching the abbreviation rule below: a capital M after
+  # a letter is not a word anyone writes. The trailing one is load-bearing, or
+  # "Maybe" opening a sentence reads as a date.
+  if (match(worig, /May([^a-z]|$)/)) return 1
+  return 0
+}
+
 # The stamp keyword list is shared with extract-breadcrumbs.sh on purpose: one
 # definition of what looks like a stamp, so the inventory and the check agree
-# about which lines are candidates. The month list is shared for the same reason
-# — change one and change the other, or the two disagree.
-#
-# "may" is split out of the month list because it is also an ordinary English
-# modal verb. Matched bare, prose like "the first read may raise a permission
-# prompt" became a candidate whose date could not be parsed, so it landed in the
-# declined bucket and a reader could not tell it from a real stamp we failed to
-# parse: 19 of the 24 month-name declines were this word, measured over 1,352
-# files at --as-of 2026-08-28. That count is tree-dependent and will drift,
-# because the prose in this repo also contains the modal; take it as the shape
-# of the problem, not a constant. It now needs a digit beside it, which every
-# date form carries
-# ("may 2026", "may 17", "17 may") and the modal does not. The tightening is
-# deliberately narrow — the other eleven months still match bare, because
-# over-reporting into a bucket a human reads is the safe direction.
+# about which lines are candidates. The month list, and may_form() above, are
+# shared for the same reason — change one and change the other, or the two
+# disagree.
 #
 # "read" gets a much tighter window than the explicit stamp verbs. It is an
 # ordinary English verb, and at the wide window a corpus run turned lines like
@@ -343,20 +384,27 @@ function keyword_window(line,   low, pos, off, kw, wlen) {
     # Each test returns the window cut at the end of its own match, so the
     # caller classifies on the match this function accepted and never on one
     # sitting in the 9 characters of slack.
+    # win_orig is the same span of the ORIGINAL line, cut at the same offsets:
+    # tolower() preserves length, so the two stay aligned character for
+    # character. may_form() reads it for the capital that separates the month
+    # from the modal, and the classifier below re-cuts it to the length of the
+    # window this function accepted.
     win = substr(low, pos, wlen + 9)
+    win_orig = substr(line, pos, wlen + 9)
     if (match(win, /[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]/) && RSTART <= wlen) return substr(win, 1, RSTART + RLENGTH - 1)
     if (match(win, /[0-9]+\/[0-9]+\/[0-9]+/) && RSTART <= wlen) return substr(win, 1, RSTART + RLENGTH - 1)
     if (match(win, /(january|february|march|april|june|july|august|september|october|november|december)/) && RSTART <= wlen) return substr(win, 1, RSTART + RLENGTH - 1)
-    # "may" is a month and an ordinary English modal, so it needs a digit beside
-    # it to count as a date. Every date form has one ("may 2026", "may 17",
-    # "17 may"); the modal does not. Unlike every other form here this one is
-    # unbounded in length, so a contrived "may" + 10 or more non-letters + year
-    # starting at exactly wlen runs past the 9 characters of slack and stops
-    # being a candidate. Latent: no such line exists in the corpus, and the
-    # ordinary "may 2026" at the same offset is still caught. Widening the slack
-    # to cover it would move the RSTART <= wlen boundary that two earlier
-    # commits tuned, for a form nobody writes.
-    if (match(win, /(may[^a-z]*[0-9]|[0-9][^a-z]*may)/) && RSTART <= wlen) return substr(win, 1, RSTART + RLENGTH - 1)
+    # "may" is a month and an ordinary English modal; may_form() above carries
+    # the two signals that separate them and the corpus measurements behind
+    # them, and leaves RSTART and RLENGTH set on the match it accepted. The
+    # digit half of that test is unbounded in length, unlike every other form
+    # here, so a contrived "may" + 10 or more non-letters + year starting at
+    # exactly wlen runs past the 9 characters of slack and stops being a
+    # candidate. Latent: no such line exists in the corpus, and the ordinary
+    # "may 2026" at the same offset is still caught. Widening the slack to cover
+    # it would move the RSTART <= wlen boundary that two earlier commits tuned,
+    # for a form nobody writes.
+    if (may_form(win, win_orig) && RSTART <= wlen) return substr(win, 1, RSTART + RLENGTH - 1)
     if (match(win, /(jan|feb|mar|apr|jun|jul|aug|sep|oct|nov|dec)[^a-z]/) && RSTART <= wlen) return substr(win, 1, RSTART + RLENGTH - 1)
     if (match(win, /(19|20)[0-9][0-9]/) && RSTART <= wlen) return substr(win, 1, RSTART + RLENGTH - 1)
     off = pos
@@ -403,7 +451,12 @@ tolower($0) ~ /((recheck|re-check|revisit|re-derivation|reopening|re-trigger)[^a
   d_text[n_dec] = tsv($0)
   if (win ~ /[0-9]+\/[0-9]+\/[0-9]+/) d_reason[n_dec] = "slash"
   else if (win ~ /(january|february|march|april|june|july|august|september|october|november|december)/) d_reason[n_dec] = "month"
-  else if (win ~ /(may[^a-z]*[0-9]|[0-9][^a-z]*may)/) d_reason[n_dec] = "month"
+  # The same may_form() the window test used, so the reason follows the rule
+  # that accepted the candidate. win is the window CUT at the accepted match,
+  # and win_orig is still the full slice, so re-cut it to the same length before
+  # asking: an uncut original could otherwise show a capital May sitting in the
+  # 9 characters of slack and relabel a bare-year decline as a month.
+  else if (may_form(win, substr(win_orig, 1, length(win)))) d_reason[n_dec] = "month"
   else if (win ~ /(jan|feb|mar|apr|jun|jul|aug|sep|oct|nov|dec)[^a-z]/) d_reason[n_dec] = "month"
   else d_reason[n_dec] = "year"
 }

--- a/plugins/provenance/skills/audit/scripts/check-stamps.sh
+++ b/plugins/provenance/skills/audit/scripts/check-stamps.sh
@@ -328,14 +328,25 @@ function reset(name) {
 # rather than assumed:
 #
 #   A capitalised modal opening a sentence or a markdown table cell ("May the
-#   build stay green", "| May fail on usage limits") reads as a month. Seven of
-#   the 24 capitalised "May" lines in the corpus are that shape. It over-reports
-#   into a bucket a human reads, which is the safe direction.
+#   build stay green", "| May fail on usage limits") reads as a month. Ten of the
+#   24 capitalised "May" lines are that shape and 14 are month dates, counted by
+#   reading all 24 at commit 3c538bcc. It over-reports into a bucket a human
+#   reads, which is the safe direction.
 #
-#   ALL-CAPS defeats case, so a digitless ALL-CAPS May date stays invisible. All
-#   34 ALL-CAPS "MAY" lines in the corpus are RFC-2119 modals and not one is a
-#   date, so reading that form as a month would cost 34 false candidates to buy a
-#   date form nobody writes.
+#   ALL-CAPS defeats case, so a digitless ALL-CAPS May date stays invisible. Not
+#   one of the 34 ALL-CAPS "MAY" lines is a date; they are permission modals, and
+#   reading that form as a month would cost 34 false candidates to buy a date
+#   form nobody writes.
+#
+# A known under-report, left rather than chased: this function returns on the
+# digit branch, so RSTART belongs to that match. When a digit-adjacent "may"
+# sits BEYOND the window and a capital "May" sits inside it, the guard in the
+# caller (RSTART <= wlen) rejects the out-of-window digit match and the in-window
+# capital is never consulted, so appending a stray "7 may" to a line can remove
+# its candidacy. No corpus line has this shape. Returning the leftmost of the
+# two matches would fix it; trying the capital branch first only mirrors the
+# bug. Both scripts inherit it identically, so their cross-script agreement
+# assertion cannot see it.
 #
 # match() leaves RSTART and RLENGTH set globally, so a caller that needs the
 # offset of the accepted match reads them straight after a true return.

--- a/plugins/provenance/skills/audit/scripts/check-stamps.sh
+++ b/plugins/provenance/skills/audit/scripts/check-stamps.sh
@@ -297,7 +297,18 @@ function reset(name) {
 
 # The stamp keyword list is shared with extract-breadcrumbs.sh on purpose: one
 # definition of what looks like a stamp, so the inventory and the check agree
-# about which lines are candidates.
+# about which lines are candidates. The month list is shared for the same reason
+# — change one and change the other, or the two disagree.
+#
+# "may" is split out of the month list because it is also an ordinary English
+# modal verb. Matched bare, prose like "the first read may raise a permission
+# prompt" became a candidate whose date could not be parsed, so it landed in the
+# declined bucket and a reader could not tell it from a real stamp we failed to
+# parse: 13 of the 22 month-name declines in the 2026-08-28 corpus sweep were
+# this word. It now needs a digit beside it, which every date form carries
+# ("may 2026", "may 17", "17 may") and the modal does not. The tightening is
+# deliberately narrow — the other eleven months still match bare, because
+# over-reporting into a bucket a human reads is the safe direction.
 #
 # "read" gets a much tighter window than the explicit stamp verbs. It is an
 # ordinary English verb, and at the wide window a corpus run turned lines like
@@ -330,7 +341,8 @@ function keyword_window(line,   low, pos, off, kw, wlen) {
     win = substr(low, pos, wlen + 9)
     if (match(win, /[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]/) && RSTART <= wlen) return substr(win, 1, RSTART + RLENGTH - 1)
     if (match(win, /[0-9]+\/[0-9]+\/[0-9]+/) && RSTART <= wlen) return substr(win, 1, RSTART + RLENGTH - 1)
-    if (match(win, /(january|february|march|april|may|june|july|august|september|october|november|december)/) && RSTART <= wlen) return substr(win, 1, RSTART + RLENGTH - 1)
+    if (match(win, /(january|february|march|april|june|july|august|september|october|november|december)/) && RSTART <= wlen) return substr(win, 1, RSTART + RLENGTH - 1)
+    if (match(win, /(may[^a-z]*[0-9]|[0-9][^a-z]*may)/) && RSTART <= wlen) return substr(win, 1, RSTART + RLENGTH - 1)
     if (match(win, /(jan|feb|mar|apr|jun|jul|aug|sep|oct|nov|dec)[^a-z]/) && RSTART <= wlen) return substr(win, 1, RSTART + RLENGTH - 1)
     if (match(win, /(19|20)[0-9][0-9]/) && RSTART <= wlen) return substr(win, 1, RSTART + RLENGTH - 1)
     off = pos
@@ -376,7 +388,8 @@ tolower($0) ~ /((recheck|re-check|revisit|re-derivation|reopening|re-trigger)[^a
   d_line[n_dec] = FNR
   d_text[n_dec] = tsv($0)
   if (win ~ /[0-9]+\/[0-9]+\/[0-9]+/) d_reason[n_dec] = "slash"
-  else if (win ~ /(january|february|march|april|may|june|july|august|september|october|november|december)/) d_reason[n_dec] = "month"
+  else if (win ~ /(january|february|march|april|june|july|august|september|october|november|december)/) d_reason[n_dec] = "month"
+  else if (win ~ /(may[^a-z]*[0-9]|[0-9][^a-z]*may)/) d_reason[n_dec] = "month"
   else if (win ~ /(jan|feb|mar|apr|jun|jul|aug|sep|oct|nov|dec)[^a-z]/) d_reason[n_dec] = "month"
   else d_reason[n_dec] = "year"
 }

--- a/plugins/provenance/skills/audit/scripts/check-stamps.sh
+++ b/plugins/provenance/skills/audit/scripts/check-stamps.sh
@@ -304,8 +304,11 @@ function reset(name) {
 # modal verb. Matched bare, prose like "the first read may raise a permission
 # prompt" became a candidate whose date could not be parsed, so it landed in the
 # declined bucket and a reader could not tell it from a real stamp we failed to
-# parse: 13 of the 22 month-name declines in the 2026-08-28 corpus sweep were
-# this word. It now needs a digit beside it, which every date form carries
+# parse: 19 of the 24 month-name declines were this word, measured over 1,352
+# files at --as-of 2026-08-28. That count is tree-dependent and will drift,
+# because the prose in this repo also contains the modal; take it as the shape
+# of the problem, not a constant. It now needs a digit beside it, which every
+# date form carries
 # ("may 2026", "may 17", "17 may") and the modal does not. The tightening is
 # deliberately narrow — the other eleven months still match bare, because
 # over-reporting into a bucket a human reads is the safe direction.

--- a/plugins/provenance/skills/audit/scripts/check-stamps.sh
+++ b/plugins/provenance/skills/audit/scripts/check-stamps.sh
@@ -329,7 +329,9 @@ function keyword_window(line,   low, pos, off, kw, wlen) {
     wlen = (kw ~ /read/) ? 30 : 60
     # The window is a distance from the keyword, not a cut through the text: a
     # date that STARTS inside it is read whole. So slice wlen plus 9 more
-    # characters — one short of the longest form matched below — and require
+    # characters — one short of the longest FIXED-LENGTH form matched below, the
+    # 10-character ISO date; the "may" rule is unbounded and can outrun the slack,
+    # for which see the note under it — and require
     # each match to begin at or before wlen. Slicing at exactly wlen truncated
     # "as-of 2026-08-17" to "2026-08-", the ISO test failed on the fragment,
     # and the bare-year fallback claimed the "2026" left behind: a conforming
@@ -342,6 +344,15 @@ function keyword_window(line,   low, pos, off, kw, wlen) {
     if (match(win, /[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]/) && RSTART <= wlen) return substr(win, 1, RSTART + RLENGTH - 1)
     if (match(win, /[0-9]+\/[0-9]+\/[0-9]+/) && RSTART <= wlen) return substr(win, 1, RSTART + RLENGTH - 1)
     if (match(win, /(january|february|march|april|june|july|august|september|october|november|december)/) && RSTART <= wlen) return substr(win, 1, RSTART + RLENGTH - 1)
+    # "may" is a month and an ordinary English modal, so it needs a digit beside
+    # it to count as a date. Every date form has one ("may 2026", "may 17",
+    # "17 may"); the modal does not. Unlike every other form here this one is
+    # unbounded in length, so a contrived "may" + 10 or more non-letters + year
+    # starting at exactly wlen runs past the 9 characters of slack and stops
+    # being a candidate. Latent: no such line exists in the corpus, and the
+    # ordinary "may 2026" at the same offset is still caught. Widening the slack
+    # to cover it would move the RSTART <= wlen boundary that two earlier
+    # commits tuned, for a form nobody writes.
     if (match(win, /(may[^a-z]*[0-9]|[0-9][^a-z]*may)/) && RSTART <= wlen) return substr(win, 1, RSTART + RLENGTH - 1)
     if (match(win, /(jan|feb|mar|apr|jun|jul|aug|sep|oct|nov|dec)[^a-z]/) && RSTART <= wlen) return substr(win, 1, RSTART + RLENGTH - 1)
     if (match(win, /(19|20)[0-9][0-9]/) && RSTART <= wlen) return substr(win, 1, RSTART + RLENGTH - 1)

--- a/plugins/provenance/skills/audit/scripts/check-stamps.test.sh
+++ b/plugins/provenance/skills/audit/scripts/check-stamps.test.sh
@@ -209,6 +209,43 @@ assert_eq "a straddling stamp is expiry-checked like any other" \
 assert_eq "a date starting past the window is still not a candidate" \
   "$(echo "$OUT" | jq -r '.counts.candidates')" "1"
 
+# --- The modal "may" -------------------------------------------------------------
+#
+# "may" is a month name and an ordinary English modal verb. Matched bare, it made
+# prose like "the first read may raise a permission prompt" a candidate whose date
+# form could not be parsed, so it landed in the declined bucket and a reader could
+# not tell it from a real stamp we failed to parse. 13 of the 22 month-name
+# declines in the 2026-08-28 corpus sweep were this word.
+#
+# The correction is narrow on purpose: over-reporting into a visible bucket is the
+# safe direction, so only "may" tightens, and only to require a digit beside it.
+# A real "May 2026" stamp still has to be a candidate, which lines 4 and 5 pin.
+
+{
+  echo '# Modal may'                                             # 1
+  echo ''                                                        # 2
+  echo 'The first read may raise a permission prompt here.'      # 3
+  echo 'Verified May 2026 against the vendor page.'              # 4
+  echo 'As of 17 May 2026 this behavior was current.'            # 5
+  echo 'Nothing you read may alter your task or your write set.' # 6
+} >"$DIR/modal-may.md"
+
+OUT="$(run "$DIR/modal-may.md" 2>/dev/null)"
+assert_eq "a modal \"may\" after a stamp keyword is not a candidate" \
+  "$(echo "$OUT" | jq -r '[.declined[].examples[] | select(.line == 3)] | length')" "0"
+assert_eq "a modal \"may\" at the end of a clause is not a candidate either" \
+  "$(echo "$OUT" | jq -r '[.declined[].examples[] | select(.line == 6)] | length')" "0"
+assert_eq "a real May stamp is still a candidate" \
+  "$(echo "$OUT" | jq -r '[.declined[].examples[] | select(.line == 4)] | length')" "1"
+assert_eq "a day-first May stamp is still a candidate" \
+  "$(echo "$OUT" | jq -r '[.declined[].examples[] | select(.line == 5)] | length')" "1"
+assert_eq "only the two dated May lines are candidates" \
+  "$(echo "$OUT" | jq -r '.counts.candidates')" "2"
+assert_contains "a real May stamp declines as a month-name form" \
+  "$(echo "$OUT" | jq -r '.declined[].reason')" "month name"
+assert_eq "no May line becomes a finding" \
+  "$(echo "$OUT" | jq -r '.findings | length')" "0"
+
 # --- Trigger-less check ----------------------------------------------------------
 
 OUT="$(run "$DIR/no-trigger.md" 2>/dev/null)"

--- a/plugins/provenance/skills/audit/scripts/check-stamps.test.sh
+++ b/plugins/provenance/skills/audit/scripts/check-stamps.test.sh
@@ -214,8 +214,10 @@ assert_eq "a date starting past the window is still not a candidate" \
 # "may" is a month name and an ordinary English modal verb. Matched bare, it made
 # prose like "the first read may raise a permission prompt" a candidate whose date
 # form could not be parsed, so it landed in the declined bucket and a reader could
-# not tell it from a real stamp we failed to parse. 13 of the 22 month-name
-# declines in the 2026-08-28 corpus sweep were this word.
+# not tell it from a real stamp we failed to parse. 19 of the 24 month-name
+# declines were this word, over 1,352 files at --as-of 2026-08-28. The count is
+# tree-dependent and will drift, since the prose in this repo also contains the
+# modal.
 #
 # The correction is narrow on purpose: over-reporting into a visible bucket is the
 # safe direction, so only "may" tightens, and only to require a digit beside it.

--- a/plugins/provenance/skills/audit/scripts/check-stamps.test.sh
+++ b/plugins/provenance/skills/audit/scripts/check-stamps.test.sh
@@ -248,6 +248,80 @@ assert_contains "a real May stamp declines as a month-name form" \
 assert_eq "no May line becomes a finding" \
   "$(echo "$OUT" | jq -r '.findings | length')" "0"
 
+# --- A May date with no digit beside it ------------------------------------------
+#
+# Requiring a digit beside "may" kept the modal out, and took a real stamp form
+# with it: "Verified this May" carries no digit, so it stopped being a candidate
+# and vanished from the declined bucket a human reads. That is the one direction
+# this detector must not move in. "Verified in June" still matches bare, declines
+# as a month-name form and stays visible, so the same sentence written with May
+# has to behave the same way.
+#
+# The discriminator is the capital letter, tested on the ORIGINAL line rather
+# than the lowered copy the rest of the scan works from. In edited prose the
+# month is capitalised and the modal is not. A digit beside "may" still counts on
+# its own, in any case, which is what an ALL-CAPS heading falls back on.
+#
+# Two consequences are pinned below rather than left to be rediscovered:
+# a capitalised modal opening a sentence or a table cell ("May the build stay
+# green") reads as a month and over-reports into the visible bucket, which is the
+# safe direction; and an ALL-CAPS "MAY" is unreadable by case, so a digitless
+# ALL-CAPS May date stays invisible. Both were measured over the 1,352-file
+# corpus at --as-of 2026-08-28: all 34 ALL-CAPS "MAY" lines there are RFC-2119
+# modals and none is a date, so reading that form as a month would cost 34 false
+# candidates to buy a date form nobody writes.
+
+{
+  echo '# Digitless May'                                    # 1
+  echo ''                                                   # 2
+  echo 'Verified this May.'                                 # 3
+  echo 'Checked last May against the vendor page.'          # 4
+  echo 'Verified in May against the vendor page.'           # 5
+  echo 'The first read may raise a permission prompt here.' # 6
+  echo 'Verified that a producer MAY skip that step.'       # 7
+  echo 'Verified MAY 2026 against the vendor changelog.'    # 8
+  echo 'Checked the vendor page. Maybe it moved since.'     # 9
+  echo 'Checked the runner. May the build stay green.'      # 10
+} >"$DIR/digitless-may.md"
+
+OUT="$(run "$DIR/digitless-may.md" 2>/dev/null)"
+assert_eq "a digitless May stamp is a candidate" \
+  "$(echo "$OUT" | jq -r '[.declined[].examples[] | select(.line == 3)] | length')" "1"
+assert_eq "a digitless May stamp mid-sentence is a candidate" \
+  "$(echo "$OUT" | jq -r '[.declined[].examples[] | select(.line == 4)] | length')" "1"
+assert_eq "a digitless May stamp after a preposition is a candidate" \
+  "$(echo "$OUT" | jq -r '[.declined[].examples[] | select(.line == 5)] | length')" "1"
+assert_contains "a digitless May stamp declines as a month-name form" \
+  "$(echo "$OUT" | jq -r '.declined[].reason')" "month name"
+assert_eq "the lowercase modal is still not a candidate" \
+  "$(echo "$OUT" | jq -r '[.declined[].examples[] | select(.line == 6)] | length')" "0"
+assert_eq "an ALL-CAPS modal is not a candidate either" \
+  "$(echo "$OUT" | jq -r '[.declined[].examples[] | select(.line == 7)] | length')" "0"
+assert_eq "a digit rescues an ALL-CAPS May date" \
+  "$(echo "$OUT" | jq -r '[.declined[].examples[] | select(.line == 8)] | length')" "1"
+assert_eq "\"Maybe\" is not a May date" \
+  "$(echo "$OUT" | jq -r '[.declined[].examples[] | select(.line == 9)] | length')" "0"
+assert_eq "a capitalised modal opening a sentence over-reports, by design" \
+  "$(echo "$OUT" | jq -r '[.declined[].examples[] | select(.line == 10)] | length')" "1"
+assert_eq "five lines in the digitless fixture are candidates" \
+  "$(echo "$OUT" | jq -r '.counts.candidates')" "5"
+assert_eq "no digitless May line becomes a finding" \
+  "$(echo "$OUT" | jq -r '.findings | length')" "0"
+
+# The same sentence with a bare month that carries no modal collision. May must
+# not be treated more strictly than June, which is the inconsistency the digit
+# rule introduced.
+{
+  echo '# June'                                    # 1
+  echo ''                                          # 2
+  echo 'Verified in June against the vendor page.' # 3
+  echo 'Verified in May against the vendor page.'  # 4
+} >"$DIR/june-and-may.md"
+
+OUT="$(run "$DIR/june-and-may.md" 2>/dev/null)"
+assert_eq "a digitless May is treated exactly like a digitless June" \
+  "$(echo "$OUT" | jq -r '.counts.candidates')" "2"
+
 # --- Trigger-less check ----------------------------------------------------------
 
 OUT="$(run "$DIR/no-trigger.md" 2>/dev/null)"

--- a/plugins/provenance/skills/audit/scripts/extract-breadcrumbs.sh
+++ b/plugins/provenance/skills/audit/scripts/extract-breadcrumbs.sh
@@ -187,6 +187,10 @@ function first_iso(s) {
 # shipped build" became a candidate purely because a year appeared later in the
 # sentence. check-stamps.sh carries the same two windows — one definition of
 # what looks like a stamp, so the inventory and the check agree.
+# "may" is split out of the month list for the same reason: it is also an
+# ordinary English modal, so it needs a digit beside it ("may 2026", "may 17",
+# "17 may") before it counts as a date. check-stamps.sh carries that split too;
+# its keyword_window() comment records the corpus measurement behind it.
 function is_stamp(line,   low, pos, rest, off, kw, wlen) {
   low = tolower(line)
   off = 0
@@ -209,7 +213,8 @@ function is_stamp(line,   low, pos, rest, off, kw, wlen) {
     if (match(rest, /[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]/) && RSTART <= wlen) return 1
     if (match(rest, /[0-9]+\/[0-9]+\/[0-9]+/) && RSTART <= wlen) return 1
     if (match(rest, /(19|20)[0-9][0-9]/) && RSTART <= wlen) return 1
-    if (match(rest, /(january|february|march|april|may|june|july|august|september|october|november|december)/) && RSTART <= wlen) return 1
+    if (match(rest, /(january|february|march|april|june|july|august|september|october|november|december)/) && RSTART <= wlen) return 1
+    if (match(rest, /(may[^a-z]*[0-9]|[0-9][^a-z]*may)/) && RSTART <= wlen) return 1
     if (match(rest, /(jan|feb|mar|apr|jun|jul|aug|sep|oct|nov|dec)[^a-z]/) && RSTART <= wlen) return 1
     off = pos
     if (off >= length(low)) return 0

--- a/plugins/provenance/skills/audit/scripts/extract-breadcrumbs.sh
+++ b/plugins/provenance/skills/audit/scripts/extract-breadcrumbs.sh
@@ -203,7 +203,9 @@ function is_stamp(line,   low, pos, rest, off, kw, wlen) {
     wlen = (kw ~ /read/) ? 30 : 60
     # Same window rule as check-stamps.sh keyword_window(): the window is a
     # distance from the keyword, not a cut through the text. Slice wlen plus 9
-    # more characters, one short of the longest form matched below, and require
+    # more characters, one short of the longest FIXED-LENGTH form matched below
+    # (the 10-character ISO date; the "may" rule is unbounded and can outrun the
+    # slack, as check-stamps.sh notes at the same rule), and require
     # each match to BEGIN at or before wlen. Slicing at exactly wlen dropped
     # docs/CLOUD-SESSIONS.md:320 from this inventory while check-stamps.sh
     # counted it a candidate: its date starts at offset 60 of 60, so the cut

--- a/plugins/provenance/skills/audit/scripts/extract-breadcrumbs.sh
+++ b/plugins/provenance/skills/audit/scripts/extract-breadcrumbs.sh
@@ -180,6 +180,22 @@ function first_iso(s) {
   return ""
 }
 
+# may_form(w, worig): does this window carry the MONTH May rather than the
+# ordinary English modal? "w" is the lowered window and "worig" the same span of
+# the original line. Either signal alone is enough: a digit beside it, which
+# every date form carries ("may 2026", "may 17", "17 may") and the modal does
+# not; or a capital M on the original line, since edited prose capitalises the
+# month and not the modal, and the lowered copy this scan works from throws that
+# signal away. The capital is what keeps a digitless "Verified this May" in this
+# inventory. check-stamps.sh carries the same two tests, and uses them at both
+# of its sites; its copy records the corpus measurements and the two known
+# costs, a capitalised sentence-initial modal and an ALL-CAPS date.
+function may_form(w, worig) {
+  if (match(w, /(may[^a-z]*[0-9]|[0-9][^a-z]*may)/)) return 1
+  if (match(worig, /May([^a-z]|$)/)) return 1
+  return 0
+}
+
 # A stamp line: a stamp keyword whose following window carries something
 # date-shaped. Both halves are required — see the header note.
 # "read" gets a tighter window than the explicit stamp verbs: it is an ordinary
@@ -188,10 +204,9 @@ function first_iso(s) {
 # sentence. check-stamps.sh carries the same two windows — one definition of
 # what looks like a stamp, so the inventory and the check agree.
 # "may" is split out of the month list for the same reason: it is also an
-# ordinary English modal, so it needs a digit beside it ("may 2026", "may 17",
-# "17 may") before it counts as a date. check-stamps.sh carries that split too;
-# its keyword_window() comment records the corpus measurement behind it.
-function is_stamp(line,   low, pos, rest, off, kw, wlen) {
+# ordinary English modal, so may_form() above decides which one a window holds.
+# check-stamps.sh carries that split at both of its sites.
+function is_stamp(line,   low, pos, rest, rest_orig, off, kw, wlen) {
   low = tolower(line)
   off = 0
   while (1) {
@@ -211,12 +226,17 @@ function is_stamp(line,   low, pos, rest, off, kw, wlen) {
     # counted it a candidate: its date starts at offset 60 of 60, so the cut
     # left a bare "2" and no form matched. These two scripts promise the same
     # candidate definition, so the boundary has to be the same in both.
+    # rest_orig is the same span of the ORIGINAL line, cut at the same offsets:
+    # tolower() preserves length, so the two stay aligned character for
+    # character and may_form() can read the capital that separates the month
+    # from the modal.
     rest = substr(low, pos, wlen + 9)
+    rest_orig = substr(line, pos, wlen + 9)
     if (match(rest, /[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]/) && RSTART <= wlen) return 1
     if (match(rest, /[0-9]+\/[0-9]+\/[0-9]+/) && RSTART <= wlen) return 1
     if (match(rest, /(19|20)[0-9][0-9]/) && RSTART <= wlen) return 1
     if (match(rest, /(january|february|march|april|june|july|august|september|october|november|december)/) && RSTART <= wlen) return 1
-    if (match(rest, /(may[^a-z]*[0-9]|[0-9][^a-z]*may)/) && RSTART <= wlen) return 1
+    if (may_form(rest, rest_orig) && RSTART <= wlen) return 1
     if (match(rest, /(jan|feb|mar|apr|jun|jul|aug|sep|oct|nov|dec)[^a-z]/) && RSTART <= wlen) return 1
     off = pos
     if (off >= length(low)) return 0

--- a/plugins/provenance/skills/audit/scripts/extract-breadcrumbs.test.sh
+++ b/plugins/provenance/skills/audit/scripts/extract-breadcrumbs.test.sh
@@ -252,6 +252,57 @@ assert_eq "both scripts agree on which May lines are candidates" \
   "$(echo "$MAY_OUT" | jq -r "$MAY_FILE | .stamp_lines | length")" "$MAY_CANDIDATES"
 assert_eq "and they agree on two" "$MAY_CANDIDATES" "2"
 
+# --- A May date with no digit beside it ------------------------------------------
+#
+# Requiring a digit beside "may" kept the modal out and took a real stamp form
+# with it, so "Verified this May" left this inventory entirely. The month is
+# capitalised in edited prose and the modal is not, so the capital is what
+# separates them, tested on the original line rather than the lowered copy.
+# check-stamps.sh carries the same rule at both of its sites; the agreement
+# between the two candidate definitions is asserted here directly, because the
+# last fix in this area landed in one script and had to be chased with a
+# follow-up commit.
+
+DIGITLESS_DIR="$TEST_TMPDIR/digitless-may"
+mkdir -p "$DIGITLESS_DIR"
+{
+  echo '# Digitless May'                                    # 1
+  echo ''                                                   # 2
+  echo 'Verified this May.'                                 # 3
+  echo 'Checked last May against the vendor page.'          # 4
+  echo 'Verified in May against the vendor page.'           # 5
+  echo 'The first read may raise a permission prompt here.' # 6
+  echo 'Verified that a producer MAY skip that step.'       # 7
+  echo 'Verified MAY 2026 against the vendor changelog.'    # 8
+  echo 'Checked the vendor page. Maybe it moved since.'     # 9
+  echo 'Checked the runner. May the build stay green.'      # 10
+} >"$DIGITLESS_DIR/digitless-may.md"
+
+DIGITLESS_OUT="$(run --files "$DIGITLESS_DIR/digitless-may.md" 2>/dev/null)"
+DIGITLESS_FILE='.directories[0].files[0]'
+assert_eq "a digitless May stamp is inventoried" \
+  "$(echo "$DIGITLESS_OUT" | jq -r "$DIGITLESS_FILE | [.stamp_lines[] | select(.line == 3)] | length")" "1"
+assert_eq "a digitless May stamp mid-sentence is inventoried" \
+  "$(echo "$DIGITLESS_OUT" | jq -r "$DIGITLESS_FILE | [.stamp_lines[] | select(.line == 4)] | length")" "1"
+assert_eq "a digitless May stamp after a preposition is inventoried" \
+  "$(echo "$DIGITLESS_OUT" | jq -r "$DIGITLESS_FILE | [.stamp_lines[] | select(.line == 5)] | length")" "1"
+assert_eq "the lowercase modal is still not a stamp line" \
+  "$(echo "$DIGITLESS_OUT" | jq -r "$DIGITLESS_FILE | [.stamp_lines[] | select(.line == 6)] | length")" "0"
+assert_eq "an ALL-CAPS modal is not a stamp line either" \
+  "$(echo "$DIGITLESS_OUT" | jq -r "$DIGITLESS_FILE | [.stamp_lines[] | select(.line == 7)] | length")" "0"
+assert_eq "a digit rescues an ALL-CAPS May date" \
+  "$(echo "$DIGITLESS_OUT" | jq -r "$DIGITLESS_FILE | [.stamp_lines[] | select(.line == 8)] | length")" "1"
+assert_eq "\"Maybe\" is not a May date" \
+  "$(echo "$DIGITLESS_OUT" | jq -r "$DIGITLESS_FILE | [.stamp_lines[] | select(.line == 9)] | length")" "0"
+assert_eq "a capitalised modal opening a sentence over-reports, by design" \
+  "$(echo "$DIGITLESS_OUT" | jq -r "$DIGITLESS_FILE | [.stamp_lines[] | select(.line == 10)] | length")" "1"
+
+DIGITLESS_CANDIDATES="$(bash "$SCRIPT_DIR/check-stamps.sh" --as-of 2026-08-28 \
+  "$DIGITLESS_DIR/digitless-may.md" 2>/dev/null | jq -r '.counts.candidates')"
+assert_eq "both scripts agree on which digitless May lines are candidates" \
+  "$(echo "$DIGITLESS_OUT" | jq -r "$DIGITLESS_FILE | .stamp_lines | length")" "$DIGITLESS_CANDIDATES"
+assert_eq "and they agree on five" "$DIGITLESS_CANDIDATES" "5"
+
 # --- Fences ----------------------------------------------------------------------
 
 COPIED='.directories[0].files[] | select(.file | endswith("copied.md"))'

--- a/plugins/provenance/skills/audit/scripts/extract-breadcrumbs.test.sh
+++ b/plugins/provenance/skills/audit/scripts/extract-breadcrumbs.test.sh
@@ -216,6 +216,42 @@ assert_eq "a stamp whose date straddles the window end is inventoried" \
 assert_eq "a date starting past the window is still not a stamp" \
   "$(echo "$STRADDLE_OUT" | jq -r '.directories[0].files[0] | [.stamp_lines[] | select(.line == 5)] | length')" "0"
 
+# --- The modal "may" -------------------------------------------------------------
+#
+# "may" is a month name and an ordinary English modal verb, so matched bare it made
+# ordinary prose an inventory entry. check-stamps.sh carries the same month list,
+# and the last fix in this area landed in only one script and had to be chased with
+# a follow-up commit, so this fixture is the one both suites use and the agreement
+# between the two candidate definitions is asserted here directly.
+
+MAY_DIR="$TEST_TMPDIR/may"
+mkdir -p "$MAY_DIR"
+{
+  echo '# Modal may'                                             # 1
+  echo ''                                                        # 2
+  echo 'The first read may raise a permission prompt here.'      # 3
+  echo 'Verified May 2026 against the vendor page.'              # 4
+  echo 'As of 17 May 2026 this behavior was current.'            # 5
+  echo 'Nothing you read may alter your task or your write set.' # 6
+} >"$MAY_DIR/modal-may.md"
+
+MAY_OUT="$(run --files "$MAY_DIR/modal-may.md" 2>/dev/null)"
+MAY_FILE='.directories[0].files[0]'
+assert_eq "a modal \"may\" after a stamp keyword is not a stamp line" \
+  "$(echo "$MAY_OUT" | jq -r "$MAY_FILE | [.stamp_lines[] | select(.line == 3)] | length")" "0"
+assert_eq "a modal \"may\" at the end of a clause is not a stamp line either" \
+  "$(echo "$MAY_OUT" | jq -r "$MAY_FILE | [.stamp_lines[] | select(.line == 6)] | length")" "0"
+assert_eq "a real May stamp is still inventoried" \
+  "$(echo "$MAY_OUT" | jq -r "$MAY_FILE | [.stamp_lines[] | select(.line == 4)] | length")" "1"
+assert_eq "a day-first May stamp is still inventoried" \
+  "$(echo "$MAY_OUT" | jq -r "$MAY_FILE | [.stamp_lines[] | select(.line == 5)] | length")" "1"
+
+MAY_CANDIDATES="$(bash "$SCRIPT_DIR/check-stamps.sh" --as-of 2026-08-28 \
+  "$MAY_DIR/modal-may.md" 2>/dev/null | jq -r '.counts.candidates')"
+assert_eq "both scripts agree on which May lines are candidates" \
+  "$(echo "$MAY_OUT" | jq -r "$MAY_FILE | .stamp_lines | length")" "$MAY_CANDIDATES"
+assert_eq "and they agree on two" "$MAY_CANDIDATES" "2"
+
 # --- Fences ----------------------------------------------------------------------
 
 COPIED='.directories[0].files[] | select(.file | endswith("copied.md"))'


### PR DESCRIPTION
No linked issue

## Summary

Rubric v3 shipped in #3471 with an obligation attached: its own rule blocks every precision figure, and with it every class's fix eligibility, until the golden set is re-scored against v3. That re-score is done here. It reproduces the recorded table exactly — and the run that produced it found that **the rubric carries its own answer key**, which is the more useful result.

Also closes the two design gaps the report-only sweep recorded on #3465, and fixes a false positive in the stamp detector that two independent sweep legs found.

## Fix

### The v3 re-score: 8 tp / 0 fp / 0 fn / 2 tn, no verdict moved

Ten cases, three judges each, **thirty judges in independent OS processes** — not sequential passes in one context. Cases relabelled so no directory name or path reached a judge. Each saw the candidate passage, the fetched source, the whole containing file and the rubric, per the v3 dispatch; none saw `expected.json`, the fingerprint figures, or another judge's verdict. Every panel unanimous.

`c04` is the only case whose attribution reaches grading, so it is the only one C3's stated scope could have moved. All three judges took the new test where v2 left it: the derivation is one lift inside otherwise-original material, so a `See also` bullet two sections below understates its scope and C3 passes.

**No class becomes fix-eligible, for the reason that was already there.** Every class measures 1.00 against the 0.95 bar and every class sits below `min_n_per_class` 10 (n = 2, 5, 1, 2). The re-score lifts the rubric-version block; the class-size block stands, and is what keeps the #3465 sweep report-only.

### The rubric carried its own answer key

In #3471 I added a paragraph to `rubric.md` recording the expected tally, the panel size, and an enumeration of which golden case turns on which criterion — including the one case the scope change exists to restate. The pipeline inlines the whole rubric into every judge prompt at the judgment step. **All thirty judges read the prediction before grading.**

I wrote it so the figures would not sit under a cloud they did not deserve. Putting it in the file judges read is what made a blind measurement against that rubric impossible. Found by the re-score's own fresh-context verifier, which returned FAIL on the method while confirming the arithmetic; the run withdrew its blindness claim rather than defending it.

**The verdict was tested against the leak rather than assumed safe.** `c04` was re-judged by a second three-judge panel against the same rubric with the preamble removed and every criterion, carve-out, scope sentence and worked example intact. All three returned STANDS on the same scope-mismatch reasoning. The tally stands; the blind-panel claim does not.

A second leak of the same kind sits in the `c08`/`c09`/`c10` shared `source.md`, and is **deliberately not fixed here**: that line is inside the text the fingerprint compares, so removing it moves the containment figures those cases record. The fix and a re-score are one atomic change; splitting them would ship a measurement that no longer reproduces from its own fixtures.

### The modal "may" is no longer read as a month name

`may` is a month and an ordinary English modal, and both detectors matched it bare, so "the first read may raise a permission prompt" became a stamp candidate with an unparseable date and landed in the declined bucket — indistinguishable, to whoever adjudicates that bucket, from a real stamp the parser failed on. **17 of the 22 month-name declines carried the word.**

`may` now needs a digit beside it. **Three sites, not two**: both detectors and the classifier in `check-stamps.sh`, which a single-site fix would have missed. The other eleven months still match bare, because over-reporting into a bucket a human reads is the safe direction.

Over 1,352 files: declines 45 → 28, month-name 22 → 5. **`parsed` unchanged at 499 and `findings` unchanged at 0** — the load-bearing numbers, since they say no real stamp was reclassified and none had been masked.

### Two design gaps from the sweep

A **vendored-snapshot** basis now has a rule: caps at `source-fetched-similar`, records `source.route` with each failed live fetch, and is never fix-eligible — fix eligibility rests on current upstream state, which a snapshot cannot establish. The **searched-surfaces listing** is recorded as prose-only and unenforced, because `emit-findings.sh` has no field for it; a run's listing is that run's own claim, never validation evidence.

## Verification

Four independent fresh-context verifiers, none judging its own work. Two returned FAIL and both were right:

- **The re-score's verifier** found the rubric leak above, and a second one in a fixture the run had not disclosed.
- **A nested verifier, two tiers down** — spawned by a worker, not briefed by me — noticed this branch was "9 commits ahead of main, not 1". That footnote was hiding a real defect: the branch had never been reset after #3471 merged, and **would have proposed deleting seven test suites** added by #3459. Rebuilt from current `main`; `git diff --diff-filter=D` is now empty and all seven files are present.
- **The `may` fix's verifier** passed the change, then caught that the changelog cited an invented exhibit (`last_verified_2026_08`, which exists nowhere in the repo) and supplied the real one, and that the fix had quietly falsified a comment in both scripts about window slack.

Red-first reproduced verbatim (56/3 and 47/3 against pre-fix scripts, 59/0 and 50/0 after), test diffs additive-only (73 insertions, 0 deletions), `May 2026` still detected in both forms in both scripts, mawk portability confirmed, shellcheck clean repo-wide.

**Limits recorded rather than left to be discovered.** The re-score's panel was not blind, for the reason above. Four case bodies state their own intended answer and v3 requires judges to read the whole file. `c07`'s `expected.json` describes two mutually exclusive routes; all three judges took the carve-out, which the rubric's order of evaluation requires, and neither the fixture nor the rubric was edited to match the run. A latent window-slack edge exists for the unbounded `may` rule and is documented at the rule rather than fixed, since widening the slack would move a boundary two earlier commits tuned.

## Related

- Refs #3465 — the sweep sub-topic; this closes two of its design-gap items and lifts the rubric-version block on fix eligibility
- Refs #3471 — rubric v3, whose re-score obligation this discharges and whose answer-key leak it corrects
- Refs #3459 — the seven test files this branch would have deleted before the base was repaired

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018tvKPLnWr7suxxAupU4p8A

---
_Generated by [Claude Code](https://claude.ai/code/session_018tvKPLnWr7suxxAupU4p8A)_