### PR TITLE
test(claude-memory): isolate ambient CLAUDE_CONFIG_DIR in scope-report suite

### DIFF
--- a/plugins/claude-memory/.claude-plugin/plugin.json
+++ b/plugins/claude-memory/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "claude-memory",
-  "version": "0.11.12",
+  "version": "0.11.13",
   "description": "Keeps a repo's Claude Code memory layer healthy and under your control, against criteria derived from official Claude Code documentation. The audit skill checks the instruction/memory layer (CLAUDE.md, CLAUDE.local.md, .claude/rules/, auto-memory) with a deterministic script-backed spine plus judgment-tier checks. The stateless skill inspects, disables, and (confirm-gated) purges Claude-written auto memory across all settings scopes.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/claude-memory/CHANGELOG.md
+++ b/plugins/claude-memory/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to the `claude-memory` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.11.13]
+
+### Changed
+
+- **`stateless/scripts/scope-report.test.sh` isolates ambient `CLAUDE_CONFIG_DIR`.** The suite
+  isolated `HOME` but left an ambient `CLAUDE_CONFIG_DIR` in place for every case except Case 6,
+  so Case 4 could write into a live config tree. Every main-case invocation now runs through
+  `iso_env`, Case 4 aborts if the resolved dir escapes the suite tmpdir, and a new Case 7
+  asserts an exported sentinel config dir is never written. The Case 4b newline-count fixture
+  from 0.11.12 is unchanged.
+
 ## [0.11.12]
 
 ### Fixed

--- a/plugins/claude-memory/skills/stateless/scripts/scope-report.test.sh
+++ b/plugins/claude-memory/skills/stateless/scripts/scope-report.test.sh
@@ -103,7 +103,7 @@ assert_contains "topic file count reported" "$OUT" "topic files: 1"
 
 printf '# topic\n' >"$MEM_DIR/oops"$'\n'"weird.md"
 
-OUT=$(cd "$REPO" && HOME="$ISO_HOME" bash "$SCRIPT")
+OUT=$(cd "$REPO" && iso_env bash "$SCRIPT")
 assert_contains "newline-named topic file counted once, not twice" "$OUT" "topic files: 2"
 
 rm -f "$MEM_DIR/oops"$'\n'"weird.md"

--- a/plugins/claude-memory/skills/stateless/scripts/scope-report.test.sh
+++ b/plugins/claude-memory/skills/stateless/scripts/scope-report.test.sh
@@ -30,6 +30,15 @@ assert_contains() {
   esac
 }
 
+# Every main-case invocation runs through this so an ambient CLAUDE_CONFIG_DIR from the
+# caller's environment can never relocate the config root out of the isolated HOME:
+# Case 4 resolves a dir and then WRITES to it, so a leaked config root would write into
+# the live user config tree. GIT_DIR and CLAUDE_CODE_DISABLE_AUTO_MEMORY are dropped for
+# the same reason. Case 6 sets CLAUDE_CONFIG_DIR deliberately and calls `env` directly.
+iso_env() {
+  env -u CLAUDE_CONFIG_DIR -u CLAUDE_CODE_DISABLE_AUTO_MEMORY -u GIT_DIR HOME="$ISO_HOME" "$@"
+}
+
 # Fixture git repos must never inherit an outer hook chain's exported git env.
 make_repo() {
   unset GIT_DIR GIT_INDEX_FILE GIT_WORK_TREE GIT_COMMON_DIR GIT_CONFIG
@@ -54,7 +63,7 @@ mkdir -p "$ISO_HOME/.claude"
 printf '{}\n' >"$ISO_HOME/.claude/settings.json"
 
 rc=0
-OUT=$(cd "$REPO" && env -u CLAUDE_CODE_DISABLE_AUTO_MEMORY HOME="$ISO_HOME" bash "$SCRIPT") || rc=$?
+OUT=$(cd "$REPO" && iso_env bash "$SCRIPT") || rc=$?
 assert_exit "repo report exits 0" 0 "$rc"
 assert_contains "reports settings-scope section" "$OUT" "Settings scopes"
 assert_contains "reports user settings PRESENT" "$OUT" "PRESENT"
@@ -64,19 +73,28 @@ assert_contains "env var reported unset when not exported" "$OUT" "unset in OS e
 
 # --- Case 3: env var set is reflected ---
 
-OUT=$(cd "$REPO" && CLAUDE_CODE_DISABLE_AUTO_MEMORY=1 HOME="$ISO_HOME" bash "$SCRIPT")
+OUT=$(cd "$REPO" && iso_env env CLAUDE_CODE_DISABLE_AUTO_MEMORY=1 bash "$SCRIPT")
 assert_contains "env var reported set when exported" "$OUT" "set in OS environment"
 
 # --- Case 4: MEMORY.md at the resolved default is counted ---
 # Derive the default dir from the resolver itself (no slug re-derivation in the test).
 
 RESOLVER="$SCRIPT_DIR/../../audit/scripts/resolve-memory-dir.sh"
-MEM_DIR=$(cd "$REPO" && HOME="$ISO_HOME" bash "$RESOLVER" 2>/dev/null | tr -d '\r')
+MEM_DIR=$(cd "$REPO" && iso_env bash "$RESOLVER" 2>/dev/null | tr -d '\r')
+
+# Hard stop before any mkdir/write: a resolved dir outside the suite temp tree means
+# isolation failed and the next two lines would write into a real config tree.
+if [[ "$MEM_DIR" != "$TEST_TMPDIR"/* ]]; then
+  printf 'ABORT: resolved memory dir escaped the test tmpdir: %s (expected under %s)\n' "$MEM_DIR" "$TEST_TMPDIR" >&2
+  exit 1
+fi
+pass "resolved memory dir stays under the test tmpdir"
+
 mkdir -p "$MEM_DIR"
 printf '# MEMORY\n- one\n- two\n' >"$MEM_DIR/MEMORY.md"
 printf '# topic\n' >"$MEM_DIR/debugging.md"
 
-OUT=$(cd "$REPO" && HOME="$ISO_HOME" bash "$SCRIPT")
+OUT=$(cd "$REPO" && iso_env bash "$SCRIPT")
 assert_contains "MEMORY.md present is reported" "$OUT" "MEMORY.md: PRESENT"
 assert_contains "topic file count reported" "$OUT" "topic files: 1"
 
@@ -96,13 +114,13 @@ rm -f "$MEM_DIR/oops"$'\n'"weird.md"
 NONREPO="$TEST_TMPDIR/plain"
 mkdir -p "$NONREPO"
 rc=0
-RES=$(cd "$NONREPO" && env -u GIT_DIR HOME="$ISO_HOME" bash "$RESOLVER" | tr -d '\r') || rc=$?
+RES=$(cd "$NONREPO" && iso_env bash "$RESOLVER" | tr -d '\r') || rc=$?
 assert_exit "resolver exits 0 outside a git repo" 0 "$rc"
 assert_contains "resolver derives the memory dir under the config root" "$RES" "$ISO_HOME/.claude/projects/"
 assert_contains "resolver slug is cwd-derived" "$RES" "plain"
 
 rc=0
-OUT=$(cd "$NONREPO" && env -u GIT_DIR HOME="$ISO_HOME" bash "$SCRIPT") || rc=$?
+OUT=$(cd "$NONREPO" && iso_env bash "$SCRIPT") || rc=$?
 assert_exit "non-git dir exits 0" 0 "$rc"
 assert_contains "non-git dir notes the cwd is the project key" "$OUT" "current directory"
 assert_contains "non-git dir reports the resolved memory dir" "$OUT" "$ISO_HOME/.claude/projects/"
@@ -117,6 +135,35 @@ OUT=$(cd "$REPO" && env -u CLAUDE_CODE_DISABLE_AUTO_MEMORY HOME="$ISO_HOME" CLAU
 assert_contains "reports CLAUDE_CONFIG_DIR when set" "$OUT" "CLAUDE_CONFIG_DIR=$CFG"
 assert_contains "user settings resolved under CLAUDE_CONFIG_DIR" "$OUT" "$CFG/settings.json"
 assert_contains "memory dir resolved under CLAUDE_CONFIG_DIR" "$OUT" "$CFG/projects/"
+
+# --- Case 7: an ambient CLAUDE_CONFIG_DIR never leaks into the isolated cases ---
+# Simulates a developer (or hook chain) running this suite with CLAUDE_CONFIG_DIR
+# already exported. The sentinel lives under the suite tmpdir so the check itself stays
+# hermetic; on a real machine the same leak would land in the live config tree.
+
+AMBIENT="$TEST_TMPDIR/ambient-config"
+mkdir -p "$AMBIENT"
+export CLAUDE_CONFIG_DIR="$AMBIENT"
+
+LEAK_REPO="$TEST_TMPDIR/leak-repo"
+make_repo "$LEAK_REPO"
+
+LEAK_DIR=$(cd "$LEAK_REPO" && iso_env bash "$RESOLVER" 2>/dev/null | tr -d '\r')
+assert_contains "ambient CLAUDE_CONFIG_DIR does not move the resolved memory dir" "$LEAK_DIR" "$ISO_HOME/.claude/projects/"
+
+mkdir -p "$LEAK_DIR"
+printf '# MEMORY\n' >"$LEAK_DIR/MEMORY.md"
+OUT=$(cd "$LEAK_REPO" && iso_env bash "$SCRIPT")
+assert_contains "report under ambient CLAUDE_CONFIG_DIR reads the isolated home" "$OUT" "$ISO_HOME/.claude/projects/"
+
+LEAKED=$(find "$AMBIENT" -mindepth 1 -print 2>/dev/null)
+if [[ -z "$LEAKED" ]]; then
+  pass "nothing written to the ambient CLAUDE_CONFIG_DIR"
+else
+  fail "nothing written to the ambient CLAUDE_CONFIG_DIR" "created: $(printf '%s' "$LEAKED" | tr '\n' ' ')"
+fi
+
+unset CLAUDE_CONFIG_DIR
 
 if [[ "$FAILED" -eq 0 ]]; then
   printf '\nAll %d checks passed.\n' "$CASE_NUM"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #3374

## Summary

`scope-report.test.sh` isolated `HOME` but left an ambient `CLAUDE_CONFIG_DIR` in place. The resolver prefers that variable, so Case 4 could `mkdir` and write fixture memory files into a live config tree.

## Fix

Test-only change. Added an `iso_env` helper that unsets `CLAUDE_CONFIG_DIR` for every main-case invocation except Case 6. Case 4 now aborts before any write when the resolved `MEM_DIR` is not under `$TEST_TMPDIR`. Added Case 7 that exports a sentinel `CLAUDE_CONFIG_DIR` and asserts it stays empty.

## Verification

- `scripts/affected-tests.sh --run`: all 25 checks pass.
- Re-ran the suite with `CLAUDE_CONFIG_DIR` exported to an arbitrary directory: 25/25 pass and the sentinel stays empty.

## Related

N/A
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7ffb619a-6ebb-4d47-9c45-d68e846edf93?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7ffb619a-6ebb-4d47-9c45-d68e846edf93&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

