### PR TITLE
fix(guardrails): match absolute-path write verbs in drive-root tmp guard

### DIFF
--- a/plugins/guardrails/.claude-plugin/plugin.json
+++ b/plugins/guardrails/.claude-plugin/plugin.json
@@ -52,7 +52,7 @@
     "block_windows_drive_tmp_enabled": {
       "type": "boolean",
       "title": "block-windows-drive-tmp guard",
-      "description": "Block writes whose target is a Windows drive-root temp path (/tmp, C:\\tmp, \\tmp, /c/tmp) that resolves to <drive>:\\tmp instead of %TEMP% — both Bash/PowerShell commands and Write/Edit/MultiEdit/NotebookEdit file paths. One switch covers both lanes",
+      "description": "Block writes whose target is a Windows drive-root temp path (/tmp, C:\\tmp, \\tmp, /c/tmp) that resolves to <drive>:\\tmp instead of %TEMP% \u2014 both Bash/PowerShell commands and Write/Edit/MultiEdit/NotebookEdit file paths. One switch covers both lanes",
       "default": true
     },
     "block_exported_msys_pathconv_enabled": {
@@ -147,5 +147,5 @@
       "min": 1
     }
   },
-  "version": "0.30.0"
+  "version": "0.30.1"
 }

--- a/plugins/guardrails/CHANGELOG.md
+++ b/plugins/guardrails/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to the `guardrails` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.30.1]
+
+### Fixed
+
+- **`block-windows-drive-tmp` matches a write utility invoked by absolute path.** The
+  command-lane verb anchor was `(^|[[:space:]])`, so `/usr/bin/mkdir -p /tmp/x` (and the
+  same spelling of `touch`, `tee`, `cp`) slipped through. An optional `[^[:space:]]*/`
+  prefix is now accepted; a verb-shaped substring such as `./bin/mkdirs` still is not.
+
 ## [0.30.0]
 
 ### Fixed

--- a/plugins/guardrails/CHANGELOG.md
+++ b/plugins/guardrails/CHANGELOG.md
@@ -10,7 +10,10 @@ All notable changes to the `guardrails` plugin are documented here. Format follo
 - **`block-windows-drive-tmp` matches a write utility invoked by absolute path.** The
   command-lane verb anchor was `(^|[[:space:]])`, so `/usr/bin/mkdir -p /tmp/x` (and the
   same spelling of `touch`, `tee`, `cp`) slipped through. An optional `[^[:space:]]*/`
-  prefix is now accepted; a verb-shaped substring such as `./bin/mkdirs` still is not.
+  prefix is accepted only in command position (start of the segment, or after
+  `sudo`), including a quoted executable (`"/usr/bin/mkdir" -p /tmp/x`). A
+  mention such as `echo /usr/bin/mkdir /tmp/x` or `cat /some/path/mkdir /tmp/x`
+  stays allowed. A verb-shaped substring such as `./bin/mkdirs` still is not.
 
 ## [0.30.0]
 

--- a/plugins/guardrails/hooks/block-windows-drive-tmp.sh
+++ b/plugins/guardrails/hooks/block-windows-drive-tmp.sh
@@ -397,15 +397,23 @@ segment_destination_operand() {
 # copy/move utilities bind only the destination operand.
 segment_writes_drive_root_tmp() {
   local subject="$1" dest
+  # Path-qualified verbs only in command position: start of the segment, or
+  # after `sudo`. After any other space the verb must be bare, or
+  # `echo /usr/bin/mkdir /tmp/x` / `cat /some/path/mkdir /tmp/x` are false
+  # positives (#3502). Optional quotes cover `"/usr/bin/mkdir" -p /tmp/x`.
+  # Assigned so the pattern can include literal `"` without breaking `=~`.
+  local creator_cmd_re copy_cmd_re
+  creator_cmd_re='((^|[[:space:]])sudo[[:space:]]+"?([^[:space:]"]*/)?|^[[:space:]]*"?([^[:space:]"]*/)?|[[:space:]])(tee|mktemp|mkdir|touch|dd|tee\.exe)"?([[:space:]]|$)'
+  copy_cmd_re='((^|[[:space:]])sudo[[:space:]]+"?([^[:space:]"]*/)?|^[[:space:]]*"?([^[:space:]"]*/)?|[[:space:]])(cp|mv|install|install\.exe|copy-item|move-item|copy|move|cpi|mi)"?([[:space:]]|$)'
   # Creators / content writers: any drive-root tmp path in the segment is a write.
-  if [[ "$subject" =~ (^|[[:space:]])([^[:space:]]*/)?(tee|mktemp|mkdir|touch|dd|tee\.exe)([[:space:]]|$) ]] ||
+  if [[ "$subject" =~ $creator_cmd_re ]] ||
     [[ "$subject" =~ (^|[[:space:];|&]|/)(set-content|add-content|out-file|tee-object|new-item|export-clixml|export-csv)([[:space:]]|:|$) ]] ||
     [[ "$subject" =~ (^|[[:space:]])(ac|ni)([[:space:]]|$) ]]; then
     has_drive_root_tmp "$subject" && return 0
     return 1
   fi
   # Copy / move / install: destination operand only (avoids `cp /tmp/src ./dst`).
-  if [[ "$subject" =~ (^|[[:space:]])([^[:space:]]*/)?(cp|mv|install|install\.exe|copy-item|move-item|copy|move|cpi|mi)([[:space:]]|$) ]]; then
+  if [[ "$subject" =~ $copy_cmd_re ]]; then
     dest=$(segment_destination_operand "$subject")
     [[ -n "$dest" ]] || return 1
     has_drive_root_tmp "$dest" && return 0

--- a/plugins/guardrails/hooks/block-windows-drive-tmp.sh
+++ b/plugins/guardrails/hooks/block-windows-drive-tmp.sh
@@ -398,14 +398,14 @@ segment_destination_operand() {
 segment_writes_drive_root_tmp() {
   local subject="$1" dest
   # Creators / content writers: any drive-root tmp path in the segment is a write.
-  if [[ "$subject" =~ (^|[[:space:]])(tee|mktemp|mkdir|touch|dd|tee\.exe)([[:space:]]|$) ]] ||
+  if [[ "$subject" =~ (^|[[:space:]])([^[:space:]]*/)?(tee|mktemp|mkdir|touch|dd|tee\.exe)([[:space:]]|$) ]] ||
     [[ "$subject" =~ (^|[[:space:];|&]|/)(set-content|add-content|out-file|tee-object|new-item|export-clixml|export-csv)([[:space:]]|:|$) ]] ||
     [[ "$subject" =~ (^|[[:space:]])(ac|ni)([[:space:]]|$) ]]; then
     has_drive_root_tmp "$subject" && return 0
     return 1
   fi
   # Copy / move / install: destination operand only (avoids `cp /tmp/src ./dst`).
-  if [[ "$subject" =~ (^|[[:space:]])(cp|mv|install|install\.exe|copy-item|move-item|copy|move|cpi|mi)([[:space:]]|$) ]]; then
+  if [[ "$subject" =~ (^|[[:space:]])([^[:space:]]*/)?(cp|mv|install|install\.exe|copy-item|move-item|copy|move|cpi|mi)([[:space:]]|$) ]]; then
     dest=$(segment_destination_operand "$subject")
     [[ -n "$dest" ]] || return 1
     has_drive_root_tmp "$dest" && return 0

--- a/plugins/guardrails/hooks/block-windows-drive-tmp.test.sh
+++ b/plugins/guardrails/hooks/block-windows-drive-tmp.test.sh
@@ -270,6 +270,12 @@ run_win "touch /tmp/x (blocked)" 'touch /tmp/x' 2
 run_win "tee /tmp/x (blocked)" 'echo x | tee /tmp/x' 2
 run_win "cp to /tmp/x (blocked)" 'cp ./a /tmp/x' 2
 run_win "mv to /tmp/x (blocked)" 'mv ./a /tmp/x' 2
+run_win "/usr/bin/mkdir /tmp/x (blocked)" '/usr/bin/mkdir -p /tmp/x' 2
+run_win "sudo /usr/bin/mkdir /tmp/x (blocked)" 'sudo /usr/bin/mkdir -p /tmp/x' 2
+run_win "/usr/bin/touch /tmp/x (blocked)" '/usr/bin/touch /tmp/x' 2
+run_win "/usr/bin/tee /tmp/x (blocked)" 'echo x | /usr/bin/tee /tmp/x' 2
+run_win "/usr/bin/cp to /tmp/x (blocked)" '/usr/bin/cp ./a /tmp/x' 2
+run_win "./bin/mkdirs /tmp/x (allowed — verb substring)" './bin/mkdirs /tmp/x' 0
 run_win "python open /tmp write (blocked)" "python3 -c \"open('/tmp/x','w').write('a')\"" 2
 
 # --- PowerShell writers (blocked) --------------------------------------------

--- a/plugins/guardrails/hooks/block-windows-drive-tmp.test.sh
+++ b/plugins/guardrails/hooks/block-windows-drive-tmp.test.sh
@@ -272,6 +272,9 @@ run_win "cp to /tmp/x (blocked)" 'cp ./a /tmp/x' 2
 run_win "mv to /tmp/x (blocked)" 'mv ./a /tmp/x' 2
 run_win "/usr/bin/mkdir /tmp/x (blocked)" '/usr/bin/mkdir -p /tmp/x' 2
 run_win "sudo /usr/bin/mkdir /tmp/x (blocked)" 'sudo /usr/bin/mkdir -p /tmp/x' 2
+run_win "quoted /usr/bin/mkdir /tmp/x (blocked)" '"/usr/bin/mkdir" -p /tmp/x' 2
+run_win "echo /usr/bin/mkdir /tmp/x (allowed — mention, not command)" 'echo /usr/bin/mkdir /tmp/x' 0
+run_win "cat /path/mkdir /tmp/x (allowed — path argument, not command)" 'cat /some/path/mkdir /tmp/x' 0
 run_win "/usr/bin/touch /tmp/x (blocked)" '/usr/bin/touch /tmp/x' 2
 run_win "/usr/bin/tee /tmp/x (blocked)" 'echo x | /usr/bin/tee /tmp/x' 2
 run_win "/usr/bin/cp to /tmp/x (blocked)" '/usr/bin/cp ./a /tmp/x' 2


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #3502

## Summary

`block-windows-drive-tmp` did not block a drive-root write when the utility was invoked by absolute path (`/usr/bin/mkdir -p /tmp/x` exited 0).

## Fix

Allow an optional `[^[:space:]]*/` prefix on creator and copy/move verbs. A verb-shaped substring (`./bin/mkdirs`) still stays quiet. guardrails 0.30.1.

## Verification

`scripts/affected-tests.sh --run`: 3 shell suites passed. New cases: `/usr/bin/mkdir`, `sudo /usr/bin/mkdir`, `/usr/bin/touch`, `/usr/bin/tee`, `/usr/bin/cp` blocked; `./bin/mkdirs /tmp/x` allowed.

## Related

N/A
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7ffb619a-6ebb-4d47-9c45-d68e846edf93?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7ffb619a-6ebb-4d47-9c45-d68e846edf93&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

