### PR TITLE
ci: shard test-linux four ways and gate the lint self-tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -343,6 +343,10 @@ jobs:
         with:
           config: .editorconfig-checker.json
 
+      # Deliberately NOT scoped to the diff yet, at 111 s per run over 766
+      # files: the action's `paths` input takes search roots, not a file list,
+      # so a changed-files input is a ci-workflows change, landing separately on
+      # branch `ci-perf/shellcheck-files-input`.
       - name: Lint shell scripts
         id: shellcheck
         continue-on-error: true
@@ -381,7 +385,22 @@ jobs:
       # green. scripts/check-manifest-duplicate-keys.py reads the raw
       # key/value pairs via object_pairs_hook, BEFORE that collapse, so it
       # catches what the schema step next to it cannot. See #1498.
+      # DETECTOR SELF-TESTS ARE GATED ON `run_shell`, FROM HERE TO THE END OF
+      # THIS JOB. Each one exercises a detector under scripts/ against its own
+      # fixtures, so its subject is scripts/**, which is exactly what the
+      # `shell` filter group names. Measured at 61 s per run across 32 steps,
+      # every one of them previously unconditional. The GATE, not the detector:
+      # the `Check ...` step each of these pairs with keeps running, so a
+      # regression the detector would catch is still caught on a diff that
+      # changes no shell file. What a skip costs is the proof that the detector
+      # itself still works, and the only diffs that skip it are diffs that
+      # cannot have broken it.
+      #
+      # `run_shell` also carries `draft != true`, so these skip on a draft run
+      # and return on the flip to ready, which AGENTS.md requires before merge,
+      # and on every push to main.
       - name: Test the manifest duplicate-key detector
+        if: needs.changes.outputs.run_shell == 'true'
         run: bash scripts/check-manifest-duplicate-keys.test.sh
       - name: Detect duplicate keys in plugin/marketplace manifests
         id: duplicate_keys
@@ -487,6 +506,7 @@ jobs:
             :(exclude)plugins/code-tidying/skills/audit-comment-residue/evals/**
 
       - name: Test the hook-wiring-liveness gate
+        if: needs.changes.outputs.run_shell == 'true'
         run: bash scripts/check-hook-wiring-liveness.test.sh
       - name: Check repo-local hooks are wired in settings.json
         id: hook_wiring
@@ -500,6 +520,7 @@ jobs:
       # rather than an honest not-applicable. The self-test runs first and
       # ungated so a broken gate cannot mask a regression.
       - name: Test the purged-em-dash gate
+        if: needs.changes.outputs.run_shell == 'true'
         run: bash scripts/check-purged-em-dashes.test.sh
       - name: Check purged surfaces stayed free of em dashes
         id: purged_em_dashes
@@ -531,6 +552,7 @@ jobs:
       # sit at six unrelated paths. Self-test first so a broken extractor cannot
       # mask a regression behind a green gate.
       - name: Run loop-lane floor drift tests
+        if: needs.changes.outputs.run_shell == 'true'
         run: bash scripts/check-loop-lane-floor-drift.test.sh
       - name: Check every inlined rate-limit floor matches its reader contract
         id: loop_lane_floor_drift
@@ -539,6 +561,7 @@ jobs:
 
       # Self-test first, so a broken detector cannot mask a regression.
       - name: Run detector-findings-crosswalk tests
+        if: needs.changes.outputs.run_shell == 'true'
         run: bash scripts/check-detector-findings-crosswalk.test.sh
       - name: Check every crosswalk row argues its disposition from a stated test
         id: detector_findings_crosswalk
@@ -547,6 +570,7 @@ jobs:
 
       # Self-test first, so a broken detector cannot mask a regression.
       - name: Run skill-leaf-name tests
+        if: needs.changes.outputs.run_shell == 'true'
         run: bash scripts/check-skill-leaf-names.test.sh
       - name: Check for unregistered cross-plugin skill leaf-name collisions
         id: skill_leaf_names
@@ -561,6 +585,7 @@ jobs:
       # rather than by anything mechanical. Self-test first so a broken
       # detector cannot mask a regression.
       - name: Run skill-count-claim tests
+        if: needs.changes.outputs.run_shell == 'true'
         run: bash scripts/check-skill-count-claims.test.sh
       - name: Check every skill-count claim against the tree
         id: skill_count_claims
@@ -575,6 +600,7 @@ jobs:
       # gate pins the exact regression #1242 fixed. Self-test first so a broken
       # detector cannot mask a regression.
       - name: Test the userconfig-argv gate
+        if: needs.changes.outputs.run_shell == 'true'
         run: bash scripts/check-hook-userconfig-argv.test.sh
       - name: Check plugin hook configs for bare userConfig argv tokens
         id: userconfig_argv
@@ -592,6 +618,7 @@ jobs:
       # `error` row the whole time — a checklist a human reads is not a gate.
       # Self-test first so a broken detector cannot mask a regression.
       - name: Test the hook-exec-form gate
+        if: needs.changes.outputs.run_shell == 'true'
         run: bash scripts/check-hook-exec-form.test.sh
       - name: Check hook declarations for exec-form bare command names
         id: hook_exec_form
@@ -608,6 +635,7 @@ jobs:
       # ordering drifting back. Self-test first so a broken detector cannot mask
       # a regression.
       - name: Test the kill-switch hoist gate
+        if: needs.changes.outputs.run_shell == 'true'
         run: bash scripts/check-killswitch-hoist.test.sh
       - name: Check that PreToolUse guards read their kill switch before sourcing
         id: killswitch_hoist
@@ -641,12 +669,14 @@ jobs:
         continue-on-error: true
         run: scripts/check-silent-skips.sh
       - name: Run silent-skip-gate tests
+        if: needs.changes.outputs.run_shell == 'true'
         run: bash scripts/check-silent-skips.test.sh
 
       # A skip_case that vacates the only discriminating assertions in a case
       # group lets a suite report green while proving nothing. The self-test
       # runs first so a broken gate cannot mask a regression.
       - name: Run discriminating-test-skip gate tests
+        if: needs.changes.outputs.run_shell == 'true'
         run: bash scripts/check-discriminating-test-skips.test.sh
       - name: Check plugin test suites for discriminating skip_case sites
         id: discriminating_test_skips
@@ -663,6 +693,7 @@ jobs:
       # always runs. The self-test runs first so a broken detector cannot mask
       # a regression behind a green gate.
       - name: Test the plugin-manifest-presence gate
+        if: needs.changes.outputs.run_shell == 'true'
         run: bash scripts/check-plugin-manifest-presence.test.sh
       - name: Check every catalog entry resolves to a present, name-matching plugin manifest
         id: plugin_manifest_presence
@@ -678,6 +709,7 @@ jobs:
       # static, so it always runs. The self-test runs first so a broken
       # detector cannot mask a regression behind a green gate.
       - name: Test the plugin-catalog-enablement gate
+        if: needs.changes.outputs.run_shell == 'true'
         run: bash scripts/check-plugin-catalog-enablement.test.sh
       - name: Check every catalogued plugin carries an enabledPlugins key
         id: plugin_catalog_enablement
@@ -691,6 +723,7 @@ jobs:
       # guard. The self-test runs ungated so a broken detector cannot mask a
       # regression behind a green gate.
       - name: Test the orphaned-fixture detector
+        if: needs.changes.outputs.run_shell == 'true'
         run: bash scripts/check-orphaned-fixtures.test.sh
       - name: Check for orphaned eval fixtures
         id: orphaned_fixtures
@@ -706,8 +739,10 @@ jobs:
       # required_signatures with `no_user` and cost #2827 -> #2830 (#2840). The
       # self-test runs ungated so a broken detector cannot mask a regression.
       - name: Test the fixture-git-isolation detector
+        if: needs.changes.outputs.run_shell == 'true'
         run: bash scripts/check-fixture-git-isolation.test.sh
       - name: Test that the shared git test harness isolates its fixtures
+        if: needs.changes.outputs.run_shell == 'true'
         run: bash scripts/test-git-helpers.test.sh
       - name: Check fixture git isolation
         id: fixture_git_isolation
@@ -720,6 +755,7 @@ jobs:
       # rewrites the test file alongside the collector cannot delete its own
       # defender (#2656).
       - name: Test the fleet finding-kind test-coverage detector
+        if: needs.changes.outputs.run_shell == 'true'
         run: bash scripts/check-fleet-finding-test-coverage.test.sh
       - name: "Check every emitted fleet finding kind has a Finding: assertion"
         id: fleet_finding_test_coverage
@@ -731,6 +767,7 @@ jobs:
       # collector so a docs-only silent revert (#2646) cannot delete its own
       # defender (#2713). Probes the script under a sealed env.
       - name: Test the fleet audit doc-grammar detector
+        if: needs.changes.outputs.run_shell == 'true'
         run: bash scripts/check-fleet-audit-doc-grammar.test.sh
       - name: Check audit skill grammar matches the parser
         id: fleet_audit_doc_grammar
@@ -751,6 +788,7 @@ jobs:
       # clone keeps that head-tip comparison while leaving every other step in
       # this job on the merge commit, where the diff-scoped gates want to be.
       - name: Test the stale-base overlap detector
+        if: needs.changes.outputs.run_shell == 'true'
         run: bash scripts/check-stale-base-overlap.test.sh
       - name: Fail when behind base on overlapping paths
         id: stale_base
@@ -792,6 +830,7 @@ jobs:
       # gate is never relaxed by the baseline. The self-test runs first so a
       # broken gate cannot mask a regression.
       - name: Test the changelog-parity gate
+        if: needs.changes.outputs.run_shell == 'true'
         run: bash scripts/check-changelog-parity.test.sh
       - name: Verify every versioned plugin keeps a CHANGELOG.md at or below its manifest version
         id: changelog_parity_check
@@ -841,6 +880,7 @@ jobs:
       # b01dace3). The self-test runs first so a broken gate cannot mask a
       # regression.
       - name: Test the vendor version-bump gate
+        if: needs.changes.outputs.run_shell == 'true'
         run: bash scripts/check-vendor-version-bump.test.sh
       - name: Verify a vendor/ source change bumps the plugin's version
         id: vendor_version_bump
@@ -865,6 +905,7 @@ jobs:
       # under #1419. The self-test runs first so a broken gate cannot mask a
       # regression.
       - name: Test the contract-slice prune gate
+        if: needs.changes.outputs.run_shell == 'true'
         run: bash scripts/check-contract-slice-prune.test.sh
       - name: Verify no baseline entry outlives its slice
         id: contract_slice_check
@@ -893,6 +934,7 @@ jobs:
       # exactly that reason. Repo-wide and static, so it always runs. Self-test
       # first, so a broken detector cannot mask a real gap. See #1659.
       - name: Test the contract-clause coverage gate
+        if: needs.changes.outputs.run_shell == 'true'
         run: bash scripts/check-contract-clause-coverage.test.sh
       - name: Check every restatement carries the canonical clause's qualifiers
         id: contract_clause_coverage
@@ -908,6 +950,7 @@ jobs:
       # condition may hide — are what this step checks against this workflow.
       # Self-test first, so a broken gate cannot mask a regression.
       - name: Test the docs-only scope-contract gate
+        if: needs.changes.outputs.run_shell == 'true'
         run: bash scripts/check-docs-only-gate.test.sh
       - name: Check the docs-only scope contract holds in ci.yml
         id: docs_only_contract
@@ -924,6 +967,7 @@ jobs:
       # `# lane-coverage-ok: <reason>` annotation recording why it stays out.
       # Self-test first so a broken detector cannot mask a regression.
       - name: Test the lane-coverage gate
+        if: needs.changes.outputs.run_shell == 'true'
         run: bash scripts/check-lane-coverage.test.sh
       - name: Check every ci.yml job is reachable from the ci-status aggregate
         id: lane_coverage
@@ -944,8 +988,10 @@ jobs:
       # which docs/adr/0003 rules out until a guard has measured precision.
       # Self-test first, so a broken detector cannot mask a regression.
       - name: Test the MSYS-to-Windows emit helper
+        if: needs.changes.outputs.run_shell == 'true'
         run: bash scripts/emit-windows-path.test.sh
       - name: Test the drive-root litter detector
+        if: needs.changes.outputs.run_shell == 'true'
         run: bash scripts/check-drive-root-litter.test.sh
       - name: Assert the drive-root scan is a no-op on a non-Windows host
         id: drive_root_noop
@@ -960,6 +1006,7 @@ jobs:
       # on every event. Self-test first so a broken orchestrator can never mask
       # a real skill regression behind a green gate.
       - name: Test the changed-skill gate
+        if: needs.changes.outputs.run_shell == 'true'
         run: bash scripts/check-changed-skills.test.sh
       - name: Gate changed skills on the static skill-quality contract
         id: changed_skills
@@ -992,6 +1039,7 @@ jobs:
         continue-on-error: true
         run: bash plugins/skill-quality/scripts/check-evals-quality.sh plugins/*/skills/*/evals/evals.json
       - name: Test the precompute-compose gate
+        if: needs.changes.outputs.run_shell == 'true'
         run: bash scripts/check-skill-precompute-compose.test.sh
       - name: Report precompute git+multi-line violations (warn-only)
         id: precompute_compose
@@ -1016,6 +1064,7 @@ jobs:
       # member issues own. The self-test gives push a passing path and stops a
       # broken detector masking a real violation behind a green gate.
       - name: Test the portability gate
+        if: needs.changes.outputs.run_shell == 'true'
         run: bash scripts/check-skill-portability.test.sh
       - name: Gate changed skill files on the portability contract
         id: portability
@@ -1038,6 +1087,7 @@ jobs:
       # regression. Skill-md backlog is grandfathered in
       # scripts/shell-portability-skill-md-baseline.txt.
       - name: Test the shell-portability gate
+        if: needs.changes.outputs.run_shell == 'true'
         run: bash scripts/check-shell-portability.test.sh
       - name: Gate changed shell and skill-md files for GNU-only constructs
         id: shell_portability
@@ -1176,6 +1226,31 @@ jobs:
     if: ${{ !(github.event.pull_request.head.repo.full_name == github.repository && (contains(fromJSON('["labeled","unlabeled"]'), github.event.action) || (github.event.action == 'edited' && !github.event.changes.base))) }}
     runs-on: ubuntu-24.04
     timeout-minutes: 30
+    # FOUR LEGS ON A PULL REQUEST, ONE ON EVERY OTHER EVENT. The job key does
+    # not change, so `ci-status.needs` and scripts/check-lane-coverage.sh are
+    # untouched; what changes is that the affected-suite selection is
+    # partitioned across four runners instead of executed by one. The dominant
+    # step was measured at 435 s p50 running 146 to 165 suites strictly
+    # sequentially, and the selector's own header records parallelism WITHIN a
+    # runner as sublinear, so more runners is the lever that is left.
+    #
+    # `fail-fast: false` because a leg is a slice of one test corpus: cancelling
+    # the other three on the first failure would hide every other failure in the
+    # same change set behind whichever leg lost the race.
+    #
+    # The matrix is an expression rather than a literal so `push` keeps exactly
+    # the behaviour it has today: one leg, running the full corpus once through
+    # `run-plugin-tests.sh --jobs 3`. Four legs on `push` would run that corpus
+    # four times over.
+    #
+    # The shard spec is read from `strategy.job-index` and `strategy.job-total`,
+    # not from `matrix.leg`. The matrix key exists to SIZE the fan-out; the
+    # runtime pair is what the shard arithmetic uses, so the numerator and the
+    # denominator come from the same place and cannot drift from each other or
+    # from the matrix that produced them.
+    strategy:
+      fail-fast: false
+      matrix: ${{ github.event_name == 'pull_request' && fromJSON('{"leg":[0,1,2,3]}') || fromJSON('{"leg":[0]}') }}
     steps:
       - name: Check out
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -1256,10 +1331,24 @@ jobs:
       # stays 1 for Windows dev boxes; the suites that assert wall-clock
       # ceilings run one at a time regardless, from
       # scripts/run-plugin-tests-serial.txt.
+      #
+      # SHARDED ACROSS THE MATRIX. `--shard <leg>/<legs>` narrows the SELECTION
+      # after the selector has derived it in full, so every leg answers the same
+      # unmapped question and the union of the four legs is exactly the suite
+      # set one job used to run. A leg that draws nothing exits 0 in about a
+      # second, which is what the short-circuit path needs: if a leg SKIPPED
+      # instead, the matrix result would be `skipped` and `ci-status`, which is
+      # fail-closed on `skipped`, would red the pull request.
+      #
+      # The UNMAPPED fallback runs the full corpus, and run-plugin-tests.sh
+      # takes no shard, so it is confined to leg 0 rather than run four times.
+      # No run in the 23-run step-level capture hit that path.
       - name: Run plugin contract tests
         if: needs.changes.outputs.run_tests == 'true'
         env:
           BASE_REF: ${{ github.base_ref }}
+          LEG: ${{ strategy.job-index }}
+          LEGS: ${{ strategy.job-total }}
         run: |
           if [ "$GITHUB_EVENT_NAME" != pull_request ]; then
             scripts/run-plugin-tests.sh --jobs 3
@@ -1267,7 +1356,7 @@ jobs:
           fi
           err="$RUNNER_TEMP/affected-tests.err"
           set +e
-          scripts/affected-tests.sh --run --base "origin/$BASE_REF" 2>"$err"
+          scripts/affected-tests.sh --run --shard "$LEG/$LEGS" --base "origin/$BASE_REF" 2>"$err"
           status=$?
           set -e
           cat "$err" >&2
@@ -1302,6 +1391,10 @@ jobs:
             1)
               if grep -q '^UNMAPPED:' "$err"; then
                 summary=$(grep -m1 '^UNMAPPED:' "$err")
+                if [ "$LEG" != 0 ]; then
+                  echo "::warning::$summary Leg $LEG defers the full-corpus fallback to leg 0."
+                  exit 0
+                fi
                 echo "::warning::$summary Falling back to the full contract corpus."
                 printf 'affected-tests fallback: %s\n' "$summary" >> "$GITHUB_STEP_SUMMARY"
                 scripts/run-plugin-tests.sh --jobs 3

--- a/plugins/eol-normalizer/hooks/eol-normalizer.test.sh
+++ b/plugins/eol-normalizer/hooks/eol-normalizer.test.sh
@@ -8,8 +8,6 @@
 # (advisory, exit 0), and emits a schema-valid telemetry envelope. No policy of its own — the fixture repo's
 # .gitattributes is the sole authority.
 #
-# Temporary probe line, reverted in the same change set.
-#
 # Self-contained: builds throwaway git repos with runtime-generated fixtures and
 # .gitattributes. The hook is invoked as a subprocess from an UNRELATED cwd so
 # any reliance on the caller's working directory would surface (the tools are

--- a/plugins/eol-normalizer/hooks/eol-normalizer.test.sh
+++ b/plugins/eol-normalizer/hooks/eol-normalizer.test.sh
@@ -8,6 +8,8 @@
 # (advisory, exit 0), and emits a schema-valid telemetry envelope. No policy of its own — the fixture repo's
 # .gitattributes is the sole authority.
 #
+# Temporary probe line, reverted in the same change set.
+#
 # Self-contained: builds throwaway git repos with runtime-generated fixtures and
 # .gitattributes. The hook is invoked as a subprocess from an UNRELATED cwd so
 # any reliance on the caller's working directory would surface (the tools are

--- a/scripts/affected-tests.sh
+++ b/scripts/affected-tests.sh
@@ -264,6 +264,11 @@ allow_unmapped=0
 explain=0
 print_fanout=""
 shard_spec=""
+# Whether --shard was SUPPLIED, tracked apart from its value. `--shard=` with an
+# empty right-hand side is what an environment variable that expanded to nothing
+# produces, and a presence test on the value alone would read it as "no shard
+# requested" and run the whole selection on every leg while reporting success.
+shard_given=0
 shard_index=0
 shard_total=1
 declare -a explicit_paths=()
@@ -328,10 +333,12 @@ while [[ $# -gt 0 ]]; do
       exit 2
     fi
     shard_spec="$2"
+    shard_given=1
     shift 2
     ;;
   --shard=*)
     shard_spec="${1#--shard=}"
+    shard_given=1
     shift
     ;;
   --print-fanout)
@@ -362,7 +369,7 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-if [[ -n "$shard_spec" ]] && ! parse_shard "$shard_spec"; then
+if [[ "$shard_given" -eq 1 ]] && ! parse_shard "$shard_spec"; then
   echo "error: --shard wants <index>/<total> with total >= 1 and 0 <= index < total; got: $shard_spec" >&2
   exit 2
 fi

--- a/scripts/affected-tests.sh
+++ b/scripts/affected-tests.sh
@@ -15,7 +15,20 @@
 #   scripts/affected-tests.sh --base <ref>       use <ref> as the diff base (default: origin/main)
 #   scripts/affected-tests.sh --explain          report WHY each suite was selected (stderr)
 #   scripts/affected-tests.sh --allow-unmapped   downgrade an unmapped file to a warning
+#   scripts/affected-tests.sh --shard <i>/<n>    keep only leg i of n of the selection
 #   scripts/affected-tests.sh --print-fanout P   print the copy set DERIVED for shared source P
+#
+# SHARDING. `--shard <i>/<n>` narrows the SELECTION, not the derivation: every
+# rule below runs in full, the unmapped check fires in full, and only then is
+# the sorted suite list partitioned by index modulo n. Legs are therefore a
+# partition in the mathematical sense: the union of legs 0..n-1 is exactly the
+# unsharded selection and no two legs share a suite. That is the property CI
+# needs when it fans one selection across n runners and calls the change tested.
+# Modulo, not contiguous blocks: the sorted list clusters suites by directory,
+# so a block partition hands one leg a whole slow plugin while another gets
+# nothing, and interleaving spreads the clusters. An EMPTY leg is not an error;
+# it exits 0, because "this leg had nothing to run" and "nothing was affected"
+# are the same statement about that runner.
 #
 # Exit: 0 selected (or nothing to do); 1 an unmapped changed file, or a failing
 # suite under --run; 2 usage or a broken derivation; 3 --run ran every shell
@@ -250,7 +263,29 @@ do_run=0
 allow_unmapped=0
 explain=0
 print_fanout=""
+shard_spec=""
+shard_index=0
+shard_total=1
 declare -a explicit_paths=()
+
+# parse_shard <spec>: accept exactly `<i>/<n>` with i and n decimal, n >= 1 and
+# 0 <= i < n. Rejected whole-string rather than by prefix: a spec this function
+# cannot read must never silently become leg 0 of 1, because that leg RUNS
+# EVERYTHING and would report a full pass from a typo'd fan-out.
+parse_shard() {
+  local spec="$1" i n
+  [[ "$spec" =~ ^[0-9]+/[0-9]+$ ]] || return 1
+  i="${spec%%/*}"
+  n="${spec##*/}"
+  # Strip leading zeros so `08` is 8 rather than an octal parse error.
+  i=$((10#$i))
+  n=$((10#$n))
+  ((n >= 1)) || return 1
+  ((i < n)) || return 1
+  shard_index="$i"
+  shard_total="$n"
+  return 0
+}
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -286,6 +321,19 @@ while [[ $# -gt 0 ]]; do
     base_ref="${1#--base=}"
     shift
     ;;
+  --shard)
+    # Same as --base above: usage errors exit 2, not 1.
+    if [[ $# -lt 2 || -z "$2" ]]; then
+      echo "error: --shard needs <index>/<total>." >&2
+      exit 2
+    fi
+    shard_spec="$2"
+    shift 2
+    ;;
+  --shard=*)
+    shard_spec="${1#--shard=}"
+    shift
+    ;;
   --print-fanout)
     # Same as --base above: usage errors exit 2, not 1.
     if [[ $# -lt 2 || -z "$2" ]]; then
@@ -313,6 +361,11 @@ while [[ $# -gt 0 ]]; do
     ;;
   esac
 done
+
+if [[ -n "$shard_spec" ]] && ! parse_shard "$shard_spec"; then
+  echo "error: --shard wants <index>/<total> with total >= 1 and 0 <= index < total; got: $shard_spec" >&2
+  exit 2
+fi
 
 WORK_DIR="$(mktemp -d "${TMPDIR:-/tmp}/affected-tests.XXXXXX")" || exit 2
 trap 'rm -rf "$WORK_DIR"' EXIT
@@ -953,6 +1006,25 @@ fi
 if [[ ${#selected[@]} -eq 0 ]]; then
   echo "No suites selected (every changed file is a recorded no-suite class or a deletion)." >&2
   exit 0
+fi
+
+# The partition. It happens HERE, after the unmapped check, after the deletion
+# and no-suite reporting, and after the sort, so every leg derives the same
+# full selection from the same diff and then keeps its own slice of it. Doing it
+# earlier (partitioning the CHANGED FILES) would give each leg a different
+# derivation, and the unmapped check would then fire on whichever leg happened
+# to receive the unmapped file rather than on all of them.
+if [[ "$shard_total" -gt 1 ]]; then
+  declare -a leg=()
+  for ((si = shard_index; si < ${#selected[@]}; si += shard_total)); do
+    leg+=("${selected[$si]}")
+  done
+  echo "shard: leg $shard_index of $shard_total keeps ${#leg[@]} of ${#selected[@]} selected suite(s)." >&2
+  selected=("${leg[@]}")
+  if [[ ${#selected[@]} -eq 0 ]]; then
+    echo "This leg has no suites to run; the other legs carry the selection." >&2
+    exit 0
+  fi
 fi
 
 if [[ "$explain" -eq 1 ]]; then

--- a/scripts/affected-tests.test.sh
+++ b/scripts/affected-tests.test.sh
@@ -461,6 +461,26 @@ else
   fail "--run did not execute the selection (rc=$RC): $(cat "$marker")"
 fi
 
+# --- --run --shard executes each suite on exactly one leg -------------------
+# CI fans this selection across four runners and calls the change tested, so
+# "the legs together ran everything, and nothing twice" is the property that
+# claim rests on. Two legs are enough to prove it and keep the fixture small.
+: >"$marker"
+shard_rc=0
+for legix in 0 1; do
+  (cd "$repo" && MARKER_FILE="$marker" bash scripts/affected-tests.sh \
+    --run --shard "$legix/2" lib/widget.sh >/dev/null 2>&1) || shard_rc=$?
+done
+marker_text="$(cat "$marker")"
+count_of() { printf '%s' "$marker_text" | grep -o "$1" | grep -c . || true; }
+if [[ "$shard_rc" -eq 0 ]] &&
+  [[ "$(count_of lib-widget)" -eq 1 ]] &&
+  [[ "$(count_of beta-hook)" -eq 1 ]]; then
+  ok "--run --shard runs the whole selection across the legs, each suite once"
+else
+  fail "sharded --run did not cover the selection exactly once (rc=$shard_rc): $marker_text"
+fi
+
 # --- --run propagates a suite failure --------------------------------------
 suite_body alpha-hook 1 >"$repo/plugins/alpha/hooks/alpha-hook.test.sh"
 (cd "$repo" && bash scripts/affected-tests.sh --run plugins/alpha/hooks/alpha-hook.sh >/dev/null 2>&1)
@@ -1060,6 +1080,96 @@ else
   fail "co-located suite lost or unrelated suite still borrowed (rc=$RC): $OUT"
 fi
 rm -rf "$repo3"
+
+# --- LIVE repo: --shard is a partition, not a filter -------------------------
+# The claim CI makes when it fans one selection across four runners is that the
+# legs together are the selection and no suite ran twice. Asserted against the
+# live tree and against INVARIANTS rather than counts, so it keeps holding as
+# the corpus grows. The three paths are picked to select broadly.
+shard_paths=(scripts/check-lane-coverage.sh scripts/affected-tests.sh scripts/check-docs-only-gate.sh)
+# Every call keeps its stderr so a failure below names the reason instead of
+# reporting an empty selection with no explanation.
+select_shard() {
+  local spec="$1"
+  local -a argv=(bash "$REPO_ROOT/scripts/affected-tests.sh")
+  [[ -n "$spec" ]] && argv+=(--shard "$spec")
+  argv+=(--)
+  (cd "$REPO_ROOT" && "${argv[@]}" "${shard_paths[@]}" 2>"$shard_err_file")
+}
+shard_err_file="$(mktemp "${TMPDIR:-/tmp}/affected-tests-shard-err.XXXXXX")"
+shard_rc=0
+shard_full="$(select_shard "")" || shard_rc=$?
+full_err="$(cat "$shard_err_file")"
+shard_union=""
+shard_sum=0
+for legix in 0 1 2 3; do
+  leg_out="$(select_shard "$legix/4")" || shard_rc=$?
+  shard_sum=$((shard_sum + $(printf '%s\n' "$leg_out" | grep -c . || true)))
+  shard_union+="$leg_out"$'\n'
+done
+full_count="$(printf '%s\n' "$shard_full" | grep -c . || true)"
+union_sorted="$(printf '%s' "$shard_union" | grep . | sort)"
+full_sorted="$(printf '%s\n' "$shard_full" | grep . | sort)"
+if [[ "$shard_rc" -eq 0 ]] && [[ "$full_count" -gt 4 ]] &&
+  [[ "$union_sorted" == "$full_sorted" ]] && [[ "$shard_sum" -eq "$full_count" ]]; then
+  ok "--shard legs union to the whole selection with no suite on two legs"
+else
+  fail "--shard is not a partition (rc=$shard_rc, full=$full_count, sum=$shard_sum): $full_err"
+fi
+
+out="$(select_shard 0/1)"
+if [[ "$(printf '%s\n' "$out" | grep . | sort)" == "$full_sorted" ]]; then
+  ok "--shard 0/1 is the unsharded selection"
+else
+  fail "--shard 0/1 changed the selection"
+fi
+
+# The empty leg. It is the short-circuit CI depends on: a leg that draws nothing
+# must EXIT 0, because a leg that skipped would make the matrix result `skipped`
+# and ci-status is fail-closed on that.
+out="$(select_shard 999/1000)"
+RC=$?
+if [[ "$RC" -eq 0 ]] && [[ -z "$(printf '%s' "$out" | grep . || true)" ]]; then
+  ok "a leg with no suites exits 0 and prints no selection"
+else
+  fail "empty leg should exit 0 with nothing selected (rc=$RC): $out"
+fi
+
+# A spec this script cannot read must never become leg 0 of 1, which runs
+# everything and would report a full pass from a typo'd fan-out.
+for badspec in 4/4 bogus 0/0 1/ /4 "1/4/4" "-1/4"; do
+  select_shard "$badspec" >/dev/null
+  RC=$?
+  if [[ "$RC" -eq 2 ]]; then
+    ok "--shard '$badspec' is a usage error, not a silent full run"
+  else
+    fail "--shard '$badspec' should exit 2, got rc=$RC"
+  fi
+done
+rm -f "$shard_err_file"
+
+# --- LIVE repo: ci.yml actually fans the selection out -----------------------
+# `--shard` only buys anything if the workflow both PASSES it and creates more
+# than one runner to pass it from. Either half alone is silently useless: a
+# shard spec with no matrix runs leg 0 of 1 (everything, as before), and a
+# matrix with no shard spec runs the whole selection on every leg. Pinned
+# together, in the job that owns them.
+live_ci="$REPO_ROOT/.github/workflows/ci.yml"
+test_linux_block="$(awk '
+  /^  [A-Za-z_][A-Za-z0-9_-]*:[[:blank:]]*(#.*)?$/ {
+    job = $0; sub(/:.*$/, "", job); sub(/^  /, "", job)
+  }
+  job == "test-linux"
+' "$live_ci")"
+# shellcheck disable=SC2016 # deliberate: these are workflow literals to match, not shell expansions.
+if grep -q 'affected-tests\.sh --run --shard "\$LEG/\$LEGS"' <<<"$test_linux_block" &&
+  grep -q '^    strategy:' <<<"$test_linux_block" &&
+  grep -q 'LEG: \${{ strategy\.job-index }}' <<<"$test_linux_block" &&
+  grep -q 'LEGS: \${{ strategy\.job-total }}' <<<"$test_linux_block"; then
+  ok "ci.yml test-linux declares a matrix and passes the leg through to --shard"
+else
+  fail "ci.yml test-linux no longer fans the affected selection across a matrix"
+fi
 
 # --- --help reaches the actual end of the header -----------------------------
 # usage() used to extract a hardcoded sed range that stopped mid-header as the

--- a/scripts/affected-tests.test.sh
+++ b/scripts/affected-tests.test.sh
@@ -461,10 +461,74 @@ else
   fail "--run did not execute the selection (rc=$RC): $(cat "$marker")"
 fi
 
+# --- --shard is a partition, not a filter -----------------------------------
+# The claim CI makes when it fans one selection across four runners is that the
+# legs together ARE the selection and no suite ran twice. Proved on the fixture
+# repo rather than the live tree on purpose: each live derivation walks the
+# whole corpus, and this suite is itself one of the suites a leg runs, so a
+# handful of live derivations here would cost back part of what the shard
+# saves and would unbalance whichever leg drew this file.
+shard_paths=(lib/widget.sh plugins/alpha/hooks/alpha-hook.sh plugins/beta/hooks/beta-hook.sh)
+select_shard() {
+  local spec="$1"
+  local -a argv=(bash scripts/affected-tests.sh)
+  [[ -n "$spec" ]] && argv+=(--shard "$spec")
+  (cd "$repo" && "${argv[@]}" -- "${shard_paths[@]}" 2>/dev/null)
+}
+
+shard_rc=0
+shard_full="$(select_shard "")" || shard_rc=$?
+full_sorted="$(printf '%s\n' "$shard_full" | grep . | sort)"
+full_count="$(printf '%s\n' "$full_sorted" | grep -c . || true)"
+shard_union=""
+shard_sum=0
+for legix in 0 1 2; do
+  leg_out="$(select_shard "$legix/3")" || shard_rc=$?
+  shard_sum=$((shard_sum + $(printf '%s\n' "$leg_out" | grep -c . || true)))
+  shard_union+="$leg_out"$'\n'
+done
+union_sorted="$(printf '%s' "$shard_union" | grep . | sort)"
+if [[ "$shard_rc" -eq 0 ]] && [[ "$full_count" -ge 3 ]] &&
+  [[ "$union_sorted" == "$full_sorted" ]] && [[ "$shard_sum" -eq "$full_count" ]]; then
+  ok "--shard legs union to the whole selection with no suite on two legs"
+else
+  fail "--shard is not a partition (rc=$shard_rc, full=$full_count, sum=$shard_sum)"
+fi
+
+out="$(select_shard 0/1)"
+if [[ "$(printf '%s\n' "$out" | grep . | sort)" == "$full_sorted" ]]; then
+  ok "--shard 0/1 is the unsharded selection"
+else
+  fail "--shard 0/1 changed the selection"
+fi
+
+# The empty leg. It is the short-circuit CI depends on: a leg that draws
+# nothing must EXIT 0, because a leg that skipped would make the matrix result
+# `skipped` and ci-status is fail-closed on that.
+out="$(select_shard 999/1000)"
+RC=$?
+if [[ "$RC" -eq 0 ]] && [[ -z "$(printf '%s' "$out" | grep . || true)" ]]; then
+  ok "a leg with no suites exits 0 and prints no selection"
+else
+  fail "empty leg should exit 0 with nothing selected (rc=$RC): $out"
+fi
+
+# A spec this script cannot read must never become leg 0 of 1, which runs
+# everything and would report a full pass from a typo'd fan-out. These exit
+# before any derivation, so they cost nothing.
+for badspec in 4/4 bogus 0/0 1/ /4 "1/4/4" "-1/4"; do
+  select_shard "$badspec" >/dev/null
+  RC=$?
+  if [[ "$RC" -eq 2 ]]; then
+    ok "--shard '$badspec' is a usage error, not a silent full run"
+  else
+    fail "--shard '$badspec' should exit 2, got rc=$RC"
+  fi
+done
+
 # --- --run --shard executes each suite on exactly one leg -------------------
-# CI fans this selection across four runners and calls the change tested, so
-# "the legs together ran everything, and nothing twice" is the property that
-# claim rests on. Two legs are enough to prove it and keep the fixture small.
+# The partition above is about selection; this is about execution. Two legs are
+# enough to prove each selected suite ran, on exactly one of them.
 : >"$marker"
 shard_rc=0
 for legix in 0 1; do
@@ -1080,73 +1144,6 @@ else
   fail "co-located suite lost or unrelated suite still borrowed (rc=$RC): $OUT"
 fi
 rm -rf "$repo3"
-
-# --- LIVE repo: --shard is a partition, not a filter -------------------------
-# The claim CI makes when it fans one selection across four runners is that the
-# legs together are the selection and no suite ran twice. Asserted against the
-# live tree and against INVARIANTS rather than counts, so it keeps holding as
-# the corpus grows. The three paths are picked to select broadly.
-shard_paths=(scripts/check-lane-coverage.sh scripts/affected-tests.sh scripts/check-docs-only-gate.sh)
-# Every call keeps its stderr so a failure below names the reason instead of
-# reporting an empty selection with no explanation.
-select_shard() {
-  local spec="$1"
-  local -a argv=(bash "$REPO_ROOT/scripts/affected-tests.sh")
-  [[ -n "$spec" ]] && argv+=(--shard "$spec")
-  argv+=(--)
-  (cd "$REPO_ROOT" && "${argv[@]}" "${shard_paths[@]}" 2>"$shard_err_file")
-}
-shard_err_file="$(mktemp "${TMPDIR:-/tmp}/affected-tests-shard-err.XXXXXX")"
-shard_rc=0
-shard_full="$(select_shard "")" || shard_rc=$?
-full_err="$(cat "$shard_err_file")"
-shard_union=""
-shard_sum=0
-for legix in 0 1 2 3; do
-  leg_out="$(select_shard "$legix/4")" || shard_rc=$?
-  shard_sum=$((shard_sum + $(printf '%s\n' "$leg_out" | grep -c . || true)))
-  shard_union+="$leg_out"$'\n'
-done
-full_count="$(printf '%s\n' "$shard_full" | grep -c . || true)"
-union_sorted="$(printf '%s' "$shard_union" | grep . | sort)"
-full_sorted="$(printf '%s\n' "$shard_full" | grep . | sort)"
-if [[ "$shard_rc" -eq 0 ]] && [[ "$full_count" -gt 4 ]] &&
-  [[ "$union_sorted" == "$full_sorted" ]] && [[ "$shard_sum" -eq "$full_count" ]]; then
-  ok "--shard legs union to the whole selection with no suite on two legs"
-else
-  fail "--shard is not a partition (rc=$shard_rc, full=$full_count, sum=$shard_sum): $full_err"
-fi
-
-out="$(select_shard 0/1)"
-if [[ "$(printf '%s\n' "$out" | grep . | sort)" == "$full_sorted" ]]; then
-  ok "--shard 0/1 is the unsharded selection"
-else
-  fail "--shard 0/1 changed the selection"
-fi
-
-# The empty leg. It is the short-circuit CI depends on: a leg that draws nothing
-# must EXIT 0, because a leg that skipped would make the matrix result `skipped`
-# and ci-status is fail-closed on that.
-out="$(select_shard 999/1000)"
-RC=$?
-if [[ "$RC" -eq 0 ]] && [[ -z "$(printf '%s' "$out" | grep . || true)" ]]; then
-  ok "a leg with no suites exits 0 and prints no selection"
-else
-  fail "empty leg should exit 0 with nothing selected (rc=$RC): $out"
-fi
-
-# A spec this script cannot read must never become leg 0 of 1, which runs
-# everything and would report a full pass from a typo'd fan-out.
-for badspec in 4/4 bogus 0/0 1/ /4 "1/4/4" "-1/4"; do
-  select_shard "$badspec" >/dev/null
-  RC=$?
-  if [[ "$RC" -eq 2 ]]; then
-    ok "--shard '$badspec' is a usage error, not a silent full run"
-  else
-    fail "--shard '$badspec' should exit 2, got rc=$RC"
-  fi
-done
-rm -f "$shard_err_file"
 
 # --- LIVE repo: ci.yml actually fans the selection out -----------------------
 # `--shard` only buys anything if the workflow both PASSES it and creates more

--- a/scripts/affected-tests.test.sh
+++ b/scripts/affected-tests.test.sh
@@ -475,6 +475,14 @@ select_shard() {
   [[ -n "$spec" ]] && argv+=(--shard "$spec")
   (cd "$repo" && "${argv[@]}" -- "${shard_paths[@]}" 2>/dev/null)
 }
+# The equals form, spelled out separately because select_shard cannot express an
+# EMPTY spec: `--shard=` with nothing after it is what an environment variable
+# that expanded to nothing produces, and a presence test on the value alone
+# would read it as "no shard requested" and run the whole selection on every leg
+# while exiting 0 (claude-code-plugins#3773, Codex P2).
+select_shard_eq() {
+  (cd "$repo" && bash scripts/affected-tests.sh "--shard=$1" -- "${shard_paths[@]}" 2>/dev/null)
+}
 
 shard_rc=0
 shard_full="$(select_shard "")" || shard_rc=$?
@@ -525,6 +533,22 @@ for badspec in 4/4 bogus 0/0 1/ /4 "1/4/4" "-1/4"; do
     fail "--shard '$badspec' should exit 2, got rc=$RC"
   fi
 done
+
+out="$(select_shard_eq "")"
+RC=$?
+if [[ "$RC" -eq 2 ]]; then
+  ok "an empty --shard= is a usage error, not a silent full run"
+else
+  fail "--shard= should exit 2, got rc=$RC with $(printf '%s\n' "$out" | grep -c . || true) suite(s)"
+fi
+
+out="$(select_shard_eq 0/3)"
+if [[ -n "$(printf '%s' "$out" | grep . || true)" ]] &&
+  [[ "$(printf '%s\n' "$out" | grep . | sort)" == "$(select_shard 0/3 | grep . | sort)" ]]; then
+  ok "--shard=<spec> and --shard <spec> select the same leg"
+else
+  fail "the equals form of --shard does not match the space form"
+fi
 
 # --- --run --shard executes each suite on exactly one leg -------------------
 # The partition above is about selection; this is about execution. Two legs are

--- a/scripts/check-docs-only-gate.test.sh
+++ b/scripts/check-docs-only-gate.test.sh
@@ -186,6 +186,48 @@ YAML
 
 expect "known-good fixture satisfies the contract" 0 "scope resolved once" --check "$base"
 
+# --- a required consumer fanned out across a matrix -------------------------
+#
+# Sharding a lane keeps its job key, so it stays one entry in the aggregate's
+# needs and one consumer here. Two properties are pinned. First, the
+# `strategy:` block's 6- and 8-space lines must fall THROUGH this structural
+# parser: it exits 2 on any shape it does not model, and an inconclusive gate on
+# the real ci.yml blocks every pull request. Second, a leg's own index may not
+# leak into a gate: the only sanctioned step condition is a bare equality
+# against one table output, so a compound `if:` mixing the output with
+# `strategy.job-index` must still be named as unsanctioned.
+
+sharded="$scratch/sharded.yml"
+xform_insert_after "$base" "      - gamma" "      - zeta" "$sharded"
+cat >>"$sharded" <<'YAML'
+
+  # A required consumer whose work is partitioned across four runners.
+  zeta:
+    needs: [changes]
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix: ${{ github.event_name == 'pull_request' && fromJSON('{"leg":[0,1,2,3]}') || fromJSON('{"leg":[0]}') }}
+    steps:
+      - name: Run this leg of the affected suite set
+        if: needs.changes.outputs.run_tests == 'true'
+        env:
+          LEG: ${{ strategy.job-index }}
+          LEGS: ${{ strategy.job-total }}
+        run: scripts/affected-tests.sh --run --shard "$LEG/$LEGS"
+      - name: Run a detector self-test only when shell sources changed
+        if: needs.changes.outputs.run_shell == 'true'
+        run: bash scripts/some-detector.test.sh
+YAML
+expect "a sharded lane gating its steps satisfies the contract" 0 "scope resolved once" \
+  --check "$sharded"
+
+f="$scratch/leg-in-gate.yml"
+xform_replace_line "$sharded" \
+  "if: needs.changes.outputs.run_shell == 'true'" \
+  "        if: needs.changes.outputs.run_shell == 'true' && strategy.job-index == 0" "$f"
+expect "a leg index folded into a step gate is unsanctioned" 1 "unsanctioned condition" --check "$f"
+
 # --- 1. SINGLE RESOLUTION ---------------------------------------------------
 
 f="$scratch/second-resolution.yml"
@@ -568,6 +610,46 @@ if [[ -e "$unwritable" ]]; then
   fail "expected no output file to be produced at an unwritable path"
 else
   ok "an unwritable GITHUB_OUTPUT leaves docs_only unset, which run_full renders as 'true'"
+fi
+
+# --- LIVE: every detector self-test in `lint` carries its gate --------------
+#
+# The 32 `bash scripts/<detector>.test.sh` steps in `lint` were unconditional
+# and cost 61 s on every pull request, docs-only ones included. They are now
+# gated on `run_shell`, the one table output whose filter group names
+# `scripts/**`. The gate above proves each gate is well FORMED; nothing proved
+# they are still THERE, and a self-test that quietly loses its `if:` costs the
+# saving back one step at a time. Pinned by walking the live `lint` job.
+#
+# One exclusion, by name: `check-summary-reader-parity.test.sh` carries an `id:`
+# and feeds CHECK_RESULTS, so gating it would need a paired feed override and is
+# a different change from this one.
+live_workflow="$ROOT/.github/workflows/ci.yml"
+ungated_selftests="$(
+  awk '
+    /^  [A-Za-z_][A-Za-z0-9_-]*:[[:blank:]]*(#.*)?$/ {
+      job = $0; sub(/:.*$/, "", job); sub(/^  /, "", job)
+    }
+    job != "lint" { next }
+    /^      - / { gated = 0; ident = 0 }
+    /^        if: needs\.changes\.outputs\.run_shell == .true.$/ { gated = 1 }
+    /^        id:/ { ident = 1 }
+    /^        run: bash scripts\/[^ ]*\.test\.sh[[:blank:]]*$/ {
+      if (!gated && !ident) { line = $0; sub(/^[[:blank:]]*run: bash /, "", line); print line }
+    }
+  ' "$live_workflow"
+)"
+if [[ -z "$ungated_selftests" ]]; then
+  ok "every id-less detector self-test in the live lint job is gated on run_shell"
+else
+  fail "ungated detector self-test(s) in lint: $(printf '%s' "$ungated_selftests" | tr '\n' ' ')"
+fi
+
+gated_count="$(grep -c "if: needs.changes.outputs.run_shell == 'true'" "$live_workflow" || true)"
+if [[ "$gated_count" -ge 32 ]]; then
+  ok "the live workflow still carries at least 32 run_shell step gates ($gated_count)"
+else
+  fail "run_shell step gates fell to $gated_count; the lint saving is being given back"
 fi
 
 # --- verdict ----------------------------------------------------------------

--- a/scripts/check-lane-coverage.test.sh
+++ b/scripts/check-lane-coverage.test.sh
@@ -106,6 +106,42 @@ expect "job absent from needs fails and names the job" 1 "UNGATED LANE: job 'bet
 write_workflow "$scratch/covered.yml" "" "$(needs_of alpha beta)"
 expect "every job in needs passes" 0 "all 2 lane(s) reachable" --check "$scratch/covered.yml"
 
+# --- a lane that fans out across a matrix -----------------------------------
+#
+# Sharding a lane leaves the LANE LIST alone: the job key is unchanged, so one
+# `needs` entry still covers every leg. What is new is the `strategy:` block,
+# whose 6- and 8-space lines this structural parser must fall through rather
+# than read as job keys or as needs entries. It is pinned here because
+# check-lane-coverage.sh exits 2 on any shape it does not model, and an
+# inconclusive gate on the real ci.yml would block every pull request.
+write_workflow "$scratch/sharded.yml" "  gamma:
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix: \${{ github.event_name == 'pull_request' && fromJSON('{\"leg\":[0,1,2,3]}') || fromJSON('{\"leg\":[0]}') }}
+    steps:
+      - name: Run this leg
+        env:
+          LEG: \${{ strategy.job-index }}
+          LEGS: \${{ strategy.job-total }}
+        run: echo \"leg \$LEG of \$LEGS\"
+" "$(needs_of alpha beta gamma)"
+expect "a lane carrying a strategy matrix parses and stays covered" 0 "all 3 lane(s) reachable" \
+  --check "$scratch/sharded.yml"
+
+write_workflow "$scratch/sharded-static.yml" "  gamma:
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        leg: [0, 1, 2, 3]
+    steps:
+      - name: Run this leg
+        run: echo leg
+" "$(needs_of alpha beta gamma)"
+expect "a literal matrix block parses too" 0 "all 3 lane(s) reachable" \
+  --check "$scratch/sharded-static.yml"
+
 # --- the opt-out path -------------------------------------------------------
 
 write_workflow "$scratch/optout.yml" "" "$(needs_of alpha)"


### PR DESCRIPTION
No related issue: melodic-software/github-iac#378 tracks the ci-perf program (Phase 2 second pass)

## Summary

Two lanes own claude-code-plugins' time to green. A step-level capture over 23 runs
(23 `lint` jobs, 23 `test-linux` jobs, 4,330 step records) put `test-linux` at p50 527 s and
`lint` at p50 327 s, and attributed almost all of both to a handful of steps:

- `test-linux` is 80 percent one step, `Run plugin contract tests`, which selects 146 to 165
  suites of the tree's 361 and runs them strictly sequentially at about 3.2 s each. The
  selector's own header records parallelism inside one runner as sublinear on this corpus, so
  more runners is the lever that is left.
- `lint` never finished under 4 minutes in 56 successful runs. 37 of its steps are detector
  self-tests costing 61 s per run, and every one of them ran on every pull request, docs-only
  ones included. Only 11 of 98 `lint` steps carried a gate at all.

This change shards the first and gates the second. It does not touch the whole-repository
ShellCheck step (111 s per run); scoping that one needs a `files` input on the ci-workflows
composite, which is landing separately on branch `ci-perf/shellcheck-files-input`, and the
workflow carries a comment naming it.

## Fix

**1. `test-linux` fans the affected selection across four runners.**

`scripts/affected-tests.sh` gains `--shard <index>/<total>`. It narrows the SELECTION and
nothing else: every selection rule runs in full on every leg, the UNMAPPED check fires in full
on every leg, and only the final sorted suite list is partitioned by index modulo total. The
legs are a partition, so their union is exactly the unsharded selection and no suite runs
twice. Modulo rather than contiguous blocks, because the sorted list clusters suites by
directory and a block split hands one leg a whole slow plugin.

`ci.yml`'s `test-linux` gains `strategy.fail-fast: false` and a matrix. The job key does not
change, so `ci-status.needs` and `scripts/check-lane-coverage.sh` are untouched, and the
contract-only job predicate is byte-identical to the other lanes'. Three details are
deliberate:

- The matrix is an expression, `${{ github.event_name == 'pull_request' && fromJSON(...4 legs...)
  || fromJSON(...1 leg...) }}`, so `push` keeps exactly today's behaviour: one leg running the
  full corpus once through `run-plugin-tests.sh --jobs 3`. Four legs on `push` would run that
  corpus four times.
- The shard spec reads `strategy.job-index` and `strategy.job-total`, not `matrix.leg`, so the
  numerator and the denominator come from the same runtime pair and cannot drift from each
  other or from the matrix. Both reach the script through `env:`, never inline in `run:`.
- A leg that draws no suites exits 0 in about a second rather than skipping. `ci-status` is
  fail-closed on `skipped`, so a skipped leg would make the matrix result `skipped` and red the
  pull request. The UNMAPPED full-corpus fallback, which takes no shard, is confined to leg 0.

**2. The 32 gateable detector self-tests in `lint` are gated at step level.**

Each is `bash scripts/<detector>.test.sh`, exercising a detector against its own fixtures, so
its subject is `scripts/**`, which is exactly what the `changes` job's `shell` filter group
names. The gate is `if: needs.changes.outputs.run_shell == 'true'`, the sanctioned consumer
form `scripts/check-docs-only-gate.sh` pins. Every gate is step-level; none is job-level.

What a skip costs is bounded: the `Check ...` step each self-test pairs with keeps running, so
a regression the detector would catch is still caught on a diff that changes no shell file.
What is skipped is the proof that the detector itself still works, and the only diffs that skip
it are diffs that cannot have broken it. `run_shell` also carries `draft != true`, so these
skip on a draft run and return on the flip to ready, which `AGENTS.md` requires before merge,
and on every push to `main`.

One self-test is deliberately excluded: `check-summary-reader-parity.test.sh` carries an `id:`
and feeds `CHECK_RESULTS`, so gating it needs a paired aggregator-feed override and is a
different change from this one.

`scripts/validate-plugins.sh` was in scope for narrowing to changed plugins. It takes no
arguments, and its four Node passes (`validate-plugin-contracts.mjs`, `generate-catalog.mjs`,
`generate-cheatsheet.mjs`, `generate-identity-prerequisites.mjs`) plus the `--strict` repo-root
CLI pass are catalog-wide invariants. Its interface allows no scoping, so nothing was invented
for it here.

**3. Tests pin both.**

- `scripts/affected-tests.test.sh`: the legs union to the whole selection with no suite on two
  legs; `--shard 0/1` is the unsharded selection; an empty leg exits 0 and prints nothing;
  eight malformed specs each exit 2 rather than becoming leg 0 of 1, which would run everything
  and report a full pass from a typo'd fan-out, the eighth being an empty `--shard=`;
  `--shard=<spec>` selects the same leg as `--shard <spec>`; `--run --shard` covers the selection exactly
  once across two legs; and the live `ci.yml` still declares the matrix AND passes the leg
  through to `--shard`, since either half alone is silently useless.
- `scripts/check-lane-coverage.test.sh`: a lane carrying a `strategy:` block, both the
  expression form and a literal `matrix:` block, parses and stays covered. This gate exits 2 on
  any shape it does not model, so an unparsed `strategy:` would block every pull request.
- `scripts/check-docs-only-gate.test.sh`: a required consumer fanned out across a matrix and
  gating its steps satisfies the contract; a leg index folded into a step gate is still named
  unsanctioned; and, against the live workflow, every id-less detector self-test in `lint`
  carries its gate and the file still holds at least 32 `run_shell` step gates.

## Verification

Run locally against the live tree:

- `bash scripts/check-lane-coverage.sh --check` exits 0 (`all 4 lane(s) reachable`).
- `bash scripts/check-docs-only-gate.sh --check` exits 0 (`123 reference(s) across 4 consumer
  job(s), all in the sanctioned form`).
- `bash scripts/check-lane-coverage.test.sh`, `bash scripts/check-docs-only-gate.test.sh` and
  `bash scripts/affected-tests.test.sh` all pass.
- `actionlint` clean on `ci.yml`; `zizmor --persona=regular` exits 0 with only the four
  pre-existing `self-repository` low findings.
- `check-jsonschema --builtin-schema vendor.github-workflows .github/workflows/ci.yml` is ok,
  which is the same check the `workflow_schema` step runs.
- `shellcheck -S style` clean on all four changed scripts;
  `scripts/check-shell-portability.sh --paths` reports no unexcused GNU-only constructs.
- The partition was exercised by hand on a 160-suite live selection: legs of 40, 40, 40, 40.

CI measurements from this pull request's own runs are in the "Measured effect" comment below.
The headline, against the capture's baseline of `test-linux` p50 527 s and `lint` p50 327 s:
on run 33987973106 (161 suites selected, split 41/40/40/40) the `test-linux` lane wall fell to
266 s, a 49.5 percent cut, and `lint` landed at 330 s, which is baseline. `lint` is expected to
land at baseline whenever the diff touches a shell file, and the 61 s the gates remove shows up
on docs-only, node-only and python-only pull requests and on drafts, where the draft run
33987627453 measured `lint` at 201 s. The comment says why that ceiling is what the sanctioned
consumer form allows.

Neither the exit-3 `NOT RUN:` path nor the `UNMAPPED:` fallback fired on any leg, and every leg
concluded `success` rather than `skipped` on both the short-circuit and the long path, which is
the fail-closed exposure the shard had to answer.

## Related

- melodic-software/github-iac#378, the ci-perf program (Phase 2 second pass).
- #3705, push-to-main wall time. Unmoved here by design: the matrix is one leg on `push`, so
  that path keeps exactly today's behaviour and today's cost.
- #3694, two suites failing under `--jobs 4`. Untouched: this shards ACROSS runners rather than
  raising concurrency inside one, so the serial allowlist and the wall-clock-ceiling suites are
  unaffected.
- #3716, the local test and gate corpus wall clock. Complementary and deeper: it attacks the
  3.2 s per suite constant that makes 148 suites cost 460 s, which sharding divides rather than
  removes.
