### PR TITLE
test(ci): probe the filter groups with a workflow-only diff

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,3 +1,4 @@
+# Probe: 2.7 filter fixture for melodic-software/github-iac#385. Closed unmerged.
 name: link-check
 
 # Advisory online external-link check (not part of ci-status). Runs weekly and


### PR DESCRIPTION
No related issue: filter fixture for Phase 2 of melodic-software/github-iac#385 (cross-repository). Closed unmerged.

Refs #3696

## Summary

A throwaway probe against #3696's branch. One comment line in
`.github/workflows/link-check.yml` and nothing else.

## Fix

Nothing is fixed. This pull request exists to exercise the consolidated
workflow's change-detection filter groups against a workflow-only diff, the
case that must reach the `workflows`-gated steps: the Actions security lint and
the runner policy.

Every filter group names `.github/**`, so every group must resolve true and
every lane must execute its work steps.

## Verification

The run ids and per-lane verdicts are recorded in #3696's body and in the
program's sub-topic plan. This branch is closed unmerged once they are.

## Related

- #3696, the pull request this probes.
- Phase 2 of melodic-software/github-iac#385.
