### PR TITLE
fix(knowledge): thread captionClass through the shared yt-dlp driver

### DIFF
--- a/plugins/knowledge/.claude-plugin/plugin.json
+++ b/plugins/knowledge/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "knowledge",
-  "version": "0.13.34",
+  "version": "0.13.35",
   "description": "Ingest external knowledge into durable, synthesized artifacts. Ships a book-distillation pipeline (PDF/EPUB into concept-organized, author-attributed skill reference files), a video-digest pipeline (watch a single public video from YouTube or X, formerly Twitter: transcript, link harvest, and repo-applicability synthesis), a course-digest pipeline (extract and synthesize online video courses \u2014 Dometrain, Teachable \u2014 into repo-applicable recommendations), a docpage-digest pipeline (single online documentation page into a verified knowledge slice with dual verification \u2014 one cross-vendor verifier \u2014 and an interview handoff), and a map-corpus pipeline (multi-resource corpus into a classified link map, deterministic node manifests, gate-verified relevance inventory, and an approved queue of docpage-digest runs), plus a re-runnable setup action; a configurable library directory governs where synthesized artifacts land in the consuming repo.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/knowledge/CHANGELOG.md
+++ b/plugins/knowledge/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to the `knowledge` plugin are recorded here. The `version` i
 `.claude-plugin/plugin.json` is the delivery vehicle — a consumer receives a change
 only after that version increases.
 
+## [0.13.35]
+
+### Fixed
+
+- **Shared yt-dlp driver threads `captionClass` into `selectCaptionFile`.**
+  `adapterSourceDeclarations` dropped the adapter's declared class, and both
+  driver call sites omitted the second argument, so every shared-driver acquire
+  walked the `manual-and-auto` ladder. A `platform-asr` source would have
+  classified a bare `.en.vtt` as `manual-en`. The declaration now carries
+  `captionClass`, and both selection sites pass it.
+
 ## [0.13.34]
 
 ### Fixed

--- a/plugins/knowledge/skills/video-digest/extraction/acquisition/acquire.js
+++ b/plugins/knowledge/skills/video-digest/extraction/acquisition/acquire.js
@@ -28,14 +28,16 @@ import { parseVideoMetadata } from "./video-metadata.js";
  * classification. Closed by default — omitted fields declare the behavior off.
  *
  * @typedef {import('./build-yt-dlp-args.js').YtDlpSourceOptions &
- *   import('./spawn-yt-dlp-with-auth-fallback.js').SourceSpawnClassification} SourceAcquisitionDeclarations
+ *   import('./spawn-yt-dlp-with-auth-fallback.js').SourceSpawnClassification & {
+ *     captionClass?: import('./select-caption.js').CaptionClass
+ *   }} SourceAcquisitionDeclarations
  */
 
 /**
  * Map a source adapter's declared attributes onto the option bundle the shared
- * yt-dlp machinery consumes (arg flags + spawn classification). The adapter
- * declarations are the single source of truth; production never re-states them
- * in a side object.
+ * yt-dlp machinery consumes (arg flags + spawn classification + caption class).
+ * The adapter declarations are the single source of truth; production never
+ * re-states them in a side object.
  *
  * @param {import('../adapters/adapter-contract.js').SourceAdapter} adapter
  * @returns {SourceAcquisitionDeclarations}
@@ -48,6 +50,7 @@ export function adapterSourceDeclarations(adapter) {
     ignoreNoFormatsError: adapter.capabilities.mediaOptional === true,
     errorPatterns: adapter.errorPatterns,
     allowBrowserCookieProfileFallback: adapter.capabilities.browserCookieFallback === true,
+    captionClass: adapter.captionClass,
   };
 }
 
@@ -322,7 +325,7 @@ export async function acquireYouTubeMedia(
     artifacts = resolveMediaArtifacts(files, videoId);
   }
 
-  let captionResult = selectCaptionFile(artifacts.captionPaths);
+  let captionResult = selectCaptionFile(artifacts.captionPaths, source.captionClass);
 
   if (!captionResult.success && mode === "full" && artifacts.videoPath) {
     const captionRetry = await throttle(() =>
@@ -335,7 +338,7 @@ export async function acquireYouTubeMedia(
     if (captionRetry.spawnResult.success) {
       files = await mergedDeps.listFiles(workDir);
       artifacts = resolveMediaArtifacts(files, videoId);
-      captionResult = selectCaptionFile(artifacts.captionPaths);
+      captionResult = selectCaptionFile(artifacts.captionPaths, source.captionClass);
     }
   }
 

--- a/plugins/knowledge/skills/video-digest/extraction/acquisition/acquire.test.js
+++ b/plugins/knowledge/skills/video-digest/extraction/acquisition/acquire.test.js
@@ -90,6 +90,53 @@ describe("acquireYouTubeMedia", () => {
     expect(result.success).toBe(false);
     expect(result.error).toContain("ladder exhausted");
   });
+
+  it("classifies a bare .en.vtt as platform-asr when the source declares that class", async () => {
+    const workDir = "/tmp/fake-work";
+    const videoId = "1001551417340022785";
+    const infoJson = JSON.stringify({
+      id: videoId,
+      title: "Platform ASR Video",
+      description: "desc",
+      chapters: [],
+      comments: [],
+    });
+
+    const result = await acquireYouTubeMedia(
+      `https://www.youtube.com/watch?v=${videoId}`,
+      {
+        workDir,
+        mode: "transcript",
+        videoId,
+        source: { captionClass: "platform-asr" },
+      },
+      {
+        ...NO_THROTTLE,
+        spawn: async () => ({
+          success: true,
+          code: 0,
+          signal: null,
+          stdout: "",
+          stderr: "",
+          timedOut: false,
+        }),
+        listFiles: async () => [
+          `${workDir}/${videoId}.en.vtt`,
+          `${workDir}/${videoId}.info.json`,
+        ],
+        readFile: async (filePath) => {
+          if (filePath.endsWith(".info.json")) return infoJson;
+          return "WEBVTT\n\n";
+        },
+      },
+    );
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data?.caption.rung).toBe("platform-asr-en");
+      expect(result.data?.caption.isAutoCaption).toBe(true);
+    }
+  });
 });
 
 describe("listWorkDirFiles", () => {

--- a/plugins/knowledge/skills/video-digest/extraction/adapters/x.test.js
+++ b/plugins/knowledge/skills/video-digest/extraction/adapters/x.test.js
@@ -177,6 +177,7 @@ describe("x adapter declarations", () => {
     expect(declarations.writeComments).toBe(false);
     expect(declarations.allowBrowserCookieProfileFallback).toBe(false);
     expect(declarations.extractorArgs).toBeNull();
+    expect(declarations.captionClass).toBe("platform-asr");
   });
 
   it("declares mediaOptional: 0-media posts are well-formed for every yt-dlp consumer", () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #3445

## Summary

The shared yt-dlp driver always walked the `manual-and-auto` caption ladder. `adapterSourceDeclarations` dropped `captionClass`, and both `selectCaptionFile` call sites omitted the second argument. Only YouTube uses that driver today (and its class matches the default), so there is no live defect, but a `platform-asr` adapter adopting the driver would classify a bare `.en.vtt` as `manual-en`.

## Fix

Thread `adapter.captionClass` through `adapterSourceDeclarations` and pass `source.captionClass` at both driver selection sites. Add a unit test that a `platform-asr` source classifies a bare `.en.vtt` as `platform-asr-en` with `isAutoCaption: true`.

knowledge 0.13.34 -> 0.13.35.

## Verification

`npx vitest run acquisition/acquire.test.js adapters/x.test.js acquisition/select-caption.test.js`: 77/77 passed.

`scripts/affected-tests.sh --run --explain`: 1 shell suite passed; 50 Node suites selected as NOT RUN on this runner (including the acquire/x suites above, which were run in their own lane).

## Related

N/A
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7ffb619a-6ebb-4d47-9c45-d68e846edf93?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7ffb619a-6ebb-4d47-9c45-d68e846edf93&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

