### PR TITLE
fix: add completion-criteria to education:explain and adhd:clarify

### DIFF
--- a/plugins/adhd/.claude-plugin/plugin.json
+++ b/plugins/adhd/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "adhd",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "Shape and restructure the assistant's output for a reader with ADHD — action-first, low-friction, and digestible. adhd:shape is a standing session posture: lead with the concrete next action, number multi-step work, restate state across turns, cap and rank lists, give concrete time estimates, make wins visible, and cut preamble, recap, and closers. adhd:clarify is a one-shot reshape of a dense, decision-heavy artifact already on screen — chunk it one-decision-at-a-time, define the session's own jargon, and surface exactly what you must decide, faithfully (operative terms quoted verbatim, no altitude loss), rendered as an HTML decision table for big content. Reauthored in part from ayghri/i-have-adhd (MIT). Deliberately mutually exclusive with terse-for-tokens output shapers like caveman — opposite objectives.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/adhd/CHANGELOG.md
+++ b/plugins/adhd/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to the `adhd` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.4.6]
+
+### Changed
+
+- **`clarify`: each core-move step now states an observable done-condition.** The
+  four-step restructure said what to do but not how to know a step was finished.
+  The SKILL.md length warning (soft target 200) is unchanged and still a
+  progressive-disclosure candidate, not a defect of this change.
+
 ## [0.4.5]
 
 ### Changed

--- a/plugins/adhd/skills/clarify/SKILL.md
+++ b/plugins/adhd/skills/clarify/SKILL.md
@@ -26,13 +26,23 @@ worse than the wall of text, so the fidelity rules below are hard, not aspiratio
 1. **Identify the target.** With an argument, that is the thing. Empty
    argument → the **previous assistant response** (see [Empty
    argument](#empty-argument-anaphora-default)).
+   Done when you can name the target, or, on a cold start, have asked what
+   to clarify instead of inventing one.
 2. **Ground it, don't recall it.** Re-read the actual artifact this turn, the
    message just sent, in full. Working from your memory of it instead of its text
    is how operative terms drift.
+   Done when you have re-read the full target this turn and can quote an
+   operative term from its text.
 3. **Restructure faithfully**. Chunk, define jargon, surface decisions
    (below), under the fidelity rules.
+   Done when every decision from the target appears in the restructured view
+   and every omission is named. A paraphrase that drops or softens a decision
+   is not done.
 4. **Choose the medium**. Artifact, local file, or terminal, per
    [Rendering](#rendering-artifact-forward).
+   Done when the output is on the rendering ladder the table names for this
+   session and content size, and you have not claimed an artifact that was
+   not produced.
 
 ## Empty argument, anaphora default
 

--- a/plugins/adhd/skills/clarify/SKILL.md
+++ b/plugins/adhd/skills/clarify/SKILL.md
@@ -26,21 +26,21 @@ worse than the wall of text, so the fidelity rules below are hard, not aspiratio
 1. **Identify the target.** With an argument, that is the thing. Empty
    argument → the **previous assistant response** (see [Empty
    argument](#empty-argument-anaphora-default)).
-   Done when you can name the target, or, on a cold start, have asked what
+   **Done when** you can name the target, or, on a cold start, have asked what
    to clarify instead of inventing one.
 2. **Ground it, don't recall it.** Re-read the actual artifact this turn, the
    message just sent, in full. Working from your memory of it instead of its text
    is how operative terms drift.
-   Done when you have re-read the full target this turn and can quote an
+   **Done when** you have re-read the full target this turn and can quote an
    operative term from its text.
 3. **Restructure faithfully**. Chunk, define jargon, surface decisions
    (below), under the fidelity rules.
-   Done when every decision from the target appears in the restructured view
-   and every omission is named. A paraphrase that drops or softens a decision
-   is not done.
+   **Done when** every decision from the target appears in the restructured
+   view and every omission is named. A paraphrase that drops or softens a
+   decision is not done.
 4. **Choose the medium**. Artifact, local file, or terminal, per
    [Rendering](#rendering-artifact-forward).
-   Done when the output is on the rendering ladder the table names for this
+   **Done when** the output is on the rendering ladder the table names for this
    session and content size, and you have not claimed an artifact that was
    not produced.
 

--- a/plugins/education/.claude-plugin/plugin.json
+++ b/plugins/education/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "education",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "Interactive multi-session learning coach: teaches a general subject or a concept grounded in the consuming repo through the Knowledge-Skills-Wisdom progression, with persistent per-topic learning state. Also a single-session domain primer, a one-shot plain-language explainer that drops anything to genuinely plain words, a picture explainer that answers the same question as a diagram-led HTML artifact for someone who knows nothing about the topic, and a post-work comprehension check that quizzes the human on a completed change.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/education/CHANGELOG.md
+++ b/plugins/education/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to the `education` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.10.2]
+
+### Changed
+
+- **`explain`: each core-move step now states an observable done-condition.** The
+  four-step plain-language first pass said what to do but not how to know a step
+  was finished, which is the premature-completion shape the completion-criteria
+  check warns on. Step 2 (ground the artifact this turn, do not recall it) is
+  the one that was invisible in the output when skipped.
+
 ## [0.10.1]
 
 ### Changed

--- a/plugins/education/skills/explain/SKILL.md
+++ b/plugins/education/skills/explain/SKILL.md
@@ -30,22 +30,24 @@ should reach it without the user naming a command. Auto-trigger is best-effort;
 
 1. **Identify the object.** With an argument, that is the thing. Empty argument →
    the **previous assistant response** (see "Empty argument" below).
-   Done when you can name the object in one sentence, or, on a cold start with
-   no prior assistant message, have asked what to explain instead of guessing.
+   **Done when** you can name the object in one sentence, or, on a cold start
+   with no prior assistant message, have asked what to explain instead of
+   guessing.
 2. **Ground it, don't recall it.** Re-read the actual artifact this turn, the
    message just sent, the file, the error text, the code. For an external concept,
    fetch a primary source rather than leaning on parametric memory (plugin
    doctrine: knowledge is grounded, not remembered).
-   Done when this turn's explanation cites a specific passage, file, error text,
-   or fetched primary source you re-read here. A recalled paraphrase does not
-   count.
+   **Done when** this turn's explanation cites a specific passage, file, error
+   text, or fetched primary source you re-read here. A recalled paraphrase does
+   not count.
 3. **Drop to plain.** One concrete analogy from everyday life. No jargon, no term
    that itself needs prior knowledge. Short. If a technical word is unavoidable,
    define it inline in ordinary words the first time.
-   Done when a reader who does not know the jargon can say back the analogy and
-   the "what it's actually doing" line without asking what a leftover term means.
+   **Done when** the explanation contains one everyday analogy whose structure
+   maps to the object, a "what it's actually doing" line, and no leftover term
+   that is not defined inline in ordinary words.
 4. **Close with the handoff line** (see "Handoff").
-   Done when the response ends with the single standard `/education:teach`
+   **Done when** the response ends with the single standard `/education:teach`
    invitation line.
 
 Lead with the analogy and the "what it's actually doing," not with vocabulary.

--- a/plugins/education/skills/explain/SKILL.md
+++ b/plugins/education/skills/explain/SKILL.md
@@ -30,14 +30,23 @@ should reach it without the user naming a command. Auto-trigger is best-effort;
 
 1. **Identify the object.** With an argument, that is the thing. Empty argument →
    the **previous assistant response** (see "Empty argument" below).
+   Done when you can name the object in one sentence, or, on a cold start with
+   no prior assistant message, have asked what to explain instead of guessing.
 2. **Ground it, don't recall it.** Re-read the actual artifact this turn, the
    message just sent, the file, the error text, the code. For an external concept,
    fetch a primary source rather than leaning on parametric memory (plugin
    doctrine: knowledge is grounded, not remembered).
+   Done when this turn's explanation cites a specific passage, file, error text,
+   or fetched primary source you re-read here. A recalled paraphrase does not
+   count.
 3. **Drop to plain.** One concrete analogy from everyday life. No jargon, no term
    that itself needs prior knowledge. Short. If a technical word is unavoidable,
    define it inline in ordinary words the first time.
+   Done when a reader who does not know the jargon can say back the analogy and
+   the "what it's actually doing" line without asking what a leftover term means.
 4. **Close with the handoff line** (see "Handoff").
+   Done when the response ends with the single standard `/education:teach`
+   invitation line.
 
 Lead with the analogy and the "what it's actually doing," not with vocabulary.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #3594

## Summary

`education:explain` and `adhd:clarify` each carry a four-step numbered core move that said what to do but not how to know a step was finished. That is the premature-completion shape `skill-quality` Check 23 warns on.

## Fix

- Add an observable `**Done when**` continuation to each core-move step in `plugins/education/skills/explain/SKILL.md` and `plugins/adhd/skills/clarify/SKILL.md`, matching the house emphasis.
- Step 2 (ground the artifact this turn, do not recall it) is the condition that was invisible in the output when skipped.
- Explain step 3 (drop to plain) completes when the generated text has one mapping analogy, a "what it's actually doing" line, and no leftover term that is not defined inline. That is inspectable in the one-shot response; a later teach-back is not.
- Bump `education` 0.10.1 → 0.10.2 and `adhd` 0.4.5 → 0.4.6 with changelog entries.
- The `clarify` SKILL.md length warning (soft target 200) is pre-existing and left as a progressive-disclosure candidate, not treated as a defect of this change.

## Verification

On `16b1272e` vs `origin/main`:

- `scripts/check-changed-skills.sh origin/main` — 2 skills checked, 0 failed.
  - `education:explain`: PASS, 0 warnings. Completion-criteria signal present.
  - `adhd:clarify`: PASS, 1 warning (SKILL.md 261/200 soft target; pre-existing). Completion-criteria signal present.
- `scripts/check-changelog-parity.sh --check-bump origin/main` — exit 0.
- `scripts/affected-tests.sh --run` — every changed file is a recorded no-suite class (`*.md`, `*.json`); exit 0.

## Related

Refs #2963, #3595. Write-side doctrine: `docs-hygiene:write-for-agents`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7ffb619a-6ebb-4d47-9c45-d68e846edf93?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7ffb619a-6ebb-4d47-9c45-d68e846edf93&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

