### PR TITLE
docs(disk-hygiene): name the hook-issued ask on the PowerShell deletion lane

### DIFF
--- a/plugins/disk-hygiene/.claude-plugin/plugin.json
+++ b/plugins/disk-hygiene/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "disk-hygiene",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "description": "Context-aware disk hygiene for arbitrary directory trees: inventories orphaned and temporary artifacts, classifies evidence into review tiers, and offers exact-path cleanup only after a fresh safety preview and explicit per-tier approval. The target is read-only by default; OS-managed paths, links and mount points, VCS-tracked content without the complete checkout evidence bundle, changed entries, and live-handle uncertainty fail closed.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/disk-hygiene/CHANGELOG.md
+++ b/plugins/disk-hygiene/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to the `disk-hygiene` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.21.1]
+
+### Changed
+
+- **Manual-handoff docs name the hook-issued `ask`, not a guaranteed human prompt.** The
+  PowerShell deletion lane returns `permissionDecision: "ask"`. Official PreToolUse docs say
+  that value prompts the user to confirm and, since v2.1.211, forces the prompt even in auto
+  mode, but an explicit `permissions.ask` rule is what those pages treat as prompting in
+  every permission mode. SKILL.md, the safety model, the unsupported-platform handoff, and
+  the guard docstring now say so.
+
 ## [0.21.0]
 
 ### Changed

--- a/plugins/disk-hygiene/CHANGELOG.md
+++ b/plugins/disk-hygiene/CHANGELOG.md
@@ -11,8 +11,9 @@ All notable changes to the `disk-hygiene` plugin are documented here. Format fol
   PowerShell deletion lane returns `permissionDecision: "ask"`. Official PreToolUse docs say
   that value prompts the user to confirm and, since v2.1.211, forces the prompt even in auto
   mode, but an explicit `permissions.ask` rule is what those pages treat as forcing a prompt
-  in `auto` and `bypassPermissions` (`dontAsk` auto-denies instead). SKILL.md, the safety
-  model, and the unsupported-platform handoff now say so.
+  in `auto` and `bypassPermissions` (`dontAsk` auto-denies instead). The engine-apply step
+  uses that same hook `ask`, so SKILL.md and README no longer call it a guaranteed final
+  prompt. The safety model and unsupported-platform handoff now say so.
 
 ## [0.21.0]
 

--- a/plugins/disk-hygiene/CHANGELOG.md
+++ b/plugins/disk-hygiene/CHANGELOG.md
@@ -10,9 +10,9 @@ All notable changes to the `disk-hygiene` plugin are documented here. Format fol
 - **Manual-handoff docs name the hook-issued `ask`, not a guaranteed human prompt.** The
   PowerShell deletion lane returns `permissionDecision: "ask"`. Official PreToolUse docs say
   that value prompts the user to confirm and, since v2.1.211, forces the prompt even in auto
-  mode, but an explicit `permissions.ask` rule is what those pages treat as prompting in
-  every permission mode. SKILL.md, the safety model, the unsupported-platform handoff, and
-  the guard docstring now say so.
+  mode, but an explicit `permissions.ask` rule is what those pages treat as forcing a prompt
+  in `auto` and `bypassPermissions` (`dontAsk` auto-denies instead). SKILL.md, the safety
+  model, and the unsupported-platform handoff now say so.
 
 ## [0.21.0]
 

--- a/plugins/disk-hygiene/README.md
+++ b/plugins/disk-hygiene/README.md
@@ -201,7 +201,8 @@ measurements below carry the conditions they were taken under.
 
 - **Code execution:** the plugin runs bundled, standard-library Python. The skill-scoped PreToolUse
   guard denies every unknown Bash command, permits only canonical bundled scan/preview calls, and
-  forces a final permission prompt for the canonical engine apply call. The guard rejects shell
+  returns a hook-issued `ask` for the canonical engine apply call (same `permissionDecision: "ask"`
+  as the PowerShell deletion lane; `dontAsk` auto-denies instead of prompting). The guard rejects shell
   expansion and operator syntax instead of validating only the post-split argument vector; script
   identity follows the host path rules and remains case-sensitive on POSIX. No `eval`, dynamic shell
   construction, or downloads are used. Paths cross the process boundary as JSON or individually

--- a/plugins/disk-hygiene/skills/clean/SKILL.md
+++ b/plugins/disk-hygiene/skills/clean/SKILL.md
@@ -375,9 +375,14 @@ and the residual fail-open → "Hook launch form".
   interpreter. Do supporting inspection with non-Bash read-only tools. Shell expansions, globs,
   splitting/escape forms, operators, redirections, aliases, and exported functions fail closed.
 - The PowerShell lane is the inverse tradeoff: open for read-only support work, hard-denying engine
-  invocations, and turning known deletion spellings into a final human permission prompt. It is a
-  raised bar, not a fail-closed lane, its flagged set is enumerated, so an unflagged mutation
-  spelling passes it. The engine's own containment and the Bash lane remain the deletion authority.
+  invocations, and turning known deletion spellings into a hook-issued `ask`
+  (`permissionDecision: "ask"`). Official PreToolUse docs say that value prompts the user to
+  confirm and, since v2.1.211, forces the prompt even in auto mode (the classifier can still
+  deny, but cannot silently approve). An explicit `permissions.ask` rule for those deletion
+  spellings is what the same docs treat as prompting in every permission mode; add one if the
+  manual handoff must not depend on hook-`ask` surfacing. The lane is a raised bar, not
+  fail-closed; its flagged set is enumerated, so an unflagged mutation spelling passes it. The
+  engine's own containment and the Bash lane remain the deletion authority.
 - The guard rejects `~` anywhere in a Bash command as a shell-expansion character, which includes
   Windows 8.3 short names (`SOMEUS~1`). Always pass long-form paths; the guard's own disclosures
   are already long-form.

--- a/plugins/disk-hygiene/skills/clean/SKILL.md
+++ b/plugins/disk-hygiene/skills/clean/SKILL.md
@@ -324,8 +324,10 @@ After an affirmative answer in this interactive session, run only:
 ```
 
 Never use `rm`, `rmdir`, `Remove-Item`, `del`, `find -delete`, or an ad-hoc Python deletion call. The
-skill-frontmatter belt blocks those bypasses and forces one final permission prompt for the exact engine
-apply command; confirm it only when it matches the tier and paths just approved. If the plan, snapshot,
+skill-frontmatter belt blocks those bypasses and returns a hook-issued `ask`
+(`permissionDecision: "ask"`) for the exact engine apply command — the same mechanism as the
+PowerShell deletion lane below, including the `dontAsk` / `permissions.ask` caveats. Confirm that
+prompt only when it matches the tier and paths just approved. If the plan, snapshot,
 path identity, descendant set, VCS state, or handle state changed, re-scan and re-ask; never reuse a
 token.
 

--- a/plugins/disk-hygiene/skills/clean/SKILL.md
+++ b/plugins/disk-hygiene/skills/clean/SKILL.md
@@ -379,10 +379,12 @@ and the residual fail-open → "Hook launch form".
   (`permissionDecision: "ask"`). Official PreToolUse docs say that value prompts the user to
   confirm and, since v2.1.211, forces the prompt even in auto mode (the classifier can still
   deny, but cannot silently approve). An explicit `permissions.ask` rule for those deletion
-  spellings is what the same docs treat as prompting in every permission mode; add one if the
-  manual handoff must not depend on hook-`ask` surfacing. The lane is a raised bar, not
-  fail-closed; its flagged set is enumerated, so an unflagged mutation spelling passes it. The
-  engine's own containment and the Bash lane remain the deletion authority.
+  spellings is what the same docs treat as forcing a prompt in `auto` and `bypassPermissions`;
+  in `dontAsk` that rule is denied with no prompt, so leave `dontAsk` first if the per-path
+  handoff confirm must appear. Add one if the manual handoff must not depend on hook-`ask`
+  surfacing. The lane is a raised bar, not fail-closed; its flagged set is enumerated, so an
+  unflagged mutation spelling passes it. The engine's own containment and the Bash lane remain
+  the deletion authority.
 - The guard rejects `~` anywhere in a Bash command as a shell-expansion character, which includes
   Windows 8.3 short names (`SOMEUS~1`). Always pass long-form paths; the guard's own disclosures
   are already long-form.

--- a/plugins/disk-hygiene/skills/clean/reference/safety-model.md
+++ b/plugins/disk-hygiene/skills/clean/reference/safety-model.md
@@ -132,7 +132,8 @@ machine-readable verdict per path. It deliberately does not apply platform execu
 it exists exactly where `execution-platform-unsupported` blocks the engine lane — and it has no
 deletion capability of any kind: the model deletes only verdict-`clear` paths in the manual lane,
 per item, under the hook-issued `ask` the PowerShell guard returns. Add a `permissions.ask`
-rule for the deletion spellings if that prompt must appear in every permission mode.
+rule for the deletion spellings if that prompt must appear in `auto` and `bypassPermissions`;
+leave `dontAsk` first, because that mode auto-denies an `ask` rule instead of prompting.
 
 ### Standalone Git checkout evidence
 

--- a/plugins/disk-hygiene/skills/clean/reference/safety-model.md
+++ b/plugins/disk-hygiene/skills/clean/reference/safety-model.md
@@ -131,7 +131,8 @@ identity/reparse/protection/descendant/VCS/handle checks against live state and 
 machine-readable verdict per path. It deliberately does not apply platform execution blockers —
 it exists exactly where `execution-platform-unsupported` blocks the engine lane — and it has no
 deletion capability of any kind: the model deletes only verdict-`clear` paths in the manual lane,
-per item, under the final human permission prompt the PowerShell guard raises.
+per item, under the hook-issued `ask` the PowerShell guard returns. Add a `permissions.ask`
+rule for the deletion spellings if that prompt must appear in every permission mode.
 
 ### Standalone Git checkout evidence
 
@@ -166,7 +167,7 @@ categorical reasons.
 
 Passing this bundle does not relax any non-Git protected name, non-Git VCS marker, mount,
 link/reparse, consumer protection, identity/descendant, or live-handle check. The mode is read-only;
-deletion remains a per-path manual handoff under the existing final permission prompt, and the
+deletion remains a per-path manual handoff under the existing hook-issued `ask`, and the
 verdict still expires immediately.
 
 | Verdict | Meaning | Manual-lane action |
@@ -224,7 +225,7 @@ a real marketplace install.
 The same guard also covers the PowerShell tool with the inverse tradeoff: PowerShell stays open for
 read-only support work, while engine invocations are hard-denied (Bash is the only engine lane) and
 known deletion spellings and .NET Delete calls resolve against the `disk_hygiene_enabled` kill
-switch. When the guard sees execution enabled they are downgraded to a final human permission prompt;
+switch. When the guard sees execution enabled they are downgraded to a hook-issued `ask`;
 when it sees a configured `false` (audit-only mode) they are denied outright, so the kill switch would
 block deletions on the PowerShell lane too and not only the Bash engine apply.
 

--- a/plugins/disk-hygiene/skills/clean/reference/unsupported-platform-handoff.md
+++ b/plugins/disk-hygiene/skills/clean/reference/unsupported-platform-handoff.md
@@ -129,8 +129,10 @@ engine plan:
 The PowerShell guard lane turns deletion spellings into a hook-issued `ask` (the same
 bar as the engine apply prompt). Confirm that prompt only when the command matches the exact
 approved list. An explicit `permissions.ask` rule for those spellings is what the official
-hooks and settings pages treat as prompting in every mode; add one if the handoff must not
-depend on hook-`ask` surfacing. Engine invocations from PowerShell stay hard-denied.
+hooks and settings pages treat as forcing a prompt in `auto` and `bypassPermissions`; in
+`dontAsk` it is denied instead. Add one if the handoff must not depend on hook-`ask`
+surfacing, and leave `dontAsk` first when the operator needs the confirm prompt. Engine
+invocations from PowerShell stay hard-denied.
 
 ## Hook registration outlives the cleanup
 

--- a/plugins/disk-hygiene/skills/clean/reference/unsupported-platform-handoff.md
+++ b/plugins/disk-hygiene/skills/clean/reference/unsupported-platform-handoff.md
@@ -126,9 +126,11 @@ engine plan:
 
 ## The PowerShell guard lane
 
-The PowerShell guard lane turns deletion spellings into a final human permission prompt (the same
-bar as the engine apply prompt); confirm that prompt only when the command matches the exact
-approved list. Engine invocations from PowerShell stay hard-denied.
+The PowerShell guard lane turns deletion spellings into a hook-issued `ask` (the same
+bar as the engine apply prompt). Confirm that prompt only when the command matches the exact
+approved list. An explicit `permissions.ask` rule for those spellings is what the official
+hooks and settings pages treat as prompting in every mode; add one if the handoff must not
+depend on hook-`ask` surfacing. Engine invocations from PowerShell stay hard-denied.
 
 ## Hook registration outlives the cleanup
 

--- a/plugins/disk-hygiene/skills/clean/scripts/destructive_guard.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/destructive_guard.py
@@ -1467,10 +1467,11 @@ def powershell_decision(command: str, enabled: bool) -> tuple[str, str] | None:
     engine invocation rather than denying unknown commands. Engine calls stay on
     the Bash lane's fail-closed deny-unknown guard. A flagged mutation spelling
     resolves against the ``disk_hygiene_enabled`` kill switch: when execution is
-    enabled it surfaces the final human permission prompt (``ask``), preserving
-    the unsupported-platform manual handoff; in audit-only mode (``enabled`` is
-    false) it is denied outright, so the kill switch blocks every deletion lane
-    and not only the Bash engine lane.
+    enabled it returns ``permissionDecision: "ask"`` (a hook-issued ask;
+    official PreToolUse docs say that value prompts the user to confirm),
+    preserving the unsupported-platform manual handoff; in audit-only mode
+    (``enabled`` is false) it is denied outright, so the kill switch blocks
+    every deletion lane and not only the Bash engine lane.
     """
     if _engine_gate_relevant(command, "PowerShell"):
         # Invocation-shaped engine references only — the same classifier the


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #3350

## Summary

The clean skill described the manual-handoff deletion step as producing a "final human permission prompt". The mechanism is a PreToolUse hook returning `permissionDecision: "ask"`. Official hooks docs say `ask` prompts the user to confirm and, since v2.1.211, forces that prompt even in auto mode. An explicit `permissions.ask` rule forces a prompt in `auto` and `bypassPermissions`; in `dontAsk` that same rule is denied with no prompt. The engine-apply step uses the same hook `ask` and had still claimed a guaranteed final prompt.

## Fix

Reword SKILL.md, README, the safety model, the unsupported-platform handoff, and the guard docstring to name the hook-issued `ask`. Tell operators to add a `permissions.ask` rule if the handoff must not depend on hook-`ask` surfacing, and to leave `dontAsk` first when the confirm must appear. Hedge the engine-apply wording the same way.

disk-hygiene 0.21.0 -> 0.21.1.

## Verification

`scripts/affected-tests.sh --run`: 7 shell suites passed (hook-failure-audit, run-python-hook, guard_launch_monitor, detect, hook-exec-form, silent-revert, stale-base-overlap). Two Python suites selected as NOT RUN on this runner. `scripts/run-ruff.sh check` on `destructive_guard.py` passed.

## Related

Refs #3347
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7ffb619a-6ebb-4d47-9c45-d68e846edf93?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7ffb619a-6ebb-4d47-9c45-d68e846edf93&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

