### PR TITLE
docs(overengineering): scope the no-writes claim to the surface under scrutiny

### DIFF
--- a/plugins/overengineering/.claude-plugin/plugin.json
+++ b/plugins/overengineering/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "overengineering",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Evidence-earned-keep audit of an existing enforcement surface — agent hooks and standing instructions, repository and version-control hooks, CI lanes and gate scripts, branch protections, forge apps, declared external integrations — treating every incumbent mechanism as a retirement candidate until empirical evidence earns its keep, arguing every verdict in cost of carry, capping retirement-direction verdicts on security-class artifacts at FLAG-FOR-HUMAN, and realigning to the simplest adequate solution behind an explicit per-item human gate. The audit is read-only and emits a diffable findings artifact; realignment is a separate, explicitly invoked skill; and a third read-only lane re-runs the audit on whatever cadence the consumer wires and reports only what moved since the last run, above a configurable noise budget. A justification lane applies the same method to whatever single artifact you point at, a decision record, a document, a component, a dependency, or a code construct, asking whether a reason existed for it and whether that reason still holds, and reporting how much evidence each verdict actually rests on.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/overengineering/CHANGELOG.md
+++ b/plugins/overengineering/CHANGELOG.md
@@ -3,6 +3,20 @@
 All notable changes to the `overengineering` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.4.3]
+
+### Fixed
+
+- **The README still carried the unqualified read-only claim `0.4.2` corrected in the skill
+  description**, and stated it more strongly: "the only skill that changes anything" of `realign`,
+  and "everything that changes the repo happens through" it. Both are false against the placement
+  binding, which records a confirmation-gated tracked write to the consumer's concern file as "the
+  one sanctioned tracked write of either producer". A reader evaluating the plugin from its README
+  concluded no producer touches tracked content, then saw one offer to. The claims are now scoped to
+  the surface under scrutiny, which is what they were always about, and the `justify` row carries the
+  same carve-out its description does. Found by verifying the previous fix rather than by a gate;
+  the parity fix had reached the description and stopped there.
+
 ## [0.4.2]
 
 ### Fixed

--- a/plugins/overengineering/README.md
+++ b/plugins/overengineering/README.md
@@ -12,9 +12,9 @@ evidence earns its keep**.
 | Skill | What it does |
 |---|---|
 | `/overengineering:audit` | Read-only walk of the enforcement surface. Reconstructs what each mechanism was built to solve, re-solves the problem fresh with a bias toward native and built-in mechanisms, and returns a verdict argued in cost of carry. KEEP / RETIRE / DOWNGRADE / CONSOLIDATE / UNPROVEN, with security-class artifacts capped at FLAG-FOR-HUMAN. Emits a diffable findings artifact plus an inline summary. |
-| `/overengineering:realign` | The only skill that changes anything. Consumes the findings artifact and, per accepted finding, drives interview → explore/research → plan → implement through presence-gated skill composition. Nothing is touched without explicit per-item acceptance. |
+| `/overengineering:realign` | The only skill that changes the surface under scrutiny. Consumes the findings artifact and, per accepted finding, drives interview → explore/research → plan → implement through presence-gated skill composition. Nothing is touched without explicit per-item acceptance. |
 | `/overengineering:delta` | The recurring lane. Re-runs the audit, compares its findings spine against the baseline the previous cycle left behind, and reports **only what moved** since that run. Above a configurable noise budget, so a repeat cycle is a short delta instead of the whole surface again. Read-only always; it never enters `realign`, and verdict changes queue for the human. |
-| `/overengineering:justify` | The pointed lane. Takes one artifact you name, a decision record, a document, a component, a dependency, or a code construct, and asks whether a reason existed for it and whether that reason still holds today. Every row says how much evidence the verdict rests on. Read-only: it reports, then discusses, and hands any remedy to the skill that owns it. A target the enforcement lane already covers routes to `audit` instead. It never sweeps the repository. |
+| `/overengineering:justify` | The pointed lane. Takes one artifact you name, a decision record, a document, a component, a dependency, or a code construct, and asks whether a reason existed for it and whether that reason still holds today. Every row says how much evidence the verdict rests on. Read-only: it reports, then discusses, and hands any remedy to the skill that owns it; its findings go to the memory tier, and its one tracked write, persisting the resolved home to the concern file, needs explicit confirmation. A target the enforcement lane already covers routes to `audit` instead. It never sweeps the repository. |
 
 The shared method every skill applies lives once, in
 [`context/scrutiny-method.md`](context/scrutiny-method.md); no skill restates it. The artifact that
@@ -53,9 +53,12 @@ audit, compares two spines, and never invokes or enters `realign`, including whe
 for it mid-run. A lane that can run on a schedule has nobody to give the per-item acceptance realign
 requires, so it queues verdict changes instead of acting on them.
 
-Everything that changes the repo happens through `/overengineering:realign`, which is invoked
-deliberately, consumes the findings artifact rather than scanning on its own, and stops at a per-item
-acceptance gate before every remediation. Its execution order is the method's rollback ladder:
+Every change to the surface under scrutiny happens through `/overengineering:realign`, which is
+invoked deliberately, consumes the findings artifact rather than scanning on its own, and stops at a
+per-item acceptance gate before every remediation. The one tracked write either producer makes is
+not a change to that surface: on the resolution rungs, `audit` and `justify` alike may offer to
+persist the resolved artifact home into the consumer's concern file, and do it only on explicit
+confirmation. Declining is a valid answer and the run proceeds either way. Its execution order is the method's rollback ladder:
 **config-disable first, observe for a window, only then delete with a recorded rationale**. Nothing
 in that ladder is autonomous.
 

--- a/plugins/overengineering/README.md
+++ b/plugins/overengineering/README.md
@@ -11,7 +11,7 @@ evidence earns its keep**.
 
 | Skill | What it does |
 |---|---|
-| `/overengineering:audit` | Read-only walk of the enforcement surface. Reconstructs what each mechanism was built to solve, re-solves the problem fresh with a bias toward native and built-in mechanisms, and returns a verdict argued in cost of carry. KEEP / RETIRE / DOWNGRADE / CONSOLIDATE / UNPROVEN, with security-class artifacts capped at FLAG-FOR-HUMAN. Emits a diffable findings artifact plus an inline summary. |
+| `/overengineering:audit` | Read-only walk of the enforcement surface. Reconstructs what each mechanism was built to solve, re-solves the problem fresh with a bias toward native and built-in mechanisms, and returns a verdict argued in cost of carry. KEEP / RETIRE / DOWNGRADE / CONSOLIDATE / UNPROVEN, with security-class artifacts capped at FLAG-FOR-HUMAN. Emits a diffable findings artifact plus an inline summary to the memory tier; its one tracked write, persisting the resolved home to the concern file, needs explicit confirmation. |
 | `/overengineering:realign` | The only skill that changes the surface under scrutiny. Consumes the findings artifact and, per accepted finding, drives interview → explore/research → plan → implement through presence-gated skill composition. Nothing is touched without explicit per-item acceptance. |
 | `/overengineering:delta` | The recurring lane. Re-runs the audit, compares its findings spine against the baseline the previous cycle left behind, and reports **only what moved** since that run. Above a configurable noise budget, so a repeat cycle is a short delta instead of the whole surface again. Read-only always; it never enters `realign`, and verdict changes queue for the human. |
 | `/overengineering:justify` | The pointed lane. Takes one artifact you name, a decision record, a document, a component, a dependency, or a code construct, and asks whether a reason existed for it and whether that reason still holds today. Every row says how much evidence the verdict rests on. Read-only: it reports, then discusses, and hands any remedy to the skill that owns it; its findings go to the memory tier, and its one tracked write, persisting the resolved home to the concern file, needs explicit confirmation. A target the enforcement lane already covers routes to `audit` instead. It never sweeps the repository. |
@@ -44,7 +44,7 @@ Three postures follow, and they are what make the audit different from an opinio
 
 ## The read-only boundary
 
-`/overengineering:audit` reports and never mutates. That is the marketplace's `audit` verb contract,
+`/overengineering:audit` reports and never mutates the surface it walks. That is the marketplace's `audit` verb contract,
 and here it is also the safety property that makes the plugin runnable on a surface nobody has
 reviewed in a year: the worst outcome of a bare run is a file in the memory tier and a wrong opinion.
 
@@ -58,7 +58,9 @@ invoked deliberately, consumes the findings artifact rather than scanning on its
 per-item acceptance gate before every remediation. The one tracked write either producer makes is
 not a change to that surface: on the resolution rungs, `audit` and `justify` alike may offer to
 persist the resolved artifact home into the consumer's concern file, and do it only on explicit
-confirmation. Declining is a valid answer and the run proceeds either way. Its execution order is the method's rollback ladder:
+confirmation. Declining is a valid answer and the run proceeds either way.
+
+`/overengineering:realign`'s execution order is the method's rollback ladder:
 **config-disable first, observe for a window, only then delete with a recorded rationale**. Nothing
 in that ladder is autonomous.
 

--- a/plugins/overengineering/skills/realign/SKILL.md
+++ b/plugins/overengineering/skills/realign/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: "Execute an enforcement-surface audit's findings behind an explicit per-item human gate. Consumes the findings artifact `overengineering:audit` produced. It never scans or re-judges the surface itself. For each finding the operator accepts, it drives interview → explore and research → plan → implement through presence-gated skill composition, executing every removal down the rollback ladder: config-disable first, observe for a window with a stated end date, delete last with a recorded rationale. Unproven items route to a bounded, time-boxed ablation batch; security-class items surface the capped verdict's evidence and wait for the human's own call; remediation owned by an upstream or a forge control plane becomes a delegation rather than a local patch. Use when the ask is to act on an enforcement-surface audit's findings ('realign our enforcement surface', 'the audit says retire it, do it'), to retire or peel back automation already judged, or to start or advance an ablation window ('disable this gate and observe it'). This is the only skill in this plugin that changes anything, and there is no blanket-approve path."
+description: "Execute an enforcement-surface audit's findings behind an explicit per-item human gate. Consumes the findings artifact either producer wrote. It never scans or re-judges the surface itself. For each finding the operator accepts, it drives interview → explore and research → plan → implement through presence-gated skill composition, executing every removal down the rollback ladder: config-disable first, observe for a window with a stated end date, delete last with a recorded rationale. Unproven items route to a time-boxed ablation batch; security-class items surface the capped verdict's evidence and wait for the human's own call; remediation owned by an upstream or a forge control plane becomes a delegation rather than a local patch. Use when the ask is to act on an enforcement-surface audit's findings ('realign our enforcement surface', 'the audit says retire it, do it'), to retire or peel back automation already judged, or to start or advance an ablation window ('disable this gate and observe it'). This is the only skill in this plugin that changes the surface under scrutiny, and there is no blanket-approve path."
 argument-hint: "[finding-id ...] [layer ...]. Default: every finding awaiting a decision, in the artifact's order"
 user-invocable: true
 disable-model-invocation: false
@@ -301,7 +301,7 @@ than inventing a name, matching the `audit` and `delta` lanes.
   so the home is not evidence of which ref the findings describe.
 
 Refusing costs a re-run on an attached checkout. Passing costs a mutation nobody can attribute to a
-surface, and this is the only skill in the plugin that mutates anything, so the asymmetry is not
+surface, and this is the only skill in the plugin that mutates that surface, so the asymmetry is not
 close. **Never fall back to `HEAD`, to the commit sha, or to the home's slug to manufacture the
 missing side of the comparison.**
 


### PR DESCRIPTION
No related issue: follow-up to #3792, found by verifying that commit rather than trusting its gates.

## Summary

#3792 corrected the skill description to disclose the confirmation-gated concern-file write. It stopped one surface short. The README, which is what a reader actually evaluates the plugin from, still carried the unqualified claim, and in stronger form.

## Fix

Two statements were false against the placement binding:

- The skill table called `realign` **"the only skill that changes anything"**.
- The boundary section said **"everything that changes the repo happens through"** it.

`reference/topic-docs.md` records a confirmation-gated tracked write to the consumer's concern file as **"the one sanctioned tracked write of either producer"**, reachable by `audit` and `justify` alike on resolution rungs 2 to 4. So a reader concluded no producer touches tracked content, and would then be surprised by one offering to.

Both claims were always about the surface under scrutiny, and now say so. The boundary section names the exception and records that declining is a valid answer. The `justify` row carries the same carve-out its description does. The `audit` row makes no absolute claim and is unchanged.

**This predates the justify lane.** `audit` has always had that write and the README has always overstated it. What changed is that #3792's parity fix made the overstatement worth correcting rather than merely inaccurate.

## Verification

| Gate | Result |
|---|---|
| `check-changed-skills.sh` | exit 0 |
| `check-changelog-parity.sh` (all three modes) | exit 0 |
| generators `--check` (catalog, cheat sheet) | exit 0 |
| `check-purged-em-dashes.sh --check` | exit 0 |
| `check-skill-count-claims.sh --check` | exit 0 |
| `check-contract-slice-prune.sh --check-diff` | exit 0 |
| `check-stale-base-overlap.sh --check` | exit 0 |
| `markdownlint-cli2` over both changed files | 0 issues |
| `ai-slop` detector | 0 findings across the 2 changed markdown files |

One note on that last row, because a first run of it was misleading. A `plugins/overengineering/**/*.md` pathspec matched nothing, so the detector fell back to scanning the whole repository and reported 6 pre-existing findings elsewhere. Re-run against the actual changed files it reports 0. Recording it because a filter that silently matches nothing and then reports someone else's findings is exactly the shape of error this change set keeps turning up.

## Related

- Follows #3792 (`b3c15edc`), #3789 (`bd60a878`), #3776 (`9ff17e29`).
- A parallel verification of the eval half of #3792 came back **clean**, with eleven candidates raised and all eleven refuted on a second adversarial pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XKg6Tnk9ssfHSu4gCwSyEQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01XKg6Tnk9ssfHSu4gCwSyEQ)_