### PR TITLE
feat(codebase-health): route the audit Boundary to the sibling drift lanes

### DIFF
--- a/plugins/codebase-health/.claude-plugin/plugin.json
+++ b/plugins/codebase-health/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "codebase-health",
-  "version": "0.8.9",
+  "version": "0.8.10",
   "description": "Repo-wide drift audit between docs, config, code, and architecture: verifies every factual claim against reality via parallel subagent fan-out, severity-rates findings, and reports read-only, delegating remediation to the implementation/verification lanes. Audit dimensions are configurable through a tracked .claude/codebase-health.md config file written by the setup skill.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/codebase-health/CHANGELOG.md
+++ b/plugins/codebase-health/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to the `codebase-health` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.8.10]
+
+### Added
+
+- **`audit`:** a `## Boundary. The sibling drift lanes` section naming the seven adjacent drift lanes with one line each on what that lane owns: review's `doc-drift-detector` agent, `/session-flow:reanchor`, `/discipline:recheck-against-upstream`, `/provenance:audit`, `/claude-config:audit` (plus `/claude-config:audit-automation-gaps`), `/instruction-placement:delta`, and `/overengineering:delta`. Every route is presence-gated with a stated fallback per the seam-phrasing convention: route when the plugin is installed, otherwise report the dimension as uncovered rather than running claim-extraction over it here (#3810).
+
+### Changed
+
+- **`audit`:** the "Scope boundary with adjacent audit lanes" paragraph in "Adapting to your environment" is now a pointer to the new Boundary section, which absorbed its `claude-config` routing so the reference is stated once. What the audit detects and how it reports are unchanged.
+- README: the "Distinct from" paragraph names the sibling drift lanes the audit's Boundary routes to.
+
 ## [0.8.9]
 
 ### Changed

--- a/plugins/codebase-health/CHANGELOG.md
+++ b/plugins/codebase-health/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to the `codebase-health` plugin are documented here. Format 
 
 ### Added
 
-- **`audit`:** a `## Boundary. The sibling drift lanes` section naming the seven adjacent drift lanes with one line each on what that lane owns: review's `doc-drift-detector` agent, `/session-flow:reanchor`, `/discipline:recheck-against-upstream`, `/provenance:audit`, `/claude-config:audit` (plus `/claude-config:audit-automation-gaps`), `/instruction-placement:delta`, and `/overengineering:delta`. Every route is presence-gated with a stated fallback per the seam-phrasing convention: route when the plugin is installed, otherwise report the dimension as uncovered rather than running claim-extraction over it here (#3810).
+- **`audit`:** a `## Boundary. The sibling drift lanes` section naming the seven adjacent drift lanes with one line each on what that lane owns: review's `doc-drift-detector` agent, `/session-flow:reanchor`, `/discipline:recheck-against-upstream`, `/provenance:audit`, `/claude-config:audit` (plus `/claude-config:audit-automation-gaps`), `/instruction-placement:delta`, and `/overengineering:delta`. The section routes the operator and is never a dispatch list for the skill itself: a dimension owned by another lane is reported as uncovered and the lane is named as a suggestion to run next, whether or not its plugin is installed. The skill does not invoke a sibling, because several of them mutate (`/discipline:recheck-against-upstream` corrects divergences forward as it finds them) and a bare `audit` is read-only under its own verb contract. `--fix` authorizes remediation of this skill's own findings and does not extend to a sibling lane (#3810).
 
 ### Changed
 

--- a/plugins/codebase-health/README.md
+++ b/plugins/codebase-health/README.md
@@ -8,6 +8,13 @@ Distinct from diff/PR review (which judges a change) and from Claude Code config
 check `settings.json` / hooks / permissions): this plugin verifies whether the repo's own written
 claims about itself are true.
 
+Other kinds of drift belong to sibling lanes, and the audit skill's **Boundary** section routes an
+operator to each one: review's documentation-freshness agent, session-premise re-anchoring,
+upstream-conformance rechecking, provenance of copied prose, Claude Code configuration and
+automation-gap audits, instruction-placement movement, and enforcement-surface movement. Every one of
+those routes is presence-gated. It applies when that plugin is installed, and the dimension is
+reported as uncovered when it is not.
+
 | Skill | What it does |
 |---|---|
 | `/codebase-health:audit` | Runs the audit. Prime conventions, fan out claim-extraction per file, independently validate, severity-rate, and report read-only; remediation is delegated to the implementation/verification lanes. |

--- a/plugins/codebase-health/skills/audit/SKILL.md
+++ b/plugins/codebase-health/skills/audit/SKILL.md
@@ -72,10 +72,14 @@ This skill owns ONE kind of drift: the **factual claims a repo makes about itsel
 code, and architecture notes, verified against that repo's own ground truth. Seven adjacent lanes own
 the other kinds, and an operator who reached this skill is often standing in one of them.
 
-Each lane is optional collaboration, never a requirement of this skill. Route to one **when its
-plugin is installed**, invoking the skill via the Skill tool (the agent lane via the Agent tool).
-When the plugin is absent, say that dimension is out of scope for this run and report it as
-uncovered, rather than running claim-extraction over it here.
+This section is a router for the operator, not a dispatch list for this skill. A bare `audit` is
+READ-ONLY, and some of these lanes mutate: `/discipline:recheck-against-upstream` corrects
+divergences forward as it finds them, and several others carry an explicit fix mode. Invoking one
+from inside a read-only run would let this skill edit the repository through a sibling, which its own
+verb contract forbids. So a dimension that belongs to another lane is reported as **uncovered**, and
+the lane is **named as a suggestion the operator can run next**, whether or not its plugin is
+installed. Under `--fix` the operator has authorized mutation for this skill's own findings only;
+that authorization does not extend to running a sibling lane's remediation.
 
 - **Documentation freshness inside a review pass** → the `review` plugin's `doc-drift-detector`
   agent, a dispatchable reviewer for stale references, outdated conventions, and pages that no longer

--- a/plugins/codebase-health/skills/audit/SKILL.md
+++ b/plugins/codebase-health/skills/audit/SKILL.md
@@ -62,13 +62,45 @@ optional; using one when your setup provides it is not, per Phase 2's external-r
 such tool, follow the inline graceful-degrade guidance, which confidence-tags the
 externally-unverifiable part `needs-review` rather than guessing.
 
-Scope boundary with adjacent audit lanes: this skill verifies **factual claims** in docs/config
-against code state. Claude Code configuration files (`settings.json`, `.mcp.json`, hooks,
-permissions) and automation-landscape gap analysis are different lanes, when the
-`claude-config` plugin is installed, route those to `/claude-config:audit` and
-`/claude-config:audit-automation-gaps`, invoked via the Skill tool; otherwise state they are out of
-scope rather than
-running claim-extraction over them.
+Scope boundary with adjacent audit lanes: see [Boundary](#boundary-the-sibling-drift-lanes) below.
+
+---
+
+## Boundary. The sibling drift lanes
+
+This skill owns ONE kind of drift: the **factual claims a repo makes about itself** in docs, config,
+code, and architecture notes, verified against that repo's own ground truth. Seven adjacent lanes own
+the other kinds, and an operator who reached this skill is often standing in one of them.
+
+Each lane is optional collaboration, never a requirement of this skill. Route to one **when its
+plugin is installed**, invoking the skill via the Skill tool (the agent lane via the Agent tool).
+When the plugin is absent, say that dimension is out of scope for this run and report it as
+uncovered, rather than running claim-extraction over it here.
+
+- **Documentation freshness inside a review pass** → the `review` plugin's `doc-drift-detector`
+  agent, a dispatchable reviewer for stale references, outdated conventions, and pages that no longer
+  earn their existence. It overlaps this skill's `documentation` dimension: that dimension is the
+  exhaustive per-file claim fan-out with an independent validation gate, the agent is the review
+  lane's single-pass sweep.
+- **A session's own working premises** → `/session-flow:reanchor`, which verifies that the PRs,
+  issues, branches, plans, and cited skills a session is building on are still in the state it
+  assumes. Premises about the work in flight, not claims written in the repo.
+- **Divergence from current upstream documentation** → `/discipline:recheck-against-upstream`, which
+  audits the surface in flight against the vendor's own current official docs and classifies each
+  divergence. This skill checks claims against the repo; that lane checks the repo against upstream.
+- **Prose restating an external source** → `/provenance:audit`, which finds passages copied from a
+  source someone else owns with no pointer or stamped record, and converts them into links,
+  citations, or stamped records. Ownership of the text, not truth of the claim.
+- **Claude Code's own configuration** → `/claude-config:audit` for settings files, `.mcp.json`,
+  hooks, plugins, permissions, and environment variables, and
+  `/claude-config:audit-automation-gaps` for automation-landscape gap analysis. Neither is this
+  skill's `configuration` dimension, which reads the consuming repo's own build, CI, and tool config.
+- **Instruction content sitting on the wrong load surface** → `/instruction-placement:delta`, which
+  re-runs the placement audit and reports only what moved: new demote/promote candidates, rule globs
+  that stopped resolving, and index drift.
+- **The enforcement surface's own accumulation** → `/overengineering:delta`, which re-runs the
+  enforcement-surface audit (hooks, CI lanes, gate scripts, branch protections) and reports only what
+  moved since the last run. Whether a guard still earns its keep, not whether a claim is true.
 
 ---
 


### PR DESCRIPTION
## What

Adds a `## Boundary. The sibling drift lanes` section to the codebase-health audit skill, naming the seven adjacent drift lanes with one line each on what that lane owns.

Closes #3810.

> Supersedes #3829, which was closed accidentally during a rebase-and-merge attempt and could not be reopened because its recorded head commit no longer existed. Same branch, same work, plus the review fix described below. The review discussion on #3829 is still worth reading.

## The lanes

The review plugin's `doc-drift-detector` agent, `/session-flow:reanchor`, `/discipline:recheck-against-upstream`, `/provenance:audit`, `/claude-config:audit` with its automation-gaps sibling, `/instruction-placement:delta`, and `/overengineering:delta`. Each ownership line was derived by reading that lane's own skill or agent definition rather than inferred.

## The review fix, which mattered

The first version told the skill to **invoke** a sibling lane whenever its plugin was installed. One of those lanes, `/discipline:recheck-against-upstream`, corrects divergences forward as it finds them, and several others carry a fix mode. A bare `audit` is read-only under this skill's own verb contract, so invoking them from inside a read-only run would have let the skill edit the repository through a sibling.

Issue #3810 only ever asked the Boundary to name the lanes so an operator has a path to them. Automatic dispatch was scope the implementation invented, and the skill already states elsewhere that it must not auto-invoke its remediation lanes.

The section is now a router for the operator. A dimension owned by another lane is reported as uncovered and the lane is named as a suggestion to run next, whether or not its plugin is installed. The body also states that `--fix` authorizes remediation of this skill's own findings only and does not extend to a sibling lane, so the mutation boundary is explicit rather than implied.

## Verification

- `bash scripts/check-changed-skills.sh main` — `CHECK-SKILL audit: PASS — 0 errors, 7 warning(s)`, `1 skill(s) checked, 0 failed`. All seven warnings predate this change.
- `npx markdownlint-cli2` on the changed files — `Summary: 0 issues in 0 files`
- `node scripts/validate-plugin-contracts.mjs` — `3330 plugin files checked`, exit 0
- `bash scripts/check-changelog-parity.sh --check-bump main` — exit 0
- Version bumped `0.8.9` → `0.8.10` with a matching changelog entry.

## Scope

Four files, all inside the codebase-health plugin: the audit skill body, the plugin README, its changelog, and its manifest. No sibling skill was edited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012jiwedVq2GxuzN7siXQbr4
