### PR TITLE
fix(ai-slop): set core.quotePath=false on the bare detect.sh listing (0.5.6)

### DIFF
--- a/plugins/ai-slop/.claude-plugin/plugin.json
+++ b/plugins/ai-slop/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "ai-slop",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "description": "Detects and removes AI-writing tells (slop) in checked-in markdown prose: em dashes, emoji formatting, AI vocabulary, negative parallelisms, chatbot phrases, filler, stacked hedging, citation artifacts, model-era phrases, and the rest of a catalog distilled from Wikipedia's Signs of AI writing plus a repo-owned, evidence-graded inventory of current-generation model vocabulary. Read-only audit by default with a deterministic detector plus a judgment rubric; an explicit fix action rewrites findings behind a semantic-diff guard. Findings conform to the detector-findings convention so the review fanout fix relay can consume them.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/ai-slop/CHANGELOG.md
+++ b/plugins/ai-slop/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## [0.5.6]
+
+### Fixed
+
+- **`audit`: a bare `detect.sh` dropped every tracked markdown file whose name held a non-ASCII
+  byte, and said nothing when the listing failed.** 0.3.9 fixed exactly this on the
+  directory-expansion path and left the no-paths path on
+  `git -C "$REPO_ROOT" ls-files '*.md' 2>/dev/null`. Per git-config, commands that output paths
+  quote bytes above 0x80 unless `core.quotePath` is false, so a tracked `café.md` arrived as the
+  literal escape `"caf\303\251.md"`, failed the scan loop's `[[ -f "$file" ]]` test, and produced
+  neither a finding nor a declined row. A bare invocation is the shape the audit skill uses to
+  sweep a whole repository, so the coverage loss was silent and repository-wide: the report claimed
+  every tracked markdown file and had never opened those.
+
+  The listing now runs with `-c core.quotePath=false`, and its failures are reported instead of
+  being swallowed. An empty target list from a failed `ls-files` is indistinguishable from a
+  repository with no tracked markdown, and both render as a clean audit. `--is-inside-work-tree`
+  picks the branch up front, matching the directory path, so a missing git binary
+  (`git is not on PATH`), a `REPO_ROOT` outside any checkout (`could not confirm a work tree`), and
+  a listing that fails inside one (`git ls-files failed in <root> (exit N)`) each say which one
+  happened, with git's own stderr left visible.
+
+  Nine new detect cases cover the bare invocation: a tracked non-ASCII-named file is scanned and no
+  C-quoted escape reaches the report, untracked markdown stays out, the same file is still reached
+  when the detector runs from outside the checkout (which pins the `REPO_ROOT` prefix, since
+  findings themselves are repo-relative), and each of the three listing-failure states is asserted
+  by its message and a zero scan count. The failing-listing case uses a `git` stub that fails only
+  `ls-files`, so the branch under test is the listing and not work-tree detection.
+
 ## [0.5.5]
 
 ### Fixed

--- a/plugins/ai-slop/CHANGELOG.md
+++ b/plugins/ai-slop/CHANGELOG.md
@@ -8,8 +8,8 @@
   byte, and said nothing when the listing failed.** 0.3.9 fixed exactly this on the
   directory-expansion path and left the no-paths path on
   `git -C "$REPO_ROOT" ls-files '*.md' 2>/dev/null`. Per git-config, commands that output paths
-  quote bytes above 0x80 unless `core.quotePath` is false, so a tracked `café.md` arrived as the
-  literal escape `"caf\303\251.md"`, failed the scan loop's `[[ -f "$file" ]]` test, and produced
+  quote bytes above 0x80 unless `core.quotePath` is false, so a tracked `notes-é.md` arrived as the
+  literal escape `"notes-\303\251.md"`, failed the scan loop's `[[ -f "$file" ]]` test, and produced
   neither a finding nor a declined row. A bare invocation is the shape the audit skill uses to
   sweep a whole repository, so the coverage loss was silent and repository-wide: the report claimed
   every tracked markdown file and had never opened those.

--- a/plugins/ai-slop/skills/audit/scripts/detect.sh
+++ b/plugins/ai-slop/skills/audit/scripts/detect.sh
@@ -420,8 +420,8 @@ fi
 #
 # `ls-files` quotes any pathname holding a byte above 0x80 unless
 # `core.quotePath=false` (git-config: "bytes higher than 0x80 are not
-# considered unusual any more"), so a tracked `café.md` arrived as the literal
-# escape `"caf\303\251.md"`, failed the scan loop's existence test, and
+# considered unusual any more"), so a tracked `notes-é.md` arrived as the literal
+# escape `"notes-\303\251.md"`, failed the scan loop's existence test, and
 # produced neither a finding nor a declined row. A bare invocation is the shape
 # the audit skill uses to sweep a whole repository, so that silent drop meant
 # every non-ASCII-named file was outside the audit while the report claimed
@@ -477,7 +477,7 @@ fi
 # any host where those disagree no candidate survived the filter and the walk
 # below silently replaced the tracked-files listing it was meant to back up.
 # `ls-files` C-quotes any path holding a non-ASCII byte unless
-# `core.quotePath=false`, so a tracked `café.md` (or a filename that itself
+# `core.quotePath=false`, so a tracked `notes-é.md` (or a filename that itself
 # holds an em dash) would arrive as a literal quoted escape, fail the scan
 # loop's existence test, and produce neither a finding nor a declined row.
 #

--- a/plugins/ai-slop/skills/audit/scripts/detect.sh
+++ b/plugins/ai-slop/skills/audit/scripts/detect.sh
@@ -415,10 +415,55 @@ if [[ -n "$PATHS_FILE" ]]; then
   done <"$PATHS_FILE"
 fi
 
+# A bare invocation lists the repository's tracked markdown, and it carries the
+# same two hazards the directory expansion below already answers.
+#
+# `ls-files` quotes any pathname holding a byte above 0x80 unless
+# `core.quotePath=false` (git-config: "bytes higher than 0x80 are not
+# considered unusual any more"), so a tracked `café.md` arrived as the literal
+# escape `"caf\303\251.md"`, failed the scan loop's existence test, and
+# produced neither a finding nor a declined row. A bare invocation is the shape
+# the audit skill uses to sweep a whole repository, so that silent drop meant
+# every non-ASCII-named file was outside the audit while the report claimed
+# repository-wide coverage.
+#
+# A listing that fails says so on stderr instead of vanishing into
+# `2>/dev/null`. An empty target list from a failed `ls-files` is
+# indistinguishable from a repository with no tracked markdown, and both read
+# as a clean audit. `--is-inside-work-tree` picks the branch up front so a
+# missing git binary and a directory outside any checkout each get their own
+# message rather than one opaque nonzero exit.
+list_repo_markdown() {
+  local inside listing status
+
+  if ! command -v git >/dev/null 2>&1; then
+    echo "detect.sh: git is not on PATH; a bare invocation has no tracked markdown to list (pass paths explicitly)" >&2
+    return 0
+  fi
+
+  inside="$(git -C "$REPO_ROOT" rev-parse --is-inside-work-tree 2>/dev/null)"
+  status=$?
+  if [[ "$status" -ne 0 || "$inside" != "true" ]]; then
+    echo "detect.sh: git could not confirm a work tree at $REPO_ROOT; a bare invocation has no tracked markdown to list (pass paths explicitly)" >&2
+    return 0
+  fi
+
+  listing="$(git -C "$REPO_ROOT" -c core.quotePath=false ls-files '*.md')"
+  status=$?
+  if [[ "$status" -ne 0 ]]; then
+    echo "detect.sh: git ls-files failed in $REPO_ROOT (exit $status); nothing was scanned" >&2
+    return 0
+  fi
+
+  [[ -n "$listing" ]] || return 0
+  printf '%s\n' "$listing"
+}
+
 if [[ "${#TARGETS[@]}" -eq 0 ]]; then
   while IFS= read -r line; do
+    [[ -n "$line" ]] || continue
     TARGETS+=("$REPO_ROOT/$line")
-  done < <(git -C "$REPO_ROOT" ls-files '*.md' 2>/dev/null)
+  done < <(list_repo_markdown)
 fi
 
 # Directory targets expand to the markdown beneath them (tracked files when the

--- a/plugins/ai-slop/skills/audit/scripts/detect.test.sh
+++ b/plugins/ai-slop/skills/audit/scripts/detect.test.sh
@@ -838,14 +838,14 @@ assert_contains "dir target, git absent: walk scans tracked and untracked markdo
 BAREREPO="$TEST_TMPDIR/barerepo"
 mkdir -p "$BAREREPO/unicode"
 git -C "$BAREREPO" init -q
-printf 'A tracked em dash %s here.\n' "$EM" >"$BAREREPO/unicode/caf${EM}name.md"
+printf 'A tracked em dash %s here.\n' "$EM" >"$BAREREPO/unicode/notes${EM}name.md"
 printf 'A tracked em dash %s here too.\n' "$EM" >"$BAREREPO/ascii.md"
 printf 'An untracked em dash %s here.\n' "$EM" >"$BAREREPO/loose.md"
-git -C "$BAREREPO" add "unicode/caf${EM}name.md" ascii.md
+git -C "$BAREREPO" add "unicode/notes${EM}name.md" ascii.md
 
 out="$(cd "$BAREREPO" && CLAUDE_PROJECT_DIR="$BAREREPO" bash "$DETECT" 2>&1)"
-assert_contains "bare invocation: tracked non-ASCII filename is scanned" "$out" "file=unicode/caf${EM}name.md"
-assert_not_contains "bare invocation: no C-quoted escape reaches the report" "$out" 'caf\342'
+assert_contains "bare invocation: tracked non-ASCII filename is scanned" "$out" "file=unicode/notes${EM}name.md"
+assert_not_contains "bare invocation: no C-quoted escape reaches the report" "$out" 'notes\342'
 assert_contains "bare invocation: both tracked files count" "$out" "2 files scanned"
 assert_not_contains "bare invocation: untracked markdown is not scanned" "$out" "loose.md"
 
@@ -854,7 +854,7 @@ assert_not_contains "bare invocation: untracked markdown is not scanned" "$out" 
 # Running from outside the checkout is what pins the REPO_ROOT prefix they are
 # joined onto: a wrong prefix leaves nothing for the scan loop to open.
 out="$(cd "$TEST_TMPDIR" && CLAUDE_PROJECT_DIR="$BAREREPO" bash "$DETECT" 2>&1)"
-assert_contains "bare invocation from outside the repo: the non-ASCII path is scanned" "$out" "file=unicode/caf${EM}name.md"
+assert_contains "bare invocation from outside the repo: the non-ASCII path is scanned" "$out" "file=unicode/notes${EM}name.md"
 assert_contains "bare invocation from outside the repo: both tracked files count" "$out" "2 files scanned"
 
 # A listing that fails must say so. Swallowed under 2>/dev/null it produces an

--- a/plugins/ai-slop/skills/audit/scripts/detect.test.sh
+++ b/plugins/ai-slop/skills/audit/scripts/detect.test.sh
@@ -826,6 +826,76 @@ out="$(PATH="$NOGIT_BIN" bash "$DETECT" "$GITDIR/docs" 2>&1)"
 assert_contains "dir target, git absent: reports the walk" "$out" "git is not on PATH"
 assert_contains "dir target, git absent: walk scans tracked and untracked markdown" "$out" "2 files scanned"
 
+# --- Bare invocation (no paths) ---------------------------------------------------
+
+# The no-paths path lists the whole repository, so it carries the same two
+# hazards the dir-target cases above pin, reached through a different listing.
+# git-config core.quotePath: commands that output paths quote bytes above 0x80
+# unless it is false, so a tracked file whose name holds a non-ASCII byte
+# arrives as a C-quoted escape, fails the scan loop's existence test, and shows
+# up as neither a finding nor a declined row. A bare invocation is the sweep the
+# audit skill runs over a repository, so that drop is silently partial coverage.
+BAREREPO="$TEST_TMPDIR/barerepo"
+mkdir -p "$BAREREPO/unicode"
+git -C "$BAREREPO" init -q
+printf 'A tracked em dash %s here.\n' "$EM" >"$BAREREPO/unicode/caf${EM}name.md"
+printf 'A tracked em dash %s here too.\n' "$EM" >"$BAREREPO/ascii.md"
+printf 'An untracked em dash %s here.\n' "$EM" >"$BAREREPO/loose.md"
+git -C "$BAREREPO" add "unicode/caf${EM}name.md" ascii.md
+
+out="$(cd "$BAREREPO" && CLAUDE_PROJECT_DIR="$BAREREPO" bash "$DETECT" 2>&1)"
+assert_contains "bare invocation: tracked non-ASCII filename is scanned" "$out" "file=unicode/caf${EM}name.md"
+assert_not_contains "bare invocation: no C-quoted escape reaches the report" "$out" 'caf\342'
+assert_contains "bare invocation: both tracked files count" "$out" "2 files scanned"
+assert_not_contains "bare invocation: untracked markdown is not scanned" "$out" "loose.md"
+
+# Findings report repo-relative paths, so the case above would also pass if the
+# listing's relative paths were used unprefixed and resolved against the CWD.
+# Running from outside the checkout is what pins the REPO_ROOT prefix they are
+# joined onto: a wrong prefix leaves nothing for the scan loop to open.
+out="$(cd "$TEST_TMPDIR" && CLAUDE_PROJECT_DIR="$BAREREPO" bash "$DETECT" 2>&1)"
+assert_contains "bare invocation from outside the repo: the non-ASCII path is scanned" "$out" "file=unicode/caf${EM}name.md"
+assert_contains "bare invocation from outside the repo: both tracked files count" "$out" "2 files scanned"
+
+# A listing that fails must say so. Swallowed under 2>/dev/null it produces an
+# empty target list, which is indistinguishable from a repository holding no
+# tracked markdown, and both render as a clean audit. The stub fails only
+# ls-files so the branch under test is the listing itself, not work-tree
+# detection.
+BADLS_BIN="$TEST_TMPDIR/bin-badls"
+mkdir -p "$BADLS_BIN"
+REAL_GIT="$(command -v git)"
+cat >"$BADLS_BIN/git" <<EOF
+#!/usr/bin/env bash
+for a in "\$@"; do
+  if [[ "\$a" == "ls-files" ]]; then
+    echo "fatal: stubbed ls-files failure" >&2
+    exit 128
+  fi
+done
+exec "$REAL_GIT" "\$@"
+EOF
+chmod +x "$BADLS_BIN/git"
+
+out="$(cd "$BAREREPO" && PATH="$BADLS_BIN:$PATH" CLAUDE_PROJECT_DIR="$BAREREPO" bash "$DETECT" 2>&1)"
+assert_contains "bare invocation, listing fails: reports the failure" "$out" "git ls-files failed in $BAREREPO"
+assert_contains "bare invocation, listing fails: names the exit status" "$out" "(exit 128)"
+assert_contains "bare invocation, listing fails: git's own stderr is not swallowed" "$out" "fatal: stubbed ls-files failure"
+assert_contains "bare invocation, listing fails: scans nothing" "$out" "0 files scanned"
+
+# Outside a checkout there is nothing tracked to list, which is a reportable
+# state rather than a clean audit of an empty set.
+BARENOREPO="$TEST_TMPDIR/barenorepo"
+mkdir -p "$BARENOREPO"
+printf 'An em dash %s here.\n' "$EM" >"$BARENOREPO/loose.md"
+out="$(cd "$BARENOREPO" && CLAUDE_PROJECT_DIR="$BARENOREPO" bash "$DETECT" 2>&1)"
+assert_contains "bare invocation outside a checkout: says so" "$out" "could not confirm a work tree at $BARENOREPO"
+assert_contains "bare invocation outside a checkout: scans nothing" "$out" "0 files scanned"
+
+out="$(cd "$BAREREPO" && PATH="$NOGIT_BIN" CLAUDE_PROJECT_DIR="$BAREREPO" bash "$DETECT" 2>&1)"
+assert_contains "bare invocation, git absent: reports it" "$out" "git is not on PATH"
+assert_contains "bare invocation, git absent: scans nothing" "$out" "0 files scanned"
+
 # --- Excerpt truncation at the byte boundary --------------------------------------
 
 # 79 ASCII bytes then an em dash: a byte cut at 80 would keep only the first


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #3407

## Summary

The no-paths target list in `detect.sh` still ran `git ls-files '*.md'` without `core.quotePath=false`. Non-ASCII filenames were C-quoted, failed `[[ -f ]]`, and were silently dropped from a whole-repo scan.

## Fix

The bare listing now uses `-c core.quotePath=false` and reports listing failures instead of swallowing them with `2>/dev/null`. Work-tree detection matches the already-fixed directory-expansion path. Plugin bumped to 0.5.6.

## Verification

`scripts/affected-tests.sh --run`: 17 suites passed. `detect.test.sh` is at 202 cases, including nine new bare-invocation cases for non-ASCII names and listing failures.

## Related

Refs #3331 (0.3.9 directory-expansion path)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7ffb619a-6ebb-4d47-9c45-d68e846edf93?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7ffb619a-6ebb-4d47-9c45-d68e846edf93&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

