### PR TITLE
test(repo-hygiene): pin batch_read_lines_into under ulimit -n 10

### DIFF
--- a/plugins/repo-hygiene/.claude-plugin/plugin.json
+++ b/plugins/repo-hygiene/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "repo-hygiene",
-  "version": "0.10.20",
+  "version": "0.10.23",
   "description": "Repo hygiene action-router: /repo-hygiene:clean sweeps reclaimable caches, build artifacts, and stale git metadata, and can realign the working tree to a fresh-pull state — dry-run-first, with destructive tiers gated behind explicit confirmation and a session-scoped destructive-command guard. Ecosystem targets are detected at runtime; secrets, runtime dependencies, and skill data are preserved by default.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/repo-hygiene/CHANGELOG.md
+++ b/plugins/repo-hygiene/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to the `repo-hygiene` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.10.23]
+
+### Fixed
+
+- **`clean`: `batch_read_lines_into` now has a `ulimit -n 10` regression case.** The helper
+  opens named sources on fixed fd 3 so a low nofile ceiling still works. The prior
+  `{fd}` allocator started at 10 and failed that limit; the case was missing from the
+  test matrix on #3641.
+
 ## [0.10.20]
 
 ### Fixed

--- a/plugins/repo-hygiene/skills/clean/scripts/lib/batch-common.test.sh
+++ b/plugins/repo-hygiene/skills/clean/scripts/lib/batch-common.test.sh
@@ -185,5 +185,36 @@ else
 fi
 chmod 644 "$UNREAD" 2>/dev/null || true
 
+# Fixed fd 3 (not Bash `{fd}`, which allocates from 10 up) so a named source
+# still opens when the runner's soft nofile ceiling is 10. Codex flagged the
+# missing case on #3641 after `{fd}` failed under that ulimit.
+printf 'keep\n' >"$TEST_TMPDIR/lowfd.txt"
+if (ulimit -n 10) >/dev/null 2>&1; then
+  LINES=()
+  rc=0
+  out="$(
+    bash -c '
+      ulimit -n 10 || exit 125
+      # shellcheck source=batch-common.sh
+      source "$1"
+      LINES=()
+      batch_read_lines_into LINES "$2" || exit $?
+      printf "%s\n" "${LINES[0]}"
+    ' bash "$SCRIPT_DIR/batch-common.sh" "$TEST_TMPDIR/lowfd.txt"
+  )" || rc=$?
+  if [[ $rc -eq 125 ]]; then
+    skip_case "ulimit -n 10 refused on this host"
+  else
+    assert_exit "named source opens under ulimit -n 10" 0 "$rc"
+    if [[ "$out" == "keep" ]]; then
+      pass "low-fd read yields the line"
+    else
+      fail "low-fd read yields the line" "keep" "$out"
+    fi
+  fi
+else
+  skip_case "cannot lower ulimit -n on this host"
+fi
+
 [[ $FAILED -eq 0 ]] || exit 1
 echo "batch-common.test.sh: all passed"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
No linked issue

## Summary

`#3641` switched `batch_read_lines_into` from `exec {fd}<` to fixed `exec 3<` so a `ulimit -n 10` runner can still open a named source. The test matrix never exercised that limit.

## Fix

Add a guarded case in `batch-common.test.sh` that lowers `ulimit -n` to 10 and reads a one-line list. Skip if the host refuses the ulimit. repo-hygiene 0.10.23 (avoids in-flight 0.10.21 / 0.10.22).

## Verification

`bash plugins/repo-hygiene/skills/clean/scripts/lib/batch-common.test.sh`: cases 28-29 pass (`named source opens under ulimit -n 10`, `low-fd read yields the line`). `scripts/affected-tests.sh --run`: 1 suite passed.

## Related

Refs #3641 (Codex review on the merged PR).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7ffb619a-6ebb-4d47-9c45-d68e846edf93?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7ffb619a-6ebb-4d47-9c45-d68e846edf93&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

