### PR TITLE
fix(work-items): gate gh 2.94 on native-surface flags only

### DIFF
--- a/plugins/work-items/.claude-plugin/plugin.json
+++ b/plugins/work-items/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "work-items",
-  "version": "0.39.45",
+  "version": "0.39.46",
   "description": "Manages development work items through a provider-neutral tracker seam that ships with the plugin (bundled dispatcher plus github, local-markdown, jira, gitea, and linear adapters; seam plugin-dir canonical, adapters consumer-local-first): dashboard, taxonomy-labeled creation, a race-safe assignee-plus-lease claim protocol, recurring-schedule checks, TODO scanning, stale-lease auditing, plan decomposition into vertical-slice items, a macro-journey router over spec containers (rollup, per-container execution shape, next-step routing), raw-intake triage (issues and unsolicited PRs through raw, verified, briefed, autonomous-eligible states), plus the two work-items loop lanes of the loop-lane convention: a self-paced autonomous work-loop drain (work-class admission gate, adaptive item cap, PR-only) and an attended attend-queue escalation lane. The re-runnable setup skill binds the provider (.work-item-tracker.json), seeds the recurring-schedule seam (.github/recurring-schedule.json), and remaps canonical role labels.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/work-items/CHANGELOG.md
+++ b/plugins/work-items/CHANGELOG.md
@@ -15,7 +15,10 @@ All notable changes to the `work-items` plugin are documented here. Format follo
   `list-items` (it still requests `--json blockedBy`, so frontier stays fail-closed),
   `list-frontier`, and `create-item` only when those gated flags are passed; the error
   names the flag. `get-item` and a plain `create-item` omit the 2.94 `--json` fields
-  (`parent_id` null, `blocked_by_count` 0, `type` null). (#3598)
+  (`parent_id` null, `blocked_by_count` 0, `type` null). `--type` is a 2.94 `gh
+  issue create` flag; on older gh the GitHub adapter omits it and applies the
+  coarse `type:` label instead, so `/work-items:track add` on an org repo still
+  files. (#3598)
 
 ## [0.39.45]
 

--- a/plugins/work-items/CHANGELOG.md
+++ b/plugins/work-items/CHANGELOG.md
@@ -3,6 +3,20 @@
 All notable changes to the `work-items` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.39.46]
+
+### Fixed
+
+- **Seam: `create-item` without `--parent` / `--blocked-by` no longer requires `gh` 2.94.**
+  The 0.39.18 per-verb floor still gated every `create-item` and `get-item`, so a cloud
+  image shipping `gh` 2.45 (the observed Claude Code cloud CLI) refused a plain create
+  with exit `3` and never reached `gh issue create`. `/work-items:track add` could file
+  nothing. The floor now applies to `link-blocks`, `add-sub-item`, `list-sub-items`,
+  `list-items` (it still requests `--json blockedBy`, so frontier stays fail-closed),
+  `list-frontier`, and `create-item` only when those gated flags are passed; the error
+  names the flag. `get-item` and a plain `create-item` omit the 2.94 `--json` fields
+  (`parent_id` null, `blocked_by_count` 0, `type` null). (#3598)
+
 ## [0.39.45]
 
 ### Fixed

--- a/plugins/work-items/skills/setup/reference/providers.md
+++ b/plugins/work-items/skills/setup/reference/providers.md
@@ -13,8 +13,9 @@ claim/renew/reclaim lease protocol, native sub-items, and dependency edges. Need
 config beyond the lease TTL.
 
 **Verifying it at bind time.** Confirm `gh` is installed — the seam hard-errors at call time when
-the binary is absent, and again on any verb reading the native sub-item/dependency surface when it
-is older than 2.94 (CONTRACT.md "Prerequisites"; the claim/renew/reclaim lease trio is exempt) —
+the binary is absent, and again on any path that uses the native sub-item/dependency surface when it
+is older than 2.94 (CONTRACT.md "Prerequisites"; `get-item`, a `create-item` with no
+`--parent`/`--blocked-by`, and the claim/renew/reclaim lease trio are exempt) —
 then confirm the checkout itself resolves:
 
 ```sh

--- a/plugins/work-items/tools/work-item-tracker/CONTRACT.md
+++ b/plugins/work-items/tools/work-item-tracker/CONTRACT.md
@@ -36,15 +36,17 @@ canonical with a project-root fallback (see "Adapter resolution"). Direction loc
 - `gh` on PATH when the bound provider is `github` and the verb shells out. Missing →
   exit `3`. `capabilities` is the one exception: it reads the adapter manifest and never
   invokes `gh`, so it answers without the binary.
-- `gh` ≥ **2.94** additionally for the verbs that read the native sub-issue/dependency
-  surface — the `--parent`, `--blocked-by`, `--add-blocked-by` flags and the `blockedBy`,
-  `parent`, `subIssues` `--json` fields. Too old → exit `3` naming the minimum. That is
-  `create-item`, `get-item`, `list-items`, `list-sub-items`, `link-blocks`, `add-sub-item`,
-  and `list-frontier` (which gates through whichever list verb it resolves to). The lease
-  trio — `claim`, `renew-lease`, `reclaim` — reads assignees and comments only, so it runs
-  on an older `gh`: a version floor applied to every verb would cost a session race-safe
-  claiming for a surface those verbs never touch. The dispatcher gates per verb, before
-  dispatch.
+- `gh` ≥ **2.94** additionally for the paths that use the native sub-issue/dependency
+  surface: the `--parent`, `--blocked-by`, `--add-blocked-by` flags and the `blockedBy`,
+  `parent`, `subIssues` `--json` fields. Too old → exit `3` naming the flag (or the
+  verb). That is `link-blocks`, `add-sub-item`, `list-sub-items`, `list-items` (which
+  requests `--json blockedBy`), `list-frontier` (which gates through whichever list verb
+  it resolves to), and `create-item` only when `--parent` or `--blocked-by` is passed.
+  A plain `create-item` (title, body, labels, repo) and `get-item` run on an older `gh`:
+  `get-item` omits the native `--json` fields, so `parent_id` is `null`, `blocked_by_count`
+  is `0`, and `type` is `null`. The lease trio (`claim`, `renew-lease`, `reclaim`) reads
+  assignees and comments only. `capabilities` never shells out. The dispatcher gates
+  before dispatch.
 - `curl` on PATH when the bound provider is `jira` (Cloud REST v3 over HTTPS). The jira
   adapter gates on it at call time (exit `3`), not the dispatcher — minimal shared-code
   blast radius.
@@ -63,9 +65,10 @@ this repository's own spec board (#2933) had to be published through MCP tools w
 blocking edges as body text, because the publishing session had no `gh`.
 
 **A too-old `gh` degrades differently from an absent one.** Where the binary is present but
-below 2.94, only the native-surface verbs above are refused; the lease trio still runs, so
-such a session can hold and renew a race-safe claim even though it cannot derive a frontier
-or read `blocked_by_count`. Selection has to come from elsewhere (an operator-named item,
+below 2.94, only the native-surface paths above are refused; the lease trio, `get-item`,
+and a `create-item` with no gated flags still run, so such a session can file a plain
+item and hold a race-safe claim even though it cannot attach sub-issue or dependency
+edges or derive a frontier. Selection has to come from elsewhere (an operator-named item,
 or a list taken through another GitHub surface), but the claim itself is not degraded, and
 an item worked this way is NOT the unclaimed-coordination case the backfill ritual below
 describes.

--- a/plugins/work-items/tools/work-item-tracker/CONTRACT.md
+++ b/plugins/work-items/tools/work-item-tracker/CONTRACT.md
@@ -42,9 +42,10 @@ canonical with a project-root fallback (see "Adapter resolution"). Direction loc
   verb). That is `link-blocks`, `add-sub-item`, `list-sub-items`, `list-items` (which
   requests `--json blockedBy`), `list-frontier` (which gates through whichever list verb
   it resolves to), and `create-item` only when `--parent` or `--blocked-by` is passed.
-  A plain `create-item` (title, body, labels, repo) and `get-item` run on an older `gh`:
+  A plain `create-item` (title, body, labels, `--type`, repo) and `get-item` run on an older `gh`:
   `get-item` omits the native `--json` fields, so `parent_id` is `null`, `blocked_by_count`
-  is `0`, and `type` is `null`. The lease trio (`claim`, `renew-lease`, `reclaim`) reads
+  is `0`, and `type` is `null`. `--type` is not a dispatcher floor: the GitHub adapter
+  drops the 2.94 `gh issue create --type` flag and applies the coarse `type:` label. The lease trio (`claim`, `renew-lease`, `reclaim`) reads
   assignees and comments only. `capabilities` never shells out. The dispatcher gates
   before dispatch.
 - `curl` on PATH when the bound provider is `jira` (Cloud REST v3 over HTTPS). The jira

--- a/plugins/work-items/tools/work-item-tracker/adapters/github/common.sh
+++ b/plugins/work-items/tools/work-item-tracker/adapters/github/common.sh
@@ -38,6 +38,9 @@ source "$WIT_GH_ADAPTER_DIR/../../lib/lease.sh"
 wit_gh_require_seam_lib "$WIT_GH_ADAPTER_DIR/../../lib/binding.sh"
 # shellcheck source=../../lib/binding.sh
 source "$WIT_GH_ADAPTER_DIR/../../lib/binding.sh"
+wit_gh_require_seam_lib "$WIT_GH_ADAPTER_DIR/../../lib/gh-version.sh"
+# shellcheck source=../../lib/gh-version.sh
+source "$WIT_GH_ADAPTER_DIR/../../lib/gh-version.sh"
 
 # wit_gh_resolve_bot_wrapper — echo the bot wrapper path using consumer-local-first
 # resolution (CONTRACT.md "Identity routing (GitHub adapter)"), mirroring the
@@ -220,13 +223,25 @@ readonly WIT_ITEM_JQ='{
   url: .url
 }'
 
+# wit_gh_issue_view_json_fields: --json field list `gh issue view` accepts on
+# this binary. 2.94+ adds issueType / blockedBy / parent; older gh (cloud images
+# ship 2.45) rejects those names, so get-item and create-item's emit path omit
+# them and WIT_ITEM_JQ fills type/parent_id with null and blocked_by_count with 0.
+wit_gh_issue_view_json_fields() {
+  if wit_gh_has_native_surface; then
+    printf '%s\n' "number,title,state,assignees,labels,issueType,blockedBy,parent,url"
+  else
+    printf '%s\n' "number,title,state,assignees,labels,url"
+  fi
+}
+
 # wit_emit_item <owner> <repo> <number> — fetch the issue and emit the normalized
 # item object (CONTRACT.md "JSON output contract"). blocked_by_count counts OPEN
 # blockers only (closed blockers stay in blockedBy.totalCount — Tier-0 verified).
 wit_emit_item() {
-  local owner="$1" repo="$2" number="$3"
-  wit_run_gh read issue view "$number" -R "$owner/$repo" \
-    --json number,title,state,assignees,labels,issueType,blockedBy,parent,url
+  local owner="$1" repo="$2" number="$3" fields
+  fields="$(wit_gh_issue_view_json_fields)"
+  wit_run_gh read issue view "$number" -R "$owner/$repo" --json "$fields"
   printf '%s\n' "$WIT_GH_OUT" | jq -c --arg sv "$WIT_SCHEMA_VERSION" --arg or "$owner/$repo" "$WIT_ITEM_JQ"
 }
 

--- a/plugins/work-items/tools/work-item-tracker/adapters/github/common.test.sh
+++ b/plugins/work-items/tools/work-item-tracker/adapters/github/common.test.sh
@@ -10,7 +10,8 @@ source "$SCRIPT_DIR/../../tests/lib.sh"
 source "$SCRIPT_DIR/common.sh"
 
 for fn in gh_write wit_run_gh wit_resolve_repo wit_emit_item wit_lease_json \
-  wit_lease_is_live wit_list_lease_comments wit_help_if_requested wit_map_gh_error; do
+  wit_lease_is_live wit_list_lease_comments wit_help_if_requested wit_map_gh_error \
+  wit_gh_issue_view_json_fields; do
   if declare -F "$fn" >/dev/null; then
     pass "common.sh exposes $fn"
   else
@@ -50,5 +51,71 @@ RESOLVED_UNSET="$(unset CLAUDE_PROJECT_DIR; wit_gh_resolve_bot_wrapper)"
 assert_eq "falls back to bundled path when CLAUDE_PROJECT_DIR unset" "$BUNDLED" "$RESOLVED_UNSET"
 
 rm -rf "$CONSUMER_ROOT" "$EMPTY_ROOT"
+
+# --- get-item / create-item emit omit 2.94 JSON fields on older gh (#3598) ---
+# A stub that rejects issueType/blockedBy/parent (what gh 2.45 does) proves
+# wit_emit_item still succeeds, and a 2.94 stub proves those fields come back.
+if command -v jq >/dev/null 2>&1; then
+  EMIT_STUB="$(mktemp -d)"
+  cat >"$EMIT_STUB/gh" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$1" == "--version" ]]; then
+  printf 'gh version %s (test)\n' "${GH_STUB_VERSION:-2.45.0}"
+  exit 0
+fi
+json=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+  --json)
+    json="$2"
+    shift 2
+    ;;
+  *)
+    shift
+    ;;
+  esac
+done
+printf 'JSON:%s\n' "$json" >>"${GH_STUB_DIR:?}/calls.log"
+if [[ "${GH_STUB_REJECT_NATIVE:-}" == "1" ]]; then
+  case "$json" in
+  *blockedBy* | *parent* | *issueType*)
+    printf 'Unknown JSON field\n' >&2
+    exit 1
+    ;;
+  *) ;;
+  esac
+fi
+printf '{"number":1,"title":"t","state":"OPEN","assignees":[],"labels":[],"url":"https://github.com/o/r/issues/1"}\n'
+EOF
+  chmod +x "$EMIT_STUB/gh"
+
+  FIELDS_OLD="$(GH_STUB_VERSION=2.45.0 PATH="$EMIT_STUB:$PATH" wit_gh_issue_view_json_fields)"
+  assert_not_contains "gh 2.45 view fields omit blockedBy" "$FIELDS_OLD" "blockedBy"
+  assert_not_contains "gh 2.45 view fields omit parent" "$FIELDS_OLD" "parent"
+  assert_not_contains "gh 2.45 view fields omit issueType" "$FIELDS_OLD" "issueType"
+
+  FIELDS_NEW="$(GH_STUB_DIR="$EMIT_STUB" GH_STUB_VERSION=2.94.0 PATH="$EMIT_STUB:$PATH" wit_gh_issue_view_json_fields)"
+  assert_contains "gh 2.94 view fields include blockedBy" "$FIELDS_NEW" "blockedBy"
+  assert_contains "gh 2.94 view fields include parent" "$FIELDS_NEW" "parent"
+  assert_contains "gh 2.94 view fields include issueType" "$FIELDS_NEW" "issueType"
+
+  : >"$EMIT_STUB/calls.log"
+  OUT="$(GH_STUB_DIR="$EMIT_STUB" GH_STUB_VERSION=2.45.0 GH_STUB_REJECT_NATIVE=1 \
+    PATH="$EMIT_STUB:$PATH" wit_emit_item o r 1)"
+  assert_eq "wit_emit_item on gh 2.45 → id" "github:o/r#1" "$(jq -r '.id' <<<"$OUT")"
+  assert_eq "wit_emit_item on gh 2.45 → parent_id null" "null" "$(jq -r '.parent_id' <<<"$OUT")"
+  assert_eq "wit_emit_item on gh 2.45 → blocked_by_count 0" "0" "$(jq -r '.blocked_by_count' <<<"$OUT")"
+  CALLS="$(cat "$EMIT_STUB/calls.log")"
+  assert_not_contains "wit_emit_item on gh 2.45 does not request blockedBy" "$CALLS" "blockedBy"
+
+  : >"$EMIT_STUB/calls.log"
+  GH_STUB_DIR="$EMIT_STUB" GH_STUB_VERSION=2.94.0 GH_STUB_REJECT_NATIVE=0 \
+    PATH="$EMIT_STUB:$PATH" wit_emit_item o r 1 >/dev/null
+  CALLS="$(cat "$EMIT_STUB/calls.log")"
+  assert_contains "wit_emit_item on gh 2.94 requests blockedBy" "$CALLS" "blockedBy"
+  assert_contains "wit_emit_item on gh 2.94 requests parent" "$CALLS" "parent"
+
+  rm -rf "$EMIT_STUB"
+fi
 
 [[ $FAILED -eq 0 ]] || exit 1

--- a/plugins/work-items/tools/work-item-tracker/adapters/github/create-item.sh
+++ b/plugins/work-items/tools/work-item-tracker/adapters/github/create-item.sh
@@ -55,11 +55,26 @@ target_repo="$(wit_resolve_repo "$repo_override")" || exit "$?"
 
 args=(issue create -R "$target_repo" --title "$title" --body "$body")
 
-# Native GitHub Issue Type (org-defined Task/Bug/Feature). gh validates the name
-# against the org's types and silently drops it without push access — the
-# projection surfaces the resulting type so callers can confirm it took.
+# Native GitHub Issue Type (org-defined Task/Bug/Feature) is a gh 2.94 flag.
+# On older gh, forwarding `--type` dies with `unknown flag` (exit 1) and
+# `/work-items:track add` on an org repo files nothing. Degrade to the same
+# coarse `type:` label personal/non-org repos already use, and say so.
 if [[ -n "$type" ]]; then
-  args+=(--type "$type")
+  if wit_gh_has_native_surface; then
+    args+=(--type "$type")
+  else
+    type_lc="$(printf '%s' "$type" | tr '[:upper:]' '[:lower:]')"
+    case "$type_lc" in
+    bug | fix) type_label="type: bug" ;;
+    feature | feat) type_label="type: feature" ;;
+    *) type_label="type: task" ;;
+    esac
+    printf 'create-item.sh: --type requires gh >= 2.94; applying %s instead\n' \
+      "$type_label" >&2
+    if [[ ",${labels}," != *",${type_label},"* ]]; then
+      labels="${labels:+$labels,}$type_label"
+    fi
+  fi
 fi
 
 if [[ -n "$labels" ]]; then

--- a/plugins/work-items/tools/work-item-tracker/adapters/github/create-item.test.sh
+++ b/plugins/work-items/tools/work-item-tracker/adapters/github/create-item.test.sh
@@ -33,7 +33,7 @@ while [[ $# -gt 0 ]]; do
     create=1
     shift
     ;;
-  --parent | --blocked-by)
+  --parent | --blocked-by | --type)
     native_flag=1
     shift 2
     ;;
@@ -72,6 +72,17 @@ EOF
   assert_eq "create-item on gh 2.45 (no gated flags) → exit 0" "0" "$rc"
   assert_eq "create-item on gh 2.45 emits id" "github:o/r#42" "$(jq -r '.id' <<<"$OUT")"
   assert_eq "create-item on gh 2.45 parent_id is null" "null" "$(jq -r '.parent_id' <<<"$OUT")"
+
+  TYPED_ERR="$(mktemp)"
+  TYPED_OUT="$(CLAUDE_PROJECT_DIR="$PROJECT" GH_STUB_VERSION=2.45.0 PATH="$STUB:$PATH" \
+    bash "$S" --title t --type Task --repo o/r 2>"$TYPED_ERR")"
+  rc=$?
+  assert_eq "create-item --type on gh 2.45 degrades → exit 0" "0" "$rc"
+  assert_eq "create-item --type on gh 2.45 still emits id" "github:o/r#42" \
+    "$(jq -r '.id' <<<"$TYPED_OUT")"
+  assert_contains "create-item --type on gh 2.45 names the label fallback" \
+    "$(cat "$TYPED_ERR")" "type: task"
+  rm -f "$TYPED_ERR"
 
   rm -rf "$STUB" "$PROJECT"
 fi

--- a/plugins/work-items/tools/work-item-tracker/adapters/github/create-item.test.sh
+++ b/plugins/work-items/tools/work-item-tracker/adapters/github/create-item.test.sh
@@ -7,4 +7,73 @@ source "$(dirname "$S")/../../lib/verb-test-helpers.sh"
 assert_help "$S"
 assert_usage_error "$S" --nope
 assert_usage_error "$S" --title x --type # --type needs a value
+
+# --- plain create-item succeeds on mocked gh 2.45 (#3598) ---
+# The stub rejects --parent / --blocked-by and the 2.94 --json fields, matching
+# what an older gh does. --repo skips `gh repo view`, so the path is create +
+# emit only. Direct adapter invocation (dispatcher gate is covered in
+# work-item-tracker.test.sh).
+if command -v jq >/dev/null 2>&1; then
+  STUB="$(mktemp -d)"
+  PROJECT="$(mktemp -d)"
+  cat >"$STUB/gh" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$1" == "--version" ]]; then
+  printf 'gh version %s (test)\n' "${GH_STUB_VERSION:-2.45.0}"
+  exit 0
+fi
+json="" create=0 native_flag=0
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+  --json)
+    json="$2"
+    shift 2
+    ;;
+  create)
+    create=1
+    shift
+    ;;
+  --parent | --blocked-by)
+    native_flag=1
+    shift 2
+    ;;
+  *)
+    shift
+    ;;
+  esac
+done
+if ((native_flag)); then
+  printf 'unknown flag: native sub-issue/dependency surface\n' >&2
+  exit 1
+fi
+if [[ -n "$json" ]]; then
+  case "$json" in
+  *blockedBy* | *parent* | *issueType*)
+    printf 'Unknown JSON field: %s\n' "$json" >&2
+    exit 1
+    ;;
+  *) ;;
+  esac
+  printf '{"number":42,"title":"t","state":"OPEN","assignees":[],"labels":[],"url":"https://github.com/o/r/issues/42"}\n'
+  exit 0
+fi
+if ((create)); then
+  printf 'https://github.com/o/r/issues/42\n'
+  exit 0
+fi
+printf 'gh-stub: unhandled\n' >&2
+exit 90
+EOF
+  chmod +x "$STUB/gh"
+
+  OUT="$(CLAUDE_PROJECT_DIR="$PROJECT" GH_STUB_VERSION=2.45.0 PATH="$STUB:$PATH" \
+    bash "$S" --title t --repo o/r)"
+  rc=$?
+  assert_eq "create-item on gh 2.45 (no gated flags) → exit 0" "0" "$rc"
+  assert_eq "create-item on gh 2.45 emits id" "github:o/r#42" "$(jq -r '.id' <<<"$OUT")"
+  assert_eq "create-item on gh 2.45 parent_id is null" "null" "$(jq -r '.parent_id' <<<"$OUT")"
+
+  rm -rf "$STUB" "$PROJECT"
+fi
+
 [[ $FAILED -eq 0 ]] || exit 1

--- a/plugins/work-items/tools/work-item-tracker/lib/gh-version.sh
+++ b/plugins/work-items/tools/work-item-tracker/lib/gh-version.sh
@@ -1,0 +1,38 @@
+# shellcheck shell=bash
+# GitHub CLI version helpers. Sourced by the dispatcher (fail-loud gate on
+# native-surface flags) and the GitHub adapter (omit 2.94+ --json fields on
+# older gh so get-item and a plain create-item still emit).
+#
+# Floor: gh 2.94.0 introduced issue types, sub-issues, and dependencies
+# (`--parent`, `--blocked-by`, `--add-blocked-by`, and the issueType / parent /
+# subIssues / blockedBy --json fields). Official changelog:
+# https://github.blog/changelog/2026-06-10-manage-sub-issues-types-and-dependencies-from-github-cli/
+
+[[ -n "${_WIT_GH_VERSION_LOADED:-}" ]] && return 0
+readonly _WIT_GH_VERSION_LOADED=1
+
+readonly WIT_GH_NATIVE_SURFACE_MAJOR=2
+readonly WIT_GH_NATIVE_SURFACE_MINOR=94
+
+# wit_gh_version_raw — echo MAJOR.MINOR from `gh --version`, or empty when the
+# binary is missing or the first line does not match `gh version X.Y…`.
+wit_gh_version_raw() {
+  local out
+  out="$(gh --version 2>/dev/null)" || true
+  out="${out%%$'\n'*}"
+  if [[ "$out" =~ ^gh\ version\ ([0-9]+\.[0-9]+) ]]; then
+    printf '%s\n' "${BASH_REMATCH[1]}"
+  fi
+}
+
+# wit_gh_has_native_surface — 0 when gh is present and >= 2.94. Does not exit.
+wit_gh_has_native_surface() {
+  local raw major minor
+  command -v gh >/dev/null 2>&1 || return 1
+  raw="$(wit_gh_version_raw)"
+  major="${raw%%.*}"
+  minor="${raw#*.}"
+  [[ "$major" =~ ^[0-9]+$ && "$minor" =~ ^[0-9]+$ ]] || return 1
+  ((major > WIT_GH_NATIVE_SURFACE_MAJOR ||
+    (major == WIT_GH_NATIVE_SURFACE_MAJOR && minor >= WIT_GH_NATIVE_SURFACE_MINOR)))
+}

--- a/plugins/work-items/tools/work-item-tracker/lib/gh-version.test.sh
+++ b/plugins/work-items/tools/work-item-tracker/lib/gh-version.test.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Version-guard boundary for the native sub-issue/dependency surface: below
+# 2.94 is refused, 2.94 and above is accepted. Stub gh on PATH; no network.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=gh-version.sh
+source "$SCRIPT_DIR/gh-version.sh"
+source "$SCRIPT_DIR/../tests/lib.sh"
+
+STUB_BIN="$(mktemp -d)"
+trap 'rm -rf "$STUB_BIN"' EXIT
+
+cat >"$STUB_BIN/gh" <<'EOF'
+#!/usr/bin/env bash
+printf 'gh version %s (test)\n' "${GH_STUB_VERSION:?}"
+EOF
+chmod +x "$STUB_BIN/gh"
+
+run_at() {
+  local ver="$1"
+  GH_STUB_VERSION="$ver" PATH="$STUB_BIN:$PATH" wit_gh_has_native_surface
+  printf '%s\n' "$?"
+}
+
+assert_eq "2.45 (observed cloud gh) is below the floor" "1" "$(run_at 2.45.0)"
+assert_eq "2.93 is below the floor" "1" "$(run_at 2.93.0)"
+assert_eq "2.94 meets the floor" "0" "$(run_at 2.94.0)"
+assert_eq "2.95 is above the floor" "0" "$(run_at 2.95.1)"
+assert_eq "3.0 (next major) meets the floor" "0" "$(run_at 3.0.0)"
+
+assert_eq "raw version from 2.45 stub" "2.45" \
+  "$(GH_STUB_VERSION=2.45.0 PATH="$STUB_BIN:$PATH" wit_gh_version_raw)"
+assert_eq "raw version from 2.94 stub" "2.94" \
+  "$(GH_STUB_VERSION=2.94.0 PATH="$STUB_BIN:$PATH" wit_gh_version_raw)"
+
+UNPARSEABLE="$STUB_BIN/unparseable"
+mkdir -p "$UNPARSEABLE"
+cat >"$UNPARSEABLE/gh" <<'EOF'
+#!/usr/bin/env bash
+printf 'not a version string\n'
+EOF
+chmod +x "$UNPARSEABLE/gh"
+PATH="$UNPARSEABLE:$PATH" wit_gh_has_native_surface
+assert_eq "unparseable gh --version fails closed" "1" "$?"
+
+NOGH="$(mktemp -d)"
+trap 'rm -rf "$STUB_BIN" "$NOGH"' EXIT
+PATH="$NOGH" wit_gh_has_native_surface
+assert_eq "missing gh fails closed" "1" "$?"
+
+[[ $FAILED -eq 0 ]] || exit 1

--- a/plugins/work-items/tools/work-item-tracker/lib/gh-version.test.sh
+++ b/plugins/work-items/tools/work-item-tracker/lib/gh-version.test.sh
@@ -34,15 +34,15 @@ assert_eq "raw version from 2.45 stub" "2.45" \
 assert_eq "raw version from 2.94 stub" "2.94" \
   "$(GH_STUB_VERSION=2.94.0 PATH="$STUB_BIN:$PATH" wit_gh_version_raw)"
 
-UNPARSEABLE="$STUB_BIN/unparseable"
-mkdir -p "$UNPARSEABLE"
-cat >"$UNPARSEABLE/gh" <<'EOF'
+UNPARSABLE="$STUB_BIN/unparsable"
+mkdir -p "$UNPARSABLE"
+cat >"$UNPARSABLE/gh" <<'EOF'
 #!/usr/bin/env bash
 printf 'not a version string\n'
 EOF
-chmod +x "$UNPARSEABLE/gh"
-PATH="$UNPARSEABLE:$PATH" wit_gh_has_native_surface
-assert_eq "unparseable gh --version fails closed" "1" "$?"
+chmod +x "$UNPARSABLE/gh"
+PATH="$UNPARSABLE:$PATH" wit_gh_has_native_surface
+assert_eq "unparsable gh --version fails closed" "1" "$?"
 
 NOGH="$(mktemp -d)"
 trap 'rm -rf "$STUB_BIN" "$NOGH"' EXIT

--- a/plugins/work-items/tools/work-item-tracker/work-item-tracker.sh
+++ b/plugins/work-items/tools/work-item-tracker/work-item-tracker.sh
@@ -14,6 +14,8 @@ source "$SCRIPT_DIR/lib/binding.sh"
 source "$SCRIPT_DIR/lib/json.sh"
 # shellcheck source=lib/frontier.sh
 source "$SCRIPT_DIR/lib/frontier.sh"
+# shellcheck source=lib/gh-version.sh
+source "$SCRIPT_DIR/lib/gh-version.sh"
 
 readonly EX_USAGE=2
 readonly EX_CONFIG=3
@@ -86,16 +88,16 @@ check_gh_present() {
     fail_config "prerequisite missing: gh (GitHub CLI) — see CONTRACT.md Prerequisites"
 }
 
+# check_gh_version [feature]: feature is the flag or verb that needs 2.94, so
+# the exit-3 message names it. Default copy covers verbs with no user-facing
+# flag (list-items' --json blockedBy, list-sub-items' subIssues).
 check_gh_version() {
   check_gh_present
-  local raw major minor
-  raw="$(gh --version 2>/dev/null | head -n1 | sed -E 's/^gh version ([0-9]+\.[0-9]+).*/\1/')"
-  major="${raw%%.*}"
-  minor="${raw#*.}"
-  if ! [[ "$major" =~ ^[0-9]+$ && "$minor" =~ ^[0-9]+$ ]] ||
-    ((major < 2 || (major == 2 && minor < 94))); then
-    fail_config "gh >= 2.94 required for native sub-issue/dependency flags (found: ${raw:-unknown})"
-  fi
+  local feature="${1:-native sub-issue/dependency flags}"
+  wit_gh_has_native_surface && return 0
+  local raw
+  raw="$(wit_gh_version_raw)"
+  fail_config "gh >= ${WIT_GH_NATIVE_SURFACE_MAJOR}.${WIT_GH_NATIVE_SURFACE_MINOR} required for ${feature} (found: ${raw:-unknown})"
 }
 
 main() {
@@ -162,20 +164,45 @@ main() {
   *) fail_usage ;;
   esac
 
-  # gh >= 2.94 buys exactly one thing: the native sub-issue/dependency surface
-  # (`--parent`, `--blocked-by`, `--add-blocked-by`, and the `blockedBy` /
-  # `parent` / `subIssues` --json fields). Gate the verbs that touch it, not the
-  # whole dispatcher — a blanket gate also blocked the lease trio (claim,
-  # renew-lease, reclaim) and `capabilities`, none of which reads that surface,
-  # so an older gh lost race-safe claiming for a prerequisite it never used.
-  # `capabilities` is the sharpest case: it reads a JSON manifest and never
-  # invokes gh at all, yet could not answer what the provider supports without
-  # meeting a requirement the answer itself might have said was unnecessary.
-  # Keyed on adapter_verb (resolved above), so `list-frontier --parent` gates
-  # through its list-sub-items dispatch rather than needing its own entry.
+  # gh >= 2.94 buys the native sub-issue/dependency surface (`--parent`,
+  # `--blocked-by`, `--add-blocked-by`, and the `blockedBy` / `parent` /
+  # `subIssues` --json fields). Gate the paths that pass those flags or read
+  # those fields, not every github verb: a blanket create-item gate refused
+  # plain creates (no parent, no blocked-by) on cloud images that ship gh 2.45,
+  # so /work-items:track add could file nothing (#3598). get-item omits the
+  # native --json fields on older gh (parent_id null, blocked_by_count 0).
+  # list-items still requests --json blockedBy, so it stays gated: silent zeros
+  # would let list-frontier treat blocked items as unblocked. Keyed on
+  # adapter_verb, so list-frontier --parent gates through list-sub-items.
   if [[ "$WIT_PROVIDER" == "github" ]]; then
     case "$adapter_verb" in
-    create-item | get-item | list-items | list-sub-items | link-blocks | add-sub-item)
+    create-item)
+      local gated_flag="" a
+      for a in "$@"; do
+        case "$a" in
+        --parent | --blocked-by)
+          gated_flag="$a"
+          break
+          ;;
+        *) ;;
+        esac
+      done
+      if [[ -n "$gated_flag" ]]; then
+        check_gh_version "$gated_flag"
+      else
+        check_gh_present
+      fi
+      ;;
+    list-sub-items)
+      check_gh_version "list-sub-items"
+      ;;
+    link-blocks)
+      check_gh_version "--blocked-by"
+      ;;
+    add-sub-item)
+      check_gh_version "--parent"
+      ;;
+    list-items)
       check_gh_version
       ;;
     capabilities)

--- a/plugins/work-items/tools/work-item-tracker/work-item-tracker.test.sh
+++ b/plugins/work-items/tools/work-item-tracker/work-item-tracker.test.sh
@@ -275,6 +275,8 @@ for v in capabilities claim renew-lease reclaim get-item; do
 done
 assert_eq "old gh: create-item without gated flags dispatches" \
   "0" "$(run_gh_verb create-item --title t)"
+assert_eq "old gh: create-item --type still dispatches (adapter degrades)" \
+  "0" "$(run_gh_verb create-item --title t --type Task)"
 
 # Verbs / flags that DO touch the native surface still fail closed (exit 3).
 for v in list-sub-items link-blocks add-sub-item; do

--- a/plugins/work-items/tools/work-item-tracker/work-item-tracker.test.sh
+++ b/plugins/work-items/tools/work-item-tracker/work-item-tracker.test.sh
@@ -233,11 +233,10 @@ assert_eq "bare shell resolves consumer-local via git toplevel" "acme-local" "$(
 
 # --- gh version gate is scoped to the native sub-issue/dependency surface ---
 # gh >= 2.94 buys `--parent` / `--blocked-by` / `--add-blocked-by` and the
-# blockedBy / parent / subIssues --json fields, and nothing else. Verbs that
-# never read that surface must dispatch on an older gh: the lease trio (claim,
-# renew-lease, reclaim) and capabilities, which invokes no gh at all. A blanket
-# dispatcher gate cost an older-gh session race-safe claiming for a prerequisite
-# it never used.
+# blockedBy / parent / subIssues --json fields. Gate those flags and the verbs
+# that always use them, not every github verb: a blanket create-item / get-item
+# gate refused plain creates on cloud images that ship gh 2.45 (#3598). The
+# lease trio and capabilities stay ungated for the same reason as 0.39.18.
 #
 # Provider is "github" so the gate applies, while WIT_ADAPTERS_DIR points at
 # stub verb scripts — the gate keys on the bound provider, not on adapter
@@ -270,15 +269,21 @@ run_gh_verb() {
   printf '%s\n' "$?"
 }
 
-# Verbs that never touch the native surface dispatch on gh 2.45.
-for v in capabilities claim renew-lease reclaim; do
+# Verbs that never pass a native-surface flag dispatch on gh 2.45.
+for v in capabilities claim renew-lease reclaim get-item; do
   assert_eq "old gh: $v dispatches (not gated)" "0" "$(run_gh_verb "$v" "github:o/r#1")"
 done
+assert_eq "old gh: create-item without gated flags dispatches" \
+  "0" "$(run_gh_verb create-item --title t)"
 
-# Verbs that DO touch it still fail closed with the config exit and its message.
-for v in get-item create-item list-sub-items link-blocks add-sub-item; do
+# Verbs / flags that DO touch the native surface still fail closed (exit 3).
+for v in list-sub-items link-blocks add-sub-item; do
   assert_eq "old gh: $v still gated → exit 3" "3" "$(run_gh_verb "$v" "github:o/r#1")"
 done
+assert_eq "old gh: create-item --parent gated → exit 3" \
+  "3" "$(run_gh_verb create-item --title t --parent "github:o/r#1")"
+assert_eq "old gh: create-item --blocked-by gated → exit 3" \
+  "3" "$(run_gh_verb create-item --title t --blocked-by "github:o/r#1")"
 
 # list-frontier gates through whichever list verb it resolves to — including the
 # --parent form, which dispatches list-sub-items rather than carrying its own entry.
@@ -287,17 +292,30 @@ assert_eq "old gh: list-frontier --parent gated via list-sub-items" \
   "3" "$(run_gh_verb list-frontier --parent "github:o/r#9")"
 
 ERR="$(PATH="$STUB_BIN:$PATH" WORK_ITEM_TRACKER_BINDING="$GH_BINDING" \
-  WIT_ADAPTERS_DIR="$GH_ADAPTERS" bash "$DISPATCHER" get-item "github:o/r#1" 2>&1 >/dev/null)"
-assert_contains "old gh: gate names the minimum" "$ERR" "2.94"
+  WIT_ADAPTERS_DIR="$GH_ADAPTERS" bash "$DISPATCHER" create-item --title t --parent "github:o/r#1" 2>&1 >/dev/null)"
+assert_contains "old gh: gated --parent names the minimum" "$ERR" "2.94"
+assert_contains "old gh: gated --parent names the flag" "$ERR" "--parent"
 
-# A conforming gh lifts the gate for every verb.
+ERR="$(PATH="$STUB_BIN:$PATH" WORK_ITEM_TRACKER_BINDING="$GH_BINDING" \
+  WIT_ADAPTERS_DIR="$GH_ADAPTERS" bash "$DISPATCHER" create-item --title t --blocked-by "github:o/r#1" 2>&1 >/dev/null)"
+assert_contains "old gh: gated --blocked-by names the flag" "$ERR" "--blocked-by"
+
+ERR="$(PATH="$STUB_BIN:$PATH" WORK_ITEM_TRACKER_BINDING="$GH_BINDING" \
+  WIT_ADAPTERS_DIR="$GH_ADAPTERS" bash "$DISPATCHER" create-item --title t 2>&1 >/dev/null)"
+assert_not_contains "old gh: plain create-item does not quote the version floor" "$ERR" "2.94"
+
+# A conforming gh lifts the gate for every verb, including gated flags.
 cat >"$STUB_BIN/gh" <<'EOF'
 #!/usr/bin/env bash
 printf 'gh version 2.94.0 (2026-01-01)\n'
 EOF
-for v in get-item create-item add-sub-item; do
+for v in get-item add-sub-item; do
   assert_eq "gh 2.94: $v dispatches" "0" "$(run_gh_verb "$v" "github:o/r#1")"
 done
+assert_eq "gh 2.94: create-item --parent dispatches" \
+  "0" "$(run_gh_verb create-item --title t --parent "github:o/r#1")"
+assert_eq "gh 2.94: create-item --blocked-by dispatches" \
+  "0" "$(run_gh_verb create-item --title t --blocked-by "github:o/r#1")"
 
 # A non-github provider is never version-gated, whatever gh reports.
 cat >"$STUB_BIN/gh" <<'EOF'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #3598

## Summary

`create-item` failed with exit 3 on every invocation when `gh` was older than 2.94, including a plain create with no gated flags. Claude Code cloud ships `gh` 2.45, so `/work-items:track add` could file nothing there.

## Fix

Move the `gh >= 2.94` floor onto the paths that actually use the native surface (`link-blocks`, `add-sub-item`, `list-sub-items`, list verbs that request `blockedBy`, and `create-item` only when `--parent` or `--blocked-by` is passed). Ungated verbs work on older `gh`. Plugin 0.39.44.

## Verification

Plain `create-item` succeeds against a mocked `gh` 2.45. Gated flags still exit 3 and name the flag. `scripts/affected-tests.sh --run`: 186 shell suites passed.

## Related

Official `gh` 2.94 surface: https://github.blog/changelog/2026-06-10-manage-sub-issues-types-and-dependencies-from-github-cli/
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7ffb619a-6ebb-4d47-9c45-d68e846edf93?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7ffb619a-6ebb-4d47-9c45-d68e846edf93&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

