### PR TITLE
ci: re-pin ci-status to ci-workflows v0.22.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1976,7 +1976,7 @@ jobs:
         # aggregation: the job still fails on the contract step's exit code, and
         # the `ci-lanes` status is on the SHA for the next contract-only run.
         if: ${{ !cancelled() }}
-        uses: melodic-software/ci-workflows/.github/actions/ci-status@906ae7ef379ea4d2b8497f64475dce1d3d8715c4 # v0.22.0
+        uses: melodic-software/ci-workflows/.github/actions/ci-status@5776760254f8b63cba44e896f51604cb755350d9 # v0.22.2
         with:
           # Derived from the needs graph above — the single source of truth for
           # the lane list. Adding a lane to needs automatically extends this


### PR DESCRIPTION
No related issue: ci-workflows#561 re-pin (ci-perf program, melodic-software/github-iac#378)

## Summary

Re-pins the `ci-status` composite in `.github/workflows/ci.yml` from `906ae7ef379ea4d2b8497f64475dce1d3d8715c4` (v0.22.0) to `5776760254f8b63cba44e896f51604cb755350d9` (v0.22.2). All other `ci-workflows` pins in this repository are unchanged and move together in Phase 6b-ii.

## Fix

v0.22.0 and v0.22.1 of the `ci-status` composite red the sole required check on contract-only runs (label or body edit) when the full run on the same SHA draws a higher run id, or when one status read fails mid-wait. `melodic-software/ci-workflows#562` (closes `melodic-software/ci-workflows#561`) fixed both: the carry-forward wait now waits on any in-flight sibling run rather than lower run ids only, and a status read that fails mid-wait takes one fresh re-read instead of failing the run. `v0.22.2` carries this fix.

## Verification

- `grep -n "actions/ci-status@" .github/workflows/ci.yml` prints one line ending `@5776760254f8b63cba44e896f51604cb755350d9 # v0.22.2`.
- `git diff origin/main --stat` shows `1 file changed, 1 insertion(+), 1 deletion(-)`.
- `actionlint .github/workflows/ci.yml` is clean.
- The full CI run on this PR's head SHA is watched for a green `ci-status` job.
- A live probe (title edit then revert) triggers a contract-only run to confirm the carry-forward fix path works as expected.

## Related

Refs melodic-software/github-iac#378
Refs melodic-software/ci-workflows#561
