### PR TITLE
fix(overengineering): restore the worktree fix justify regressed, and grade what its suite missed

### DIFF
--- a/plugins/overengineering/.claude-plugin/plugin.json
+++ b/plugins/overengineering/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "overengineering",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Evidence-earned-keep audit of an existing enforcement surface — agent hooks and standing instructions, repository and version-control hooks, CI lanes and gate scripts, branch protections, forge apps, declared external integrations — treating every incumbent mechanism as a retirement candidate until empirical evidence earns its keep, arguing every verdict in cost of carry, capping retirement-direction verdicts on security-class artifacts at FLAG-FOR-HUMAN, and realigning to the simplest adequate solution behind an explicit per-item human gate. The audit is read-only and emits a diffable findings artifact; realignment is a separate, explicitly invoked skill; and a third read-only lane re-runs the audit on whatever cadence the consumer wires and reports only what moved since the last run, above a configurable noise budget. A justification lane applies the same method to whatever single artifact you point at, a decision record, a document, a component, a dependency, or a code construct, asking whether a reason existed for it and whether that reason still holds, and reporting how much evidence each verdict actually rests on.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/overengineering/CHANGELOG.md
+++ b/plugins/overengineering/CHANGELOG.md
@@ -3,6 +3,44 @@
 All notable changes to the `overengineering` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.4.1]
+
+### Fixed
+
+- **`justify` could not load inside a worktree-isolated session**, and this is a regression of the
+  fix `0.3.7` applied to the other three skills. Its branch call sat in `## Pre-computed context`,
+  which the harness runs as one shell invocation, and such a session refuses a compound command
+  containing git. The call moves into a "Repository context. Gather first" body section like its
+  siblings. The `|| echo` sentinel goes with it: `0.3.7` removed exactly that pattern because it
+  swallows the exit status, which is the datum the branch-identity step reads, and it guaranteed the
+  pre-compute line was never absent, so the skill's own escape hatch could never fire. Neither the
+  pre-compute-compose gate nor any other check flags this; it was found by reading the new skill
+  against its three siblings.
+- **An unresolved import was directed into `Routed-to`**, a field the contract scopes to a routing
+  that actually happened. An import pointing at nothing was handed to no one, so it is recorded in
+  the row's prose instead, and a consumer reading `Routed-to` no longer looks for a neighbour skill
+  that was never named.
+- **The placement binding still described three consumers and one producer.** Its detached-checkout
+  consequence named `audit`, `realign` and `delta` while asserting four skills read it, so a reader
+  concluded the new lane was unconstrained; and it attributed the ask-gated concern-file write to
+  the audit alone after a second producer began running the same rung order.
+- **The lane binding stated a measurement of this repository as though it were the consumer's.** It
+  gave a ranked-candidate precision figure counted here, in a document that loads inside someone
+  else's tree, where it reads as a fact about the tree in front of the reader. The claim is now the
+  general one the number supported.
+
+### Changed
+
+- **Four evals added and two tightened**, closing coverage gaps in what the lane's own suite grades.
+  Nothing exercised the targeted-run merge clause, which is the reason the schema-2 contract exists,
+  so a run that closed every prior finding in a layer it never walked passed the whole suite. Nothing
+  exercised either write refusal, the detached checkout or the unrecognized schema, though the
+  sibling lane grades both. Nothing exercised the corroboration step, so presenting a raw age ranking
+  as candidates passed. The line-widening case permitted widening to the whole file on a judgment the
+  body does not grant, and its fixture's line sits under a heading, so an incorrect run passed; and
+  the full-row case shared a fixture with the case that asserts the operator must be asked first,
+  while supplying no answer, so a correct run asked, stopped, and failed it.
+
 ## [0.4.0]
 
 ### Added

--- a/plugins/overengineering/context/findings-artifact.md
+++ b/plugins/overengineering/context/findings-artifact.md
@@ -26,7 +26,9 @@ One markdown file is the whole seam between this plugin's four skills. **Two of 
 `overengineering:justify` writes a `mode: targeted` run over the five justification layers. Both are
 read-only on everything else. `overengineering:realign` is its **only mutating** consumer and its
 only writer of operator judgment. `overengineering:delta` reads it across runs and writes nothing
-here at all. All four skills read this document; **none restates it**, and no other plugin is
+here at all. All four skills read this document; **none restates a rule of it as a second
+authority** — where a skill states one in its own voice, as `realign` does for the moved-verdict
+trigger it acts on, this document governs and settles every disagreement. No other plugin is
 assumed to read it.
 
 The artifact is the single source of truth for a run: everything that drives the reasoning —

--- a/plugins/overengineering/context/justification-lane.md
+++ b/plugins/overengineering/context/justification-lane.md
@@ -43,8 +43,10 @@ point at, the target was inventoried whole and routes.
 **Imports are read, not inferred.** An instruction file that pulls in others is a different item from
 the files it pulls in. Open them, decide which of them an enforcement probe claims, and classify only
 what is left. Guessing at an import graph produces a verdict about a file nobody examined. **An
-import that does not resolve is recorded as unresolved**, named in `Routed-to` as an import whose
-target was not found, and never treated as though the file had been read: an unresolvable import is
+import that does not resolve is recorded as unresolved** in the row's own prose, named as an import
+whose target was not found, and never treated as though the file had been read. It does **not** go
+in `Routed-to`: that field is contract-scoped to a routing that actually happened, and an import
+pointing at nothing was handed to no one. An unresolvable import is
 itself evidence about the host file, and inventing its contents would put a verdict on a file that
 does not exist.
 
@@ -273,8 +275,9 @@ used:
 2. **Offer git-age discovery.** Offer to rank candidates by first-seen date, oldest first, and
    **wait**. Never run it unasked, and never present its output as findings.
 
-   **Corroborate before presenting.** Age plus low churn ranks; it does not evidence disuse, and on
-   this repository it was measured at 1 real candidate in 638 ranked ones. So the ranking is a
+   **Corroborate before presenting.** Age plus low churn ranks; it does not evidence disuse, and
+   where the precision of that ranking has been measured it has been poor, with the overwhelming
+   majority of ranked paths turning out to be cited. So the ranking is a
    shortlist to check, not a shortlist to show: every ranked path is searched for inbound references
    under section 7's varied query forms, and a path that has one is dropped before the operator ever
    sees it. The search counts a citation from **anywhere in the repository, the path's own directory

--- a/plugins/overengineering/context/scrutiny-method.md
+++ b/plugins/overengineering/context/scrutiny-method.md
@@ -20,8 +20,10 @@
 Shared method for every skill in this plugin. `audit` and `justify` apply it to produce verdicts,
 one by walking a surface and one by being pointed at an artifact; `realign` applies its rollback
 ladder and its protected-class rules to execute them; `delta` reports what moved between two runs of
-it. **No SKILL.md restates any of it** — a second statement of a verdict definition is a second
-thing to drift.
+it. **No SKILL.md restates a definition from it** — a second statement of a verdict definition is a
+second thing to drift. A lane may name the rungs or classes it executes, as `realign` names §11's
+ladder to record which rung a finding reached, but the section named governs and settles every
+disagreement.
 
 The posture is the inverse of a gap audit: every incumbent mechanism on the surface is a retirement
 candidate until evidence earns its keep. That posture is a default, not a conclusion — the whole

--- a/plugins/overengineering/reference/topic-docs.md
+++ b/plugins/overengineering/reference/topic-docs.md
@@ -68,9 +68,10 @@ judgments are not kept here.
 **Persisting at rungs 2–4 is ask-gated, never automatic.** Each of those rungs persists the
 resolution to the concern file only on the user's explicit confirmation; declining is a valid answer
 that leaves the resolution session-local, and the run proceeds either way. A non-interactive context
-never reaches these rungs (see below). This is the audit's one sanctioned tracked write, and the
-audit SKILL's "Read-only contract" discloses it — the read-only headline is scoped to unasked
-writes, which all stay in the memory tier.
+never reaches these rungs (see below). This is the one sanctioned tracked write of **either
+producer**, `overengineering:audit` and `overengineering:justify` alike, since both run this rung
+order and either can reach it; each skill's "Read-only contract" discloses it, and the read-only
+headline in both is scoped to unasked writes, which all stay in the memory tier.
 
 Only rungs 1 and 5 compose `overengineering/<branch-slug>` themselves. Rungs 2–4 yield whatever
 location the consumer declared, inferred, or chose — **resolve the home, never assume its shape.** A
@@ -112,9 +113,9 @@ keys a new home every commit, which never collides but never resumes either, tur
 an unbounded scatter of single-use homes that no consumer ever reads back. A fixed literal such as
 `detached` is `HEAD` under another name.
 
-The consumers state the consequence at their own sites: `overengineering:audit` persists no findings
-artifact, `overengineering:realign` refuses rather than comparing, and `overengineering:delta`
-compares nothing and captures no baseline. This binding fixes only the resolution's outcome — that a
+The consumers state the consequence at their own sites: `overengineering:audit` and
+`overengineering:justify` each persist no findings artifact, `overengineering:realign` refuses
+rather than comparing, and `overengineering:delta` compares nothing and captures no baseline. This binding fixes only the resolution's outcome — that a
 run reaching it without an identity has no path to resolve, and asks for none.
 
 `overengineering` is this plugin's concern name under the memory root, alongside the contract's own

--- a/plugins/overengineering/skills/justify/SKILL.md
+++ b/plugins/overengineering/skills/justify/SKILL.md
@@ -9,9 +9,18 @@ metadata:
   summary: Make one artifact you point at justify its own existence, on evidence
 ---
 
-## Pre-computed context
+## Repository context. Gather first
 
-- Branch: !`git symbolic-ref --quiet --short HEAD 2>/dev/null || echo "no branch ref (detached HEAD or no checkout)"`
+Collect this with an **individual** Bash call, never combined into a single invocation with
+anything else:
+
+- Branch, `git symbolic-ref --quiet --short HEAD`
+
+Treat a failure (not a repository, git unavailable) as an unknown value and carry on. Keep it as a
+separate body Bash call rather than a pre-compute line: the harness runs a skill's whole
+pre-compute block as one shell invocation, and a worktree-isolated session refuses a compound
+command that contains git. The call **fails with no output** on a detached checkout rather than
+printing a sentinel, so read its exit status rather than matching on a string.
 
 ## Purpose
 
@@ -128,9 +137,10 @@ resting on a line number derives a different id as soon as an edit above it move
 
 1. **Resolve the branch identity, then the artifact home**, exactly as
    `${CLAUDE_PLUGIN_ROOT}/skills/audit/SKILL.md`, section "Before the walk", step 1 does. The
-   precompute above is a convenience, not the source of truth; where its line is absent, run
-   `git symbolic-ref --quiet --short HEAD` and read the exit status. Run the topic-docs binding's
-   whole rung order rather than assuming the default's shape.
+   branch call in "Repository context" above is the source of that identity, and **its exit status
+   is the datum**, not its output: a detached checkout produces no output and a non-zero status, and
+   an empty line is the answer rather than a missing one. Never accept the literal `HEAD` as an
+   identity. Run the topic-docs binding's whole rung order rather than assuming the default's shape.
 2. **Run the shared preflight**, `${CLAUDE_PLUGIN_ROOT}/skills/audit/context/surface-walk.md`,
    section "Preflight". Its sanctioning-record probe matters here: a repetition a record sanctions
    and a check maintains is never duplication to collapse.

--- a/plugins/overengineering/skills/justify/SKILL.md
+++ b/plugins/overengineering/skills/justify/SKILL.md
@@ -60,8 +60,8 @@ restated. Five things are specific to this lane:
 - **The frontmatter this lane writes** is `type: overengineering-findings`, `schema: 2`,
   `mode: targeted`, `targets`, this run's own `date` and `branch`, and a `scope` carrying the prior
   artifact's value forward with these targets' layers added. `type` is named first because a first
-  pointed run at a home with no artifact **creates** the file, and it is the selector every consumer
-  matches on: an artifact written without it is one no consumer finds. An on-disk `schema` of neither `1` nor `2` **stops the run** with a visible message,
+  pointed run that writes a row at a home with no artifact **creates** the file, and it is the
+  selector every consumer matches on: an artifact written without it is one no consumer finds. An on-disk `schema` of neither `1` nor `2` **stops the run** with a visible message,
   because an unrecognized shape cannot be merged into without guessing; a `schema: 1` artifact is
   merged into and rewritten at `2`.
 - **Re-read before write.** Load the on-disk artifact immediately before writing, merge against that
@@ -151,6 +151,10 @@ resting on a line number derives a different id as soon as an edit above it move
    partly inventoried is classified with the routed part named in `Routed-to`.
 5. **Resolve consumer configuration and load the prior artifact**, as the sibling does. This skill
    writes `Status: OPEN` on a finding it has not seen and carries every other status forward.
+   **Surface any verdict that moved under a carried-forward judgment**, per merge rule 5: a direction
+   flip, and equally a same-direction change to what the acceptance authorized. This lane is the
+   second producer, the flag is written only on merge by whichever producer recomputed the row, and
+   no consumer re-derives it, so a move this step fails to flag is a move nobody surfaces.
 
 ## The walk
 

--- a/plugins/overengineering/skills/justify/SKILL.md
+++ b/plugins/overengineering/skills/justify/SKILL.md
@@ -19,8 +19,9 @@ anything else:
 Treat a failure (not a repository, git unavailable) as an unknown value and carry on. Keep it as a
 separate body Bash call rather than a pre-compute line: the harness runs a skill's whole
 pre-compute block as one shell invocation, and a worktree-isolated session refuses a compound
-command that contains git. The call **fails with no output** on a detached checkout rather than
-printing a sentinel, so read its exit status rather than matching on a string.
+command that contains git. The call prints the branch name on stdout and **fails with no output** on
+a detached checkout rather than printing a sentinel, so read its exit status to tell those two apart
+rather than matching on a string, and take the branch name itself from stdout.
 
 ## Purpose
 
@@ -137,10 +138,12 @@ resting on a line number derives a different id as soon as an edit above it move
 
 1. **Resolve the branch identity, then the artifact home**, exactly as
    `${CLAUDE_PLUGIN_ROOT}/skills/audit/SKILL.md`, section "Before the walk", step 1 does. The
-   branch call in "Repository context" above is the source of that identity, and **its exit status
-   is the datum**, not its output: a detached checkout produces no output and a non-zero status, and
-   an empty line is the answer rather than a missing one. Never accept the literal `HEAD` as an
-   identity. Run the topic-docs binding's whole rung order rather than assuming the default's shape.
+   branch call in "Repository context" above yields a branch name on stdout, or fails with no output
+   (detached HEAD or no checkout). **Read its exit status to decide whether the lookup succeeded,
+   then take the identity from stdout**: the status answers only whether there is a branch, and the
+   name itself is the output. Never infer an identity from a failed call, and never accept the
+   literal `HEAD` as one. Run the topic-docs binding's whole rung order rather than assuming the
+   default's shape.
 2. **Run the shared preflight**, `${CLAUDE_PLUGIN_ROOT}/skills/audit/context/surface-walk.md`,
    section "Preflight". Its sanctioning-record probe matters here: a repetition a record sanctions
    and a check maintains is never duplication to collapse.

--- a/plugins/overengineering/skills/justify/evals/evals.json
+++ b/plugins/overengineering/skills/justify/evals/evals.json
@@ -19,7 +19,7 @@
     {
       "id": 2,
       "name": "pointed-target-full-row",
-      "prompt": "/overengineering:justify evals/fixtures/decision-0001.md relative to the skill directory.",
+      "prompt": "/overengineering:justify evals/fixtures/decision-0001.md relative to the skill directory. When the run asks whether anything outside the repository records why the relay was kept after the provider change, the operator answers: yes, the platform team reconfirmed it at the 2024 review, the send log is still the only audit trail we have.",
       "expected_output": "One finding for the decision record. Its spine carries `Layer: decision-records`, an `Artifact` naming the fixture, a `Verdict` that is one of the six tokens, and a `Status`. Its prose carries a `Basis` of measured, class-inferred, or unexamined; the evidence tiers consulted, each marked silent or unavailable where it returned nothing; and `Ablation: n/a` because the ablation gate does not apply on this lane's layers. The artifact frontmatter reads `schema: 2`, `mode: targeted`, and a `targets` list naming the fixture and nothing else. The record's own text is tier 5, so a verdict resting only on it is marked unverified rather than promoted.",
       "files": ["evals/fixtures/decision-0001.md"],
       "expectations": [
@@ -124,10 +124,11 @@
       "id": 9,
       "name": "line-target-widens-and-says-so",
       "prompt": "/overengineering:justify evals/fixtures/lonely-doc.md:7 relative to the skill directory.",
-      "expected_output": "The first line of the report states the widening: the operator pointed at a line, and the item being judged is the enclosing heading, or the file where the run judges the heading too small to stand alone. It names both, so nothing is silently substituted. One row follows, for the widened item, with the layer and basis a `documents` row carries. The reason for widening is available: an identity that rests on a line number breaks the moment an edit above it shifts the line, so the same item would derive two ids across two runs. No row is filed against the line itself.",
+      "expected_output": "The first line of the report states the widening: the operator pointed at a line, and the item being judged is `## Before you start`, the heading enclosing line 7. The file HAS headings, so the rule resolves to the heading and the whole file is the wrong answer here, not a permitted alternative. It names both the target and the widened item, so nothing is silently substituted. One row follows, for the widened item, with the layer and basis a `documents` row carries. The reason for widening is available: an identity that rests on a line number breaks the moment an edit above it shifts the line, so the same item would derive two ids across two runs. No row is filed against the line itself.",
       "files": ["evals/fixtures/lonely-doc.md"],
       "expectations": [
         "The FIRST line of the report states the widening and names both the target and the widened item",
+        "Widens to the ENCLOSING HEADING, not the whole file, because this file has headings",
         "Exactly one row, for the widened item, never for the line",
         "The row carries a `documents` layer and a `Basis`",
         "The widening is stated as a rule with a reason, not performed silently"
@@ -174,6 +175,62 @@
         "Persists NOTHING: the pre-existing artifact keeps its own `date`, `scope`, summary and run-level sections",
         "Still reports inline what routed and which layer claimed it",
         "Does not write a `targets` list for a run that produced no finding"
+      ]
+    },
+    {
+      "id": 13,
+      "name": "targeted-run-closes-nothing-it-did-not-examine",
+      "prompt": "/overengineering:justify evals/fixtures/decision-0001.md relative to the skill directory. The findings artifact at the resolved home already holds four findings from an earlier walk: two in `ci-lanes`, one in `agent-hooks`, and one in `documents` about a different file. The operator confirms the relay's reason still holds and says so.",
+      "expected_output": "The run writes or refreshes its own row for the decision record and leaves all four prior findings intact. None is closed. The three in enforcement layers are not this producer's at all, and the `documents` one is about a file this run never opened, so none of them is a deleted artifact. `## Closed since last run` gains no row. Every prior finding is carried forward with its status verbatim and marked not re-evaluated this run. The defect this case exists to catch is the reason the whole schema-2 contract was written: a pointed run applying the closure rule to a layer it never walked, and silently retiring every finding it simply did not look at. `scope` grows rather than being replaced, so the record of what the last walk covered survives.",
+      "files": ["evals/fixtures/decision-0001.md"],
+      "narration": true,
+      "expectations": [
+        "Closes NOTHING: `## Closed since last run` gains no row for any of the four prior findings",
+        "Carries all four prior findings forward with their statuses verbatim, marked not re-evaluated this run",
+        "Writes or refreshes only the row for the target it actually examined",
+        "`scope` carries the earlier walk's layers forward and adds this run's, rather than replacing them"
+      ]
+    },
+    {
+      "id": 14,
+      "name": "detached-checkout-judges-but-persists-nothing",
+      "prompt": "/overengineering:justify evals/fixtures/decision-0001.md relative to the skill directory, from a detached checkout with no logical ref supplied by the environment.",
+      "expected_output": "The pass runs in full and the inline report is emitted in full: the target is judged, the verdict argued, the tiers named. What is declined is the persisted write, and the run says why in those terms. No findings artifact is written, and no home is keyed, because a branch identity that does not resolve keys no home: `HEAD` is the same string for every ref and a commit sha is a different one every commit, so either substitute collapses the axis the branch segment exists to separate. The run does not fall back to `HEAD`, to the sha, or to whatever slug the default would produce. The defect this case exists to catch is a run that quietly writes to a shared home every detached run of every branch would also write to.",
+      "files": ["evals/fixtures/decision-0001.md"],
+      "narration": true,
+      "expectations": [
+        "Runs the pass and emits the full inline report, including the verdict and the tiers consulted",
+        "Writes NO findings artifact, and says the write was declined because no branch identity resolved",
+        "Does NOT substitute `HEAD`, a commit sha, or a fixed literal as the branch identity",
+        "Declines the persisted write only, never the judgment"
+      ]
+    },
+    {
+      "id": 15,
+      "name": "unrecognized-schema-stops-before-merging",
+      "prompt": "/overengineering:justify evals/fixtures/decision-0001.md relative to the skill directory. The findings artifact at the resolved home declares `schema: 7`.",
+      "expected_output": "The run STOPS with a visible message naming the unrecognized value, and merges nothing into that artifact. It does not guess at the shape, does not treat the file as absent and overwrite it, and does not strip or rewrite the frontmatter to a value it recognizes. `1` and `2` are the recognized values; anything else is a shape this lane cannot merge into without inventing what the fields mean. The defect this case exists to catch is a producer that reads an unknown contract version and writes anyway, destroying an artifact written by something it does not understand.",
+      "files": ["evals/fixtures/decision-0001.md"],
+      "narration": true,
+      "expectations": [
+        "STOPS with a visible message that names the unrecognized `schema` value",
+        "Merges nothing and overwrites nothing in the existing artifact",
+        "Does NOT downgrade, strip, or rewrite the frontmatter to a recognized value",
+        "Does NOT treat the unreadable artifact as absent and start a fresh one over it"
+      ]
+    },
+    {
+      "id": 16,
+      "name": "age-ranking-is-corroborated-before-it-is-shown",
+      "prompt": "/overengineering:justify\n\nThen, when the run offers to rank candidates by age: yes, go ahead.",
+      "expected_output": "Having taken the offer, the run ranks by first-seen date and then CORROBORATES before presenting anything. Each ranked path is searched for inbound references under varied query forms, counting a citation from anywhere in the repository including the path's own directory, and every path that has one is dropped before the operator sees it. What is presented is the survivors, with both counts given: how many were ranked and how many survived, so the operator can tell an uncited path from an unsearched one. The list is offered as candidates to choose from, never as findings, and no verdict is attached to any of them. The defect this case exists to catch is presenting a raw age ranking as if age evidenced disuse, which the measurement behind this lane showed has poor precision: of the two candidates it originally confirmed, one was cited by a live link from a neighbouring document.",
+      "files": [],
+      "narration": true,
+      "expectations": [
+        "Corroborates each ranked path for inbound references BEFORE presenting, and drops those that have any",
+        "Counts a citation from anywhere in the repository, including the path's own directory",
+        "Reports both the ranked count and the surviving count",
+        "Presents survivors as candidates to choose from, never as findings, and attaches no verdict"
       ]
     }
   ]

--- a/plugins/overengineering/skills/realign/SKILL.md
+++ b/plugins/overengineering/skills/realign/SKILL.md
@@ -105,12 +105,15 @@ An acceptance given earlier is not an approval of the edit that later falls out 
 5. **A `Status` value outside the artifact's closed vocabulary** is reported and that finding is
    skipped, soft degradation, never a guess about what an unknown state meant.
 6. **Surface a verdict that moved under a carried-forward judgment before anything else, and never
-   act on it.** An `ACCEPTED` finding now recomputed to `KEEP`, or a `REJECTED` one now recomputed
-   to a retirement-direction verdict, means the evidence moved under a decision the operator already
-   made. **Direction is not the only trigger:** surface it too where the recomputed verdict
-   materially changes *what the acceptance authorized* without flipping direction, an `ACCEPTED`
-   `DOWNGRADE` now recomputed to `CONSOLIDATE` authorizes a different act on a different artifact.
-   Re-confirm the act before anything proceeds; the earlier yes was given to the old one.
+   act on it.** Read the flag whichever producer recomputed the row wrote on merge; never re-derive
+   the trigger, since a second derivation here is a second answer that can disagree with the one on
+   the artifact. What the flag means: an `ACCEPTED` finding now recomputed to `KEEP`, or a
+   `REJECTED` one now recomputed to a retirement-direction verdict, means the evidence moved under a
+   decision the operator already made. **Direction is not the only trigger:** it is set too where
+   the recomputed verdict materially changes *what the acceptance authorized* without flipping
+   direction, an `ACCEPTED` `DOWNGRADE` now recomputed to `CONSOLIDATE` authorizes a different act
+   on a different artifact. Re-confirm the act before anything proceeds; the earlier yes was given
+   to the old one.
 
 ## Arguments
 


### PR DESCRIPTION
No related issue: post-merge follow-up to #3776, found by a verification round run against the shipped result rather than the branch.

## Summary

#3776 merged as `9ff17e29`. A round run afterward, two leads over disjoint surfaces, found a runtime regression that shipped plus a set of coverage gaps that let a wrong run pass the entire eval suite. This fixes both, and carries forward five contract fixes from a sibling session that were sitting unmerged on the old branch.

## Fix

**The regression, and it is a re-break of a fix this plugin already shipped.** `justify` put its branch call in `## Pre-computed context`. Version `0.3.7` moved exactly that out of the other three skills because the harness runs a pre-compute block as one shell invocation and a worktree-isolated session refuses a compound command containing git. The new skill reintroduced it, so it cannot load in a worktree at all. It also reintroduced the `|| echo` sentinel that release removed, which swallows the exit status the branch-identity step reads and guarantees the pre-compute line is never absent, making the skill's own fallback unreachable. Both are now the sibling shape.

**No gate catches this.** `check-skill-precompute-compose.sh` passes on the defect. It was found by reading the new skill against its three siblings.

Three smaller defects:

- An unresolved import was directed into `Routed-to`, a field the contract scopes to a routing that actually happened. An import pointing at nothing was handed to no one, so it is recorded in the row's prose instead.
- The placement binding still described three consumers and one producer, in the same file that asserts four skills read it, so a reader concluded the new lane was unconstrained on a detached checkout and made no tracked write.
- The lane binding stated a ranked-candidate precision figure measured on **this** repository, in a document that loads inside a consumer's tree, where it reads as a fact about the tree in front of the reader.

**Four evals added, two corrected.** Nothing graded the targeted-run merge clause, which is the entire reason the schema-2 contract exists, so a run that closed every prior finding in a layer it never walked passed all twelve cases. Nothing graded either write refusal, the detached checkout or the unrecognized schema, though the sibling lane grades both. Nothing graded the corroboration step, so presenting a raw age ranking as candidates passed. Of the two corrected: the line-widening case permitted widening to the whole file on a judgment the body does not grant, while its fixture's line sits under a heading, so an incorrect run passed; and the full-row case shared a fixture with the case asserting the operator must be asked first, while supplying no answer, so a correct run asked, stopped, and failed it.

**Five contract fixes carried forward** by cherry-pick from `b536acfa`, which was on the old branch and never reached main: the obligations table naming only one of the two no-row states, two documents carrying a false absolute about restatement, the unconditional file-creation claim, and realign deriving the moved-verdict trigger instead of reading the flag.

## Verification

| Gate | Result |
|---|---|
| `check-changed-skills.sh` | exit 0, 2 skills checked, 0 failed |
| `check-evals-quality.sh` | exit 0 |
| `check-skill-precompute-compose.sh` | exit 0 (and passed on the defect too, which is the point) |
| `check-orphaned-fixtures.sh --check` | exit 0 |
| `check-purged-em-dashes.sh --check` | exit 0 |
| `check-changelog-parity.sh` (all three modes) | exit 0 |
| `check-contract-slice-prune.sh --check-diff` | exit 0 |
| `check-stale-base-overlap.sh --check` | exit 0 |
| generators `--check` (catalog, cheat sheet) | exit 0 |
| `markdownlint-cli2` over every changed file | 0 issues |
| `ai-slop` detector | 0 findings |

`scripts/affected-tests.sh --run` exits **1** here, on two process-budget cases in `plugins/claude-ops/skills/plugins/scripts/cache-content-check.test.sh`. **That failure is not from this change**, which touches no `claude-ops` file. It reproduces identically on a clean `git archive origin/main` snapshot, and its own detail line reads `measured -1 — the pid-stamped PS4 did not reach the traced shell`, so the probe counted nothing. It is a container tracing limitation, the same class as the SCP-remote rewrite that affects `test_save_point.py`.

## Related

- Follows #3776, merged as `9ff17e29`.
- **Branch note:** this is on a new branch rather than the original one. That branch was squash-merged, so its merge base now predates the squash and a pull request from it would show 35 files, re-proposing the whole justify lane. Rebuilt from `main` the real change is 9 files. Rewriting the old branch needed a force-with-lease that was not permitted, so the follow-up got its own branch; the old one can be deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XKg6Tnk9ssfHSu4gCwSyEQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01XKg6Tnk9ssfHSu4gCwSyEQ)_