### PR TITLE
fix(claude-memory): count newline-named topic files once in scope-report

### DIFF
--- a/plugins/claude-memory/.claude-plugin/plugin.json
+++ b/plugins/claude-memory/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "claude-memory",
-  "version": "0.11.11",
+  "version": "0.11.12",
   "description": "Keeps a repo's Claude Code memory layer healthy and under your control, against criteria derived from official Claude Code documentation. The audit skill checks the instruction/memory layer (CLAUDE.md, CLAUDE.local.md, .claude/rules/, auto-memory) with a deterministic script-backed spine plus judgment-tier checks. The stateless skill inspects, disables, and (confirm-gated) purges Claude-written auto memory across all settings scopes.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/claude-memory/CHANGELOG.md
+++ b/plugins/claude-memory/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to the `claude-memory` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.11.12]
+
+### Fixed
+
+- **`stateless/scripts/scope-report.sh` topic-file count over-counted a filename with an
+  embedded newline.** The count piped `find` output through `wc -l`, which counts newlines
+  in the stream rather than files, so a single topic filename containing a literal newline
+  was reported twice. It now uses the null-delimited idiom already used by the sibling
+  `enumerate-all-projects.sh` (`find -print0` read with `IFS= read -r -d ''`), so each file
+  counts once regardless of its name.
+
 ## [0.11.11]
 
 ### Changed

--- a/plugins/claude-memory/skills/stateless/scripts/scope-report.sh
+++ b/plugins/claude-memory/skills/stateless/scripts/scope-report.sh
@@ -111,7 +111,11 @@ fi
 echo "$mem_dir"
 if [[ -f "$mem_dir/MEMORY.md" ]]; then
   lines=$(wc -l <"$mem_dir/MEMORY.md" | tr -d ' \r')
-  topics=$(find "$mem_dir" -maxdepth 1 -name '*.md' ! -name 'MEMORY.md' 2>/dev/null | wc -l | tr -d ' \r')
+  # Null-delimited count — a filename with an embedded newline must count once.
+  topics=0
+  while IFS= read -r -d '' _; do topics=$((topics + 1)); done < <(
+    find "$mem_dir" -maxdepth 1 -name '*.md' ! -name 'MEMORY.md' -print0 2>/dev/null
+  )
   echo "MEMORY.md: PRESENT (${lines} lines); topic files: ${topics}"
 else
   echo "MEMORY.md: absent (no auto-memory written to the default location for this project)"

--- a/plugins/claude-memory/skills/stateless/scripts/scope-report.test.sh
+++ b/plugins/claude-memory/skills/stateless/scripts/scope-report.test.sh
@@ -80,6 +80,16 @@ OUT=$(cd "$REPO" && HOME="$ISO_HOME" bash "$SCRIPT")
 assert_contains "MEMORY.md present is reported" "$OUT" "MEMORY.md: PRESENT"
 assert_contains "topic file count reported" "$OUT" "topic files: 1"
 
+# --- Case 4b: a topic filename with an embedded newline counts once ---
+# Regression for the wc -l over-count on newline-delimited find output.
+
+printf '# topic\n' >"$MEM_DIR/oops"$'\n'"weird.md"
+
+OUT=$(cd "$REPO" && HOME="$ISO_HOME" bash "$SCRIPT")
+assert_contains "newline-named topic file counted once, not twice" "$OUT" "topic files: 2"
+
+rm -f "$MEM_DIR/oops"$'\n'"weird.md"
+
 # --- Case 5: outside a git repo, the cwd is the project key (docs: "Outside a git
 # repo, the project root is used instead") — resolver and report both resolve, no bail-out ---
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #3444

## Summary

`scope-report.sh` counted topic files with `find | wc -l`, which counts newlines in the stream, so a filename containing an embedded newline was counted twice.

## Fix

Replaced the pipeline with the sibling null-delimited idiom: `find -print0` plus `read -r -d ''`. Plugin bumped to 0.11.12.

## Verification

Added a fixture whose name contains a literal newline and asserted `topic files: 2`. Confirmed the new assertion fails against the pre-fix script and passes after. `scripts/affected-tests.sh --run` selected the co-located suite; all 22 checks passed.

## Related

N/A

Note: this PR and #3374 both touch `scope-report.test.sh`. Merge #3374 first, then rebase this one.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7ffb619a-6ebb-4d47-9c45-d68e846edf93?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7ffb619a-6ebb-4d47-9c45-d68e846edf93&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

