### PR TITLE
fix(machine-health): refresh an empty CISA KEV cache file

### DIFF
--- a/plugins/machine-health/.claude-plugin/plugin.json
+++ b/plugins/machine-health/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "machine-health",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "Workstation health audit: OS-specific checks (disk, OS updates, security posture, CISA KEV correlation) run from a versioned catalog with trend-aware severity, approval-gated remediations, and dated markdown reports. Windows fully implemented; macOS/Linux scaffolded (report UNKNOWN and stop). Machine state persists in the plugin data directory; the report directory and check catalog are configurable.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/machine-health/CHANGELOG.md
+++ b/plugins/machine-health/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to the `machine-health` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.12.2]
+
+### Fixed
+
+- **`Get-CisaKevCache` refreshes an empty or whitespace cache file.** That path left
+  `needsRefresh` false and `$cached` null, so a truncated cache never self-healed. Empty
+  content now takes the same refresh path as a missing file.
+
 ## [0.12.1]
 
 ### Changed

--- a/plugins/machine-health/skills/audit/scripts/windows/lib/Get-CisaKevCache.ps1
+++ b/plugins/machine-health/skills/audit/scripts/windows/lib/Get-CisaKevCache.ps1
@@ -53,6 +53,11 @@ function Get-CisaKevCache {
             $raw = Get-Content -LiteralPath $CachePath -Raw -ErrorAction Stop
             if (-not [string]::IsNullOrWhiteSpace($raw)) {
                 $cached = $raw | ConvertFrom-Json -ErrorAction Stop
+            } else {
+                # Empty or whitespace is the same class as a missing file: the
+                # cache cannot be reused and must refresh (#3436). Leaving
+                # needsRefresh false here skipped every other malformed path.
+                $needsRefresh = $true
             }
         } catch {
             Write-Warning "Get-CisaKevCache: cache parse failed, will refresh. $($_.Exception.Message)"

--- a/plugins/machine-health/skills/audit/tests/windows/lib/Get-CisaKevCache.Tests.ps1
+++ b/plugins/machine-health/skills/audit/tests/windows/lib/Get-CisaKevCache.Tests.ps1
@@ -52,6 +52,17 @@ Describe 'Get-CisaKevCache' -Tag 'lib' {
             Should -Invoke Invoke-WebRequest -Times 1
         }
 
+        It 'fetches when the cache file is empty or whitespace' {
+            Set-Content -LiteralPath $script:cachePath -Value "   `r`n`t  " -Encoding utf8
+
+            Set-KevFetchMock -CveId 'CVE-2024-EMPTY'
+
+            $result = Get-CisaKevCache -CachePath $script:cachePath -LogPath $script:logPath
+            $result.vulnerabilities.Count | Should -Be 1
+            $result.vulnerabilities[0].cveID | Should -Be 'CVE-2024-EMPTY'
+            Should -Invoke Invoke-WebRequest -Times 1
+        }
+
         It 'fetches when the cache is the checked-in seed stub (empty vulnerabilities)' {
             $stub = '{"_comment":"placeholder","vulnerabilities":[]}'
             Set-Content -LiteralPath $script:cachePath -Value $stub -Encoding utf8


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #3436

## Summary

An empty or whitespace CISA KEV cache left `needsRefresh` false, so a truncated file never self-healed.

## Fix

Treat empty/whitespace content as the missing-file path (`needsRefresh = true`). machine-health 0.12.2.

## Verification

Pester `Get-CisaKevCache.Tests.ps1`: 14 passed, including the new empty/whitespace fixture. Official runner is Windows-only; this lib suite also ran on Linux.

## Related

N/A
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7ffb619a-6ebb-4d47-9c45-d68e846edf93?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7ffb619a-6ebb-4d47-9c45-d68e846edf93&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

