### PR TITLE
ci: pin the claude lanes to ci-workflows v0.22.1

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -58,7 +58,7 @@ jobs:
     concurrency:
       group: claude-review-${{ github.repository }}
       queue: max
-    uses: melodic-software/ci-workflows/.github/workflows/claude-review.yml@62bef7bab01e8532fedfa739879034a210e9e67d # v0.14.0
+    uses: melodic-software/ci-workflows/.github/workflows/claude-review.yml@cd2f4e6d500e7923c0db521b4d10034d36331ed3 # v0.22.1
     with:
       runner: ubuntu-24.04
       # Empty on a pull_request event, where the payload supplies the number

--- a/.github/workflows/claude-security-review.yml
+++ b/.github/workflows/claude-security-review.yml
@@ -105,7 +105,7 @@ jobs:
       contents: read         # checkout + read the diff
       pull-requests: write   # post the security review
       id-token: write        # OIDC — mints the Claude GitHub App token
-    uses: melodic-software/ci-workflows/.github/workflows/claude-security-review.yml@7107b34832a7b6db5d08d3b132621c599fbe5e50 # v0.14.2
+    uses: melodic-software/ci-workflows/.github/workflows/claude-security-review.yml@cd2f4e6d500e7923c0db521b4d10034d36331ed3 # v0.22.1
     with:
       runner: ubuntu-24.04
       paths-file: .github/claude-security-paths


### PR DESCRIPTION
No related issue: locally owned claude-lane pins left behind by the Phase 6b-i convergence (ci-perf program, melodic-software/github-iac#378)

## Summary

Re-pin the two claude-lane callers, claude-review.yml and claude-security-review.yml, from stale ci-workflows versions to the current v0.22.1, matching the convergence already applied elsewhere in the ci-perf program.

## Fix

Updated the `uses:` reference in `.github/workflows/claude-review.yml` from `@62bef7bab01e8532fedfa739879034a210e9e67d # v0.14.0` to `@cd2f4e6d500e7923c0db521b4d10034d36331ed3 # v0.22.1`, and in `.github/workflows/claude-security-review.yml` from `@7107b34832a7b6db5d08d3b132621c599fbe5e50 # v0.14.2` to the same v0.22.1 SHA. The reusable `workflow_call` inputs and secrets for both workflows are unchanged across that version range, and the synced `.github/standards/runner-policy/policy.json` already carries both contracts at that SHA, so no other file requires a change.

## Verification

`git diff --stat` on the branch shows exactly two files changed, one line each. No behavior change beyond the pin: `with:` blocks, permissions, and concurrency settings for both callers are untouched.

## Related

melodic-software/github-iac#378
