### PR TITLE
fix(docs-hygiene): count path-ref occurrences and accept repo-relative rules

### DIFF
--- a/plugins/docs-hygiene/.claude-plugin/plugin.json
+++ b/plugins/docs-hygiene/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "docs-hygiene",
-  "version": "0.21.31",
+  "version": "0.21.32",
   "description": "Documentation-hygiene toolkit: compress (flavor-trim markdown with a semantic-diff safety net), audit-noise (classify markdown noise), extract-ssot (deduplicate repeated content into a single source of truth), audit-encapsulation (detect citations into skill-private surfaces), rename-references (sweep stale references after renames), audit-derivability (classify whether a whole document earns its existence \u2014 could a fresh agent re-derive it from the code?), audit-progressive-disclosure (grade instruction files against a load-tier model for split opportunities and hub/spoke disclosure defects), write-for-agents (authoring-time doctrine that fires while agent-consumed markdown is being written), and write-for-humans (the same moment for the other reader \u2014 end-user READMEs, RFCs, release notes and guides \u2014 resolving the consuming project's own style guide first).",
   "author": {
     "name": "Melodic Software",

--- a/plugins/docs-hygiene/CHANGELOG.md
+++ b/plugins/docs-hygiene/CHANGELOG.md
@@ -7,10 +7,13 @@
 - **`compress` `audit-scan.sh` counts path-reference occurrences, not lines.** `grep -Eoc`
   made `path_hits` a line count while the `path_dens > 8` threshold and the "cross-ref
   density %s/kw" label assume occurrences, so two refs on one line under-counted. It now
-  uses `grep -Eo | wc -l`, matching the flavor-token counter.
+  uses `grep -Eo | wc -l`, matching the flavor-token counter. An `@`-prefixed path
+  (`@docs/a.md`) is one hit: the longer `@…ext` alternative is tried before a bare `@`.
 - **Signal 1 accepts a repo-relative `.claude/rules/` path.** The matcher required a
   literal `/` before `.claude/rules/`, so a target spelled from the repo root skipped
-  signal 1 and fell through to flavor density.
+  signal 1 and fell through to flavor density. The contract test invokes the scanner
+  from the fixture directory with `.claude/rules/example.md`, not an absolute
+  `mktemp` path that already matched the old glob.
 
 ## [0.21.31]
 

--- a/plugins/docs-hygiene/CHANGELOG.md
+++ b/plugins/docs-hygiene/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog — docs-hygiene plugin
 
+## [0.21.32]
+
+### Fixed
+
+- **`compress` `audit-scan.sh` counts path-reference occurrences, not lines.** `grep -Eoc`
+  made `path_hits` a line count while the `path_dens > 8` threshold and the "cross-ref
+  density %s/kw" label assume occurrences, so two refs on one line under-counted. It now
+  uses `grep -Eo | wc -l`, matching the flavor-token counter.
+- **Signal 1 accepts a repo-relative `.claude/rules/` path.** The matcher required a
+  literal `/` before `.claude/rules/`, so a target spelled from the repo root skipped
+  signal 1 and fell through to flavor density.
+
 ## [0.21.31]
 
 ### Changed

--- a/plugins/docs-hygiene/skills/compress/scripts/audit-scan.sh
+++ b/plugins/docs-hygiene/skills/compress/scripts/audit-scan.sh
@@ -94,7 +94,9 @@ classify_file() {
   # Occurrence count, not line count: -c reports lines, so two refs on one
   # line under-counted against the "/kw" density label and the path_dens > 8
   # threshold (#3441). Same shape as flavor_hits below.
-  path_hits=$(grep -Eo '(@|[a-z][a-z0-9._/-]+\.(md|cs|sh|json|yaml))' "$file" 2>/dev/null | wc -l | tr -d ' ')
+  # Longer @-prefixed alternative first so `@docs/a.md` is one hit, not `@`
+  # plus `docs/a.md`.
+  path_hits=$(grep -Eo '(@[a-z][a-z0-9._/-]+\.(md|cs|sh|json|yaml)|@[A-Za-z0-9._/-]+|[a-z][a-z0-9._/-]+\.(md|cs|sh|json|yaml))' "$file" 2>/dev/null | wc -l | tr -d ' ')
   path_hits=${path_hits:-0}
   flavor_hits=$(grep -oiwE "$FLAVOR_RE" "$file" 2>/dev/null | wc -l | tr -d ' ')
 

--- a/plugins/docs-hygiene/skills/compress/scripts/audit-scan.sh
+++ b/plugins/docs-hygiene/skills/compress/scripts/audit-scan.sh
@@ -49,7 +49,10 @@ FLAVOR_RE='just|really|basically|actually|simply|perhaps|somewhat|very|quite|mig
 is_signal1_path() {
   local f="$1" base
   base="$(basename "$f")"
-  [[ "$f" == *'/.claude/rules/'* ]] && return 0
+  # Repo-relative `.claude/rules/...` has no leading slash; the old
+  # `*/.claude/rules/` glob only matched an absolute or nested path (#3441).
+  [[ "$f" == '.claude/rules' || "$f" == '.claude/rules/'* ||
+    "$f" == *'/.claude/rules' || "$f" == *'/.claude/rules/'* ]] && return 0
   [[ "$base" == 'AGENTS.md' || "$base" == 'CLAUDE.md' || "$base" == 'SKILL.md' ]] && return 0
   return 1
 }
@@ -88,8 +91,11 @@ classify_file() {
 
   tick_pairs=$(grep -o '`' "$file" 2>/dev/null | wc -l | tr -d ' ')
   tick_pairs=$((tick_pairs / 2))
-  path_hits=$(grep -Eoc '(@|[a-z][a-z0-9._/-]+\.(md|cs|sh|json|yaml))' "$file" 2>/dev/null || echo 0)
-  path_hits=${path_hits//$'\n'/}
+  # Occurrence count, not line count: -c reports lines, so two refs on one
+  # line under-counted against the "/kw" density label and the path_dens > 8
+  # threshold (#3441). Same shape as flavor_hits below.
+  path_hits=$(grep -Eo '(@|[a-z][a-z0-9._/-]+\.(md|cs|sh|json|yaml))' "$file" 2>/dev/null | wc -l | tr -d ' ')
+  path_hits=${path_hits:-0}
   flavor_hits=$(grep -oiwE "$FLAVOR_RE" "$file" 2>/dev/null | wc -l | tr -d ' ')
 
   local tick_dens path_dens flavor_dens

--- a/plugins/docs-hygiene/skills/compress/scripts/audit-scan.test.sh
+++ b/plugins/docs-hygiene/skills/compress/scripts/audit-scan.test.sh
@@ -29,6 +29,40 @@ case "$out3" in
 *) fail "lean fixture classifies SKIP (got: $out3)" ;;
 esac
 
+# Repo-relative .claude/rules path is signal 1 (no leading slash).
+RULES_REL="$(mktemp -d)"
+mkdir -p "$RULES_REL/.claude/rules"
+printf '# rule\n\njust really basically actually simply perhaps somewhat very quite might note that keep in mind\n' >"$RULES_REL/.claude/rules/example.md"
+# Enough flavor tokens that a missed signal-1 would fall through to COMPRESS
+# rather than SKIP. Word-count floor is 50.
+out4="$(bash "$SCAN" "$RULES_REL/.claude/rules/example.md" 2>/dev/null)" || true
+case "$out4" in
+*'author-time-disciplined path (signal 1)'*) ok "repo-relative .claude/rules classifies as signal 1" ;;
+*) fail "repo-relative .claude/rules should be signal 1 (got: $out4)" ;;
+esac
+rm -rf "$RULES_REL"
+
+# Two path-shaped tokens on one line count as two occurrences, not one line.
+OCC="$(mktemp)"
+# 50+ words so the density floor does not rewrite the count; two .md refs on
+# one line; enough flavor tokens to escape the flavor-density SKIP.
+{
+  printf 'see docs/a.md and docs/b.md on one line. '
+  printf 'just really basically actually simply perhaps somewhat very quite might '
+  printf 'in order to due to the fact that make use of it is important to note that keep in mind '
+  printf 'word word word word word word word word word word word word word word word '
+  printf 'word word word word word word word word word word word word word word word\n'
+} >"$OCC"
+# Isolated occurrence counter: same regex the scanner uses.
+occ_count=$(grep -Eo '(@|[a-z][a-z0-9._/-]+\.(md|cs|sh|json|yaml))' "$OCC" | wc -l | tr -d ' ')
+line_count=$(grep -Ec '(@|[a-z][a-z0-9._/-]+\.(md|cs|sh|json|yaml))' "$OCC" | tr -d ' ')
+if [[ "$occ_count" -gt "$line_count" ]]; then
+  ok "path-hit regex counts occurrences ($occ_count) above line hits ($line_count)"
+else
+  fail "expected occurrence count > line count (occ=$occ_count line=$line_count)"
+fi
+rm -f "$OCC"
+
 if [[ $FAIL -ne 0 ]]; then
   echo "$FAIL check(s) failed." >&2
   exit 1

--- a/plugins/docs-hygiene/skills/compress/scripts/audit-scan.test.sh
+++ b/plugins/docs-hygiene/skills/compress/scripts/audit-scan.test.sh
@@ -29,39 +29,65 @@ case "$out3" in
 *) fail "lean fixture classifies SKIP (got: $out3)" ;;
 esac
 
-# Repo-relative .claude/rules path is signal 1 (no leading slash).
+# Repo-relative .claude/rules path is signal 1 (no leading slash). mktemp -d
+# is already absolute, so invoking the scanner with that path would match the
+# old `*/.claude/rules/` glob and never exercise the repo-relative arm. Run
+# from the temp dir with the relative argument the matcher is supposed to see.
 RULES_REL="$(mktemp -d)"
 mkdir -p "$RULES_REL/.claude/rules"
 printf '# rule\n\njust really basically actually simply perhaps somewhat very quite might note that keep in mind\n' >"$RULES_REL/.claude/rules/example.md"
 # Enough flavor tokens that a missed signal-1 would fall through to COMPRESS
 # rather than SKIP. Word-count floor is 50.
-out4="$(bash "$SCAN" "$RULES_REL/.claude/rules/example.md" 2>/dev/null)" || true
+out4="$(
+  cd "$RULES_REL" || exit 1
+  bash "$SCAN" .claude/rules/example.md 2>/dev/null
+)" || true
 case "$out4" in
 *'author-time-disciplined path (signal 1)'*) ok "repo-relative .claude/rules classifies as signal 1" ;;
 *) fail "repo-relative .claude/rules should be signal 1 (got: $out4)" ;;
 esac
 rm -rf "$RULES_REL"
 
-# Two path-shaped tokens on one line count as two occurrences, not one line.
-OCC="$(mktemp)"
-# 50+ words so the density floor does not rewrite the count; two .md refs on
-# one line; enough flavor tokens to escape the flavor-density SKIP.
+# Five path refs on one line, ~500 words: line-count density is 1*1000/500 = 2
+# (COMPRESS), occurrence density is 5*1000/500 = 10 > 8 (UNCERTAIN). Flavor
+# tokens keep the file out of the flavor-density SKIP. The scanner itself must
+# classify — a regex-only check never exercises path_dens.
+OCC="$(mktemp -d)"
 {
-  printf 'see docs/a.md and docs/b.md on one line. '
-  printf 'just really basically actually simply perhaps somewhat very quite might '
-  printf 'in order to due to the fact that make use of it is important to note that keep in mind '
-  printf 'word word word word word word word word word word word word word word word '
-  printf 'word word word word word word word word word word word word word word word\n'
-} >"$OCC"
-# Isolated occurrence counter: same regex the scanner uses.
-occ_count=$(grep -Eo '(@|[a-z][a-z0-9._/-]+\.(md|cs|sh|json|yaml))' "$OCC" | wc -l | tr -d ' ')
-line_count=$(grep -Ec '(@|[a-z][a-z0-9._/-]+\.(md|cs|sh|json|yaml))' "$OCC" | tr -d ' ')
-if [[ "$occ_count" -gt "$line_count" ]]; then
-  ok "path-hit regex counts occurrences ($occ_count) above line hits ($line_count)"
-else
-  fail "expected occurrence count > line count (occ=$occ_count line=$line_count)"
-fi
-rm -f "$OCC"
+  printf 'see docs/a.md and docs/b.md and docs/c.md and docs/d.md and docs/e.md. '
+  printf 'just really basically '
+  i=0
+  while [[ $i -lt 480 ]]; do
+    printf 'word '
+    i=$((i + 1))
+  done
+  printf '\n'
+} >"$OCC/occ.md"
+out_occ="$(bash "$SCAN" "$OCC/occ.md" 2>/dev/null)" || true
+case "$out_occ" in
+*'| UNCERTAIN |'*'cross-ref density'*) ok "one-line path refs classify UNCERTAIN by occurrence density" ;;
+*) fail "one-line path refs should classify UNCERTAIN (got: $out_occ)" ;;
+esac
+rm -rf "$OCC"
+
+# `@docs/a.md` is one occurrence. The old `(@|path.ext)` regex emitted `@` and
+# `docs/a.md`, doubling density over the 8/kw threshold at ~200 words.
+AT="$(mktemp -d)"
+{
+  printf 'see @docs/a.md on one line. just really '
+  i=0
+  while [[ $i -lt 200 ]]; do
+    printf 'word '
+    i=$((i + 1))
+  done
+  printf '\n'
+} >"$AT/at.md"
+out_at="$(bash "$SCAN" "$AT/at.md" 2>/dev/null)" || true
+case "$out_at" in
+*'| COMPRESS |'*) ok "@-prefixed path ref counts as one occurrence (COMPRESS)" ;;
+*) fail "@-prefixed path ref should classify COMPRESS, not double-count (got: $out_at)" ;;
+esac
+rm -rf "$AT"
 
 if [[ $FAIL -ne 0 ]]; then
   echo "$FAIL check(s) failed." >&2


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #3441

## Summary

`audit-scan.sh` counted path-reference *lines* while its density threshold and label assume *occurrences*, and signal 1 missed a repo-relative `.claude/rules/` target.

## Fix

Count with `grep -Eo | wc -l` (same shape as the flavor-token counter). Accept `.claude/rules` and `.claude/rules/...` without a leading slash. docs-hygiene 0.21.32.

## Verification

`scripts/affected-tests.sh --run`: `audit-scan.test.sh` passed, including repo-relative signal 1 and occurrence-count > line-count (2 vs 1).

## Related

N/A
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7ffb619a-6ebb-4d47-9c45-d68e846edf93?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7ffb619a-6ebb-4d47-9c45-d68e846edf93&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

