### PR TITLE
fix(ai-briefing): stop advertising a phantom *.local.* overlay

### DIFF
--- a/docs/conventions/config-cascade/CHANGELOG.md
+++ b/docs/conventions/config-cascade/CHANGELOG.md
@@ -7,6 +7,15 @@ by a pointer line). Per-concern keys and schema are versioned by their own owner
 change independently. A change to the precedence order or the meaning of a layer is a major bump;
 adding an optional layer or relaxing a rule additively is a minor bump.
 
+## Implementers table — 2026-09-02
+
+- **`ai-briefing` team-only, no local overlay (#3580).** The surface no longer recommends a
+  `.claude/ai-briefing/**/*.local.*` gitignore line. The implementers row and declared-deviation
+  text now record team-only with no local overlay. Named profile selection is profile selection,
+  not a `*.local.*` cascade layer. `sources.md`, optional `audience.md`, and optional
+  `brand.json` are profile files in the selected team directory, not personal overlays. No
+  contract rule change, so no version bump.
+
 ## 1.2 — 2026-09-01
 
 - **Expression doctrine (additive, minor).** A second sanctioned expression form joins the

--- a/docs/conventions/config-cascade/README.md
+++ b/docs/conventions/config-cascade/README.md
@@ -112,9 +112,9 @@ surface is covered.
 ```
 
 That is the whole convention — **one line, recursive form, for every surface**. `.claude/**/` matches
-zero or more directories, so this single rule covers a flat `.claude/source-control.local.md`, a
-one-deep `.claude/ecosystems/python.local.yaml`, and a profiled
-`.claude/ai-briefing/<profile>/x.local.md` alike, while leaving team files tracked. The narrower
+zero or more directories, so this single rule covers a flat `.claude/source-control.local.md` and a
+one-deep `.claude/ecosystems/python.local.yaml` alike, and would cover a deeper nested overlay if a
+surface grew one, while leaving team files tracked. The narrower
 `.claude/*.local.*` silently fails to ignore any folder-form overlay; recommend the recursive form
 only, and never ask a consumer for two lines where one is exact.
 
@@ -257,14 +257,18 @@ surface, or amend this contract) is a separate human-gated decision.
 - **`disk-hygiene`'s `--policy` replaces both standing layers.** Its standing layers merge additively
   (overlays may disable or add hints and add protected globs, never weaken a hard guard); the
   wholesale replacement is confined to an explicit per-invocation flag, not a file layer.
+- **`ai-briefing` is team-only, with no local overlay (#3580).** Tracked files live under
+  `.claude/ai-briefing/` (default profile) or `.claude/ai-briefing/<name>/` (a named profile).
+  Selecting a named profile is profile selection, not resolution of a `*.local.*` cascade layer.
+  `sources.md`, optional `audience.md`, and optional `brand.json` are profile files in that
+  team directory; no read path resolves a `.local.*` file, and setup does not recommend
+  gitignoring one. Claude Code documents local behavior only for surfaces it actually resolves
+  (`CLAUDE.local.md`, `settings.local.json`); a generic `*.local.*` filename has no
+  platform-defined meaning.
 
 **Undeclared** — divergence with no recorded rationale:
 
-- **`ai-briefing` advertises an overlay layer it does not implement.** Its setup recommends the
-  recursive `.claude/**/*.local.*` gitignore line, but no read path resolves a `.local.*` file and
-  no file defines what one would do. Its documented resolution covers profile *selection* only, never
-  layer precedence. This is the only surface telling consumers to gitignore a layer that has no
-  effect.
+- none currently.
 
 ## Implementers
 
@@ -285,7 +289,7 @@ convention home, layers → `team, via pointer line`, conformance → the retire
 | `autonomy` | `.claude/autonomy/binding.json` | all three, plus an org rung | declared deviation |
 | `standards` (`planning`, `review`) | `<standards_dir>/`, rooted by `.claude/standards.yaml` | all three | precedence inversion ratified via policy-floor class (#649); layer location outside `.claude/` still observed, not ratified |
 | `disk-hygiene` | `.claude/disk-hygiene.json` | user-global + team | declared deviation; no overlay layer |
-| `ai-briefing` | `.claude/ai-briefing/` | team only | undeclared: overlay recommended, never resolved |
+| `ai-briefing` | `.claude/ai-briefing/` | team only | declared deviation; team-only, no local overlay (#3580). Named profile selection (`--profile`, `active_profile`, or `.claude/ai-briefing/<name>/`) is profile selection, not a `*.local.*` cascade layer. `sources.md`, optional `audience.md`, and optional `brand.json` are tracked profile files in the selected directory, not personal overlays |
 | `code-tidying` | `.claude/tidy-lanes/<lane>.md` | team only | declared deviation; no user-global or `*.local.*` overlay (#723). Team layer over a bundled default. A project lane declaring `## Merge semantics` merges per-section with its bundled lane (`Scope` per-section override, watch-for patterns additive — `docs-prose` #701, `shell-tooling` #724). Residual deviation: a project lane that declares nothing still resolves project-only wholesale — the first-match fallback retained in #701 so unmigrated consumer lanes keep working, undeclared at the layer that takes it. Personal variation is limited to lane names the team does not track — an uncommitted `.claude/tidy-lanes/<lane>.md` never added to the index; gitignoring a path the team already tracks does not make it personal |
 | `topic-docs` | `.claude/topic-docs.yaml` | team only | single-layer |
 | `repo-fleet-hygiene` | `.claude/repo-fleet-hygiene.conf` | user-global + team | declared deviation; whole-file precedence (explicit `--config` > team > user-global fallback), no per-key merge, no overlay layer (#1099) |
@@ -302,14 +306,18 @@ sweep — and each migration updates its own row in the same change.
 
 ### Overlay spelling drift
 
-Every setup surface now recommends (or, for `source-control`, appends) the
-recursive line above. The narrow spellings the fleet used to ship — `.claude/*.local.*`,
-`.claude/ecosystems/*.local.*`, `.claude/autonomy/**/*.local.*` — were each narrowly correct for
-their own surface but collectively defeated the one-line promise: a consumer running three plugins
-was asked for three lines, and the non-recursive spellings would silently miss a nested overlay if
-their surface ever grew a folder. Two deliberate exceptions remain: the bare `*.local.md` inside
-the setup-owned `<standards_dir>/.gitignore` (a dedicated ignore file scoped to the standards
-root, not the consumer's `.gitignore`), and `work-items`' repo-root
-`.work-item-tracker.local.json` line (ADR 0015; outside `.claude/` entirely). This contract does
-not retroactively rewrite narrow lines already written into consumer repositories — the recursive
-line simply supersedes them where both exist.
+Every setup surface that owns a `*.local.*` overlay now recommends (or, for
+`source-control`, appends) the recursive line above. The narrow spellings the
+fleet used to ship — `.claude/*.local.*`, `.claude/ecosystems/*.local.*`,
+`.claude/autonomy/**/*.local.*` — were each narrowly correct for their own
+surface but collectively defeated the one-line promise: a consumer running
+three plugins was asked for three lines, and the non-recursive spellings
+would silently miss a nested overlay if their surface ever grew a folder.
+Three deliberate exceptions remain: the bare `*.local.md` inside the
+setup-owned `<standards_dir>/.gitignore` (a dedicated ignore file scoped to
+the standards root, not the consumer's `.gitignore`); `work-items`' repo-root
+`.work-item-tracker.local.json` line (ADR 0015; outside `.claude/` entirely);
+and `ai-briefing`, which is team-only and recommends no overlay line at all
+(#3580). This contract does not retroactively rewrite narrow lines already
+written into consumer repositories — the recursive line simply supersedes
+them where both exist.

--- a/plugins/ai-briefing/.claude-plugin/plugin.json
+++ b/plugins/ai-briefing/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "ai-briefing",
-  "version": "0.7.18",
+  "version": "0.7.19",
   "description": "Build source-backed AI-industry briefings from official vendor publications, configured RSS/Atom feeds, GitHub releases, reputable secondary reporting, and user-supplied URLs. Deduplicate, rank, and present results as markdown or optional HTML/PPTX decks, with repository-owned profile, audience, and brand configuration. Automated X/Twitter collection is disabled; Playwright is used only for deterministic local rendering.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/ai-briefing/CHANGELOG.md
+++ b/plugins/ai-briefing/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to the `ai-briefing` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.7.19]
+
+### Fixed
+
+- **Stop advertising a phantom `*.local.*` overlay (#3580).** Setup no longer recommends
+  `.claude/ai-briefing/**/*.local.*` (and does not switch that recommendation to the
+  recursive `.claude/**/*.local.*` line). `sources.md`, `audience.md`, and `brand.json`
+  are team-tracked profile files. Named profile selection (`--profile` /
+  `active_profile` / `.claude/ai-briefing/<name>/`) is not a config-cascade overlay
+  layer. This surface is team-only; there is no local overlay to gitignore or resolve.
+
 ## [0.7.18]
 
 ### Changed

--- a/plugins/ai-briefing/README.md
+++ b/plugins/ai-briefing/README.md
@@ -58,14 +58,16 @@ deterministic PDF generation and layout validation; it is not a collection provi
 ## Profiles and configuration
 
 Files at `.claude/ai-briefing/` form the default profile. Each
-`.claude/ai-briefing/<name>/` directory is a named overlay containing:
+`.claude/ai-briefing/<name>/` directory is a named profile containing:
 
 - `sources.md` for approved source URLs and feeds;
 - optional `audience.md` for impact ranking;
 - optional declarative `brand.json` and local assets for presentation branding.
 
-Select a profile through the `active_profile` plugin option or a per-run
-`--profile <name>` argument. The per-run argument wins. Claude Code renders the configured
+These are team-tracked profile files, not a gitignored `*.local.*` cascade
+overlay. Selecting a named profile is profile selection, not cascade-layer
+resolution. Select a profile through the `active_profile` plugin option or a
+per-run `--profile <name>` argument. The per-run argument wins. Claude Code renders the configured
 option into the skill; the skill then explicitly sets `AI_BRIEFING_PROFILE` on each launched
 build process. Users do not need to export an environment variable globally.
 Profile names must be portable 1-63 character lowercase-kebab slugs (for example,

--- a/plugins/ai-briefing/skills/generate/SKILL.md
+++ b/plugins/ai-briefing/skills/generate/SKILL.md
@@ -58,8 +58,9 @@ Actions:
 ## Profile resolution
 
 Files at `.claude/ai-briefing/` form the default profile. Each
-`.claude/ai-briefing/<name>/` directory is a named profile overlay. Resolve the active
-profile in this order:
+`.claude/ai-briefing/<name>/` directory is a named profile. Selecting a named
+profile is profile selection, not resolution of a `*.local.*` cascade layer.
+Resolve the active profile in this order:
 
 1. `--profile <name>` for this invocation.
 2. The rendered `${user_config.active_profile}` value when it is non-empty.
@@ -77,13 +78,14 @@ AI_BRIEFING_PROFILE="$PROFILE" node "${CLAUDE_PLUGIN_DATA}/runtime/build/run.js"
 
 Never ask the consumer to export the variable globally.
 
-A profile may contain:
+A profile may contain these team-tracked files. They are not a `*.local.*`
+cascade overlay:
 
 | Artifact | Purpose |
 |---|---|
 | `sources.md` | Approved RSS/Atom feeds, official release pages, GitHub repositories, and user-supplied URLs. |
 | `audience.md` | Optional stack/audience lens for impact annotations. |
-| `brand.json` | Optional declarative deck brand overlay. |
+| `brand.json` | Optional declarative deck brand file. |
 
 ## Default run
 

--- a/plugins/ai-briefing/skills/generate/output/build/lib/paths.js
+++ b/plugins/ai-briefing/skills/generate/output/build/lib/paths.js
@@ -41,8 +41,9 @@ export function activeProfile() {
 }
 
 // Tracked per-profile config directory under the consumer's project — the home
-// of the profile's brand.json overlay + logo assets. The default profile lives at
-// the folder root; a named profile overlays it in a subfolder. Mirrors
+// of the profile's brand.json + logo assets. The default profile lives at
+// the folder root; a named profile is a subdirectory of that folder, selected
+// by name. That is profile selection, not a `*.local.*` cascade layer. Mirrors
 // scripts/lib/paths.js configDir() so the build resolves the same config seam.
 export function configDir(profile = activeProfile()) {
   const safeProfile = validateProfileName(profile);

--- a/plugins/ai-briefing/skills/generate/references/audience-defaults.md
+++ b/plugins/ai-briefing/skills/generate/references/audience-defaults.md
@@ -3,7 +3,7 @@
 The engine's **default** audience framing, pragmatic-use ranking lens, and apolitical
 filter. Loaded by S4 categorize (ranking) and Step 4.5 enrichment (impact tag). These
 are documented, **overridable** defaults: a consumer profile can refine or replace them
-(a profile's `audience.md` in `.claude/ai-briefing/[<profile>/]` overlays this file).
+(a profile's `audience.md` in `.claude/ai-briefing/[<profile>/]` may refine this file).
 
 ## Pragmatic-use filter (ranking lens)
 

--- a/plugins/ai-briefing/skills/generate/references/slide-generation.md
+++ b/plugins/ai-briefing/skills/generate/references/slide-generation.md
@@ -2,7 +2,7 @@
 
 This file documents how to generate presentation slides from ai-briefing output.
 
-**Canonical pipeline = in-tree `output/build/*.js`** (Node ESM, pptxgenjs + playwright direct). Reproduces the deck deterministically from the active brand (default neutral tokens in `output/build/brand.js`, or a declarative profile `brand.json` overlay). Build commands, the `slides-data.js` schema, slide types, and prerequisites: see `references/build-pipeline.md`.
+**Canonical pipeline = in-tree `output/build/*.js`** (Node ESM, pptxgenjs + playwright direct). Reproduces the deck deterministically from the active brand (default neutral tokens in `output/build/brand.js`, or a declarative profile `brand.json`). Build commands, the `slides-data.js` schema, slide types, and prerequisites: see `references/build-pipeline.md`.
 
 The `/document-skills:pptx` skill stack is documented as a **fallback path** at the bottom of this file — only used when the in-tree pipeline cannot run.
 

--- a/plugins/ai-briefing/skills/setup/SKILL.md
+++ b/plugins/ai-briefing/skills/setup/SKILL.md
@@ -33,7 +33,8 @@ prompt when the action and profile are given.
 ## Profile contents
 
 Files at `.claude/ai-briefing/` form the default profile. Each
-`.claude/ai-briefing/<name>/` directory is a named profile overlay.
+`.claude/ai-briefing/<name>/` directory is a named profile. Selecting a named
+profile is profile selection, not resolution of a `*.local.*` cascade layer.
 
 | Artifact | Purpose |
 |---|---|
@@ -77,7 +78,7 @@ anything.
      touching stored config.
 2. **`sources.md`.** FAIL if the resolved profile has no `sources.md`: `/ai-briefing:generate`
    has no authorized sources to collect from. Remediation: `apply`.
-3. **Optional overlays.** INFO: report whether `audience.md` and declarative `brand.json`
+3. **Optional profile files.** INFO: report whether `audience.md` and declarative `brand.json`
    exist; their absence is expected and never a FAIL.
 4. **Build toolchain.** INFO unless the consumer intends `--format html`/`--format slides`.
    Report whether the locked runtime at `${CLAUDE_PLUGIN_DATA}/runtime/build` exists and its
@@ -102,10 +103,10 @@ nothing and reports "already configured".
    existing file unchanged. Do not seed X handles, navigate X, scrape following graphs, or
    install an X API provider. Note the current X access restriction and link the
    authoritative terms: <https://x.com/en/tos>.
-2. **Offer optional overlays.** Offer `audience.md` and declarative `brand.json`, creating only
-   the files the consumer requests. Keep local logo assets beside `brand.json`. Recommend the
-   recursive `.claude/**/*.local.*` ignore line for personal overlays while keeping shared
-   profile files tracked.
+2. **Offer optional profile files.** Offer `audience.md` and declarative `brand.json`, creating only
+   the files the consumer requests. Keep local logo assets beside `brand.json`. These files are
+   team-tracked in the selected profile directory. This surface has no gitignored `*.local.*`
+   overlay.
 3. **`apply install-build-deps` installs the optional build toolchain.** Parse the subaction
    before invoking a shell and never interpolate raw arguments into a command. Without it,
    skip this step and change no existing runtime. With it, build and validate a temporary
@@ -190,7 +191,7 @@ nothing and reports "already configured".
    Never claim the toolchain is ready on the swap's exit code alone.
 
 4. **Confirm.** Report the profile path, whether `sources.md` was created or preserved, which
-   optional overlays were created, and whether build dependencies were installed or
+   optional profile files were created, and whether build dependencies were installed or
    intentionally skipped. Point the consumer to `/ai-briefing:generate`.
 
 ## This skill does not

--- a/plugins/ai-briefing/skills/setup/evals/evals.json
+++ b/plugins/ai-briefing/skills/setup/evals/evals.json
@@ -18,12 +18,13 @@
       "id": 2,
       "name": "optional-branding-and-lens-skipped-cleanly",
       "prompt": "/ai-briefing:setup",
-      "expected_output": "Offers declarative brand.json and audience.md as optional profile overlays, creates only accepted files, and leaves the neutral defaults intact when declined.",
+      "expected_output": "Offers declarative brand.json and audience.md as optional profile files, creates only accepted files, and leaves the neutral defaults intact when declined. Does not recommend a .claude/ai-briefing/**/*.local.* gitignore line or any *.local.* overlay.",
       "files": [],
       "expectations": [
         "Offers brand.json and audience.md rather than forcing them",
-        "Writes accepted overlays only to the tracked profile directory",
-        "Skips declined overlays without writing machine-local configuration"
+        "Writes accepted optional files only to the tracked profile directory",
+        "Skips declined optional files without writing machine-local configuration",
+        "Does not recommend a .claude/ai-briefing/**/*.local.* gitignore line or any *.local.* overlay"
       ]
     },
     {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #3580

## Summary

`/ai-briefing:setup` recommended `.claude/ai-briefing/**/*.local.*` for personal overlays, but no read path resolves a `.local.*` file. This stops advertising the phantom layer and records the surface as team-only.

## Fix

- Remove the setup gitignore recommendation for `.claude/ai-briefing/**/*.local.*`.
- Call `sources.md`, `audience.md`, and `brand.json` profile files rather than personal overlays.
- Clarify that named profile selection is not a `*.local.*` cascade layer.
- Update `docs/conventions/config-cascade/README.md` to declare `ai-briefing` team-only, no local overlay.
- Bump `ai-briefing` to 0.7.18.

## Verification

Covering suites passed (`validate-plugin-contracts`, changelog parity, changed-skills). `plugins/ai-briefing/skills/generate/scripts/run-tests.sh all`: 41/41.

## Related

Layering contract: `docs/conventions/config-cascade/README.md`. Official docs: [The `.claude` directory](https://code.claude.com/docs/en/claude-directory.md).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7ffb619a-6ebb-4d47-9c45-d68e846edf93?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7ffb619a-6ebb-4d47-9c45-d68e846edf93&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

