### PR TITLE
test(ci): probe the filter groups with a lockfile-only diff

### DIFF
--- a/.github/requirements-ci.txt
+++ b/.github/requirements-ci.txt
@@ -1,3 +1,4 @@
+# Probe: 2.7 filter fixture for melodic-software/github-iac#385. Closed unmerged.
 # Keep this exact Linux x64 wheel pin and hash on a reviewed Dependabot surface.
 # Hosted and local plugin-gate jobs both use Ubuntu 24.04 x64.
 # pytest (and its dependency closure — pure-Python wheels, one hash each) is


### PR DESCRIPTION
No related issue: filter fixture for Phase 2 of melodic-software/github-iac#385 (cross-repository). Closed unmerged.

Refs #3696

## Summary

A throwaway probe against #3696's branch. One comment line in
`.github/requirements-ci.txt` and nothing else.

## Fix

Nothing is fixed. This pull request exists to exercise the consolidated
workflow's change-detection filter groups against a real diff, and to prove the
draft filter both ways: opened as a draft first, so the test lanes report not
applicable and the Windows lane skips, then flipped to ready, so the
`ready_for_review` trigger delivers a run in which `test-linux` actually
executes the contract suite.

Every filter group names the lockfile and configuration paths, so every group
must resolve true and every lane must execute its work steps.

## Verification

The run ids and per-lane verdicts are recorded in #3696's body and in the
program's sub-topic plan. This branch is closed unmerged once they are.

## Related

- #3696, the pull request this probes.
- Phase 2 of melodic-software/github-iac#385.
