### PR TITLE
feat(planning): default interview emoji question markers on

### DIFF
--- a/plugins/planning/.claude-plugin/plugin.json
+++ b/plugins/planning/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "planning",
-  "version": "0.35.4",
+  "version": "0.36.0",
   "userConfig": {
     "use_ask_user_question": {
       "type": "boolean",
@@ -12,8 +12,8 @@
     "use_emoji_question_markers": {
       "type": "boolean",
       "title": "Emoji anchors on interview round questions",
-      "description": "When enabled, each inline interview round question leads with a \u2753 anchor on its Q<N> line and its 'My recommendation:' line leads with \u27a1\ufe0f. Purely presentational. Q<N> numbering stays the functional handle, and persisted artifacts (ledger, register, Brief) never carry the emoji. Default: plain text.",
-      "default": false
+      "description": "When enabled, each inline interview round question leads with a \u2753 anchor on its Q<N> line and its 'My recommendation:' line leads with \u27a1\ufe0f. Purely presentational. Q<N> numbering stays the functional handle, and persisted artifacts (ledger, register, Brief) never carry the emoji. Default: emoji anchors. Set false for plain text.",
+      "default": true
     }
   },
   "description": "Pre-implementation planning pipeline: chart a too-big, foggy effort as a decision map, diverge on candidate approaches, lock product intent and the engineering contract, route resolved domain language to the domain-driven-design glossary steward, explore the design space, stress-test adversarially, and produce a structured implementation plan with an approval gate.",

--- a/plugins/planning/CHANGELOG.md
+++ b/plugins/planning/CHANGELOG.md
@@ -7,14 +7,15 @@ All notable changes to the `planning` plugin are documented here. Format follows
 
 ### Changed
 
-- **`interview`: emoji anchors on by default.** `use_emoji_question_markers` now
-  defaults to `true`, matching the upstream mattpocock/skills `grilling` ❓/➡️
-  shape. Inline rounds lead with those prefixes unless the option is set false
-  (plain text). The option stays presentational: `Q<N>` is still the answer
-  handle, and the ledger, register, and Brief stay undecorated. An existing
-  install that already stored `false` keeps plain text until reconfigured. The
-  Stance-section digest in `tests/interview-defenses.test.sh` is refreshed for
-  the same wording change; the in-round no-silent-resolve defense is unchanged.
+- **`interview`: emoji anchors on by default.** `use_emoji_question_markers`
+  stays a userConfig boolean and now defaults to `true`, matching the upstream
+  mattpocock/skills `grilling` ❓/➡️ shape. Inline rounds lead with those
+  prefixes when the option is true; set it false for plain text. The option
+  stays presentational: `Q<N>` is still the answer handle, and the ledger,
+  register, and Brief stay undecorated. An existing install that already stored
+  `false` keeps plain text until reconfigured. The Stance-section digest in
+  `tests/interview-defenses.test.sh` is refreshed for the same wording change;
+  the in-round no-silent-resolve defense is unchanged.
 
 ## [0.35.4]
 

--- a/plugins/planning/CHANGELOG.md
+++ b/plugins/planning/CHANGELOG.md
@@ -3,6 +3,19 @@
 All notable changes to the `planning` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.36.0]
+
+### Changed
+
+- **`interview`: emoji anchors on by default.** `use_emoji_question_markers` now
+  defaults to `true`, matching the upstream mattpocock/skills `grilling` ❓/➡️
+  shape. Inline rounds lead with those prefixes unless the option is set false
+  (plain text). The option stays presentational: `Q<N>` is still the answer
+  handle, and the ledger, register, and Brief stay undecorated. An existing
+  install that already stored `false` keeps plain text until reconfigured. The
+  Stance-section digest in `tests/interview-defenses.test.sh` is refreshed for
+  the same wording change; the in-round no-silent-resolve defense is unchanged.
+
 ## [0.35.4]
 
 ### Changed

--- a/plugins/planning/README.md
+++ b/plugins/planning/README.md
@@ -78,7 +78,7 @@ reads it from.
 | Option | Type | Default | Environment variable | Description |
 | --- | --- | --- | --- | --- |
 | `use_ask_user_question` | boolean | `false` | `CLAUDE_PLUGIN_OPTION_USE_ASK_USER_QUESTION` | When enabled, the planning skills' question rounds (interview, prd, design, plan) render a round of up to 4 independent questions through the AskUserQuestion tool instead of inline prose. Default: inline prose (dictation-friendly). |
-| `use_emoji_question_markers` | boolean | `false` | `CLAUDE_PLUGIN_OPTION_USE_EMOJI_QUESTION_MARKERS` | When enabled, each inline interview round question leads with a ❓ anchor on its Q<N> line and its 'My recommendation:' line leads with ➡️. Purely presentational. Q<N> numbering stays the functional handle, and persisted artifacts (ledger, register, Brief) never carry the emoji. Default: plain text. |
+| `use_emoji_question_markers` | boolean | `true` | `CLAUDE_PLUGIN_OPTION_USE_EMOJI_QUESTION_MARKERS` | When enabled, each inline interview round question leads with a ❓ anchor on its Q<N> line and its 'My recommendation:' line leads with ➡️. Purely presentational. Q<N> numbering stays the functional handle, and persisted artifacts (ledger, register, Brief) never carry the emoji. Default: emoji anchors. Set false for plain text. |
 
 ### How to set these
 

--- a/plugins/planning/skills/interview/SKILL.md
+++ b/plugins/planning/skills/interview/SKILL.md
@@ -91,10 +91,10 @@ Read [`context/relentless-mode.md`](context/relentless-mode.md) before the first
 **Ask each round inline as one numbered set.** Per-question shape within the round:
 
 ```text
-Q<N>: <one question>
+❓ Q<N>: <one question>
 [<one line of context — ONLY when the round-header restate doesn't reach this question, or the first round after a session gap>]
 
-My recommendation: **<answer>** — <2-3 sentences; grounded in codebase/convention; why it beats the alternatives>.
+➡️ My recommendation: **<answer>** — <2-3 sentences; grounded in codebase/convention; why it beats the alternatives>.
 
 Alternatives to consider:
 - (a) <option> — <one-line tradeoff>
@@ -106,7 +106,7 @@ Alternatives to consider:
 
 **One verdict marker, at most one context line.** The `My recommendation:` line is the *single* verdict marker for the question. Never stack a second one: no standalone `**(RECOMMENDED)**` badge line above it, and no `(recommended)` tag repeated in the Alternatives list; the recommended answer is named once, on that line. Per-question context is at most ONE line and usually absent. The round-header restate carries shared context, so add a line only when it doesn't reach this question or the session just resumed after a gap.
 
-**Emoji anchors (opt-in).** When `${user_config.use_emoji_question_markers}` is enabled (default off), prefix the `Q<N>:` line with `❓` and the `My recommendation:` line with `➡️`. Decoration of the existing single verdict marker, never a second one. Conversational rendering only: the ledger, register, and Brief stay plain, and `Q<N>` remains the answer handle.
+**Emoji anchors (default on).** The shape above is the default: prefix the `Q<N>:` line with `❓` and the `My recommendation:` line with `➡️`. Decoration of the existing single verdict marker, never a second one. Conversational rendering only: the ledger, register, and Brief stay plain, and `Q<N>` remains the answer handle. When `${user_config.use_emoji_question_markers}` is false, drop both emoji prefixes; the rest of the shape is unchanged.
 
 **Define session shorthand once, then park it.** When a round introduces session-local shorthand, a coined label, an abbreviation, or cross-repo jargon the user may not share ("lanes", "gate vacuity"), define it in one clause at first use and record it in the ledger's shorthand glossary, then use the term freely. This is ephemeral session vocabulary, distinct from the project's ubiquitous language (owned by `/domain-driven-design:curate-language`), and never touches a project glossary. Ledger shape: [`context/loop.md`](context/loop.md) "Session-shorthand glossary".
 

--- a/plugins/planning/skills/interview/SKILL.md
+++ b/plugins/planning/skills/interview/SKILL.md
@@ -91,10 +91,10 @@ Read [`context/relentless-mode.md`](context/relentless-mode.md) before the first
 **Ask each round inline as one numbered set.** Per-question shape within the round:
 
 ```text
-❓ Q<N>: <one question>
+Q<N>: <one question>
 [<one line of context — ONLY when the round-header restate doesn't reach this question, or the first round after a session gap>]
 
-➡️ My recommendation: **<answer>** — <2-3 sentences; grounded in codebase/convention; why it beats the alternatives>.
+My recommendation: **<answer>** — <2-3 sentences; grounded in codebase/convention; why it beats the alternatives>.
 
 Alternatives to consider:
 - (a) <option> — <one-line tradeoff>
@@ -106,7 +106,7 @@ Alternatives to consider:
 
 **One verdict marker, at most one context line.** The `My recommendation:` line is the *single* verdict marker for the question. Never stack a second one: no standalone `**(RECOMMENDED)**` badge line above it, and no `(recommended)` tag repeated in the Alternatives list; the recommended answer is named once, on that line. Per-question context is at most ONE line and usually absent. The round-header restate carries shared context, so add a line only when it doesn't reach this question or the session just resumed after a gap.
 
-**Emoji anchors (default on).** The shape above is the default: prefix the `Q<N>:` line with `❓` and the `My recommendation:` line with `➡️`. Decoration of the existing single verdict marker, never a second one. Conversational rendering only: the ledger, register, and Brief stay plain, and `Q<N>` remains the answer handle. When `${user_config.use_emoji_question_markers}` is false, drop both emoji prefixes; the rest of the shape is unchanged.
+**Emoji anchors (default on, still configurable).** When `${user_config.use_emoji_question_markers}` is true (the default), prefix the `Q<N>:` line with `❓` and the `My recommendation:` line with `➡️`. When it is false, keep the undecorated shape above. Decoration of the existing single verdict marker, never a second one. Conversational rendering only: the ledger, register, and Brief stay plain, and `Q<N>` remains the answer handle. The option is the plugin's `use_emoji_question_markers` user config; set it false for plain text.
 
 **Define session shorthand once, then park it.** When a round introduces session-local shorthand, a coined label, an abbreviation, or cross-repo jargon the user may not share ("lanes", "gate vacuity"), define it in one clause at first use and record it in the ledger's shorthand glossary, then use the term freely. This is ephemeral session vocabulary, distinct from the project's ubiquitous language (owned by `/domain-driven-design:curate-language`), and never touches a project glossary. Ledger shape: [`context/loop.md`](context/loop.md) "Session-shorthand glossary".
 

--- a/plugins/planning/tests/interview-defenses.test.sh
+++ b/plugins/planning/tests/interview-defenses.test.sh
@@ -473,7 +473,7 @@ pin_section "SKILL.md Stance section is unchanged (the in-round no-silent-resolv
   "$SKILL" \
   "## Stance: supportive, depth-first, opinionated" \
   "## The interview loop" \
-  "e627a2702a4ab924a8b681e9d6279d3d9f53e8039b4fbb30fdcf1f503fada711"
+  "9357efb5e0f4fc3cfd812a121b39627acfc3191fff5881bb565723fd56492ea1"
 pin_section "SKILL.md interview-loop preamble is unchanged (it governs every step below it)" \
   "$SKILL" \
   "## The interview loop" \

--- a/plugins/planning/tests/interview-defenses.test.sh
+++ b/plugins/planning/tests/interview-defenses.test.sh
@@ -473,7 +473,7 @@ pin_section "SKILL.md Stance section is unchanged (the in-round no-silent-resolv
   "$SKILL" \
   "## Stance: supportive, depth-first, opinionated" \
   "## The interview loop" \
-  "9357efb5e0f4fc3cfd812a121b39627acfc3191fff5881bb565723fd56492ea1"
+  "bb8d3d643a7d0478a51d04abdfb6420e4b0b86b47d3317c861107baacf12fb7c"
 pin_section "SKILL.md interview-loop preamble is unchanged (it governs every step below it)" \
   "$SKILL" \
   "## The interview loop" \


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
No linked issue

## Summary

Default `use_emoji_question_markers` on so `/planning:interview` uses the upstream mattpocock/skills `grilling` ❓/➡️ question shape. The option stays a userConfig boolean: set it `false` for plain text.

## Fix

- Flip `use_emoji_question_markers` to `default: true` in the planning plugin manifest (0.36.0). The option itself is unchanged: still a boolean userConfig, still honored by `${user_config.use_emoji_question_markers}`.
- Keep the inline-round template undecorated. The skill prefixes ❓/➡️ only when the option is true (the default) and keeps the plain shape when it is false.
- The option stays presentational: `Q<N>` stays the answer handle, and the ledger, register, and Brief stay plain.
- Refresh the Stance-section digest in `tests/interview-defenses.test.sh` for the wording change. The in-round no-silent-resolve defense is unchanged.

An existing install that already stored `false` keeps plain text until reconfigured.

## Verification

- `scripts/affected-tests.sh --run` selected `plugins/planning/tests/interview-defenses.test.sh`: PASS=89 FAIL=0
- `scripts/check-changelog-parity.sh --check-bump origin/main`: pass
- `scripts/check-changed-skills.sh origin/main`: `interview` PASS (0 errors; existing 272-line soft-target warning)
- Manifest assertion: `use_emoji_question_markers` is a boolean userConfig, default `true`, disable path documented

Full log: `/opt/cursor/artifacts/interview-emoji-configurable-tests.log`

## Related

N/A. House follow-up to the v1.2 adoption of the ❓/➡️ shape as an opt-in (`docs/upstream/mattpocock-skills.md`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7217939f-9f82-4518-9b7a-55e92de7ea66?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7217939f-9f82-4518-9b7a-55e92de7ea66&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

