### PR TITLE
fix(machine-health): length-guard winget short-row Substring

### DIFF
--- a/plugins/machine-health/.claude-plugin/plugin.json
+++ b/plugins/machine-health/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "machine-health",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "description": "Workstation health audit: OS-specific checks (disk, OS updates, security posture, CISA KEV correlation) run from a versioned catalog with trend-aware severity, approval-gated remediations, and dated markdown reports. Windows fully implemented; macOS/Linux scaffolded (report UNKNOWN and stop). Machine state persists in the plugin data directory; the report directory and check catalog are configurable.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/machine-health/CHANGELOG.md
+++ b/plugins/machine-health/CHANGELOG.md
@@ -9,7 +9,9 @@ All notable changes to the `machine-health` plugin are documented here. Format f
 
 - **`ConvertFrom-WingetTextOutput` length-guards every column `Substring`.** A row that
   reached the Version column but stopped before Available threw, and the row-level catch
-  dropped the package. Short rows now parse with empty later columns.
+  dropped the package. Short rows now parse with empty later columns. The Available
+  span also requires `$idxSource -gt $idxAvail`, matching the Version span, so a
+  malformed header cannot subtract a negative length.
 
 ## [0.12.2]
 

--- a/plugins/machine-health/CHANGELOG.md
+++ b/plugins/machine-health/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to the `machine-health` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.12.3]
+
+### Fixed
+
+- **`ConvertFrom-WingetTextOutput` length-guards every column `Substring`.** A row that
+  reached the Version column but stopped before Available threw, and the row-level catch
+  dropped the package. Short rows now parse with empty later columns.
+
 ## [0.12.2]
 
 ### Fixed

--- a/plugins/machine-health/skills/audit/scripts/windows/lib/Get-WingetPackageUpdate.ps1
+++ b/plugins/machine-health/skills/audit/scripts/windows/lib/Get-WingetPackageUpdate.ps1
@@ -65,12 +65,19 @@ function ConvertFrom-WingetTextOutput {
             # The $line.Length -lt $idxVer rows are skipped above, so this
             # substring is always in range.
             $ident = $line.Substring($idxId, $idxVer - $idxId).Trim()
-            $ver = if ($line.Length -ge $idxAvail) {
+            $ver = if ($idxAvail -gt $idxVer -and $line.Length -ge $idxAvail) {
                 $line.Substring($idxVer, $idxAvail - $idxVer).Trim()
+            } elseif ($line.Length -gt $idxVer) {
+                $line.Substring($idxVer).Trim()
             } else { '' }
-            $avail = if ($idxSource -gt 0 -and $line.Length -ge $idxSource) {
+            # Length-guard every later column: a row past idxVer but short of
+            # idxAvail used to throw in Substring($idxAvail), and the
+            # row-level catch swallowed the package (#3437).
+            $avail = if ($idxSource -gt 0 -and $idxAvail -ge 0 -and $line.Length -ge $idxSource) {
                 $line.Substring($idxAvail, $idxSource - $idxAvail).Trim()
-            } else { $line.Substring($idxAvail).Trim() }
+            } elseif ($idxAvail -ge 0 -and $line.Length -gt $idxAvail) {
+                $line.Substring($idxAvail).Trim()
+            } else { '' }
             $src = if ($idxSource -gt 0 -and $line.Length -gt $idxSource) {
                 $line.Substring($idxSource).Trim()
             } else { '' }

--- a/plugins/machine-health/skills/audit/scripts/windows/lib/Get-WingetPackageUpdate.ps1
+++ b/plugins/machine-health/skills/audit/scripts/windows/lib/Get-WingetPackageUpdate.ps1
@@ -73,7 +73,7 @@ function ConvertFrom-WingetTextOutput {
             # Length-guard every later column: a row past idxVer but short of
             # idxAvail used to throw in Substring($idxAvail), and the
             # row-level catch swallowed the package (#3437).
-            $avail = if ($idxSource -gt 0 -and $idxAvail -ge 0 -and $line.Length -ge $idxSource) {
+            $avail = if ($idxSource -gt $idxAvail -and $idxAvail -ge 0 -and $line.Length -ge $idxSource) {
                 $line.Substring($idxAvail, $idxSource - $idxAvail).Trim()
             } elseif ($idxAvail -ge 0 -and $line.Length -gt $idxAvail) {
                 $line.Substring($idxAvail).Trim()

--- a/plugins/machine-health/skills/audit/tests/windows/lib/Get-WingetPackageUpdate.Tests.ps1
+++ b/plugins/machine-health/skills/audit/tests/windows/lib/Get-WingetPackageUpdate.Tests.ps1
@@ -1,0 +1,38 @@
+#Requires -Version 7.4
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.7.0' }
+<#
+.SYNOPSIS
+Tests for ConvertFrom-WingetTextOutput short-row handling (#3437).
+#>
+
+BeforeAll {
+    $script:TestsRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+    $script:LibRoot = Join-Path (Split-Path -Parent $script:TestsRoot) 'scripts\windows\lib'
+    . (Join-Path $script:LibRoot 'Get-WingetPackageUpdate.ps1')
+}
+
+Describe 'ConvertFrom-WingetTextOutput' -Tag 'lib' {
+    It 'parses a full-width row' {
+        $header = 'Name                 Id                 Version    Available  Source'
+        $row = 'Git                  Git.Git            2.45.1     2.46.0     winget'
+        $items = @(ConvertFrom-WingetTextOutput -Lines @($header, ('-' * $header.Length), $row))
+        $items.Count | Should -Be 1
+        $items[0].id | Should -Be 'Git.Git'
+        $items[0].available_version | Should -Be '2.46.0'
+    }
+
+    It 'parses a short row instead of swallowing a Substring exception' {
+        $header = 'Name                 Id                 Version    Available  Source'
+        $idxAvail = $header.IndexOf('Available')
+        # Row reaches the Version column but stops before Available, the shape
+        # that used to throw in Substring($idxAvail) and disappear into catch.
+        $row = 'ShortPkg             Short.Id           1.0'
+        $row.Length | Should -BeLessThan $idxAvail
+        $items = @(ConvertFrom-WingetTextOutput -Lines @($header, ('-' * $header.Length), $row))
+        $items.Count | Should -Be 1
+        $items[0].name | Should -Be 'ShortPkg'
+        $items[0].id | Should -Be 'Short.Id'
+        $items[0].current_version | Should -Be '1.0'
+        $items[0].available_version | Should -Be ''
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #3437

## Summary

A winget upgrade row that reached Version but not Available threw in `Substring`, and the row-level catch dropped the package.

## Fix

Length-guard every later column and parse what is present. machine-health 0.12.3.

## Verification

New Pester suite `Get-WingetPackageUpdate.Tests.ps1`: 2 passed (full-width row and short-row). Ran on Linux.

## Related

N/A
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7ffb619a-6ebb-4d47-9c45-d68e846edf93?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7ffb619a-6ebb-4d47-9c45-d68e846edf93&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

