### PR TITLE
fix(knowledge): isolate build-yt-dlp-args tests from host cookie env

### DIFF
--- a/plugins/knowledge/.claude-plugin/plugin.json
+++ b/plugins/knowledge/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "knowledge",
-  "version": "0.13.33",
+  "version": "0.13.34",
   "description": "Ingest external knowledge into durable, synthesized artifacts. Ships a book-distillation pipeline (PDF/EPUB into concept-organized, author-attributed skill reference files), a video-digest pipeline (watch a single public video from YouTube or X, formerly Twitter: transcript, link harvest, and repo-applicability synthesis), a course-digest pipeline (extract and synthesize online video courses \u2014 Dometrain, Teachable \u2014 into repo-applicable recommendations), a docpage-digest pipeline (single online documentation page into a verified knowledge slice with dual verification \u2014 one cross-vendor verifier \u2014 and an interview handoff), and a map-corpus pipeline (multi-resource corpus into a classified link map, deterministic node manifests, gate-verified relevance inventory, and an approved queue of docpage-digest runs), plus a re-runnable setup action; a configurable library directory governs where synthesized artifacts land in the consuming repo.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/knowledge/CHANGELOG.md
+++ b/plugins/knowledge/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to the `knowledge` plugin are recorded here. The `version` i
 `.claude-plugin/plugin.json` is the delivery vehicle — a consumer receives a change
 only after that version increases.
 
+## [0.13.34]
+
+### Fixed
+
+- **`build-yt-dlp-args` tests pass an empty `env` so host cookie settings cannot inject argv.** Six
+  cases omitted `env`, so `resolveYtDlpAuthArgs` fell through to `process.env`. A runner with
+  `VIDEO_DIGEST_YT_DLP_COOKIES_FILE` (or the legacy `YOUTUBE_` spelling) exported then failed the
+  positional and `not.toContain` assertions. They now match the adapter-argv conformance suite.
+
 ## [0.13.33]
 
 ### Fixed

--- a/plugins/knowledge/skills/video-digest/extraction/acquisition/build-yt-dlp-args.test.js
+++ b/plugins/knowledge/skills/video-digest/extraction/acquisition/build-yt-dlp-args.test.js
@@ -22,6 +22,7 @@ describe("buildYtDlpArgs", () => {
       mode: "full",
       outputTemplate: OUTPUT,
       workDir: WORK_DIR,
+      env: {},
       source: adapterSourceDeclarations(youtubeAdapter),
     });
 
@@ -52,6 +53,7 @@ describe("buildYtDlpArgs", () => {
       mode: "full",
       outputTemplate: OUTPUT,
       workDir: WORK_DIR,
+      env: {},
     });
 
     expect(args).toContain("--write-info-json");
@@ -64,6 +66,7 @@ describe("buildYtDlpArgs", () => {
       mode: "full",
       outputTemplate: OUTPUT,
       workDir: WORK_DIR,
+      env: {},
     });
     expect(args).toContain("--no-playlist");
   });
@@ -73,6 +76,7 @@ describe("buildYtDlpArgs", () => {
       mode: "video-only",
       outputTemplate: OUTPUT,
       workDir: WORK_DIR,
+      env: {},
     });
 
     expect(args).not.toContain("--write-subs");
@@ -87,6 +91,7 @@ describe("buildYtDlpArgs", () => {
       mode: "transcript",
       outputTemplate: OUTPUT,
       workDir: WORK_DIR,
+      env: {},
     });
 
     expect(args).toContain("--skip-download");
@@ -99,10 +104,32 @@ describe("buildYtDlpArgs", () => {
       mode: "transcript",
       outputTemplate: OUTPUT,
       workDir: WORK_DIR,
+      env: {},
     });
 
     expect(args).toContain("--paths");
     expect(args[args.indexOf("--paths") + 1]).toBe(`temp:${WORK_DIR}`);
+  });
+
+  it("does not leak process.env cookie settings into isolated argv", () => {
+    const previous = process.env.VIDEO_DIGEST_YT_DLP_COOKIES_FILE;
+    process.env.VIDEO_DIGEST_YT_DLP_COOKIES_FILE = "/tmp/should-not-appear.txt";
+    try {
+      const args = buildYtDlpArgs(URL, {
+        mode: "full",
+        outputTemplate: OUTPUT,
+        workDir: WORK_DIR,
+        env: {},
+      });
+      expect(args).not.toContain("--cookies");
+      expect(args).not.toContain("/tmp/should-not-appear.txt");
+    } finally {
+      if (previous === undefined) {
+        delete process.env.VIDEO_DIGEST_YT_DLP_COOKIES_FILE;
+      } else {
+        process.env.VIDEO_DIGEST_YT_DLP_COOKIES_FILE = previous;
+      }
+    }
   });
 
   it("appends default js runtime before the URL", () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #3447

## Summary

Six `buildYtDlpArgs` cases omitted `env`, so `resolveYtDlpAuthArgs` fell through to `process.env`. A runner with `VIDEO_DIGEST_YT_DLP_COOKIES_FILE` (or the legacy `YOUTUBE_` spelling) exported then failed the positional and `not.toContain` assertions.

## Fix

Pass `env: {}` in those six cases, matching `adapter-argv-conformance.test.js`. Add a case that exports a cookies file on `process.env` and asserts isolated argv does not contain `--cookies`.

knowledge 0.13.33 -> 0.13.34.

## Verification

`scripts/affected-tests.sh --run` selected the Node suite (this runner reports NOT RUN for that ecosystem). Ran `npx vitest run acquisition/build-yt-dlp-args.test.js` with `VIDEO_DIGEST_YT_DLP_COOKIES_FILE=/tmp/should-not-appear.txt` exported: 16/16 passed.

## Related

N/A
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7ffb619a-6ebb-4d47-9c45-d68e846edf93?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7ffb619a-6ebb-4d47-9c45-d68e846edf93&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

