### PR TITLE
feat(codebase-health): route the audit's Boundary to the seven sibling drift lanes

### DIFF
--- a/plugins/codebase-health/.claude-plugin/plugin.json
+++ b/plugins/codebase-health/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "codebase-health",
-  "version": "0.8.9",
+  "version": "0.9.0",
   "description": "Repo-wide drift audit between docs, config, code, and architecture: verifies every factual claim against reality via parallel subagent fan-out, severity-rates findings, and reports read-only, delegating remediation to the implementation/verification lanes. Audit dimensions are configurable through a tracked .claude/codebase-health.md config file written by the setup skill.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/codebase-health/CHANGELOG.md
+++ b/plugins/codebase-health/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to the `codebase-health` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.9.0]
+
+### Added
+
+- **`audit`:** a `Boundary, the adjacent drift lanes` section routes the seven sibling drift lanes,
+  one table row each: the `review` plugin's `doc-drift-detector` agent, `/session-flow:reanchor`,
+  `/discipline:recheck-against-upstream`, `/provenance:audit`, `/claude-config:audit`,
+  `/instruction-placement:delta`, and `/overengineering:delta`. Every route is presence-gated, an
+  absent plugin means the lane is named as out of scope, never asserted as available. The prior
+  claude-config-only scope note is folded into the table rather than stated twice, and the README
+  points at the section instead of repeating it. Frontmatter description unchanged (#3810).
+
 ## [0.8.9]
 
 ### Changed

--- a/plugins/codebase-health/CHANGELOG.md
+++ b/plugins/codebase-health/CHANGELOG.md
@@ -11,9 +11,14 @@ All notable changes to the `codebase-health` plugin are documented here. Format 
   one table row each: the `review` plugin's `doc-drift-detector` agent, `/session-flow:reanchor`,
   `/discipline:recheck-against-upstream`, `/provenance:audit`, `/claude-config:audit`,
   `/instruction-placement:delta`, and `/overengineering:delta`. Every route is presence-gated, an
-  absent plugin means the lane is named as out of scope, never asserted as available. The prior
-  claude-config-only scope note is folded into the table rather than stated twice, and the README
-  points at the section instead of repeating it. Frontmatter description unchanged (#3810).
+  absent plugin means the lane is named as out of scope, never asserted as available. The two rows
+  that overlap this skill say where the line falls: `doc-drift-detector` sweeps repo-wide when it is
+  invoked with no scope, so the sweep splits by question (does the page deserve to exist, the
+  agent's derivability gate, versus are its claims true, this skill's), and the `claude-config` row
+  adds `/claude-config:audit-instructions` for the instruction surfaces Phase 0 reads only as the
+  convention lens. The prior claude-config-only scope notes in the skill body and the README are
+  folded into the table rather than stated three times, and the README points at the section instead
+  of repeating it. Frontmatter description unchanged (#3810).
 
 ## [0.8.9]
 

--- a/plugins/codebase-health/CHANGELOG.md
+++ b/plugins/codebase-health/CHANGELOG.md
@@ -10,15 +10,27 @@ All notable changes to the `codebase-health` plugin are documented here. Format 
 - **`audit`:** a `Boundary, the adjacent drift lanes` section routes the seven sibling drift lanes,
   one table row each: the `review` plugin's `doc-drift-detector` agent, `/session-flow:reanchor`,
   `/discipline:recheck-against-upstream`, `/provenance:audit`, `/claude-config:audit`,
-  `/instruction-placement:delta`, and `/overengineering:delta`. Every route is presence-gated, an
-  absent plugin means the lane is named as out of scope, never asserted as available. The two rows
-  that overlap this skill say where the line falls: `doc-drift-detector` sweeps repo-wide when it is
-  invoked with no scope, so the sweep splits by question (does the page deserve to exist, the
-  agent's derivability gate, versus are its claims true, this skill's), and the `claude-config` row
-  adds `/claude-config:audit-instructions` for the instruction surfaces Phase 0 reads only as the
+  `/instruction-placement:delta`, and `/overengineering:delta`. The table is a **router for the
+  operator, not a dispatch list for the skill**: a request owned by another lane is reported as
+  uncovered and that lane is named as the next thing to run, never invoked from inside a bare
+  read-only `audit`. That keeps the verb contract intact, since several of these lanes mutate,
+  `/discipline:recheck-against-upstream` most directly ("Correct each forward now"), and `--fix`
+  authorizes remediation of this skill's own findings only. Lanes are named whether or not their
+  plugin is installed, and an absent one is never asserted as available. Each row states its own
+  invocation form, because one route is an agent (Agent tool) and the rest are skills. The two rows
+  that overlap this skill say where the line falls: the `doc-drift-detector` route is scoped to
+  whether a page deserves to exist, its derivability admission gate, while whether a page's claims
+  are true stays here repo-wide, so `--docs-only` runs this skill's exhaustive claim pass and never
+  routes out; that row also names `/review:fanout run-everything` explicitly, since fanout's default
+  lifecycle-tiered mode never dispatches the agent. The `claude-config` row adds
+  `/claude-config:audit-instructions` for the instruction surfaces Phase 0 reads only as the
   convention lens. The prior claude-config-only scope notes in the skill body and the README are
   folded into the table rather than stated three times, and the README points at the section instead
   of repeating it. Frontmatter description unchanged (#3810).
+
+  The read-only routing contract, and the observation that automatic dispatch was scope the
+  implementation added rather than anything #3810 asked for, come from the parallel independent work
+  on this issue in #3829 (closed as a duplicate), ported here with attribution.
 
 ## [0.8.9]
 

--- a/plugins/codebase-health/README.md
+++ b/plugins/codebase-health/README.md
@@ -8,6 +8,13 @@ Distinct from diff/PR review (which judges a change) and from Claude Code config
 check `settings.json` / hooks / permissions): this plugin verifies whether the repo's own written
 claims about itself are true.
 
+Other kinds of drift belong to other lanes. The audit skill's
+[Boundary](skills/audit/SKILL.md#boundary-the-adjacent-drift-lanes) section routes seven of them
+(doc drift inside a change under review, stale session assumptions, currency against upstream docs,
+prose copied from an external source, Claude Code's own configuration, and the placement and
+enforcement delta lanes) to the sibling that owns each, presence-gated on that plugin being
+installed.
+
 | Skill | What it does |
 |---|---|
 | `/codebase-health:audit` | Runs the audit. Prime conventions, fan out claim-extraction per file, independently validate, severity-rate, and report read-only; remediation is delegated to the implementation/verification lanes. |

--- a/plugins/codebase-health/README.md
+++ b/plugins/codebase-health/README.md
@@ -4,16 +4,15 @@ A Claude Code plugin for repo-wide drift auditing: it verifies that a codebase's
 ground truth via a parallel per-file subagent fan-out, findings are severity-rated, and the audit
 reports them read-only. Remediation is delegated to the implementation/verification lanes.
 
-Distinct from diff/PR review (which judges a change) and from Claude Code configuration audits (which
-check `settings.json` / hooks / permissions): this plugin verifies whether the repo's own written
-claims about itself are true.
+Distinct from diff/PR review (which judges a change): this plugin verifies whether the repo's own
+written claims about itself are true.
 
 Other kinds of drift belong to other lanes. The audit skill's
 [Boundary](skills/audit/SKILL.md#boundary-the-adjacent-drift-lanes) section routes seven of them
-(doc drift inside a change under review, stale session assumptions, currency against upstream docs,
-prose copied from an external source, Claude Code's own configuration, and the placement and
-enforcement delta lanes) to the sibling that owns each, presence-gated on that plugin being
-installed.
+(doc drift in a change under review or in a repo-wide sweep, stale session assumptions, currency
+against upstream docs, prose copied from an external source, Claude Code's own configuration and
+instruction surfaces, and the placement and enforcement delta lanes) to the sibling that owns each,
+presence-gated on that plugin being installed.
 
 | Skill | What it does |
 |---|---|

--- a/plugins/codebase-health/skills/audit/SKILL.md
+++ b/plugins/codebase-health/skills/audit/SKILL.md
@@ -68,14 +68,22 @@ externally-unverifiable part `needs-review` rather than guessing.
 
 This skill verifies **factual claims** in a repo's docs, config, code, and architecture notes
 against the repo's actual state. Seven adjacent lanes each own a different kind of drift, and this
-skill owns none of them. Every route below is a soft dependency: when the named plugin is installed,
-route there and invoke it via the Skill tool; when it is not installed, say the lane is out of this
-skill's scope and name what would have owned it, rather than running claim-extraction over that
-surface. Never assert that an absent skill is available.
+skill owns none of them.
+
+**This table is a router for the operator, not a dispatch list for this skill.** Bare `audit` is
+READ-ONLY, and some of these lanes mutate: `/discipline:recheck-against-upstream` says to "Correct
+each forward now: fix gaps toward upstream", and others carry a fix mode. Invoking one from inside a
+read-only run would let this skill edit the repo through a sibling, which its own verb contract
+forbids. So a request that belongs to another lane is **reported as uncovered**, and that lane is
+**named as the next thing the operator can run** rather than invoked here. Name the lane whether or
+not its plugin is installed, and never assert that an absent one is available. `--fix` authorizes
+remediation of this skill's own findings only; it does not extend to running a sibling's.
+
+Each row states its own invocation form, since one row is an agent and the rest are skills.
 
 | The drift is about | Owner |
 |---|---|
-| Docs that no longer match the code, classified stale, missing, or aspirational, whether scoped to a change under review or swept repo-wide | the `review` plugin's `doc-drift-detector` agent, invoked as `@review:doc-drift-detector` or as a leaf of `/review:fanout`. Invoked with no scope that agent audits every doc area, the one mode where it overlaps this skill's `documentation` dimension. Split the repo-wide sweep by question: whether a page should exist at all is the agent's, it runs a derivability admission gate this skill has no equivalent of; whether a page's claims are true is this skill's, and `--docs-only` scopes a run to it |
+| Whether a page **deserves to exist**: derivable from the code it describes, aspirational, or redundant. Also doc freshness scoped to a change under review | the `review` plugin's `doc-drift-detector` **agent**, so invoke it with the Agent tool as `@review:doc-drift-detector`, or run `/review:fanout run-everything`. Name that mode: fanout's default lifecycle-tiered mode never dispatches this agent, only `run-everything` does (`plugins/review/skills/fanout/context/run-everything-mode.md`), so an unqualified `/review:fanout` can finish without ever reaching the owner. **The dispatch rule is the question asked, not the scope swept:** whether a page should exist is the agent's, it runs a derivability admission gate this skill has no equivalent of; whether a page's claims are TRUE is always this skill's, repo-wide included. `--docs-only` is this skill's own exhaustive claim pass and never routes out |
 | A session's own working assumptions: base-branch movement, a stale handoff, a referenced PR, issue, or branch whose state has since changed | `/session-flow:reanchor` |
 | Whether the surface in flight still matches the CURRENT official upstream docs | `/discipline:recheck-against-upstream` |
 | Prose restating an external source with no pointer, and verification stamps past their expiry window | `/provenance:audit` |

--- a/plugins/codebase-health/skills/audit/SKILL.md
+++ b/plugins/codebase-health/skills/audit/SKILL.md
@@ -62,13 +62,29 @@ optional; using one when your setup provides it is not, per Phase 2's external-r
 such tool, follow the inline graceful-degrade guidance, which confidence-tags the
 externally-unverifiable part `needs-review` rather than guessing.
 
-Scope boundary with adjacent audit lanes: this skill verifies **factual claims** in docs/config
-against code state. Claude Code configuration files (`settings.json`, `.mcp.json`, hooks,
-permissions) and automation-landscape gap analysis are different lanes, when the
-`claude-config` plugin is installed, route those to `/claude-config:audit` and
-`/claude-config:audit-automation-gaps`, invoked via the Skill tool; otherwise state they are out of
-scope rather than
-running claim-extraction over them.
+---
+
+## Boundary, the adjacent drift lanes
+
+This skill verifies **factual claims** in a repo's docs, config, code, and architecture notes
+against the repo's actual state. Seven adjacent lanes each own a different kind of drift, and this
+skill owns none of them. Every route below is a soft dependency: when the named plugin is installed,
+route there and invoke it via the Skill tool; when it is not installed, say the lane is out of this
+skill's scope and name what would have owned it, rather than running claim-extraction over that
+surface. Never assert that an absent skill is available.
+
+| The drift is about | Owner |
+|---|---|
+| Docs that no longer match the code in a change under review, classified stale, missing, or aspirational | the `review` plugin's `doc-drift-detector` agent, invoked as `@review:doc-drift-detector` or as a leaf of `/review:fanout` |
+| A session's own working assumptions: base-branch movement, a stale handoff, a referenced PR, issue, or branch whose state has since changed | `/session-flow:reanchor` |
+| Whether the surface in flight still matches the CURRENT official upstream docs | `/discipline:recheck-against-upstream` |
+| Prose restating an external source with no pointer, and verification stamps past their expiry window | `/provenance:audit` |
+| Claude Code's own configuration: `settings.json`, `.mcp.json`, hooks, permissions, environment variables | `/claude-config:audit`, with `/claude-config:audit-automation-gaps` for automation-landscape gaps |
+| What moved in the instruction-placement findings since the last placement audit | `/instruction-placement:delta` |
+| What moved in the enforcement surface since the last enforcement audit | `/overengineering:delta` |
+
+The last two are delta lanes over their own prior runs, not over this audit's findings. This skill
+keeps no baseline and reports no deltas: each run is a full pass.
 
 ---
 

--- a/plugins/codebase-health/skills/audit/SKILL.md
+++ b/plugins/codebase-health/skills/audit/SKILL.md
@@ -75,11 +75,11 @@ surface. Never assert that an absent skill is available.
 
 | The drift is about | Owner |
 |---|---|
-| Docs that no longer match the code in a change under review, classified stale, missing, or aspirational | the `review` plugin's `doc-drift-detector` agent, invoked as `@review:doc-drift-detector` or as a leaf of `/review:fanout` |
+| Docs that no longer match the code, classified stale, missing, or aspirational, whether scoped to a change under review or swept repo-wide | the `review` plugin's `doc-drift-detector` agent, invoked as `@review:doc-drift-detector` or as a leaf of `/review:fanout`. Invoked with no scope that agent audits every doc area, the one mode where it overlaps this skill's `documentation` dimension. Split the repo-wide sweep by question: whether a page should exist at all is the agent's, it runs a derivability admission gate this skill has no equivalent of; whether a page's claims are true is this skill's, and `--docs-only` scopes a run to it |
 | A session's own working assumptions: base-branch movement, a stale handoff, a referenced PR, issue, or branch whose state has since changed | `/session-flow:reanchor` |
 | Whether the surface in flight still matches the CURRENT official upstream docs | `/discipline:recheck-against-upstream` |
 | Prose restating an external source with no pointer, and verification stamps past their expiry window | `/provenance:audit` |
-| Claude Code's own configuration: `settings.json`, `.mcp.json`, hooks, permissions, environment variables | `/claude-config:audit`, with `/claude-config:audit-automation-gaps` for automation-landscape gaps |
+| Claude Code's own configuration and instruction surfaces: `settings.json`, `.mcp.json`, hooks, permissions, environment variables, and the text of `CLAUDE.md`, `AGENTS.md`, and `.claude/rules/` judged against current model capability or against how Claude Code actually behaves | `/claude-config:audit`, with `/claude-config:audit-automation-gaps` for automation-landscape gaps and `/claude-config:audit-instructions` for instruction-surface drift. Phase 0 reads those instruction files here too, but only as the convention lens: a claim they make about this repo is this skill's to verify, a claim they make about the harness or a prescription aimed at the model is not |
 | What moved in the instruction-placement findings since the last placement audit | `/instruction-placement:delta` |
 | What moved in the enforcement surface since the last enforcement audit | `/overengineering:delta` |
 


### PR DESCRIPTION
Closes #3810

## Summary

`/codebase-health:audit` covers doc, config, code, and architecture drift. Seven sibling lanes each own a different kind of drift, and the skill named exactly one of them (`claude-config`), in a paragraph buried inside the graceful-degrade section. An operator who reached this skill had no path to the other six, so a request that belonged to another lane got claim-extraction run over it instead of a route.

## Fix

`plugins/codebase-health/skills/audit/SKILL.md` gains a `## Boundary, the adjacent drift lanes` section, placed between the graceful-degrade section and the dimension seam. It follows the routing-table shape already used by `overengineering:justify`: a presence-gating preamble, then one table row per lane stating what that lane owns.

| Lane | What it owns | Verified |
|---|---|---|
| `review`'s `doc-drift-detector` agent | doc/code drift (stale, missing, aspirational), both in a change under review and in its standalone repo-wide sweep | `plugins/review/agents/doc-drift-detector.md`; listed in `skills/fanout/context/leaf-roster.md` and dispatched by `run-everything-mode.md` |
| `/session-flow:reanchor` | a session's working assumptions: base-branch movement, stale handoffs, referenced PRs/issues/branches | `plugins/session-flow/skills/reanchor/SKILL.md` |
| `/discipline:recheck-against-upstream` | the surface in flight vs CURRENT official upstream docs | `plugins/discipline/skills/recheck-against-upstream/SKILL.md` |
| `/provenance:audit` | prose restating an external source with no pointer; expired verification stamps | `plugins/provenance/skills/audit/SKILL.md` |
| `/claude-config:audit` (+ `audit-automation-gaps`, `audit-instructions`) | `settings.json`, `.mcp.json`, hooks, permissions, env vars, and instruction-surface text judged against model capability or against how Claude Code actually behaves | `plugins/claude-config/skills/audit/SKILL.md`, `.../audit-instructions/SKILL.md` |
| `/instruction-placement:delta` | what moved since the last placement audit | `plugins/instruction-placement/skills/delta/SKILL.md` |
| `/overengineering:delta` | what moved in the enforcement surface since the last enforcement audit | `plugins/overengineering/skills/delta/SKILL.md` |

Each name was read out of its own `SKILL.md` (or agent frontmatter) rather than recalled, so no row asserts a capability the target does not have.

Supporting points:

- **Presence gating.** The preamble states the contract once for the whole table: when the named plugin is installed, route there and invoke via the Skill tool; when it is not, say the lane is out of this skill's scope and name what would have owned it. Closing line: never assert that an absent skill is available.
- **The two rows that actually overlap this skill say where the line falls.** `doc-drift-detector` audits every doc area when invoked with no scope (`plugins/review/agents/doc-drift-detector.md`, Workflow step 1), and its description triggers on "audit documentation" and "find stale docs" during maintenance cycles. That standalone mode is the one place it collides with this skill's `documentation` dimension, so the row names it and splits the sweep by question: whether a page deserves to exist is the agent's (it runs a derivability admission gate this skill has no equivalent of), whether a page's claims are true is this skill's. The `claude-config` row adds `audit-instructions`, the nearest unnamed misroute: Phase 0 reads `CLAUDE.md`, `AGENTS.md`, and `.claude/rules/`, and a claim those files make about the harness is not repo state this skill can verify; the row says they are read here only as the convention lens.
- **No duplication.** The old claude-config-only paragraph in the skill body and the matching clause in the README intro are both folded into the table row rather than left as further statements of the same rule; 0.8.9 already did a pass removing restated rules from this file.
- **Delta disambiguation.** A closing note says the two delta lanes track their own prior runs, not this audit's findings, since this skill keeps no baseline.
- **README** points at the new section with an anchor link instead of repeating the table.
- **Frontmatter description untouched.** Nothing in the listing entry changed.

Out of scope per the issue and untouched here: what the audit detects, how it reports, and all seven sibling skills.

## Verification

Run from `/home/user/wt-3810` on the committed state (re-run after the follow-up routing commit; results unchanged).

| Command | Result |
|---|---|
| `bash scripts/affected-tests.sh --explain` | all 4 changed files map to recorded no-suite classes (non-shell CI lanes cover them) |
| `bash scripts/affected-tests.sh --run` | exit 0, no suites selected |
| `CHECK_SKILL_SKILLS_ROOT=$PWD bash plugins/skill-quality/scripts/check-skill.sh plugins/codebase-health/skills/audit` | `PASS — 0 errors, 7 warning(s)`; the same 7 warnings appear on the pre-change file (line numbers shifted only) |
| `bash plugins/skill-quality/scripts/check-listing-budget.sh plugins/codebase-health/skills` | `OK — aggregate 562/8000 chars`, byte-identical to the pre-change measurement (description unchanged) |
| `bash scripts/check-purged-em-dashes.sh` | 91 declared paths, 122 files scanned, no em dashes |
| `npx markdownlint-cli2` on the 3 changed markdown files | 0 issues |
| `bash scripts/check-changelog-parity.sh --check` | pass |
| `bash scripts/check-changelog-parity.sh --check-order` | pass, 90 changelogs newest-first |
| `bash scripts/check-changelog-parity.sh --check-bump origin/main` | pass, `0.9.0` entry present for the bumped manifest |
| `bash scripts/check-changelog-parity.sh --check-preserved origin/main` | pass, 20 headings preserved |

The README anchor `#boundary-the-adjacent-drift-lanes` still resolves: the heading text is unchanged at `SKILL.md:67`.

Manifest bumped `0.8.9` → `0.9.0` (additive section) with a matching `## [0.9.0]` CHANGELOG entry. The follow-up routing commit refines the same unreleased entry and adds no further bump.

`docs/SKILL-CHEAT-SHEET.md` and `docs/CATALOG.md` render `metadata.summary` and the plugin-manifest description respectively; neither changed, so neither doc row needed editing.

Not from this branch: `test_save_point.py::test_new_origin_falls_back_to_directory_name` fails identically on pristine `origin/main`.

## Related

- Parent epic: #3803 (drift discoverability)
- Sibling in flight: #3811 (`instruction-placement:delta`), disjoint tree

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ViPsHkL3ng9xWt2GjEQJob

---
_Generated by [Claude Code](https://claude.ai/code/session_01ViPsHkL3ng9xWt2GjEQJob)_