### PR TITLE
fix(work-items): stop gitea label paging on a malformed page

### DIFF
--- a/plugins/work-items/.claude-plugin/plugin.json
+++ b/plugins/work-items/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "work-items",
-  "version": "0.39.46",
+  "version": "0.39.47",
   "description": "Manages development work items through a provider-neutral tracker seam that ships with the plugin (bundled dispatcher plus github, local-markdown, jira, gitea, and linear adapters; seam plugin-dir canonical, adapters consumer-local-first): dashboard, taxonomy-labeled creation, a race-safe assignee-plus-lease claim protocol, recurring-schedule checks, TODO scanning, stale-lease auditing, plan decomposition into vertical-slice items, a macro-journey router over spec containers (rollup, per-container execution shape, next-step routing), raw-intake triage (issues and unsolicited PRs through raw, verified, briefed, autonomous-eligible states), plus the two work-items loop lanes of the loop-lane convention: a self-paced autonomous work-loop drain (work-class admission gate, adaptive item cap, PR-only) and an attended attend-queue escalation lane. The re-runnable setup skill binds the provider (.work-item-tracker.json), seeds the recurring-schedule seam (.github/recurring-schedule.json), and remaps canonical role labels.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/work-items/CHANGELOG.md
+++ b/plugins/work-items/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to the `work-items` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.39.47]
+
+### Fixed
+
+- **Gitea `create-item` label paging treats a non-array page as length 0.** The
+  no-`X-Total-Count` arm ran `$(($(jq 'length') < PAGE_SIZE))` with no `2>/dev/null`
+  fallback. A 200 object body made jq print nothing, bash reported an arithmetic syntax
+  error, and the walk continued to the next page. It now matches the sibling
+  `jq 'length' ... 2>/dev/null || 0` form so a malformed page ends the walk.
+
 ## [0.39.46]
 
 ### Fixed

--- a/plugins/work-items/tools/work-item-tracker/adapters/gitea/create-item.sh
+++ b/plugins/work-items/tools/work-item-tracker/adapters/gitea/create-item.sh
@@ -121,7 +121,8 @@ if [[ -n "$LABELS" ]]; then
     if [[ -n "$LABEL_TOTAL" ]]; then
       ((LABEL_SEEN >= LABEL_TOTAL)) && break
     else
-      (($(jq 'length' <<<"$WIT_GITEA_BODY") < WIT_GITEA_PAGE_SIZE)) && break
+      PAGE_LEN="$(jq 'length' <<<"$WIT_GITEA_BODY" 2>/dev/null)" || PAGE_LEN=0
+      ((PAGE_LEN < WIT_GITEA_PAGE_SIZE)) && break
     fi
     # Bounded like every other paginated loop in this adapter: a server that keeps answering
     # a full page would otherwise spin forever with ALL_LABELS growing without limit. Measured

--- a/plugins/work-items/tools/work-item-tracker/adapters/gitea/create-item.test.sh
+++ b/plugins/work-items/tools/work-item-tracker/adapters/gitea/create-item.test.sh
@@ -193,4 +193,20 @@ rc="$(gitea_run "$S" --title "t" --labels "nonexistent")"
 assert_eq "a label in neither scope → exit 5" "5" "$rc"
 assert_contains "and it is named" "$(gitea_err)" "nonexistent"
 
+# A non-array 200 on the first labels page used to make `jq 'length'` empty
+# and `(( < PAGE_SIZE ))` an arithmetic error, so the walk continued to page 2
+# instead of treating the page as exhausted (#3484). No X-Total-Count, so the
+# page-length arm is the one that fires.
+gitea_reset_routes
+gitea_seed "/labels?page=1" 200 '{"message":"not a list"}'
+gitea_seed "/labels?page=2" 200 "$(jq -cn '[{id:3,name:"type: fix"}]')"
+gitea_seed "/issues" 201 "$(gitea_issue_json 12 open 'x')"
+rc="$(gitea_run "$S" --title "x" --labels "type: fix")"
+assert_eq "non-array labels page → no hang, non-zero" "5" "$rc"
+if [[ "$(gitea_requests)" == *"page=2"* ]]; then
+  fail "malformed labels page must not continue paging" "no page=2" "page=2 requested"
+else
+  pass "malformed labels page stops the walk"
+fi
+
 [[ $FAILED -eq 0 ]] || exit 1


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #3484

## Summary

Gitea `create-item` label paging continued past a non-array 200 because `jq 'length'` had no numeric fallback and the arithmetic error skipped `break`.

## Fix

Use the sibling `jq 'length' ... 2>/dev/null || 0` form so a malformed page is length 0 and ends the walk. work-items 0.39.47 (0.39.45/46 reserved for in-flight PRs).

## Verification

`scripts/affected-tests.sh --run`: 180 shell suites passed. New create-item case: non-array labels page does not request page 2.

## Related

Refs #3439 (fail-closed type check; separate follow-up).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7ffb619a-6ebb-4d47-9c45-d68e846edf93?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7ffb619a-6ebb-4d47-9c45-d68e846edf93&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

