### PR TITLE
fix(knowledge): drain analyze-harvested-repos stdout via process.exitCode

### DIFF
--- a/plugins/knowledge/.claude-plugin/plugin.json
+++ b/plugins/knowledge/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "knowledge",
-  "version": "0.13.32",
+  "version": "0.13.33",
   "description": "Ingest external knowledge into durable, synthesized artifacts. Ships a book-distillation pipeline (PDF/EPUB into concept-organized, author-attributed skill reference files), a video-digest pipeline (watch a single public video from YouTube or X, formerly Twitter: transcript, link harvest, and repo-applicability synthesis), a course-digest pipeline (extract and synthesize online video courses \u2014 Dometrain, Teachable \u2014 into repo-applicable recommendations), a docpage-digest pipeline (single online documentation page into a verified knowledge slice with dual verification \u2014 one cross-vendor verifier \u2014 and an interview handoff), and a map-corpus pipeline (multi-resource corpus into a classified link map, deterministic node manifests, gate-verified relevance inventory, and an approved queue of docpage-digest runs), plus a re-runnable setup action; a configurable library directory governs where synthesized artifacts land in the consuming repo.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/knowledge/CHANGELOG.md
+++ b/plugins/knowledge/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to the `knowledge` plugin are recorded here. The `version` i
 `.claude-plugin/plugin.json` is the delivery vehicle — a consumer receives a change
 only after that version increases.
 
+## [0.13.33]
+
+### Fixed
+
+- **`analyze-harvested-repos.js` lets stdout drain before exit.** The CLI called
+  `process.exit(code)` immediately after an async `writeStdout`, which can truncate a
+  piped report (especially on Windows). It now sets `process.exitCode` and returns, matching
+  the other video-digest CLIs.
+
 ## [0.13.32]
 
 ### Fixed

--- a/plugins/knowledge/skills/video-digest/extraction/harvesting/analyze-harvested-repos.js
+++ b/plugins/knowledge/skills/video-digest/extraction/harvesting/analyze-harvested-repos.js
@@ -153,9 +153,11 @@ export async function runAnalyzeHarvestedReposCli(argv) {
 
 if (isMainModule(import.meta.url)) {
   runAnalyzeHarvestedReposCli(process.argv)
-    .then((code) => process.exit(code))
+    .then((code) => {
+      process.exitCode = code;
+    })
     .catch((err) => {
       writeStderr(err instanceof Error ? err.message : String(err));
-      process.exit(1);
+      process.exitCode = 1;
     });
 }

--- a/plugins/knowledge/skills/video-digest/extraction/harvesting/analyze-harvested-repos.test.js
+++ b/plugins/knowledge/skills/video-digest/extraction/harvesting/analyze-harvested-repos.test.js
@@ -101,3 +101,14 @@ describe("analyzeHarvestedRepos clone target", () => {
     expect(clonedUrls).toEqual(["https://github.com/melodic-software/medley"]);
   });
 });
+
+describe("CLI exit handling", () => {
+  it("sets process.exitCode instead of calling process.exit after the stdout write", () => {
+    const src = fs.readFileSync(
+      new URL("./analyze-harvested-repos.js", import.meta.url),
+      "utf8",
+    );
+    expect(src).not.toMatch(/process\.exit\(/);
+    expect(src).toMatch(/process\.exitCode = code/);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #3434

## Summary

The analyze-harvested-repos CLI called `process.exit` immediately after an async stdout write, which can truncate a piped report.

## Fix

Set `process.exitCode` and return, matching the other video-digest CLIs. knowledge 0.13.33.

## Verification

`scripts/affected-tests.sh --run` selected the vitest suite (`NOT RUN` from the shell runner, exit 3). `npx vitest run harvesting/analyze-harvested-repos.test.js`: 6 passed, including the exitCode source pin.

## Related

N/A
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7ffb619a-6ebb-4d47-9c45-d68e846edf93?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7ffb619a-6ebb-4d47-9c45-d68e846edf93&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

