### PR TITLE
fix(claude-config): guard --input against missing value in fix-plugin-drift.sh

### DIFF
--- a/plugins/claude-config/.claude-plugin/plugin.json
+++ b/plugins/claude-config/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "claude-config",
-  "version": "0.40.24",
+  "version": "0.40.25",
   "description": "Nine configuration-health skills (plus setup) for a repo's Claude Code configuration: audit (settings.json / .mcp.json / hooks / plugins / permissions drift), audit-automation-gaps (evidence-gated verdicts on automation gaps), audit-permission-grants (allow-rule / allowed-tools grants for auto-mode durability and portability), audit-permission-state (the permission rules actually in effect — every settings scope merged with per-rule provenance, what auto mode drops on entry, config written where nothing reads it, and which managed intents are enforced versus loosenable), draft-auto-mode-rules (interview and draft a paste-ready autoMode classifier block; prints only, never writes), audit-instructions (locally-owned instruction surfaces vs current model capability — proposes removals/rewrites of instructions the model no longer needs, and detects cross-surface instruction conflicts), audit-prompting-postures (the additive lane — posture guidance the prompting guide says a component's purpose needs but the component does not carry), audit-pass (one coordinated, ordered, resumable pass over a named target — three-scope inventory, run-time-derived exclusion set, stable finding identity, suppression memory, resume, one human gate — delegating every check to the plugin that owns it), and unhobble (the empirical bare-baseline experiment: reversibly strip a repo's standing instructions, log real stumbles against the current model, re-add only what evidence earns).",
   "author": {
     "name": "Melodic Software",

--- a/plugins/claude-config/CHANGELOG.md
+++ b/plugins/claude-config/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to the `claude-config` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.40.25]
+
+### Fixed
+
+- **`audit`: `fix-plugin-drift.sh` no longer crashes on a trailing bare `--input`.** Under
+  `set -u`, a missing option-argument dereferenced `$2` and exited 1 with an unbound-variable
+  error. A missing value now prints `Missing value for --input` to stderr and exits 2, matching
+  the script's other argument-validation errors.
+
 ## [0.40.24]
 
 ### Changed

--- a/plugins/claude-config/skills/audit/scripts/fix-plugin-drift.sh
+++ b/plugins/claude-config/skills/audit/scripts/fix-plugin-drift.sh
@@ -52,6 +52,10 @@ while [[ $# -gt 0 ]]; do
     shift
     ;;
   --input)
+    if [[ $# -lt 2 ]]; then
+      echo "Missing value for --input" >&2
+      exit 2
+    fi
     INPUT_JSON="$2"
     shift 2
     ;;

--- a/plugins/claude-config/skills/audit/scripts/fix-plugin-drift.test.sh
+++ b/plugins/claude-config/skills/audit/scripts/fix-plugin-drift.test.sh
@@ -240,6 +240,16 @@ alpha_preserved=$(jq -e '.enabledPlugins["alpha@market1"] == true' "$case_dir/se
 assert_eq "case-7: hostile-name entry removed literally" "yes" "$evil_absent"
 assert_eq "case-7: other entries untouched (no filter injection)" "yes" "$alpha_preserved"
 
+# --- Case 8: bare --input (no value) is a usage error, not a set -u crash ---------
+
+CASE_NUM=$((CASE_NUM + 1))
+
+exit_code=0
+out=$(bash "$SCRIPT" --input 2>&1) || exit_code=$?
+
+assert_exit "case-8: bare --input exits 2" 2 "$exit_code"
+assert_contains "case-8: usage error message" "$out" "Missing value for --input"
+
 # --- Final ------------------------------------------------------------------
 
 if [[ "$FAILED" -eq 0 ]]; then


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #3430

## Summary

A bare `--input` as the final argument to `fix-plugin-drift.sh` dereferenced `$2` under `set -u`, crashing with exit 1 instead of the documented usage error.

## Fix

Guard the `--input` option-argument read: when no value follows, print a usage message to stderr and exit 2, matching the script's other argument-validation errors.

## Verification

- `bash plugins/claude-config/skills/audit/scripts/fix-plugin-drift.sh --input` now exits 2 with `Missing value for --input` on stderr.
- Added a regression case (case-8) to `fix-plugin-drift.test.sh`.
- Ran `scripts/affected-tests.sh --run`: all 4 selected suites passed.

## Related

N/A
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7ffb619a-6ebb-4d47-9c45-d68e846edf93?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7ffb619a-6ebb-4d47-9c45-d68e846edf93&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

