### PR TITLE
ci: converge the reusable workflow pins on ci-workflows v0.22.0

### DIFF
--- a/.github/workflows/issue-triage-label.yml
+++ b/.github/workflows/issue-triage-label.yml
@@ -18,6 +18,6 @@ jobs:
   issue-triage-label:
     permissions:
       issues: write # passed to the reusable, which reads and adds issue labels
-    uses: melodic-software/ci-workflows/.github/workflows/issue-triage-label.yml@c5e729c0af0e55ffed4675ec85c1b57356fef79e # c5e729c 2026-07-21
+    uses: melodic-software/ci-workflows/.github/workflows/issue-triage-label.yml@906ae7ef379ea4d2b8497f64475dce1d3d8715c4 # v0.22.0
     with:
       runner: ubuntu-24.04

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -20,7 +20,7 @@ jobs:
     permissions:
       contents: read
       issues: write
-    uses: melodic-software/ci-workflows/.github/workflows/link-check.yml@90f1c54935203fa31b5b3d1f41531228be2c2b7f # 90f1c54 2026-07-18
+    uses: melodic-software/ci-workflows/.github/workflows/link-check.yml@906ae7ef379ea4d2b8497f64475dce1d3d8715c4 # v0.22.0
     with:
       runner: ubuntu-24.04
       args: >-


### PR DESCRIPTION
No related issue: melodic-software/github-iac#378 tracks the ci-perf program (Phase 6b-i)

## Summary

Phase 6b-i converged eighteen ci-workflows references on v0.22.0 in #3777 but held three back. Two of them, `issue-triage-label.yml` and `link-check.yml`, were held for one reason only: `reusableWorkflowStatus` in the runner policy fails closed on a reusable workflow `path@SHA` that carries no reviewed contract, and `.github/standards/runner-policy/policy.json` carried an entry for each of these paths at its OLD pin and none at the tag. That file is standards-managed, so the convergence pull request could not add them.

standards#535 added both contracts at `906ae7ef379ea4d2b8497f64475dce1d3d8715c4`, each a verbatim copy of its predecessor's terms, and its sync round delivered them here in #3782. `policy.json` on `main` now carries 100 approved reusable workflow contracts, five of them at the wave tag. The block is gone, so this pull request moves the two pins.

## Fix

Two lines, one per workflow file.

- `.github/workflows/issue-triage-label.yml`: `@c5e729c0af0e55ffed4675ec85c1b57356fef79e` to `@906ae7ef379ea4d2b8497f64475dce1d3d8715c4`
- `.github/workflows/link-check.yml`: `@90f1c54935203fa31b5b3d1f41531228be2c2b7f` to `@906ae7ef379ea4d2b8497f64475dce1d3d8715c4`

Both pin comments move from the short-SHA fallback form to `# v0.22.0`, which is the form the pin-comment convention asks for once a pin names a release. No input changes: neither reusable's `on.workflow_call` contract moved.

## Verification

**Input contracts, compared at the old pin and at the tag.** `issue-triage-label.yml` is byte-identical between `c5e729c0af0e55ffed4675ec85c1b57356fef79e` and the tag: `diff` over the two files returns nothing at all. `link-check.yml`'s `on.workflow_call` block is byte-identical (`yq` extraction of the `on` key at both refs diffs clean); so are its workflow-level `permissions`, its job `permissions` and its `runs-on` routing. Its whole file diff is a port of the tracking-issue steps from the `gh` CLI to `actions/github-script`, plus an `actions/checkout` pin bump from v7.0.0 to v7.0.1. That port removes the lane's dependence on the runner image shipping the `gh` CLI, which a self-hosted image is not guaranteed to do.

**Runner policy, run locally against the synced policy.** `npm ci` in `.github/standards/runner-policy/`, then `node .github/standards/runner-policy/runner-policy.mjs --root .` prints `Runner policy passed.` This is the gate that failed closed on both files during #3777, quoted there as `the reusable workflow path@SHA has no reviewed runner-input contract`. It passes now because the contracts exist.

**actionlint** on both changed files is clean.

**Pin sweep** over `.github/workflows` and `.github/actions`:

```text
      1 62bef7bab01e8532fedfa739879034a210e9e67d   claude-review.yml
      1 7107b34832a7b6db5d08d3b132621c599fbe5e50   claude-security-review.yml
     21 906ae7ef379ea4d2b8497f64475dce1d3d8715c4   the convergence target
      1 c2654182bc2d78f7909795df78304d482aa69226   machine-specific-paths (held, #3699)
```

`machine-specific-paths` is the one remaining deliberate hold: v0.22.0's shared `machine-path-patterns.sh` drops the trailing-separator requirement and adds `projects` and `dev` repo roots, which reproduces 42 hits across 25 files here. A repository clean-up pull request is owed before that pin can move, and the comment block at the call site already says so.

The two claude lane callers are a separate finding, recorded here for the coordinator rather than fixed. Phase 6b-i's report classed them as standards-managed, but they are not managed in THIS repository: neither file carries the `SYNC-MANAGED FILE` header, every commit that has ever touched them is a local one, and the standards sync manifest lists `claude-code-plugins` as taking only the managed-files-guard caller and the runner policy, because a public target takes no fleet-routed claude lane caller. So these two pins are locally owned and nothing is going to move them by sync. Both `claude-review.yml` and `claude-security-review.yml` already carry a reviewed contract at the wave tag from standards#534, so the bump is unblocked whenever someone wants it; it is out of scope here because it touches credential-bearing review lanes and deserves its own verification.

## Related

Refs melodic-software/github-iac#378
