### PR TITLE
docs(cloud-fleet): describe the pinned gh install and assert a version floor

### DIFF
--- a/docs/CLOUD-FLEET-SETUP.md
+++ b/docs/CLOUD-FLEET-SETUP.md
@@ -117,7 +117,9 @@ exit 0
 
 What the canonical script does (details and lifecycle in the
 [component README](https://github.com/melodic-software/standards/blob/main/components/cloud-environment/README.md)):
-parallel tracks install `gh` + PowerShell (apt), the fleet's exact .NET SDK pins into
+parallel tracks install `gh` (the pinned, checksum-verified `linux_amd64` release tarball from
+`github.com/cli/cli`, at the same version and SHA-256 the CI runner image and dotfiles' mise pin
+carry — Ubuntu's archive `gh` is years stale) and PowerShell (apt), the fleet's exact .NET SDK pins into
 `/opt/dotnet`, and Node 24.18.0 via the VM's nvm; it then runs the checked-out repo's own
 `.claude/cloud-bootstrap.sh` — baking its results into the snapshot, and, because it runs before
 the session process launches, making the repo's plugins live at turn one. Every step logs with a timestamp to
@@ -225,7 +227,12 @@ session on this repo in the new environment and ask Claude to verify:
    #2654 Blocker 2 failure, where dpkg logs showed the build stopping ~13 s in with PowerShell
    and the baked-in bootstrap never run. Force a rebuild (any trivial script-field edit) before
    debugging anything else; `/var/log/melodic-env-setup.log` shows how far the build got.
-1. `gh --version`, `pwsh --version`, `dotnet --list-sdks` (expect 10.0.302 and 10.0.400),
+1. `gh --version` — read the number, don't just confirm the binary exists. Expect **2.98.0 or
+   newer**, the version the CI runner image and dotfiles' mise pin both carry. A `2.45.x` here
+   means the session fell back to Ubuntu's archive `gh`: the setup script's pinned-tarball step
+   failed (`grep gh /var/log/melodic-env-setup.log` for its `WARN`), and scripts that shell out
+   to `gh` are running against a CLI 53 minor versions behind the other two lanes.
+   Then `pwsh --version`, `dotnet --list-sdks` (expect 10.0.302 and 10.0.400),
    `node --version` (expect the `.node-version` pin), `check-tools` for the VM inventory.
 2. The repo's bootstrap ran: `node_modules/.bin` populated, pinned lint tools present (`typos`,
    `actionlint`), and re-running the bootstrap is a fast no-op.

--- a/docs/CLOUD-FLEET-SETUP.md
+++ b/docs/CLOUD-FLEET-SETUP.md
@@ -229,9 +229,14 @@ session on this repo in the new environment and ask Claude to verify:
    debugging anything else; `/var/log/melodic-env-setup.log` shows how far the build got.
 1. `gh --version` — read the number, don't just confirm the binary exists. Expect **2.98.0 or
    newer**, the version the CI runner image and dotfiles' mise pin both carry. A `2.45.x` here
-   means the session fell back to Ubuntu's archive `gh`: the setup script's pinned-tarball step
-   failed (`grep gh /var/log/melodic-env-setup.log` for its `WARN`), and scripts that shell out
-   to `gh` are running against a CLI 53 minor versions behind the other two lanes.
+   has two possible causes, and step 0's completion stamp tells them apart before you dig
+   further: if the stamp predates this pin (check its timestamp against when the pinned-tarball
+   change landed in `components/cloud-environment/setup.sh`), the session simply cached an
+   older script version — force a rebuild (any trivial script-field edit) rather than treating
+   this as a failure. Only once the stamp is current does a `2.45.x` reading mean the setup
+   script's pinned-tarball step actually failed (`grep gh /var/log/melodic-env-setup.log` for
+   its `WARN`), leaving scripts that shell out to `gh` running against a CLI 53 minor versions
+   behind the other two lanes.
    Then `pwsh --version`, `dotnet --list-sdks` (expect 10.0.302 and 10.0.400),
    `node --version` (expect the `.node-version` pin), `check-tools` for the VM inventory.
 2. The repo's bootstrap ran: `node_modules/.bin` populated, pinned lint tools present (`typos`,


### PR DESCRIPTION
No related issue: infrastructure parity found during PR-merge-lane operation.

## Summary

The org runs `gh` in three lanes. Two pin it; one did not.

| Lane | Source | Version |
| --- | --- | --- |
| Local dev machines | `melodic-software/dotfiles` → mise | 2.98.0 |
| Self-hosted CI runner | `melodic-software/ci-runner` `Dockerfile` | 2.98.0 |
| Claude Code cloud sessions | standards `components/cloud-environment/setup.sh`, `apt-get install -y gh` | **2.45.0** |

A live cloud session on this fleet reports `gh version 2.45.0 (2025-07-18 Ubuntu
2.45.0-1ubuntu0.3)` — 53 minor versions behind the other two lanes. The several
`source-control`, `guardrails`, and `work-items` suites that shell out to `gh` were
running against a different CLI depending on where they ran.

The fix belongs upstream and is in
[melodic-software/standards#533](https://github.com/melodic-software/standards/pull/533),
which replaces the apt install with the pinned, checksum-verified `linux_amd64` release
tarball at 2.98.0. This PR is the docs half: this guide is where the fleet's install method
and its verification checklist are written down, and both had gone stale.

Worth naming the second-order finding: step 1 of the verification checklist ran
`gh --version` and asserted nothing about the number it printed, so the drift passed
verification every single time it was run. A presence check on a tool whose *version* is
the thing under contract cannot detect the failure it exists to detect.

## Fix

Two edits to `docs/CLOUD-FLEET-SETUP.md`:

- **"What the canonical script does"** — `gh` is no longer described as an apt install. It
  now names the pinned, checksum-verified `linux_amd64` release tarball from
  `github.com/cli/cli`, at the same version and SHA-256 the CI runner image and dotfiles'
  mise pin carry, and says why (Ubuntu's archive `gh` is years stale). PowerShell is still
  apt and still described that way.
- **Verification checklist, step 1** — `gh --version` gets a floor instead of a presence
  check: expect **2.98.0 or newer**, matching the other two lanes. The step also says what a
  `2.45.x` reading means (the pinned-tarball step failed and the session fell back to
  Ubuntu's archive `gh`), and where to look for the cause
  (`grep gh /var/log/melodic-env-setup.log` for the `WARN` line the standards script logs on
  every failure path). The rest of step 1 — `pwsh`, `dotnet --list-sdks`, `node --version`,
  `check-tools` — is unchanged.

No behavior change here; the install itself lives in standards.

## Verification

- `scripts/affected-tests.sh --run docs/CLOUD-FLEET-SETUP.md`: the file is a recorded
  no-suite class in `scripts/affected-tests-no-suite.txt` (a non-shell CI lane covers it);
  exit 0, no suites selected.
- `markdownlint-cli2 --config .markdownlint-cli2.jsonc docs/CLOUD-FLEET-SETUP.md`: 0 issues.
- The 2.98.0 floor is not asserted from memory. Downloaded
  `https://github.com/cli/cli/releases/download/v2.98.0/gh_2.98.0_linux_amd64.tar.gz` from a
  live cloud session: `sha256sum` returns
  `3b8ac6b30336802fc1a858d7c084e11cdf24ac1a761ca90b68022d7d729208de`, matching `ci-runner`'s
  `ARG GH_SHA256` exactly, and the extracted binary reports `gh version 2.98.0 (2026-08-20)`.
  The same session's PATH `gh` reports 2.45.0 — the drift this documents, observed directly
  rather than inferred.

Sequencing: the standards PR should merge first, and the environment needs a cache rebuild
(any trivial edit to the setup-script field) before a session picks up the new `gh`. Until
then a session will still read 2.45.0 and step 1 will correctly fail — which is the point of
adding the floor.

## Related

- [melodic-software/standards#533](https://github.com/melodic-software/standards/pull/533)
  — the install change this documents.
- `melodic-software/ci-runner` `Dockerfile` — `ARG GH_VERSION` / `ARG GH_SHA256`, the pinned
  pair both lanes now share.
- `melodic-software/dotfiles` `.chezmoidata/packages.yaml` and
  `dot_config/mise/create_mise.lock` — the local-machine lane at the same version.
- [#2654](https://github.com/melodic-software/claude-code-plugins/issues/2654) — the
  cloud-environment blockers whose network findings the standards change reuses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VPLatLkg4329L8eyfxhuMa

---
_Generated by [Claude Code](https://claude.ai/code/session_01VPLatLkg4329L8eyfxhuMa)_