### PR TITLE
fix: guard empty-array expansions under set -u

### DIFF
--- a/plugins/repo-hygiene/.claude-plugin/plugin.json
+++ b/plugins/repo-hygiene/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "repo-hygiene",
-  "version": "0.10.23",
+  "version": "0.10.24",
   "description": "Repo hygiene action-router: /repo-hygiene:clean sweeps reclaimable caches, build artifacts, and stale git metadata, and can realign the working tree to a fresh-pull state — dry-run-first, with destructive tiers gated behind explicit confirmation and a session-scoped destructive-command guard. Ecosystem targets are detected at runtime; secrets, runtime dependencies, and skill data are preserved by default.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/repo-hygiene/CHANGELOG.md
+++ b/plugins/repo-hygiene/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to the `repo-hygiene` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.10.24]
+
+### Fixed
+
+- **`clean`: `git-tree-reset.sh` and `git-tree-reset-batch.sh` no longer expand
+  empty arrays under `set -u`.** `CHILD_PASS` stays empty on a default dry-run,
+  `REPO_KEYS` is empty on the first `key_seen` call, and `PRESERVE_ARGS` is
+  passed through to `git clean`. Bare `"${arr[@]}"` is an unbound-variable abort
+  on bash 4.0-4.3. Those sites now use the house `${arr[@]+"${arr[@]}"}` idiom
+  ([#3425](https://github.com/melodic-software/claude-code-plugins/issues/3425)).
+
 ## [0.10.23]
 
 ### Fixed

--- a/plugins/repo-hygiene/skills/clean/scripts/git-tree-reset-batch.sh
+++ b/plugins/repo-hygiene/skills/clean/scripts/git-tree-reset-batch.sh
@@ -174,11 +174,11 @@ INVALID_REASONS=()
 
 key_seen() {
   local k="$1" e
-  for e in "${REPO_KEYS[@]}"; do [[ "$e" == "$k" ]] && return 0; done
+  for e in ${REPO_KEYS[@]+"${REPO_KEYS[@]}"}; do [[ "$e" == "$k" ]] && return 0; done
   return 1
 }
 
-for input in "${REPO_INPUTS[@]}"; do
+for input in ${REPO_INPUTS[@]+"${REPO_INPUTS[@]}"}; do
   [[ -n "$input" ]] || continue
   if [[ ! -d "$input" ]]; then
     INVALID_INPUTS+=("$input")
@@ -271,7 +271,7 @@ for ((i = 0; i < ${#REPO_TOPS[@]}; i++)); do
 
   # 3. Delegate to the unchanged single-repo tree reset.
   rc=0
-  out="$(cd "$top" && bash "$TREE_RESET" "$([[ "$DRY_RUN" -eq 1 ]] && echo --dry-run || echo --apply)" "${CHILD_PASS[@]}" 2>&1)" || rc=$?
+  out="$(cd "$top" && bash "$TREE_RESET" "$([[ "$DRY_RUN" -eq 1 ]] && echo --dry-run || echo --apply)" ${CHILD_PASS[@]+"${CHILD_PASS[@]}"} 2>&1)" || rc=$?
   case "$rc" in
   0)
     # The child exits 0 for a clean success AND for success-with-signal cases the

--- a/plugins/repo-hygiene/skills/clean/scripts/git-tree-reset-batch.test.sh
+++ b/plugins/repo-hygiene/skills/clean/scripts/git-tree-reset-batch.test.sh
@@ -401,7 +401,15 @@ assert_contains "greedy --repo still enumerates both paths" "$out" "Repos: 2"
 assert_contains "greedy --repo stops at --skip (parsed as a flag, not a path)" "$out" "skip-list"
 assert_not_contains "--skip value 'keepme' was not swallowed as a repo path" "$out" "UnmatchedSkip: keepme"
 
-# --- 25. --repo with no path (immediately at a flag or end of args) is a usage error ---
+# --- 25. empty CHILD_PASS / first-seen REPO_KEYS under set -u must not abort ---
+# Default dry-run passes no --force-default-branch/--include-deps/--include-secrets/
+# --include-dirty, so CHILD_PASS stays (). key_seen also walks REPO_KEYS while it
+# is still empty on the first input. Bare "${arr[@]}" aborts on bash 4.0-4.3.
+out="$(bash "$BATCH" --dry-run --repo "$CLEAN_REPO" 2>&1)" || true
+assert_not_contains "empty CHILD_PASS and REPO_KEYS do not unbound-variable abort" "$out" "unbound variable"
+assert_contains "empty-pass-through dry-run still classifies the repo" "$out" "would-reset"
+
+# --- 26. --repo with no path (immediately at a flag or end of args) is a usage error ---
 # A bare --repo followed by another flag has no path to consume; it must fail loud
 # (exit 2), not silently absorb the following flag as a directory path (the pre-fix
 # single-arg arm did the latter, classifying e.g. `--skip` as a blocked non-directory).

--- a/plugins/repo-hygiene/skills/clean/scripts/git-tree-reset.sh
+++ b/plugins/repo-hygiene/skills/clean/scripts/git-tree-reset.sh
@@ -191,7 +191,7 @@ if [[ "$DRY_RUN" -eq 1 ]]; then
   # Dry-run is inventory-only: never fetch (it would mutate .git remote-tracking
   # refs and can prompt/fail on credentials before the user confirms anything).
   echo "--- clean preview (git clean -fdxn, default-preserve applied) ---"
-  git clean -fdxn "${PRESERVE_ARGS[@]}" 2>/dev/null | head -200 || true
+  git clean -fdxn ${PRESERVE_ARGS[@]+"${PRESERVE_ARGS[@]}"} 2>/dev/null | head -200 || true
   exit 0
 fi
 
@@ -230,7 +230,7 @@ printf 'AppliedReset: git reset --hard %s\n' "$UPSTREAM"
 # fails to remove any path; the expected, non-fatal case is a locked / in-use file
 # (surfaced below as Unremovable). CLEAN_RC must be read on the very next line —
 # before any other command runs — or $? is clobbered.
-CLEAN_STDERR="$(git clean -fdx "${PRESERVE_ARGS[@]}" 2>&1 >/dev/null)"
+CLEAN_STDERR="$(git clean -fdx ${PRESERVE_ARGS[@]+"${PRESERVE_ARGS[@]}"} 2>&1 >/dev/null)"
 CLEAN_RC=$?
 UNREMOVABLE="$(printf '%s\n' "$CLEAN_STDERR" | grep -c 'failed to remove' || true)"
 CLEAN_NON_LOCKED_FAILURE=0

--- a/plugins/repo-hygiene/skills/clean/scripts/git-tree-reset.test.sh
+++ b/plugins/repo-hygiene/skills/clean/scripts/git-tree-reset.test.sh
@@ -65,6 +65,7 @@ assert_contains "dry-run lists upstream" "$out" "Upstream:"
 assert_contains "dry-run plans clean" "$out" "PlannedClean: git clean -fdx"
 assert_contains "dry-run preserves secrets by default" "$out" "PreserveSecrets: yes"
 assert_contains "dry-run preserves deps by default" "$out" "PreserveDeps: yes"
+assert_not_contains "dry-run PRESERVE_ARGS expansion does not unbound-variable abort" "$out" "unbound variable"
 
 # --- 3. default apply preserves secrets + deps, removes plain untracked ---
 echo ignored >"$R/.env"

--- a/plugins/work-items/.claude-plugin/plugin.json
+++ b/plugins/work-items/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "work-items",
-  "version": "0.39.47",
+  "version": "0.39.48",
   "description": "Manages development work items through a provider-neutral tracker seam that ships with the plugin (bundled dispatcher plus github, local-markdown, jira, gitea, and linear adapters; seam plugin-dir canonical, adapters consumer-local-first): dashboard, taxonomy-labeled creation, a race-safe assignee-plus-lease claim protocol, recurring-schedule checks, TODO scanning, stale-lease auditing, plan decomposition into vertical-slice items, a macro-journey router over spec containers (rollup, per-container execution shape, next-step routing), raw-intake triage (issues and unsolicited PRs through raw, verified, briefed, autonomous-eligible states), plus the two work-items loop lanes of the loop-lane convention: a self-paced autonomous work-loop drain (work-class admission gate, adaptive item cap, PR-only) and an attended attend-queue escalation lane. The re-runnable setup skill binds the provider (.work-item-tracker.json), seeds the recurring-schedule seam (.github/recurring-schedule.json), and remaps canonical role labels.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/work-items/CHANGELOG.md
+++ b/plugins/work-items/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to the `work-items` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.39.48]
+
+### Fixed
+
+- **`backfill-capability-tier-labels.sh` no longer expands an empty `repo_args` under
+  `set -u`.** When `--repo` is omitted the array stays `()`. Bare `"${repo_args[@]}"`
+  is an unbound-variable abort on bash 4.0-4.3. Those sites now use the house
+  `${arr[@]+"${arr[@]}"}` idiom so `check` and `apply` reach `gh` instead of dying
+  first ([#3425](https://github.com/melodic-software/claude-code-plugins/issues/3425)).
+
 ## [0.39.47]
 
 ### Fixed

--- a/plugins/work-items/scripts/backfill-capability-tier-labels.sh
+++ b/plugins/work-items/scripts/backfill-capability-tier-labels.sh
@@ -59,14 +59,14 @@ require_gh() {
 
 label_exists_in_repo() {
   require_gh
-  gh label list "${repo_args[@]}" --limit 200 --json name \
+  gh label list ${repo_args[@]+"${repo_args[@]}"} --limit 200 --json name \
     | jq -e --arg want "$CAPABILITY_TIER_LABEL" '[.[] | .name] | index($want) != null' >/dev/null
 }
 
 list_open_items_without_label_json() {
   require_gh
   local items
-  items="$(gh issue list "${repo_args[@]}" --state open \
+  items="$(gh issue list ${repo_args[@]+"${repo_args[@]}"} --state open \
     --json number,title,body,labels \
     --limit 1000 | tr -d '\r')"
 
@@ -131,8 +131,8 @@ case "$MODE" in
         *) echo "Aborted." >&2; exit 2 ;;
       esac
     fi
-    for number in "${candidates[@]}"; do
-      gh issue edit "$number" "${repo_args[@]}" --add-label "$CAPABILITY_TIER_LABEL"
+    for number in ${candidates[@]+"${candidates[@]}"}; do
+      gh issue edit "$number" ${repo_args[@]+"${repo_args[@]}"} --add-label "$CAPABILITY_TIER_LABEL"
       echo "Applied $CAPABILITY_TIER_LABEL to #$number"
     done
     ;;

--- a/plugins/work-items/scripts/backfill-capability-tier-labels.test.sh
+++ b/plugins/work-items/scripts/backfill-capability-tier-labels.test.sh
@@ -24,6 +24,50 @@ else
   pass "apply without gh exits non-zero"
 fi
 
+# Empty repo_args under set -u must not abort (bash 4.0-4.3 unbound-variable).
+# check and apply both expand repo_args=() when --repo is omitted; a stub gh
+# lets the expansion run instead of dying at require_gh.
+STUB_BIN="$(mktemp -d)"
+trap 'rm -rf "$STUB_BIN"' EXIT
+cat >"$STUB_BIN/gh" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$1" == "issue" && "$2" == "list" ]]; then
+  printf '%s\n' '[]'
+  exit 0
+fi
+if [[ "$1" == "label" && "$2" == "list" ]]; then
+  printf '%s\n' '[{"name":"capability-tier: frontier"}]'
+  exit 0
+fi
+echo "unexpected gh invocation: $*" >&2
+exit 1
+EOF
+chmod +x "$STUB_BIN/gh"
+
+out="$(PATH="$STUB_BIN:$PATH" "$BACKFILL" check 2>&1)"
+rc=$?
+if [[ $rc -eq 0 && "$out" != *"unbound variable"* ]]; then
+  pass "check without --repo expands empty repo_args without aborting"
+else
+  fail "check without --repo must not abort on empty repo_args: rc=$rc out=$out"
+fi
+
+out="$(PATH="$STUB_BIN:$PATH" "$BACKFILL" apply --dry-run --yes 2>&1)"
+rc=$?
+if [[ $rc -eq 0 && "$out" != *"unbound variable"* && "$out" == *"No legacy frontier-tier body stamps need backfill."* ]]; then
+  pass "apply without --repo expands empty repo_args without aborting"
+else
+  fail "apply without --repo must not abort on empty repo_args: rc=$rc out=$out"
+fi
+
+out="$(PATH="$STUB_BIN:$PATH" "$BACKFILL" check --repo owner/repo 2>&1)"
+rc=$?
+if [[ $rc -eq 0 && "$out" != *"unbound variable"* ]]; then
+  pass "check with --repo still expands a populated repo_args"
+else
+  fail "check with --repo must still succeed: rc=$rc out=$out"
+fi
+
 if [[ "$FAILED" -eq 0 ]]; then
   exit 0
 fi

--- a/scripts/check-changed-skills.sh
+++ b/scripts/check-changed-skills.sh
@@ -130,7 +130,7 @@ done
 checked=0
 failed=0
 
-for skill_dir in "${changed[@]}"; do
+for skill_dir in ${changed[@]+"${changed[@]}"}; do
   # A deletion/rename-away leaves no SKILL.md in the tree — not a regression to
   # gate (and the checker would FAIL "not found"). Skip those.
   [[ -f "$skill_dir/SKILL.md" ]] || continue
@@ -149,7 +149,7 @@ for skill_dir in "${changed[@]}"; do
   if ! CHECK_SKILL_SKILLS_ROOT="$PWD/$skills_root" \
     CHECK_SKILL_BASE_REF="$BASE" \
     CHECK_SKILL_SKIP_MARKDOWNLINT=1 \
-    bash "$CHECKER" "${require_evals_args[@]}" "$skill_name"; then
+    bash "$CHECKER" ${require_evals_args[@]+"${require_evals_args[@]}"} "$skill_name"; then
     failed=$((failed + 1))
   fi
 done

--- a/scripts/check-changed-skills.test.sh
+++ b/scripts/check-changed-skills.test.sh
@@ -82,10 +82,10 @@ commit_all "$r" base >/dev/null
 b="$(base_sha "$r")"
 printf 'unrelated\n' >"$r/README.md" # non-skill change
 if out="$(run "$r" "$b" 2>&1)"; then
-  if echo "$out" | grep -q "nothing to gate"; then
+  if echo "$out" | grep -q "nothing to gate" && [[ "$out" != *"unbound variable"* ]]; then
     ok "no changed skills passes"
   else
-    fail "expected nothing-to-gate message, got: $out"
+    fail "expected nothing-to-gate message without unbound-variable, got: $out"
   fi
 else
   fail "no changed skills should pass, got: $out"
@@ -220,12 +220,13 @@ add_skill "$r" p1 alpha context/note.md
 commit_all "$r" base >/dev/null
 b="$(base_sha "$r")"
 printf 'updated\n' >"$r/plugins/p1/skills/alpha/context/note.md"
-run "$r" "$b" >/dev/null 2>&1
+out="$(run "$r" "$b" 2>&1)"
 if grep -q 'args=alpha ' "$r/checklog" 2>/dev/null &&
-  ! grep -q 'args=--require-evals alpha ' "$r/checklog" 2>/dev/null; then
+  ! grep -q 'args=--require-evals alpha ' "$r/checklog" 2>/dev/null &&
+  [[ "$out" != *"unbound variable"* ]]; then
   ok "non-SKILL.md touch does not forward --require-evals"
 else
-  fail "context-only change should not forward --require-evals, got: $(cat "$r/checklog" 2>/dev/null)"
+  fail "context-only change should not forward --require-evals, got: $(cat "$r/checklog" 2>/dev/null) out=$out"
 fi
 rm -rf "$r"
 

--- a/scripts/check-changelog-parity.sh
+++ b/scripts/check-changelog-parity.sh
@@ -267,10 +267,10 @@ missing_preserved_headings() {
   ((${#base_versions[@]} > 0)) || return 0
 
   mapfile -t head_versions < <(changelog_versions "$changelog")
-  for v in "${head_versions[@]}"; do head_seen["$v"]=1; done
+  for v in ${head_versions[@]+"${head_versions[@]}"}; do head_seen["$v"]=1; done
 
   missing=""
-  for v in "${base_versions[@]}"; do
+  for v in ${base_versions[@]+"${base_versions[@]}"}; do
     [[ -n "${head_seen[$v]:-}" ]] && continue
     missing+="${missing:+$'\n'}$v"
   done
@@ -285,13 +285,13 @@ if [[ "$mode" == "--check-order" ]]; then
   misordered=0
   duplicated=0
   checked=0
-  for changelog in "${changelogs[@]}"; do
+  for changelog in ${changelogs[@]+"${changelogs[@]}"}; do
     [[ -f "$changelog" ]] || continue
     checked=$((checked + 1))
     mapfile -t versions < <(changelog_versions "$changelog")
     ((${#versions[@]} > 1)) || continue
 
-    dupes="$(printf '%s\n' "${versions[@]}" | sort | uniq -d)"
+    dupes="$(printf '%s\n' ${versions[@]+"${versions[@]}"} | sort | uniq -d)"
     if [[ -n "$dupes" ]]; then
       echo "DUPLICATE CHANGELOG VERSION: $changelog lists $(printf '%s' "$dupes" | tr '\n' ' ') more than once. Two branches almost certainly staged the same version; renumber one." >&2
       duplicated=$((duplicated + 1))
@@ -303,7 +303,7 @@ if [[ "$mode" == "--check-order" ]]; then
     # still outranks 9.0.0.
     prev=""
     prev_key=""
-    for v in "${versions[@]}"; do
+    for v in ${versions[@]+"${versions[@]}"}; do
       key="$(version_sort_key "$v")"
       if [[ -n "$prev_key" && "$key" > "$prev_key" ]]; then
         echo "MISORDERED CHANGELOG: $changelog is not newest-first — $v (below $prev). A version that merged after a higher one already landed is a regression; renumber it above the entry it followed." >&2
@@ -327,7 +327,7 @@ if [[ "$mode" == "--check" ]]; then
   declare -A saw_debt
   missing=0
   ahead=0
-  for manifest in "${manifests[@]}"; do
+  for manifest in ${manifests[@]+"${manifests[@]}"}; do
     plugin_dir="${manifest%/.claude-plugin/plugin.json}"
     name="${plugin_dir##*/}"
     version="$(version_of "$manifest")"
@@ -505,7 +505,7 @@ if [[ "$mode" == "--check-preserved" ]]; then
   deleted=0
   compared=0
   declare -A head_seen
-  for changelog in "${touched_changelogs[@]}"; do
+  for changelog in ${touched_changelogs[@]+"${touched_changelogs[@]}"}; do
     # Absent at the fork point => added by this change set; nothing to preserve.
     # `git ls-tree` is the probe that separates that from a git invocation which
     # genuinely FAILED: a path missing from the tree is exit 0 with EMPTY output,
@@ -541,10 +541,10 @@ if [[ "$mode" == "--check-preserved" ]]; then
 
     head_seen=()
     if ((${#head_versions[@]} > 0)); then
-      for v in "${head_versions[@]}"; do head_seen["$v"]=1; done
+      for v in ${head_versions[@]+"${head_versions[@]}"}; do head_seen["$v"]=1; done
     fi
     missing=""
-    for v in "${base_versions[@]}"; do
+    for v in ${base_versions[@]+"${base_versions[@]}"}; do
       [[ -n "${head_seen[$v]:-}" ]] && continue
       head_seen["$v"]=1 # a version repeated at base is reported once
       missing="${missing}${missing:+ }$v"
@@ -585,7 +585,7 @@ absorbed=0
 
 # touched_changelogs is already unique (the seen_changelog guard where it is
 # built), so each changelog is inspected exactly once.
-for changelog in "${touched_changelogs[@]}"; do
+for changelog in ${touched_changelogs[@]+"${touched_changelogs[@]}"}; do
   [[ -f "$changelog" ]] || continue
   missing_headings="$(missing_preserved_headings "$merge_base" "$changelog")" ||
     exit 2
@@ -599,7 +599,7 @@ for changelog in "${touched_changelogs[@]}"; do
   fi
 done
 
-for manifest in "${manifests[@]}"; do
+for manifest in ${manifests[@]+"${manifests[@]}"}; do
   plugin_dir="${manifest%/.claude-plugin/plugin.json}"
   name="${plugin_dir##*/}"
   changelog="$plugin_dir/CHANGELOG.md"

--- a/scripts/check-changelog-parity.test.sh
+++ b/scripts/check-changelog-parity.test.sh
@@ -501,7 +501,13 @@ git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm base
 base="$(git -C "$repo" rev-parse HEAD)"
 printf 'unrelated\n' >"$repo/README.md"
 git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm noop
-if (cd "$repo" && bash scripts/check-changelog-parity.sh --check-bump "$base" >/dev/null 2>&1); then ok "unchanged version with no plugin edits passes --check-bump"; else fail "repo-only edit wrongly failed --check-bump"; fi
+out="$(cd "$repo" && bash scripts/check-changelog-parity.sh --check-bump "$base" 2>&1)"
+rc=$?
+if [[ $rc -eq 0 && "$out" != *"unbound variable"* ]]; then ok "unchanged version with no plugin edits passes --check-bump"; else fail "repo-only edit wrongly failed --check-bump: rc=$rc out='$out'"; fi
+# Same empty touched_changelogs=() path --check-preserved walks first (#3425).
+out="$(cd "$repo" && bash scripts/check-changelog-parity.sh --check-preserved "$base" 2>&1)"
+rc=$?
+if [[ $rc -eq 0 && "$out" != *"unbound variable"* ]]; then ok "repo-only edit expands empty touched_changelogs without aborting --check-preserved"; else fail "empty touched_changelogs aborted --check-preserved: rc=$rc out='$out'"; fi
 rm -rf "$repo"
 
 # new plugin absent at base -> --check-bump skips it (static --check owns it)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #3425

## Summary

Several scripts expand possibly-empty arrays as bare `"${arr[@]}"` under `set -u`, which aborts on bash 4.0-4.3. Convert the listed sites to the house `${arr[@]+"${arr[@]}"}` idiom.

## Fix

- `backfill-capability-tier-labels.sh`: `repo_args` and sibling `candidates`
- `git-tree-reset-batch.sh`: `REPO_KEYS`, `REPO_INPUTS`, `CHILD_PASS`
- `git-tree-reset.sh`: both `PRESERVE_ARGS` sites
- `check-changed-skills.sh` and `check-changelog-parity.sh`: empty-array loops and siblings

work-items 0.39.48, repo-hygiene 0.10.21.

## Verification

`scripts/affected-tests.sh --run`: 133 shell suites passed. Exit 3 is the documented `NOT RUN` for 7 selected Python suites. Co-located suites pin the empty-array paths.

## Related

N/A
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7ffb619a-6ebb-4d47-9c45-d68e846edf93?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7ffb619a-6ebb-4d47-9c45-d68e846edf93&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

