### PR TITLE
fix(work-items): scope github sub-issue rollup off the node url

### DIFF
--- a/plugins/work-items/.claude-plugin/plugin.json
+++ b/plugins/work-items/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "work-items",
-  "version": "0.39.65",
+  "version": "0.39.66",
   "description": "Manages development work items through a provider-neutral tracker seam that ships with the plugin (bundled dispatcher plus github, local-markdown, jira, gitea, and linear adapters; seam plugin-dir canonical, adapters consumer-local-first): dashboard, taxonomy-labeled creation, a race-safe assignee-plus-lease claim protocol, recurring-schedule checks, TODO scanning, stale-lease auditing, plan decomposition into vertical-slice items, a macro-journey router over spec containers (rollup, per-container execution shape, next-step routing), raw-intake triage (issues and unsolicited PRs through raw, verified, briefed, autonomous-eligible states), plus the two work-items loop lanes of the loop-lane convention: a self-paced autonomous work-loop drain (work-class admission gate, adaptive item cap, PR-only) and an attended attend-queue escalation lane. The re-runnable setup skill binds the provider (.work-item-tracker.json), seeds the recurring-schedule seam (.github/recurring-schedule.json), and remaps canonical role labels.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/work-items/CHANGELOG.md
+++ b/plugins/work-items/CHANGELOG.md
@@ -15,6 +15,17 @@ All notable changes to the `work-items` plugin are documented here. Format follo
   GraphQL-shaped payloads, and treats a node carrying neither field as same-repo. Extracted to
   `wit_gh_subissue_child_numbers` in `common.sh` and covered by offline verb tests that serve the
   real gh 2.97 projection.
+- **The same-repo comparison is case-insensitive.** The ID grammar admits uppercase owner and
+  repository components while GitHub's canonical URL casing may differ, and GitHub treats these
+  identifiers case-insensitively, so an exact compare rejected every child of `github:O/R#1` whose
+  URL read `/o/r/` and reinstated the empty rollup for those callers.
+- **An unattributable node now warns on stderr.** Failing open on a node carrying neither `.url`
+  nor `.repository.nameWithOwner` is a defensive default, not a safe one: a parent's `subIssues`
+  list can carry cross-repo children, which is why the predicate exists at all, so admitting an
+  unattributable node can misattribute a foreign child whose number collides locally. No known gh
+  payload omits both fields; the warning makes a real occurrence observable instead of silent. The
+  prior comment justified the fallback with the claim that gh scopes the list to the parent's own
+  repo, which the suite's own cross-repo fixture contradicts.
 
 ## [0.39.65]
 

--- a/plugins/work-items/CHANGELOG.md
+++ b/plugins/work-items/CHANGELOG.md
@@ -3,6 +3,19 @@
 All notable changes to the `work-items` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.39.66]
+
+### Fixed
+
+- **GitHub adapter: sub-issue rollup no longer returns empty.** `list-sub-items` and
+  `list-frontier --parent` filtered `subIssues.nodes` on `.repository.nameWithOwner`, a field
+  `gh issue view --json subIssues` does not emit (verified against gh 2.97.0), so every node was
+  discarded and both verbs returned an empty set on every repository. The same-repo predicate now
+  derives each child's repository from its `url`, falls back to `repository.nameWithOwner` for
+  GraphQL-shaped payloads, and treats a node carrying neither field as same-repo. Extracted to
+  `wit_gh_subissue_child_numbers` in `common.sh` and covered by offline verb tests that serve the
+  real gh 2.97 projection.
+
 ## [0.39.65]
 
 ### Changed

--- a/plugins/work-items/tools/work-item-tracker/adapters/github/README.md
+++ b/plugins/work-items/tools/work-item-tracker/adapters/github/README.md
@@ -436,3 +436,11 @@ items", the `--add-label`-vs-`--label` rule under "Edit labels / assignees"). Cr
   the secondary content-generation limit — e.g. 30 items per batch with short pauses.
 - **Issue Forms auto-labeling** fires only on web-form creation, not `gh issue create` — apply
   labels explicitly when creating programmatically.
+- **`--json subIssues` nodes carry no `repository` object.** `gh issue view <n> --json subIssues`
+  projects each node as `{id, number, state, title, url}` only. A same-repo filter written against
+  `.repository.nameWithOwner` therefore matches nothing and every container rolls up empty
+  (#3825). Scope such a filter off the node's `url` instead; `repository { nameWithOwner }` exists
+  only when you request it in a GraphQL query, and the seam deliberately avoids extra GraphQL
+  operations because sandboxed sessions serve only a pinned set and `403` the rest (see the note
+  above `wit_read_assignees` in `common.sh`). Verified against **gh 2.97.0** (2026-07-31); the
+  seam's native sub-issue floor is gh 2.94 (`../../lib/gh-version.sh`).

--- a/plugins/work-items/tools/work-item-tracker/adapters/github/common.sh
+++ b/plugins/work-items/tools/work-item-tracker/adapters/github/common.sh
@@ -202,6 +202,40 @@ wit_issue_url() {
   printf 'https://github.com/%s/%s/issues/%s\n' "$1" "$2" "$3"
 }
 
+# wit_gh_subissue_child_numbers <owner/repo> <subIssues-payload> — echo a compact
+# JSON array of the payload's child issue NUMBERS that live in <owner/repo>.
+#
+# Same-repo scoping is required (a cross-repo sub-issue's number would collide
+# with an unrelated same-numbered issue in this repo), but it must read a field
+# the payload actually carries. `gh issue view --json subIssues` projects nodes
+# as {id, number, state, title, url} with NO `repository` object (verified on gh
+# 2.97.0), so the former `.repository.nameWithOwner` filter dropped every child
+# and left containers with an empty rollup (#3825). Per node, in order:
+#   1. `.url` — always present on the gh projection. Owner/repo come from the
+#      `/<owner>/<repo>/issues/<n>` tail, so GHES hosts parse too. `test()`
+#      guards `capture()`: an unmatched capture emits an empty stream, which
+#      inside a select would silently drop the node — the same fail-closed bug.
+#   2. `.repository.nameWithOwner` — carried only when the payload came from a
+#      GraphQL query that selected it explicitly.
+#   3. Neither → treat as same-repo. gh scopes a parent's subIssues list to that
+#      parent's own repo, so dropping an unattributable node would reinstate the
+#      empty rollup; fail OPEN here, not closed.
+wit_gh_subissue_child_numbers() {
+  local repo="$1" payload="$2"
+  # shellcheck disable=SC2016  # jq program — $repo is a jq variable
+  jq -c --arg repo "$repo" '
+    def node_repo:
+      (.url // "") as $u
+      | if ($u | test("/[^/]+/[^/]+/issues/[0-9]+$"))
+        then ($u | capture("/(?<o>[^/]+)/(?<r>[^/]+)/issues/[0-9]+$") | .o + "/" + .r)
+        else (.repository.nameWithOwner // null)
+        end;
+    [ (.subIssues.nodes // [])[]
+      | select((node_repo) as $nr | $nr == null or $nr == $repo)
+      | .number ]
+  ' <<<"$payload"
+}
+
 # shellcheck disable=SC2016  # jq program — $sv/$or are jq variables, not bash expansions
 readonly WIT_ITEM_JQ='{
   schema_version: $sv,

--- a/plugins/work-items/tools/work-item-tracker/adapters/github/common.sh
+++ b/plugins/work-items/tools/work-item-tracker/adapters/github/common.sh
@@ -231,7 +231,8 @@ wit_issue_url() {
 # Comparison is case-insensitive: the ID grammar admits uppercase owner and repo
 # components while GitHub's canonical URL casing may differ, and GitHub treats
 # these identifiers case-insensitively. An exact compare would reject every child
-# of `github:O/R#1` whose URL reads `/o/r/`, reinstating the empty rollup.
+# of a parent whose id capitalises the owner or repo segment while the canonical
+# URL spells it lowercase, reinstating the empty rollup for that caller.
 wit_gh_subissue_child_numbers() {
   local repo="$1" payload="$2" parsed unattributed
   # shellcheck disable=SC2016  # jq program — $repo is a jq variable

--- a/plugins/work-items/tools/work-item-tracker/adapters/github/common.sh
+++ b/plugins/work-items/tools/work-item-tracker/adapters/github/common.sh
@@ -217,23 +217,47 @@ wit_issue_url() {
 #      inside a select would silently drop the node — the same fail-closed bug.
 #   2. `.repository.nameWithOwner` — carried only when the payload came from a
 #      GraphQL query that selected it explicitly.
-#   3. Neither → treat as same-repo. gh scopes a parent's subIssues list to that
-#      parent's own repo, so dropping an unattributable node would reinstate the
-#      empty rollup; fail OPEN here, not closed.
+#   3. Neither → treat as same-repo, and warn on stderr.
+#
+# On rung 3, note what is NOT being claimed: a parent's subIssues list can carry
+# cross-repo children (that is the whole reason this predicate exists, and the
+# suite's FOREIGN_PAYLOAD fixture exercises it). So an unattributable node is
+# genuinely ambiguous, and neither direction is safe in the abstract. No known gh
+# payload omits both fields — 2.97.0 always projects `.url` — so this is a
+# defensive default rather than a reasoned-about case. It fails OPEN because the
+# observed failure (#3825) was the silent empty rollup, and it warns so that a
+# real occurrence is visible instead of quietly misattributing a foreign child.
+#
+# Comparison is case-insensitive: the ID grammar admits uppercase owner and repo
+# components while GitHub's canonical URL casing may differ, and GitHub treats
+# these identifiers case-insensitively. An exact compare would reject every child
+# of `github:O/R#1` whose URL reads `/o/r/`, reinstating the empty rollup.
 wit_gh_subissue_child_numbers() {
-  local repo="$1" payload="$2"
+  local repo="$1" payload="$2" parsed unattributed
   # shellcheck disable=SC2016  # jq program — $repo is a jq variable
-  jq -c --arg repo "$repo" '
+  parsed="$(jq -c --arg repo "$repo" '
     def node_repo:
       (.url // "") as $u
       | if ($u | test("/[^/]+/[^/]+/issues/[0-9]+$"))
         then ($u | capture("/(?<o>[^/]+)/(?<r>[^/]+)/issues/[0-9]+$") | .o + "/" + .r)
         else (.repository.nameWithOwner // null)
         end;
-    [ (.subIssues.nodes // [])[]
-      | select((node_repo) as $nr | $nr == null or $nr == $repo)
-      | .number ]
-  ' <<<"$payload"
+    ($repo | ascii_downcase) as $want
+    | [ (.subIssues.nodes // [])[] | . + {_nr: node_repo} ] as $nodes
+    | {
+        numbers: [ $nodes[]
+          | select((._nr == null) or ((._nr | ascii_downcase) == $want))
+          | .number ],
+        unattributed: ([ $nodes[] | select(._nr == null) ] | length)
+      }
+  ' <<<"$payload")" || return 1
+
+  unattributed="$(jq -r '.unattributed' <<<"$parsed")"
+  if [[ "$unattributed" -gt 0 ]]; then
+    printf 'work-item-tracker: %s sub-issue node(s) carried neither .url nor .repository.nameWithOwner; counted as same-repo\n' \
+      "$unattributed" >&2
+  fi
+  jq -c '.numbers' <<<"$parsed"
 }
 
 # shellcheck disable=SC2016  # jq program — $sv/$or are jq variables, not bash expansions

--- a/plugins/work-items/tools/work-item-tracker/adapters/github/common.test.sh
+++ b/plugins/work-items/tools/work-item-tracker/adapters/github/common.test.sh
@@ -11,7 +11,7 @@ source "$SCRIPT_DIR/common.sh"
 
 for fn in gh_write wit_run_gh wit_resolve_repo wit_emit_item wit_lease_json \
   wit_lease_is_live wit_list_lease_comments wit_help_if_requested wit_map_gh_error \
-  wit_gh_issue_view_json_fields; do
+  wit_gh_issue_view_json_fields wit_gh_subissue_child_numbers; do
   if declare -F "$fn" >/dev/null; then
     pass "common.sh exposes $fn"
   else
@@ -119,6 +119,38 @@ EOF
   assert_contains "wit_emit_item on gh 2.94 requests parent" "$CALLS" "parent"
 
   rm -rf "$EMIT_STUB"
+fi
+
+# --- sub-issue same-repo predicate (#3825) -----------------------------------
+# The gh 2.97 `--json subIssues` projection carries NO `repository` object, so
+# the former `.repository.nameWithOwner == $repo` filter matched nothing and
+# every container rolled up empty. Case 1 is verbatim gh 2.97.0 output and is
+# the case the old predicate fails.
+if command -v jq >/dev/null 2>&1; then
+  REPO_UT="melodic-software/claude-code-plugins"
+
+  GH_297_PAYLOAD='{"subIssues":{"nodes":[{"id":"I_kwDOTCGFQM8AAAABP7GlVw","number":3805,"state":"OPEN","title":"planning: plan the typed-ticket-body lane","url":"https://github.com/melodic-software/claude-code-plugins/issues/3805"},{"id":"I_kwDOTCGFQM8AAAABP7IQuQ","number":3814,"state":"OPEN","title":"docs/conventions: register acceptance-criteria format and diagram-dialect conventions","url":"https://github.com/melodic-software/claude-code-plugins/issues/3814"}],"totalCount":2}}'
+  assert_eq "gh --json subIssues nodes (no repository field) keep same-repo children" \
+    "[3805,3814]" "$(wit_gh_subissue_child_numbers "$REPO_UT" "$GH_297_PAYLOAD")"
+
+  FOREIGN_PAYLOAD='{"subIssues":{"nodes":[{"number":7,"url":"https://github.com/melodic-software/claude-code-plugins/issues/7"},{"number":9,"url":"https://github.com/other-org/other-repo/issues/9"}],"totalCount":2}}'
+  assert_eq "cross-repo child dropped by url-derived scope" \
+    "[7]" "$(wit_gh_subissue_child_numbers "$REPO_UT" "$FOREIGN_PAYLOAD")"
+
+  GHES_PAYLOAD='{"subIssues":{"nodes":[{"number":11,"url":"https://ghe.example.com/melodic-software/claude-code-plugins/issues/11"}]}}'
+  assert_eq "url scope is host-agnostic (GHES)" \
+    "[11]" "$(wit_gh_subissue_child_numbers "$REPO_UT" "$GHES_PAYLOAD")"
+
+  GRAPHQL_PAYLOAD='{"subIssues":{"nodes":[{"number":21,"repository":{"nameWithOwner":"melodic-software/claude-code-plugins"}},{"number":22,"repository":{"nameWithOwner":"other-org/other-repo"}}]}}'
+  assert_eq "GraphQL shape (repository, no url) still scopes" \
+    "[21]" "$(wit_gh_subissue_child_numbers "$REPO_UT" "$GRAPHQL_PAYLOAD")"
+
+  UNATTRIBUTABLE_PAYLOAD='{"subIssues":{"nodes":[{"number":31},{"number":32,"url":"not-an-issue-url"}]}}'
+  assert_eq "unattributable node fails OPEN (gh scopes the list to the parent)" \
+    "[31,32]" "$(wit_gh_subissue_child_numbers "$REPO_UT" "$UNATTRIBUTABLE_PAYLOAD")"
+
+  assert_eq "no subIssues connection → empty" \
+    "[]" "$(wit_gh_subissue_child_numbers "$REPO_UT" '{}')"
 fi
 
 [[ $FAILED -eq 0 ]] || exit 1

--- a/plugins/work-items/tools/work-item-tracker/adapters/github/common.test.sh
+++ b/plugins/work-items/tools/work-item-tracker/adapters/github/common.test.sh
@@ -146,8 +146,25 @@ if command -v jq >/dev/null 2>&1; then
     "[21]" "$(wit_gh_subissue_child_numbers "$REPO_UT" "$GRAPHQL_PAYLOAD")"
 
   UNATTRIBUTABLE_PAYLOAD='{"subIssues":{"nodes":[{"number":31},{"number":32,"url":"not-an-issue-url"}]}}'
-  assert_eq "unattributable node fails OPEN (gh scopes the list to the parent)" \
-    "[31,32]" "$(wit_gh_subissue_child_numbers "$REPO_UT" "$UNATTRIBUTABLE_PAYLOAD")"
+  assert_eq "unattributable node fails OPEN (defensive default, no gh payload omits both fields)" \
+    "[31,32]" "$(wit_gh_subissue_child_numbers "$REPO_UT" "$UNATTRIBUTABLE_PAYLOAD" 2>/dev/null)"
+
+  # Failing open is a judgement call, not a free action, so it must be observable.
+  assert_eq "unattributable node warns on stderr" \
+    "1" "$(wit_gh_subissue_child_numbers "$REPO_UT" "$UNATTRIBUTABLE_PAYLOAD" 2>&1 >/dev/null | grep -c 'carried neither')"
+
+  assert_eq "attributable payload is silent on stderr" \
+    "0" "$(wit_gh_subissue_child_numbers "$REPO_UT" "$GH_297_PAYLOAD" 2>&1 >/dev/null | wc -c | tr -d ' ')"
+
+  # GitHub identifiers are case-insensitive and the ID grammar admits uppercase,
+  # so a parent id whose casing differs from the canonical URL must still match.
+  MIXED_CASE_PAYLOAD='{"subIssues":{"nodes":[{"number":41,"url":"https://github.com/melodic-software/claude-code-plugins/issues/41"},{"number":42,"url":"https://github.com/other-org/other-repo/issues/42"}]}}'
+  assert_eq "parent id casing differing from the url still scopes same-repo" \
+    "[41]" "$(wit_gh_subissue_child_numbers "Melodic-Software/Claude-Code-Plugins" "$MIXED_CASE_PAYLOAD")"
+
+  UPPER_URL_PAYLOAD='{"subIssues":{"nodes":[{"number":51,"url":"https://github.com/Melodic-Software/Claude-Code-Plugins/issues/51"}]}}'
+  assert_eq "url casing differing from the parent id still scopes same-repo" \
+    "[51]" "$(wit_gh_subissue_child_numbers "$REPO_UT" "$UPPER_URL_PAYLOAD")"
 
   assert_eq "no subIssues connection → empty" \
     "[]" "$(wit_gh_subissue_child_numbers "$REPO_UT" '{}')"

--- a/plugins/work-items/tools/work-item-tracker/adapters/github/list-sub-items.sh
+++ b/plugins/work-items/tools/work-item-tracker/adapters/github/list-sub-items.sh
@@ -12,8 +12,11 @@
 # yields the child NUMBERS, then the adapter's own list-items output is filtered
 # to that set (reusing its exact normalized projection) and re-parented. Same
 # repo only: subIssues nodes in another repo are dropped (the intersect is
-# number-keyed against this repo's list). Truncation bound is list-items' own
-# (limits.list_items_max) — safe while sub_items_per_parent <= list_items_max.
+# number-keyed against this repo's list), scoped off each node's own `url`
+# because the gh projection carries no `repository` object —
+# wit_gh_subissue_child_numbers owns that predicate (#3825). Truncation bound is
+# list-items' own (limits.list_items_max) — safe while
+# sub_items_per_parent <= list_items_max.
 set -uo pipefail
 # shellcheck source=common.sh
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/common.sh"
@@ -44,9 +47,7 @@ target_repo="$WIT_ID_OWNER/$WIT_ID_REPO"
 # Native child numbers, scoped to the parent's own repo (a cross-repo sub-issue's
 # number would collide with an unrelated same-numbered issue in this repo).
 wit_run_gh read issue view "$WIT_ID_NUMBER" -R "$target_repo" --json subIssues
-child_nums="$(jq -c --arg repo "$target_repo" \
-  '[(.subIssues.nodes // [])[] | select(.repository.nameWithOwner == $repo) | .number]' \
-  <<<"$WIT_GH_OUT")"
+child_nums="$(wit_gh_subissue_child_numbers "$target_repo" "$WIT_GH_OUT")"
 
 if [[ "$child_nums" == "[]" ]]; then
   jq -cn --arg sv "$WIT_SCHEMA_VERSION" '{schema_version: $sv, items: []}'

--- a/plugins/work-items/tools/work-item-tracker/adapters/github/list-sub-items.test.sh
+++ b/plugins/work-items/tools/work-item-tracker/adapters/github/list-sub-items.test.sh
@@ -12,4 +12,57 @@ assert_usage_error "$S"                              # no parent id
 assert_usage_error "$S" "github:o/r#1" --state bogus # bad state
 assert_usage_error "$S" "not-an-id"                  # malformed id
 assert_usage_error "$S" "local-markdown:o/r#1"       # foreign provider
+
+# --- container rollup over the real gh subIssues shape (#3825) ---------------
+# A gh stub serving the projection gh 2.97 actually returns — subIssues nodes
+# with NO `repository` object — proves the enumeration survives it end to end.
+# The predicate this replaced (`.repository.nameWithOwner == $repo`) returned an
+# empty item list here, which is exactly the reported bug.
+if command -v jq >/dev/null 2>&1; then
+  STUB_DIR="$(mktemp -d)"
+  cat >"$STUB_DIR/gh" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$1" == "--version" ]]; then
+  printf 'gh version 2.97.0 (test)\n'
+  exit 0
+fi
+if [[ "$1" == "issue" && "$2" == "view" ]]; then
+  cat <<'JSON'
+{"subIssues":{"nodes":[
+  {"id":"I_a","number":11,"state":"OPEN","title":"child open","url":"https://github.com/o/r/issues/11"},
+  {"id":"I_b","number":12,"state":"CLOSED","title":"child closed","url":"https://github.com/o/r/issues/12"},
+  {"id":"I_c","number":13,"state":"OPEN","title":"foreign child","url":"https://github.com/other/repo/issues/13"}
+],"totalCount":3}}
+JSON
+  exit 0
+fi
+if [[ "$1" == "issue" && "$2" == "list" ]]; then
+  cat <<'JSON'
+[
+  {"number":11,"title":"child open","state":"OPEN","assignees":[],"labels":[],"issueType":null,"blockedBy":{"nodes":[]},"url":"https://github.com/o/r/issues/11"},
+  {"number":12,"title":"child closed","state":"CLOSED","assignees":[],"labels":[],"issueType":null,"blockedBy":{"nodes":[]},"url":"https://github.com/o/r/issues/12"},
+  {"number":13,"title":"unrelated same-numbered issue","state":"OPEN","assignees":[],"labels":[],"issueType":null,"blockedBy":{"nodes":[]},"url":"https://github.com/o/r/issues/13"},
+  {"number":99,"title":"not a child","state":"OPEN","assignees":[],"labels":[],"issueType":null,"blockedBy":{"nodes":[]},"url":"https://github.com/o/r/issues/99"}
+]
+JSON
+  exit 0
+fi
+printf 'unexpected gh call: %s\n' "$*" >&2
+exit 1
+EOF
+  chmod +x "$STUB_DIR/gh"
+
+  SUBS="$(PATH="$STUB_DIR:$PATH" bash "$S" "github:o/r#1" --state all)"
+  IDS="$(jq -c '[.items[].id]' <<<"$SUBS")"
+  assert_eq "container with sub-issues rolls up its same-repo children" \
+    '["github:o/r#11","github:o/r#12"]' "$IDS"
+  assert_not_contains "cross-repo sub-issue number does not pull in the local same-numbered issue" \
+    "$IDS" "github:o/r#13"
+  assert_not_contains "non-child rows stay out" "$IDS" "github:o/r#99"
+  assert_eq "children are re-parented to the container" \
+    '["github:o/r#1","github:o/r#1"]' "$(jq -c '[.items[].parent_id]' <<<"$SUBS")"
+
+  rm -rf "$STUB_DIR"
+fi
+
 [[ $FAILED -eq 0 ]] || exit 1


### PR DESCRIPTION
## What was wrong

The GitHub adapter's `list-sub-items` scoped a container's children to the parent's own repo with:

```jq
[(.subIssues.nodes // [])[] | select(.repository.nameWithOwner == $repo) | .number]
```

`gh issue view <n> --json subIssues` does not emit a `repository` object on those nodes, so the predicate matched nothing. Every container returned an empty item list, and `list-frontier --parent` — a core-side derivation over the `list-sub-items` envelope (`lib/frontier.sh`, dispatcher `adapter_verb` switch) — went blind with it. Five spec containers (#3799–#3803) with 17 sub-items had no rollup.

## Probe evidence

`gh --version` → `gh version 2.97.0 (2026-07-31)`.

`gh issue view 3799 --repo melodic-software/claude-code-plugins --json subIssues` — nodes carry `id`, `number`, `state`, `title`, `url`. **No `repository`:**

```json
{"subIssues":{"nodes":[{"id":"I_kwDOTCGFQM8AAAABP7GlVw","number":3805,"state":"OPEN","title":"planning: plan the typed-ticket-body lane","url":"https://github.com/melodic-software/claude-code-plugins/issues/3805"}, ...],"totalCount":6}}
```

The same selection via GraphQL *does* carry it, because it is requested explicitly:

```console
$ gh api graphql -f query='query { repository(owner:"melodic-software", name:"claude-code-plugins") { issue(number:3799) { subIssues(first:50) { totalCount nodes { number state repository { nameWithOwner } } } } } }'
{"data":{"repository":{"issue":{"subIssues":{"totalCount":6,"nodes":[{"number":3805,"state":"OPEN","repository":{"nameWithOwner":"melodic-software/claude-code-plugins"}}, ...]}}}}}
```

## Fix choice: (b), scoped off `url`

Keep the single `gh issue view --json subIssues` read and derive each node's repo from its `url` rather than switching the verb to GraphQL.

**Reason.** `common.sh` already documents why this adapter avoids extra GraphQL operations: sandboxed sessions (Claude Code on the web / remote execution) serve only a pinned set of GraphQL operations and refuse the rest with HTTP 403, which is what made the whole lease protocol unrunnable there and drove it onto REST. Option (a) would reintroduce exactly that fragility for container rollup. `url` is on the projection gh already returns, it carries owner/repo, and the issue body names it as an acceptable source — so cross-repo safety is preserved with the blast radius confined to one predicate.

The predicate moved to `wit_gh_subissue_child_numbers` in `common.sh` so it is unit-testable offline. Resolution order per node:

1. `.url` — owner/repo from the `/<owner>/<repo>/issues/<n>` tail, host-agnostic so GHES parses too. `test()` guards `capture()`: an unmatched `capture` emits an empty stream, which inside a `select` would silently drop the node — the same fail-closed shape as the bug.
2. `.repository.nameWithOwner` — carried only when the payload came from a GraphQL query that selected it.
3. Neither → treat as same-repo. gh scopes a parent's subIssues list to that parent's own repo, so an unattributable node fails **open**; failing closed would reinstate the empty rollup.

`add-sub-item` carries no such filter (it is a `gh issue edit --parent` write plus a synthesized record), and `list-frontier --parent` needed no change — fixing `list-sub-items` fixes it by derivation.

## Verification

Run from this branch's worktree adapter (`.work-item-tracker.json` at the worktree root), not the installed plugin cache.

```console
$ bash plugins/work-items/tools/work-item-tracker/work-item-tracker.sh list-sub-items "github:melodic-software/claude-code-plugins#3799" | jq -c '[.items[] | {id, state, blocked_by_count, parent_id}]'
[{"id":"github:melodic-software/claude-code-plugins#3824","state":"open","blocked_by_count":1,"parent_id":"github:melodic-software/claude-code-plugins#3799"},
 {"id":"github:melodic-software/claude-code-plugins#3823","state":"open","blocked_by_count":1,"parent_id":"github:melodic-software/claude-code-plugins#3799"},
 {"id":"github:melodic-software/claude-code-plugins#3822","state":"open","blocked_by_count":1,"parent_id":"github:melodic-software/claude-code-plugins#3799"},
 {"id":"github:melodic-software/claude-code-plugins#3821","state":"open","blocked_by_count":1,"parent_id":"github:melodic-software/claude-code-plugins#3799"},
 {"id":"github:melodic-software/claude-code-plugins#3814","state":"open","blocked_by_count":1,"parent_id":"github:melodic-software/claude-code-plugins#3799"},
 {"id":"github:melodic-software/claude-code-plugins#3805","state":"open","blocked_by_count":0,"parent_id":"github:melodic-software/claude-code-plugins#3799"}]
```

All six sub-issues, correctly re-parented. (Before the fix: `{"schema_version":"1.0","items":[]}`.)

```console
$ bash plugins/work-items/tools/work-item-tracker/work-item-tracker.sh list-frontier --parent "github:melodic-software/claude-code-plugins#3799" | jq -c '{schema_version, ids: [.items[].id]}'
{"schema_version":"1.0","ids":["github:melodic-software/claude-code-plugins#3805"]}
```

#3805 is the only child with zero open blockers and no assignee, so it is the whole scoped frontier — matching the acceptance criterion.

## Tests

- `common.test.sh` — six fixtures for `wit_gh_subissue_child_numbers`: verbatim gh 2.97.0 output (no `repository`), a foreign-repo url, a GHES url, the GraphQL shape, an unattributable node, and an absent connection.
- `list-sub-items.test.sh` — a gh stub serving the real 2.97 projection drives the verb end to end over a container with three sub-issues (open, closed, cross-repo) and asserts the rollup, the cross-repo drop, and re-parenting.

Both fail on the old predicate — verified by temporarily reinstating it:

```
FAIL: [30] gh --json subIssues nodes (no repository field) keep same-repo children — expected [3805,3814] got []
FAIL: [7] container with sub-issues rolls up its same-repo children — expected ["github:o/r#11","github:o/r#12"] got []
```

## Checks

| check | result |
| --- | --- |
| `node scripts/validate-plugin-contracts.mjs` | pass (3330 plugin files) |
| `shellcheck -x` on the four changed shell files | pass |
| `shfmt -d -i 2` | clean |
| `markdownlint-cli2` on the adapter README | 0 issues |
| seam suite `adapters/github/*.test.sh` | 105 pass / 0 fail |
| `lib/*.test.sh`, `conformance/*.test.sh` | pass, except `lib/binding.test.sh` (2 pre-existing Git-Bash `/tmp` path-translation failures) |
| `work-item-tracker.test.sh` | 61 pass / 2 fail — both pre-existing, reproduced identically on the unmodified tree (the no-gh case also loses `jq` from the stripped `PATH`) |

Acceptance criterion 4 (record the verified gh version) is satisfied by a new Gotchas entry in `adapters/github/README.md`.

Closes #3825

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012jiwedVq2GxuzN7siXQbr4
