### PR TITLE
fix(machine-health): sort SDK oldest label and render null stability as n/a

### DIFF
--- a/plugins/machine-health/.claude-plugin/plugin.json
+++ b/plugins/machine-health/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "machine-health",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "description": "Workstation health audit: OS-specific checks (disk, OS updates, security posture, CISA KEV correlation) run from a versioned catalog with trend-aware severity, approval-gated remediations, and dated markdown reports. Windows fully implemented; macOS/Linux scaffolded (report UNKNOWN and stop). Machine state persists in the plugin data directory; the report directory and check catalog are configurable.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/machine-health/CHANGELOG.md
+++ b/plugins/machine-health/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to the `machine-health` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.12.4]
+
+### Fixed
+
+- **`Test-SdkVersions` labels the oldest runtime by EOL date, not detection order.** The
+  INFO summary used `$findings[0]`, which is first-detected (dotnet, then node, then
+  python), not oldest.
+- **`Test-Reliability` renders a null stability average as `n/a`.** The OK and INFO
+  summaries interpolated `$stabilityAvg` directly, producing `Stability avg  / 10`.
+
 ## [0.12.3]
 
 ### Fixed

--- a/plugins/machine-health/CHANGELOG.md
+++ b/plugins/machine-health/CHANGELOG.md
@@ -10,7 +10,8 @@ All notable changes to the `machine-health` plugin are documented here. Format f
 - **`Test-SdkVersions` labels the oldest runtime by EOL date, not detection order.** The
   INFO summary used `$findings[0]`, which is first-detected (dotnet, then node, then
   python), not oldest. The contract test invokes the check script (global command
-  shadows plus a mocked EOL table) so a `$findings[0]` regression fails.
+  shadows plus a mocked EOL table with dates relative to `Get-Date`) so a
+  `$findings[0]` regression fails.
   `Add-SdkFinding` now allows an empty accumulator (`AllowEmptyCollection`); Mandatory
   on a `List` rejected the first insert and the inner catch reported zero SDKs.
 - **`Test-Reliability` renders a null stability average as `n/a`.** The OK and INFO

--- a/plugins/machine-health/CHANGELOG.md
+++ b/plugins/machine-health/CHANGELOG.md
@@ -9,7 +9,10 @@ All notable changes to the `machine-health` plugin are documented here. Format f
 
 - **`Test-SdkVersions` labels the oldest runtime by EOL date, not detection order.** The
   INFO summary used `$findings[0]`, which is first-detected (dotnet, then node, then
-  python), not oldest.
+  python), not oldest. The contract test invokes the check script (global command
+  shadows plus a mocked EOL table) so a `$findings[0]` regression fails.
+  `Add-SdkFinding` now allows an empty accumulator (`AllowEmptyCollection`); Mandatory
+  on a `List` rejected the first insert and the inner catch reported zero SDKs.
 - **`Test-Reliability` renders a null stability average as `n/a`.** The OK and INFO
   summaries interpolated `$stabilityAvg` directly, producing `Stability avg  / 10`.
 

--- a/plugins/machine-health/skills/audit/scripts/windows/checks/Test-Reliability.ps1
+++ b/plugins/machine-health/skills/audit/scripts/windows/checks/Test-Reliability.ps1
@@ -95,8 +95,9 @@ try {
                 Group-Object -Property ProductName |
                 Where-Object { $_.Count -ge 5 }).Count
 
+        $avgText = if ($null -eq $stabilityAvg) { 'n/a' } else { "$stabilityAvg" }
         $severity = 'OK'
-        $summary = "Stability avg $stabilityAvg / 10, $($records.Count) event(s) in 7d."
+        $summary = "Stability avg $avgText / 10, $($records.Count) event(s) in 7d."
         if ($null -ne $stabilityMin -and $stabilityMin -lt 3) {
             $severity = 'CRIT'
             $summary = "Stability dropped below 3 (min $stabilityMin) in last 7d."
@@ -111,7 +112,7 @@ try {
             $summary = "$repeatCrashCount application(s) crashed >=5 times in last 7d."
         } elseif ($records.Count -gt 0) {
             $severity = 'INFO'
-            $summary = "$($records.Count) event(s) in last 7d, stability avg $stabilityAvg."
+            $summary = "$($records.Count) event(s) in last 7d, stability avg $avgText."
         }
 
         $detail = @{

--- a/plugins/machine-health/skills/audit/scripts/windows/checks/Test-SdkVersions.ps1
+++ b/plugins/machine-health/skills/audit/scripts/windows/checks/Test-SdkVersions.ps1
@@ -129,7 +129,16 @@ try {
         $summary = "$($warn.Count) SDK(s) reach EOL within 90 days."
     } elseif ($findings.Count -gt 0) {
         $severity = 'INFO'
-        $summary = "$($findings.Count) SDK(s) detected; oldest: $($findings[0].runtime) $($findings[0].version)."
+        # Detection order is not age. Sort by EOL date (unknown last) so
+        # "oldest" names the runtime whose support window ends first (#3435).
+        $oldest = @(
+            $findings | Sort-Object @{
+                Expression = {
+                    if ($_.eol_date) { [datetime]$_.eol_date } else { [datetime]::MaxValue }
+                }
+            }, runtime, version
+        )[0]
+        $summary = "$($findings.Count) SDK(s) detected; oldest: $($oldest.runtime) $($oldest.version)."
     }
 
     $result = New-HealthResult -Id $id -Category $category -Os 'windows' `

--- a/plugins/machine-health/skills/audit/scripts/windows/checks/Test-SdkVersions.ps1
+++ b/plugins/machine-health/skills/audit/scripts/windows/checks/Test-SdkVersions.ps1
@@ -43,7 +43,9 @@ function Get-SdkState {
 
 function Add-SdkFinding {
     param(
-        [Parameter(Mandatory)] [System.Collections.Generic.List[pscustomobject]] $Findings,
+        [Parameter(Mandatory)]
+        [AllowEmptyCollection()]
+        [System.Collections.Generic.List[pscustomobject]] $Findings,
         [Parameter(Mandatory)] [string] $Runtime,
         [Parameter(Mandatory)] [string] $Version,
         [Parameter(Mandatory)] [datetime] $Now,

--- a/plugins/machine-health/skills/audit/tests/windows/checks/Test-Reliability.Tests.ps1
+++ b/plugins/machine-health/skills/audit/tests/windows/checks/Test-Reliability.Tests.ps1
@@ -80,4 +80,23 @@ Describe 'Test-Reliability -- severity rubric' -Tag 'check' {
         $result = Invoke-ReliabilityAsObject
         $result.severity | Should -Be 'CRIT'
     }
+
+    It 'renders n/a when the stability average is null and records exist' {
+        Mock Get-CimInstance {
+            if ($ClassName -eq 'Win32_ReliabilityStabilityMetrics') {
+                [pscustomobject]@{
+                    TimeGenerated        = (Get-Date).AddDays(-1)
+                    SystemStabilityIndex = $null
+                }
+            } else {
+                @(
+                    New-MockReliabilityRecord -SourceName 'Application Error' -ProductName 'MockApp'
+                )
+            }
+        }
+        $result = Invoke-ReliabilityAsObject
+        $result.severity | Should -Be 'INFO'
+        $result.summary | Should -Match 'stability avg n/a'
+        $result.summary | Should -Not -Match 'avg  /'
+    }
 }

--- a/plugins/machine-health/skills/audit/tests/windows/checks/Test-SdkVersions.Tests.ps1
+++ b/plugins/machine-health/skills/audit/tests/windows/checks/Test-SdkVersions.Tests.ps1
@@ -30,21 +30,36 @@ Describe 'Test-SdkVersions -- baseline' -Tag 'check' {
 }
 
 Describe 'Test-SdkVersions -- oldest label' -Tag 'check' {
-    It 'sorts by EOL date so the first-detected runtime is not automatically oldest' {
-        # Pin the sort the INFO summary uses: earliest eol_date wins, unknown last.
-        $findings = @(
-            [pscustomobject]@{ runtime = 'node'; version = '22'; eol_date = '2027-04-30'; state = 'active' }
-            [pscustomobject]@{ runtime = 'dotnet'; version = '6.0'; eol_date = '2024-11-12'; state = 'eol' }
-            [pscustomobject]@{ runtime = 'python'; version = '3.12'; eol_date = $null; state = 'unknown_eol' }
-        )
-        $oldest = @(
-            $findings | Sort-Object @{
-                Expression = {
-                    if ($_.eol_date) { [datetime]$_.eol_date } else { [datetime]::MaxValue }
-                }
-            }, runtime, version
-        )[0]
-        $oldest.runtime | Should -Be 'dotnet'
-        $oldest.version | Should -Be '6.0'
+    BeforeAll {
+        # `& $Path` runs the check in its own script scope, so a test-script
+        # function is invisible. Global shadows are what `& dotnet` resolves.
+        function global:dotnet { $args | Out-Null; '8.0.100 [C:\sdk]' }
+        function global:node { $args | Out-Null; 'v22.0.0' }
+    }
+    AfterAll {
+        Remove-Item function:global:dotnet -ErrorAction SilentlyContinue
+        Remove-Item function:global:node -ErrorAction SilentlyContinue
+    }
+
+    It 'labels oldest by EOL date, not detection order' {
+        # INFO is only reachable with no eol / eol_soon findings. First-detected
+        # is always dotnet, so the table gives node the earlier (still-active)
+        # EOL. A `$findings[0]` regression would name dotnet 8.0.
+        Mock Get-Command {
+            param($Name)
+            if ($Name -eq 'dotnet' -or $Name -eq 'node') {
+                return [pscustomobject]@{ Name = $Name; Source = $Name }
+            }
+            if ($Name -in @('python', 'python3')) { return $null }
+            return (Microsoft.PowerShell.Core\Get-Command $Name -ErrorAction SilentlyContinue)
+        }
+        Mock Get-Content {
+            '{"dotnet":{"eol":{"8.0":"2028-01-01"}},"node":{"eol":{"22":"2027-01-01"}},"python":{"eol":{}}}'
+        } -ParameterFilter { $LiteralPath -match 'sdk-eol-table\.json$' }
+        $result = Invoke-SdkVersionsAsObject
+        { Assert-CheckResult $result } | Should -Not -Throw
+        $result.severity | Should -Be 'INFO'
+        $result.summary | Should -Match 'oldest: node 22'
+        $result.summary | Should -Not -Match 'oldest: dotnet'
     }
 }

--- a/plugins/machine-health/skills/audit/tests/windows/checks/Test-SdkVersions.Tests.ps1
+++ b/plugins/machine-health/skills/audit/tests/windows/checks/Test-SdkVersions.Tests.ps1
@@ -28,3 +28,23 @@ Describe 'Test-SdkVersions -- baseline' -Tag 'check' {
         $result.detail.runtimes_detected | Should -Be 0
     }
 }
+
+Describe 'Test-SdkVersions -- oldest label' -Tag 'check' {
+    It 'sorts by EOL date so the first-detected runtime is not automatically oldest' {
+        # Pin the sort the INFO summary uses: earliest eol_date wins, unknown last.
+        $findings = @(
+            [pscustomobject]@{ runtime = 'node'; version = '22'; eol_date = '2027-04-30'; state = 'active' }
+            [pscustomobject]@{ runtime = 'dotnet'; version = '6.0'; eol_date = '2024-11-12'; state = 'eol' }
+            [pscustomobject]@{ runtime = 'python'; version = '3.12'; eol_date = $null; state = 'unknown_eol' }
+        )
+        $oldest = @(
+            $findings | Sort-Object @{
+                Expression = {
+                    if ($_.eol_date) { [datetime]$_.eol_date } else { [datetime]::MaxValue }
+                }
+            }, runtime, version
+        )[0]
+        $oldest.runtime | Should -Be 'dotnet'
+        $oldest.version | Should -Be '6.0'
+    }
+}

--- a/plugins/machine-health/skills/audit/tests/windows/checks/Test-SdkVersions.Tests.ps1
+++ b/plugins/machine-health/skills/audit/tests/windows/checks/Test-SdkVersions.Tests.ps1
@@ -53,9 +53,14 @@ Describe 'Test-SdkVersions -- oldest label' -Tag 'check' {
             if ($Name -in @('python', 'python3')) { return $null }
             return (Microsoft.PowerShell.Core\Get-Command $Name -ErrorAction SilentlyContinue)
         }
-        Mock Get-Content {
-            '{"dotnet":{"eol":{"8.0":"2028-01-01"}},"node":{"eol":{"22":"2027-01-01"}},"python":{"eol":{}}}'
-        } -ParameterFilter { $LiteralPath -match 'sdk-eol-table\.json$' }
+        $nodeEol = (Get-Date).AddYears(5).ToString('yyyy-MM-dd')
+        $dotnetEol = (Get-Date).AddYears(8).ToString('yyyy-MM-dd')
+        $eolJson = (@{
+                dotnet = @{ eol = @{ '8.0' = $dotnetEol } }
+                node   = @{ eol = @{ '22' = $nodeEol } }
+                python = @{ eol = @{} }
+            } | ConvertTo-Json -Compress -Depth 5)
+        Mock Get-Content { $eolJson } -ParameterFilter { $LiteralPath -match 'sdk-eol-table\.json$' }
         $result = Invoke-SdkVersionsAsObject
         { Assert-CheckResult $result } | Should -Not -Throw
         $result.severity | Should -Be 'INFO'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #3435

## Summary

`Test-SdkVersions` labeled the first-detected runtime as oldest. `Test-Reliability` interpolated a null stability average as empty (`Stability avg  / 10`).

## Fix

Oldest label sorts by EOL date. Null stability renders as `n/a`. `Add-SdkFinding` allows an empty accumulator (`AllowEmptyCollection`) so the first insert is not rejected on pwsh 7.x. The contract test invokes the real script with global command shadows and a mocked EOL table whose dates are relative to `Get-Date`, so they stay outside the 90-day `eol_soon` window.

machine-health 0.12.3 -> 0.12.4 (rebased onto #3648).

## Verification

Pester `Test-SdkVersions.Tests.ps1` 2/2 on Linux (`pwsh` + Pester 6.1) after the relative-date fixture change.

## Related

Refs #3648
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7ffb619a-6ebb-4d47-9c45-d68e846edf93?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7ffb619a-6ebb-4d47-9c45-d68e846edf93&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

