### PR TITLE
fix(machine-health): advertise audit RunMode in argument-hint

### DIFF
--- a/plugins/machine-health/.claude-plugin/plugin.json
+++ b/plugins/machine-health/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "machine-health",
-  "version": "0.12.8",
+  "version": "0.12.9",
   "description": "Workstation health audit: OS-specific checks (disk, OS updates, security posture, CISA KEV correlation) run from a versioned catalog with trend-aware severity, approval-gated remediations, and dated markdown reports. Windows fully implemented; macOS/Linux scaffolded (report UNKNOWN and stop). Machine state persists in the plugin data directory; the report directory and check catalog are configurable.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/machine-health/CHANGELOG.md
+++ b/plugins/machine-health/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to the `machine-health` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.12.9]
+
+### Changed
+
+- **audit:** add `argument-hint: "[weekly|on-demand|first-run] [--dry-run]"` so
+  autocomplete shows the RunMode and dry-run arguments the skill already
+  accepts (#3542).
+
 ## [0.12.8]
 
 ### Changed

--- a/plugins/machine-health/skills/audit/SKILL.md
+++ b/plugins/machine-health/skills/audit/SKILL.md
@@ -1,5 +1,6 @@
 ---
 description: "Audits local workstation health and emits a findings report: runs OS-specific checks (disk, OS updates, security posture, CISA KEV) from a versioned catalog with trend-aware severity; remediation only when pre-approved. Use when: 'machine health check', 'health check', 'audit my machine', 'system health', 'workstation audit', 'check my computer', 'run health check', 'workstation status report', or when a scheduled weekly routine fires. Outputs a dated markdown report; updates append-only history state. Windows fully implemented; macOS/Linux scaffolded (reports UNKNOWN and stops)."
+argument-hint: "[weekly|on-demand|first-run] [--dry-run]"
 user-invocable: true
 disable-model-invocation: false
 ---


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
No linked issue

## Summary

`machine-health:audit` already accepts `weekly|on-demand|first-run` and `--dry-run`, but autocomplete had no `argument-hint`. This is the leftover concrete fix from `#3542` after `#3673`.

## Fix

- Add `argument-hint: "[weekly|on-demand|first-run] [--dry-run]"` to `plugins/machine-health/skills/audit/SKILL.md`.
- Bump machine-health to 0.12.9 and record the change.

House-style convention docs and a `check-skill.sh` argument-hint criterion stay deferred (`#3620` post-pilot gate). This PR does not close `#3542`.

## Verification

`scripts/affected-tests.sh --run --explain` selected no suites: every changed file is a recorded no-suite class.

[affected-tests no-suite result](https://cursor.com/agents/bc-7ffb619a-6ebb-4d47-9c45-d68e846edf93/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2F3542-mh-argument-hint-demo.log)

## Related

Refs #3542. Follows #3673 (items 2-5) and #3672 (machine-health 0.12.8 `reference/` rename).

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7ffb619a-6ebb-4d47-9c45-d68e846edf93?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7ffb619a-6ebb-4d47-9c45-d68e846edf93&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

