### PR TITLE
fix: correct four argument-hint outliers

### DIFF
--- a/plugins/bugs/.claude-plugin/plugin.json
+++ b/plugins/bugs/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "bugs",
-  "version": "0.9.7",
+  "version": "0.9.8",
   "description": "Produces a structured five-field bug report \u2014 title, steps to reproduce, expected vs actual, severity with justification, and suggested fix location \u2014 from an informal defect description. Read-only by default: it emits the report and never edits code, opens a PR, or files an issue on its own.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/bugs/CHANGELOG.md
+++ b/plugins/bugs/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to the `bugs` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.9.8]
+
+### Changed
+
+- **`setup`:** spell the argument hint `check | apply` to match sibling
+  setup skills (#3542).
+
 ## [0.9.7]
 
 ### Changed

--- a/plugins/bugs/skills/setup/SKILL.md
+++ b/plugins/bugs/skills/setup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 description: "Verify and configure the bugs plugin for this repository. check inspects both surfaces read-only, the rendered output_dir userConfig value, and the tracked .claude/bugs.md lane config across its cascade layers; apply writes or updates that tracked file and nothing else. Use when: 'set up bugs', 'configure bugs', 'bugs setup', 'where do bug reports land', you want --file reports committed alongside code, or '/bugs:scan' needs project lanes and a filing posture. Actions: check (read-only, default) | apply (creates or updates the tracked lane config; output_dir still routes through Claude Code's own configuration prompt)."
-argument-hint: "check|apply"
+argument-hint: "check | apply"
 user-invocable: true
 disable-model-invocation: true
 ---

--- a/plugins/computer-use/.claude-plugin/plugin.json
+++ b/plugins/computer-use/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "computer-use",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Operating knowledge for Claude Code's built-in computer-use MCP server — the desktop screen-control surface. `/computer-use:diagnose` resolves a symptom to a cause instead of retrying: why every screenshot is downscaled to a fixed pixel budget and why zoom (not a bigger display) is the way back to detail, how to read a capture or input failure, and the per-OS quirks that make a synthesized key or menu behave unlike a human's. `/computer-use:setup` verifies the prerequisites the surface cannot verify for itself and reports the environment settings that end a session mid-run.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/computer-use/CHANGELOG.md
+++ b/plugins/computer-use/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to the `computer-use` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.1.3]
+
+### Changed
+
+- **`diagnose`:** drop the em dash from `argument-hint`. The hint is the
+  closed enum `[screenshots|failures|quirks]`; omit-for-guide stays in
+  the Arguments body (#3542).
+
 ## [0.1.2]
 
 ### Changed

--- a/plugins/computer-use/skills/diagnose/SKILL.md
+++ b/plugins/computer-use/skills/diagnose/SKILL.md
@@ -1,7 +1,7 @@
 ---
 description: "Diagnose unexpected behavior from Claude Code's built-in computer-use MCP server (desktop screen control). Use when: 'computer use', 'control my screen', 'screenshot is blurry', 'why is the screenshot low resolution', 'zoom in on the screen', 'screenshot capture failed', 'empty capture', 'clicks are landing in the wrong place', 'the screensaver killed the session', 'UIPI', 'app is not in the allowed applications', 'escape is not closing this menu', or before driving a native desktop app. Resolves a symptom to a cause instead of retrying: the fixed screenshot pixel budget and when zoom recovers detail, the capture and input failure ladders, and the per-OS quirks that make synthesized input behave unlike a human's. Not for: browser work (use Claude in Chrome), shell work (use Bash), or a service with its own MCP server."
 when_to_use: "a screenshot, click, or keystroke did not do what you expected; sizing up the hazards before driving a native app unattended"
-argument-hint: "[screenshots|failures|quirks] — omit for the symptom guide"
+argument-hint: "[screenshots|failures|quirks]"
 user-invocable: true
 disable-model-invocation: false
 metadata:

--- a/plugins/review/.claude-plugin/plugin.json
+++ b/plugins/review/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "review",
-  "version": "0.26.15",
+  "version": "0.26.16",
   "description": "Code-review toolkit: six read-only reviewer agents (code, security, architecture, doc drift, build/test/lint, CI-log audit) plus orchestration skills \u2014 quality gate, fan-out, and CI lane commands (/review:code-review, /review:security-review) for org reusable workflows.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/review/CHANGELOG.md
+++ b/plugins/review/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to the `review` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.26.16]
+
+### Changed
+
+- **`code-review` and `security-review`:** drop empty `argument-hint: ""`.
+  These skills take no user arguments; omit the key to match the other
+  no-arg skills (#3542).
+
 ## [0.26.15]
 
 ### Changed

--- a/plugins/review/skills/code-review/SKILL.md
+++ b/plugins/review/skills/code-review/SKILL.md
@@ -1,6 +1,5 @@
 ---
 description: "CI code-review lane for a GitHub pull request. High-signal correctness and maintainability findings only, scoped out of security when a security lane exists. Use when: 'CI code review', 'claude-review lane', '/review:code-review', or a reusable workflow invokes the org code-review plugin command."
-argument-hint: ""
 user-invocable: true
 disable-model-invocation: false
 allowed-tools: ["Bash(gh pr diff:*)", "Bash(gh pr view:*)", "Bash(gh pr comment:*)", "Bash(gh pr review:*)", "Read", "Glob", "Grep"]

--- a/plugins/review/skills/security-review/SKILL.md
+++ b/plugins/review/skills/security-review/SKILL.md
@@ -1,6 +1,5 @@
 ---
 description: "CI security-review lane for a GitHub pull request. Logic, trust-boundary, and Actions security findings static analysis misses. Use when: 'CI security review', 'claude-security-review lane', '/review:security-review', or a reusable workflow invokes the org security-review plugin command."
-argument-hint: ""
 user-invocable: true
 disable-model-invocation: false
 allowed-tools: ["Bash(gh pr diff:*)", "Bash(gh pr view:*)", "Bash(gh pr comment:*)", "Bash(gh pr review:*)", "Read", "Glob", "Grep"]

--- a/plugins/wizard/.claude-plugin/plugin.json
+++ b/plugins/wizard/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "wizard",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "Generate an interactive bash wizard that walks a human, step by step, through the manual procedures an agent cannot perform — provisioning infrastructure or credentials, setting CI secrets, clicking through third-party dashboards, one-off migrations and cutovers. One skill, generate (/wizard:generate): the agent scopes the stages from the repo (reading key NAMES only from a live .env, never values), authors them onto a fixed hardened library (TTY-only fail-closed prompts, https-only URL opening, hidden secret entry, single-quoted 0600 .env upserts with a gitignore check, repo-confirmed gh secret/variable writes over stdin, names-only summary), prints the full STAGES block for explicit human approval BEFORE the script is made executable, and never runs the wizard itself — the human does, in their own terminal. Ephemeral by default: built for one run, committed only when the setup path should live in the repo. The generated script requires bash (Windows: Git Bash or WSL); gh is optional — CI-secret stages degrade to a visible warning plus a closing-summary entry when it is absent.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/wizard/CHANGELOG.md
+++ b/plugins/wizard/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to the `wizard` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.2.7]
+
+### Changed
+
+- **`generate`:** add `argument-hint: "<procedure to wizardize>"` so autocomplete
+  shows that the skill takes free-text procedure input (#3542).
+
 ## [0.2.6]
 
 ### Changed

--- a/plugins/wizard/skills/generate/SKILL.md
+++ b/plugins/wizard/skills/generate/SKILL.md
@@ -1,5 +1,6 @@
 ---
 description: "Generate an interactive bash wizard script that walks a human through the steps only they can perform. The agent authors the script and never runs it; the human runs it in their own terminal. Use when: 'provisioning infrastructure', 'provisioning credentials', 'set up CI secrets', 'walk me through the dashboard', 'guided setup script', 'one-off migration', 'cutover', or a manual dashboard, credential, or third-party-console step is what blocks progress. Don't invoke this for steps the agent can perform itself."
+argument-hint: "<procedure to wizardize>"
 user-invocable: true
 disable-model-invocation: false
 metadata:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
No linked issue

## Summary

Four concrete `argument-hint` outliers from the 2026-08-31 fleet skills audit. Official docs treat the field as an optional autocomplete hint (`[issue-number]`, `[filename] [format]`); an empty string is not a documented spelling, and the repo's instruction-surface style rejects em dashes.

## Fix

- `wizard:generate`: add `argument-hint: "<procedure to wizardize>"`.
- `review:code-review` and `review:security-review`: drop `argument-hint: ""` so they match the other no-arg skills.
- `bugs:setup`: spell `check | apply` like sibling setups.
- `computer-use:diagnose`: drop the em dash; hint is the closed enum `[screenshots|failures|quirks]`. Omit-for-guide stays in the Arguments body.

Left for later slices of #3542: `machine-health:audit` (version overlap with #3672), the proposed house-style convention doc (blocked on the #3620 post-pilot gate), and the `check-skill.sh` criterion that would point at that doc.

## Verification

- Official `argument-hint` row: optional autocomplete hint; examples are terse placeholders.
- `scripts/affected-tests.sh --run --explain` → every changed file is a recorded no-suite class (SKILL.md / CHANGELOG / plugin.json). Exit 0.

## Related

Refs #3542
Refs #3672
Official: https://code.claude.com/docs/en/skills#frontmatter-reference

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7ffb619a-6ebb-4d47-9c45-d68e846edf93?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7ffb619a-6ebb-4d47-9c45-d68e846edf93&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

