### PR TITLE
docs: state that this repository is the authoritative listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,19 @@ This repo tracks policy and wiring only; authoritative behavior lives in the off
 be read fresh rather than recalled. Start at the
 [Claude Code plugins guide](https://code.claude.com/docs/en/plugins).
 
+## What this marketplace actually publishes
+
+This repository is the only authoritative listing of what this marketplace publishes. The plugins and
+skills it ships are the ones present in `plugins/` on the default branch, and the
+[marketplace manifest](.claude-plugin/marketplace.json) is the machine-readable form of that list.
+
+Several third-party aggregator and directory sites republish Claude Code skill listings, and some of
+them attribute skills to this publisher that have never existed here. A search of the full commit
+history of this repository found no trace of them. If you find a skill credited to this marketplace
+that you cannot locate in `plugins/` on the default branch, it is not ours, whatever a directory
+says. Install from the source above rather than from a mirror or a directory listing, and treat an
+aggregator's metadata as unverified.
+
 ## License
 
 [MIT](LICENSE).


### PR DESCRIPTION
No related issue: this PR refs #3804 but must not close it. It executes one of the three dispositions that issue offered; the takedown-or-correction decision for the six third-party sites stays open there.

Refs: #3804

## Summary

Adds a README section naming this repository and its marketplace manifest as the only authoritative listing of what this marketplace publishes.

Several third-party aggregator and directory sites list Claude Code skills attributed to this publisher that have never existed here. A search of the full commit history of this repository found no trace of any of them.

#3804 offered three dispositions: send takedown or correction requests, add a README disclaimer, or ignore it. The disclaimer is the one this repository can execute on its own. Takedown requests mean contacting six third parties and are a separate decision that stays open; ignoring leaves the false attribution unanswered for anyone who arrives from a directory listing.

## Fix

One additive section in `README.md`, 13 lines, no other file touched.

The section states the positive fact first, that `plugins/` on the default branch and `.claude-plugin/marketplace.json` are the real list, and then gives the reader a test they can apply themselves: a skill credited here that is not in `plugins/` is not ours.

It deliberately does not name the individual aggregator sites. That list would go stale as sites appear, rename, and disappear, and it would put this repository in the position of maintaining a register of other people's mistakes. The durable, actionable half is the statement of where the authoritative list lives.

## Verification

- `npx markdownlint-cli2 README.md` — `Summary: 0 issues in 0 files`
- `node scripts/validate-plugin-contracts.mjs` — `3330 plugin files checked`, exit 0
- `bash scripts/check-changelog-parity.sh --check-bump main` — passes; no plugin files changed, so no version bump is required
- The relative link target `.claude-plugin/marketplace.json` was confirmed to exist on this branch

## Related

- #3804, referenced rather than closed. The issue is closed separately by recording the chosen disposition in a closing comment.

---

_Body restructured to the `pr-issue-linkage` contract by the merge lane (`ccr-session-babysit-loop-20260906`): added the opening linkage line and the `## Summary`, `## Fix`, and `## Related` headings the gate reported missing. No claim, verification result, or reasoning was changed, added, or removed; the original `## What`, `## Why`, and `## Shape of the wording` prose is preserved verbatim under the required headings._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012jiwedVq2GxuzN7siXQbr4