### PR TITLE
fix(scripts): run only rule-em-dash in the purged-em-dash gate

### DIFF
--- a/scripts/check-purged-em-dashes.sh
+++ b/scripts/check-purged-em-dashes.sh
@@ -48,12 +48,19 @@
 # (#2891, checkbox 4). So this gate does not touch that file, and running it
 # changes nothing about what /ai-slop:audit reports. It instead builds a
 # THROWAWAY config layer for its own detector invocation: the tracked config
-# copied, with every switch that can quiet rule-em-dash removed and nothing else
-# altered. Copying rather than synthesizing is deliberate: excluded_paths and
-# every threshold stay whatever the tracked file says, so the vendor, catalog
-# and eval-fixture exclusions that exist precisely because they contain em
-# dashes as DATA keep applying here, and keep applying without a second copy of
-# that list to drift.
+# copied, with every switch that can quiet rule-em-dash removed, and with every
+# other detector rule disabled. Copying rather than synthesizing is deliberate:
+# excluded_paths and every threshold stay whatever the tracked file says, so the
+# vendor, catalog and eval-fixture exclusions that exist precisely because they
+# contain em dashes as DATA keep applying here, and keep applying without a
+# second copy of that list to drift.
+#
+# THE GATE ONLY JUDGES rule-em-dash. The rest of the roster is wasted work here:
+# each enabled rule greps every declared file, and this script ignores those
+# findings. #3342 needs a several-hundred-file allowlist; that is only
+# affordable when this invocation is a one-rule run. Slugs are read from the
+# detector's own rule tables so a newly shipped rule is disabled here without a
+# second roster to drift.
 #
 # WHAT THE THROWAWAY LAYER DOES OVERRIDE is exactly the set of keys that would
 # let a declared path pass without being judged: rule-em-dash's entry in
@@ -198,10 +205,11 @@ if [[ "$MODE" == list ]]; then
 fi
 
 # --- Throwaway detector config ----------------------------------------------
-# The tracked config with every switch that can quiet rule-em-dash removed. An
-# empty HOME keeps the user-global layer out: detect.sh cascades
-# $HOME/.claude/ai-slop.json under the repo layer, and a contributor who happens
-# to carry one must not be able to change this gate's verdict.
+# The tracked config with every switch that can quiet rule-em-dash removed, and
+# with every other detector rule disabled. An empty HOME keeps the user-global
+# layer out: detect.sh cascades $HOME/.claude/ai-slop.json under the repo layer,
+# and a contributor who happens to carry one must not be able to change this
+# gate's verdict.
 #
 # Three keys can silence this rule and all three are stripped, because a path on
 # the allowlist declares the surface purged and a per-rule exemption claims it
@@ -216,9 +224,37 @@ fi
 # `excluded_paths` is deliberately NOT stripped. Those files are never opened,
 # so they surface as excluded-glob declines that the verdict below names and
 # fails on, which is the report this gate wants rather than a silent override.
+#
+# `disabled_rules` is REPLACED, not merged, with every detector slug except
+# rule-em-dash. Merging with the tracked list would keep the rest of the roster
+# enabled (this repo only disables three rules corpus-wide) and the one-rule
+# claim would be a comment, not a property of the run.
 
 mkdir -p "$TMP/root/.claude" "$TMP/home" || exit 2
-if ! jq '.disabled_rules |= ((. // []) | map(select(. != "rule-em-dash")))
+
+# Table rows in detect.sh are `  "rule-<slug>|...`. Reading them from $DETECT
+# keeps this list identical to the roster the invocation will actually run.
+mapfile -t DETECT_SLUGS < <(sed -n 's/^  "\(rule-[a-z0-9-]*\)|.*/\1/p' "$DETECT")
+if ((${#DETECT_SLUGS[@]} == 0)); then
+  echo "check-purged-em-dashes: could not read the detector rule roster from $DETECT" >&2
+  exit 2
+fi
+have_em_dash=0
+for slug in "${DETECT_SLUGS[@]}"; do
+  [[ "$slug" == rule-em-dash ]] && have_em_dash=1 && break
+done
+if ((have_em_dash == 0)); then
+  echo "check-purged-em-dashes: detector roster from $DETECT does not include rule-em-dash" >&2
+  exit 2
+fi
+other_rules="$(printf '%s\n' "${DETECT_SLUGS[@]}" | grep -vx 'rule-em-dash' | jq -R . | jq -s .)"
+if [[ -z "$other_rules" || "$other_rules" == '[]' ]]; then
+  echo "check-purged-em-dashes: detector roster from $DETECT has no rules to disable besides rule-em-dash" >&2
+  exit 2
+fi
+
+if ! jq --argjson disabled "$other_rules" \
+  '.disabled_rules = $disabled
   | del(.em_dash_allowed_paths)
   | .rule_allowed_paths |= ((. // {}) | del(."rule-em-dash"))' \
   "$SLOP_CONFIG" >"$TMP/root/.claude/ai-slop.json"; then
@@ -243,6 +279,22 @@ if [[ -z "$summary" ]]; then
 fi
 if [[ "$summary" != *" disabled=0"* ]]; then
   echo "check-purged-em-dashes: rule-em-dash was disabled for this run ($summary); the config layer did not take effect" >&2
+  exit 2
+fi
+
+# Narrow-rule liveness. The coverage arithmetic below is only the one-rule run
+# this gate claims if every other Summary line reports disabled=1. A throwaway
+# layer that re-enabled the rest of the roster would still look live
+# (rule-em-dash disabled=0, file counts balance) and would silently put the
+# backfill cost back.
+enabled_rules=0
+while IFS= read -r line; do
+  case "$line" in
+  *' disabled=0'*) enabled_rules=$((enabled_rules + 1)) ;;
+  esac
+done < <(grep '^Summary rule=' "$OUT")
+if ((enabled_rules != 1)); then
+  echo "check-purged-em-dashes: expected only rule-em-dash enabled, found $enabled_rules enabled rule(s)" >&2
   exit 2
 fi
 

--- a/scripts/check-purged-em-dashes.sh
+++ b/scripts/check-purged-em-dashes.sh
@@ -287,12 +287,7 @@ fi
 # layer that re-enabled the rest of the roster would still look live
 # (rule-em-dash disabled=0, file counts balance) and would silently put the
 # backfill cost back.
-enabled_rules=0
-while IFS= read -r line; do
-  case "$line" in
-  *' disabled=0'*) enabled_rules=$((enabled_rules + 1)) ;;
-  esac
-done < <(grep '^Summary rule=' "$OUT")
+enabled_rules="$(grep -c '^Summary rule=.* disabled=0$' "$OUT" || true)"
 if ((enabled_rules != 1)); then
   echo "check-purged-em-dashes: expected only rule-em-dash enabled, found $enabled_rules enabled rule(s)" >&2
   exit 2

--- a/scripts/check-purged-em-dashes.test.sh
+++ b/scripts/check-purged-em-dashes.test.sh
@@ -92,6 +92,13 @@ printf '%s\n' \
 
 write "other/unlisted.md" "Not on the allowlist ${EM} so not this gate's business."
 
+# Tells that OTHER detector rules would fire on, and no em dash. The gate
+# must stay clean: it judges rule-em-dash only. Combined with the one-rule
+# liveness assertion in the SUT, a passing run of this surface is what pins
+# that the throwaway layer disabled the rest of the roster rather than
+# merely ignoring those findings.
+write "surface/other-tells.md" 'I hope this helps. It is important to note this, in order to keep the check cheap.'
+
 # A file the detector opens and then declines on an in-file marker. The detector
 # counts such a file BOTH as scanned and as declined, so a gate that adds those
 # two totals sees one file too many and reports a coverage mismatch on a file the
@@ -119,6 +126,7 @@ list() {
 }
 
 list "only-clean" 'surface/clean.md'
+list "other-tells" 'surface/clean.md' 'surface/other-tells.md'
 list "marked" 'surface/clean.md' 'surface/marked.md'
 list "clean-and-data" 'surface/clean.md' 'surface/data.md'
 list "with-dirty" 'surface/clean.md' 'surface/dirty.md'
@@ -182,12 +190,35 @@ if [[ "$OUT" != *"config layer did not take effect"* ]]; then
 else
   fail "the derived config layer takes effect: $OUT"
 fi
+# The real detector ships ~15 rules. A throwaway layer that only re-enabled
+# rule-em-dash and left the rest of the roster running would still fail the
+# seeded violation (so the case above would stay green) and would still
+# balance the file-count arithmetic. The one-rule liveness guard is what
+# makes that shape exit 2 instead of a slow, silently-wide check.
+if [[ "$OUT" != *"expected only rule-em-dash enabled"* ]]; then
+  ok "the one-rule liveness guard is not what failed the seeded violation"
+else
+  fail "the one-rule liveness guard is not what failed the seeded violation: $OUT"
+fi
 
 run "$REPO" "clean-and-data.txt"
 if ((RC == 0)); then
   ok "em dashes in a code fence and an ignore-marked line do not fire"
 else
   fail "em dashes in a code fence and an ignore-marked line do not fire (rc=$RC): $OUT"
+fi
+
+# THE NARROW-RULE PIN. other-tells.md carries chatbot and filler residue the
+# real detector would report if those rules ran enabled. The SUT only greps
+# rule-em-dash findings, so ignoring those rows is not enough to stay cheap;
+# the one-rule liveness guard is what fails a wide run at exit 2. A passing
+# result here is the coverage arithmetic re-proven under the narrower config
+# #3342 asked for: two declared files, one enabled rule, no em dashes.
+run "$REPO" "other-tells.txt"
+if ((RC == 0)) && [[ "$OUT" == *"2 declared paths, 2 files scanned"* ]]; then
+  ok "other-rule tells on a declared path do not fail a one-rule run"
+else
+  fail "other-rule tells on a declared path do not fail a one-rule run (rc=$RC): $OUT"
 fi
 
 # A whole-file ignore marker is one of the exemptions this gate documents, so an


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
No linked issue

## Summary

The purged-em-dash gate copied the tracked detector config and only re-enabled `rule-em-dash`, so the rest of the roster still grepped every declared file. That cost is why the allowlist in #3342 has not grown.

## Fix

The throwaway layer now replaces `disabled_rules` with every detector slug except `rule-em-dash` (slugs read from the detector's own rule tables). A new liveness assertion fails the run at exit 2 unless exactly one rule is enabled, so a later edit that widens the roster again cannot look live.

The contract suite now plants chatbot and filler residue on a declared path and requires a clean one-rule run, which re-proves the coverage arithmetic under the narrower config.

## Verification

`scripts/affected-tests.sh --run --explain` selected `scripts/check-purged-em-dashes.test.sh` (23/23).

## Related

Refs #3342 (first slice: make the allowlist backfill affordable). Refs #2891.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7ffb619a-6ebb-4d47-9c45-d68e846edf93?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7ffb619a-6ebb-4d47-9c45-d68e846edf93&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

