### PR TITLE
fix(github): report setup check layers as PASS/FAIL/INFO

### DIFF
--- a/plugins/github/.claude-plugin/plugin.json
+++ b/plugins/github/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "github",
-  "version": "0.3.11",
+  "version": "0.3.12",
   "description": "GitHub admin-plane audit, advice, and guided setup over the authenticated user's own gh CLI: billing and cost control, security posture, rulesets and settings drift, Actions policy, and every other org/repo/enterprise settings area. Grounded in live state and current official GitHub docs (zero vendored knowledge); read-only by default, every mutation user-in-loop.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/github/CHANGELOG.md
+++ b/plugins/github/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to the `github` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.3.12]
+
+### Changed
+
+- **setup `check` reports PASS/FAIL/INFO.** The per-layer table used
+  exists/absent and "hard finding" instead of the setup-contract verdict
+  vocabulary. Rows are now PASS/FAIL/INFO; all-layers-absent is INFO, not
+  FAIL. `user-invocable: true` was already explicit in 0.3.10.
+
 ## [0.3.11]
 
 ### Changed

--- a/plugins/github/CHANGELOG.md
+++ b/plugins/github/CHANGELOG.md
@@ -9,8 +9,10 @@ All notable changes to the `github` plugin are documented here. Format follows
 
 - **setup `check` reports PASS/FAIL/INFO.** The per-layer table used
   exists/absent and "hard finding" instead of the setup-contract verdict
-  vocabulary. Rows are now PASS/FAIL/INFO; all-layers-absent is INFO, not
-  FAIL. `user-invocable: true` was already explicit in 0.3.10.
+  vocabulary. Rows are now PASS/FAIL/INFO with a remediation line per FAIL
+  (team: unignore or commit; overlay: `git rm --cached` plus rotate, or
+  recommend the gitignore line when present but unignored). All-layers-absent
+  is INFO, not FAIL. `user-invocable: true` was already explicit in 0.3.10.
 
 ## [0.3.11]
 

--- a/plugins/github/skills/setup/SKILL.md
+++ b/plugins/github/skills/setup/SKILL.md
@@ -34,7 +34,7 @@ Report a PASS/FAIL/INFO table with one remediation line per FAIL. Modify nothing
    |---|---|
    | user-global | INFO exists or INFO absent. No git verdict applies outside the worktree |
    | team | PASS when the pair (`git check-ignore -v` no match AND `git ls-files --error-unmatch` exit 0) holds. Present but ignored: FAIL, report the matching rule and say to unignore it. Present but untracked: FAIL, "commit it to share with the team" |
-   | local overlay | PASS when present, gitignored, and never staged. Tracked or staged: FAIL, remediation is `git rm --cached <path>` plus rotating any credential that was committed (adding a gitignore line does not untrack it). Present but unignored: FAIL, recommend `.claude/**/*.local.*` for the user to add themselves |
+   | local overlay | PASS when present, gitignored, and never staged. Tracked or staged: FAIL, remediation is `git rm --cached <path>` plus rotating any credential that was committed (adding a gitignore line does not untrack it). Present but unignored: FAIL, recommend `.claude/**/*.local.*` for the user to add themselves. Tracked outranks unignored: when both hold, name the tracked finding |
 
    All three layers absent is INFO: "unconfigured: routing resolves to propose-only", not FAIL.
    A malformed layer is named and skipped, per the contract.

--- a/plugins/github/skills/setup/SKILL.md
+++ b/plugins/github/skills/setup/SKILL.md
@@ -12,7 +12,9 @@ config). No action given: run `check`, then offer `apply` if anything is missing
 
 ## `check`, verify, report, change nothing
 
-1. **`gh` present?** If not: stop with a concise message naming the missing prerequisite and the
+Report a PASS/FAIL/INFO table with one remediation line per FAIL. Modify nothing.
+
+1. **`gh` present?** If not: FAIL, stop with a concise message naming the missing prerequisite and the
    official install page (`https://cli.github.com`). Remediation is the user's to run.
 2. **`gh auth status`**. Confirm an authenticated session; name the account and host in the
    report. **Never store, echo, or persist credentials or token values.**
@@ -26,16 +28,16 @@ config). No action given: run `check`, then offer `apply` if anything is missing
 4. **Config layers**. Resolve both surfaces (`routing.yaml`,`conventions.md`) per
    `${CLAUDE_PLUGIN_ROOT}/reference/change-routing.md` and
    `${CLAUDE_PLUGIN_ROOT}/reference/conventions-file.md`, anchored at the repo root, and report a
-   **per-layer verdict**:
+   PASS/FAIL/INFO row per layer:
 
-   | Layer | Verdict to check |
+   | Layer | Verdict |
    |---|---|
-   | user-global | exists / absent. No git verdict applies outside the worktree |
-   | team | must be tracked in git, probed as the pair (`git check-ignore -v` no match AND `git ls-files --error-unmatch` exit 0); untracked team config is a hard finding |
-   | local overlay | must be gitignored and never staged |
+   | user-global | INFO exists or INFO absent. No git verdict applies outside the worktree |
+   | team | PASS when the pair (`git check-ignore -v` no match AND `git ls-files --error-unmatch` exit 0) holds; FAIL when present but ignored or untracked |
+   | local overlay | PASS when gitignored and never staged; FAIL when tracked or staged |
 
-   All three layers absent is a **valid state**, reported as "unconfigured: routing resolves to
-   propose-only", not as an error. A malformed layer is named and skipped, per the contract.
+   All three layers absent is INFO: "unconfigured: routing resolves to propose-only", not FAIL.
+   A malformed layer is named and skipped, per the contract.
 5. **Report** the effective routing per scope block with the layer that supplied each value
    (policy-floor provenance included), and the recursive overlay gitignore line
    (`.claude/**/*.local.*`) when it is missing from the consumer's `.gitignore`. Recommend it;

--- a/plugins/github/skills/setup/SKILL.md
+++ b/plugins/github/skills/setup/SKILL.md
@@ -28,13 +28,13 @@ Report a PASS/FAIL/INFO table with one remediation line per FAIL. Modify nothing
 4. **Config layers**. Resolve both surfaces (`routing.yaml`,`conventions.md`) per
    `${CLAUDE_PLUGIN_ROOT}/reference/change-routing.md` and
    `${CLAUDE_PLUGIN_ROOT}/reference/conventions-file.md`, anchored at the repo root, and report a
-   PASS/FAIL/INFO row per layer:
+   PASS/FAIL/INFO row per layer, with one remediation line per FAIL:
 
    | Layer | Verdict |
    |---|---|
    | user-global | INFO exists or INFO absent. No git verdict applies outside the worktree |
-   | team | PASS when the pair (`git check-ignore -v` no match AND `git ls-files --error-unmatch` exit 0) holds; FAIL when present but ignored or untracked |
-   | local overlay | PASS when gitignored and never staged; FAIL when tracked or staged |
+   | team | PASS when the pair (`git check-ignore -v` no match AND `git ls-files --error-unmatch` exit 0) holds. Present but ignored: FAIL, report the matching rule and say to unignore it. Present but untracked: FAIL, "commit it to share with the team" |
+   | local overlay | PASS when present, gitignored, and never staged. Tracked or staged: FAIL, remediation is `git rm --cached <path>` plus rotating any credential that was committed (adding a gitignore line does not untrack it). Present but unignored: FAIL, recommend `.claude/**/*.local.*` for the user to add themselves |
 
    All three layers absent is INFO: "unconfigured: routing resolves to propose-only", not FAIL.
    A malformed layer is named and skipped, per the contract.

--- a/plugins/github/skills/setup/evals/evals.json
+++ b/plugins/github/skills/setup/evals/evals.json
@@ -5,13 +5,13 @@
       "id": 1,
       "name": "check-happy-path",
       "prompt": "/github:setup check",
-      "expected_output": "A prerequisite and config report: gh present and authenticated (account/host named, credentials never echoed or stored), the credential-modality picture for the areas the consumer cares about resolved from live auth state plus freshly fetched docs, and a per-layer verdict for each config layer that exists.",
+      "expected_output": "A PASS/FAIL/INFO prerequisite and config report: gh present and authenticated (account/host named, credentials never echoed or stored), the credential-modality picture for the areas the consumer cares about resolved from live auth state plus freshly fetched docs, and a PASS/FAIL/INFO row per config layer.",
       "files": [],
       "expectations": [
         "gh presence and gh auth status are verified live, and no token or credential value is echoed, stored, or persisted anywhere",
         "The credential-modality picture is diagnosed from live gh auth state and freshly fetched official docs, not from a shipped scope table or training-data recall",
-        "Config layers get per-layer verdicts: team layer tracked-in-git check, local overlay gitignored check, and no git verdict is attempted for the user-global layer",
-        "All layers absent is reported as a valid state with propose-only routing, not as an error"
+        "Config layers get PASS/FAIL/INFO rows: team layer tracked-in-git check, local overlay gitignored check, and no git verdict is attempted for the user-global layer",
+        "All layers absent is INFO (propose-only routing), not FAIL"
       ]
     },
     {

--- a/plugins/github/skills/setup/evals/evals.json
+++ b/plugins/github/skills/setup/evals/evals.json
@@ -10,7 +10,7 @@
       "expectations": [
         "gh presence and gh auth status are verified live, and no token or credential value is echoed, stored, or persisted anywhere",
         "The credential-modality picture is diagnosed from live gh auth state and freshly fetched official docs, not from a shipped scope table or training-data recall",
-        "Config layers get PASS/FAIL/INFO rows: team layer tracked-in-git check, local overlay gitignored check, and no git verdict is attempted for the user-global layer",
+        "Config layers get PASS/FAIL/INFO rows: team layer tracked-in-git check with unignore or commit remediations, local overlay FAIL when tracked/staged (git rm --cached plus rotate) or present-but-unignored (recommend the gitignore line), and no git verdict is attempted for the user-global layer",
         "All layers absent is INFO (propose-only routing), not FAIL"
       ]
     },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #3578

## Summary

`plugins/github/skills/setup/SKILL.md` already carries `user-invocable: true` (0.3.10). The remaining drift was the per-layer `check` table using exists/absent and "hard finding" instead of the setup-contract PASS/FAIL/INFO vocabulary.

## Fix

- `check` now opens with a PASS/FAIL/INFO table and one remediation line per FAIL
- user-global: INFO exists/absent (no git verdict)
- team: PASS on the check-ignore + ls-files pair; FAIL ignored (report the matching rule, unignore) or untracked ("commit it to share with the team")
- local overlay: PASS when gitignored and unstaged; FAIL when tracked or staged (`git rm --cached` plus rotate any committed credential) or present but unignored (recommend `.claude/**/*.local.*`; the skill never edits `.gitignore`)
- All three layers absent is INFO (propose-only routing), not FAIL
- Evals 1 updated to the same vocabulary

github 0.3.11 → 0.3.12.

## Verification

- `scripts/affected-tests.sh --run` selected a wide shell fan-out from `evals.json`; the only failure was the known locale flake `plugins/skill-quality/scripts/check-listing-budget.test.sh`. Unrelated to this change.
- Pending CI on the review-fix head

## Related

N/A
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7ffb619a-6ebb-4d47-9c45-d68e846edf93?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7ffb619a-6ebb-4d47-9c45-d68e846edf93&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

