### PR TITLE
fix(work-items): make run-conformance's provider check non-vacuous

### DIFF
--- a/plugins/work-items/.claude-plugin/plugin.json
+++ b/plugins/work-items/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "work-items",
-  "version": "0.39.43",
+  "version": "0.39.44",
   "description": "Manages development work items through a provider-neutral tracker seam that ships with the plugin (bundled dispatcher plus github, local-markdown, jira, gitea, and linear adapters; seam plugin-dir canonical, adapters consumer-local-first): dashboard, taxonomy-labeled creation, a race-safe assignee-plus-lease claim protocol, recurring-schedule checks, TODO scanning, stale-lease auditing, plan decomposition into vertical-slice items, a macro-journey router over spec containers (rollup, per-container execution shape, next-step routing), raw-intake triage (issues and unsolicited PRs through raw, verified, briefed, autonomous-eligible states), plus the two work-items loop lanes of the loop-lane convention: a self-paced autonomous work-loop drain (work-class admission gate, adaptive item cap, PR-only) and an attended attend-queue escalation lane. The re-runnable setup skill binds the provider (.work-item-tracker.json), seeds the recurring-schedule seam (.github/recurring-schedule.json), and remaps canonical role labels.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/work-items/CHANGELOG.md
+++ b/plugins/work-items/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to the `work-items` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.39.44]
+
+### Fixed
+
+- **Conformance `run-conformance.sh` drops its own vacuous assertion.** The capabilities case
+  asserted that `"provider=$PROVIDER"` contains `"provider="`, which is true for every possible
+  value including an empty one, because the haystack is built from the needle. It now checks that
+  the provider read back from the real capabilities output is non-empty, the same pattern the
+  suite already uses for `claim`'s holder field a few cases later. An empty provider now fails
+  this case; a real provider still passes.
+
 ## [0.39.43]
 
 ### Changed

--- a/plugins/work-items/CHANGELOG.md
+++ b/plugins/work-items/CHANGELOG.md
@@ -9,10 +9,12 @@ All notable changes to the `work-items` plugin are documented here. Format follo
 
 - **Conformance `run-conformance.sh` drops its own vacuous assertion.** The capabilities case
   asserted that `"provider=$PROVIDER"` contains `"provider="`, which is true for every possible
-  value including an empty one, because the haystack is built from the needle. It now checks that
-  the provider read back from the real capabilities output is non-empty, the same pattern the
-  suite already uses for `claim`'s holder field a few cases later. An empty provider now fails
-  this case; a real provider still passes.
+  value including an empty one, because the haystack is built from the needle. It now requires
+  `.provider` to be a JSON string of length greater than 0
+  (`jq -e '.provider | type == "string" and length > 0'`). Empty and JSON null fail. A provider
+  literally named `null` is a valid adapter name and is no longer rejected because `jq -r`
+  prints the text `null` for both JSON null and the string `"null"`. A real provider still
+  passes.
 
 ## [0.39.43]
 

--- a/plugins/work-items/tools/work-item-tracker/conformance/run-conformance.sh
+++ b/plugins/work-items/tools/work-item-tracker/conformance/run-conformance.sh
@@ -128,8 +128,10 @@ if jq -e '.provider | type == "string" and length > 0' <<<"$WIT_OUT" >/dev/null;
   PROVIDER="$(jq -r '.provider' <<<"$WIT_OUT")"
   pass "capabilities names a provider"
 else
-  PROVIDER="$(jq -c '.provider' <<<"$WIT_OUT")"
-  fail "capabilities names a provider" "JSON string of length > 0" "$PROVIDER"
+  # Keep PROVIDER as raw text for later path/JSON reuse; compact JSON is
+  # only the diagnostic shown by fail (empty → `""`, null → `null`).
+  PROVIDER="$(jq -r '.provider' <<<"$WIT_OUT")"
+  fail "capabilities names a provider" "JSON string of length > 0" "$(jq -c '.provider' <<<"$WIT_OUT")"
 fi
 CAPS="$WIT_OUT"
 

--- a/plugins/work-items/tools/work-item-tracker/conformance/run-conformance.sh
+++ b/plugins/work-items/tools/work-item-tracker/conformance/run-conformance.sh
@@ -121,7 +121,11 @@ RUN_TAG="conf-$(date -u +%Y%m%dT%H%M%SZ)-$$"
 wit_case "capabilities" 0 capabilities
 assert_schema_version "capabilities"
 PROVIDER="$(jq -r '.provider' <<<"$WIT_OUT")"
-assert_contains "capabilities names a provider" "provider=$PROVIDER" "provider="
+if [[ -n "$PROVIDER" && "$PROVIDER" != "null" ]]; then
+  pass "capabilities names a provider"
+else
+  fail "capabilities names a provider" "non-empty provider" "$PROVIDER"
+fi
 CAPS="$WIT_OUT"
 
 # --- usage / binding errors ---

--- a/plugins/work-items/tools/work-item-tracker/conformance/run-conformance.sh
+++ b/plugins/work-items/tools/work-item-tracker/conformance/run-conformance.sh
@@ -120,11 +120,16 @@ RUN_TAG="conf-$(date -u +%Y%m%dT%H%M%SZ)-$$"
 
 wit_case "capabilities" 0 capabilities
 assert_schema_version "capabilities"
-PROVIDER="$(jq -r '.provider' <<<"$WIT_OUT")"
-if [[ -n "$PROVIDER" && "$PROVIDER" != "null" ]]; then
+# jq -r prints the text `null` for both JSON null and the string `"null"`. A
+# provider literally named `null` is a valid adapter name
+# (`^[a-z][a-z0-9-]{0,31}$`), so reject on JSON type instead: require a string
+# of length > 0. Empty and JSON null still fail; `"null"` is accepted as a name.
+if jq -e '.provider | type == "string" and length > 0' <<<"$WIT_OUT" >/dev/null; then
+  PROVIDER="$(jq -r '.provider' <<<"$WIT_OUT")"
   pass "capabilities names a provider"
 else
-  fail "capabilities names a provider" "non-empty provider" "$PROVIDER"
+  PROVIDER="$(jq -c '.provider' <<<"$WIT_OUT")"
+  fail "capabilities names a provider" "JSON string of length > 0" "$PROVIDER"
 fi
 CAPS="$WIT_OUT"
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #3485

## Summary

`run-conformance.sh` asserted `"provider=$PROVIDER"` contains `"provider="`, which is always true. An adapter that returned an empty provider would pass conformance undetected. The e2e-probe half of this issue is already fixed on main.

## Fix

The provider read back from `WIT_OUT` via jq must be non-empty and not the literal `null`, matching the suite's existing holder-field check. Plugin bumped to 0.39.44.

## Verification

`scripts/affected-tests.sh --run` passed 6 suites, including real conformance runs against jira, linear, and local-markdown. A throwaway binding with `provider: ""` now fails this case.

## Related

N/A
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7ffb619a-6ebb-4d47-9c45-d68e846edf93?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7ffb619a-6ebb-4d47-9c45-d68e846edf93&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

