### PR TITLE
ci: fold the pull-request contract into ci-status and carry it forward on contract-only events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,24 @@ on:
     # heavy lanes reporting not-applicable while a pull request is a draft, and
     # without this type a draft flipped to ready triggers no run at all, so the
     # lanes would never get their real answer.
-    types: [opened, synchronize, reopened, ready_for_review]
+    #
+    # `edited`, `labeled` and `unlabeled` can change the pr-title /
+    # do-not-merge / issue-linkage answers without a new commit, so the required
+    # check has to re-evaluate. Whether such an event is CONTRACT-ONLY (lanes
+    # gated off, ci-status carrying the recorded `ci-lanes` verdict forward) is
+    # decided by one predicate, repeated verbatim in `cancel-in-progress` and in
+    # every job's `if:` except `ci-status`:
+    #
+    #   github.event.pull_request.head.repo.full_name == github.repository &&
+    #   (contains(fromJSON('["labeled","unlabeled"]'), github.event.action) ||
+    #    (github.event.action == 'edited' && !github.event.changes.base))
+    #
+    # An `edited` event carrying `changes.base` is a BASE-BRANCH change: the
+    # merge commit the lanes test changes with it, so that runs in full. A fork
+    # pull request is never contract-only — its token is read-only on
+    # `pull_request` whatever `permissions:` requests, so it cannot record lane
+    # state — and runs the full workflow on every event exactly as before.
+    types: [opened, synchronize, reopened, ready_for_review, edited, labeled, unlabeled]
 
 permissions:
   contents: read
@@ -16,16 +33,26 @@ permissions:
 # The PR number scopes cancellation to exactly one PR (head_ref would collide
 # across same-named fork branches); push runs fall back to the unique run_id,
 # so default-branch runs are never cancelled.
+#
+# A contract-only event never cancels: it must queue behind an in-flight full
+# run so the `ci-lanes` status it reads is already written. GitHub keeps one
+# running and one pending run per group and the newest pending wins, so the
+# carry-forward always executes after the full run it depends on. A
+# `synchronize` still cancels everything on the old SHA. The value carries no
+# event guard because the group key already gives every push run a group of its
+# own.
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ !(github.event.pull_request.head.repo.full_name == github.repository && (contains(fromJSON('["labeled","unlabeled"]'), github.event.action) || (github.event.action == 'edited' && !github.event.changes.base))) }}
 
 # Quality lanes run the ci-workflows composite actions (referenced by SHA,
 # bumped via Dependabot — never copied) against this repo's exact standards
 # materializations. Tool configs live at their tool-native root paths;
-# comment-hygiene's default policy is bundled with its action. The local
-# ci-status gateway aggregates every lane into the single required check the
-# org ci-gate ruleset keys on.
+# comment-hygiene's default policy is bundled with its action. The `ci-status`
+# gateway aggregates every lane into the single required check the org ci-gate
+# ruleset keys on, through the ci-workflows composite of the same name, and
+# carries the pull-request contract (title, do-not-merge label, issue linkage)
+# as steps of that one check.
 #
 # SIX JOBS, NOT FIFTY-FIVE. Each of the fifty-odd lanes this file used to carry
 # paid a fresh runner, a fresh checkout and a fresh toolchain install to run a
@@ -77,6 +104,13 @@ jobs:
   # broken detector turns this job red rather than resolving a scope nobody
   # verified.
   changes:
+    # The contract-only gate, verbatim on every job but `ci-status` (see the
+    # predicate spelled out under `on.pull_request.types`). It carries no
+    # status-check function, so on every job that has `needs` those edges still
+    # govern exactly as before: the gate only subtracts the label-flip and
+    # body-edit events, where the lanes would re-run a SHA a full run already
+    # answered and `ci-status` carries that answer forward instead.
+    if: ${{ !(github.event.pull_request.head.repo.full_name == github.repository && (contains(fromJSON('["labeled","unlabeled"]'), github.event.action) || (github.event.action == 'edited' && !github.event.changes.base))) }}
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     # The change-detection action lists the pull request's files through the
@@ -251,6 +285,8 @@ jobs:
   # against.
   lint:
     needs: [changes]
+    # The contract-only gate, verbatim.
+    if: ${{ !(github.event.pull_request.head.repo.full_name == github.repository && (contains(fromJSON('["labeled","unlabeled"]'), github.event.action) || (github.event.action == 'edited' && !github.event.changes.base))) }}
     runs-on: ubuntu-24.04
     timeout-minutes: 25
     steps:
@@ -1122,6 +1158,8 @@ jobs:
   # `--check-bump` below still resolves `origin/$BASE_REF` from it.
   test-linux:
     needs: [changes]
+    # The contract-only gate, verbatim.
+    if: ${{ !(github.event.pull_request.head.repo.full_name == github.repository && (contains(fromJSON('["labeled","unlabeled"]'), github.event.action) || (github.event.action == 'edited' && !github.event.changes.base))) }}
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     steps:
@@ -1668,7 +1706,9 @@ jobs:
   test-windows:
     needs:
       - changes
-    if: needs.changes.outputs.run_windows == 'true'
+    # The contract-only gate ANDed with the existing resolver gate. This lane is
+    # outside the ci-status aggregate, so it may gate at job level.
+    if: ${{ !(github.event.pull_request.head.repo.full_name == github.repository && (contains(fromJSON('["labeled","unlabeled"]'), github.event.action) || (github.event.action == 'edited' && !github.event.changes.base))) && needs.changes.outputs.run_windows == 'true' }}
     runs-on: windows-2025
     timeout-minutes: 20
     defaults:
@@ -1705,6 +1745,8 @@ jobs:
   hook-utils:
     needs:
       - changes
+    # The contract-only gate, verbatim.
+    if: ${{ !(github.event.pull_request.head.repo.full_name == github.repository && (contains(fromJSON('["labeled","unlabeled"]'), github.event.action) || (github.event.action == 'edited' && !github.event.changes.base))) }}
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     steps:
@@ -1741,25 +1783,48 @@ jobs:
       - test-linux
       - hook-utils
     # Fail-closed through execution: !cancelled() (never a success-guard) so a
-    # lane failure still runs this required aggregate and the result join below
+    # lane failure still runs this required aggregate and the aggregation below
     # turns it red. A success-guard would skip the job, and a skipped required
     # check reports success to branch protection. This condition is safe where
     # a consumer's would not be: this job reads no resolver output, so there is
     # no empty-string state for it to misread.
+    #
+    # This is the ONE job that carries no contract-only gate: on a label flip or
+    # a body edit it is the only job that runs, and it answers from the
+    # `ci-lanes` commit status the last full run recorded on this SHA.
     if: ${{ !cancelled() }}
     runs-on: ubuntu-24.04
     timeout-minutes: 5
+    permissions:
+      contents: read
+      # pr-contract upserts the advisory linkage comment and moves the linkage
+      # label; ci-status records the `ci-lanes` commit status the carry-forward
+      # branch reads back on the next contract-only event.
+      pull-requests: write
+      statuses: write
     steps:
+      - name: Check the pull-request contract
+        uses: melodic-software/ci-workflows/.github/actions/pr-contract@449157aaa8e30f7b1457305d8048ebe6168e174a # v0.20.0
+        with:
+          token: ${{ github.token }}
+          # Carried over verbatim from `pr-issue-linkage.yml`, the caller this
+          # step replaces: dependabot PR bodies cannot carry the closing keyword
+          # and the four contract sections, so its login is exempt from the
+          # linkage check and its pull requests stay mergeable. An exact-login
+          # match, never a `*[bot]` pattern.
+          exempt-authors: 'dependabot[bot]'
       - name: Aggregate lane results
-        # Derived from the needs graph above — the single source of truth for the
-        # lane list. Adding a lane to needs automatically extends this check.
-        env:
-          RESULTS: ${{ join(needs.*.result, ' ') }}
-        run: |
-          for r in $RESULTS; do
-            case "$r" in
-              success) ;;
-              *) echo "A required lane did not pass (result: $r)."; exit 1 ;;
-            esac
-          done
-          echo "All required lanes passed."
+        # `!cancelled()` so a failing pr-contract step does not skip the
+        # aggregation: the job still fails on the contract step's exit code, and
+        # the `ci-lanes` status is on the SHA for the next contract-only run.
+        if: ${{ !cancelled() }}
+        uses: melodic-software/ci-workflows/.github/actions/ci-status@449157aaa8e30f7b1457305d8048ebe6168e174a # v0.20.0
+        with:
+          # Derived from the needs graph above — the single source of truth for
+          # the lane list. Adding a lane to needs automatically extends this
+          # check.
+          results: ${{ join(needs.*.result, ' ') }}
+          # The replaced inline aggregator passed only `success`, so a `skipped`
+          # lane was already red here.
+          treat-skipped-as: fail
+          token: ${{ github.token }}

--- a/scripts/check-docs-only-gate.sh
+++ b/scripts/check-docs-only-gate.sh
@@ -57,17 +57,20 @@
 #                           aggregate); adding one for an UNGATED step is
 #                           fail-open, because it replaces that step's real
 #                           outcome with `success` on every docs-only diff.
-#   7. NO JOB-LEVEL IF    — a consumer carries no job-level condition at all. It
-#                           reaches the output through `needs`, so it runs only
-#                           when the resolver succeeded — which is what makes the
-#                           output's domain exactly {'true','false'} and the two
-#                           sanctioned forms exact complements. `if: always()` or
-#                           `if: ${{ !cancelled() }}` breaks that: the job runs
-#                           with an EMPTY output, both forms are false, and every
-#                           gated step and its not-applicable reporter skip
-#                           together — the lane reports success having run
-#                           nothing. The condition need not mention the output to
-#                           do this, so this check does not read what it says.
+#   7. NO JOB-LEVEL IF    — a consumer carries no job-level condition other than
+#                           the contract-only gate, pinned below as an exact
+#                           literal. It reaches the output through `needs`, so it
+#                           runs only when the resolver succeeded — which is what
+#                           makes the output's domain exactly {'true','false'}
+#                           and the two sanctioned forms exact complements.
+#                           `if: always()` or `if: ${{ !cancelled() }}` breaks
+#                           that: the job runs with an EMPTY output, both forms
+#                           are false, and every gated step and its
+#                           not-applicable reporter skip together — the lane
+#                           reports success having run nothing. Only a
+#                           status-check function can produce that state, and the
+#                           gate carries none; every other condition is rejected
+#                           without reading what it says.
 #   8. EDGE DECLARED      — a job that reads the output declares the resolving
 #                           job in its `needs`. Without the edge the expression
 #                           yields an empty string, with the same consequence.
@@ -144,6 +147,15 @@ run_workflows${TAB_LIT}\${{ steps.${DETECT_STEP_ID}.outputs.docs_only != 'true' 
 # is a defect (check 5c) and whether a lane may opt out of coverage (check 8).
 AGGREGATE_JOB="ci-status"
 LANE_OPT_OUT="lane-coverage-ok:"
+# The one sanctioned job-level condition on a required consumer: the
+# contract-only gate, which subtracts the label-flip and body-edit events where
+# `ci-status` carries the recorded `ci-lanes` verdict forward instead of
+# re-running the lanes. Pinned as a WHOLE SHAPE for the same reason the consumer
+# forms are: a variant is a different condition with different consequences, and
+# the equality is also what proves each job's copy has not drifted from the
+# others. See check 5c.
+CONTRACT_ONLY_PREDICATE="github.event.pull_request.head.repo.full_name == github.repository && (contains(fromJSON('[\"labeled\",\"unlabeled\"]'), github.event.action) || (github.event.action == 'edited' && !github.event.changes.base))"
+JOB_GATE="\${{ !(${CONTRACT_ONLY_PREDICATE}) }}"
 REFERENCE_PREFIX="needs.${RESOLVER_JOB}.outputs."
 REFERENCE="${REFERENCE_PREFIX}${OUTPUT_NAME}"
 
@@ -820,13 +832,35 @@ is_required() { [[ "$required_closure" == *$'\n'"$1"$'\n'* ]]; }
 # skipped informational lane rather than a false green, and skipping the whole
 # job is the cheaper shape: it is why a non-required Windows lane may gate at
 # job level while every aggregated lane gates its steps.
+#
+# ONE EXEMPTION, PINNED AS A WHOLE SHAPE: `$JOB_GATE`, the contract-only gate.
+# The hazard above is specifically a condition that lets a job run when the
+# resolver did NOT succeed, and only a status-check function (`always()`,
+# `!cancelled()`, `failure()`, `success()`) can do that — without one, GitHub
+# still requires every `needs` job to have succeeded before it evaluates the
+# condition at all. The gate contains none, so the needs edge governs exactly as
+# it does with no condition: the job either runs with the resolver's real
+# outputs or does not run. What the gate subtracts is the label-flip and
+# body-edit events, where the lanes would re-answer a SHA the last full run
+# already answered and `ci-status` carries that verdict forward from the
+# `ci-lanes` commit status instead. The exemption is an exact-text match, not a
+# family of shapes: a variant is a different condition, and pinning the literal
+# is also what keeps every job's copy equal to each other. Their equality with
+# the `contract-only` default the `ci-status` composite resolves its
+# carry-forward branch on is NOT checked here and is checked nowhere else
+# either: ci-workflows tests its composite against its own ci.yml, not against
+# this repository's. It was verified by hand at pin
+# 449157aaa8e30f7b1457305d8048ebe6168e174a and must be re-verified whenever that
+# pin moves. A drifted copy that skipped the lanes while the composite still
+# aggregated would turn all-`skipped` into a pass with nothing executed.
 
 while IFS= read -r refjob; do
   [[ -n "$refjob" ]] || continue
   is_required "$refjob" || continue
   while IFS="$TAB" read -r cjob ctext; do
     [[ "$cjob" == "$refjob" ]] || continue
-    report "NO JOB-LEVEL CONDITION ON A REQUIRED CONSUMER: job '$refjob' reads $OUTPUT_NAME, is reachable from ${AGGREGATE_JOB}.needs, and carries a job-level condition: if: $ctext. If that condition ever lets the job run when '$RESOLVER_JOB' did not succeed, $OUTPUT_NAME is the empty string, both sanctioned forms are false, and the lane reports success having run nothing. Gate the steps and let the needs edge decide whether the job runs at all."
+    [[ "$ctext" == "$JOB_GATE" ]] && continue
+    report "NO JOB-LEVEL CONDITION ON A REQUIRED CONSUMER: job '$refjob' reads $OUTPUT_NAME, is reachable from ${AGGREGATE_JOB}.needs, and carries a job-level condition that is not the contract-only gate: if: $ctext. If that condition ever lets the job run when '$RESOLVER_JOB' did not succeed, $OUTPUT_NAME is the empty string, both sanctioned forms are false, and the lane reports success having run nothing. Gate the steps and let the needs edge decide whether the job runs at all. The only sanctioned job-level condition here is exactly: $JOB_GATE"
   done <<<"$REC_JOBIF"
 done <<<"$refjobs"
 

--- a/scripts/check-docs-only-gate.test.sh
+++ b/scripts/check-docs-only-gate.test.sh
@@ -373,6 +373,34 @@ f="$scratch/consumer-not-cancelled.yml"
 xform_insert_after "$base" "  gamma:" "    if: \${{ !cancelled() }}" "$f"
 expect "a consumer carrying !cancelled() is rejected" 1 "NO JOB-LEVEL CONDITION ON A REQUIRED CONSUMER" --check "$f"
 
+# The one exemption: the contract-only gate, matched as a whole shape. It
+# carries no status-check function, so GitHub still requires the resolver to
+# have succeeded before it evaluates at all — the empty-output state the rule
+# above guards against cannot arise. Every case below shows the match is EXACT:
+# the literal passes, and two near-misses that would each mean something
+# different are rejected as any other job-level condition is.
+contract_gate="\${{ !(github.event.pull_request.head.repo.full_name == github.repository && (contains(fromJSON('[\"labeled\",\"unlabeled\"]'), github.event.action) || (github.event.action == 'edited' && !github.event.changes.base))) }}"
+
+f="$scratch/consumer-contract-gate.yml"
+xform_insert_after "$base" "  gamma:" "    if: $contract_gate" "$f"
+expect "a consumer carrying exactly the contract-only gate is allowed" 0 "scope resolved once" --check "$f"
+
+# One token added. `|| always()` reintroduces precisely the status-check
+# function the exemption rests on not having: the job would run with the
+# resolver skipped or failed, and the output empty.
+f="$scratch/consumer-contract-gate-always.yml"
+xform_insert_after "$base" "  gamma:" "    if: \${{ !(github.event.pull_request.head.repo.full_name == github.repository && (contains(fromJSON('[\"labeled\",\"unlabeled\"]'), github.event.action) || (github.event.action == 'edited' && !github.event.changes.base))) || always() }}" "$f"
+expect "the contract-only gate widened with always() is rejected" 1 "NO JOB-LEVEL CONDITION ON A REQUIRED CONSUMER" --check "$f"
+
+# The predicate itself drifted: this copy drops the fork clause, so it no longer
+# equals the copy every other gated job carries, nor the predicate the ci-status
+# composite resolves its carry-forward branch on. A fork pull request would skip
+# this lane while the composite aggregated it, turning a `skipped` into a pass
+# with nothing executed.
+f="$scratch/consumer-contract-gate-drifted.yml"
+xform_insert_after "$base" "  gamma:" "    if: \${{ !(contains(fromJSON('[\"labeled\",\"unlabeled\"]'), github.event.action) || (github.event.action == 'edited' && !github.event.changes.base)) }}" "$f"
+expect "a drifted copy of the contract-only predicate is rejected" 1 "NO JOB-LEVEL CONDITION ON A REQUIRED CONSUMER" --check "$f"
+
 # The aggregate's own job-level condition is not a consumer's, and must stand.
 expect "the aggregate's own job-level condition is untouched" 0 "scope resolved once" --check "$base"
 


### PR DESCRIPTION
No related issue: melodic-software/github-iac#396 tracks Phase 3 of the ci-perf program

## Summary

The pull-request contract (Conventional Commits title, `do-not-merge` label,
issue linkage) lives in three `pull_request_target` workflows emitting three
required contexts. Each re-answers on an `edited`, `labeled` or `unlabeled`
event that changed no file, and each pays a runner to do it.

This folds all three into the one required check as steps of `ci-status`,
through the ci-workflows `pr-contract` composite at `v0.20.0`, and gates every
lane off on exactly the events where only the contract could have changed. The
old callers stay in place; they are deleted after the org ruleset moves to the
single `ci-status` context.

## Fix

The contract-only predicate, verbatim in `cancel-in-progress` and in every job's
`if:` except `ci-status`:

```text
github.event.pull_request.head.repo.full_name == github.repository && (contains(fromJSON('["labeled","unlabeled"]'), github.event.action) || (github.event.action == 'edited' && !github.event.changes.base))
```

- `on.pull_request.types` gains `edited`, `labeled`, `unlabeled`.
  `ready_for_review` was already there and stays: this workflow is draft-gated.
  `on.push` is untouched.
- `concurrency.group` keeps its existing per-pull-request key.
  `cancel-in-progress` becomes `${{ !(<predicate>) }}` so a contract-only event
  queues behind an in-flight full run instead of cancelling it, and the
  carry-forward always executes after the full run whose verdict it reads. A
  `synchronize` still cancels everything on the old SHA. No event guard is ANDed
  in: the group key already gives every push run a group of its own, so a push
  run has nothing to cancel.
- `changes`, `lint`, `test-linux`, `test-windows` and `hook-utils` each carry the
  gate. `test-windows` ANDs it with its existing `needs.changes.outputs.run_windows == 'true'`.
  The lane steps stay step-gated exactly as Phase 2 left them; this is a job-level
  gate added on top.
- `ci-status` keeps `needs`, `if: ${{ !cancelled() }}` and `runs-on`. It gains
  job-level `permissions: contents: read / pull-requests: write / statuses: write`
  (no `actions: read`, which it never had), then runs `pr-contract` followed by
  the `ci-status` composite under `if: ${{ !cancelled() }}`. Without that guard a
  failing contract step would skip the aggregation, no `ci-lanes` status would be
  written even with every lane green, and the title fix or label removal that
  follows would start a carry-forward run that could never go green.
- The inline aggregation loop is replaced by the composite at
  `treat-skipped-as: fail`, which is what the loop already did: its `case`
  accepted only `success` and exited 1 on everything else, `skipped` included.
- `exempt-authors: 'dependabot[bot]'` is carried over verbatim from
  `pr-issue-linkage.yml`, the caller this step replaces, so dependabot pull
  requests stay mergeable.

On a contract-only event `ci-status` is the only job that runs, and the
composite answers from the `ci-lanes` commit status the last full run recorded on
that SHA rather than from an aggregation of jobs that were never dispatched. A
commit status, not the check-run list, because a check run cannot say which event
produced it and a chain of contract-only runs could otherwise self-certify. A
fork pull request is never contract-only: its token is read-only on
`pull_request` whatever `permissions:` requests, so it cannot record lane state,
and it runs the full workflow on every event as before.

### The docs-only gate had to learn one exemption

`scripts/check-docs-only-gate.sh` check 5c rejected every job-level condition on
a required consumer. The hazard is real and unchanged: a condition that lets a
job run while `changes` did not succeed leaves `run_full` empty, both sanctioned
consumer forms false, and every gated step and its not-applicable reporter skip
together, so the lane reports success having run nothing.

Only a status-check function (`always()`, `!cancelled()`, `failure()`,
`success()`) can produce that state. Without one, GitHub still requires every
`needs` job to have succeeded before it evaluates a job's condition at all. The
contract-only gate carries none, so the `needs` edge governs exactly as it does
with no condition. It is admitted as ONE exact literal rather than a family of
shapes, and three new cases prove the match is exact: the literal passes, the
same gate widened with `|| always()` is rejected, and a copy of the predicate
missing the fork clause is rejected.

## Verification

`yq '.jobs | to_entries[] | select(.key != "ci-status") | .key + ": " + (.value.if // "MISSING")' .github/workflows/ci.yml`:

```text
changes: ${{ !(github.event.pull_request.head.repo.full_name == github.repository && (contains(fromJSON('["labeled","unlabeled"]'), github.event.action) || (github.event.action == 'edited' && !github.event.changes.base))) }}
lint: ${{ !(github.event.pull_request.head.repo.full_name == github.repository && (contains(fromJSON('["labeled","unlabeled"]'), github.event.action) || (github.event.action == 'edited' && !github.event.changes.base))) }}
test-linux: ${{ !(github.event.pull_request.head.repo.full_name == github.repository && (contains(fromJSON('["labeled","unlabeled"]'), github.event.action) || (github.event.action == 'edited' && !github.event.changes.base))) }}
test-windows: ${{ !(github.event.pull_request.head.repo.full_name == github.repository && (contains(fromJSON('["labeled","unlabeled"]'), github.event.action) || (github.event.action == 'edited' && !github.event.changes.base))) && needs.changes.outputs.run_windows == 'true' }}
hook-utils: ${{ !(github.event.pull_request.head.repo.full_name == github.repository && (contains(fromJSON('["labeled","unlabeled"]'), github.event.action) || (github.event.action == 'edited' && !github.event.changes.base))) }}
```

Each copy is byte-identical to the `contract-only` default in the composite's
`action.yml` at pin `449157aaa8e30f7b1457305d8048ebe6168e174a`, compared
directly against the fetched file. Nothing checks that equality automatically:
ci-workflows tests its composite against its own `ci.yml`, not against this
repository's, so the pin comment in `check-docs-only-gate.sh` names the SHA the
equality was verified at.

- `actionlint .github/workflows/ci.yml` — exit 0, no output.
- `zizmor --persona regular .github/workflows/ci.yml` — 4 `help[self-repository]`
  findings, identical in kind and count to the `origin/main` baseline. Nothing
  new. The one extra suppressed item is
  `help[undocumented-permissions]` on the new `permissions:` block, visible only
  at `--persona pedantic`.
- `bash scripts/check-docs-only-gate.sh --check` — passes; 91 references across
  4 consumer jobs, all sanctioned.
- `bash scripts/check-docs-only-gate.test.sh` — all tests pass, including the
  three new contract-only-gate cases.
- `bash scripts/check-lane-coverage.sh --check` — 4 lanes reachable, unchanged.
- `bash scripts/check-lane-coverage.test.sh` — ALL PASS; it asserts nothing about
  the aggregator's step text, so it needed no change.
- `bash scripts/check-docs-only.test.sh` — PASS=21 FAIL=0.
- `bash scripts/check-purged-em-dashes.sh`, `bash scripts/check-silent-skips.sh`,
  `bash scripts/check-shell-portability.sh --paths <the two changed scripts>`,
  `shellcheck` on both — all clean.
- `git diff origin/main --stat` — three files: the workflow and the docs-only
  gate with its test.

Live proof runs are recorded in the worker report.

## Related

Refs melodic-software/github-iac#396
Refs melodic-software/github-iac#378
