### PR TITLE
fix(work-items): fail closed when a gitea label page is not an array

### DIFF
--- a/plugins/work-items/.claude-plugin/plugin.json
+++ b/plugins/work-items/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "work-items",
-  "version": "0.39.48",
+  "version": "0.39.49",
   "description": "Manages development work items through a provider-neutral tracker seam that ships with the plugin (bundled dispatcher plus github, local-markdown, jira, gitea, and linear adapters; seam plugin-dir canonical, adapters consumer-local-first): dashboard, taxonomy-labeled creation, a race-safe assignee-plus-lease claim protocol, recurring-schedule checks, TODO scanning, stale-lease auditing, plan decomposition into vertical-slice items, a macro-journey router over spec containers (rollup, per-container execution shape, next-step routing), raw-intake triage (issues and unsolicited PRs through raw, verified, briefed, autonomous-eligible states), plus the two work-items loop lanes of the loop-lane convention: a self-paced autonomous work-loop drain (work-class admission gate, adaptive item cap, PR-only) and an attended attend-queue escalation lane. The re-runnable setup skill binds the provider (.work-item-tracker.json), seeds the recurring-schedule seam (.github/recurring-schedule.json), and remaps canonical role labels.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/work-items/CHANGELOG.md
+++ b/plugins/work-items/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to the `work-items` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.39.49]
+
+### Fixed
+
+- **Gitea label walk fails closed on a non-array 200 body.** `create-item` treated any 200 as
+  iterable. A proxy error page or auth-redirect object has `jq length` equal to its key count, so
+  the walk accepted garbage instead of erroring. `wit_gitea_require_array` now type-checks each
+  label page (`jq 'type == "array"'`) after the HTTP-status gate.
+
 ## [0.39.48]
 
 ### Fixed

--- a/plugins/work-items/tools/work-item-tracker/adapters/gitea/common.sh
+++ b/plugins/work-items/tools/work-item-tracker/adapters/gitea/common.sh
@@ -348,6 +348,20 @@ wit_gitea_http() {
   rm -f "$hdrs"
 }
 
+# wit_gitea_require_array <context> — fail closed unless WIT_GITEA_BODY is a
+# JSON array. A 200 proxy error page or auth-redirect body would otherwise be
+# treated as iterable (jq `length` of an object is its key count), yielding an
+# empty or garbage label set instead of an error.
+wit_gitea_require_array() {
+  local ctx="$1"
+  local kind
+  kind="$(jq -r 'type' <<<"$WIT_GITEA_BODY" 2>/dev/null)" || kind=""
+  if [[ "$kind" != "array" ]]; then
+    printf 'gitea: %s — expected a JSON array, got %s\n' "$ctx" "${kind:-non-JSON}" >&2
+    exit "$EX_INTERNAL"
+  fi
+}
+
 # wit_gitea_require_ok <context> — map WIT_GITEA_STATUS to a
 # contract exit code, printing the provider's error text to stderr on failure. 2xx
 # returns 0.

--- a/plugins/work-items/tools/work-item-tracker/adapters/gitea/common.test.sh
+++ b/plugins/work-items/tools/work-item-tracker/adapters/gitea/common.test.sh
@@ -43,7 +43,7 @@ trap 'rm -rf "$FIX"' EXIT
 for fn in wit_require_gitea_id wit_need_gitea_config \
   wit_gitea_scope_in_scope wit_gitea_token \
   wit_gitea_auth_header wit_gitea_http \
-  wit_gitea_require_ok wit_gitea_unimplemented \
+  wit_gitea_require_ok wit_gitea_require_array wit_gitea_unimplemented \
   wit_help_if_requested; do
   if declare -F "$fn" >/dev/null; then
     pass "common.sh exposes $fn"
@@ -91,6 +91,19 @@ check_map() {
   )
   assert_eq "$label" "$want" "$?"
 }
+check_array() {
+  local label="$1" body="$2" want="$3"
+  (
+    WIT_GITEA_BODY="$body"
+    wit_gitea_require_array "test" 2>/dev/null
+  )
+  assert_eq "$label" "$want" "$?"
+}
+check_array "empty array → 0" "[]" "0"
+check_array "label array → 0" '[{"id":1,"name":"type: fix"}]' "0"
+check_array "object 200 → 1" '{"message":"proxy error"}' "1"
+check_array "html 200 → 1" "<html>login</html>" "1"
+
 check_map "200 → ok (0)" "200" "0"
 check_map "401 → auth (4)" "401" "4"
 check_map "403 → auth (4)" "403" "4"

--- a/plugins/work-items/tools/work-item-tracker/adapters/gitea/create-item.sh
+++ b/plugins/work-items/tools/work-item-tracker/adapters/gitea/create-item.sh
@@ -105,6 +105,7 @@ LABEL_IDS='[]'
 if [[ -n "$LABELS" ]]; then
   wit_gitea_http GET "/repos/$WIT_GITEA_OWNER/$WIT_GITEA_REPO/labels?page=1&limit=$WIT_GITEA_PAGE_SIZE"
   wit_gitea_require_ok "listing labels in $REPO"
+  wit_gitea_require_array "listing labels in $REPO"
   ALL_LABELS="$WIT_GITEA_BODY"
   PAGE=2
   LABELS_TRUNCATED=0
@@ -136,6 +137,7 @@ if [[ -n "$LABELS" ]]; then
     fi
     wit_gitea_http GET "/repos/$WIT_GITEA_OWNER/$WIT_GITEA_REPO/labels?page=$PAGE&limit=$WIT_GITEA_PAGE_SIZE"
     wit_gitea_require_ok "listing labels in $REPO (page $PAGE)"
+    wit_gitea_require_array "listing labels in $REPO (page $PAGE)"
     # Accumulator on stdin, page in argv: the reverse puts an unboundedly growing array on
     # jq's command line, and past ARG_MAX the exec fails outright — leaving ALL_LABELS empty,
     # which here means every requested label reads as nonexistent and is refused.
@@ -161,6 +163,7 @@ if [[ -n "$LABELS" ]]; then
   wit_gitea_http GET "/orgs/$WIT_GITEA_OWNER/labels?page=1&limit=$WIT_GITEA_PAGE_SIZE"
   if [[ "$WIT_GITEA_STATUS" != "404" ]]; then
     wit_gitea_require_ok "listing organization labels for $WIT_GITEA_OWNER"
+    wit_gitea_require_array "listing organization labels for $WIT_GITEA_OWNER"
     # Same walk as the repo labels above, and deliberately the SAME SHAPE: this endpoint sets
     # X-Total-Count too, so the header decides. A largest-page-seen heuristic would be wrong
     # twice over — it always spends one extra request (the page that establishes the baseline
@@ -191,6 +194,7 @@ if [[ -n "$LABELS" ]]; then
       fi
       wit_gitea_http GET "/orgs/$WIT_GITEA_OWNER/labels?page=$ORG_PAGE_NUM&limit=$WIT_GITEA_PAGE_SIZE"
       wit_gitea_require_ok "listing organization labels for $WIT_GITEA_OWNER (page $ORG_PAGE_NUM)"
+      wit_gitea_require_array "listing organization labels for $WIT_GITEA_OWNER (page $ORG_PAGE_NUM)"
       ORG_PAGE="$WIT_GITEA_BODY"
       ORG_PAGE_NUM=$((ORG_PAGE_NUM + 1))
     done

--- a/plugins/work-items/tools/work-item-tracker/adapters/gitea/create-item.test.sh
+++ b/plugins/work-items/tools/work-item-tracker/adapters/gitea/create-item.test.sh
@@ -73,21 +73,6 @@ else
   pass "no issue is created when a label is unknown"
 fi
 
-# A non-array 200 (proxy error page, auth redirect body) must fail closed, not
-# be treated as an empty/garbage label set. jq length of an object is its key
-# count, which would otherwise look like a one-item page.
-gitea_reset_routes
-gitea_seed "/labels" 200 '{"message":"proxy error"}'
-gitea_seed "/issues" 201 "$(gitea_issue_json 12 open 'x')"
-rc="$(gitea_run "$S" --title "x" --labels "type: fix")"
-assert_eq "non-array label 200 → exit 1" "1" "$rc"
-assert_contains "names the type failure" "$(gitea_err)" "expected a JSON array"
-if [[ "$(gitea_requests)" == *"POST"* ]]; then
-  fail "no issue is created when the label list is not an array" "no POST" "POST issued"
-else
-  pass "no issue is created when the label list is not an array"
-fi
-
 # --- --type cannot be honored, and says so ---
 # Gitea has no issue-type registry, so the normalized `type` is structurally null.
 gitea_reset_routes
@@ -208,20 +193,28 @@ rc="$(gitea_run "$S" --title "t" --labels "nonexistent")"
 assert_eq "a label in neither scope → exit 5" "5" "$rc"
 assert_contains "and it is named" "$(gitea_err)" "nonexistent"
 
-# A non-array 200 on the first labels page used to make `jq 'length'` empty
-# and `(( < PAGE_SIZE ))` an arithmetic error, so the walk continued to page 2
-# instead of treating the page as exhausted (#3484). No X-Total-Count, so the
-# page-length arm is the one that fires.
+# A non-array 200 (proxy error page, auth redirect body) must fail closed with
+# an explicit adapter error, not be treated as an empty or garbage label set
+# (#3439). jq length of an object is its key count, which would otherwise look
+# like a one-item page. The same fixture used to hang into page 2 via an
+# arithmetic error on empty jq length (#3484); the type gate stops the walk
+# before that arm.
 gitea_reset_routes
 gitea_seed "/labels?page=1" 200 '{"message":"not a list"}'
 gitea_seed "/labels?page=2" 200 "$(jq -cn '[{id:3,name:"type: fix"}]')"
 gitea_seed "/issues" 201 "$(gitea_issue_json 12 open 'x')"
 rc="$(gitea_run "$S" --title "x" --labels "type: fix")"
-assert_eq "non-array labels page → no hang, non-zero" "5" "$rc"
+assert_eq "non-array labels page → exit 1" "1" "$rc"
+assert_contains "names the type failure" "$(gitea_err)" "expected a JSON array"
 if [[ "$(gitea_requests)" == *"page=2"* ]]; then
   fail "malformed labels page must not continue paging" "no page=2" "page=2 requested"
 else
   pass "malformed labels page stops the walk"
+fi
+if [[ "$(gitea_requests)" == *"POST"* ]]; then
+  fail "no issue is created when the label list is not an array" "no POST" "POST issued"
+else
+  pass "no issue is created when the label list is not an array"
 fi
 
 [[ $FAILED -eq 0 ]] || exit 1

--- a/plugins/work-items/tools/work-item-tracker/adapters/gitea/create-item.test.sh
+++ b/plugins/work-items/tools/work-item-tracker/adapters/gitea/create-item.test.sh
@@ -73,6 +73,21 @@ else
   pass "no issue is created when a label is unknown"
 fi
 
+# A non-array 200 (proxy error page, auth redirect body) must fail closed, not
+# be treated as an empty/garbage label set. jq length of an object is its key
+# count, which would otherwise look like a one-item page.
+gitea_reset_routes
+gitea_seed "/labels" 200 '{"message":"proxy error"}'
+gitea_seed "/issues" 201 "$(gitea_issue_json 12 open 'x')"
+rc="$(gitea_run "$S" --title "x" --labels "type: fix")"
+assert_eq "non-array label 200 → exit 1" "1" "$rc"
+assert_contains "names the type failure" "$(gitea_err)" "expected a JSON array"
+if [[ "$(gitea_requests)" == *"POST"* ]]; then
+  fail "no issue is created when the label list is not an array" "no POST" "POST issued"
+else
+  pass "no issue is created when the label list is not an array"
+fi
+
 # --- --type cannot be honored, and says so ---
 # Gitea has no issue-type registry, so the normalized `type` is structurally null.
 gitea_reset_routes


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #3439

## Summary

The gitea adapter's label walk treated any 200 body as iterable. A proxy error page or auth-redirect object has `jq length` equal to its key count, so the walk accepted garbage instead of erroring.

## Fix

Add `wit_gitea_require_array` in `common.sh` (`jq 'type' == array`) and call it after every label-page `wit_gitea_require_ok` in `create-item.sh`. A non-array 200 now exits 1 with `expected a JSON array`, does not request page 2, and does not POST an issue.

work-items 0.39.48 -> 0.39.49 (rebased onto #3647).

## Verification

`create-item.test.sh` 49/49 and `common.test.sh` 69/69 after updating the #3484 fixture from expected exit 5 to exit 1.

## Related

Refs #3647
Refs #3651
Refs #3484
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7ffb619a-6ebb-4d47-9c45-d68e846edf93?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7ffb619a-6ebb-4d47-9c45-d68e846edf93&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

