### PR TITLE
fix(scripts): derive usage() header ranges instead of hardcoded sed

### DIFF
--- a/plugins/songwriting/.claude-plugin/plugin.json
+++ b/plugins/songwriting/.claude-plugin/plugin.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "songwriting",
-  "version": "1.4.19",
-  "description": "Songwriting craft companion — nine concern-scoped lyric-craft skills (workflow router, rhyme, object-writing, metaphor, meter-prosody, song-form, co-write, diagnose, practice) applying Pat Pattison's methods, with an object-writing agent that performs the sensory exercise itself and per-skill emission boundaries that route generation to the skill that owns it, plus Suno v5.5 prompt engineering (style prompts, tagged lyrics, genre templates, troubleshooting).",
+  "version": "1.4.20",
+  "description": "Songwriting craft companion \u2014 nine concern-scoped lyric-craft skills (workflow router, rhyme, object-writing, metaphor, meter-prosody, song-form, co-write, diagnose, practice) applying Pat Pattison's methods, with an object-writing agent that performs the sensory exercise itself and per-skill emission boundaries that route generation to the skill that owns it, plus Suno v5.5 prompt engineering (style prompts, tagged lyrics, genre templates, troubleshooting).",
   "author": {
     "name": "Melodic Software",
     "email": "info@melodicsoftware.com"

--- a/plugins/songwriting/CHANGELOG.md
+++ b/plugins/songwriting/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to the `songwriting` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [1.4.20]
+
+### Fixed
+
+- **`datamuse.sh --help` prints the whole header, including the Examples block.** `usage()`
+  extracted `sed -n '2,28p'`, so the five example lines that landed on 29-33 never appeared.
+  It now derives the header the same way `babysit-readiness-gate.sh` does (awk to the first
+  non-comment line). `--help` / `-h` exit 0 with that block.
+
 ## [1.4.19]
 
 ### Changed

--- a/plugins/songwriting/context/pat-pattison/scripts/datamuse.sh
+++ b/plugins/songwriting/context/pat-pattison/scripts/datamuse.sh
@@ -39,10 +39,21 @@ MODE="${1:-}"
 shift || true
 ARG="${*:-}"
 
-usage() { sed -n '2,28p' "$0" >&2; }
+# Print the header block (shebang to first non-comment line). Derived rather
+# than a hardcoded sed range, which dropped the Examples lines as the header
+# grew (#3424).
+usage() {
+  awk 'NR == 1 { next } /^#/ { sub(/^# ?/, ""); print; next } { exit }' \
+    "${BASH_SOURCE[0]}" >&2
+}
 
 # jq: emit each result as TSV (word, score, numSyllables, tags).
 emit_tsv() { jq -r '.[] | [.word, (.score // 0), (.numSyllables // 0), ((.tags // []) | join(","))] | @tsv'; }
+
+if [[ "$MODE" == "-h" || "$MODE" == "--help" ]]; then
+  usage
+  exit 0
+fi
 
 if [[ -z "$MODE" || -z "$ARG" ]]; then
   usage

--- a/plugins/songwriting/context/pat-pattison/scripts/datamuse.test.sh
+++ b/plugins/songwriting/context/pat-pattison/scripts/datamuse.test.sh
@@ -184,13 +184,14 @@ assert_contains "usage banner documents the LIMIT override" "$ERR" "LIMIT=<n>"
 assert_contains "usage banner reaches the Examples block" "$ERR" "datamuse.sh rhyme lonely"
 assert_contains "usage banner includes the LIMIT=50 example" "$ERR" "LIMIT=50 datamuse.sh near grief"
 assert_eq "no arguments issues no request" "0" "$(request_count)"
+assert_eq "no arguments writes nothing to stdout" "" "$OUT"
 
 reset_stub
 run_datamuse --help
 assert_eq "--help -> exit 0" "0" "$RC"
 assert_contains "--help reaches the Examples block" "$ERR" "datamuse.sh rhyme lonely"
 assert_eq "--help issues no request" "0" "$(request_count)"
-assert_eq "no arguments writes nothing to stdout" "" "$OUT"
+assert_eq "--help writes nothing to stdout" "" "$OUT"
 
 reset_stub
 run_datamuse rhyme

--- a/plugins/songwriting/context/pat-pattison/scripts/datamuse.test.sh
+++ b/plugins/songwriting/context/pat-pattison/scripts/datamuse.test.sh
@@ -181,7 +181,15 @@ assert_contains "usage banner names the API" "$ERR" "https://www.datamuse.com/ap
 # Narrowing the range drops one or both.
 assert_contains "usage banner reaches the last mode listed" "$ERR" "datamuse.sh family"
 assert_contains "usage banner documents the LIMIT override" "$ERR" "LIMIT=<n>"
+assert_contains "usage banner reaches the Examples block" "$ERR" "datamuse.sh rhyme lonely"
+assert_contains "usage banner includes the LIMIT=50 example" "$ERR" "LIMIT=50 datamuse.sh near grief"
 assert_eq "no arguments issues no request" "0" "$(request_count)"
+
+reset_stub
+run_datamuse --help
+assert_eq "--help -> exit 0" "0" "$RC"
+assert_contains "--help reaches the Examples block" "$ERR" "datamuse.sh rhyme lonely"
+assert_eq "--help issues no request" "0" "$(request_count)"
 assert_eq "no arguments writes nothing to stdout" "" "$OUT"
 
 reset_stub

--- a/scripts/affected-tests.sh
+++ b/scripts/affected-tests.sh
@@ -237,8 +237,12 @@ STRUCTURAL_BASENAMES="README.md SKILL.md AGENTS.md CLAUDE.md CHANGELOG.md
 plugin.json marketplace.json settings.json hooks.json package.json
 package-lock.json index.md LICENSE"
 
+# Print the header block (everything after the shebang up to the first
+# non-comment line) with its comment markers stripped. Derived rather than a
+# hardcoded line range, which silently truncated as the header grew.
 usage() {
-  sed -n '2,30p' "$0" | sed 's/^# \{0,1\}//'
+  awk 'NR == 1 { next } /^#/ { sub(/^# ?/, ""); print; next } { exit }' \
+    "${BASH_SOURCE[0]}"
 }
 
 base_ref=""

--- a/scripts/affected-tests.test.sh
+++ b/scripts/affected-tests.test.sh
@@ -1018,4 +1018,15 @@ else
 fi
 rm -rf "$repo3"
 
+# --- --help reaches the actual end of the header -----------------------------
+# usage() used to extract a hardcoded sed range that stopped mid-header as the
+# comment block grew (#3424). Pin a sentence that lives on the last header
+# lines so a drifted range cannot come back unnoticed.
+help_out="$(bash scripts/affected-tests.sh --help)"
+if printf '%s' "$help_out" | grep -q 'Both stages fail loud'; then
+  ok "--help reaches the end of the header (derived usage)"
+else
+  fail "--help truncated before the header's last sentence: $help_out"
+fi
+
 test_harness::report


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #3424

## Summary

`--help` for `scripts/affected-tests.sh` and `datamuse.sh` extracted a hardcoded `sed -n` range that had drifted behind the header, so the printed usage cut off mid-block. The listed babysit scripts already use derived extraction.

## Fix

Replace the hardcoded ranges with the `babysit-readiness-gate.sh` awk (shebang to first non-comment line). `datamuse.sh` also accepts `--help` / `-h` (exit 0). songwriting 1.4.20.

## Verification

`scripts/affected-tests.sh --run` from the worktree: 129 shell suites passed. Exit 3 is the documented `NOT RUN` for 7 selected Python suites. New assertions pin the last header sentence and the datamuse Examples block.

## Related

N/A
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7ffb619a-6ebb-4d47-9c45-d68e846edf93?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7ffb619a-6ebb-4d47-9c45-d68e846edf93&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

