### PR TITLE
fix(knowledge): match check_linkmap spacing in check_inventory FAILED banner

### DIFF
--- a/plugins/knowledge/.claude-plugin/plugin.json
+++ b/plugins/knowledge/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "knowledge",
-  "version": "0.13.31",
+  "version": "0.13.32",
   "description": "Ingest external knowledge into durable, synthesized artifacts. Ships a book-distillation pipeline (PDF/EPUB into concept-organized, author-attributed skill reference files), a video-digest pipeline (watch a single public video from YouTube or X, formerly Twitter: transcript, link harvest, and repo-applicability synthesis), a course-digest pipeline (extract and synthesize online video courses \u2014 Dometrain, Teachable \u2014 into repo-applicable recommendations), a docpage-digest pipeline (single online documentation page into a verified knowledge slice with dual verification \u2014 one cross-vendor verifier \u2014 and an interview handoff), and a map-corpus pipeline (multi-resource corpus into a classified link map, deterministic node manifests, gate-verified relevance inventory, and an approved queue of docpage-digest runs), plus a re-runnable setup action; a configurable library directory governs where synthesized artifacts land in the consuming repo.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/knowledge/CHANGELOG.md
+++ b/plugins/knowledge/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to the `knowledge` plugin are recorded here. The `version` i
 `.claude-plugin/plugin.json` is the delivery vehicle — a consumer receives a change
 only after that version increases.
 
+## [0.13.32]
+
+### Fixed
+
+- **map-corpus: `check_inventory` FAILED banner spacing matches `check_linkmap`.** The checker
+  printed `FAILED --{n}` while the sibling prints `FAILED -- {n}` (space after the dashes). Both
+  `FAILED` print statements now carry the same space.
+
 ## [0.13.31]
 
 ### Changed

--- a/plugins/knowledge/skills/map-corpus/verification/check_inventory.py
+++ b/plugins/knowledge/skills/map-corpus/verification/check_inventory.py
@@ -243,7 +243,7 @@ def main(argv=None) -> int:
     rows = check_inventory_shape(inventory)
 
     if nodes_by_id is None:
-        print(f"check_inventory: FAILED --{len(failures.items)} failure(s); "
+        print(f"check_inventory: FAILED -- {len(failures.items)} failure(s); "
               f"manifest did not verify, rows not checked.")
         return 1
 
@@ -282,7 +282,7 @@ def main(argv=None) -> int:
             f"(unrepresented content): {', '.join(sorted(unrepresented))}.")
 
     if failures.items:
-        print(f"check_inventory: FAILED --{len(failures.items)} failure(s) "
+        print(f"check_inventory: FAILED -- {len(failures.items)} failure(s) "
               f"across {len(rows)} row(s) / {len(nodes_by_id)} node(s).")
         return 1
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #3433

## Summary

check_inventory.py printed `FAILED --{n}` while the sibling check_linkmap.py prints `FAILED -- {n}` (space after the dashes). The two checkers now emit the same banner shape.

## Fix

Added the missing space after `--` in both `FAILED` print statements in `plugins/knowledge/skills/map-corpus/verification/check_inventory.py` (the manifest-did-not-verify early return and the failures.items branch).

## Verification

Ran `scripts/affected-tests.sh --run` from the worktree, which selected `plugins/knowledge/skills/map-corpus/verification/test_check_inventory.py` and reported NOT RUN (Python suite, own lane) with exit code 3. Ran that suite directly with python3; all 29 tests pass. No test or transcript pinned the old `FAILED --{n}` string.

## Related

N/A
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7ffb619a-6ebb-4d47-9c45-d68e846edf93?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7ffb619a-6ebb-4d47-9c45-d68e846edf93&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

