### PR TITLE
fix(context-budget): correct the additivity claim and report the verdict per bucket

### DIFF
--- a/plugins/context-budget/.claude-plugin/plugin.json
+++ b/plugins/context-budget/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "context-budget",
-  "version": "0.6.23",
+  "version": "0.6.24",
   "description": "Measure a Claude Code session's fixed startup context payload per item, on the consumer's machine at a pinned, version-stamped binary \u2014 including per-tool attribution of the built-in tool pools that /context reports only as lump sums, derived live by A/B bare-name-deny differencing with enforced comparability rules (skill-listing signature, one mode, one binary), an SDK-primary exact meter degrading to a version-aware headless /context parser and then to an honest structured error (never a wrong number), and a per-project measure-toggle-remeasure ledger under the plugin data directory recording every lever's real before/after delta. Report-only: prints exact config, applies nothing.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/context-budget/CHANGELOG.md
+++ b/plugins/context-budget/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to the `context-budget` plugin.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.24]
+
+### Changed
+
+- **The additivity claim is corrected in every home that carried it.** The skill
+  body, the `deny-bare-tool` lever's `categoryBasis`, and the plugin README each
+  asserted flatly that deltas add and a basket prices from its members. Measured
+  readings say otherwise per bucket: the deferred side sums to the token, while
+  the prefix side double-counts, so the sum of prefix deltas is only an upper
+  bound on a basket's prefix saving. All three now say which side composes and
+  which does not, and point at `attribute --verify-additivity` for the
+  per-bucket verdict. (#3863)
+- **`attribute --verify-additivity` reports a verdict per attributed bucket.**
+  The record gains `perBucket`, carrying `{sumOfParts, combinedSaved, additive,
+  reasons}` for each bucket, derived from the `prefixDelta`/`deferredDelta`
+  values the per-tool rows already carry: no extra measurement pass, and one
+  bucket vanishing no longer costs the other bucket its verdict. A bucket absent
+  from both runs is outside the binary's category vocabulary and gets no verdict
+  row. (#3863)
+- **`additive` is tri-state instead of boolean.** It was computed from the
+  comparability flag, so an unmeasurable reading published as a definite
+  `false`. `true` and `false` are now measured verdicts and `null` means the
+  reading could not be measured, top level and per bucket alike. The saturation
+  guard that produces the null saving is unchanged. (#3863)
+
 ## [0.6.23]
 
 ### Changed

--- a/plugins/context-budget/CHANGELOG.md
+++ b/plugins/context-budget/CHANGELOG.md
@@ -15,8 +15,9 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   readings say otherwise per bucket: the deferred side sums to the token, while
   the prefix side double-counts, so the sum of prefix deltas is only an upper
   bound on a basket's prefix saving. All three now say which side composes and
-  which does not, and point at `attribute --verify-additivity` for the
-  per-bucket verdict. (#3863)
+  which does not. The skill body and the lever's `categoryBasis` also point at
+  `attribute --verify-additivity` for the per-bucket verdict; the README states
+  the corrected claim without that pointer. (#3863)
 - **`attribute --verify-additivity` reports a verdict per attributed bucket.**
   The record gains `perBucket`, carrying `{sumOfParts, combinedSaved, additive,
   reasons}` for each bucket, derived from the `prefixDelta`/`deferredDelta`

--- a/plugins/context-budget/CHANGELOG.md
+++ b/plugins/context-budget/CHANGELOG.md
@@ -22,9 +22,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   The record gains `perBucket`, carrying `{sumOfParts, combinedSaved, additive,
   reasons}` for each bucket, derived from the `prefixDelta`/`deferredDelta`
   values the per-tool rows already carry: no extra measurement pass, and one
-  bucket vanishing no longer costs the other bucket its verdict. A bucket absent
-  from both runs is outside the binary's category vocabulary and gets no verdict
-  row. (#3863)
+  bucket vanishing no longer costs the other bucket its verdict. Skill-listing
+  and Skills-token checks gate only the prefix column; the shared mode/binary
+  checks gate both, so a combined-run listing mismatch does not publish the
+  deferred verdict as unmeasured. A bucket absent from both runs is outside the
+  binary's category vocabulary and gets no verdict row. (#3863)
 - **`additive` is tri-state instead of boolean.** It was computed from the
   comparability flag, so an unmeasurable reading published as a definite
   `false`. `true` and `false` are now measured verdicts and `null` means the

--- a/plugins/context-budget/README.md
+++ b/plugins/context-budget/README.md
@@ -7,8 +7,10 @@ pinned binary, and record what every trim actually saved.
 the built-in tool pool: `System tools` and `System tools (deferred)` are lump sums, and together
 they are typically the largest single contributor to the fixed payload. This plugin attributes
 them per tool by A/B differencing: a baseline headless session versus one session per candidate
-tool with that tool denied by bare name. The deltas are compositional, so a basket of trims can be
-priced from its members.
+tool with that tool denied by bare name. The two attributed buckets compose differently:
+deferred-side deltas add, so a basket's deferred saving is the sum of its members, while
+prefix-side deltas double-count, so their sum is only an upper bound on the basket's prefix
+saving.
 
 ## Install
 

--- a/plugins/context-budget/skills/audit/SKILL.md
+++ b/plugins/context-budget/skills/audit/SKILL.md
@@ -15,8 +15,11 @@ What it structurally cannot itemise is the built-in tool pool: `System tools` an
 `System tools (deferred)` are lump sums, and together they are typically the largest single
 contributor to the fixed startup payload. This skill measures that attribution on the consumer's
 own machine by A/B differencing: a baseline session versus one session per candidate tool with
-that tool denied by bare name, which is compositional (deltas add), so a basket of trims can be
-priced from its members.
+that tool denied by bare name. The two attributed buckets compose differently, so price a basket
+per bucket rather than as one number: deferred-side deltas add, and a basket's deferred saving is
+the sum of its members; prefix-side deltas double-count, and their sum is only an upper bound on
+what the basket saves on the prefix side. Confirm both on this binary with
+`attribute --verify-additivity`, which reports its verdict per bucket.
 
 Two rules govern everything this skill says, per the plugin's
 [`reference/engine.md`](reference/engine.md):

--- a/plugins/context-budget/skills/audit/reference/engine.md
+++ b/plugins/context-budget/skills/audit/reference/engine.md
@@ -65,7 +65,14 @@ All records are JSON on stdout (and `--out <file>`), schema-tagged:
 - `context-budget.attribution/1` — `baseline` (summary), ranked `perTool[]` rows
   `{tool, prefixDelta, deferredDelta, savedTokens, comparable, reasons}`, optional `additivity`
   (`--verify-additivity`: one combined-deny run checked against the sum of parts, with its own
-  `comparable`/`reasons`), `knownUncovered` (interactive-only product tools from
+  `comparable`/`reasons`, plus `perBucket` carrying `{sumOfParts, combinedSaved, additive,
+  reasons}` for each attributed bucket, read off the `prefixDelta`/`deferredDelta` the saver rows
+  already carry rather than from any extra run; a bucket absent from both runs is outside the
+  binary's category vocabulary and gets no verdict row). Every `additive` field, top level and per
+  bucket, is tri-state: `true` and `false` are measured verdicts, `null` means the reading could
+  not be measured, so an incomparable run is never published as a definite negative. The two
+  buckets are reported separately because they do not compose alike: the deferred side adds, the
+  prefix side double-counts. `knownUncovered` (interactive-only product tools from
   [`interactive-only-tools.json`](interactive-only-tools.json) that were not candidates this
   run — structurally unreachable from a headless inventory, not silent zeros), plus the binary
   stamp and `skillListingSignature`. A deny can empty a

--- a/plugins/context-budget/skills/audit/reference/engine.md
+++ b/plugins/context-budget/skills/audit/reference/engine.md
@@ -35,14 +35,17 @@ never silently assumed durable.
 
 ## Comparability rules (enforced, not advisory)
 
-1. **Skill-listing signature.** The `System tools` bucket has listed skill-frontmatter tokens
-   subtracted from it, so its value is only meaningful relative to a run with an identical skill
-   listing. Every snapshot carries `skillListing.signature` — a hash of the sorted
+1. **Skill-listing signature.** The prefix `System tools` bucket has listed skill-frontmatter
+   tokens subtracted from it, so its value is only meaningful relative to a run with an identical
+   skill listing. Every snapshot carries `skillListing.signature` — a hash of the sorted
    (name, source) listing — and `compare`/`attribute` mark `systemToolsComparable: false` on
-   mismatch, with the reason in `comparability.reasons`. Denying a tool changes no skills, which
-   is what makes per-tool attribution well-posed under this rule.
+   mismatch, with the reason in `comparability.reasons`. The deferred bucket is a separate pool
+   and listing or Skills-token drift does not poison it: per-bucket additivity applies this gate
+   only to the prefix column. Denying a tool changes no skills, which is what makes per-tool
+   attribution well-posed under this rule.
 2. **One mode, one binary.** Deltas across modes mix precisions; deltas across binary versions or
-   paths measure the upgrade, not the lever. Both mark the row incomparable.
+   paths measure the upgrade, not the lever. Both mark the row incomparable. These shared checks
+   apply to both attributed buckets (`comparability.modeBinaryComparable`).
 3. **Signed deltas.** `delta` is after-minus-before (a saving is negative); `attribute` rows carry
    `savedTokens` with the sign flipped for ranking. `prefixDelta` and `deferredDelta` stay
    separate: a deferred-bucket saving reduces request weight without moving the context-usage
@@ -68,11 +71,14 @@ All records are JSON on stdout (and `--out <file>`), schema-tagged:
   `comparable`/`reasons`, plus `perBucket` carrying `{sumOfParts, combinedSaved, additive,
   reasons}` for each attributed bucket, read off the `prefixDelta`/`deferredDelta` the saver rows
   already carry rather than from any extra run; a bucket absent from both runs is outside the
-  binary's category vocabulary and gets no verdict row). Every `additive` field, top level and per
-  bucket, is tri-state: `true` and `false` are measured verdicts, `null` means the reading could
-  not be measured, so an incomparable run is never published as a definite negative. The two
-  buckets are reported separately because they do not compose alike: the deferred side adds, the
-  prefix side double-counts. `knownUncovered` (interactive-only product tools from
+  binary's category vocabulary and gets no verdict row). Per-bucket measurability is independent:
+  skill-listing and Skills-token checks gate only the prefix column, while the shared mode/binary
+  checks gate both, so a combined-run listing mismatch leaves a measurable deferred verdict in
+  place. Every `additive` field, top level and per bucket, is tri-state: `true` and `false` are
+  measured verdicts, `null` means the reading could not be measured, so an incomparable run is
+  never published as a definite negative. The two buckets are reported separately because they
+  do not compose alike: the deferred side adds, the prefix side double-counts.
+  `knownUncovered` (interactive-only product tools from
   [`interactive-only-tools.json`](interactive-only-tools.json) that were not candidates this
   run — structurally unreachable from a headless inventory, not silent zeros), plus the binary
   stamp and `skillListingSignature`. A deny can empty a
@@ -86,8 +92,9 @@ All records are JSON on stdout (and `--out <file>`), schema-tagged:
   consumer can tell a reported 0 from a filled-in omission. A bucket absent from *both* runs is
   outside that binary's category vocabulary and simply contributes nothing.
 - `context-budget.ledger/1` — one before/after: `lever`, `emittedConfig`, `before`/`after`
-  summaries, `delta` per category, `totalDelta`, `comparability`. A category present in only one
-  run gets `null`, never an invented number.
+  summaries, `delta` per category, `totalDelta`, `comparability` (`ok`, `systemToolsComparable`
+  for the prefix bucket, `modeBinaryComparable` for the shared mode/binary checks, `reasons`).
+  A category present in only one run gets `null`, never an invented number.
 - `context-budget.catalogue-verify/1` — `verify-catalogue`: a docs-independent existence
   check. Reads the stamped binary and reports `present`/`absent` (with hit counts) for every
   settings key and env name the catalogue row names. The binary is the authority on *existence

--- a/plugins/context-budget/skills/audit/reference/levers.json
+++ b/plugins/context-budget/skills/audit/reference/levers.json
@@ -27,7 +27,7 @@
       "title": "Bare tool name in permissions.deny (or --disallowedTools per invocation)",
       "mechanism": "A deny rule that is a bare tool name removes that tool's definition from the request; the schema no longer ships.",
       "category": "removes-weight",
-      "categoryBasis": "Documented in request terms and reproduced by this plugin's own differencing engine; deltas are additive, so a basket prices from its members.",
+      "categoryBasis": "Documented in request terms and reproduced by this plugin's own differencing engine. The two attributed buckets compose differently: deferred-side deltas add, so a basket's deferred saving is the sum of its members, while prefix-side deltas double-count, so their sum is only an upper bound on the basket's prefix saving. attribute --verify-additivity reports its verdict per bucket.",
       "conditions": null,
       "posture": "recommendable-on-fit",
       "scope": "permissions.deny in any settings scope (user, project, local, managed); --disallowedTools for one invocation.",

--- a/plugins/context-budget/skills/audit/reference/report.md
+++ b/plugins/context-budget/skills/audit/reference/report.md
@@ -27,7 +27,8 @@ mode; the displayed fraction in cli-parse mode).
 4. **Ranked per-tool attribution.** From the attribution record: one row per measured tool —
    `savedTokens`, split into `prefixDelta` / `deferredDelta`, with the `comparable` flag. Rows
    the engine marked incomparable appear with their reason instead of their numbers. If the
-   additivity check ran, state its verdict in one line. Unmeasured tools (candidates this run
+   additivity check ran, state its verdict per bucket, one line each, and report a null verdict as
+   not measurable rather than as not additive. Unmeasured tools (candidates this run
    that were not priced) are listed as unmeasured, not omitted — silence reads as "measured
    zero". Tools that exist only in an interactive session — Artifact, SendUserFile,
    AskUserQuestion, plan-mode tools, interactive-only MCP servers — are listed as

--- a/plugins/context-budget/skills/audit/scripts/measure.mjs
+++ b/plugins/context-budget/skills/audit/scripts/measure.mjs
@@ -616,6 +616,49 @@ function vanishedReason(vanished) {
     + 'snapshot, so its delta is unmeasured, not zero';
 }
 
+// Per-bucket additivity, read off the deltas the per-tool rows already carry:
+// no extra measurement pass, just the rows this run produced. The two sides
+// do not compose alike — the deferred side sums to the token while the prefix
+// side double-counts — so one verdict over the pair hides which column an
+// operator can price a basket from.
+const BUCKET_ROW_FIELD = {
+  'System tools': 'prefixDelta',
+  'System tools (deferred)': 'deferredDelta',
+};
+
+// A verdict is `true`/`false` only when the bucket was measured on both sides
+// of the comparison; anything unmeasured is `null` — "not measurable" is not
+// the same answer as "measured, and not additive".
+function bucketAdditivity(rows, cmp, runComparable) {
+  const perBucket = {};
+  for (const bucket of SYSTEM_TOOL_BUCKETS) {
+    // A bucket absent from BOTH runs is outside this binary's category
+    // vocabulary: a non-event, so it gets no verdict row at all.
+    if (!(bucket in cmp.delta)) continue;
+    const parts = rows.map((r) => r[BUCKET_ROW_FIELD[bucket]]);
+    const sumOfParts = parts.some((d) => typeof d !== 'number')
+      ? null
+      : -parts.reduce((sum, d) => sum + d, 0);
+    const combinedDelta = cmp.delta[bucket];
+    const combinedSaved = typeof combinedDelta === 'number' ? -combinedDelta : null;
+    const measured = runComparable && sumOfParts !== null && combinedSaved !== null;
+    const reasons = [];
+    if (!runComparable) reasons.push(...cmp.comparability.reasons);
+    if (combinedSaved === null) reasons.push(vanishedReason([bucket]));
+    if (sumOfParts === null) {
+      reasons.push(`${bucket} is unmeasured on at least one per-tool row, so the sum of parts `
+        + 'for this bucket is unmeasured, not zero');
+    }
+    perBucket[bucket] = {
+      sumOfParts,
+      combinedSaved,
+      additive: measured ? combinedSaved === sumOfParts : null,
+      reasons,
+    };
+  }
+  return perBucket;
+}
+
 function loadInteractiveOnly() {
   let data;
   try {
@@ -689,12 +732,21 @@ async function runAttribute(args) {
       const comparable = cmp.comparability.systemToolsComparable && !vanished.length;
       const sumOfParts = perTool.filter((t) => savers.includes(t.tool))
         .reduce((s, t) => s + t.savedTokens, 0);
+      const saverRows = perTool.filter((t) => savers.includes(t.tool));
       additivity = {
         tools: savers,
         sumOfParts,
         combinedSaved,
-        additive: comparable && combinedSaved === sumOfParts,
+        // Tri-state: true/false are measured verdicts, null means the run
+        // could not be measured. A boolean here would publish an unmeasured
+        // reading as a definite "not additive".
+        additive: comparable ? combinedSaved === sumOfParts : null,
         comparable,
+        perBucket: bucketAdditivity(
+          saverRows,
+          cmp,
+          cmp.comparability.systemToolsComparable,
+        ),
         reasons: vanished.length
           ? [...cmp.comparability.reasons, vanishedReason(vanished)]
           : cmp.comparability.reasons,

--- a/plugins/context-budget/skills/audit/scripts/measure.mjs
+++ b/plugins/context-budget/skills/audit/scripts/measure.mjs
@@ -30,11 +30,14 @@
 //
 // Comparability rules the engine enforces (measured, see the plugin's
 // reference/engine.md):
-//   - `System tools` deltas are only meaningful between runs whose skill
-//     listing is identical (listed skill-frontmatter tokens are subtracted
-//     from that bucket). Every record carries a skill-listing signature and
-//     compare/attribute refuse to call mismatched runs comparable.
-//   - Deltas are computed within one mode and one binary version only.
+//   - Prefix `System tools` deltas are only meaningful between runs whose
+//     skill listing is identical (listed skill-frontmatter tokens are
+//     subtracted from that bucket). The deferred bucket is a separate pool
+//     and listing drift does not poison it. Every record carries a
+//     skill-listing signature; compare/attribute mark
+//     `systemToolsComparable: false` on mismatch.
+//   - Deltas are computed within one mode and one binary version only. Those
+//     shared checks apply to both attributed buckets.
 
 import { spawnSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
@@ -541,6 +544,22 @@ function summarize(snap) {
   };
 }
 
+// Mode and binary have to match for any attributed delta: a cross-mode
+// comparison mixes precisions, and a cross-binary comparison measures the
+// upgrade, not the lever. Skill-listing tokens are subtracted from the
+// prefix `System tools` bucket, so listing or Skills-token drift poisons
+// that bucket only; the deferred pool is separate and stays measurable.
+function modeBinaryComparable(before, after) {
+  return before.mode === after.mode
+    && before.binary?.version === after.binary?.version
+    && before.binary?.path === after.binary?.path;
+}
+
+function skillListingComparable(before, after) {
+  return before.skillListing?.signature === after.skillListing?.signature
+    && before.skillListing?.tokens === after.skillListing?.tokens;
+}
+
 function compareSnapshots(before, after, { lever = null, emittedConfig = null } = {}) {
   const reasons = [];
   if (before.mode !== after.mode) reasons.push(`mode differs (${before.mode} vs ${after.mode}) — deltas across modes mix precisions`);
@@ -566,6 +585,8 @@ function compareSnapshots(before, after, { lever = null, emittedConfig = null } 
   const totalDelta = (typeof before.totalTokens === 'number' && typeof after.totalTokens === 'number')
     ? after.totalTokens - before.totalTokens : null;
 
+  const sharedOk = modeBinaryComparable(before, after);
+  const listingOk = skillListingComparable(before, after);
   return {
     schema: LEDGER_SCHEMA,
     timestampUtc: nowUtc(),
@@ -580,13 +601,12 @@ function compareSnapshots(before, after, { lever = null, emittedConfig = null } 
     totalDelta,
     comparability: {
       ok: reasons.length === 0,
-      // Every recorded mismatch poisons the predicate — a reason the caller
-      // could read but a `true` flag would let it ignore is how an
+      // Every recorded mismatch poisons the prefix predicate — a reason the
+      // caller could read but a `true` flag would let it ignore is how an
       // acknowledged-incomparable run gets published as attribution.
-      systemToolsComparable: sigMatch && skillTokensMatch
-        && before.mode === after.mode
-        && before.binary?.version === after.binary?.version
-        && before.binary?.path === after.binary?.path,
+      systemToolsComparable: listingOk && sharedOk,
+      // Shared mode/binary checks only: listing drift does not apply.
+      modeBinaryComparable: sharedOk,
       reasons,
     },
   };
@@ -629,7 +649,7 @@ const BUCKET_ROW_FIELD = {
 // A verdict is `true`/`false` only when the bucket was measured on both sides
 // of the comparison; anything unmeasured is `null` — "not measurable" is not
 // the same answer as "measured, and not additive".
-function bucketAdditivity(rows, cmp, runComparable) {
+function bucketAdditivity(rows, cmp) {
   const perBucket = {};
   for (const bucket of SYSTEM_TOOL_BUCKETS) {
     // A bucket absent from BOTH runs is outside this binary's category
@@ -641,9 +661,21 @@ function bucketAdditivity(rows, cmp, runComparable) {
       : -parts.reduce((sum, d) => sum + d, 0);
     const combinedDelta = cmp.delta[bucket];
     const combinedSaved = typeof combinedDelta === 'number' ? -combinedDelta : null;
+    // Skill-listing / Skills-token drift poisons only the prefix bucket.
+    // The deferred bucket still has a measurable delta under the shared
+    // mode/binary checks, so one listing mismatch no longer takes the other
+    // column's verdict with it.
+    const runComparable = bucket === 'System tools'
+      ? cmp.comparability.systemToolsComparable
+      : cmp.comparability.modeBinaryComparable;
     const measured = runComparable && sumOfParts !== null && combinedSaved !== null;
     const reasons = [];
-    if (!runComparable) reasons.push(...cmp.comparability.reasons);
+    if (!runComparable) {
+      const gateReasons = bucket === 'System tools'
+        ? cmp.comparability.reasons
+        : cmp.comparability.reasons.filter((r) => !r.startsWith('skill listing'));
+      reasons.push(...gateReasons);
+    }
     if (combinedSaved === null) reasons.push(vanishedReason([bucket]));
     if (sumOfParts === null) {
       reasons.push(`${bucket} is unmeasured on at least one per-tool row, so the sum of parts `
@@ -742,11 +774,7 @@ async function runAttribute(args) {
         // reading as a definite "not additive".
         additive: comparable ? combinedSaved === sumOfParts : null,
         comparable,
-        perBucket: bucketAdditivity(
-          saverRows,
-          cmp,
-          cmp.comparability.systemToolsComparable,
-        ),
+        perBucket: bucketAdditivity(saverRows, cmp),
         reasons: vanished.length
           ? [...cmp.comparability.reasons, vanishedReason(vanished)]
           : cmp.comparability.reasons,

--- a/plugins/context-budget/skills/audit/scripts/measure.test.sh
+++ b/plugins/context-budget/skills/audit/scripts/measure.test.sh
@@ -8,7 +8,8 @@
 # (one file per run plus an appended history line; schema-checked append),
 # the attribute/additivity pipeline in cli-parse mode against a fake
 # `claude` binary (a vanished bucket is unmeasured and incomparable, never a
-# coerced zero), and verify-catalogue (binary-scan present/absent, never
+# coerced zero; per-bucket verdicts; an unmeasured verdict distinct from a
+# measured negative), and verify-catalogue (binary-scan present/absent, never
 # invents presence). The sdk measurement path spawns a real Claude Code
 # binary and is exercised manually, not here — this suite must stay hermetic.
 #
@@ -264,6 +265,11 @@ const mode = process.env.FAKE_MODE || 'control';
 // Savings per deny set, constructed additive: combined always equals the sum.
 const prefixSaved = { AlphaTool: 1000, BetaTool: 600, GammaTool: 500, 'AlphaTool+BetaTool': 1600 };
 const deferredSaved = { AlphaTool: 400, BetaTool: 100, GammaTool: 0, 'AlphaTool+BetaTool': 500 };
+// nonadd — the measured shape the audit found: the prefix side double-counts
+// (combined saves 400 less than the sum of parts) while the deferred side
+// sums to the token. Every bucket is present in every run, so the reading is
+// comparable and the negative verdict is measured, not unmeasured.
+if (mode === 'nonadd') prefixSaved['AlphaTool+BetaTool'] = 1200;
 const table = { 'System tools': 18000 - (prefixSaved[key] ?? 0) };
 // The deferred bucket is dropped (omitted, not reported as 0) when:
 //   novocab      — this fake "version" has no deferred bucket in any run;
@@ -314,15 +320,50 @@ if attr vanish "$avanish" --tools AlphaTool,BetaTool --verify-additivity; then
     "vanished bucket yields combinedSaved null, never a coerced 0" "combinedSaved fabricated from a null delta"
   assert_eq "$(jsonget "$avanish" 'j.additivity.comparable')" "false" \
     "vanished bucket marks the additivity record incomparable" "additivity published comparable despite a vanished bucket"
-  assert_eq "$(jsonget "$avanish" 'j.additivity.additive')" "false" \
-    "incomparable additivity is never reported additive" "additive true despite a vanished bucket"
+  assert_eq "$(jsonget "$avanish" 'j.additivity.additive')" "null" \
+    "an unmeasurable additivity reading reports a null verdict, not a definite negative" \
+    "unmeasured additivity published as a boolean verdict"
   if [[ "$(jsonget "$avanish" 'j.additivity.reasons.join(" ")')" == *"System tools (deferred)"* ]]; then
     ok "additivity record names the vanished bucket in its reasons"
   else
     fail "vanished-bucket reason missing from additivity record"
   fi
+  # Per bucket: the vanished deferred side is unmeasured, but the prefix side
+  # was measured in both runs and still gets a verdict.
+  assert_eq "$(jsonget "$avanish" 'j.additivity.perBucket["System tools"].sumOfParts')" "1600" \
+    "per-bucket sum of parts comes off the per-tool prefixDelta values" "per-bucket prefix sumOfParts wrong"
+  assert_eq "$(jsonget "$avanish" 'j.additivity.perBucket["System tools"].combinedSaved')" "1600" \
+    "per-bucket combined saving comes off the combined run's prefix delta" "per-bucket prefix combinedSaved wrong"
+  assert_eq "$(jsonget "$avanish" 'j.additivity.perBucket["System tools"].additive')" "true" \
+    "a vanished deferred bucket does not poison the prefix bucket's verdict" "prefix verdict lost to an unrelated vanish"
+  assert_eq "$(jsonget "$avanish" 'j.additivity.perBucket["System tools (deferred)"].combinedSaved')" "null" \
+    "the vanished bucket's combined saving stays null" "vanished per-bucket saving coerced to a number"
+  assert_eq "$(jsonget "$avanish" 'j.additivity.perBucket["System tools (deferred)"].additive')" "null" \
+    "the vanished bucket's verdict is unmeasured, not a negative" "vanished per-bucket verdict published as a boolean"
 else
   fail "attribute --verify-additivity (vanish scenario) exited nonzero"
+fi
+
+# A measured negative: every bucket present in every run, the reading
+# comparable, and the prefix side genuinely failing to add. The unmeasured
+# verdict above must NOT be the same value as this one.
+anon="$WORK/attr-nonadditive.json"
+if attr nonadd "$anon" --tools AlphaTool,BetaTool --verify-additivity; then
+  assert_eq "$(jsonget "$anon" 'j.additivity.comparable')" "true" \
+    "the measured-negative reading is comparable" "nonadd reading marked incomparable"
+  assert_eq "$(jsonget "$anon" 'j.additivity.additive')" "false" \
+    "a comparable reading whose parts overshoot reports a measured false" "nonadd verdict wrong"
+  assert_eq "$(jsonget "$anon" 'j.additivity.additive === JSON.parse(require("fs").readFileSync("'"$avanish"'","utf8")).additivity.additive')" "false" \
+    "the unmeasured verdict is a different value from the measured negative" \
+    "unmeasured and measured-negative additivity verdicts are indistinguishable"
+  assert_eq "$(jsonget "$anon" 'j.additivity.perBucket["System tools"].additive')" "false" \
+    "the prefix bucket reports its own measured negative" "per-bucket prefix verdict wrong under nonadd"
+  assert_eq "$(jsonget "$anon" 'j.additivity.perBucket["System tools"].combinedSaved')" "1200" \
+    "the prefix bucket's combined saving is the combined run's own number" "per-bucket prefix combinedSaved wrong under nonadd"
+  assert_eq "$(jsonget "$anon" 'j.additivity.perBucket["System tools (deferred)"].additive')" "true" \
+    "the deferred bucket adds even when the prefix bucket does not" "per-bucket deferred verdict wrong under nonadd"
+else
+  fail "attribute --verify-additivity (nonadd scenario) exited nonzero"
 fi
 
 # Control: all buckets present in every run — the verdict must be untouched.
@@ -385,6 +426,8 @@ if attr novocab "$anv" --tools AlphaTool,BetaTool --verify-additivity; then
     "additivity over the present bucket alone still measures" "vocabulary-absent combinedSaved wrong"
   assert_eq "$(jsonget "$anv" 'j.additivity.additive')" "true" \
     "additivity over the present bucket alone still verifies" "vocabulary-absent additive wrong"
+  assert_eq "$(jsonget "$anv" 'Object.keys(j.additivity.perBucket).join(",")')" "System tools" \
+    "a bucket absent from both runs gets no per-bucket verdict row" "vocabulary-absent bucket invented a per-bucket verdict"
 else
   fail "attribute (novocab scenario) exited nonzero"
 fi

--- a/plugins/context-budget/skills/audit/scripts/measure.test.sh
+++ b/plugins/context-budget/skills/audit/scripts/measure.test.sh
@@ -153,6 +153,8 @@ assert_eq "$(jsonget "$row2" 'j.delta["System tools"]')" "-1000" \
   "delta is after-minus-before (a saving prints negative)" "delta sign/magnitude wrong"
 assert_eq "$(jsonget "$row2" 'j.comparability.systemToolsComparable')" "true" \
   "same-signature runs keep System tools comparable" "same-signature runs lost comparability"
+assert_eq "$(jsonget "$row2" 'j.comparability.modeBinaryComparable')" "true" \
+  "same-signature runs keep the shared mode/binary predicate" "same-signature runs lost modeBinaryComparable"
 
 # --- compare: signature mismatch poisons the System tools delta -----------
 
@@ -160,6 +162,9 @@ row3="$WORK/row-sig.json"
 node "$ENGINE" compare --before "$WORK/a.json" --after "$WORK/c.json" --out "$row3" >/dev/null
 assert_eq "$(jsonget "$row3" 'j.comparability.systemToolsComparable')" "false" \
   "skill-listing signature mismatch marks System tools incomparable" "signature mismatch not detected"
+assert_eq "$(jsonget "$row3" 'j.comparability.modeBinaryComparable')" "true" \
+  "skill-listing signature mismatch does not poison the shared mode/binary predicate" \
+  "signature mismatch wrongly flipped modeBinaryComparable"
 if grep -q 'skill listing differs' "$row3"; then
   ok "signature mismatch carries its reason in the row"
 else
@@ -173,12 +178,18 @@ node "$ENGINE" compare --before "$WORK/a.json" --after "$WORK/d.json" --out "$WO
 assert_eq "$(jsonget "$WORK/row-path.json" 'j.comparability.systemToolsComparable')" "false" \
   "same version but different binary path marks System tools incomparable" \
   "binary-path mismatch not reflected in the predicate"
+assert_eq "$(jsonget "$WORK/row-path.json" 'j.comparability.modeBinaryComparable')" "false" \
+  "binary-path mismatch also flips the shared mode/binary predicate" \
+  "binary-path mismatch not reflected in modeBinaryComparable"
 
 node -e "const fs=require('fs');const j=JSON.parse(fs.readFileSync(process.argv[1],'utf8'));j.skillListing.tokens=2500;fs.writeFileSync(process.argv[2],JSON.stringify(j));" "$WORK/a.json" "$WORK/e.json"
 node "$ENGINE" compare --before "$WORK/a.json" --after "$WORK/e.json" --out "$WORK/row-skills.json" >/dev/null
 assert_eq "$(jsonget "$WORK/row-skills.json" 'j.comparability.systemToolsComparable')" "false" \
   "matching listing but moved Skills bucket marks System tools incomparable" \
   "skills-bucket drift not reflected in the predicate"
+assert_eq "$(jsonget "$WORK/row-skills.json" 'j.comparability.modeBinaryComparable')" "true" \
+  "Skills-token drift does not poison the shared mode/binary predicate" \
+  "Skills-token drift wrongly flipped modeBinaryComparable"
 
 # --- emit: --out creates missing parent directories -----------------------
 
@@ -280,10 +291,20 @@ const dropDeferred = mode === 'novocab'
   || key === 'GammaTool';
 if (!dropDeferred) table['System tools (deferred)'] = 12000 - (deferredSaved[key] ?? 0);
 table.Messages = 42;
+// skilltok — combined run only: Skills-token count moves while the listing
+// signature stays identical, so systemToolsComparable is false and the
+// shared mode/binary predicate stays true.
+if (mode === 'skilltok') table.Skills = key === 'AlphaTool+BetaTool' ? 2500 : 2000;
 const lines = ['## Context Usage', '', '**Model:** fake-model', '',
   '### Estimated usage by category', '',
   '| Category | Tokens | Percentage |', '|---|---|---|'];
 for (const [name, tokens] of Object.entries(table)) lines.push(`| ${name} | ${tokens} | 0% |`);
+// skillsig — combined run only: a Skills table appears, changing the listing
+// signature. Per-tool runs stay matching so they remain savers.
+if (mode === 'skillsig' && key === 'AlphaTool+BetaTool') {
+  lines.push('', '### Skills', '', '| Skill | Source | Tokens |', '|---|---|---|',
+    '| drift-skill | User | 100 |');
+}
 process.stdout.write(lines.join('\n') + '\n');
 EOF
 case "$(uname -s)" in
@@ -430,6 +451,61 @@ if attr novocab "$anv" --tools AlphaTool,BetaTool --verify-additivity; then
     "a bucket absent from both runs gets no per-bucket verdict row" "vocabulary-absent bucket invented a per-bucket verdict"
 else
   fail "attribute (novocab scenario) exited nonzero"
+fi
+
+# Prefix-only listing drift: the combined run's skill listing (or Skills-token
+# count) changes, so systemToolsComparable is false, but the deferred bucket's
+# numeric deltas remain valid under the shared mode/binary checks. Applying
+# the prefix flag to every bucket would publish the deferred verdict as null.
+askillsig="$WORK/attr-skillsig.json"
+if attr skillsig "$askillsig" --tools AlphaTool,BetaTool --verify-additivity; then
+  assert_eq "$(jsonget "$askillsig" 'j.additivity.comparable')" "false" \
+    "combined listing drift marks the top-level additivity record incomparable" \
+    "skillsig top-level comparable stayed true"
+  assert_eq "$(jsonget "$askillsig" 'j.additivity.additive')" "null" \
+    "combined listing drift leaves the top-level verdict unmeasured" \
+    "skillsig top-level additive published as a boolean"
+  assert_eq "$(jsonget "$askillsig" 'j.additivity.perBucket["System tools"].additive')" "null" \
+    "listing drift leaves the prefix bucket verdict unmeasured" \
+    "skillsig prefix verdict published as a boolean"
+  assert_eq "$(jsonget "$askillsig" 'j.additivity.perBucket["System tools"].sumOfParts')" "1600" \
+    "listing drift still reports the prefix sum of parts" "skillsig prefix sumOfParts wrong"
+  assert_eq "$(jsonget "$askillsig" 'j.additivity.perBucket["System tools"].combinedSaved')" "1600" \
+    "listing drift still reports the prefix combined saving" "skillsig prefix combinedSaved wrong"
+  assert_eq "$(jsonget "$askillsig" 'j.additivity.perBucket["System tools (deferred)"].additive')" "true" \
+    "listing drift does not take the deferred bucket's measured verdict" \
+    "skillsig deferred verdict lost to a prefix-only mismatch"
+  assert_eq "$(jsonget "$askillsig" 'j.additivity.perBucket["System tools (deferred)"].sumOfParts')" "500" \
+    "listing drift still reports the deferred sum of parts" "skillsig deferred sumOfParts wrong"
+  assert_eq "$(jsonget "$askillsig" 'j.additivity.perBucket["System tools (deferred)"].combinedSaved')" "500" \
+    "listing drift still reports the deferred combined saving" "skillsig deferred combinedSaved wrong"
+  if [[ "$(jsonget "$askillsig" 'j.additivity.perBucket["System tools"].reasons.join(" ")')" == *"skill listing"* ]]; then
+    ok "prefix bucket names the listing mismatch in its reasons"
+  else
+    fail "skillsig prefix reasons missing the listing mismatch"
+  fi
+  if [[ "$(jsonget "$askillsig" 'j.additivity.perBucket["System tools (deferred)"].reasons.join(" ")')" == *"skill listing"* ]]; then
+    fail "skillsig deferred reasons inherited a prefix-only listing mismatch"
+  else
+    ok "deferred bucket does not inherit prefix-only listing reasons"
+  fi
+else
+  fail "attribute --verify-additivity (skillsig scenario) exited nonzero"
+fi
+
+askilltok="$WORK/attr-skilltok.json"
+if attr skilltok "$askilltok" --tools AlphaTool,BetaTool --verify-additivity; then
+  assert_eq "$(jsonget "$askilltok" 'j.additivity.comparable')" "false" \
+    "combined Skills-token drift marks the top-level additivity record incomparable" \
+    "skilltok top-level comparable stayed true"
+  assert_eq "$(jsonget "$askilltok" 'j.additivity.perBucket["System tools"].additive')" "null" \
+    "Skills-token drift leaves the prefix bucket verdict unmeasured" \
+    "skilltok prefix verdict published as a boolean"
+  assert_eq "$(jsonget "$askilltok" 'j.additivity.perBucket["System tools (deferred)"].additive')" "true" \
+    "Skills-token drift does not take the deferred bucket's measured verdict" \
+    "skilltok deferred verdict lost to a prefix-only mismatch"
+else
+  fail "attribute --verify-additivity (skilltok scenario) exited nonzero"
 fi
 
 # --- verify-catalogue: binary existence, never invents presence -----------


### PR DESCRIPTION
Closes #3863

## Summary

`context-budget` asserted flatly that the per-tool deny deltas are compositional, so a basket of
trims prices from its members. Measured readings do not support that as one statement over both
attributed buckets: the deferred side sums to the token, while the prefix side double-counts, so
the sum of prefix deltas overstates what a basket saves on the prefix. The claim lived in three
places that each stated it independently, and the engine reported a single additivity verdict
computed as a boolean, so an unmeasurable reading surfaced as a definite "not additive".

## Fix

Prose, all in this change so no home keeps the old claim:

- `plugins/context-budget/skills/audit/SKILL.md` and
  `plugins/context-budget/skills/audit/reference/levers.json` (the `deny-bare-tool` lever's
  `categoryBasis`) now say which side composes: deferred-side deltas add and a basket's deferred
  saving is the sum of its members; prefix-side deltas double-count and their sum is only an upper
  bound on the basket's prefix saving. Both point at `attribute --verify-additivity` for the
  per-bucket verdict.
- `plugins/context-budget/README.md` carried the same unqualified sentence. The issue names two
  homes; this is a third instance of the identical claim, so it is corrected with them rather than
  left as the one surface still asserting the old wording. Called out here because it is beyond
  the two homes the issue names.
- `reference/engine.md` documents the new record shape; `reference/report.md` tells the reporter to
  state the verdict per bucket and to report a null verdict as not measurable rather than as not
  additive.

Engine, `skills/audit/scripts/measure.mjs`:

- `additivity.additive` is tri-state. `true`/`false` are measured verdicts; `null` means the
  reading could not be measured. Previously `comparable && combinedSaved === sumOfParts`, which
  published every incomparable reading as `false`.
- New `additivity.perBucket`, one entry per attributed bucket carrying
  `{sumOfParts, combinedSaved, additive, reasons}`. It is derived from the
  `prefixDelta`/`deferredDelta` values already on the saver rows plus the combined-deny comparison
  this run already performs: no extra measurement pass, no new snapshot. Each bucket's verdict is
  gated on its own measurability, so one bucket vanishing out of the combined snapshot no longer
  costs the other bucket its verdict. A bucket absent from both runs is outside the binary's
  category vocabulary and gets no verdict row at all.
- The saturation guard (`systemBucketSaving`, the null-not-zero vanished-bucket path) is untouched;
  the per-bucket reporting reads its `cmp.delta` output.

Version bumped to `0.6.24` with the matching CHANGELOG entry.

## Verification

Run in a worktree at `9f8babcd` off `origin/main` (`912d6b3e`).

- `bash scripts/affected-tests.sh --run` exits 3 (the runner's success code).
  `plugins/context-budget/skills/audit/scripts/measure.test.sh` PASS at 73 passed / 0 failed (61
  before this change, measured on a clean `git archive origin/main` export).
  `plugins/context-budget/skills/audit/scripts/levers.test.sh` run directly:
  3 passed / 0 failed. `--explain` also selects
  `plugins/session-flow/skills/running-retro/scripts/test_observer.py` (a filename match on
  `report.md`), which the runner reports as NOT RUN for its ecosystem; run in its own lane with
  `python3 -m pytest`, 73 passed, 6 subtests passed. No changed file mapped to zero suites: the
  four that report `no-suite` are recorded in `scripts/affected-tests-no-suite.txt`.
- All four changelog-parity modes green: `--check`, `--check-order`, `--check-bump origin/main`,
  `--check-preserved origin/main` (30 headings compared).
- `ai-slop` detector over the five changed markdown surfaces: 0 findings, 5 files scanned. No em
  dash appears on any added line in any instruction surface in this diff (checked over the full
  `git diff origin/main` added lines for the prose files).

New tests, and the mutations run against them to show they are not vacuous:

- Vanish scenario (deferred bucket emptied out of the combined snapshot): asserts
  `additivity.additive` is `null`, that the prefix bucket still gets `additive: true` with
  `sumOfParts`/`combinedSaved` of 1600, and that the deferred bucket's saving and verdict are both
  `null`.
- New `nonadd` fake-binary mode: every bucket present in every run, the reading comparable, and the
  combined prefix deny saving 1200 against a 1600 sum of parts. Asserts a measured
  `additive: false`, a prefix bucket verdict of `false`, a deferred bucket verdict of `true`, and
  explicitly that this run's verdict is a different value from the vanish run's verdict.
- `novocab` scenario: a bucket absent from both runs produces no `perBucket` row.

Mutations applied to `measure.mjs`, each reverted after:

1. `additive: comparable ? … : null` reverted to the old `additive: comparable && …`. Two tests
   fail: "unmeasured additivity published as a boolean verdict" and "unmeasured and
   measured-negative additivity verdicts are indistinguishable" (71 passed / 2 failed).
2. Per-bucket gate `runComparable && sumOfParts !== null && combinedSaved !== null` weakened to drop
   the `combinedSaved !== null` term. One test fails: "vanished per-bucket verdict published as a
   boolean" (72 passed / 1 failed).
3. Per-bucket `parts` sourced from `-r.savedTokens` instead of the bucket's own row field. Three
   tests fail, including "per-bucket prefix sumOfParts wrong (got: 2100)" (70 passed / 3 failed).

Not verified: the sdk measurement path, which spawns a real Claude Code binary and is outside this
suite's hermetic scope, is unchanged by this PR but was not exercised. The measured 956-token
double-count figure the issue cites comes from the parent audit and is not reproduced here; this PR
does not re-measure anything.

Acceptance criteria status: all seven met. The one deviation from the issue's literal text is the
extra README correction described under Fix.

## Related

- Closes #3863
- Parent: #3356 (cluster 1, finding H2 plus the unimplemented per-bucket half of H1)
- Builds on the H1 saturation guard from #3197, which is unchanged here

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ViPsHkL3ng9xWt2GjEQJob

---
_Generated by [Claude Code](https://claude.ai/code/session_01ViPsHkL3ng9xWt2GjEQJob)_