### PR TITLE
fix(knowledge): serialize acquire-throttle stale-slot reclaim

### DIFF
--- a/plugins/knowledge/.claude-plugin/plugin.json
+++ b/plugins/knowledge/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "knowledge",
-  "version": "0.13.36",
+  "version": "0.13.37",
   "description": "Ingest external knowledge into durable, synthesized artifacts. Ships a book-distillation pipeline (PDF/EPUB into concept-organized, author-attributed skill reference files), a video-digest pipeline (watch a single public video from YouTube or X, formerly Twitter: transcript, link harvest, and repo-applicability synthesis), a course-digest pipeline (extract and synthesize online video courses \u2014 Dometrain, Teachable \u2014 into repo-applicable recommendations), a docpage-digest pipeline (single online documentation page into a verified knowledge slice with dual verification \u2014 one cross-vendor verifier \u2014 and an interview handoff), and a map-corpus pipeline (multi-resource corpus into a classified link map, deterministic node manifests, gate-verified relevance inventory, and an approved queue of docpage-digest runs), plus a re-runnable setup action; a configurable library directory governs where synthesized artifacts land in the consuming repo.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/knowledge/CHANGELOG.md
+++ b/plugins/knowledge/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to the `knowledge` plugin are recorded here. The `version` i
 `.claude-plugin/plugin.json` is the delivery vehicle — a consumer receives a change
 only after that version increases.
 
+## [0.13.37]
+
+### Fixed
+
+- **`acquire-throttle` stale-slot reclaim is exclusive.** Two reclaimers could
+  both pass `isStaleSlot` and `rm` the same path. The first delete freed the
+  directory, a peer `mkdir` became a live holder, and the second `rm` evicted
+  that holder so a third acquire exceeded `maxSlots`. Reclaim now takes
+  `slot-N.reclaim` (mkdir, EEXIST skips), re-stats, and only then removes the
+  slot. Rename-then-rm is not used: the original holder still releases
+  `slot-N` in `finally` and would delete a relocated occupant.
+
 ## [0.13.36]
 
 ### Changed

--- a/plugins/knowledge/CHANGELOG.md
+++ b/plugins/knowledge/CHANGELOG.md
@@ -13,8 +13,10 @@ only after that version increases.
   directory, a peer `mkdir` became a live holder, and the second `rm` evicted
   that holder so a third acquire exceeded `maxSlots`. Reclaim now takes
   `slot-N.reclaim` (mkdir, EEXIST skips), re-stats, and only then removes the
-  slot. Rename-then-rm is not used: the original holder still releases
-  `slot-N` in `finally` and would delete a relocated occupant.
+  slot. A leftover reclaim lock older than the slot TTL is stolen by renaming
+  it to a unique tombstone so only one racer can win. Rename-then-rm of the
+  live slot is not used: the original holder still releases `slot-N` in
+  `finally` and would delete a relocated occupant.
 
 ## [0.13.36]
 

--- a/plugins/knowledge/skills/video-digest/extraction/acquisition/acquire-throttle.js
+++ b/plugins/knowledge/skills/video-digest/extraction/acquisition/acquire-throttle.js
@@ -39,20 +39,41 @@ function lockDirPath() {
 }
 
 /**
- * @param {string} slotPath
+ * @param {unknown} error
+ * @returns {boolean}
+ */
+function isAlreadyExists(error) {
+  return Boolean(
+    error && typeof error === "object" && "code" in error && error.code === "EEXIST",
+  );
+}
+
+/**
+ * @param {string} dirPath
  * @returns {Promise<boolean>}
  */
-async function tryAcquireSlot(slotPath) {
+async function tryMkdirExclusive(dirPath) {
   try {
-    await fs.mkdir(slotPath);
-    await fs.writeFile(path.join(slotPath, "pid"), `${process.pid}\n`, "utf8");
+    await fs.mkdir(dirPath);
     return true;
   } catch (error) {
-    if (error && typeof error === "object" && "code" in error && error.code === "EEXIST") {
+    if (isAlreadyExists(error)) {
       return false;
     }
     throw error;
   }
+}
+
+/**
+ * @param {string} slotPath
+ * @returns {Promise<boolean>}
+ */
+async function tryAcquireSlot(slotPath) {
+  if (!(await tryMkdirExclusive(slotPath))) {
+    return false;
+  }
+  await fs.writeFile(path.join(slotPath, "pid"), `${process.pid}\n`, "utf8");
+  return true;
 }
 
 /**
@@ -64,6 +85,8 @@ async function releaseSlot(slotPath) {
 }
 
 /**
+ * Missing paths count as stale so a vanished slot is treated as free.
+ *
  * @param {string} slotPath
  * @returns {Promise<boolean>}
  */
@@ -73,6 +96,63 @@ async function isStaleSlot(slotPath) {
     return Date.now() - stat.mtimeMs > LOCK_STALE_MS;
   } catch {
     return true;
+  }
+}
+
+/**
+ * Exclusive create of `slotPath.reclaim`. A leftover lock older than the
+ * slot TTL is stolen so a crashed reclaimer cannot wedge the slot forever.
+ *
+ * @param {string} reclaimPath
+ * @returns {Promise<boolean>}
+ */
+async function tryAcquireReclaimLock(reclaimPath) {
+  if (await tryMkdirExclusive(reclaimPath)) {
+    return true;
+  }
+  if (!(await isStaleSlot(reclaimPath))) {
+    return false;
+  }
+  await fs.rm(reclaimPath, { recursive: true, force: true });
+  return tryMkdirExclusive(reclaimPath);
+}
+
+/**
+ * Remove a stale slot only after winning an exclusive reclaim lock and
+ * re-statting. A bare rm between `isStaleSlot` and `releaseSlot` lets two
+ * reclaimers both pass the stale check; the first rm frees the path, a peer
+ * `mkdir`s a live holder, and the second rm evicts that holder so a third
+ * acquire exceeds `maxSlots`.
+ *
+ * Rename-then-rm of the live path is unsafe: the original holder still
+ * `releaseSlot(slot-N)` in `finally` and would delete the new occupant.
+ *
+ * @param {string} slotPath
+ * @returns {Promise<boolean>} true when this caller removed the slot
+ */
+export async function reclaimStaleSlot(slotPath) {
+  if (!(await isStaleSlot(slotPath))) {
+    return false;
+  }
+
+  const reclaimPath = `${slotPath}.reclaim`;
+  if (!(await tryAcquireReclaimLock(reclaimPath))) {
+    return false;
+  }
+
+  try {
+    try {
+      const stat = await fs.stat(slotPath);
+      if (Date.now() - stat.mtimeMs <= LOCK_STALE_MS) {
+        return false;
+      }
+    } catch {
+      return false;
+    }
+    await fs.rm(slotPath, { recursive: true, force: true });
+    return true;
+  } finally {
+    await fs.rm(reclaimPath, { recursive: true, force: true });
   }
 }
 
@@ -162,7 +242,7 @@ export async function withAcquireThrottle(
       }
 
       if (await isStaleSlot(slotPath)) {
-        await releaseSlot(slotPath);
+        await reclaimStaleSlot(slotPath);
       }
     }
 

--- a/plugins/knowledge/skills/video-digest/extraction/acquisition/acquire-throttle.js
+++ b/plugins/knowledge/skills/video-digest/extraction/acquisition/acquire-throttle.js
@@ -2,6 +2,7 @@
  * Process-wide throttle for concurrent yt-dlp acquisition runs.
  */
 
+import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -101,7 +102,9 @@ async function isStaleSlot(slotPath) {
 
 /**
  * Exclusive create of `slotPath.reclaim`. A leftover lock older than the
- * slot TTL is stolen so a crashed reclaimer cannot wedge the slot forever.
+ * slot TTL is stolen by renaming it to a unique tombstone (only one racer
+ * can win that rename) so a crashed reclaimer cannot wedge the slot, and
+ * two stealers cannot both believe they hold the lock.
  *
  * @param {string} reclaimPath
  * @returns {Promise<boolean>}
@@ -113,7 +116,13 @@ async function tryAcquireReclaimLock(reclaimPath) {
   if (!(await isStaleSlot(reclaimPath))) {
     return false;
   }
-  await fs.rm(reclaimPath, { recursive: true, force: true });
+  const tombstone = `${reclaimPath}.${process.pid}.${randomUUID()}.dead`;
+  try {
+    await fs.rename(reclaimPath, tombstone);
+  } catch {
+    return false;
+  }
+  await fs.rm(tombstone, { recursive: true, force: true });
   return tryMkdirExclusive(reclaimPath);
 }
 

--- a/plugins/knowledge/skills/video-digest/extraction/acquisition/acquire-throttle.js
+++ b/plugins/knowledge/skills/video-digest/extraction/acquisition/acquire-throttle.js
@@ -226,23 +226,34 @@ export async function withAcquireThrottle(
     path.join(baseDir, `slot-${index}`),
   );
 
+  /**
+   * @param {string} slotPath
+   * @returns {Promise<T>}
+   */
+  const runHeld = async (slotPath) => {
+    const heartbeat = startSlotHeartbeat(slotPath, heartbeatMs);
+    try {
+      return await fn();
+    } finally {
+      heartbeat.stop();
+      await releaseSlot(slotPath);
+    }
+  };
+
   let waitedMs = 0;
 
   // biome-ignore lint/suspicious/noUnnecessaryConditions: intentional lock poll loop
   while (true) {
     for (const slotPath of slotPaths) {
       if (await tryAcquireSlot(slotPath)) {
-        const heartbeat = startSlotHeartbeat(slotPath, heartbeatMs);
-        try {
-          return await fn();
-        } finally {
-          heartbeat.stop();
-          await releaseSlot(slotPath);
-        }
+        return await runHeld(slotPath);
       }
 
       if (await isStaleSlot(slotPath)) {
         await reclaimStaleSlot(slotPath);
+        if (await tryAcquireSlot(slotPath)) {
+          return await runHeld(slotPath);
+        }
       }
     }
 

--- a/plugins/knowledge/skills/video-digest/extraction/acquisition/acquire-throttle.test.js
+++ b/plugins/knowledge/skills/video-digest/extraction/acquisition/acquire-throttle.test.js
@@ -5,7 +5,31 @@ import path from "node:path";
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { refreshSlot, resolveMaxConcurrentAcquires, withAcquireThrottle } from "./acquire-throttle.js";
+import {
+  reclaimStaleSlot,
+  refreshSlot,
+  resolveMaxConcurrentAcquires,
+  withAcquireThrottle,
+} from "./acquire-throttle.js";
+
+/**
+ * @param {string} slotPath
+ * @returns {Promise<void>}
+ */
+async function makeStale(slotPath) {
+  await fs.mkdir(slotPath);
+  const longAgo = new Date(Date.now() - 20 * 60 * 1000);
+  await fs.utimes(slotPath, longAgo, longAgo);
+}
+
+/**
+ * @param {string} dir
+ * @returns {Promise<number>}
+ */
+async function countOccupiedSlots(dir) {
+  const names = await fs.readdir(dir);
+  return names.filter((name) => /^slot-\d+$/.test(name)).length;
+}
 
 /** @type {string} */
 let baseDir;
@@ -32,9 +56,7 @@ describe("withAcquireThrottle", () => {
 
   it("reclaims a stale slot and proceeds", async () => {
     const stale = path.join(baseDir, "slot-0");
-    await fs.mkdir(stale);
-    const longAgo = new Date(Date.now() - 20 * 60 * 1000); // older than the 15-min TTL
-    await fs.utimes(stale, longAgo, longAgo);
+    await makeStale(stale);
 
     const fn = vi.fn(async () => "reclaimed");
     const result = await withAcquireThrottle(fn, {
@@ -46,6 +68,40 @@ describe("withAcquireThrottle", () => {
 
     expect(fn).toHaveBeenCalledTimes(1);
     expect(result).toBe("reclaimed");
+  });
+
+  it("interleaved reclaim and acquire never exceed maxSlots", async () => {
+    await makeStale(path.join(baseDir, "slot-0"));
+    await makeStale(path.join(baseDir, "slot-1"));
+
+    let current = 0;
+    let peakFn = 0;
+    let peakSlots = 0;
+
+    const worker = () =>
+      withAcquireThrottle(
+        async () => {
+          current += 1;
+          peakFn = Math.max(peakFn, current);
+          peakSlots = Math.max(peakSlots, await countOccupiedSlots(baseDir));
+          await new Promise((resolve) => setTimeout(resolve, 40));
+          current -= 1;
+        },
+        {
+          maxSlots: 2,
+          heartbeatMs: 0,
+          baseDir,
+          timeoutMs: 8000,
+          sleep: () => new Promise((resolve) => setTimeout(resolve, 2)),
+        },
+      );
+
+    await Promise.all(Array.from({ length: 6 }, () => worker()));
+
+    expect(peakFn).toBeGreaterThan(0);
+    expect(peakFn).toBeLessThanOrEqual(2);
+    expect(peakSlots).toBeLessThanOrEqual(2);
+    expect(await countOccupiedSlots(baseDir)).toBe(0);
   });
 
   it("throws a descriptive timeout when a fresh slot stays held", async () => {
@@ -61,6 +117,54 @@ describe("withAcquireThrottle", () => {
         sleep: async () => {},
       }),
     ).rejects.toThrow(/timed out after \d+ms/);
+  });
+});
+
+describe("reclaimStaleSlot", () => {
+  it("leaves a live slot in place", async () => {
+    const slot = path.join(baseDir, "slot-0");
+    await fs.mkdir(slot);
+    await fs.writeFile(path.join(slot, "pid"), "live\n");
+
+    expect(await reclaimStaleSlot(slot)).toBe(false);
+    expect(await fs.readFile(path.join(slot, "pid"), "utf8")).toBe("live\n");
+  });
+
+  it("steals a stale leftover reclaim lock so a crashed reclaimer cannot wedge the slot", async () => {
+    const slot = path.join(baseDir, "slot-0");
+    await makeStale(slot);
+    const reclaim = `${slot}.reclaim`;
+    await fs.mkdir(reclaim);
+    const longAgo = new Date(Date.now() - 20 * 60 * 1000);
+    await fs.utimes(reclaim, longAgo, longAgo);
+
+    expect(await reclaimStaleSlot(slot)).toBe(true);
+    expect(fsSync.existsSync(slot)).toBe(false);
+    expect(fsSync.existsSync(reclaim)).toBe(false);
+  });
+
+  it("does not evict a live holder that appears after the first of two reclaimers wins", async () => {
+    const slot = path.join(baseDir, "slot-0");
+    await makeStale(slot);
+
+    /** @type {boolean[]} */
+    const removed = [];
+    await Promise.all(
+      Array.from({ length: 8 }, () =>
+        (async () => {
+          const won = await reclaimStaleSlot(slot);
+          removed.push(won);
+          if (won) {
+            await fs.mkdir(slot);
+            await fs.writeFile(path.join(slot, "pid"), "live\n");
+          }
+        })(),
+      ),
+    );
+
+    expect(removed.filter(Boolean)).toHaveLength(1);
+    expect(await fs.readFile(path.join(slot, "pid"), "utf8")).toBe("live\n");
+    expect(await countOccupiedSlots(baseDir)).toBe(1);
   });
 });
 

--- a/plugins/knowledge/skills/video-digest/extraction/acquisition/acquire-throttle.test.js
+++ b/plugins/knowledge/skills/video-digest/extraction/acquisition/acquire-throttle.test.js
@@ -143,6 +143,34 @@ describe("reclaimStaleSlot", () => {
     expect(fsSync.existsSync(reclaim)).toBe(false);
   });
 
+  it("concurrent steal of a leftover reclaim lock does not evict a live holder", async () => {
+    const slot = path.join(baseDir, "slot-0");
+    await makeStale(slot);
+    const reclaim = `${slot}.reclaim`;
+    await fs.mkdir(reclaim);
+    const longAgo = new Date(Date.now() - 20 * 60 * 1000);
+    await fs.utimes(reclaim, longAgo, longAgo);
+
+    /** @type {boolean[]} */
+    const removed = [];
+    await Promise.all(
+      Array.from({ length: 8 }, () =>
+        (async () => {
+          const won = await reclaimStaleSlot(slot);
+          removed.push(won);
+          if (won) {
+            await fs.mkdir(slot);
+            await fs.writeFile(path.join(slot, "pid"), "live\n");
+          }
+        })(),
+      ),
+    );
+
+    expect(removed.filter(Boolean)).toHaveLength(1);
+    expect(await fs.readFile(path.join(slot, "pid"), "utf8")).toBe("live\n");
+    expect(await countOccupiedSlots(baseDir)).toBe(1);
+  });
+
   it("does not evict a live holder that appears after the first of two reclaimers wins", async () => {
     const slot = path.join(baseDir, "slot-0");
     await makeStale(slot);

--- a/plugins/knowledge/skills/video-digest/extraction/acquisition/acquire-throttle.test.js
+++ b/plugins/knowledge/skills/video-digest/extraction/acquisition/acquire-throttle.test.js
@@ -84,15 +84,15 @@ describe("withAcquireThrottle", () => {
           current += 1;
           peakFn = Math.max(peakFn, current);
           peakSlots = Math.max(peakSlots, await countOccupiedSlots(baseDir));
-          await new Promise((resolve) => setTimeout(resolve, 40));
+          await new Promise((resolve) => setTimeout(resolve, 25));
           current -= 1;
         },
         {
           maxSlots: 2,
           heartbeatMs: 0,
           baseDir,
-          timeoutMs: 8000,
-          sleep: () => new Promise((resolve) => setTimeout(resolve, 2)),
+          timeoutMs: 60_000,
+          sleep: () => new Promise((resolve) => setTimeout(resolve, 5)),
         },
       );
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #3446

## Summary

Stale-slot reclaim in `acquire-throttle` was a bare `isStaleSlot` plus recursive `rm`. Two reclaimers could both pass the stale check; the first delete freed the path, a peer `mkdir` became a live holder, and the second `rm` evicted that holder so a third acquire exceeded `maxSlots`.

## Fix

Reclaim now takes an exclusive `slot-N.reclaim` directory (mkdir; `EEXIST` skips), re-stats the slot, and only then removes it. The waiter who just reclaimed retries `tryAcquire` on that path so the freed slot is taken without waiting out a full poll. A leftover reclaim lock older than the slot TTL is stolen by renaming it to a unique tombstone so only one racer can win; a bare `rm` then `mkdir` would reintroduce the same double-holder race one layer up. Rename-then-rm of the live slot is not used: the original holder still `releaseSlot(slot-N)` in `finally` and would delete a relocated occupant.

knowledge 0.13.36 → 0.13.37.

## Verification

- `npx vitest run acquisition/acquire-throttle.test.js` — 13/13, three consecutive runs after the steal-path fix
- `npm test` in `plugins/knowledge/skills/video-digest/extraction` — 71 files, 508 tests (pre-review-fix)
- `scripts/affected-tests.sh --run` — selected shell suite passed; Node suites run via vitest above

## Related

N/A
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7ffb619a-6ebb-4d47-9c45-d68e846edf93?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7ffb619a-6ebb-4d47-9c45-d68e846edf93&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

