### PR TITLE
feat(cloud): read the snapshot fleet plugin list in the cloud bootstrap

### DIFF
--- a/.claude/cloud-bootstrap.sh
+++ b/.claude/cloud-bootstrap.sh
@@ -160,15 +160,38 @@ if [[ -x "$claude_bin" ]] && command -v jq >/dev/null 2>&1; then
       echo "cloud-bootstrap: warning: could not register the $marketplace_name marketplace" >&2
   fi
 
-  # Enabled-and-not-yet-installed, computed from the tracked settings file so
-  # this script can never drift from the catalog the repo actually enables.
+  # Enabled set: the fleet list the shared environment baked into the snapshot
+  # (standards cloud-environment component; the /tmp copy is its fallback when
+  # /opt was unwritable at cache build), overlaid with the tracked settings
+  # file, so a repo entry set to false opts out of a fleet entry and a repo
+  # entry beyond the fleet is added. Only this marketplace's ids count, and
+  # they resolve against the checkout registered above, so a settings block
+  # reduced to deltas still dogfoods the whole catalog from the current
+  # branch. Absent outside a managed environment, in which case the settings
+  # file is the only source, as before. CLOUD_BOOTSTRAP_FLEET_LIST is the test
+  # seam.
+  fleet_list="${CLOUD_BOOTSTRAP_FLEET_LIST:-}"
+  if [[ -z "$fleet_list" ]]; then
+    for candidate in /opt/melodic-fleet-plugins.json /tmp/melodic-fleet-plugins.json; do
+      if [[ -f "$candidate" ]]; then
+        fleet_list="$candidate"
+        break
+      fi
+    done
+  fi
+  # A present-but-unparsable list (partial write at cache build) must degrade
+  # to settings-only, not empty the whole enabled set: `--slurpfile` fails
+  # before emitting anything.
+  if ! [[ -f "$fleet_list" ]] || ! jq empty "$fleet_list" 2>/dev/null; then
+    fleet_list=.claude/settings.json
+  fi
   mapfile -t wanted < <(
-    jq -r --arg n "$marketplace_name" \
-      '.enabledPlugins // {} | to_entries[]
+    jq -r --arg n "$marketplace_name" --slurpfile f "$fleet_list" \
+      '(($f[0].enabledPlugins // {}) + (.enabledPlugins // {})) | to_entries[]
        | select(.value == true and (.key | endswith("@" + $n))) | .key' \
-      .claude/settings.json 2>/dev/null
+      .claude/settings.json 2>/dev/null | tr -d '\r'
   )
-  mapfile -t have < <("$claude_bin" plugin list --json 2>/dev/null | jq -r '.[].id' 2>/dev/null)
+  mapfile -t have < <("$claude_bin" plugin list --json 2>/dev/null | jq -r '.[].id' 2>/dev/null | tr -d '\r')
 
   # A directory-source install cache is keyed by the semver in plugin.json, not
   # by commit, so a later commit under the same version never replaces the

--- a/.claude/cloud-bootstrap.sh
+++ b/.claude/cloud-bootstrap.sh
@@ -161,28 +161,28 @@ if [[ -x "$claude_bin" ]] && command -v jq >/dev/null 2>&1; then
   fi
 
   # Enabled set: the fleet list the shared environment baked into the snapshot
-  # (standards cloud-environment component; the /tmp copy is its fallback when
-  # /opt was unwritable at cache build), overlaid with the tracked settings
-  # file, so a repo entry set to false opts out of a fleet entry and a repo
-  # entry beyond the fleet is added. Only this marketplace's ids count, and
-  # they resolve against the checkout registered above, so a settings block
-  # reduced to deltas still dogfoods the whole catalog from the current
+  # (standards cloud-environment component), overlaid with the tracked
+  # settings file, so a repo entry set to false opts out of a fleet entry and
+  # a repo entry beyond the fleet is added. Only this marketplace's ids count,
+  # and they resolve against the checkout registered above, so a settings
+  # block reduced to deltas still dogfoods the whole catalog from the current
   # branch. Absent outside a managed environment, in which case the settings
   # file is the only source, as before. CLOUD_BOOTSTRAP_FLEET_LIST is the test
   # seam.
-  fleet_list="${CLOUD_BOOTSTRAP_FLEET_LIST:-}"
-  if [[ -z "$fleet_list" ]]; then
-    for candidate in /opt/melodic-fleet-plugins.json /tmp/melodic-fleet-plugins.json; do
-      if [[ -f "$candidate" ]]; then
-        fleet_list="$candidate"
-        break
-      fi
-    done
-  fi
-  # A present-but-unparsable list (partial write at cache build) must degrade
-  # to settings-only, not empty the whole enabled set: `--slurpfile` fails
-  # before emitting anything.
-  if ! [[ -f "$fleet_list" ]] || ! jq empty "$fleet_list" 2>/dev/null; then
+  #
+  # Only the /opt copy is read. The environment component also leaves a /tmp
+  # copy when /opt was unwritable at cache build, but /tmp is world-writable
+  # and a list at a predictable path there is an input any code running in
+  # the session could plant to enable a plugin with no settings diff; a
+  # snapshot whose /opt was unwritable simply gets the settings-only path.
+  fleet_list="${CLOUD_BOOTSTRAP_FLEET_LIST:-/opt/melodic-fleet-plugins.json}"
+  # A list that is absent, unparsable (partial write at cache build), or not
+  # the settings shape (an error body, an array) must degrade to settings-only,
+  # not empty the whole enabled set: `--slurpfile` and the object merge below
+  # both fail before emitting anything.
+  if ! [[ -f "$fleet_list" ]] ||
+    ! jq -e 'type == "object" and ((.enabledPlugins // {}) | type == "object")' \
+      "$fleet_list" >/dev/null 2>&1; then
     fleet_list=.claude/settings.json
   fi
   mapfile -t wanted < <(

--- a/.claude/hooks/cloud-bootstrap-plugins.test.sh
+++ b/.claude/hooks/cloud-bootstrap-plugins.test.sh
@@ -193,8 +193,17 @@ run_case() {
   local fx="$TMP/$name"
   mkdir -p "$fx/.claude" "$fx/node_modules/.bin" "$fx/plugins/alpha" "$fx/plugins/beta" "$fx/cfg/plugins"
 
-  printf '{"enabledPlugins":{"alpha@melodic-software":true,"beta@melodic-software":true}}\n' \
+  printf '%s\n' "${CASE_SETTINGS:-{\"enabledPlugins\":{\"alpha@melodic-software\":true,\"beta@melodic-software\":true\}\}}" \
     >"$fx/.claude/settings.json"
+  # A fleet list for the case, handed to the block through its test seam. The
+  # default points at a path that does not exist, so the settings file stays
+  # the only source, as on a machine outside the managed environment, and no
+  # case ever reads a real /opt or /tmp list from the host.
+  local fleet_env=(CLOUD_BOOTSTRAP_FLEET_LIST="$fx/no-fleet-list.json")
+  if [[ -n "${CASE_FLEET:-}" ]]; then
+    printf '%s\n' "$CASE_FLEET" >"$fx/fleet.json"
+    fleet_env=(CLOUD_BOOTSTRAP_FLEET_LIST="$fx/fleet.json")
+  fi
   printf 'a\n' >"$fx/plugins/alpha/f.txt"
   printf 'b\n' >"$fx/plugins/beta/f.txt"
 
@@ -247,7 +256,7 @@ STUB
   chmod +x "$fx/node_modules/.bin/claude"
 
   set +e
-  OUT="$(CLAUDE_CONFIG_DIR="$fx/cfg" bash "$BLOCK" "$fx" 2>&1)"
+  OUT="$(env "${fleet_env[@]}" CLAUDE_CONFIG_DIR="$fx/cfg" bash "$BLOCK" "$fx" 2>&1)"
   RC=$?
   set -e
 
@@ -354,6 +363,35 @@ expect "with one warning for the batch" \
   "could not read \`claude plugin list --json\`; no plugin could be verified"
 refute "and no per-plugin flood" \
   "failed verification after"
+
+# --- the fleet list baked into the snapshot is a source too -------------------
+# The shared environment writes the fleet plugin list into the snapshot; a
+# settings block reduced to deltas must still enable the fleet's entries for
+# this marketplace, a settings false must opt out of a fleet entry, and other
+# marketplaces' fleet entries are out of scope here.
+
+CASE_SETTINGS='{"enabledPlugins":{"alpha@melodic-software":true}}' \
+  CASE_FLEET='{"enabledPlugins":{"alpha@melodic-software":true,"beta@melodic-software":true,"gamma@elsewhere":true}}' \
+  run_case fleet_union "$BOTH_USER" "$BOTH_USER" "$REG_BOTH_HEAD" NONE
+expect "a fleet entry beyond the settings block counts as enabled" \
+  "plugins 2 enabled, 0 newly installed, 0 refreshed, 0 failed"
+
+CASE_SETTINGS='{"enabledPlugins":{"alpha@melodic-software":true,"beta@melodic-software":false}}' \
+  CASE_FLEET='{"enabledPlugins":{"alpha@melodic-software":true,"beta@melodic-software":true}}' \
+  run_case fleet_opt_out "$BOTH_USER" "$BOTH_USER" "$REG_BOTH_HEAD" NONE
+expect "a settings false opts out of a fleet entry" \
+  "plugins 1 enabled, 0 newly installed, 0 refreshed, 0 failed"
+
+CASE_SETTINGS='{"enabledPlugins":{"alpha@melodic-software":true}}' \
+  run_case fleet_absent "$BOTH_USER" "$BOTH_USER" "$REG_BOTH_HEAD" NONE
+expect "without a fleet list the settings block is the only source" \
+  "plugins 1 enabled, 0 newly installed, 0 refreshed, 0 failed"
+
+CASE_SETTINGS='{"enabledPlugins":{"alpha@melodic-software":true}}' \
+  CASE_FLEET='not json at all' \
+  run_case fleet_malformed "$BOTH_USER" "$BOTH_USER" "$REG_BOTH_HEAD" NONE
+expect "a malformed fleet list degrades to the settings block, not to an empty set" \
+  "plugins 1 enabled, 0 newly installed, 0 refreshed, 0 failed"
 
 # --- report -------------------------------------------------------------------
 echo

--- a/.claude/hooks/cloud-bootstrap-plugins.test.sh
+++ b/.claude/hooks/cloud-bootstrap-plugins.test.sh
@@ -193,8 +193,8 @@ run_case() {
   local fx="$TMP/$name"
   mkdir -p "$fx/.claude" "$fx/node_modules/.bin" "$fx/plugins/alpha" "$fx/plugins/beta" "$fx/cfg/plugins"
 
-  printf '%s\n' "${CASE_SETTINGS:-{\"enabledPlugins\":{\"alpha@melodic-software\":true,\"beta@melodic-software\":true\}\}}" \
-    >"$fx/.claude/settings.json"
+  local default_settings='{"enabledPlugins":{"alpha@melodic-software":true,"beta@melodic-software":true}}'
+  printf '%s\n' "${CASE_SETTINGS:-$default_settings}" >"$fx/.claude/settings.json"
   # A fleet list for the case, handed to the block through its test seam. The
   # default points at a path that does not exist, so the settings file stays
   # the only source, as on a machine outside the managed environment, and no
@@ -391,6 +391,20 @@ CASE_SETTINGS='{"enabledPlugins":{"alpha@melodic-software":true}}' \
   CASE_FLEET='not json at all' \
   run_case fleet_malformed "$BOTH_USER" "$BOTH_USER" "$REG_BOTH_HEAD" NONE
 expect "a malformed fleet list degrades to the settings block, not to an empty set" \
+  "plugins 1 enabled, 0 newly installed, 0 refreshed, 0 failed"
+
+# Valid JSON of the wrong shape (an error body, an array where the object
+# should be) would break the merge the same way a parse failure does.
+CASE_SETTINGS='{"enabledPlugins":{"alpha@melodic-software":true}}' \
+  CASE_FLEET='{"enabledPlugins":["alpha@melodic-software"]}' \
+  run_case fleet_wrong_shape "$BOTH_USER" "$BOTH_USER" "$REG_BOTH_HEAD" NONE
+expect "a wrong-shaped fleet list degrades to the settings block, not to an empty set" \
+  "plugins 1 enabled, 0 newly installed, 0 refreshed, 0 failed"
+
+CASE_SETTINGS='{"enabledPlugins":{"alpha@melodic-software":true}}' \
+  CASE_FLEET='[]' \
+  run_case fleet_array "$BOTH_USER" "$BOTH_USER" "$REG_BOTH_HEAD" NONE
+expect "a fleet list that is a bare array degrades to the settings block" \
   "plugins 1 enabled, 0 newly installed, 0 refreshed, 0 failed"
 
 # --- report -------------------------------------------------------------------


### PR DESCRIPTION
No related issue: part of #3688's remediation (Phase A, standards side merged as melodic-software/standards#542); this PR does not close the issue, the block reduction in a later PR will.

## Summary

The shared cloud environment now fetches a single fleet plugin list from standards at snapshot build, writes it into the snapshot at `/opt/melodic-fleet-plugins.json` (or the `/tmp` fallback), and installs it before the checkout's own `enabledPlugins` block. This repo holds its `.claude/cloud-bootstrap.sh` `locally-owned` in the standards sync manifest because of the directory-source dogfooding, so the canonical change does not fan out here and the copy needs the same two-source read by hand.

## Fix

- The bootstrap's enabled set is the snapshot fleet list overlaid with `.claude/settings.json` (`jq` object addition, settings on the right), filtered to this marketplace. A settings `false` opts out of a fleet entry; a settings entry beyond the fleet is added; other marketplaces' fleet entries are out of scope. The ids resolve against the checkout registered as `melodic-software`, so once the block shrinks to deltas the session still dogfoods the whole catalog from the current branch, and the same-version drift refresh and end-state verification run over the full set.
- Only the `/opt` copy is read; the `/tmp` fallback the environment writes when `/opt` is unwritable is not, because `/tmp` is world-writable at a predictable path (follow-up for the canonical and medley copies: melodic-software/standards#545). No usable list leaves the settings file as the only source, byte-for-byte the previous behaviour.
- The id list is passed through `tr -d '\r'`, the same Windows `jq` CRLF guard the plugins skill uses; the accounting suite's cases fail on a Windows host without it.
- `CLOUD_BOOTSTRAP_FLEET_LIST` is a test seam. `cloud-bootstrap-plugins.test.sh` gains six cases: a fleet entry beyond the settings block counts as enabled, a settings `false` opts out of a fleet entry, an absent list leaves the settings block alone, a malformed list degrades to the settings block rather than an empty set, and so do a wrong-shaped object and a bare array. The fleet seam defaults to a missing path in every case so no case reads a real `/opt` or `/tmp` list. `run_case` takes `CASE_SETTINGS` and `CASE_FLEET` overrides for them.

## Verification

- `bash -n` and `shellcheck -S info` on the script and the suite: clean.
- `bash .claude/hooks/cloud-bootstrap-plugins.test.sh`: run locally under a long timeout because the fixture repos make it slow on this host; 44 cases, 0 failed on the authoring Windows host. CI runs it through `scripts/run-plugin-tests.sh`.
- No plugin version bump: only `.claude/` files change.

## Related

- #3688 (the remediation; stays open)
- melodic-software/standards#542 (the fleet list, `setup.sh`, canonical `cloud-bootstrap.sh`)
- #3813 (the probe that established the local write path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
