### PR TITLE
fix(tooling): stop two silent false signals, in test selection and in bootstrap health

### DIFF
--- a/.claude/cloud-bootstrap.sh
+++ b/.claude/cloud-bootstrap.sh
@@ -148,7 +148,9 @@ fi
 #
 # Best effort by design: a plugin that fails to install costs that plugin's
 # skills, not the session. Idempotent — installed plugins are skipped, so a
-# resume re-run costs one `claude plugin list` call.
+# resume re-run costs two `claude plugin list` calls: one to see what is
+# installed, one to verify the end state afterwards. Measured on this VM with
+# nothing to do: 72 enabled, 0 installed, 0 refreshed, 0 failed.
 claude_bin="$repo_root/node_modules/.bin/claude"
 marketplace_name="melodic-software"
 if [[ -x "$claude_bin" ]] && command -v jq >/dev/null 2>&1; then
@@ -198,11 +200,68 @@ if [[ -x "$claude_bin" ]] && command -v jq >/dev/null 2>&1; then
     ! git diff --quiet "$recorded" HEAD -- "plugins/$name" 2>/dev/null
   }
 
+  # snapshot_problem <plugin-id> — the VERIFICATION counterpart of
+  # needs_refresh. It prints a reason when this run cannot show the installed
+  # snapshot is serving the plugin's current sources, and prints nothing when it
+  # can. Always exits 0; the OUTPUT is the verdict.
+  #
+  # Same question, deliberately OPPOSITE default, which is why this is a second
+  # function and not a second caller of the first. needs_refresh decides whether
+  # to spend an uninstall/install cycle, so every "cannot tell" case (no HEAD
+  # sha, no registry file, no recorded gitCommitSha, a JSON null flattened by
+  # `// ""`) correctly answers "do not bother". Verification asks whether the
+  # session is healthy, where "cannot tell" must NOT read as "healthy" — that
+  # fail-open is how a machine with no registry at all reported 0 failed. So
+  # each unknown becomes a named failure here. The one case needs_refresh
+  # already fails CLOSED on, a recorded commit this clone does not have
+  # (shallow fetch or force-push), is kept and reported for the same reason.
+  snapshot_problem() {
+    local id="$1" name="${1%@*}" recorded
+    if [[ -z "$head_sha" ]]; then
+      printf 'cannot verify snapshot: this checkout has no resolvable HEAD'
+      return 0
+    fi
+    if [[ ! -f "$plugins_registry" ]]; then
+      printf 'cannot verify snapshot: no plugin registry at %s' "$plugins_registry"
+      return 0
+    fi
+    recorded="$(jq -r --arg id "$id" \
+      '(.plugins[$id] // []) | map(select(.scope == "user")) | .[0].gitCommitSha // ""' \
+      "$plugins_registry" 2>/dev/null)"
+    if [[ -z "$recorded" || "$recorded" == "null" ]]; then
+      printf 'cannot verify snapshot: no user-scope gitCommitSha recorded in %s' \
+        "$plugins_registry"
+      return 0
+    fi
+    [[ "$recorded" != "$head_sha" ]] || return 0
+    if ! git cat-file -e "${recorded}^{commit}" 2>/dev/null; then
+      printf 'cannot verify snapshot: installed from commit %s, which this clone does not have' \
+        "$recorded"
+      return 0
+    fi
+    if ! git diff --quiet "$recorded" HEAD -- "plugins/$name" 2>/dev/null; then
+      printf 'plugins/%s changed between the installed commit %s and HEAD' "$name" "$recorded"
+    fi
+    return 0
+  }
+
+  # A subcommand's exit status is NOT the verdict here, because one of them is
+  # nonzero on the healthy path. `plugin install --scope user` leaves the
+  # plugin ENABLED, so the trailing `plugin enable --scope user` then exits 1
+  # with `Plugin "<id>" is already enabled at user scope`. Measured on claude
+  # 2.1.246 against this checkout: uninstall exit 0, install exit 0,
+  # `plugin list --json` showing the id at scope=user with enabled=true and the
+  # registry's gitCommitSha advanced to HEAD, and enable exit 1 with that
+  # message. Chaining the three with `&&` therefore scored almost every healthy
+  # refresh as a failure (observed startup lines: 65 failed of 66 refreshes,
+  # then 54), which buried the one real signal this block emits. So run the
+  # chain for effect, then verify the END STATE and let that decide.
   installed=0
   refreshed=0
-  failed=0
+  declare -A action_of=()
   for id in "${wanted[@]}"; do
     [[ -n "$id" ]] || continue
+    action_of["$id"]="no action"
     if [[ " ${have[*]} " == *" $id "* ]]; then
       # shellcheck disable=SC2310  # the return status IS the verdict
       needs_refresh "$id" || continue
@@ -210,24 +269,75 @@ if [[ -x "$claude_bin" ]] && command -v jq >/dev/null 2>&1; then
       # goes silently absent instead of silently stale. `--keep-data` preserves
       # the plugin's persistent data directory. It does not preserve
       # pluginConfigs — uninstall still drops stored userConfig.
-      if "$claude_bin" plugin uninstall "$id" --keep-data >/dev/null 2>&1 &&
-        "$claude_bin" plugin install "$id" --scope user -y >/dev/null 2>&1 &&
-        "$claude_bin" plugin enable "$id" --scope user >/dev/null 2>&1; then
-        refreshed=$((refreshed + 1))
-      else
-        failed=$((failed + 1))
-        echo "cloud-bootstrap: warning: plugin refresh failed: $id" >&2
-      fi
+      "$claude_bin" plugin uninstall "$id" --keep-data >/dev/null 2>&1 || true
+      "$claude_bin" plugin install "$id" --scope user -y >/dev/null 2>&1 || true
+      "$claude_bin" plugin enable "$id" --scope user >/dev/null 2>&1 || true
+      action_of["$id"]="refresh"
       continue
     fi
-    if "$claude_bin" plugin install "$id" --scope user -y >/dev/null 2>&1; then
-      installed=$((installed + 1))
+    "$claude_bin" plugin install "$id" --scope user -y >/dev/null 2>&1 || true
+    action_of["$id"]="install"
+  done
+
+  # End-state verification over the FULL enabled set, not just the plugins this
+  # run touched. Verifying only what was attempted fails open twice over, and
+  # both holes are reachable on a real machine: `have` is built from every scope
+  # `plugin list` reports (this VM carries 145 entries, 73 user and 72 project),
+  # so a plugin present only at PROJECT scope counts as present and is never
+  # installed at user scope; and `needs_refresh` skips a plugin it cannot judge,
+  # so one sitting at user scope with enabled:false, or with no recorded
+  # gitCommitSha, was never looked at again. Both then printed 0 failed. The
+  # whole set costs nothing extra: verification is one batched `plugin list
+  # --json` regardless of how many ids it covers.
+  #
+  # A plugin passes only when it is installed at user scope, enabled there
+  # (enabled must be the JSON boolean true, so a string "true" is rejected), and
+  # snapshot_problem finds nothing. Failures are NAMED, not just counted,
+  # because a bare count cannot be acted on.
+  failed_ids=()
+  end_state="$("$claude_bin" plugin list --json 2>/dev/null || true)"
+  listed=1
+  jq -e 'type == "array"' <<<"$end_state" >/dev/null 2>&1 || listed=0
+  if [[ "$listed" -eq 0 ]]; then
+    # One line for the batch. A per-plugin warning here would reproduce exactly
+    # the log flood this accounting change exists to end.
+    echo "cloud-bootstrap: warning: could not read \`claude plugin list --json\`; no plugin could be verified" >&2
+  fi
+  for id in "${wanted[@]}"; do
+    [[ -n "$id" ]] || continue
+    action="${action_of[$id]}"
+    reason=""
+    if [[ "$listed" -eq 0 ]]; then
+      reason="unverified"
+    elif ! jq -e --arg id "$id" 'any(.[]?; .id == $id and .scope == "user")' \
+      <<<"$end_state" >/dev/null 2>&1; then
+      reason="not installed at user scope"
+    elif ! jq -e --arg id "$id" \
+      'any(.[]?; .id == $id and .scope == "user" and .enabled == true)' \
+      <<<"$end_state" >/dev/null 2>&1; then
+      reason="installed at user scope but not enabled"
     else
-      failed=$((failed + 1))
-      echo "cloud-bootstrap: warning: plugin install failed: $id" >&2
+      reason="$(snapshot_problem "$id")"
+    fi
+    if [[ -n "$reason" ]]; then
+      failed_ids+=("$id")
+      [[ "$listed" -eq 0 ]] ||
+        echo "cloud-bootstrap: warning: $id failed verification after $action: $reason" >&2
+    elif [[ "$action" == "refresh" ]]; then
+      refreshed=$((refreshed + 1))
+    elif [[ "$action" == "install" ]]; then
+      installed=$((installed + 1))
     fi
   done
-  echo "cloud-bootstrap: plugins ${#wanted[@]} enabled, $installed newly installed, $refreshed refreshed, $failed failed"
+
+  plugin_summary="cloud-bootstrap: plugins ${#wanted[@]} enabled, $installed newly installed, $refreshed refreshed, ${#failed_ids[@]} failed"
+  if [[ "$listed" -eq 0 ]]; then
+    plugin_summary="$plugin_summary: none could be verified, see the warning above"
+  elif ((${#failed_ids[@]} > 0)); then
+    failed_list="$(printf '%s, ' "${failed_ids[@]}")"
+    plugin_summary="$plugin_summary: ${failed_list%, }"
+  fi
+  echo "$plugin_summary"
 else
   echo "cloud-bootstrap: warning: claude CLI or jq unavailable; plugins will not load" >&2
 fi

--- a/.claude/hooks/cloud-bootstrap-plugins.test.sh
+++ b/.claude/hooks/cloud-bootstrap-plugins.test.sh
@@ -1,0 +1,365 @@
+#!/usr/bin/env bash
+# Contract test for the plugin accounting in .claude/cloud-bootstrap.sh: the
+# block that installs/refreshes this repo's own catalog on a cloud VM and prints
+# `cloud-bootstrap: plugins N enabled, X newly installed, Y refreshed, Z failed`.
+#
+# That summary is the ONLY health signal a cloud session start emits for
+# plugins, and it has failed in both directions. It over-reported first: the
+# refresh chain was `uninstall && install && enable`, and `claude plugin install
+# --scope user` already leaves the plugin enabled, so the trailing `enable`
+# exits 1 with `Plugin "<id>" is already enabled at user scope` on every HEALTHY
+# refresh (measured on claude 2.1.246). Startup lines read `65 failed` of 66
+# refreshes while every one of those plugins was in fact reinstalled at HEAD.
+# Then it under-reported: verifying only the plugins a run had touched left five
+# genuinely broken end states printing `0 failed`, because the plugins most
+# likely to be wrong are exactly the ones the run decided to skip.
+#
+# So the cases below pin BOTH directions. A healthy outcome must not be counted
+# as a failure, and each broken end state must be named and counted.
+#
+# WHY IT LIVES IN .claude/hooks/. cloud-bootstrap.sh is the SessionStart hook
+# .claude/settings.json registers, and this directory is a CI discovery root:
+# `scripts/run-plugin-tests.sh` and `scripts/check-discriminating-test-skips.sh`
+# both enumerate `find plugins .claude/hooks -type f -name '*.test.sh'`, so this
+# suite runs on every push with no workflow change. A sibling
+# `.claude/cloud-bootstrap.test.sh` would sit outside both roots and outside
+# ci.yml's named `scripts/*.test.sh` steps, and would therefore never run.
+#
+# HOW IT DRIVES THE SCRIPT. cloud-bootstrap.sh is a linear provisioning script
+# whose earlier steps install Node, run `npm ci` and pip-install hash-locked CI
+# deps, none of which belong in a unit test. The plugin block is extracted by
+# its two surrounding anchors (`claude_bin=` and the Python CI deps banner) and
+# run on its own against a stub `claude` CLI plus synthetic
+# `installed_plugins.json` fixtures.
+#
+# THE TRAILING ANCHOR IS THE DANGEROUS ONE, and it needs a guard of its own
+# rather than the content checks that cover the leading one. The extractor is
+# `awk '/^claude_bin=/ {p=1} /^# --- Python CI deps/ {p=0} p'`, so a leading
+# anchor that moves yields nothing and every content check below fires. A
+# TRAILING anchor that moves silently sets no stop: `p` stays 1 to end of file,
+# extraction grows from ~191 lines to the whole tail of the script, and all
+# three content checks still pass because the plugin block is still in there.
+# The suite would keep reporting green while each of the thirteen cases below
+# actually ran `python3 -m pip install --require-hashes`, `curl`ed release
+# assets over the network, `install -m 0755`'d them into ~/.local/bin, and ran
+# `git fetch --unshallow` against the fixture repo. So the end anchor is
+# asserted to EXIST before extraction, and the extracted text is asserted NOT
+# to contain `pip install` afterwards: the first check names the breakage, the
+# second is the backstop that catches any other way the region could run long.
+#
+# Runner: scripts/run-plugin-tests.sh; also runnable directly:
+#   bash .claude/hooks/cloud-bootstrap-plugins.test.sh
+# Set CLOUD_BOOTSTRAP_SCRIPT to point the extraction at another copy of the
+# script (used to confirm these cases fail against the pre-fix versions).
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$here/../.." && pwd)"
+# Clears GIT_DIR/GIT_WORK_TREE/GIT_CONFIG and friends, so the fixture repos
+# below cannot write their throwaway identity into the caller's checkout.
+# shellcheck source=../../scripts/test-git-helpers.sh
+source "$repo_root/scripts/test-git-helpers.sh"
+
+BOOTSTRAP="${CLOUD_BOOTSTRAP_SCRIPT:-$repo_root/.claude/cloud-bootstrap.sh}"
+
+for tool in jq git; do
+  if ! command -v "$tool" >/dev/null 2>&1; then
+    echo "SKIP: $tool unavailable; the accounting block is gated on it anyway"
+    exit 0
+  fi
+done
+
+if [[ ! -f "$BOOTSTRAP" ]]; then
+  echo "FAIL: bootstrap script not found: $BOOTSTRAP"
+  exit 1
+fi
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# --- extract the block under test -------------------------------------------
+extract_fail=0
+
+# Checked BEFORE extracting: awk sets no stop condition for an anchor that is
+# not there, so a missing end anchor cannot be detected from the output.
+if ! grep -q '^# --- Python CI deps' "$BOOTSTRAP"; then
+  echo "FAIL: end anchor '# --- Python CI deps' not found in $BOOTSTRAP"
+  echo "      Without it the extraction runs to end of file and would execute the"
+  echo "      script's pip, curl, install and git fetch steps once per case."
+  extract_fail=1
+fi
+if ! grep -q '^claude_bin=' "$BOOTSTRAP"; then
+  echo "FAIL: start anchor '^claude_bin=' not found in $BOOTSTRAP"
+  extract_fail=1
+fi
+if [[ "$extract_fail" -ne 0 ]]; then
+  echo "Re-point the anchors in this suite at the plugin block in $BOOTSTRAP."
+  exit 1
+fi
+
+BLOCK="$TMP/plugin-block.sh"
+{
+  # shellcheck disable=SC2016  # the preamble is fixture text; $1 must stay literal
+  printf '#!/usr/bin/env bash\nset -euo pipefail\nrepo_root="$1"\ncd -- "$repo_root"\n'
+  awk '/^claude_bin=/ {p = 1} /^# --- Python CI deps/ {p = 0} p' "$BOOTSTRAP"
+} >"$BLOCK"
+
+if ! grep -q 'plugin list --json' "$BLOCK"; then
+  echo "FAIL: extracted block does not call \`plugin list --json\`; the \`claude_bin=\` anchor moved"
+  extract_fail=1
+fi
+if ! grep -q 'newly installed' "$BLOCK"; then
+  echo "FAIL: extracted block does not print the summary line; the extraction is not the plugin block"
+  extract_fail=1
+fi
+# The backstop for an end anchor that exists but no longer terminates the
+# region. Anything from a later section is out of bounds, and the hash-locked
+# pip install is the first and loudest of them.
+if grep -q 'pip install' "$BLOCK"; then
+  echo "FAIL: extracted block reaches past the plugin section into the Python CI deps install"
+  echo "      ($(wc -l <"$BLOCK") lines extracted). It would run pip, curl and git fetch per case."
+  extract_fail=1
+fi
+if ! bash -n "$BLOCK" 2>/dev/null; then
+  echo "FAIL: extracted block is not valid bash; the anchors no longer bracket a whole block"
+  extract_fail=1
+fi
+if [[ "$extract_fail" -ne 0 ]]; then
+  echo "Re-point the anchors in this suite at the plugin block in $BOOTSTRAP."
+  exit 1
+fi
+
+# --- harness -----------------------------------------------------------------
+pass=0
+fail=0
+ok() {
+  echo "ok   - $1"
+  pass=$((pass + 1))
+}
+bad() {
+  echo "not ok - $1"
+  fail=$((fail + 1))
+}
+
+BOTH_USER='[{"id":"alpha@melodic-software","scope":"user","enabled":true},
+            {"id":"beta@melodic-software","scope":"user","enabled":true}]'
+# The real shape on a cloud VM: the harness installs at project scope and the
+# bootstrap at user scope, so every id appears twice.
+BOTH_DUPLICATED='[{"id":"alpha@melodic-software","scope":"project","enabled":true},
+                  {"id":"alpha@melodic-software","scope":"user","enabled":true},
+                  {"id":"beta@melodic-software","scope":"project","enabled":true},
+                  {"id":"beta@melodic-software","scope":"user","enabled":true}]'
+BETA_PROJECT_ONLY='[{"id":"alpha@melodic-software","scope":"user","enabled":true},
+                    {"id":"beta@melodic-software","scope":"project","enabled":true}]'
+BETA_DISABLED='[{"id":"alpha@melodic-software","scope":"user","enabled":true},
+                {"id":"beta@melodic-software","scope":"user","enabled":false}]'
+BETA_ENABLED_STRING='[{"id":"alpha@melodic-software","scope":"user","enabled":true},
+                      {"id":"beta@melodic-software","scope":"user","enabled":"true"}]'
+NONE='[]'
+
+REG_BOTH_HEAD='{"plugins":{
+  "alpha@melodic-software":[{"scope":"user","gitCommitSha":"@HEAD@"}],
+  "beta@melodic-software":[{"scope":"user","gitCommitSha":"@HEAD@"}]}}'
+REG_BOTH_FIRST='{"plugins":{
+  "alpha@melodic-software":[{"scope":"user","gitCommitSha":"@FIRST@"}],
+  "beta@melodic-software":[{"scope":"user","gitCommitSha":"@FIRST@"}]}}'
+REG_BETA_SHA_ABSENT='{"plugins":{
+  "alpha@melodic-software":[{"scope":"user","gitCommitSha":"@HEAD@"}],
+  "beta@melodic-software":[{"scope":"user"}]}}'
+REG_BETA_SHA_NULL='{"plugins":{
+  "alpha@melodic-software":[{"scope":"user","gitCommitSha":"@HEAD@"}],
+  "beta@melodic-software":[{"scope":"user","gitCommitSha":null}]}}'
+# A 40-hex sha no clone contains: the force-push / shallow-fetch shape.
+REG_BETA_UNKNOWN='{"plugins":{
+  "alpha@melodic-software":[{"scope":"user","gitCommitSha":"@HEAD@"}],
+  "beta@melodic-software":[{"scope":"user","gitCommitSha":"0123456789abcdef0123456789abcdef01234567"}]}}'
+
+# run_case <name> <list-before> <list-after> <registry|MISSING> <registry-after|NONE>
+# Builds a throwaway repo whose plugins/alpha changed between the first commit
+# and HEAD while plugins/beta did not, runs the extracted block against a stub
+# CLI, and leaves the combined output in $OUT.
+#
+# It also asserts the block's own EXIT STATUS is 0, in every case, healthy or
+# not. That is not a formality: this block is a middle section of a script
+# running under `set -euo pipefail`, so a nonzero exit here does not merely get
+# the plugin count wrong, it aborts the whole cloud bootstrap before the Python
+# CI deps install, the hygiene binaries and the session PATH export. A plugin
+# that failed to install is best-effort by design and must still leave status
+# 0; the summary line is how it reports, not the exit code.
+OUT=""
+RC=0
+run_case() {
+  local name="$1" before="$2" after="$3" registry="$4" registry_after="$5"
+  local fx="$TMP/$name"
+  mkdir -p "$fx/.claude" "$fx/node_modules/.bin" "$fx/plugins/alpha" "$fx/plugins/beta" "$fx/cfg/plugins"
+
+  printf '{"enabledPlugins":{"alpha@melodic-software":true,"beta@melodic-software":true}}\n' \
+    >"$fx/.claude/settings.json"
+  printf 'a\n' >"$fx/plugins/alpha/f.txt"
+  printf 'b\n' >"$fx/plugins/beta/f.txt"
+
+  git_init_test_repo "$fx" >/dev/null
+  git_test_config "$fx" add -A
+  git_test_config "$fx" commit -qm one
+  local first head
+  first="$(git_test_config "$fx" rev-parse HEAD)"
+  printf 'a2\n' >>"$fx/plugins/alpha/f.txt"
+  git_test_config "$fx" add -A
+  git_test_config "$fx" commit -qm two
+  head="$(git_test_config "$fx" rev-parse HEAD)"
+
+  local subst="s/@HEAD@/$head/g; s/@FIRST@/$first/g"
+  if [[ "$registry" != "MISSING" ]]; then
+    printf '%s\n' "$registry" | sed "$subst" >"$fx/cfg/plugins/installed_plugins.json"
+  fi
+  if [[ "$registry_after" != "NONE" ]]; then
+    printf '%s\n' "$registry_after" | sed "$subst" >"$fx/registry-after.json"
+  fi
+
+  printf '%s\n' "$before" >"$fx/list-before.json"
+  printf '%s\n' "$after" >"$fx/list-after.json"
+
+  # Stub CLI. Mutations are no-ops unless registry-after.json exists, so only
+  # the block's own end-state verification can decide anything. `plugin enable`
+  # exits 1 to reproduce the real "already enabled at user scope" status.
+  cat >"$fx/node_modules/.bin/claude" <<'STUB'
+#!/usr/bin/env bash
+fx="$(cd -- "$(dirname -- "$0")/../.." && pwd)"
+case "$*" in
+*"marketplace list"*) printf '[{"name":"melodic-software"}]\n' ;;
+*"plugin list --json"*)
+  if [[ -f "$fx/.listed" ]]; then
+    cat "$fx/list-after.json"
+  else
+    : >"$fx/.listed"
+    cat "$fx/list-before.json"
+  fi
+  ;;
+*"plugin install"*)
+  if [[ -f "$fx/registry-after.json" ]]; then
+    cp "$fx/registry-after.json" "$fx/cfg/plugins/installed_plugins.json"
+  fi
+  ;;
+*"plugin enable"*) exit 1 ;;
+*) : ;;
+esac
+STUB
+  chmod +x "$fx/node_modules/.bin/claude"
+
+  set +e
+  OUT="$(CLAUDE_CONFIG_DIR="$fx/cfg" bash "$BLOCK" "$fx" 2>&1)"
+  RC=$?
+  set -e
+
+  if [[ "$RC" -eq 0 ]]; then
+    ok "$name: the block exits 0, so the rest of the bootstrap still runs"
+  else
+    bad "$name: the block exited $RC, which under \`set -e\` aborts the whole bootstrap"
+    printf '%s\n' "$OUT" | sed 's/^/       /'
+  fi
+}
+
+expect() {
+  local name="$1" needle="$2"
+  if grep -qF -- "$needle" <<<"$OUT"; then
+    ok "$name"
+  else
+    bad "$name (expected: $needle)"
+    printf '%s\n' "$OUT" | sed 's/^/       /'
+  fi
+}
+
+refute() {
+  local name="$1" needle="$2"
+  if grep -qF -- "$needle" <<<"$OUT"; then
+    bad "$name (unexpected: $needle)"
+    printf '%s\n' "$OUT" | sed 's/^/       /'
+  else
+    ok "$name"
+  fi
+}
+
+# --- healthy end states must not be counted as failures ----------------------
+
+run_case steady "$BOTH_USER" "$BOTH_USER" "$REG_BOTH_HEAD" NONE
+expect "a settled catalog reports no work and no failures" \
+  "plugins 2 enabled, 0 newly installed, 0 refreshed, 0 failed"
+
+run_case duplicated "$BOTH_DUPLICATED" "$BOTH_DUPLICATED" "$REG_BOTH_HEAD" NONE
+expect "the real project+user duplicate listing passes" \
+  "plugins 2 enabled, 0 newly installed, 0 refreshed, 0 failed"
+
+run_case fresh "$NONE" "$BOTH_USER" "$REG_BOTH_HEAD" NONE
+expect "a first-run install counts as installed, not failed" \
+  "plugins 2 enabled, 2 newly installed, 0 refreshed, 0 failed"
+
+# The regression this whole change set exists for: the refresh chain's trailing
+# `plugin enable` exits 1 on the healthy path, and the stub reproduces that.
+run_case refreshed "$BOTH_USER" "$BOTH_USER" "$REG_BOTH_FIRST" "$REG_BOTH_HEAD"
+expect "a healthy refresh is not a failure even though \`plugin enable\` exits 1" \
+  "plugins 2 enabled, 0 newly installed, 1 refreshed, 0 failed"
+
+# --- broken end states must be named and counted -----------------------------
+
+run_case project_only "$BETA_PROJECT_ONLY" "$BETA_PROJECT_ONLY" "$REG_BOTH_HEAD" NONE
+expect "a plugin present only at project scope is a failure" \
+  "beta@melodic-software failed verification after no action: not installed at user scope"
+expect "and is named in the summary" \
+  "0 refreshed, 1 failed: beta@melodic-software"
+
+run_case disabled "$BETA_DISABLED" "$BETA_DISABLED" "$REG_BOTH_HEAD" NONE
+expect "a plugin installed at user scope but disabled is a failure" \
+  "beta@melodic-software failed verification after no action: installed at user scope but not enabled"
+
+run_case enabled_string "$BETA_ENABLED_STRING" "$BETA_ENABLED_STRING" "$REG_BOTH_HEAD" NONE
+expect "enabled as the string \"true\" is rejected, not accepted" \
+  "beta@melodic-software failed verification after no action: installed at user scope but not enabled"
+
+run_case sha_absent "$BOTH_USER" "$BOTH_USER" "$REG_BETA_SHA_ABSENT" NONE
+expect "an absent gitCommitSha cannot be verified and fails closed" \
+  "beta@melodic-software failed verification after no action: cannot verify snapshot: no user-scope gitCommitSha recorded"
+
+run_case sha_null "$BOTH_USER" "$BOTH_USER" "$REG_BETA_SHA_NULL" NONE
+expect "a null gitCommitSha cannot be verified and fails closed" \
+  "beta@melodic-software failed verification after no action: cannot verify snapshot: no user-scope gitCommitSha recorded"
+
+run_case registry_missing "$BOTH_USER" "$BOTH_USER" MISSING NONE
+expect "a missing installed_plugins.json fails every plugin closed" \
+  "cannot verify snapshot: no plugin registry at"
+expect "and both plugins are named" \
+  "2 failed: alpha@melodic-software, beta@melodic-software"
+
+run_case unknown_sha "$BOTH_USER" "$BOTH_USER" "$REG_BETA_UNKNOWN" NONE
+expect "a recorded commit this clone does not have fails closed" \
+  "cannot verify snapshot: installed from commit 0123456789abcdef0123456789abcdef01234567, which this clone does not have"
+
+# alpha's directory changed between the recorded commit and HEAD; beta's did
+# not. Only alpha is stale, which pins the criterion as a per-plugin directory
+# diff rather than "recorded sha differs from HEAD".
+run_case stale_refresh_stuck "$BOTH_USER" "$BOTH_USER" "$REG_BOTH_FIRST" NONE
+expect "a refresh that did not take is reported with the directory that changed" \
+  "alpha@melodic-software failed verification after refresh: plugins/alpha changed between the installed commit"
+refute "and a plugin whose own directory did not change is not called stale" \
+  "beta@melodic-software failed verification"
+# The only case where a plugin was ATTEMPTED and then failed, so it is the only
+# one that can catch an id credited to `refreshed` (or `installed`) and to
+# `failed` at the same time. The counts must partition, not overlap.
+expect "an attempted plugin that failed is counted once, as failed only" \
+  "plugins 2 enabled, 0 newly installed, 0 refreshed, 1 failed: alpha@melodic-software"
+
+run_case unreadable "$BOTH_USER" 'not json at all' "$REG_BOTH_HEAD" NONE
+expect "an unreadable plugin list fails the whole batch" \
+  "none could be verified, see the warning above"
+expect "with one warning for the batch" \
+  "could not read \`claude plugin list --json\`; no plugin could be verified"
+refute "and no per-plugin flood" \
+  "failed verification after"
+
+# --- report -------------------------------------------------------------------
+echo
+echo "PASS=$pass FAIL=$fail"
+if [[ "$fail" -ne 0 ]]; then
+  echo "FAIL: .claude/cloud-bootstrap.sh plugin accounting contract broken" >&2
+  exit 1
+fi
+echo "All cloud-bootstrap plugin accounting checks passed."

--- a/docs/CLOUD-SESSIONS.md
+++ b/docs/CLOUD-SESSIONS.md
@@ -268,6 +268,33 @@ enables; the cloud bootstrap installs (see
   uninstall/install/enable cycle for the plugins whose own directory changed between the two, so
   the usual resume stays cheap. Uncommitted edits are out of scope by design — use
   `claude --plugin-dir ./plugins/<name>`, which takes session precedence over the cached install.
+- **Reading the summary line's `failed` count (corrected 2026-08-28).** That count used to be the
+  exit status of the refresh chain, and the chain's tail step is nonzero on the healthy path:
+  `claude plugin install --scope user` already leaves the plugin enabled, so the following
+  `claude plugin enable --scope user` exits 1 with `Plugin "<id>" is already enabled at user
+  scope`. Startup lines like `plugins 71 enabled, 5 newly installed, 0 refreshed, 65 failed` were
+  therefore false alarms, and dozens of them per session start buried the only health signal this
+  block emits. The script now runs the chain for effect and verifies the end state once per run,
+  over every plugin `enabledPlugins` turns on rather than only the ones that run touched, since
+  the plugins most likely to be wrong are the ones it decided to skip. A plugin counts as failed
+  when any of these holds:
+  - `claude plugin list --json` does not list it at user scope, or lists it there with `enabled`
+    anything other than the JSON boolean `true`;
+  - its own directory under `plugins/` changed between the `gitCommitSha` recorded for the
+    user-scope install and `HEAD`, so the session would serve that plugin's older sources. A
+    recorded sha that merely differs from `HEAD` is NOT a failure: the check is
+    `git diff <recorded> HEAD -- plugins/<name>`, so unrelated commits since the install are
+    correctly ignored;
+  - the snapshot cannot be judged at all: no resolvable `HEAD` for the checkout, no registry
+    file, no recorded `gitCommitSha`, a `null` one, or a recorded commit this clone does not
+    have. Verification is deliberately fail-CLOSED here, unlike the refresh decision that reuses
+    the same inputs and skips what it cannot judge.
+
+  Each failure is named on stderr with its reason and the summary line appends the failing ids
+  after the count. So `0 failed` means every enabled plugin was checked and each one is installed
+  at user scope, enabled there, and serving sources that match `HEAD`; the one case where nothing
+  can be claimed, `claude plugin list --json` itself being unreadable, counts every plugin as
+  failed and says so in one line rather than one per plugin.
 - **Consumer repos** should declare the marketplace with a `github` source —
   `{"source": "github", "repo": "melodic-software/claude-code-plugins"}` — since the relative
   `directory` source is specific to this repo, whose reason to exist is validating in-flight

--- a/scripts/affected-tests.sh
+++ b/scripts/affected-tests.sh
@@ -127,6 +127,23 @@
 # <stem>.test.sh." names that suite too — which is how most of this repo's
 # comments cite the suite covering them.
 #
+# A leading run of shell PARAMETER-EXPANSION OPERATOR characters is stripped for
+# the same reason: `"${TARGET:-<name>.sh}"` is a mention of <name>.sh, but the
+# `-` of the `:-` sits INSIDE the token class, so without the strip the token is
+# `-<name>.sh` and nothing matches. The stripped set is `-`, `+`, `=`, `?` — every
+# operator character of the `${V:-x}` / `${V:+x}` / `${V:=x}` / `${V:?x}` family
+# and its colon-less forms. Only `-` is load-bearing today: the other three are
+# already outside [A-Za-z0-9_.-] and so already end a token on their own. They
+# are stripped anyway so the two sets cannot drift apart if the token class is
+# ever widened. This errs toward OVER-selection — a token that merely BEGINS
+# with one of those characters now names the file — which is the direction
+# DIRECTION above calls safe, and every pair it admits is one the pre-token
+# substring rule admitted too. What it buys is the failure it removes: without
+# it, a file whose only mention from some dependent is `${VAR:-<name>.sh}` still
+# looked MAPPED whenever it had a co-located suite, so the run exited 0 while
+# that dependent's suite was quietly left out. A silent under-selection is
+# exactly what this tool exists to refuse.
+#
 # What no longer counts is a basename buried INSIDE a longer token:
 # `handoff-paths.json` is not a mention of `paths.js`,
 # `status.showUntrackedFiles` is not a mention of `status.sh`, and
@@ -150,14 +167,18 @@
 #
 # The class cuts BOTH ways, and this is the strict edge of the rule: a
 # token-class character abutting the basename ends the match exactly as a letter
-# does, because `-`, `_` and `.` are INSIDE the class while `/` is not. So
-# `<name>-shaped` in a sentence, and the `-` that `${2:-<name>}` puts in front of
-# a default, both stop naming <name>. Two files in this corpus are mentioned that
-# way today and keep their suites only because they are ALSO named in bounded
-# form elsewhere. A file mentioned only in such a form loses R3/R4 outright — and
-# that lands LOUD rather than silent: with no other rule reaching it, the file is
-# reported UNMAPPED at exit 1, which is the fail-CLOSED direction this tool is
-# built to shout about, not the silent under-selection it is built to refuse.
+# does, because `-`, `_` and `.` are INSIDE the class while `/` is not. With the
+# leading strips above, that is now a TRAILING-side statement only:
+# `<name>-shaped` in a sentence stops naming <name>, while a leading `-`, the one
+# `${2:-<name>}` puts in front of a default, does not. The asymmetry is forced
+# rather than chosen — a leading strip cannot reach the trailing case, where the
+# whole token is `<name>-shaped` and there is no prefix to remove. Two files in
+# this corpus are mentioned in the trailing form today and keep their suites only
+# because they are ALSO named in bounded form elsewhere. A file mentioned only in
+# such a form loses R3/R4 outright — and that lands LOUD rather than silent: with
+# no other rule reaching it, the file is reported UNMAPPED at exit 1, which is
+# the fail-CLOSED direction this tool is built to shout about, not the silent
+# under-selection it is built to refuse.
 #
 # SWEPT over every tracked file when this landed: 534 files selected fewer
 # suites (15.8% fewer selected-suite slots across the tree), 4 files that had
@@ -168,6 +189,14 @@
 # scripts/affected-tests-no-suite.txt, so they report as no-suite at exit 0
 # rather than as a finding. "Nothing became unmapped" is therefore the true
 # statement, and "nothing lost its whole selection" is NOT.
+#
+# That sweep was measured before the expansion-operator strip landed, and the
+# strip only ADDS pairs back, every one of them a pair the old substring rule
+# also served. So it moves the counts toward the pre-rule baseline and can
+# reverse none of the sweep's directions: nothing that was mapped becomes
+# unmapped, and no file gains a suite the old behaviour did not already give it.
+# Measured on the corpus as it stands, the strip re-admits two (file, basename)
+# pairs in total, one of which R3/R4 discards anyway as a structural basename.
 #
 # Three things stay deliberately generous, all in the over-selecting direction:
 #   - a token match on the SAME basename in ANOTHER directory counts. This is a
@@ -505,7 +534,11 @@ token_hits() {
         # already delimits the token, so it fires only on a literal `...x`.
         sub(/\.+$/, "", t)
         if (t in want) { keep(path, t); continue }
-        sub(/^\.+/, "", t)
+        # The leading strip also drops a run of parameter-expansion operator
+        # characters, so `${V:-<name>}` names <name>. Only `-` is load-bearing:
+        # it is the one operator character inside the token class, so it glues
+        # onto the name instead of ending the token. See MATCHING in the header.
+        sub(/^[-+=?.]+/, "", t)
         if (t in want) keep(path, t)
       }
       for (name in loose)

--- a/scripts/affected-tests.sh
+++ b/scripts/affected-tests.sh
@@ -42,23 +42,31 @@
 #                    <dir>/test_<stem>.py — the last also with `-` folded to `_`,
 #                    which is how this repo names the Python suites covering its
 #                    hyphenated scripts (check-manifest-duplicate-keys.py ->
-#                    test_check_manifest_duplicate_keys.py). EVERY match is taken,
+#                    test_check_manifest_duplicate_keys.py) — and
+#                    <dir>/tests/test_<stem>.py, the one convention here that
+#                    puts the suite in a SUBDIRECTORY rather than beside the
+#                    file (13 of the 59 non-suite .py files in this repo). R3
+#                    cannot stand in for that arm and never could: a Python
+#                    suite reaches its subject with `import babysit_lease`, so
+#                    the filename is never spelled and there is nothing for a
+#                    text match to find. EVERY match is taken,
 #                    never just the first: a .py can carry both a test_<stem>.py
 #                    and a wrapping <stem>.test.sh, and stopping at one
 #                    under-selects, which is the unsafe direction.
-#   R3 referenced    any SUITE whose text contains the file's basename is a
-#                    covering suite (it names the file, so it exercises it). This
-#                    rule is a text match and therefore language-agnostic: a
-#                    Pester suite dot-sourcing Foo.ps1 and a Node suite importing
-#                    foo.js are found exactly the way a shell suite is. Widening
-#                    the corpus is what taught it the other three ecosystems; the
-#                    rule itself did not change.
+#   R3 referenced    any SUITE that NAMES the file — carries its basename as a
+#                    whole path token, see MATCHING below — is a covering suite
+#                    (it names the file, so it exercises it). This rule is a text
+#                    match and therefore language-agnostic: a Pester suite
+#                    dot-sourcing Foo.ps1 and a Node suite importing foo.js are
+#                    found exactly the way a shell suite is. Widening the corpus
+#                    is what taught it the other three ecosystems; the rule
+#                    itself did not change.
 #   R4 dependents    any other source file (.sh .bash .js .mjs .cjs .py .ps1
 #                    .psm1 — the same set the reverse-lookup pathspec searches,
 #                    and the same set lang_family() names; all three move
 #                    together or a path is classified into a family nothing ever
-#                    greps) whose
-#                    text contains the file's basename is a dependent; R2/R3 are
+#                    greps) that
+#                    NAMES the file the same way is a dependent; R2/R3 are
 #                    then applied to IT, transitively. This is what carries a lib
 #                    change out to the hooks that source it.
 #   R5 shared-lib    a file that is the `src` of a scripts/sync-*.sh selects
@@ -108,19 +116,81 @@
 # the reverse lookup was `-- '*.sh'`, so cross-language edges did not exist at
 # all and no shell-to-shell chain is shortened by any of this.
 #
-# KNOWN LIMIT, in the safe direction: R3/R4 look the basename up with
-# `git grep -o -F`, which is an unanchored SUBSTRING search — not a token match
-# and not a path match. So ANY basename that is a suffix-substring of another
-# path in the corpus matches every mention of that other path. `utils.sh` is a
-# substring of `hook-utils.sh`, so a new plugins/guardrails/hooks/utils.sh with
-# no real coverage at all selects 64 suites and exits 0 (measured) instead of
-# failing unmapped. Naming a file "distinctively" is NOT a defense: whether the
-# collision happens is decided by every OTHER path already in the repo, not by
-# how distinctive the new name reads on its own. Narrowing this needs real
-# shell/path parsing rather than a substring match, which is not worth the
-# fail-open risk the narrowing itself would carry. When a new file's basename
-# is a substring of an existing path, do not trust a non-empty selection to
-# mean the file is covered — check that the selected suites actually name it.
+# MATCHING, for R3 and R4. One file NAMES another when the basename stands
+# there as a WHOLE PATH TOKEN: bounded on both sides by a character that cannot
+# occur inside a single path component, which is anything outside
+# [A-Za-z0-9_.-]. `/` is deliberately OUTSIDE that class, so a path-qualified
+# mention names the file — `source "$dir/hook-utils.sh"`, `"./gadget.js"`,
+# `. (Join-Path $PSScriptRoot 'Get-Thing.ps1')` — and so does a bare mention in
+# prose or a comment. A leading or trailing run of `.` is sentence punctuation
+# rather than part of a name, so a comment ending "... is covered by
+# <stem>.test.sh." names that suite too — which is how most of this repo's
+# comments cite the suite covering them.
+#
+# What no longer counts is a basename buried INSIDE a longer token:
+# `handoff-paths.json` is not a mention of `paths.js`,
+# `status.showUntrackedFiles` is not a mention of `status.sh`, and
+# `common.sh.tmpl` is not a mention of `common.sh` — all three are real hits
+# this corpus used to serve. Those were not merely noisy over-selection. They
+# were FALSE COVERAGE, which is the fail-OPEN direction: a file nothing covers
+# came back with a non-empty selection and exit 0 instead of failing unmapped,
+# so the FAIL LOUD contract above silently did not apply to it. Measured on this
+# corpus: a new hooks helper named with a basename that another path merely ENDS
+# with, covered by nothing at all, selected 131 suites at exit 0 — most of the
+# shell corpus, and an answer that would have been the same for any name in that
+# collision class; under this rule the same file is UNMAPPED. (The count tracks
+# the corpus and will drift; "most of it" is the part that matters.) Naming a
+# file "distinctively" was never a defense — whether the collision happens is
+# decided by every OTHER path already in the repo, not by how the new name reads
+# on its own. This paragraph deliberately does not spell that helper's basename:
+# a name written HERE is a name this file then references, and the tool would map
+# the file to this hub instead of failing loud, which is the very report the
+# example exists to describe. Every example below is spelled the same careful
+# way, and for the same reason.
+#
+# The class cuts BOTH ways, and this is the strict edge of the rule: a
+# token-class character abutting the basename ends the match exactly as a letter
+# does, because `-`, `_` and `.` are INSIDE the class while `/` is not. So
+# `<name>-shaped` in a sentence, and the `-` that `${2:-<name>}` puts in front of
+# a default, both stop naming <name>. Two files in this corpus are mentioned that
+# way today and keep their suites only because they are ALSO named in bounded
+# form elsewhere. A file mentioned only in such a form loses R3/R4 outright — and
+# that lands LOUD rather than silent: with no other rule reaching it, the file is
+# reported UNMAPPED at exit 1, which is the fail-CLOSED direction this tool is
+# built to shout about, not the silent under-selection it is built to refuse.
+#
+# SWEPT over every tracked file when this landed: 534 files selected fewer
+# suites (15.8% fewer selected-suite slots across the tree), 4 files that had
+# been UNMAPPED became mapped, and NOTHING became unmapped. 25 files did drop to
+# an EMPTY selection — every one a markdown context file whose basename had been
+# landing inside a longer one (a `<verb>.md` matching inside a
+# `<something>-<verb>.md`), and every one already covered by a class in
+# scripts/affected-tests-no-suite.txt, so they report as no-suite at exit 0
+# rather than as a finding. "Nothing became unmapped" is therefore the true
+# statement, and "nothing lost its whole selection" is NOT.
+#
+# Three things stay deliberately generous, all in the over-selecting direction:
+#   - a token match on the SAME basename in ANOTHER directory counts. This is a
+#     basename rule and has to stay one: R5's entire fan-out is copies that share
+#     a basename across directories (lib/hook-utils.sh ->
+#     plugins/*/hooks/hook-utils.sh), so a suite naming its own plugin's copy is
+#     naming the shared source. Requiring the whole repo-relative path would cut
+#     that, which is under-selection.
+#   - a mention in a comment counts, exactly as it did before.
+#   - a basename the token rule cannot express — one carrying a character
+#     outside [A-Za-z0-9_.-], which no tracked path in this repo does today —
+#     falls back to the old substring test rather than to no coverage at all. A
+#     name this rule cannot spell must over-select, never quietly stop matching.
+#
+# MECHANICALLY this is two stages, and the split is a measured cost rather than
+# taste. `git grep -F` keeps its fixed-string fast path (~4s over this corpus
+# for a 559-basename level); spelling the boundaries as an ERE alternation
+# instead — `git grep -o -E`, one bounded pattern per basename — took over two
+# minutes for that same level, which is not a usable per-level cost. So git grep
+# still finds the candidate LINES with the substring test, and one awk pass over
+# those lines (~0.06s) splits each into path tokens and keeps only the pairs
+# whose token IS one of the basenames asked about. Both stages fail loud; see
+# the call site in select_for.
 set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 2
@@ -390,6 +460,60 @@ lang_family() {
   esac
 }
 
+# token_hits <patterns-file> <grep-output-file> <hits-file>
+# Reduce `git grep`'s SUBSTRING hits to the TOKEN hits R3/R4 actually mean: keep
+# a (file, basename) pair only where that basename stands in the matched line as
+# a whole path token. See MATCHING in the header for the rule and for why the
+# boundary test lives here instead of in the grep pattern.
+#
+# The input is git grep's `<path>:<line>` output; the output is `<path>:<name>`,
+# deduplicated, which is the shape the caller already parses. Splitting the LINE
+# rather than the path keeps a basename that appears only in the path prefix
+# from counting as a mention of itself.
+token_hits() {
+  awk -v pat="$1" '
+    # First file: the basenames this level asked about. A name that is itself a
+    # path token gets the exact test; anything else cannot be tokenized at all,
+    # so it keeps the old substring test rather than losing coverage silently.
+    FILENAME == pat {
+      if ($0 == "") next
+      if ($0 ~ /^[A-Za-z0-9_.-]+$/) want[$0] = 1
+      else loose[$0] = 1
+      next
+    }
+    function keep(path, name) {
+      if ((path SUBSEP name) in seen) return
+      seen[path SUBSEP name] = 1
+      print path ":" name
+    }
+    {
+      i = index($0, ":")
+      # No separator means no path: git grep says "Binary file X matches" that
+      # way, and a hit with no readable path must not become a frontier entry.
+      if (i == 0) next
+      path = substr($0, 1, i - 1)
+      text = substr($0, i + 1)
+      n = split(text, tok, /[^A-Za-z0-9_.-]+/)
+      for (j = 1; j <= n; j++) {
+        t = tok[j]
+        if (t == "") continue
+        if (t in want) { keep(path, t); continue }
+        # A trailing dot run is sentence punctuation (a comment ending "... in
+        # that suite."), and a leading one is an ellipsis butted against the
+        # name. Neither is part of a filename. The leading arm is the narrow
+        # one: a relative path needs no stripping, because the `/` in `./x`
+        # already delimits the token, so it fires only on a literal `...x`.
+        sub(/\.+$/, "", t)
+        if (t in want) { keep(path, t); continue }
+        sub(/^\.+/, "", t)
+        if (t in want) keep(path, t)
+      }
+      for (name in loose)
+        if (index(text, name) > 0) keep(path, name)
+    }
+  ' "$1" "$2" >"$3"
+}
+
 # colocated_suites <path> -> every sibling suite covering it, one per line.
 # PLURAL on purpose: one source file can carry suites in two ecosystems at once
 # — a .py with both a co-located test_<stem>.py and a wrapping <stem>.test.sh
@@ -413,11 +537,19 @@ colocated_suites() {
     "$stem.test.mjs"
     "$stem.Tests.ps1"
     "$dir/test_$base.py"
+    # The one suite this repo puts in a SUBDIRECTORY instead of beside its
+    # subject. It has to be a path rule: the suites in question reach their
+    # subject with `import <module>`, which never spells the filename, so the
+    # reference rule has no text to match and the file looks uncovered.
+    "$dir/tests/test_$base.py"
   )
   # The hyphen fold is a SECOND candidate only when there is a hyphen to fold;
   # otherwise it is character-for-character the previous entry and would emit
   # the same path twice.
-  [[ "$base" == *-* ]] && candidates+=("$dir/test_${base//-/_}.py")
+  [[ "$base" == *-* ]] && candidates+=(
+    "$dir/test_${base//-/_}.py"
+    "$dir/tests/test_${base//-/_}.py"
+  )
   for candidate in ${candidates[@]+"${candidates[@]}"}; do
     [[ -f "$candidate" ]] && printf '%s\n' "$candidate"
   done
@@ -499,9 +631,11 @@ select_for() {
 
     [[ -s "$WORK_DIR/patterns" ]] || break
 
-    # R3/R4: one batched reverse lookup per level. The hits go through a FILE,
-    # not a process substitution, so this lookup can FAIL LOUD like every other
-    # step here. `done < <(git grep ... 2>/dev/null || true)` could not: after
+    # R3/R4: one batched reverse lookup per level, in the two stages MATCHING
+    # describes — git grep finds the candidate lines, token_hits keeps only the
+    # ones that NAME a basename rather than merely containing it. The hits go
+    # through a FILE, not a process substitution, so this lookup can FAIL LOUD
+    # like every other step here. `done < <(git grep ... 2>/dev/null || true)` could not: after
     # the loop `$?` holds the LOOP's status, git's stderr was discarded, and
     # `|| true` erased the code, so a git ERROR (exit >= 2 — a bad flag, an
     # unreadable pattern file, a corrupt index) was indistinguishable from NO
@@ -515,14 +649,23 @@ select_for() {
     # path into a family but nothing ever greps that path's content, the file is
     # silently under-covered while LOOKING supported — fail-open, and the reason
     # .bash and .cjs are in this list despite the repo carrying none today.
-    git grep --untracked -o -F -f "$WORK_DIR/patterns" \
+    git grep --untracked -F -f "$WORK_DIR/patterns" \
       -- '*.sh' '*.bash' '*.js' '*.mjs' '*.cjs' '*.py' '*.ps1' '*.psm1' \
-      >"$WORK_DIR/hits" || grep_rc=$?
+      >"$WORK_DIR/matched-lines" || grep_rc=$?
     # Exit 1 is "no match" and is completely ordinary — most seeds reach a level
     # with no further dependents. Only above 1 is git itself failing.
     if [[ "$grep_rc" -gt 1 ]]; then
       echo "error: 'git grep' failed (exit $grep_rc) resolving dependents of the current level." >&2
       echo "       Refusing to continue: an unreadable reverse lookup silently UNDER-selects, and" >&2
+      echo "       under-selection is reported as success by everything downstream." >&2
+      exit 2
+    fi
+    # The boundary half of the lookup, and fatal for the same reason: a filter
+    # that dies mid-stream hands the walk a TRUNCATED hit set, which is an
+    # under-selection wearing a successful exit code.
+    if ! token_hits "$WORK_DIR/patterns" "$WORK_DIR/matched-lines" "$WORK_DIR/hits"; then
+      echo "error: the token filter over the reverse lookup failed on the current level." >&2
+      echo "       Refusing to continue: a partial filter silently UNDER-selects, and" >&2
       echo "       under-selection is reported as success by everything downstream." >&2
       exit 2
     fi

--- a/scripts/affected-tests.test.sh
+++ b/scripts/affected-tests.test.sh
@@ -893,6 +893,30 @@ printf 'echo plus\n' >"$repo3/eco/name/plus+tool.sh"
   printf 'bash eco/name/plus+tool.sh\n'
 } >"$repo3/eco/name/plus.test.sh"
 
+# A file whose only mention from its DEPENDENT sits behind a shell default:
+# `"${TARGET:-<name>}"`. The `-` of the `:-` operator is inside the path-token
+# class, so without the operator strip the token is `-<name>` and the reverse
+# lookup never reaches the dependent.
+#
+# This case is here because it fails SILENTLY, which is worse than the shapes
+# above and is why it must be tested rather than argued about. The target has a
+# co-located suite of its own, so it stays MAPPED and the run still exits 0 —
+# while the dependent's suite, the one that actually drives it, is quietly
+# dropped. That is an under-selection reported as success, the exact failure
+# this whole file is built to refuse. Both suites must come back.
+printf 'echo defaulted\n' >"$repo3/eco/name/defaulted-target.sh"
+suite_body defaulted-target >"$repo3/eco/name/defaulted-target.test.sh"
+# shellcheck disable=SC2016 # deliberate: the emitted fixture must expand these
+{
+  printf '#!/usr/bin/env bash\n'
+  printf 'TARGET="${TARGET:-defaulted-target.sh}"\n'
+  printf 'bash "$(dirname "${BASH_SOURCE[0]}")/$TARGET"\n'
+} >"$repo3/eco/name/defaulting-runner.sh"
+{
+  printf '#!/usr/bin/env bash\n'
+  printf 'bash eco/name/defaulting-runner.sh\n'
+} >"$repo3/eco/name/defaulting-runner.test.sh"
+
 git_test_config "$repo3" add plugins eco >/dev/null
 git_test_config "$repo3" commit -qm names >/dev/null
 
@@ -933,6 +957,15 @@ if [[ "$RC" -eq 0 ]] && has_line "$OUT" eco/name/ellipsis.test.sh; then
   ok "a reference butted against an ellipsis still names the file"
 else
   fail "ellipsis-prefixed reference lost (rc=$RC): $OUT"
+fi
+
+run_sel "$repo3" eco/name/defaulted-target.sh
+if [[ "$RC" -eq 0 ]] &&
+  has_line "$OUT" eco/name/defaulted-target.test.sh &&
+  has_line "$OUT" eco/name/defaulting-runner.test.sh; then
+  ok "a reference behind a \${VAR:-default} still names the file"
+else
+  fail "defaulted reference lost its dependent's suite (rc=$RC): $OUT"
 fi
 
 run_sel "$repo3" eco/name/plus+tool.sh

--- a/scripts/affected-tests.test.sh
+++ b/scripts/affected-tests.test.sh
@@ -538,7 +538,7 @@ fi
 # is not tidiness — a literal basename here would make this file a suite that
 # "references" the probe, R3 would select it, and the path would come back
 # MAPPED at exit 0. The assertion would then fail for a reason that has nothing
-# to do with the no-suite list. This is the substring-match limit documented in
+# to do with the no-suite list. This is the MATCHING rule documented in
 # affected-tests.sh's header, met head-on: naming a file in a suite is exactly
 # what makes the selector consider it covered.
 mapfile -t eco_yaml < <(cd "$REPO_ROOT" && git ls-files \
@@ -607,6 +607,24 @@ for y in ${wf_yaml[@]+"${wf_yaml[@]}"}; do
   fi
 done
 
+# --- LIVE repo: the false coverage that masked a real suite ----------------
+# babysit_lease.py's suite is scripts/tests/test_babysit_lease.py, and nothing
+# in the corpus spells that filename: every consumer says `import
+# babysit_lease`. Under the old substring lookup the file still came back
+# MAPPED, at exit 0, with five suites — none of them its own — purely because
+# `babysit_lease.py` is a substring of `manage_babysit_lease.py`. That is the
+# masked-zero-coverage shape the boundary rule exists to expose, and exposing it
+# is only half the fix: the co-located rule then has to find the real suite by
+# path, or a covered file reports UNMAPPED.
+out="$(cd "$REPO_ROOT" && bash scripts/affected-tests.sh plugins/source-control/skills/babysit-prs/scripts/babysit_lease.py 2>/dev/null)"
+RC=$?
+if [[ "$RC" -eq 0 ]] &&
+  has_line "$out" plugins/source-control/skills/babysit-prs/scripts/tests/test_babysit_lease.py; then
+  ok "live: a .py whose only suite sits in tests/ maps to that suite"
+else
+  fail "live tests/ subdirectory suite (rc=$RC): $out"
+fi
+
 # --- LIVE repo: a co-located change stays narrow ---------------------------
 out="$(cd "$REPO_ROOT" && bash scripts/affected-tests.sh plugins/eol-normalizer/hooks/eol-normalizer.sh 2>/dev/null)"
 RC=$?
@@ -634,6 +652,13 @@ printf 'import widget_mod\n' >"$repo/eco/test_widget_mod.py"
 printf 'def helper():\n    return 1\n' >"$repo/eco/check-thing.py"
 printf 'import importlib\n' >"$repo/eco/test_check_thing.py"
 
+# ... and the one convention that puts the suite in a SUBDIRECTORY. The suite
+# imports the MODULE, so it never spells the filename and the reference rule
+# has nothing to match: only a path rule can find it.
+mkdir -p "$repo/eco/pkg/tests"
+printf 'def helper():\n    return 1\n' >"$repo/eco/pkg/mod_thing.py"
+printf 'import mod_thing\n' >"$repo/eco/pkg/tests/test_mod_thing.py"
+
 # Node: co-located <stem>.test.js / .test.mjs.
 printf 'export const a = 1;\n' >"$repo/eco/gadget.js"
 printf 'import { a } from "./gadget.js";\n' >"$repo/eco/gadget.test.js"
@@ -658,6 +683,13 @@ if [[ "$RC" -eq 0 ]] && has_line "$OUT" eco/test_check_thing.py; then
   ok "python: a hyphenated stem finds its underscore-folded suite"
 else
   fail "python hyphen fold (rc=$RC): $OUT"
+fi
+
+run_sel "$repo" eco/pkg/mod_thing.py
+if [[ "$RC" -eq 0 ]] && has_line "$OUT" eco/pkg/tests/test_mod_thing.py; then
+  ok "python: a suite in a tests/ subdirectory covers its module"
+else
+  fail "python tests/ subdirectory (rc=$RC): $OUT"
 fi
 
 run_sel "$repo" eco/gadget.js
@@ -810,5 +842,118 @@ if has_line "$OUT" eco/agg/test_zed_user.py; then
 else
   fail "crossing budget was spent by an incidental hit (rc=$RC): $OUT"
 fi
+
+# --- R3/R4 NAME a file, they do not merely contain its name ----------------
+# The reverse lookup used to be an unanchored substring search, so any basename
+# that sat inside another path in the corpus inherited that path's suites. That
+# is not just noisy over-selection: it is FALSE COVERAGE at exit 0, which is the
+# one direction this tool is built to refuse. `get.sh` is a substring of
+# `widget.sh`, which this fixture references from every plugin, so a new
+# get.sh covered by nothing at all used to come back mapped.
+repo3="$(mk_repo)"
+mkdir -p "$repo3/eco/name"
+printf 'echo get\n' >"$repo3/plugins/alpha/hooks/get.sh"
+
+# A file that is ONLY ever named path-qualified. `/` is not a path-token
+# character, so this must keep selecting: it is the shape of every real
+# `source "$dir/lib.sh"` and `import "./gadget.js"` in the corpus.
+printf 'echo target\n' >"$repo3/eco/name/deep-target.sh"
+# shellcheck disable=SC2016 # deliberate: the emitted fixture must expand these
+{
+  printf '#!/usr/bin/env bash\n'
+  printf 'bash "$REPO_ROOT/eco/name/deep-target.sh"\n'
+} >"$repo3/eco/name/driver.test.sh"
+
+# A file only ever named at the END OF A SENTENCE. The trailing `.` is
+# punctuation, not part of the name, and this is how half the comments in this
+# repo cite the suite that covers them.
+printf 'echo prose\n' >"$repo3/eco/name/prose-target.sh"
+{
+  printf '#!/usr/bin/env bash\n'
+  printf '# Every rejected shape is covered by prose-target.sh.\n'
+} >"$repo3/eco/name/prose.test.sh"
+
+# A file named with an ELLIPSIS butted straight against it. The mirror of the
+# sentence-final case, and the narrower one: `./x` never needs the strip because
+# the `/` already delimits the token, so only a literal `...x` reaches it. It is
+# a real prose shape and it is in the over-selecting direction, so it is kept —
+# and kept means tested, or the branch is just an untested claim.
+printf 'echo ellipsis\n' >"$repo3/eco/name/ellipsis-target.sh"
+{
+  printf '#!/usr/bin/env bash\n'
+  printf '# the rest of that argument lives in ...ellipsis-target.sh\n'
+} >"$repo3/eco/name/ellipsis.test.sh"
+
+# A basename the token rule cannot spell, because `+` is not a path-token
+# character. Such a name must fall back to the old substring test rather than
+# to no coverage at all — a name the rule cannot express has to over-select.
+printf 'echo plus\n' >"$repo3/eco/name/plus+tool.sh"
+{
+  printf '#!/usr/bin/env bash\n'
+  printf 'bash eco/name/plus+tool.sh\n'
+} >"$repo3/eco/name/plus.test.sh"
+
+git_test_config "$repo3" add plugins eco >/dev/null
+git_test_config "$repo3" commit -qm names >/dev/null
+
+out="$(cd "$repo3" && bash scripts/affected-tests.sh plugins/alpha/hooks/get.sh 2>&1)"
+RC=$?
+if [[ "$RC" -eq 1 ]] && printf '%s' "$out" | grep -q 'UNMAPPED'; then
+  ok "a basename buried in a longer token is UNMAPPED, not falsely covered"
+else
+  fail "get.sh should be UNMAPPED, not covered by widget.sh's suites (rc=$RC): $out"
+fi
+
+# The exit code alone is not the assertion: what must be gone is the SELECTION
+# the substring match handed it. Under --allow-unmapped the run proceeds, so an
+# empty stdout is direct evidence that no unrelated suite was borrowed.
+run_sel "$repo3" --allow-unmapped plugins/alpha/hooks/get.sh
+if [[ "$RC" -eq 0 && -z "$OUT" ]]; then
+  ok "the borrowed suites are gone, not merely re-labelled"
+else
+  fail "get.sh still selects unrelated suites (rc=$RC): $OUT"
+fi
+
+run_sel "$repo3" eco/name/deep-target.sh
+if [[ "$RC" -eq 0 ]] && has_line "$OUT" eco/name/driver.test.sh; then
+  ok "a path-qualified reference still names the file"
+else
+  fail "path-qualified reference lost (rc=$RC): $OUT"
+fi
+
+run_sel "$repo3" eco/name/prose-target.sh
+if [[ "$RC" -eq 0 ]] && has_line "$OUT" eco/name/prose.test.sh; then
+  ok "a reference at the end of a sentence still names the file"
+else
+  fail "sentence-final reference lost (rc=$RC): $OUT"
+fi
+
+run_sel "$repo3" eco/name/ellipsis-target.sh
+if [[ "$RC" -eq 0 ]] && has_line "$OUT" eco/name/ellipsis.test.sh; then
+  ok "a reference butted against an ellipsis still names the file"
+else
+  fail "ellipsis-prefixed reference lost (rc=$RC): $OUT"
+fi
+
+run_sel "$repo3" eco/name/plus+tool.sh
+if [[ "$RC" -eq 0 ]] && has_line "$OUT" eco/name/plus.test.sh; then
+  ok "a basename the token rule cannot spell falls back to the substring test"
+else
+  fail "untokenizable basename lost its coverage (rc=$RC): $OUT"
+fi
+
+# R1/R2 are a path rule and never went through the reverse lookup, so the same
+# substring-shaped file must still find its own co-located suite — and still not
+# the ones it used to borrow.
+suite_body get >"$repo3/plugins/alpha/hooks/get.test.sh"
+run_sel "$repo3" plugins/alpha/hooks/get.sh
+if [[ "$RC" -eq 0 ]] &&
+  has_line "$OUT" plugins/alpha/hooks/get.test.sh &&
+  ! has_line "$OUT" plugins/beta/hooks/beta-hook.test.sh; then
+  ok "co-located selection is untouched by the boundary rule"
+else
+  fail "co-located suite lost or unrelated suite still borrowed (rc=$RC): $OUT"
+fi
+rm -rf "$repo3"
 
 test_harness::report


### PR DESCRIPTION
No linked issue

## Summary

Two independent false signals found by an evidence-first improvement scan, both of the same shape: a check that reported healthy when it was not. Each is fixed and each now has a test that fails without the fix.

1. `scripts/affected-tests.sh` claimed coverage a file did not have, because R3/R4 matched a basename as an unanchored substring. A file with no suite of its own could select many suites and exit 0, so the repo's "a changed file that maps to zero suites is an error" contract silently did not apply. This is the gap class behind the kindle-dedrm firewall defect (#3396).
2. `.claude/cloud-bootstrap.sh` reported dozens of failures per session start for a perfectly healthy plugin registry, because `claude plugin install --scope user -y` already leaves a plugin enabled, so the chain's tail `plugin enable` exits 1 with "already enabled at user scope" and the three steps were joined with `&&`. The failure count is the bootstrap's only health signal, and the false alarms buried it.

## Fix

**Test selection.** A file now names another only when the basename appears bounded on both sides by a character outside `[A-Za-z0-9_.-]`. `/` is deliberately outside that class, so path-qualified, prose and comment mentions all still count; a trailing run of `.` is sentence punctuation; a basename the rule cannot spell falls back to the old substring test rather than to zero coverage. Matching stays a basename rule because the cross-plugin copy fan-out depends on it. Exposing the false coverage revealed a real gap it had been masking: several Python files whose only suite is `<dir>/tests/test_<stem>.py` were unreachable by any name match, since those suites `import <module>` and never spell the filename, so R2 gained that path arm.

**Bootstrap health.** The three subcommand exit statuses are now advisory. Verification reads the end state once per run, over every plugin `enabledPlugins` turns on, and counts a plugin failed only when it is absent at user scope, present without `enabled: true`, or its own directory under `plugins/` changed between the recorded `gitCommitSha` and HEAD. Cases where the snapshot cannot be determined at all (no resolvable HEAD, no registry, absent or null recorded sha, a commit this clone lacks) fail closed with a named reason rather than reading as healthy. An unreadable `plugin list --json` fails the batch in one line instead of one warning per plugin.

## Verification

Measured, not asserted:

- **Selection hazard, end to end:** an uncovered hook body dropped into a scratch clone selected **131 suites at exit 0** before; it is now **UNMAPPED at exit 1**.
- **Sweep over every tracked file (3,455):** 534 files select fewer suites (15.8% fewer selected-suite slots), 4 previously-UNMAPPED files became mapped to the suites that genuinely test them, **nothing became unmapped**. 25 files dropped to an empty selection, every one a markdown context file whose basename had been landing inside a longer one, and every one already covered by a class in `affected-tests-no-suite.txt`, so they report as no-suite at exit 0.
- **Bootstrap, live on a real machine:** `72 enabled, 0 newly installed, 0 refreshed, 0 failed`, where the previous code reported every refresh as failed.
- Suites: `affected-tests.test.sh` 56 assertions green (47 before); new `.claude/hooks/cloud-bootstrap-plugins.test.sh` 32 assertions green, discovered by the existing `find plugins .claude/hooks` roots with no ci.yml change.

Both changes were reviewed by independent fresh-context verifiers that re-derived the evidence rather than trusting it. The selector verifier recomputed the full sweep itself, hand-read all 190 dropped basename/enclosing-token pairs (only two name the real file, and both keep their suites through other bounded mentions), proved a direct-coverage invariant over all 3,455 files with zero missing a suite that genuinely names it, and killed 8 of its own 10 mutations. The bootstrap verifier ran 19 fail-open probes (glob and space-bearing ids, `declare -A` re-entry, duplicate ids, degenerate list JSON and registry shapes, no-git-repo, `set -u` interaction) without constructing a fail-open, and its first pass **rejected** an earlier version that still printed `0 failed` for five bad end states; those five are now pinned by tests, along with the extraction anchors and the block's exit status, since a nonzero exit there would abort the whole bootstrap under `set -e`.

## Related

- #3396 (the shipped defect exemplifying the false-coverage class)
- A third scan candidate, a 43x speedup of the shell-portability scan, is deliberately **not** in this PR. A verifier found a correctness regression in it, so it is parked unmerged on `wip/portability-perf-unverified` with the defect, the reproducer and the fix shape recorded in its commit message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XGLX1xYgy27JiRqLjoiH8T

---
_Generated by [Claude Code](https://claude.ai/code/session_01XGLX1xYgy27JiRqLjoiH8T)_