### PR TITLE
chore(playwright): sync to upstream v0.1.19

### DIFF
--- a/plugins/playwright/.claude-plugin/plugin.json
+++ b/plugins/playwright/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "playwright",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "description": "Live E2E browser automation via Microsoft's @playwright/cli — named sessions, accessibility-ref snapshots, click/fill by ref, screenshots, console and network capture, mocking, tracing, video, and auth state, with artifacts written to disk so only paths enter context, plus a vendored upstream baseline and maintainer drift-check update flow.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/playwright/CHANGELOG.md
+++ b/plugins/playwright/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to the `playwright` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.6.8]
+
+### Changed
+
+- **Synced `@playwright/cli` vendor baseline to 0.1.19.** Added distilled `recording-start` /
+  `recording-stop` to `reference/commands.md` (record a user-driven browser flow as Playwright
+  code). Corrected the trace output directory in `reference/tracing-and-video.md` to
+  `.playwright-cli/traces/`. Upstream: [playwright-cli v0.1.19](https://github.com/microsoft/playwright-cli/releases/tag/v0.1.19).
+
 ## [0.6.7]
 
 ### Changed

--- a/plugins/playwright/skills/playwright/SKILL.md
+++ b/plugins/playwright/skills/playwright/SKILL.md
@@ -8,9 +8,9 @@ allowed-tools: Bash(playwright-cli:*)
 metadata:
   source: https://github.com/microsoft/playwright-cli
   upstream-package: "@playwright/cli"
-  upstream-version: 0.1.18
-  upstream-sha: 28616039f0fa7f1c18d8d3b56204ebea38776d82
-  synced: 2026-08-12
+  upstream-version: 0.1.19
+  upstream-sha: 8de691a19c25f49a19525e9676bafe8f21e0e604
+  synced: 2026-09-02
   workflow-stage: test
   summary: Live E2E browser automation with disk-written artifacts
 ---

--- a/plugins/playwright/skills/playwright/reference/commands.md
+++ b/plugins/playwright/skills/playwright/reference/commands.md
@@ -154,12 +154,12 @@ playwright-cli close
 
 **Record a demonstrated flow**
 
-When the user performs the steps in the browser instead of describing them, capture the actions as Playwright code:
+When the user performs the steps in the browser instead of describing them, capture the actions as Playwright code. Use the same `-s=<flow>` as the rest of the named-session flow (`reference/sessions.md`); omitting `-s` records the unnamed default browser.
 
 ```bash
-playwright-cli recording-start
+playwright-cli -s=<flow> recording-start
 # user drives the browser
-playwright-cli recording-stop
+playwright-cli -s=<flow> recording-stop
 ```
 
 ## Help

--- a/plugins/playwright/skills/playwright/reference/commands.md
+++ b/plugins/playwright/skills/playwright/reference/commands.md
@@ -1,6 +1,6 @@
 # Command reference
 
-Distilled from upstream `@playwright/cli@0.1.17` SKILL.md. For verbatim upstream, see `vendor/SKILL.md` beside this skill.
+Distilled from upstream `@playwright/cli@0.1.19` SKILL.md. For verbatim upstream, see `vendor/SKILL.md` beside this skill.
 
 ## Core interaction
 
@@ -150,6 +150,16 @@ playwright-cli click e4
 playwright-cli console          # list console messages
 playwright-cli network          # list network requests since load
 playwright-cli close
+```
+
+**Record a demonstrated flow**
+
+When the user performs the steps in the browser instead of describing them, capture the actions as Playwright code:
+
+```bash
+playwright-cli recording-start
+# user drives the browser
+playwright-cli recording-stop
 ```
 
 ## Help

--- a/plugins/playwright/skills/playwright/reference/tracing-and-video.md
+++ b/plugins/playwright/skills/playwright/reference/tracing-and-video.md
@@ -19,7 +19,7 @@ playwright-cli fill e2 "test"
 playwright-cli tracing-stop
 ```
 
-Creates `traces/` with:
+Creates `.playwright-cli/traces/` with:
 
 - `trace-<ts>.trace` — action log + DOM snapshots before/after + screenshots + timing + console
 - `trace-<ts>.network` — full HTTP requests/responses, headers, bodies, timing, failures

--- a/plugins/playwright/skills/playwright/vendor/SKILL.md
+++ b/plugins/playwright/skills/playwright/vendor/SKILL.md
@@ -165,6 +165,11 @@ playwright-cli run-code "async page => await page.context().grantPermissions(['g
 playwright-cli run-code --filename=script.js
 playwright-cli tracing-start
 playwright-cli tracing-stop
+
+# record user actions in the browser, print them as Playwright code on stop
+playwright-cli recording-start
+playwright-cli recording-stop
+
 playwright-cli video-start video.webm
 playwright-cli video-chapter "Chapter Title" --description="Details" --duration=2000
 playwright-cli video-stop

--- a/plugins/playwright/skills/playwright/vendor/references/tracing.md
+++ b/plugins/playwright/skills/playwright/vendor/references/tracing.md
@@ -19,7 +19,7 @@ playwright-cli tracing-stop
 
 ## Trace Output Files
 
-When you start tracing, Playwright creates a `traces/` directory with several files:
+When you start tracing, Playwright creates a `.playwright-cli/traces/` directory with several files:
 
 ### `trace-{timestamp}.trace`
 


### PR DESCRIPTION
No related issue: this repo has no matching issue; the maintenance tracker is melodic-software/medley#1899.

## Summary

Sync the Playwright plugin vendor baseline and distilled references from `@playwright/cli` 0.1.18 to 0.1.19 so `/playwright:playwright` matches current upstream.

## Fix

- Ran `plugins/playwright/skills/playwright/scripts/update.sh --apply` (procedure: `actions/update.md`)
- Frontmatter: `upstream-version` 0.1.19, `upstream-sha` 8de691a19c25f49a19525e9676bafe8f21e0e604, `synced` 2026-09-02
- Distilled `recording-start` / `recording-stop` into `reference/commands.md`
- Corrected trace output dir in `reference/tracing-and-video.md` to `.playwright-cli/traces/`
- Plugin version 0.6.7 → 0.6.8 + CHANGELOG

Authoritative sources:
- https://github.com/microsoft/playwright-cli/releases/tag/v0.1.19
- https://www.npmjs.com/package/@playwright/cli

## Verification

- `update.sh --check` reported 0.1.18 → 0.1.19 before apply
- `update.sh --apply` exit 0
- Vendor diff vs HEAD is only `vendor/SKILL.md` (new recording commands) and `vendor/references/tracing.md` (trace directory)

## Related

- Refs melodic-software/medley#1899 — close that issue only after this PR merges and Medley rechecks `update-playwright-cli`