### PR TITLE
feat(formatters): pin the manifest if rows to each script's extension set and state the budget share (#3411)

### DIFF
--- a/plugins/actionlint/.claude-plugin/plugin.json
+++ b/plugins/actionlint/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "actionlint",
-  "version": "0.8.42",
+  "version": "0.8.43",
   "description": "Lint GitHub Actions workflow files on edit via actionlint, surfacing findings as advisory context.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/actionlint/CHANGELOG.md
+++ b/plugins/actionlint/CHANGELOG.md
@@ -12,12 +12,17 @@ All notable changes to the `actionlint` plugin are documented here. Format follo
   The `if` rows are what keep a Write of any other file from spawning the
   hook (Claude Code drops a non-matching handler at match time, before a
   spawn); the script's `case` filter stays as defense in depth, and the new
-  case reads every arm of that filter's whole `case` block, requires every
-  handler in the manifest, under any event, to carry one of the derived
-  rows, and fails on drift in either direction, since an extension the
-  script lints with no `if` row is a silent regression. The README's "Hook
-  budget accounting" section carries a Linux-host measurement and kernel
-  census per hook-budget rule 1; no hook behavior changes.
+  case reads every arm of that filter's whole `case` block (each of bash's
+  arm terminators, `;;`, `;&` and `;;&`, ends an arm, and the
+  `case "$FILE_NORM"` re-check must yield the same extension set), requires
+  every handler in the manifest, under any event, to carry one of the
+  derived rows and to sit in a PostToolUse group whose matcher is exactly
+  Write and Edit and whose command is the plugin's own script, and fails on
+  drift in either direction, since an extension the script lints with no
+  `if` row is a silent regression, and so is a matcher narrowed to one tool.
+  The README's "Hook budget accounting" section carries a Linux-host
+  measurement and kernel census per hook-budget rule 1; no hook behavior
+  changes.
 
 ## [0.8.42]
 

--- a/plugins/actionlint/CHANGELOG.md
+++ b/plugins/actionlint/CHANGELOG.md
@@ -12,11 +12,12 @@ All notable changes to the `actionlint` plugin are documented here. Format follo
   The `if` rows are what keep a Write of any other file from spawning the
   hook (Claude Code drops a non-matching handler at match time, before a
   spawn); the script's `case` filter stays as defense in depth, and the new
-  case reads that filter's extension list and fails on drift in either
-  direction, since an extension the script lints with no `if` row is a
-  silent regression. The README's "Hook budget accounting" section carries a
-  Linux-host measurement and kernel census per hook-budget rule 1; no hook
-  behavior changes.
+  case reads every arm of that filter's whole `case` block, requires every
+  handler in the manifest, under any event, to carry one of the derived
+  rows, and fails on drift in either direction, since an extension the
+  script lints with no `if` row is a silent regression. The README's "Hook
+  budget accounting" section carries a Linux-host measurement and kernel
+  census per hook-budget rule 1; no hook behavior changes.
 
 ## [0.8.42]
 

--- a/plugins/actionlint/CHANGELOG.md
+++ b/plugins/actionlint/CHANGELOG.md
@@ -3,6 +3,21 @@
 All notable changes to the `actionlint` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.8.43]
+
+### Added
+
+- **The suite pins the manifest's `if` rows to the script's own workflow
+  filter, and the README states the hook's measured budget share (#3411).**
+  The `if` rows are what keep a Write of any other file from spawning the
+  hook (Claude Code drops a non-matching handler at match time, before a
+  spawn); the script's `case` filter stays as defense in depth, and the new
+  case reads that filter's extension list and fails on drift in either
+  direction, since an extension the script lints with no `if` row is a
+  silent regression. The README's "Hook budget accounting" section carries a
+  Linux-host measurement and kernel census per hook-budget rule 1; no hook
+  behavior changes.
+
 ## [0.8.42]
 
 ### Changed

--- a/plugins/actionlint/README.md
+++ b/plugins/actionlint/README.md
@@ -40,6 +40,28 @@ your `PATH`.
   with a visible once-per-session notice. See the
   [actionlint install guide](https://github.com/rhysd/actionlint/blob/main/docs/install.md).
 
+### Hook budget accounting
+
+Per [`docs/conventions/hook-budget/README.md`](../../docs/conventions/hook-budget/README.md),
+this hook is always-on for every `Write` and `Edit` of a `.yml` or `.yaml` file under
+`.github/workflows/` (the two `if` rows in `hooks/hooks.json` keep every other file from
+spawning it, and the suite pins those rows to the script's own workflow filter), so its cost on
+a clean workflow is the figure that counts. Measured on Linux x86_64 under bash 5.2 in a
+container, twelve interleaved trials against an interleaved `bash -c :` floor S of about 2 ms,
+with a kernel census from `strace -f -e trace=clone,clone3,fork,vfork,execve` (2026-09-07,
+0.8.43):
+
+| Event | Fires | Wall | Spawn-equivalents | Kernel census |
+| --- | --- | --- | --- | --- |
+| PostToolUse `Write`, clean `.github/workflows/*.yml` | 1 | 32 ms | 14.3 | 14 process creations, 5 execs: `actionlint`, `git`, two `jq`, the hook's own `bash` |
+| PostToolUse `Write`, any other file | 0 | none | 0 | no process; the `if` rows drop the handler before a spawn |
+
+At a 2 ms floor the spawn-equivalent column mostly measures actionlint's own run time rather
+than spawns, so the census column is the number that transfers to the Windows 11 Git Bash
+reference host the convention calls binding; that host's figure for this plugin has not been
+taken. The residual is actionlint itself plus the payload parse (`jq`) and the root resolver
+(`git`).
+
 ## Install
 
 ```shell

--- a/plugins/actionlint/README.md
+++ b/plugins/actionlint/README.md
@@ -44,19 +44,20 @@ your `PATH`.
 
 Per [`docs/conventions/hook-budget/README.md`](../../docs/conventions/hook-budget/README.md),
 this hook is always-on for every `Write` and `Edit` of a `.yml` or `.yaml` file under
-`.github/workflows/` (the two `if` rows in `hooks/hooks.json` keep every other file from
-spawning it, and the suite pins those rows to the script's own workflow filter), so its cost on
-a clean workflow is the figure that counts. Measured on Linux x86_64 under bash 5.2 in a
-container, twelve interleaved trials against an interleaved `bash -c :` floor S of about 2 ms,
-with a kernel census from `strace -f -e trace=clone,clone3,fork,vfork,execve` (2026-09-07,
-0.8.43):
+`.github/workflows/` (every handler in `hooks/hooks.json` carries one of the two `if` rows,
+which keep every other file from spawning it, and the suite pins the whole handler set to the
+script's own workflow filter), so its cost on a clean workflow is the figure that counts.
+Measured on Linux x86_64 under bash 5.2 in a container with `HOOK_TELEMETRY_SINK` and
+`CLAUDE_PROJECT_DIR` unset, twelve interleaved trials against an interleaved `bash -c :` floor
+S of about 4 ms, with a kernel census from `strace -f -e trace=clone,clone3,fork,vfork,execve`
+(2026-09-07, 0.8.43):
 
 | Event | Fires | Wall | Spawn-equivalents | Kernel census |
 | --- | --- | --- | --- | --- |
-| PostToolUse `Write`, clean `.github/workflows/*.yml` | 1 | 32 ms | 14.3 | 14 process creations, 5 execs: `actionlint`, `git`, two `jq`, the hook's own `bash` |
+| PostToolUse `Write`, clean `.github/workflows/*.yml` | 1 | 34 ms | 7.9 | 14 process creations (one trial in nine reached 15; actionlint's own threads vary), 5 execs: `actionlint`, `git`, two `jq`, the hook's own `bash` |
 | PostToolUse `Write`, any other file | 0 | none | 0 | no process; the `if` rows drop the handler before a spawn |
 
-At a 2 ms floor the spawn-equivalent column mostly measures actionlint's own run time rather
+At a 4 ms floor the spawn-equivalent column mostly measures actionlint's own run time rather
 than spawns, so the census column is the number that transfers to the Windows 11 Git Bash
 reference host the convention calls binding; that host's figure for this plugin has not been
 taken. The residual is actionlint itself plus the payload parse (`jq`) and the root resolver

--- a/plugins/actionlint/hooks/actionlint-check.test.sh
+++ b/plugins/actionlint/hooks/actionlint-check.test.sh
@@ -503,30 +503,50 @@ fi
 #
 # The expected set is every pattern of every arm in the script's whole
 # `case "${RAW_FILE//\\//}" ... esac` block except the bare `*` catch-all, so
-# an arm added anywhere in the block counts, and an alternation wrapped across
-# lines (a backslash continuation, or `;;` on its own line) reads the same as
-# one line. Every pattern must have the script's `*/.github/*workflows/*.<ext>`
-# shape, the only shape a manifest row is derived from here; the
+# an arm added anywhere in the block counts. The block is read the way bash
+# reads it: a backslash continuation joins lines with nothing in between (so
+# `;\` and a following `;` is one `;;`), a comment after `in` or on any arm is
+# dropped, a one-line `case ... esac` is one block, `in` on the line after
+# the `case` word opens the block all the same, and every arm terminator
+# bash has (`;;`, the `;&` fall-through and the `;;&` continue-matching form)
+# ends an arm, so the patterns of an arm reached only by fall-through count
+# too. What the parser does not read is an arm's body, so a pattern in any
+# arm, even one after `*)` that can never match, counts as handled and must
+# have its row. The script's `case "$FILE_NORM"` re-check after path
+# normalization (the duplicate #3408 owns folding) is read the same way, and
+# every such gate must yield the same extension set, so an exclusion added to
+# either gate fails here instead of sitting unread; a script with one gate
+# left passes as it is. Every pattern must have the script's
+# `*/.github/*workflows/*.<ext>` shape (the re-check's `*/.github/workflows/`
+# twin included), the only shapes a manifest row is derived from here; the
 # `**/.github/workflows/` anchor is the manifest's own (per the hooks
 # reference, a single-segment `Edit(.github/workflows/*.yml)` has matched only
-# the working directory's own tree since v2.1.214). On the manifest side every
-# handler under every event and matcher group is read, not only the
-# `Write|Edit` group: the if values across all of them must be exactly the
-# derived set, one row each, so a handler with no if, an if outside the set, a
-# `Write(...)` rule, a duplicate row, an unfiltered group under any event, or a
-# command pointing elsewhere fails here. What this does not reach is a
+# the working directory's own tree since v2.1.214).
+#
+# On the manifest side every handler under every event and matcher group is
+# read. Two things are pinned separately, since they answer different
+# questions. The `if` rows, which paths a handler applies to: the values
+# across every handler must be exactly the derived set, one row each, so a
+# handler with no if, an if outside the set, a `Write(...)` rule, a duplicate
+# row or an unfiltered group under any event fails. The group, which tools
+# invoke the handler at all: every group must be PostToolUse with a matcher
+# whose alternation is exactly Write and Edit in either order, the two tools
+# whose payload carries a workflow file this script lints (the rule validator
+# folds Write and NotebookEdit into an Edit(...) rule, but the matcher is the
+# tool name regex the harness consults first, and a matcher narrowed to one
+# tool is the hook silently never running for the other, which no if row can
+# show). The command must be the plugin's own script by either quoting
+# placement, with no prefix, suffix or argument. What this does not reach is a
 # registration outside hooks/hooks.json.
 HOOKS_JSON="$HOOK_DIR/hooks.json"
-SCRIPT_PATTERNS="$(awk '
-  /^case "[$][{]RAW_FILE[^"]*" in[[:space:]]*$/ { inblock = 1; next }
-  inblock && /^esac([[:space:]]|$)/ { exit }
-  inblock {
-    sub(/#.*/, "")
-    sub(/\\$/, " ")
-    block = block " " $0
-  }
-  END {
-    n = split(block, arms, ";;")
+SCRIPT_GATES="$(awk '
+  function flush(   n, i, m, j, p, pats, arms, alts) {
+    inblock = 0
+    print nblocks "\t"
+    gsub(/;;&/, "\n", block)
+    gsub(/;;/, "\n", block)
+    gsub(/;&/, "\n", block)
+    n = split(block, arms, "\n")
     for (i = 1; i <= n; i++) {
       if (index(arms[i], ")") == 0) continue
       pats = substr(arms[i], 1, index(arms[i], ")") - 1)
@@ -535,29 +555,75 @@ SCRIPT_PATTERNS="$(awk '
       for (j = 1; j <= m; j++) {
         p = alts[j]
         gsub(/[[:space:]]+/, "", p)
-        if (p != "" && p != "*") print p
+        if (p != "" && p != "*") print nblocks "\t" p
       }
     }
-  }' "$HOOK" | LC_ALL=C sort -u)"
-OFF_SHAPE="$(printf '%s\n' "$SCRIPT_PATTERNS" | grep -v -E '^\*/\.github/\*workflows/\*\.[A-Za-z0-9]+$' | grep -c .)"
-SCRIPT_EXTS="$(printf '%s\n' "$SCRIPT_PATTERNS" | sed -n 's|^\*/\.github/\*workflows/\(\*\.[A-Za-z0-9]*\)$|\1|p')"
+  }
+  !inblock && !pending && $0 ~ /^case "[$][{]?(RAW_FILE|FILE_NORM)[^"]*"[[:space:]]*(#.*)?$/ {
+    pending = 1
+    next
+  }
+  pending && match($0, /^[[:space:]]*in([[:space:]]|$)/) {
+    pending = 0
+    inblock = 1
+    nblocks++
+    block = ""
+    sep = ""
+    $0 = substr($0, RLENGTH + 1)
+  }
+  !inblock && match($0, /^case "[$][{]?(RAW_FILE|FILE_NORM)[^"]*" in([[:space:]]|$)/) {
+    inblock = 1
+    nblocks++
+    block = ""
+    sep = ""
+    $0 = substr($0, RLENGTH + 1)
+  }
+  inblock {
+    sub(/#.*/, "")
+    if ($0 ~ /^[[:space:]]*esac([[:space:]]|$)/) {
+      flush()
+      next
+    }
+    if (match($0, /[[:space:]]esac([[:space:]]|$)/)) {
+      block = block sep substr($0, 1, RSTART - 1)
+      flush()
+      next
+    }
+    if (sub(/\\$/, "")) {
+      block = block sep $0
+      sep = ""
+    } else {
+      block = block sep $0
+      sep = " "
+    }
+  }' "$HOOK")"
+CASE_BLOCKS="$(printf '%s\n' "$SCRIPT_GATES" | cut -f1 | LC_ALL=C sort -u | grep -c .)"
+SCRIPT_PATTERNS="$(printf '%s\n' "$SCRIPT_GATES" | awk -F'\t' '$2 != "" { print $2 }' | LC_ALL=C sort -u)"
+OFF_SHAPE="$(printf '%s\n' "$SCRIPT_PATTERNS" | grep -v -E '^\*/\.github/\*?workflows/\*\.[A-Za-z0-9]+$' | grep -c .)"
+SCRIPT_EXTS="$(printf '%s\n' "$SCRIPT_GATES" | awk -F'\t' '$1 == 1 && $2 != "" { print $2 }' | sed -n 's|^\*/\.github/\*\{0,1\}workflows/\(\*\.[A-Za-z0-9]*\)$|\1|p' | LC_ALL=C sort -u)"
+GATES_OFF=""
+for ((g = 2; g <= CASE_BLOCKS; g++)); do
+  GATE_EXTS="$(printf '%s\n' "$SCRIPT_GATES" | awk -F'\t' -v g="$g" '$1 == g && $2 != "" { print $2 }' | sed -n 's|^\*/\.github/\*\{0,1\}workflows/\(\*\.[A-Za-z0-9]*\)$|\1|p' | LC_ALL=C sort -u)"
+  [[ "$GATE_EXTS" == "$SCRIPT_EXTS" ]] || GATES_OFF+=" gate$g=(${GATE_EXTS//$'\n'/ })"
+done
 EXPECTED_IF="$(printf '%s\n' "$SCRIPT_EXTS" | sed 's|.*|Edit(**/.github/workflows/&)|' | tr '\n' ' ')"
 EXPECTED_IF="${EXPECTED_IF% }"
 EXPECTED_COUNT="$(printf '%s\n' "$SCRIPT_EXTS" | grep -c .)"
-if command -v jq >/dev/null 2>&1 && [[ -f "$HOOKS_JSON" && "$EXPECTED_COUNT" -gt 0 && "$OFF_SHAPE" == "0" ]]; then
+if command -v jq >/dev/null 2>&1 && [[ -f "$HOOKS_JSON" && "$CASE_BLOCKS" -ge 1 && -z "$GATES_OFF" && "$EXPECTED_COUNT" -gt 0 && "$OFF_SHAPE" == "0" ]]; then
   HANDLERS="$(jq -c '[.hooks | to_entries[] | .key as $ev | .value[]? | .matcher as $m | .hooks[]? | . + {event: $ev, matcher: ($m // "(none)")}]' "$HOOKS_JSON")"
   HANDLER_COUNT="$(jq 'length' <<<"$HANDLERS")"
   HANDLER_GROUPS="$(jq -r '[.[] | "\(.event):\(.matcher)"] | unique | join(",")' <<<"$HANDLERS")"
+  GROUPS_OFF="$(jq -r '[.[] | select(.event != "PostToolUse" or ((.matcher | split("|") | sort | unique) != ["Edit", "Write"])) | "\(.event):\(.matcher)"] | unique | join(",")' <<<"$HANDLERS")"
   IF_VALUES="$(jq -r '[.[] | (.if // "(none)")] | sort | join(" ")' <<<"$HANDLERS")"
   WRITE_IF="$(jq '[.[] | select(has("if") and (.if | startswith("Write(")))] | length' <<<"$HANDLERS")"
-  CMD_OK="$(jq '[.[] | select((.command | contains("\"${CLAUDE_PLUGIN_ROOT}\"")) and (.command | contains("actionlint-check.sh")))] | length' <<<"$HANDLERS")"
-  if [[ "$HANDLER_COUNT" == "$EXPECTED_COUNT" && "$IF_VALUES" == "$EXPECTED_IF" && "$WRITE_IF" == "0" && "$CMD_OK" == "$EXPECTED_COUNT" ]]; then
-    ok "hooks.json: every handler ($HANDLER_GROUPS) carries an if row, and the rows are exactly $EXPECTED_IF, the script's own workflow filter"
+  CMD_OFF="$(jq -r '[.[] | (.command // "(none)") | select(test("^(\"[$][{]?CLAUDE_PLUGIN_ROOT[}]?\"/hooks/actionlint-check[.]sh|\"[$][{]?CLAUDE_PLUGIN_ROOT[}]?/hooks/actionlint-check[.]sh\")$") | not)] | unique | join(",")' <<<"$HANDLERS")"
+  if [[ "$HANDLER_COUNT" == "$EXPECTED_COUNT" && "$IF_VALUES" == "$EXPECTED_IF" && "$WRITE_IF" == "0" && -z "$GROUPS_OFF" && -z "$CMD_OFF" ]]; then
+    ok "hooks.json: every handler ($HANDLER_GROUPS) is a PostToolUse Write and Edit group running the plugin's script, and the if rows are exactly $EXPECTED_IF, the script's own workflow filter ($CASE_BLOCKS case gates agree)"
   else
-    fail "hooks.json launch gate: handlers=$HANDLER_COUNT/$EXPECTED_COUNT groups=$HANDLER_GROUPS if='$IF_VALUES' expected='$EXPECTED_IF' write_if=$WRITE_IF cmd=$CMD_OK"
+    fail "hooks.json launch gate: handlers=$HANDLER_COUNT/$EXPECTED_COUNT groups=$HANDLER_GROUPS groups_off='$GROUPS_OFF' if='$IF_VALUES' expected='$EXPECTED_IF' write_if=$WRITE_IF cmd_off='$CMD_OFF'"
   fi
 else
-  fail "hooks.json launch-gate assertions need jq, $HOOKS_JSON and a script pre-filter made only of */.github/*workflows/*.<ext> patterns (off-shape=$OFF_SHAPE, patterns: ${SCRIPT_PATTERNS//$'\n'/ })"
+  fail "hooks.json launch-gate assertions need jq, $HOOKS_JSON and agreeing script gates made only of */.github/*workflows/*.<ext> patterns (gates=$CASE_BLOCKS off-shape=$OFF_SHAPE gate1=(${SCRIPT_EXTS//$'\n'/ }) disagreeing:${GATES_OFF:- none} patterns: ${SCRIPT_PATTERNS//$'\n'/ })"
 fi
 
 echo

--- a/plugins/actionlint/hooks/actionlint-check.test.sh
+++ b/plugins/actionlint/hooks/actionlint-check.test.sh
@@ -499,28 +499,65 @@ fi
 # cover the same extensions under .github/workflows: an if row the script does
 # not lint spawns a process that exits at the case, and an extension the script
 # lints with no if row is a silent regression, since the hook then never runs
-# for it. The extensions are read from the script's pre-filter line; the
+# for it.
+#
+# The expected set is every pattern of every arm in the script's whole
+# `case "${RAW_FILE//\\//}" ... esac` block except the bare `*` catch-all, so
+# an arm added anywhere in the block counts, and an alternation wrapped across
+# lines (a backslash continuation, or `;;` on its own line) reads the same as
+# one line. Every pattern must have the script's `*/.github/*workflows/*.<ext>`
+# shape, the only shape a manifest row is derived from here; the
 # `**/.github/workflows/` anchor is the manifest's own (per the hooks
 # reference, a single-segment `Edit(.github/workflows/*.yml)` has matched only
-# the working directory's own tree since v2.1.214).
+# the working directory's own tree since v2.1.214). On the manifest side every
+# handler under every event and matcher group is read, not only the
+# `Write|Edit` group: the if values across all of them must be exactly the
+# derived set, one row each, so a handler with no if, an if outside the set, a
+# `Write(...)` rule, a duplicate row, an unfiltered group under any event, or a
+# command pointing elsewhere fails here. What this does not reach is a
+# registration outside hooks/hooks.json.
 HOOKS_JSON="$HOOK_DIR/hooks.json"
-SCRIPT_EXTS="$(grep -m1 -E '^\*/\.github/\*workflows/' "$HOOK" | grep -o '\*\.[a-z]*' | LC_ALL=C sort -u)"
+SCRIPT_PATTERNS="$(awk '
+  /^case "[$][{]RAW_FILE[^"]*" in[[:space:]]*$/ { inblock = 1; next }
+  inblock && /^esac([[:space:]]|$)/ { exit }
+  inblock {
+    sub(/#.*/, "")
+    sub(/\\$/, " ")
+    block = block " " $0
+  }
+  END {
+    n = split(block, arms, ";;")
+    for (i = 1; i <= n; i++) {
+      if (index(arms[i], ")") == 0) continue
+      pats = substr(arms[i], 1, index(arms[i], ")") - 1)
+      sub(/^[[:space:]]*\(/, "", pats)
+      m = split(pats, alts, "|")
+      for (j = 1; j <= m; j++) {
+        p = alts[j]
+        gsub(/[[:space:]]+/, "", p)
+        if (p != "" && p != "*") print p
+      }
+    }
+  }' "$HOOK" | LC_ALL=C sort -u)"
+OFF_SHAPE="$(printf '%s\n' "$SCRIPT_PATTERNS" | grep -v -E '^\*/\.github/\*workflows/\*\.[A-Za-z0-9]+$' | grep -c .)"
+SCRIPT_EXTS="$(printf '%s\n' "$SCRIPT_PATTERNS" | sed -n 's|^\*/\.github/\*workflows/\(\*\.[A-Za-z0-9]*\)$|\1|p')"
 EXPECTED_IF="$(printf '%s\n' "$SCRIPT_EXTS" | sed 's|.*|Edit(**/.github/workflows/&)|' | tr '\n' ' ')"
 EXPECTED_IF="${EXPECTED_IF% }"
 EXPECTED_COUNT="$(printf '%s\n' "$SCRIPT_EXTS" | grep -c .)"
-if command -v jq >/dev/null 2>&1 && [[ -f "$HOOKS_JSON" && "$EXPECTED_COUNT" -gt 0 ]]; then
-  HANDLERS="$(jq -c '[.hooks.PostToolUse[]? | select(.matcher == "Write|Edit") | .hooks[]?]' "$HOOKS_JSON")"
+if command -v jq >/dev/null 2>&1 && [[ -f "$HOOKS_JSON" && "$EXPECTED_COUNT" -gt 0 && "$OFF_SHAPE" == "0" ]]; then
+  HANDLERS="$(jq -c '[.hooks | to_entries[] | .key as $ev | .value[]? | .matcher as $m | .hooks[]? | . + {event: $ev, matcher: ($m // "(none)")}]' "$HOOKS_JSON")"
   HANDLER_COUNT="$(jq 'length' <<<"$HANDLERS")"
+  HANDLER_GROUPS="$(jq -r '[.[] | "\(.event):\(.matcher)"] | unique | join(",")' <<<"$HANDLERS")"
   IF_VALUES="$(jq -r '[.[] | (.if // "(none)")] | sort | join(" ")' <<<"$HANDLERS")"
   WRITE_IF="$(jq '[.[] | select(has("if") and (.if | startswith("Write(")))] | length' <<<"$HANDLERS")"
   CMD_OK="$(jq '[.[] | select((.command | contains("\"${CLAUDE_PLUGIN_ROOT}\"")) and (.command | contains("actionlint-check.sh")))] | length' <<<"$HANDLERS")"
   if [[ "$HANDLER_COUNT" == "$EXPECTED_COUNT" && "$IF_VALUES" == "$EXPECTED_IF" && "$WRITE_IF" == "0" && "$CMD_OK" == "$EXPECTED_COUNT" ]]; then
-    ok "hooks.json launches only for $EXPECTED_IF, the script's own workflow filter"
+    ok "hooks.json: every handler ($HANDLER_GROUPS) carries an if row, and the rows are exactly $EXPECTED_IF, the script's own workflow filter"
   else
-    fail "hooks.json launch gate: count=$HANDLER_COUNT/$EXPECTED_COUNT if='$IF_VALUES' expected='$EXPECTED_IF' write_if=$WRITE_IF cmd=$CMD_OK"
+    fail "hooks.json launch gate: handlers=$HANDLER_COUNT/$EXPECTED_COUNT groups=$HANDLER_GROUPS if='$IF_VALUES' expected='$EXPECTED_IF' write_if=$WRITE_IF cmd=$CMD_OK"
   fi
 else
-  fail "hooks.json launch-gate assertions need jq, $HOOKS_JSON and the script's workflow pre-filter"
+  fail "hooks.json launch-gate assertions need jq, $HOOKS_JSON and a script pre-filter made only of */.github/*workflows/*.<ext> patterns (off-shape=$OFF_SHAPE, patterns: ${SCRIPT_PATTERNS//$'\n'/ })"
 fi
 
 echo

--- a/plugins/actionlint/hooks/actionlint-check.test.sh
+++ b/plugins/actionlint/hooks/actionlint-check.test.sh
@@ -489,6 +489,40 @@ else
   echo "SKIP: symlinks unavailable on this filesystem -- symlinked-root case skipped"
 fi
 
+# --- hooks.json: the if rows equal the script's own workflow filter (#3411) --
+# The if rows are what keep a Write or Edit of any other file from spawning
+# this hook: Claude Code evaluates a handler's `if` at match time and drops the
+# handler without a spawn (hooks reference, `if`, re-fetched 2026-09-07; the
+# installed CLI logs "Skipping hook due to if condition ... not matching"), and
+# an Edit(...) rule is the one consulted for Write and NotebookEdit as well.
+# The script's own case filter stays as defense in depth, so the two must
+# cover the same extensions under .github/workflows: an if row the script does
+# not lint spawns a process that exits at the case, and an extension the script
+# lints with no if row is a silent regression, since the hook then never runs
+# for it. The extensions are read from the script's pre-filter line; the
+# `**/.github/workflows/` anchor is the manifest's own (per the hooks
+# reference, a single-segment `Edit(.github/workflows/*.yml)` has matched only
+# the working directory's own tree since v2.1.214).
+HOOKS_JSON="$HOOK_DIR/hooks.json"
+SCRIPT_EXTS="$(grep -m1 -E '^\*/\.github/\*workflows/' "$HOOK" | grep -o '\*\.[a-z]*' | LC_ALL=C sort -u)"
+EXPECTED_IF="$(printf '%s\n' "$SCRIPT_EXTS" | sed 's|.*|Edit(**/.github/workflows/&)|' | tr '\n' ' ')"
+EXPECTED_IF="${EXPECTED_IF% }"
+EXPECTED_COUNT="$(printf '%s\n' "$SCRIPT_EXTS" | grep -c .)"
+if command -v jq >/dev/null 2>&1 && [[ -f "$HOOKS_JSON" && "$EXPECTED_COUNT" -gt 0 ]]; then
+  HANDLERS="$(jq -c '[.hooks.PostToolUse[]? | select(.matcher == "Write|Edit") | .hooks[]?]' "$HOOKS_JSON")"
+  HANDLER_COUNT="$(jq 'length' <<<"$HANDLERS")"
+  IF_VALUES="$(jq -r '[.[] | (.if // "(none)")] | sort | join(" ")' <<<"$HANDLERS")"
+  WRITE_IF="$(jq '[.[] | select(has("if") and (.if | startswith("Write(")))] | length' <<<"$HANDLERS")"
+  CMD_OK="$(jq '[.[] | select((.command | contains("\"${CLAUDE_PLUGIN_ROOT}\"")) and (.command | contains("actionlint-check.sh")))] | length' <<<"$HANDLERS")"
+  if [[ "$HANDLER_COUNT" == "$EXPECTED_COUNT" && "$IF_VALUES" == "$EXPECTED_IF" && "$WRITE_IF" == "0" && "$CMD_OK" == "$EXPECTED_COUNT" ]]; then
+    ok "hooks.json launches only for $EXPECTED_IF, the script's own workflow filter"
+  else
+    fail "hooks.json launch gate: count=$HANDLER_COUNT/$EXPECTED_COUNT if='$IF_VALUES' expected='$EXPECTED_IF' write_if=$WRITE_IF cmd=$CMD_OK"
+  fi
+else
+  fail "hooks.json launch-gate assertions need jq, $HOOKS_JSON and the script's workflow pre-filter"
+fi
+
 echo
 echo "PASS=$PASS FAIL=$FAIL"
 [[ $FAIL -eq 0 ]]

--- a/plugins/bash-format/.claude-plugin/plugin.json
+++ b/plugins/bash-format/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "bash-format",
-  "version": "0.7.43",
+  "version": "0.7.44",
   "description": "Auto-format and lint shell scripts on edit via shfmt + ShellCheck, using the consuming repo's own .editorconfig and .shellcheckrc.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/bash-format/CHANGELOG.md
+++ b/plugins/bash-format/CHANGELOG.md
@@ -12,11 +12,12 @@ All notable changes to the `bash-format` plugin are documented here. Format foll
   `if` rows are what keep a Write of any other file from spawning the hook
   (Claude Code drops a non-matching handler at match time, before a spawn);
   the script's `case` filter stays as defense in depth, and the new case
-  reads that filter's extension list and fails on drift in either direction,
-  since an extension the script handles with no `if` row is a silent
-  regression. The README's "Hook budget accounting" section carries a
-  Linux-host measurement and kernel census per hook-budget rule 1; no hook
-  behavior changes.
+  reads every arm of that filter's whole `case` block, requires every
+  handler in the manifest, under any event, to carry one of the derived
+  rows, and fails on drift in either direction, since an extension the
+  script handles with no `if` row is a silent regression. The README's
+  "Hook budget accounting" section carries a Linux-host measurement and
+  kernel census per hook-budget rule 1; no hook behavior changes.
 
 ## [0.7.43]
 

--- a/plugins/bash-format/CHANGELOG.md
+++ b/plugins/bash-format/CHANGELOG.md
@@ -3,6 +3,21 @@
 All notable changes to the `bash-format` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.7.44]
+
+### Added
+
+- **The suite pins the manifest's `if` rows to the script's own extension
+  set, and the README states the hook's measured budget share (#3411).** The
+  `if` rows are what keep a Write of any other file from spawning the hook
+  (Claude Code drops a non-matching handler at match time, before a spawn);
+  the script's `case` filter stays as defense in depth, and the new case
+  reads that filter's extension list and fails on drift in either direction,
+  since an extension the script handles with no `if` row is a silent
+  regression. The README's "Hook budget accounting" section carries a
+  Linux-host measurement and kernel census per hook-budget rule 1; no hook
+  behavior changes.
+
 ## [0.7.43]
 
 ### Changed

--- a/plugins/bash-format/CHANGELOG.md
+++ b/plugins/bash-format/CHANGELOG.md
@@ -12,10 +12,14 @@ All notable changes to the `bash-format` plugin are documented here. Format foll
   `if` rows are what keep a Write of any other file from spawning the hook
   (Claude Code drops a non-matching handler at match time, before a spawn);
   the script's `case` filter stays as defense in depth, and the new case
-  reads every arm of that filter's whole `case` block, requires every
-  handler in the manifest, under any event, to carry one of the derived
-  rows, and fails on drift in either direction, since an extension the
-  script handles with no `if` row is a silent regression. The README's
+  reads every arm of that filter's whole `case` block (each of bash's arm
+  terminators, `;;`, `;&` and `;;&`, ends an arm, and the `case "$FILE"`
+  re-check must yield the same set), requires every handler in the
+  manifest, under any event, to carry one of the derived rows and to sit in
+  a PostToolUse group whose matcher is exactly Write and Edit and whose
+  command is the plugin's own script, and fails on drift in either
+  direction, since an extension the script handles with no `if` row is a
+  silent regression, and so is a matcher narrowed to one tool. The README's
   "Hook budget accounting" section carries a Linux-host measurement and
   kernel census per hook-budget rule 1; no hook behavior changes.
 

--- a/plugins/bash-format/README.md
+++ b/plugins/bash-format/README.md
@@ -72,6 +72,28 @@ The hook itself runs on Bash 3.2+. Telemetry timing uses `EPOCHREALTIME`
 (Bash 5.0+); on older bash the telemetry envelope is skipped while linting and
 formatting still run.
 
+### Hook budget accounting
+
+Per [`docs/conventions/hook-budget/README.md`](../../docs/conventions/hook-budget/README.md),
+this hook is always-on for every `Write` and `Edit` of a `.sh` or `.bash` file (the two `if`
+rows in `hooks/hooks.json` keep every other extension from spawning it, and the suite pins those
+rows to the script's own extension set), so its cost on a clean shell file is the figure that
+counts. Measured on Linux x86_64 under bash 5.2 in a container, twelve interleaved trials
+against an interleaved `bash -c :` floor S of about 2 ms, with a kernel census from
+`strace -f -e trace=clone,clone3,fork,vfork,execve` (2026-09-07, 0.7.44):
+
+| Event | Fires | Wall | Spawn-equivalents | Kernel census |
+| --- | --- | --- | --- | --- |
+| PostToolUse `Write`, clean `.sh`, no `.editorconfig` shell section | 1 | 37 ms | 17.3 | 13 process creations, 5 execs: `shellcheck`, `git`, `jq`, `realpath`, the hook's own `bash` |
+| PostToolUse `Write`, clean `.sh`, `.editorconfig` `[*.sh]` present | 1 | 55 ms | 25.1 | 32 process creations, 11 execs: the row above plus two `shfmt` and the disclosure snapshot's `mktemp`, `cp`, `cmp`, `rm` |
+| PostToolUse `Write`, any other extension | 0 | none | 0 | no process; the `if` rows drop the handler before a spawn |
+
+At a 2 ms floor the spawn-equivalent column mostly measures the tools' own run time rather
+than spawns, so the census column is the number that transfers to the Windows 11 Git Bash
+reference host the convention calls binding; that host's figure for this plugin has not been
+taken. The residual is ShellCheck and shfmt themselves plus the shared library's payload reader
+(`jq`), root resolver (`git`, `realpath`) and the disclosure snapshot.
+
 ## Install
 
 ```shell

--- a/plugins/bash-format/README.md
+++ b/plugins/bash-format/README.md
@@ -75,24 +75,26 @@ formatting still run.
 ### Hook budget accounting
 
 Per [`docs/conventions/hook-budget/README.md`](../../docs/conventions/hook-budget/README.md),
-this hook is always-on for every `Write` and `Edit` of a `.sh` or `.bash` file (the two `if`
-rows in `hooks/hooks.json` keep every other extension from spawning it, and the suite pins those
-rows to the script's own extension set), so its cost on a clean shell file is the figure that
-counts. Measured on Linux x86_64 under bash 5.2 in a container, twelve interleaved trials
-against an interleaved `bash -c :` floor S of about 2 ms, with a kernel census from
+this hook is always-on for every `Write` and `Edit` of a `.sh` or `.bash` file (every handler in
+`hooks/hooks.json` carries one of the two `if` rows, which keep every other extension from
+spawning it, and the suite pins the whole handler set to the script's own extension set), so its
+cost on a clean shell file is the figure that counts. Measured on Linux x86_64 under bash 5.2 in
+a container with `HOOK_TELEMETRY_SINK` and `CLAUDE_PROJECT_DIR` unset, twelve interleaved trials
+against an interleaved `bash -c :` floor S of about 4 ms, with a kernel census from
 `strace -f -e trace=clone,clone3,fork,vfork,execve` (2026-09-07, 0.7.44):
 
 | Event | Fires | Wall | Spawn-equivalents | Kernel census |
 | --- | --- | --- | --- | --- |
-| PostToolUse `Write`, clean `.sh`, no `.editorconfig` shell section | 1 | 37 ms | 17.3 | 13 process creations, 5 execs: `shellcheck`, `git`, `jq`, `realpath`, the hook's own `bash` |
-| PostToolUse `Write`, clean `.sh`, `.editorconfig` `[*.sh]` present | 1 | 55 ms | 25.1 | 32 process creations, 11 execs: the row above plus two `shfmt` and the disclosure snapshot's `mktemp`, `cp`, `cmp`, `rm` |
+| PostToolUse `Write`, clean `.sh`, no `.editorconfig` shell section | 1 | 45 ms | 10.5 | 14 process creations, 6 execs: `shellcheck`, two `git rev-parse` (the working-tree probe and the root resolver), `jq`, `realpath`, the hook's own `bash` |
+| PostToolUse `Write`, clean `.sh`, `.editorconfig` `[*.sh]` present | 1 | 55 ms | 14.1 | 31 to 32 process creations (the tools' own threads vary), 12 execs: the row above plus two `shfmt` and the disclosure snapshot's `mktemp`, `cp`, `cmp`, `rm` |
 | PostToolUse `Write`, any other extension | 0 | none | 0 | no process; the `if` rows drop the handler before a spawn |
 
-At a 2 ms floor the spawn-equivalent column mostly measures the tools' own run time rather
+At a 4 ms floor the spawn-equivalent column mostly measures the tools' own run time rather
 than spawns, so the census column is the number that transfers to the Windows 11 Git Bash
 reference host the convention calls binding; that host's figure for this plugin has not been
 taken. The residual is ShellCheck and shfmt themselves plus the shared library's payload reader
-(`jq`), root resolver (`git`, `realpath`) and the disclosure snapshot.
+(`jq`), working-tree probe and root resolver (`git` twice, `realpath`) and the disclosure
+snapshot.
 
 ## Install
 

--- a/plugins/bash-format/hooks/bash-format.test.sh
+++ b/plugins/bash-format/hooks/bash-format.test.sh
@@ -708,6 +708,37 @@ else
   fail "jq-absent out-of-scope edit (rc=$RC_OOS out=$OUT_OOS)"
 fi
 
+# --- hooks.json: the if rows equal the script's own extension set (#3411) ----
+# The if rows are what keep a Write or Edit of any other file from spawning
+# this hook: Claude Code evaluates a handler's `if` at match time and drops the
+# handler without a spawn (hooks reference, `if`, re-fetched 2026-09-07; the
+# installed CLI logs "Skipping hook due to if condition ... not matching"), and
+# an Edit(...) rule is the one consulted for Write and NotebookEdit as well.
+# The script's own case filter stays as defense in depth, so the two sets must
+# be IDENTICAL: an if row the script does not handle spawns a process that
+# exits at the case, and an extension the script handles with no if row is a
+# silent regression, since the hook then never runs for it. The expected set is
+# read from the script's pre-filter line, so drift on either side fails here.
+HOOKS_JSON="$HOOK_DIR/hooks.json"
+SCRIPT_EXTS="$(sed -n '/^case "\$RAW_FILE" in$/{n;p;q;}' "$HOOK" | tr -d ' );' | tr '|' '\n' | LC_ALL=C sort)"
+EXPECTED_IF="$(printf '%s\n' "$SCRIPT_EXTS" | sed 's/.*/Edit(&)/' | tr '\n' ' ')"
+EXPECTED_IF="${EXPECTED_IF% }"
+EXPECTED_COUNT="$(printf '%s\n' "$SCRIPT_EXTS" | grep -c .)"
+if command -v jq >/dev/null 2>&1 && [[ -f "$HOOKS_JSON" && "$EXPECTED_COUNT" -gt 0 ]]; then
+  HANDLERS="$(jq -c '[.hooks.PostToolUse[]? | select(.matcher == "Write|Edit") | .hooks[]?]' "$HOOKS_JSON")"
+  HANDLER_COUNT="$(jq 'length' <<<"$HANDLERS")"
+  IF_VALUES="$(jq -r '[.[] | (.if // "(none)")] | sort | join(" ")' <<<"$HANDLERS")"
+  WRITE_IF="$(jq '[.[] | select(has("if") and (.if | startswith("Write(")))] | length' <<<"$HANDLERS")"
+  CMD_OK="$(jq '[.[] | select((.command | contains("\"${CLAUDE_PLUGIN_ROOT}\"")) and (.command | contains("bash-format.sh")))] | length' <<<"$HANDLERS")"
+  if [[ "$HANDLER_COUNT" == "$EXPECTED_COUNT" && "$IF_VALUES" == "$EXPECTED_IF" && "$WRITE_IF" == "0" && "$CMD_OK" == "$EXPECTED_COUNT" ]]; then
+    ok "hooks.json launches only for $EXPECTED_IF, the script's own extension set"
+  else
+    fail "hooks.json launch gate: count=$HANDLER_COUNT/$EXPECTED_COUNT if='$IF_VALUES' expected='$EXPECTED_IF' write_if=$WRITE_IF cmd=$CMD_OK"
+  fi
+else
+  fail "hooks.json launch-gate assertions need jq, $HOOKS_JSON and the script's case \"\$RAW_FILE\" pre-filter"
+fi
+
 echo
 echo "PASS=$PASS FAIL=$FAIL"
 [[ $FAIL -eq 0 ]]

--- a/plugins/bash-format/hooks/bash-format.test.sh
+++ b/plugins/bash-format/hooks/bash-format.test.sh
@@ -717,23 +717,55 @@ fi
 # The script's own case filter stays as defense in depth, so the two sets must
 # be IDENTICAL: an if row the script does not handle spawns a process that
 # exits at the case, and an extension the script handles with no if row is a
-# silent regression, since the hook then never runs for it. The expected set is
-# read from the script's pre-filter line, so drift on either side fails here.
+# silent regression, since the hook then never runs for it.
+#
+# The expected set is every pattern of every arm in the script's whole
+# `case "$RAW_FILE" ... esac` block except the bare `*` catch-all, so an arm
+# added anywhere in the block counts, and an alternation wrapped across lines
+# (a backslash continuation, or `;;` on its own line) reads the same as one
+# line. On the manifest side every handler under every event and matcher
+# group is read, not only the `Write|Edit` group: the if values across all of
+# them must be exactly the derived set, one row each, so a handler with no if,
+# an if outside the set, a `Write(...)` rule, a duplicate row, an unfiltered
+# group under any event, or a command pointing elsewhere fails here. What
+# this does not reach is a registration outside hooks/hooks.json.
 HOOKS_JSON="$HOOK_DIR/hooks.json"
-SCRIPT_EXTS="$(sed -n '/^case "\$RAW_FILE" in$/{n;p;q;}' "$HOOK" | tr -d ' );' | tr '|' '\n' | LC_ALL=C sort)"
+SCRIPT_EXTS="$(awk '
+  /^case "[$]RAW_FILE" in[[:space:]]*$/ { inblock = 1; next }
+  inblock && /^esac([[:space:]]|$)/ { exit }
+  inblock {
+    sub(/#.*/, "")
+    sub(/\\$/, " ")
+    block = block " " $0
+  }
+  END {
+    n = split(block, arms, ";;")
+    for (i = 1; i <= n; i++) {
+      if (index(arms[i], ")") == 0) continue
+      pats = substr(arms[i], 1, index(arms[i], ")") - 1)
+      sub(/^[[:space:]]*\(/, "", pats)
+      m = split(pats, alts, "|")
+      for (j = 1; j <= m; j++) {
+        p = alts[j]
+        gsub(/[[:space:]]+/, "", p)
+        if (p != "" && p != "*") print p
+      }
+    }
+  }' "$HOOK" | LC_ALL=C sort -u)"
 EXPECTED_IF="$(printf '%s\n' "$SCRIPT_EXTS" | sed 's/.*/Edit(&)/' | tr '\n' ' ')"
 EXPECTED_IF="${EXPECTED_IF% }"
 EXPECTED_COUNT="$(printf '%s\n' "$SCRIPT_EXTS" | grep -c .)"
 if command -v jq >/dev/null 2>&1 && [[ -f "$HOOKS_JSON" && "$EXPECTED_COUNT" -gt 0 ]]; then
-  HANDLERS="$(jq -c '[.hooks.PostToolUse[]? | select(.matcher == "Write|Edit") | .hooks[]?]' "$HOOKS_JSON")"
+  HANDLERS="$(jq -c '[.hooks | to_entries[] | .key as $ev | .value[]? | .matcher as $m | .hooks[]? | . + {event: $ev, matcher: ($m // "(none)")}]' "$HOOKS_JSON")"
   HANDLER_COUNT="$(jq 'length' <<<"$HANDLERS")"
+  HANDLER_GROUPS="$(jq -r '[.[] | "\(.event):\(.matcher)"] | unique | join(",")' <<<"$HANDLERS")"
   IF_VALUES="$(jq -r '[.[] | (.if // "(none)")] | sort | join(" ")' <<<"$HANDLERS")"
   WRITE_IF="$(jq '[.[] | select(has("if") and (.if | startswith("Write(")))] | length' <<<"$HANDLERS")"
   CMD_OK="$(jq '[.[] | select((.command | contains("\"${CLAUDE_PLUGIN_ROOT}\"")) and (.command | contains("bash-format.sh")))] | length' <<<"$HANDLERS")"
   if [[ "$HANDLER_COUNT" == "$EXPECTED_COUNT" && "$IF_VALUES" == "$EXPECTED_IF" && "$WRITE_IF" == "0" && "$CMD_OK" == "$EXPECTED_COUNT" ]]; then
-    ok "hooks.json launches only for $EXPECTED_IF, the script's own extension set"
+    ok "hooks.json: every handler ($HANDLER_GROUPS) carries an if row, and the rows are exactly $EXPECTED_IF, the script's own extension set"
   else
-    fail "hooks.json launch gate: count=$HANDLER_COUNT/$EXPECTED_COUNT if='$IF_VALUES' expected='$EXPECTED_IF' write_if=$WRITE_IF cmd=$CMD_OK"
+    fail "hooks.json launch gate: handlers=$HANDLER_COUNT/$EXPECTED_COUNT groups=$HANDLER_GROUPS if='$IF_VALUES' expected='$EXPECTED_IF' write_if=$WRITE_IF cmd=$CMD_OK"
   fi
 else
   fail "hooks.json launch-gate assertions need jq, $HOOKS_JSON and the script's case \"\$RAW_FILE\" pre-filter"

--- a/plugins/bash-format/hooks/bash-format.test.sh
+++ b/plugins/bash-format/hooks/bash-format.test.sh
@@ -721,25 +721,44 @@ fi
 #
 # The expected set is every pattern of every arm in the script's whole
 # `case "$RAW_FILE" ... esac` block except the bare `*` catch-all, so an arm
-# added anywhere in the block counts, and an alternation wrapped across lines
-# (a backslash continuation, or `;;` on its own line) reads the same as one
-# line. On the manifest side every handler under every event and matcher
-# group is read, not only the `Write|Edit` group: the if values across all of
-# them must be exactly the derived set, one row each, so a handler with no if,
-# an if outside the set, a `Write(...)` rule, a duplicate row, an unfiltered
-# group under any event, or a command pointing elsewhere fails here. What
-# this does not reach is a registration outside hooks/hooks.json.
+# added anywhere in the block counts. The block is read the way bash reads it:
+# a backslash continuation joins lines with nothing in between (so `;\` and a
+# following `;` is one `;;`), a comment after `in` or on any arm is dropped, a
+# one-line `case ... esac` is one block, `in` on the line after the `case`
+# word opens the block all the same, and every arm terminator bash has
+# (`;;`, the `;&` fall-through and the `;;&` continue-matching form) ends an
+# arm, so the patterns of an arm reached only by fall-through count too. What
+# the parser does not read is an arm's body, so a pattern in any arm, even one
+# after `*)` that can never match, counts as handled and must have its row.
+# The script's `case "$FILE"` re-check after path normalization (the duplicate
+# #3408 owns folding) is read the same way, and every such gate must yield the
+# same set, so an exclusion added to either gate fails here instead of sitting
+# unread; a script with one gate left passes as it is.
+#
+# On the manifest side every handler under every event and matcher group is
+# read. Two things are pinned separately, since they answer different
+# questions. The `if` rows, which paths a handler applies to: the values
+# across every handler must be exactly the derived set, one row each, so a
+# handler with no if, an if outside the set, a `Write(...)` rule, a duplicate
+# row or an unfiltered group under any event fails. The group, which tools
+# invoke the handler at all: every group must be PostToolUse with a matcher
+# whose alternation is exactly Write and Edit in either order, the two tools
+# whose payload carries a file this script formats (the rule validator folds
+# Write and NotebookEdit into an Edit(...) rule, but the matcher is the tool
+# name regex the harness consults first, and a matcher narrowed to one tool
+# is the hook silently never running for the other, which no if row can show).
+# The command must be the plugin's own script by either quoting placement,
+# with no prefix, suffix or argument. What this does not reach is a
+# registration outside hooks/hooks.json.
 HOOKS_JSON="$HOOK_DIR/hooks.json"
-SCRIPT_EXTS="$(awk '
-  /^case "[$]RAW_FILE" in[[:space:]]*$/ { inblock = 1; next }
-  inblock && /^esac([[:space:]]|$)/ { exit }
-  inblock {
-    sub(/#.*/, "")
-    sub(/\\$/, " ")
-    block = block " " $0
-  }
-  END {
-    n = split(block, arms, ";;")
+SCRIPT_GATES="$(awk '
+  function flush(   n, i, m, j, p, pats, arms, alts) {
+    inblock = 0
+    print nblocks "\t"
+    gsub(/;;&/, "\n", block)
+    gsub(/;;/, "\n", block)
+    gsub(/;&/, "\n", block)
+    n = split(block, arms, "\n")
     for (i = 1; i <= n; i++) {
       if (index(arms[i], ")") == 0) continue
       pats = substr(arms[i], 1, index(arms[i], ")") - 1)
@@ -748,27 +767,73 @@ SCRIPT_EXTS="$(awk '
       for (j = 1; j <= m; j++) {
         p = alts[j]
         gsub(/[[:space:]]+/, "", p)
-        if (p != "" && p != "*") print p
+        if (p != "" && p != "*") print nblocks "\t" p
       }
     }
-  }' "$HOOK" | LC_ALL=C sort -u)"
+  }
+  !inblock && !pending && $0 ~ /^case "[$](RAW_FILE|FILE)"[[:space:]]*(#.*)?$/ {
+    pending = 1
+    next
+  }
+  pending && match($0, /^[[:space:]]*in([[:space:]]|$)/) {
+    pending = 0
+    inblock = 1
+    nblocks++
+    block = ""
+    sep = ""
+    $0 = substr($0, RLENGTH + 1)
+  }
+  !inblock && match($0, /^case "[$](RAW_FILE|FILE)" in([[:space:]]|$)/) {
+    inblock = 1
+    nblocks++
+    block = ""
+    sep = ""
+    $0 = substr($0, RLENGTH + 1)
+  }
+  inblock {
+    sub(/#.*/, "")
+    if ($0 ~ /^[[:space:]]*esac([[:space:]]|$)/) {
+      flush()
+      next
+    }
+    if (match($0, /[[:space:]]esac([[:space:]]|$)/)) {
+      block = block sep substr($0, 1, RSTART - 1)
+      flush()
+      next
+    }
+    if (sub(/\\$/, "")) {
+      block = block sep $0
+      sep = ""
+    } else {
+      block = block sep $0
+      sep = " "
+    }
+  }' "$HOOK")"
+CASE_BLOCKS="$(printf '%s\n' "$SCRIPT_GATES" | cut -f1 | LC_ALL=C sort -u | grep -c .)"
+SCRIPT_EXTS="$(printf '%s\n' "$SCRIPT_GATES" | awk -F'\t' '$1 == 1 && $2 != "" { print $2 }' | LC_ALL=C sort -u)"
+GATES_OFF=""
+for ((g = 2; g <= CASE_BLOCKS; g++)); do
+  GATE_EXTS="$(printf '%s\n' "$SCRIPT_GATES" | awk -F'\t' -v g="$g" '$1 == g && $2 != "" { print $2 }' | LC_ALL=C sort -u)"
+  [[ "$GATE_EXTS" == "$SCRIPT_EXTS" ]] || GATES_OFF+=" gate$g=(${GATE_EXTS//$'\n'/ })"
+done
 EXPECTED_IF="$(printf '%s\n' "$SCRIPT_EXTS" | sed 's/.*/Edit(&)/' | tr '\n' ' ')"
 EXPECTED_IF="${EXPECTED_IF% }"
 EXPECTED_COUNT="$(printf '%s\n' "$SCRIPT_EXTS" | grep -c .)"
-if command -v jq >/dev/null 2>&1 && [[ -f "$HOOKS_JSON" && "$EXPECTED_COUNT" -gt 0 ]]; then
+if command -v jq >/dev/null 2>&1 && [[ -f "$HOOKS_JSON" && "$CASE_BLOCKS" -ge 1 && -z "$GATES_OFF" && "$EXPECTED_COUNT" -gt 0 ]]; then
   HANDLERS="$(jq -c '[.hooks | to_entries[] | .key as $ev | .value[]? | .matcher as $m | .hooks[]? | . + {event: $ev, matcher: ($m // "(none)")}]' "$HOOKS_JSON")"
   HANDLER_COUNT="$(jq 'length' <<<"$HANDLERS")"
   HANDLER_GROUPS="$(jq -r '[.[] | "\(.event):\(.matcher)"] | unique | join(",")' <<<"$HANDLERS")"
+  GROUPS_OFF="$(jq -r '[.[] | select(.event != "PostToolUse" or ((.matcher | split("|") | sort | unique) != ["Edit", "Write"])) | "\(.event):\(.matcher)"] | unique | join(",")' <<<"$HANDLERS")"
   IF_VALUES="$(jq -r '[.[] | (.if // "(none)")] | sort | join(" ")' <<<"$HANDLERS")"
   WRITE_IF="$(jq '[.[] | select(has("if") and (.if | startswith("Write(")))] | length' <<<"$HANDLERS")"
-  CMD_OK="$(jq '[.[] | select((.command | contains("\"${CLAUDE_PLUGIN_ROOT}\"")) and (.command | contains("bash-format.sh")))] | length' <<<"$HANDLERS")"
-  if [[ "$HANDLER_COUNT" == "$EXPECTED_COUNT" && "$IF_VALUES" == "$EXPECTED_IF" && "$WRITE_IF" == "0" && "$CMD_OK" == "$EXPECTED_COUNT" ]]; then
-    ok "hooks.json: every handler ($HANDLER_GROUPS) carries an if row, and the rows are exactly $EXPECTED_IF, the script's own extension set"
+  CMD_OFF="$(jq -r '[.[] | (.command // "(none)") | select(test("^(\"[$][{]?CLAUDE_PLUGIN_ROOT[}]?\"/hooks/bash-format[.]sh|\"[$][{]?CLAUDE_PLUGIN_ROOT[}]?/hooks/bash-format[.]sh\")$") | not)] | unique | join(",")' <<<"$HANDLERS")"
+  if [[ "$HANDLER_COUNT" == "$EXPECTED_COUNT" && "$IF_VALUES" == "$EXPECTED_IF" && "$WRITE_IF" == "0" && -z "$GROUPS_OFF" && -z "$CMD_OFF" ]]; then
+    ok "hooks.json: every handler ($HANDLER_GROUPS) is a PostToolUse Write and Edit group running the plugin's script, and the if rows are exactly $EXPECTED_IF, the script's own extension set ($CASE_BLOCKS case gates agree)"
   else
-    fail "hooks.json launch gate: handlers=$HANDLER_COUNT/$EXPECTED_COUNT groups=$HANDLER_GROUPS if='$IF_VALUES' expected='$EXPECTED_IF' write_if=$WRITE_IF cmd=$CMD_OK"
+    fail "hooks.json launch gate: handlers=$HANDLER_COUNT/$EXPECTED_COUNT groups=$HANDLER_GROUPS groups_off='$GROUPS_OFF' if='$IF_VALUES' expected='$EXPECTED_IF' write_if=$WRITE_IF cmd_off='$CMD_OFF'"
   fi
 else
-  fail "hooks.json launch-gate assertions need jq, $HOOKS_JSON and the script's case \"\$RAW_FILE\" pre-filter"
+  fail "hooks.json launch-gate assertions need jq, $HOOKS_JSON and agreeing case \"\$RAW_FILE\" / \"\$FILE\" gates in the script (gates=$CASE_BLOCKS gate1=(${SCRIPT_EXTS//$'\n'/ }) disagreeing:${GATES_OFF:- none})"
 fi
 
 echo

--- a/plugins/biome-format/.claude-plugin/plugin.json
+++ b/plugins/biome-format/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "biome-format",
-  "version": "0.6.41",
+  "version": "0.6.42",
   "description": "Auto-format and lint JS/TS/JSX/JSON on edit via Biome, only when a biome.json governs the repo — using the consuming repo's own Biome config.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/biome-format/CHANGELOG.md
+++ b/plugins/biome-format/CHANGELOG.md
@@ -12,10 +12,14 @@ All notable changes to the `biome-format` plugin are documented here. Format fol
   `if` rows are what keep a Write of any other file from spawning the hook
   (Claude Code drops a non-matching handler at match time, before a spawn);
   the script's `case` filter stays as defense in depth, and the new case
-  reads every arm of that filter's whole `case` block, requires every
-  handler in the manifest, under any event, to carry one of the derived
-  rows, and fails on drift in either direction, since an extension the
-  script handles with no `if` row is a silent regression. The README's
+  reads every arm of that filter's whole `case` block (each of bash's arm
+  terminators, `;;`, `;&` and `;;&`, ends an arm, and the `case "$FILE"`
+  re-check must yield the same set), requires every handler in the
+  manifest, under any event, to carry one of the derived rows and to sit in
+  a PostToolUse group whose matcher is exactly Write and Edit and whose
+  command is the plugin's own script, and fails on drift in either
+  direction, since an extension the script handles with no `if` row is a
+  silent regression, and so is a matcher narrowed to one tool. The README's
   "Hook budget accounting" section carries a Linux-host measurement and
   kernel census per hook-budget rule 1; no hook behavior changes.
 

--- a/plugins/biome-format/CHANGELOG.md
+++ b/plugins/biome-format/CHANGELOG.md
@@ -12,11 +12,12 @@ All notable changes to the `biome-format` plugin are documented here. Format fol
   `if` rows are what keep a Write of any other file from spawning the hook
   (Claude Code drops a non-matching handler at match time, before a spawn);
   the script's `case` filter stays as defense in depth, and the new case
-  reads that filter's extension list and fails on drift in either direction,
-  since an extension the script handles with no `if` row is a silent
-  regression. The README's "Hook budget accounting" section carries a
-  Linux-host measurement and kernel census per hook-budget rule 1; no hook
-  behavior changes.
+  reads every arm of that filter's whole `case` block, requires every
+  handler in the manifest, under any event, to carry one of the derived
+  rows, and fails on drift in either direction, since an extension the
+  script handles with no `if` row is a silent regression. The README's
+  "Hook budget accounting" section carries a Linux-host measurement and
+  kernel census per hook-budget rule 1; no hook behavior changes.
 
 ## [0.6.41]
 

--- a/plugins/biome-format/CHANGELOG.md
+++ b/plugins/biome-format/CHANGELOG.md
@@ -3,6 +3,21 @@
 All notable changes to the `biome-format` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.6.42]
+
+### Added
+
+- **The suite pins the manifest's `if` rows to the script's own extension
+  set, and the README states the hook's measured budget share (#3411).** The
+  `if` rows are what keep a Write of any other file from spawning the hook
+  (Claude Code drops a non-matching handler at match time, before a spawn);
+  the script's `case` filter stays as defense in depth, and the new case
+  reads that filter's extension list and fails on drift in either direction,
+  since an extension the script handles with no `if` row is a silent
+  regression. The README's "Hook budget accounting" section carries a
+  Linux-host measurement and kernel census per hook-budget rule 1; no hook
+  behavior changes.
+
 ## [0.6.41]
 
 ### Changed

--- a/plugins/biome-format/README.md
+++ b/plugins/biome-format/README.md
@@ -64,24 +64,25 @@ linting still run.
 
 Per [`docs/conventions/hook-budget/README.md`](../../docs/conventions/hook-budget/README.md),
 this hook is always-on for every `Write` and `Edit` of a `.ts`, `.tsx`, `.js`, `.jsx`, `.mjs`,
-`.cjs`, `.mts`, `.cts`, `.json` or `.jsonc` file (the ten `if` rows in `hooks/hooks.json` keep
-every other extension from spawning it, and the suite pins those rows to the script's own
-extension set), so its cost on a clean file is the figure that counts. Measured on Linux x86_64
-under bash 5.2 in a container, twelve interleaved trials against an interleaved `bash -c :`
-floor S of about 2 ms, with a kernel census from
+`.cjs`, `.mts`, `.cts`, `.json` or `.jsonc` file (every handler in `hooks/hooks.json` carries
+one of the ten `if` rows, which keep every other extension from spawning it, and the suite pins
+the whole handler set to the script's own extension set), so its cost on a clean file is the
+figure that counts. Measured on Linux x86_64 under bash 5.2 in a container with
+`HOOK_TELEMETRY_SINK` and `CLAUDE_PROJECT_DIR` unset, twelve interleaved trials against an
+interleaved `bash -c :` floor S of about 4 ms, with a kernel census from
 `strace -f -e trace=clone,clone3,fork,vfork,execve` (2026-09-07, 0.6.42):
 
 | Event | Fires | Wall | Spawn-equivalents | Kernel census |
 | --- | --- | --- | --- | --- |
-| PostToolUse `Write`, clean `.ts`, no `biome.json` (opt-in absent) | 1 | 31 ms | 14.2 | 10 process creations, 4 execs: `git`, `jq`, `realpath`, the hook's own `bash` |
-| PostToolUse `Write`, clean `.ts`, `biome.json` present | 1 | 116 ms | 52.0 | 33 process creations, 16 execs: the row above plus three `biome` runs, the `node_modules/.bin` launcher and the `node` and `ldd` it spawns, and the disclosure snapshot's `mktemp`, `cp`, `cmp`, `rm` |
+| PostToolUse `Write`, clean `.ts`, no `biome.json` (opt-in absent) | 1 | 31 ms | 7.9 | 11 process creations, 5 execs: two `git rev-parse` (the working-tree probe and the root resolver), `jq`, `realpath`, the hook's own `bash` |
+| PostToolUse `Write`, clean `.ts`, `biome.json` present | 1 | 117 ms | 27.5 | 34 process creations, 15 execs: the row above plus the hook's `env -u BIOME_CONFIG_PATH` wrapper, the `node_modules/.bin/biome` launcher script and the `node` it runs, the `sh -c "ldd --version"` and `ldd` of that launcher's libc probe, one `biome` binary run, and the disclosure snapshot's `mktemp`, `cp`, `cmp`, `rm` |
 | PostToolUse `Write`, any other extension | 0 | none | 0 | no process; the `if` rows drop the handler before a spawn |
 
-At a 2 ms floor the spawn-equivalent column mostly measures Biome's own run time rather than
+At a 4 ms floor the spawn-equivalent column mostly measures Biome's own run time rather than
 spawns, so the census column is the number that transfers to the Windows 11 Git Bash reference
 host the convention calls binding; that host's figure for this plugin has not been taken. The
-residual is Biome itself plus the shared library's payload reader (`jq`), root resolver (`git`,
-`realpath`) and the disclosure snapshot.
+residual is Biome and its launcher plus the shared library's payload reader (`jq`), working-tree
+probe and root resolver (`git` twice, `realpath`) and the disclosure snapshot.
 
 ## Install
 

--- a/plugins/biome-format/README.md
+++ b/plugins/biome-format/README.md
@@ -60,6 +60,29 @@ The hook itself runs on Bash 3.2+. Telemetry timing uses `EPOCHREALTIME`
 (Bash 5.0+); on older bash the telemetry envelope is skipped while formatting and
 linting still run.
 
+### Hook budget accounting
+
+Per [`docs/conventions/hook-budget/README.md`](../../docs/conventions/hook-budget/README.md),
+this hook is always-on for every `Write` and `Edit` of a `.ts`, `.tsx`, `.js`, `.jsx`, `.mjs`,
+`.cjs`, `.mts`, `.cts`, `.json` or `.jsonc` file (the ten `if` rows in `hooks/hooks.json` keep
+every other extension from spawning it, and the suite pins those rows to the script's own
+extension set), so its cost on a clean file is the figure that counts. Measured on Linux x86_64
+under bash 5.2 in a container, twelve interleaved trials against an interleaved `bash -c :`
+floor S of about 2 ms, with a kernel census from
+`strace -f -e trace=clone,clone3,fork,vfork,execve` (2026-09-07, 0.6.42):
+
+| Event | Fires | Wall | Spawn-equivalents | Kernel census |
+| --- | --- | --- | --- | --- |
+| PostToolUse `Write`, clean `.ts`, no `biome.json` (opt-in absent) | 1 | 31 ms | 14.2 | 10 process creations, 4 execs: `git`, `jq`, `realpath`, the hook's own `bash` |
+| PostToolUse `Write`, clean `.ts`, `biome.json` present | 1 | 116 ms | 52.0 | 33 process creations, 16 execs: the row above plus three `biome` runs, the `node_modules/.bin` launcher and the `node` and `ldd` it spawns, and the disclosure snapshot's `mktemp`, `cp`, `cmp`, `rm` |
+| PostToolUse `Write`, any other extension | 0 | none | 0 | no process; the `if` rows drop the handler before a spawn |
+
+At a 2 ms floor the spawn-equivalent column mostly measures Biome's own run time rather than
+spawns, so the census column is the number that transfers to the Windows 11 Git Bash reference
+host the convention calls binding; that host's figure for this plugin has not been taken. The
+residual is Biome itself plus the shared library's payload reader (`jq`), root resolver (`git`,
+`realpath`) and the disclosure snapshot.
+
 ## Install
 
 ```shell

--- a/plugins/biome-format/hooks/biome-format.test.sh
+++ b/plugins/biome-format/hooks/biome-format.test.sh
@@ -437,23 +437,55 @@ rm -f "$TELS"
 # The script's own case filter stays as defense in depth, so the two sets must
 # be IDENTICAL: an if row the script does not handle spawns a process that
 # exits at the case, and an extension the script handles with no if row is a
-# silent regression, since the hook then never runs for it. The expected set is
-# read from the script's pre-filter line, so drift on either side fails here.
+# silent regression, since the hook then never runs for it.
+#
+# The expected set is every pattern of every arm in the script's whole
+# `case "$RAW_FILE" ... esac` block except the bare `*` catch-all, so an arm
+# added anywhere in the block counts, and an alternation wrapped across lines
+# (a backslash continuation, or `;;` on its own line) reads the same as one
+# line. On the manifest side every handler under every event and matcher
+# group is read, not only the `Write|Edit` group: the if values across all of
+# them must be exactly the derived set, one row each, so a handler with no if,
+# an if outside the set, a `Write(...)` rule, a duplicate row, an unfiltered
+# group under any event, or a command pointing elsewhere fails here. What
+# this does not reach is a registration outside hooks/hooks.json.
 HOOKS_JSON="$HOOK_DIR/hooks.json"
-SCRIPT_EXTS="$(sed -n '/^case "\$RAW_FILE" in$/{n;p;q;}' "$HOOK" | tr -d ' );' | tr '|' '\n' | LC_ALL=C sort)"
+SCRIPT_EXTS="$(awk '
+  /^case "[$]RAW_FILE" in[[:space:]]*$/ { inblock = 1; next }
+  inblock && /^esac([[:space:]]|$)/ { exit }
+  inblock {
+    sub(/#.*/, "")
+    sub(/\\$/, " ")
+    block = block " " $0
+  }
+  END {
+    n = split(block, arms, ";;")
+    for (i = 1; i <= n; i++) {
+      if (index(arms[i], ")") == 0) continue
+      pats = substr(arms[i], 1, index(arms[i], ")") - 1)
+      sub(/^[[:space:]]*\(/, "", pats)
+      m = split(pats, alts, "|")
+      for (j = 1; j <= m; j++) {
+        p = alts[j]
+        gsub(/[[:space:]]+/, "", p)
+        if (p != "" && p != "*") print p
+      }
+    }
+  }' "$HOOK" | LC_ALL=C sort -u)"
 EXPECTED_IF="$(printf '%s\n' "$SCRIPT_EXTS" | sed 's/.*/Edit(&)/' | tr '\n' ' ')"
 EXPECTED_IF="${EXPECTED_IF% }"
 EXPECTED_COUNT="$(printf '%s\n' "$SCRIPT_EXTS" | grep -c .)"
 if command -v jq >/dev/null 2>&1 && [[ -f "$HOOKS_JSON" && "$EXPECTED_COUNT" -gt 0 ]]; then
-  HANDLERS="$(jq -c '[.hooks.PostToolUse[]? | select(.matcher == "Write|Edit") | .hooks[]?]' "$HOOKS_JSON")"
+  HANDLERS="$(jq -c '[.hooks | to_entries[] | .key as $ev | .value[]? | .matcher as $m | .hooks[]? | . + {event: $ev, matcher: ($m // "(none)")}]' "$HOOKS_JSON")"
   HANDLER_COUNT="$(jq 'length' <<<"$HANDLERS")"
+  HANDLER_GROUPS="$(jq -r '[.[] | "\(.event):\(.matcher)"] | unique | join(",")' <<<"$HANDLERS")"
   IF_VALUES="$(jq -r '[.[] | (.if // "(none)")] | sort | join(" ")' <<<"$HANDLERS")"
   WRITE_IF="$(jq '[.[] | select(has("if") and (.if | startswith("Write(")))] | length' <<<"$HANDLERS")"
   CMD_OK="$(jq '[.[] | select((.command | contains("\"${CLAUDE_PLUGIN_ROOT}\"")) and (.command | contains("biome-format.sh")))] | length' <<<"$HANDLERS")"
   if [[ "$HANDLER_COUNT" == "$EXPECTED_COUNT" && "$IF_VALUES" == "$EXPECTED_IF" && "$WRITE_IF" == "0" && "$CMD_OK" == "$EXPECTED_COUNT" ]]; then
-    ok "hooks.json launches only for $EXPECTED_IF, the script's own extension set"
+    ok "hooks.json: every handler ($HANDLER_GROUPS) carries an if row, and the rows are exactly $EXPECTED_IF, the script's own extension set"
   else
-    fail "hooks.json launch gate: count=$HANDLER_COUNT/$EXPECTED_COUNT if='$IF_VALUES' expected='$EXPECTED_IF' write_if=$WRITE_IF cmd=$CMD_OK"
+    fail "hooks.json launch gate: handlers=$HANDLER_COUNT/$EXPECTED_COUNT groups=$HANDLER_GROUPS if='$IF_VALUES' expected='$EXPECTED_IF' write_if=$WRITE_IF cmd=$CMD_OK"
   fi
 else
   fail "hooks.json launch-gate assertions need jq, $HOOKS_JSON and the script's case \"\$RAW_FILE\" pre-filter"

--- a/plugins/biome-format/hooks/biome-format.test.sh
+++ b/plugins/biome-format/hooks/biome-format.test.sh
@@ -441,25 +441,44 @@ rm -f "$TELS"
 #
 # The expected set is every pattern of every arm in the script's whole
 # `case "$RAW_FILE" ... esac` block except the bare `*` catch-all, so an arm
-# added anywhere in the block counts, and an alternation wrapped across lines
-# (a backslash continuation, or `;;` on its own line) reads the same as one
-# line. On the manifest side every handler under every event and matcher
-# group is read, not only the `Write|Edit` group: the if values across all of
-# them must be exactly the derived set, one row each, so a handler with no if,
-# an if outside the set, a `Write(...)` rule, a duplicate row, an unfiltered
-# group under any event, or a command pointing elsewhere fails here. What
-# this does not reach is a registration outside hooks/hooks.json.
+# added anywhere in the block counts. The block is read the way bash reads it:
+# a backslash continuation joins lines with nothing in between (so `;\` and a
+# following `;` is one `;;`), a comment after `in` or on any arm is dropped, a
+# one-line `case ... esac` is one block, `in` on the line after the `case`
+# word opens the block all the same, and every arm terminator bash has
+# (`;;`, the `;&` fall-through and the `;;&` continue-matching form) ends an
+# arm, so the patterns of an arm reached only by fall-through count too. What
+# the parser does not read is an arm's body, so a pattern in any arm, even one
+# after `*)` that can never match, counts as handled and must have its row.
+# The script's `case "$FILE"` re-check after path normalization (the duplicate
+# #3408 owns folding) is read the same way, and every such gate must yield the
+# same set, so an exclusion added to either gate fails here instead of sitting
+# unread; a script with one gate left passes as it is.
+#
+# On the manifest side every handler under every event and matcher group is
+# read. Two things are pinned separately, since they answer different
+# questions. The `if` rows, which paths a handler applies to: the values
+# across every handler must be exactly the derived set, one row each, so a
+# handler with no if, an if outside the set, a `Write(...)` rule, a duplicate
+# row or an unfiltered group under any event fails. The group, which tools
+# invoke the handler at all: every group must be PostToolUse with a matcher
+# whose alternation is exactly Write and Edit in either order, the two tools
+# whose payload carries a file this script formats (the rule validator folds
+# Write and NotebookEdit into an Edit(...) rule, but the matcher is the tool
+# name regex the harness consults first, and a matcher narrowed to one tool
+# is the hook silently never running for the other, which no if row can show).
+# The command must be the plugin's own script by either quoting placement,
+# with no prefix, suffix or argument. What this does not reach is a
+# registration outside hooks/hooks.json.
 HOOKS_JSON="$HOOK_DIR/hooks.json"
-SCRIPT_EXTS="$(awk '
-  /^case "[$]RAW_FILE" in[[:space:]]*$/ { inblock = 1; next }
-  inblock && /^esac([[:space:]]|$)/ { exit }
-  inblock {
-    sub(/#.*/, "")
-    sub(/\\$/, " ")
-    block = block " " $0
-  }
-  END {
-    n = split(block, arms, ";;")
+SCRIPT_GATES="$(awk '
+  function flush(   n, i, m, j, p, pats, arms, alts) {
+    inblock = 0
+    print nblocks "\t"
+    gsub(/;;&/, "\n", block)
+    gsub(/;;/, "\n", block)
+    gsub(/;&/, "\n", block)
+    n = split(block, arms, "\n")
     for (i = 1; i <= n; i++) {
       if (index(arms[i], ")") == 0) continue
       pats = substr(arms[i], 1, index(arms[i], ")") - 1)
@@ -468,27 +487,73 @@ SCRIPT_EXTS="$(awk '
       for (j = 1; j <= m; j++) {
         p = alts[j]
         gsub(/[[:space:]]+/, "", p)
-        if (p != "" && p != "*") print p
+        if (p != "" && p != "*") print nblocks "\t" p
       }
     }
-  }' "$HOOK" | LC_ALL=C sort -u)"
+  }
+  !inblock && !pending && $0 ~ /^case "[$](RAW_FILE|FILE)"[[:space:]]*(#.*)?$/ {
+    pending = 1
+    next
+  }
+  pending && match($0, /^[[:space:]]*in([[:space:]]|$)/) {
+    pending = 0
+    inblock = 1
+    nblocks++
+    block = ""
+    sep = ""
+    $0 = substr($0, RLENGTH + 1)
+  }
+  !inblock && match($0, /^case "[$](RAW_FILE|FILE)" in([[:space:]]|$)/) {
+    inblock = 1
+    nblocks++
+    block = ""
+    sep = ""
+    $0 = substr($0, RLENGTH + 1)
+  }
+  inblock {
+    sub(/#.*/, "")
+    if ($0 ~ /^[[:space:]]*esac([[:space:]]|$)/) {
+      flush()
+      next
+    }
+    if (match($0, /[[:space:]]esac([[:space:]]|$)/)) {
+      block = block sep substr($0, 1, RSTART - 1)
+      flush()
+      next
+    }
+    if (sub(/\\$/, "")) {
+      block = block sep $0
+      sep = ""
+    } else {
+      block = block sep $0
+      sep = " "
+    }
+  }' "$HOOK")"
+CASE_BLOCKS="$(printf '%s\n' "$SCRIPT_GATES" | cut -f1 | LC_ALL=C sort -u | grep -c .)"
+SCRIPT_EXTS="$(printf '%s\n' "$SCRIPT_GATES" | awk -F'\t' '$1 == 1 && $2 != "" { print $2 }' | LC_ALL=C sort -u)"
+GATES_OFF=""
+for ((g = 2; g <= CASE_BLOCKS; g++)); do
+  GATE_EXTS="$(printf '%s\n' "$SCRIPT_GATES" | awk -F'\t' -v g="$g" '$1 == g && $2 != "" { print $2 }' | LC_ALL=C sort -u)"
+  [[ "$GATE_EXTS" == "$SCRIPT_EXTS" ]] || GATES_OFF+=" gate$g=(${GATE_EXTS//$'\n'/ })"
+done
 EXPECTED_IF="$(printf '%s\n' "$SCRIPT_EXTS" | sed 's/.*/Edit(&)/' | tr '\n' ' ')"
 EXPECTED_IF="${EXPECTED_IF% }"
 EXPECTED_COUNT="$(printf '%s\n' "$SCRIPT_EXTS" | grep -c .)"
-if command -v jq >/dev/null 2>&1 && [[ -f "$HOOKS_JSON" && "$EXPECTED_COUNT" -gt 0 ]]; then
+if command -v jq >/dev/null 2>&1 && [[ -f "$HOOKS_JSON" && "$CASE_BLOCKS" -ge 1 && -z "$GATES_OFF" && "$EXPECTED_COUNT" -gt 0 ]]; then
   HANDLERS="$(jq -c '[.hooks | to_entries[] | .key as $ev | .value[]? | .matcher as $m | .hooks[]? | . + {event: $ev, matcher: ($m // "(none)")}]' "$HOOKS_JSON")"
   HANDLER_COUNT="$(jq 'length' <<<"$HANDLERS")"
   HANDLER_GROUPS="$(jq -r '[.[] | "\(.event):\(.matcher)"] | unique | join(",")' <<<"$HANDLERS")"
+  GROUPS_OFF="$(jq -r '[.[] | select(.event != "PostToolUse" or ((.matcher | split("|") | sort | unique) != ["Edit", "Write"])) | "\(.event):\(.matcher)"] | unique | join(",")' <<<"$HANDLERS")"
   IF_VALUES="$(jq -r '[.[] | (.if // "(none)")] | sort | join(" ")' <<<"$HANDLERS")"
   WRITE_IF="$(jq '[.[] | select(has("if") and (.if | startswith("Write(")))] | length' <<<"$HANDLERS")"
-  CMD_OK="$(jq '[.[] | select((.command | contains("\"${CLAUDE_PLUGIN_ROOT}\"")) and (.command | contains("biome-format.sh")))] | length' <<<"$HANDLERS")"
-  if [[ "$HANDLER_COUNT" == "$EXPECTED_COUNT" && "$IF_VALUES" == "$EXPECTED_IF" && "$WRITE_IF" == "0" && "$CMD_OK" == "$EXPECTED_COUNT" ]]; then
-    ok "hooks.json: every handler ($HANDLER_GROUPS) carries an if row, and the rows are exactly $EXPECTED_IF, the script's own extension set"
+  CMD_OFF="$(jq -r '[.[] | (.command // "(none)") | select(test("^(\"[$][{]?CLAUDE_PLUGIN_ROOT[}]?\"/hooks/biome-format[.]sh|\"[$][{]?CLAUDE_PLUGIN_ROOT[}]?/hooks/biome-format[.]sh\")$") | not)] | unique | join(",")' <<<"$HANDLERS")"
+  if [[ "$HANDLER_COUNT" == "$EXPECTED_COUNT" && "$IF_VALUES" == "$EXPECTED_IF" && "$WRITE_IF" == "0" && -z "$GROUPS_OFF" && -z "$CMD_OFF" ]]; then
+    ok "hooks.json: every handler ($HANDLER_GROUPS) is a PostToolUse Write and Edit group running the plugin's script, and the if rows are exactly $EXPECTED_IF, the script's own extension set ($CASE_BLOCKS case gates agree)"
   else
-    fail "hooks.json launch gate: handlers=$HANDLER_COUNT/$EXPECTED_COUNT groups=$HANDLER_GROUPS if='$IF_VALUES' expected='$EXPECTED_IF' write_if=$WRITE_IF cmd=$CMD_OK"
+    fail "hooks.json launch gate: handlers=$HANDLER_COUNT/$EXPECTED_COUNT groups=$HANDLER_GROUPS groups_off='$GROUPS_OFF' if='$IF_VALUES' expected='$EXPECTED_IF' write_if=$WRITE_IF cmd_off='$CMD_OFF'"
   fi
 else
-  fail "hooks.json launch-gate assertions need jq, $HOOKS_JSON and the script's case \"\$RAW_FILE\" pre-filter"
+  fail "hooks.json launch-gate assertions need jq, $HOOKS_JSON and agreeing case \"\$RAW_FILE\" / \"\$FILE\" gates in the script (gates=$CASE_BLOCKS gate1=(${SCRIPT_EXTS//$'\n'/ }) disagreeing:${GATES_OFF:- none})"
 fi
 
 echo

--- a/plugins/biome-format/hooks/biome-format.test.sh
+++ b/plugins/biome-format/hooks/biome-format.test.sh
@@ -428,6 +428,37 @@ else
 fi
 rm -f "$TELS"
 
+# --- hooks.json: the if rows equal the script's own extension set (#3411) ----
+# The if rows are what keep a Write or Edit of any other file from spawning
+# this hook: Claude Code evaluates a handler's `if` at match time and drops the
+# handler without a spawn (hooks reference, `if`, re-fetched 2026-09-07; the
+# installed CLI logs "Skipping hook due to if condition ... not matching"), and
+# an Edit(...) rule is the one consulted for Write and NotebookEdit as well.
+# The script's own case filter stays as defense in depth, so the two sets must
+# be IDENTICAL: an if row the script does not handle spawns a process that
+# exits at the case, and an extension the script handles with no if row is a
+# silent regression, since the hook then never runs for it. The expected set is
+# read from the script's pre-filter line, so drift on either side fails here.
+HOOKS_JSON="$HOOK_DIR/hooks.json"
+SCRIPT_EXTS="$(sed -n '/^case "\$RAW_FILE" in$/{n;p;q;}' "$HOOK" | tr -d ' );' | tr '|' '\n' | LC_ALL=C sort)"
+EXPECTED_IF="$(printf '%s\n' "$SCRIPT_EXTS" | sed 's/.*/Edit(&)/' | tr '\n' ' ')"
+EXPECTED_IF="${EXPECTED_IF% }"
+EXPECTED_COUNT="$(printf '%s\n' "$SCRIPT_EXTS" | grep -c .)"
+if command -v jq >/dev/null 2>&1 && [[ -f "$HOOKS_JSON" && "$EXPECTED_COUNT" -gt 0 ]]; then
+  HANDLERS="$(jq -c '[.hooks.PostToolUse[]? | select(.matcher == "Write|Edit") | .hooks[]?]' "$HOOKS_JSON")"
+  HANDLER_COUNT="$(jq 'length' <<<"$HANDLERS")"
+  IF_VALUES="$(jq -r '[.[] | (.if // "(none)")] | sort | join(" ")' <<<"$HANDLERS")"
+  WRITE_IF="$(jq '[.[] | select(has("if") and (.if | startswith("Write(")))] | length' <<<"$HANDLERS")"
+  CMD_OK="$(jq '[.[] | select((.command | contains("\"${CLAUDE_PLUGIN_ROOT}\"")) and (.command | contains("biome-format.sh")))] | length' <<<"$HANDLERS")"
+  if [[ "$HANDLER_COUNT" == "$EXPECTED_COUNT" && "$IF_VALUES" == "$EXPECTED_IF" && "$WRITE_IF" == "0" && "$CMD_OK" == "$EXPECTED_COUNT" ]]; then
+    ok "hooks.json launches only for $EXPECTED_IF, the script's own extension set"
+  else
+    fail "hooks.json launch gate: count=$HANDLER_COUNT/$EXPECTED_COUNT if='$IF_VALUES' expected='$EXPECTED_IF' write_if=$WRITE_IF cmd=$CMD_OK"
+  fi
+else
+  fail "hooks.json launch-gate assertions need jq, $HOOKS_JSON and the script's case \"\$RAW_FILE\" pre-filter"
+fi
+
 echo
 echo "PASS=$PASS FAIL=$FAIL"
 [[ $FAIL -eq 0 ]]

--- a/plugins/eol-normalizer/.claude-plugin/plugin.json
+++ b/plugins/eol-normalizer/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "eol-normalizer",
-  "version": "0.6.41",
+  "version": "0.6.42",
   "description": "Normalize a written file's working-tree line endings to its .gitattributes eol value on edit \u2014 symmetric CRLF/LF driven by git check-attr, advisory and never blocking.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/eol-normalizer/CHANGELOG.md
+++ b/plugins/eol-normalizer/CHANGELOG.md
@@ -3,6 +3,19 @@
 All notable changes to the `eol-normalizer` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.6.42]
+
+### Changed
+
+- **The README records why the manifest carries no `if` row (#3411).** The
+  sibling formatters filter by extension at the manifest; this hook has no
+  extension filter of its own, because `.gitattributes` decides which files
+  it normalizes, so the set a declarative filter would reproduce is every
+  file and a file-type row would silently stop normalizing whatever it left
+  out. The section also records the kernel census on an already-normalized
+  Write (no `mktemp`, no `cp`; the plan step decides before any snapshot).
+  Documentation only; no hook behavior changes.
+
 ## [0.6.41]
 
 ### Changed

--- a/plugins/eol-normalizer/README.md
+++ b/plugins/eol-normalizer/README.md
@@ -63,6 +63,17 @@ vendored `hook-utils.sh` (one batched `realpath`, no jq on the envelope). 0.6.41
 `$(hook::repo_root)` / `$(hook::repo_relative_path)` capture subshells around those helpers'
 `_to` forms; the git check-attr probe is unchanged.
 
+`hooks/hooks.json` carries no `if` row, and that is deliberate (#3411). The sibling formatters
+filter by extension at the manifest so a Write of any other file spawns nothing, but this hook
+has no extension filter of its own: which files it normalizes is decided by the consuming
+repository's `.gitattributes` through `git check-attr eol text`, not by file type, so the set a
+declarative filter would have to reproduce is every file, and a file-type row would silently
+stop normalizing whatever it left out. What the manifest cannot filter the script keeps cheap:
+a file that already carries its `eol=` ending is decided by the plan step before any snapshot,
+so the kernel census (`strace -f -e trace=clone,clone3,fork,vfork,execve`, Linux x86_64,
+2026-09-07, 0.6.42) on such a `Write` is 12 process creations and 5 execs (`git` twice, `jq`,
+`realpath`, the hook's own `bash`) with no `mktemp` or `cp`.
+
 ## Install
 
 ```shell

--- a/plugins/eol-normalizer/README.md
+++ b/plugins/eol-normalizer/README.md
@@ -71,8 +71,9 @@ declarative filter would have to reproduce is every file, and a file-type row wo
 stop normalizing whatever it left out. What the manifest cannot filter the script keeps cheap:
 a file that already carries its `eol=` ending is decided by the plan step before any snapshot,
 so the kernel census (`strace -f -e trace=clone,clone3,fork,vfork,execve`, Linux x86_64,
-2026-09-07, 0.6.42) on such a `Write` is 12 process creations and 5 execs (`git` twice, `jq`,
-`realpath`, the hook's own `bash`) with no `mktemp` or `cp`.
+`HOOK_TELEMETRY_SINK` and `CLAUDE_PROJECT_DIR` unset, 2026-09-07, 0.6.42) on such a `Write` is
+13 process creations and 6 execs (`git` three times: the working-tree probe, the root resolver
+and `check-attr`; `jq`, `realpath`, the hook's own `bash`) with no `mktemp` or `cp`.
 
 ## Install
 

--- a/plugins/go-format/.claude-plugin/plugin.json
+++ b/plugins/go-format/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "go-format",
-  "version": "0.3.45",
+  "version": "0.3.46",
   "description": "Auto-fix Go formatting and import management on edit via goimports \u2014 runs unconditionally (no consumer-config gate), skipping generated files.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/go-format/CHANGELOG.md
+++ b/plugins/go-format/CHANGELOG.md
@@ -3,6 +3,21 @@
 All notable changes to the `go-format` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.3.46]
+
+### Added
+
+- **The suite pins the manifest's `if` row to the script's own extension
+  set, and the README states the hook's measured budget share (#3411).** The
+  `if` row is what keeps a Write of any other file from spawning the hook
+  (Claude Code drops a non-matching handler at match time, before a spawn);
+  the script's `case` filter stays as defense in depth, and the new case
+  reads that filter's extension list and fails on drift in either direction,
+  since an extension the script handles with no `if` row is a silent
+  regression. The README's "Hook budget accounting" section carries a
+  Linux-host measurement and kernel census per hook-budget rule 1; no hook
+  behavior changes.
+
 ## [0.3.45]
 
 ### Changed

--- a/plugins/go-format/CHANGELOG.md
+++ b/plugins/go-format/CHANGELOG.md
@@ -12,11 +12,12 @@ All notable changes to the `go-format` plugin are documented here. Format follow
   `if` row is what keeps a Write of any other file from spawning the hook
   (Claude Code drops a non-matching handler at match time, before a spawn);
   the script's `case` filter stays as defense in depth, and the new case
-  reads that filter's extension list and fails on drift in either direction,
-  since an extension the script handles with no `if` row is a silent
-  regression. The README's "Hook budget accounting" section carries a
-  Linux-host measurement and kernel census per hook-budget rule 1; no hook
-  behavior changes.
+  reads every arm of that filter's whole `case` block, requires every
+  handler in the manifest, under any event, to carry the derived row, and
+  fails on drift in either direction, since an extension the script handles
+  with no `if` row is a silent regression. The README's "Hook budget
+  accounting" section carries a Linux-host measurement and kernel census per
+  hook-budget rule 1; no hook behavior changes.
 
 ## [0.3.45]
 

--- a/plugins/go-format/CHANGELOG.md
+++ b/plugins/go-format/CHANGELOG.md
@@ -12,12 +12,16 @@ All notable changes to the `go-format` plugin are documented here. Format follow
   `if` row is what keeps a Write of any other file from spawning the hook
   (Claude Code drops a non-matching handler at match time, before a spawn);
   the script's `case` filter stays as defense in depth, and the new case
-  reads every arm of that filter's whole `case` block, requires every
-  handler in the manifest, under any event, to carry the derived row, and
-  fails on drift in either direction, since an extension the script handles
-  with no `if` row is a silent regression. The README's "Hook budget
-  accounting" section carries a Linux-host measurement and kernel census per
-  hook-budget rule 1; no hook behavior changes.
+  reads every arm of that filter's whole `case` block (each of bash's arm
+  terminators, `;;`, `;&` and `;;&`, ends an arm, and the `case "$FILE"`
+  re-check must yield the same set), requires every handler in the
+  manifest, under any event, to carry the derived row and to sit in a
+  PostToolUse group whose matcher is exactly Write and Edit and whose
+  command is the plugin's own script, and fails on drift in either
+  direction, since an extension the script handles with no `if` row is a
+  silent regression, and so is a matcher narrowed to one tool. The README's
+  "Hook budget accounting" section carries a Linux-host measurement and
+  kernel census per hook-budget rule 1; no hook behavior changes.
 
 ## [0.3.45]
 

--- a/plugins/go-format/README.md
+++ b/plugins/go-format/README.md
@@ -72,23 +72,25 @@ formatting still runs.
 ### Hook budget accounting
 
 Per [`docs/conventions/hook-budget/README.md`](../../docs/conventions/hook-budget/README.md),
-this hook is always-on for every `Write` and `Edit` of a `.go` file (the one `if` row in
-`hooks/hooks.json` keeps every other extension from spawning it, and the suite pins that row to
-the script's own extension set), so its cost on a clean Go file is the figure that counts.
-Measured on Linux x86_64 under bash 5.2 in a container, twelve interleaved trials against an
-interleaved `bash -c :` floor S of about 2 ms, with a kernel census from
+this hook is always-on for every `Write` and `Edit` of a `.go` file (every handler in
+`hooks/hooks.json` carries the one `if` row, which keeps every other extension from spawning it,
+and the suite pins the whole handler set to the script's own extension set), so its cost on a
+clean Go file is the figure that counts. Measured on Linux x86_64 under bash 5.2 in a container
+with `HOOK_TELEMETRY_SINK` and `CLAUDE_PROJECT_DIR` unset, twelve interleaved trials against an
+interleaved `bash -c :` floor S of about 4 ms, with a kernel census from
 `strace -f -e trace=clone,clone3,fork,vfork,execve` (2026-09-07, 0.3.46):
 
 | Event | Fires | Wall | Spawn-equivalents | Kernel census |
 | --- | --- | --- | --- | --- |
-| PostToolUse `Write`, clean `.go` (no opt-in; goimports always runs) | 1 | 58 ms | 25.6 | 35 process creations, 11 execs: `goimports`, two `go` (the module-path probe), `git`, `jq`, `realpath`, the disclosure snapshot's `mktemp`, `cp`, `cmp`, `rm`, and the hook's own `bash` |
+| PostToolUse `Write`, clean `.go` (no opt-in; goimports always runs) | 1 | 63 ms | 15.0 | 35 to 37 process creations (the Go runtimes' own threads vary), 12 execs: `goimports` and the `go env` it runs, the hook's own `go list -m` module-path probe, two `git rev-parse` (the working-tree probe and the root resolver), `jq`, `realpath`, the disclosure snapshot's `mktemp`, `cp`, `cmp`, `rm`, and the hook's own `bash` |
 | PostToolUse `Write`, any other extension | 0 | none | 0 | no process; the `if` row drops the handler before a spawn |
 
-At a 2 ms floor the spawn-equivalent column mostly measures goimports' own run time rather
+At a 4 ms floor the spawn-equivalent column mostly measures goimports' own run time rather
 than spawns, so the census column is the number that transfers to the Windows 11 Git Bash
 reference host the convention calls binding; that host's figure for this plugin has not been
 taken. The residual is goimports and the `go list` probe plus the shared library's payload
-reader (`jq`), root resolver (`git`, `realpath`) and the disclosure snapshot.
+reader (`jq`), working-tree probe and root resolver (`git` twice, `realpath`) and the
+disclosure snapshot.
 
 ## Install
 

--- a/plugins/go-format/README.md
+++ b/plugins/go-format/README.md
@@ -69,6 +69,27 @@ The hook itself runs on Bash 3.2+. Telemetry timing uses `EPOCHREALTIME`
 (Bash 5.0+); on older bash the telemetry envelope is skipped while
 formatting still runs.
 
+### Hook budget accounting
+
+Per [`docs/conventions/hook-budget/README.md`](../../docs/conventions/hook-budget/README.md),
+this hook is always-on for every `Write` and `Edit` of a `.go` file (the one `if` row in
+`hooks/hooks.json` keeps every other extension from spawning it, and the suite pins that row to
+the script's own extension set), so its cost on a clean Go file is the figure that counts.
+Measured on Linux x86_64 under bash 5.2 in a container, twelve interleaved trials against an
+interleaved `bash -c :` floor S of about 2 ms, with a kernel census from
+`strace -f -e trace=clone,clone3,fork,vfork,execve` (2026-09-07, 0.3.46):
+
+| Event | Fires | Wall | Spawn-equivalents | Kernel census |
+| --- | --- | --- | --- | --- |
+| PostToolUse `Write`, clean `.go` (no opt-in; goimports always runs) | 1 | 58 ms | 25.6 | 35 process creations, 11 execs: `goimports`, two `go` (the module-path probe), `git`, `jq`, `realpath`, the disclosure snapshot's `mktemp`, `cp`, `cmp`, `rm`, and the hook's own `bash` |
+| PostToolUse `Write`, any other extension | 0 | none | 0 | no process; the `if` row drops the handler before a spawn |
+
+At a 2 ms floor the spawn-equivalent column mostly measures goimports' own run time rather
+than spawns, so the census column is the number that transfers to the Windows 11 Git Bash
+reference host the convention calls binding; that host's figure for this plugin has not been
+taken. The residual is goimports and the `go list` probe plus the shared library's payload
+reader (`jq`), root resolver (`git`, `realpath`) and the disclosure snapshot.
+
 ## Install
 
 ```shell

--- a/plugins/go-format/hooks/go-format.test.sh
+++ b/plugins/go-format/hooks/go-format.test.sh
@@ -514,23 +514,55 @@ fi
 # The script's own case filter stays as defense in depth, so the two sets must
 # be IDENTICAL: an if row the script does not handle spawns a process that
 # exits at the case, and an extension the script handles with no if row is a
-# silent regression, since the hook then never runs for it. The expected set is
-# read from the script's pre-filter line, so drift on either side fails here.
+# silent regression, since the hook then never runs for it.
+#
+# The expected set is every pattern of every arm in the script's whole
+# `case "$RAW_FILE" ... esac` block except the bare `*` catch-all, so an arm
+# added anywhere in the block counts, and an alternation wrapped across lines
+# (a backslash continuation, or `;;` on its own line) reads the same as one
+# line. On the manifest side every handler under every event and matcher
+# group is read, not only the `Write|Edit` group: the if values across all of
+# them must be exactly the derived set, one row each, so a handler with no if,
+# an if outside the set, a `Write(...)` rule, a duplicate row, an unfiltered
+# group under any event, or a command pointing elsewhere fails here. What
+# this does not reach is a registration outside hooks/hooks.json.
 HOOKS_JSON="$HOOK_DIR/hooks.json"
-SCRIPT_EXTS="$(sed -n '/^case "\$RAW_FILE" in$/{n;p;q;}' "$HOOK" | tr -d ' );' | tr '|' '\n' | LC_ALL=C sort)"
+SCRIPT_EXTS="$(awk '
+  /^case "[$]RAW_FILE" in[[:space:]]*$/ { inblock = 1; next }
+  inblock && /^esac([[:space:]]|$)/ { exit }
+  inblock {
+    sub(/#.*/, "")
+    sub(/\\$/, " ")
+    block = block " " $0
+  }
+  END {
+    n = split(block, arms, ";;")
+    for (i = 1; i <= n; i++) {
+      if (index(arms[i], ")") == 0) continue
+      pats = substr(arms[i], 1, index(arms[i], ")") - 1)
+      sub(/^[[:space:]]*\(/, "", pats)
+      m = split(pats, alts, "|")
+      for (j = 1; j <= m; j++) {
+        p = alts[j]
+        gsub(/[[:space:]]+/, "", p)
+        if (p != "" && p != "*") print p
+      }
+    }
+  }' "$HOOK" | LC_ALL=C sort -u)"
 EXPECTED_IF="$(printf '%s\n' "$SCRIPT_EXTS" | sed 's/.*/Edit(&)/' | tr '\n' ' ')"
 EXPECTED_IF="${EXPECTED_IF% }"
 EXPECTED_COUNT="$(printf '%s\n' "$SCRIPT_EXTS" | grep -c .)"
 if command -v jq >/dev/null 2>&1 && [[ -f "$HOOKS_JSON" && "$EXPECTED_COUNT" -gt 0 ]]; then
-  HANDLERS="$(jq -c '[.hooks.PostToolUse[]? | select(.matcher == "Write|Edit") | .hooks[]?]' "$HOOKS_JSON")"
+  HANDLERS="$(jq -c '[.hooks | to_entries[] | .key as $ev | .value[]? | .matcher as $m | .hooks[]? | . + {event: $ev, matcher: ($m // "(none)")}]' "$HOOKS_JSON")"
   HANDLER_COUNT="$(jq 'length' <<<"$HANDLERS")"
+  HANDLER_GROUPS="$(jq -r '[.[] | "\(.event):\(.matcher)"] | unique | join(",")' <<<"$HANDLERS")"
   IF_VALUES="$(jq -r '[.[] | (.if // "(none)")] | sort | join(" ")' <<<"$HANDLERS")"
   WRITE_IF="$(jq '[.[] | select(has("if") and (.if | startswith("Write(")))] | length' <<<"$HANDLERS")"
   CMD_OK="$(jq '[.[] | select((.command | contains("\"${CLAUDE_PLUGIN_ROOT}\"")) and (.command | contains("go-format.sh")))] | length' <<<"$HANDLERS")"
   if [[ "$HANDLER_COUNT" == "$EXPECTED_COUNT" && "$IF_VALUES" == "$EXPECTED_IF" && "$WRITE_IF" == "0" && "$CMD_OK" == "$EXPECTED_COUNT" ]]; then
-    ok "hooks.json launches only for $EXPECTED_IF, the script's own extension set"
+    ok "hooks.json: every handler ($HANDLER_GROUPS) carries an if row, and the rows are exactly $EXPECTED_IF, the script's own extension set"
   else
-    fail "hooks.json launch gate: count=$HANDLER_COUNT/$EXPECTED_COUNT if='$IF_VALUES' expected='$EXPECTED_IF' write_if=$WRITE_IF cmd=$CMD_OK"
+    fail "hooks.json launch gate: handlers=$HANDLER_COUNT/$EXPECTED_COUNT groups=$HANDLER_GROUPS if='$IF_VALUES' expected='$EXPECTED_IF' write_if=$WRITE_IF cmd=$CMD_OK"
   fi
 else
   fail "hooks.json launch-gate assertions need jq, $HOOKS_JSON and the script's case \"\$RAW_FILE\" pre-filter"

--- a/plugins/go-format/hooks/go-format.test.sh
+++ b/plugins/go-format/hooks/go-format.test.sh
@@ -518,25 +518,44 @@ fi
 #
 # The expected set is every pattern of every arm in the script's whole
 # `case "$RAW_FILE" ... esac` block except the bare `*` catch-all, so an arm
-# added anywhere in the block counts, and an alternation wrapped across lines
-# (a backslash continuation, or `;;` on its own line) reads the same as one
-# line. On the manifest side every handler under every event and matcher
-# group is read, not only the `Write|Edit` group: the if values across all of
-# them must be exactly the derived set, one row each, so a handler with no if,
-# an if outside the set, a `Write(...)` rule, a duplicate row, an unfiltered
-# group under any event, or a command pointing elsewhere fails here. What
-# this does not reach is a registration outside hooks/hooks.json.
+# added anywhere in the block counts. The block is read the way bash reads it:
+# a backslash continuation joins lines with nothing in between (so `;\` and a
+# following `;` is one `;;`), a comment after `in` or on any arm is dropped, a
+# one-line `case ... esac` is one block, `in` on the line after the `case`
+# word opens the block all the same, and every arm terminator bash has
+# (`;;`, the `;&` fall-through and the `;;&` continue-matching form) ends an
+# arm, so the patterns of an arm reached only by fall-through count too. What
+# the parser does not read is an arm's body, so a pattern in any arm, even one
+# after `*)` that can never match, counts as handled and must have its row.
+# The script's `case "$FILE"` re-check after path normalization (the duplicate
+# #3408 owns folding) is read the same way, and every such gate must yield the
+# same set, so an exclusion added to either gate fails here instead of sitting
+# unread; a script with one gate left passes as it is.
+#
+# On the manifest side every handler under every event and matcher group is
+# read. Two things are pinned separately, since they answer different
+# questions. The `if` rows, which paths a handler applies to: the values
+# across every handler must be exactly the derived set, one row each, so a
+# handler with no if, an if outside the set, a `Write(...)` rule, a duplicate
+# row or an unfiltered group under any event fails. The group, which tools
+# invoke the handler at all: every group must be PostToolUse with a matcher
+# whose alternation is exactly Write and Edit in either order, the two tools
+# whose payload carries a file this script formats (the rule validator folds
+# Write and NotebookEdit into an Edit(...) rule, but the matcher is the tool
+# name regex the harness consults first, and a matcher narrowed to one tool
+# is the hook silently never running for the other, which no if row can show).
+# The command must be the plugin's own script by either quoting placement,
+# with no prefix, suffix or argument. What this does not reach is a
+# registration outside hooks/hooks.json.
 HOOKS_JSON="$HOOK_DIR/hooks.json"
-SCRIPT_EXTS="$(awk '
-  /^case "[$]RAW_FILE" in[[:space:]]*$/ { inblock = 1; next }
-  inblock && /^esac([[:space:]]|$)/ { exit }
-  inblock {
-    sub(/#.*/, "")
-    sub(/\\$/, " ")
-    block = block " " $0
-  }
-  END {
-    n = split(block, arms, ";;")
+SCRIPT_GATES="$(awk '
+  function flush(   n, i, m, j, p, pats, arms, alts) {
+    inblock = 0
+    print nblocks "\t"
+    gsub(/;;&/, "\n", block)
+    gsub(/;;/, "\n", block)
+    gsub(/;&/, "\n", block)
+    n = split(block, arms, "\n")
     for (i = 1; i <= n; i++) {
       if (index(arms[i], ")") == 0) continue
       pats = substr(arms[i], 1, index(arms[i], ")") - 1)
@@ -545,27 +564,73 @@ SCRIPT_EXTS="$(awk '
       for (j = 1; j <= m; j++) {
         p = alts[j]
         gsub(/[[:space:]]+/, "", p)
-        if (p != "" && p != "*") print p
+        if (p != "" && p != "*") print nblocks "\t" p
       }
     }
-  }' "$HOOK" | LC_ALL=C sort -u)"
+  }
+  !inblock && !pending && $0 ~ /^case "[$](RAW_FILE|FILE)"[[:space:]]*(#.*)?$/ {
+    pending = 1
+    next
+  }
+  pending && match($0, /^[[:space:]]*in([[:space:]]|$)/) {
+    pending = 0
+    inblock = 1
+    nblocks++
+    block = ""
+    sep = ""
+    $0 = substr($0, RLENGTH + 1)
+  }
+  !inblock && match($0, /^case "[$](RAW_FILE|FILE)" in([[:space:]]|$)/) {
+    inblock = 1
+    nblocks++
+    block = ""
+    sep = ""
+    $0 = substr($0, RLENGTH + 1)
+  }
+  inblock {
+    sub(/#.*/, "")
+    if ($0 ~ /^[[:space:]]*esac([[:space:]]|$)/) {
+      flush()
+      next
+    }
+    if (match($0, /[[:space:]]esac([[:space:]]|$)/)) {
+      block = block sep substr($0, 1, RSTART - 1)
+      flush()
+      next
+    }
+    if (sub(/\\$/, "")) {
+      block = block sep $0
+      sep = ""
+    } else {
+      block = block sep $0
+      sep = " "
+    }
+  }' "$HOOK")"
+CASE_BLOCKS="$(printf '%s\n' "$SCRIPT_GATES" | cut -f1 | LC_ALL=C sort -u | grep -c .)"
+SCRIPT_EXTS="$(printf '%s\n' "$SCRIPT_GATES" | awk -F'\t' '$1 == 1 && $2 != "" { print $2 }' | LC_ALL=C sort -u)"
+GATES_OFF=""
+for ((g = 2; g <= CASE_BLOCKS; g++)); do
+  GATE_EXTS="$(printf '%s\n' "$SCRIPT_GATES" | awk -F'\t' -v g="$g" '$1 == g && $2 != "" { print $2 }' | LC_ALL=C sort -u)"
+  [[ "$GATE_EXTS" == "$SCRIPT_EXTS" ]] || GATES_OFF+=" gate$g=(${GATE_EXTS//$'\n'/ })"
+done
 EXPECTED_IF="$(printf '%s\n' "$SCRIPT_EXTS" | sed 's/.*/Edit(&)/' | tr '\n' ' ')"
 EXPECTED_IF="${EXPECTED_IF% }"
 EXPECTED_COUNT="$(printf '%s\n' "$SCRIPT_EXTS" | grep -c .)"
-if command -v jq >/dev/null 2>&1 && [[ -f "$HOOKS_JSON" && "$EXPECTED_COUNT" -gt 0 ]]; then
+if command -v jq >/dev/null 2>&1 && [[ -f "$HOOKS_JSON" && "$CASE_BLOCKS" -ge 1 && -z "$GATES_OFF" && "$EXPECTED_COUNT" -gt 0 ]]; then
   HANDLERS="$(jq -c '[.hooks | to_entries[] | .key as $ev | .value[]? | .matcher as $m | .hooks[]? | . + {event: $ev, matcher: ($m // "(none)")}]' "$HOOKS_JSON")"
   HANDLER_COUNT="$(jq 'length' <<<"$HANDLERS")"
   HANDLER_GROUPS="$(jq -r '[.[] | "\(.event):\(.matcher)"] | unique | join(",")' <<<"$HANDLERS")"
+  GROUPS_OFF="$(jq -r '[.[] | select(.event != "PostToolUse" or ((.matcher | split("|") | sort | unique) != ["Edit", "Write"])) | "\(.event):\(.matcher)"] | unique | join(",")' <<<"$HANDLERS")"
   IF_VALUES="$(jq -r '[.[] | (.if // "(none)")] | sort | join(" ")' <<<"$HANDLERS")"
   WRITE_IF="$(jq '[.[] | select(has("if") and (.if | startswith("Write(")))] | length' <<<"$HANDLERS")"
-  CMD_OK="$(jq '[.[] | select((.command | contains("\"${CLAUDE_PLUGIN_ROOT}\"")) and (.command | contains("go-format.sh")))] | length' <<<"$HANDLERS")"
-  if [[ "$HANDLER_COUNT" == "$EXPECTED_COUNT" && "$IF_VALUES" == "$EXPECTED_IF" && "$WRITE_IF" == "0" && "$CMD_OK" == "$EXPECTED_COUNT" ]]; then
-    ok "hooks.json: every handler ($HANDLER_GROUPS) carries an if row, and the rows are exactly $EXPECTED_IF, the script's own extension set"
+  CMD_OFF="$(jq -r '[.[] | (.command // "(none)") | select(test("^(\"[$][{]?CLAUDE_PLUGIN_ROOT[}]?\"/hooks/go-format[.]sh|\"[$][{]?CLAUDE_PLUGIN_ROOT[}]?/hooks/go-format[.]sh\")$") | not)] | unique | join(",")' <<<"$HANDLERS")"
+  if [[ "$HANDLER_COUNT" == "$EXPECTED_COUNT" && "$IF_VALUES" == "$EXPECTED_IF" && "$WRITE_IF" == "0" && -z "$GROUPS_OFF" && -z "$CMD_OFF" ]]; then
+    ok "hooks.json: every handler ($HANDLER_GROUPS) is a PostToolUse Write and Edit group running the plugin's script, and the if rows are exactly $EXPECTED_IF, the script's own extension set ($CASE_BLOCKS case gates agree)"
   else
-    fail "hooks.json launch gate: handlers=$HANDLER_COUNT/$EXPECTED_COUNT groups=$HANDLER_GROUPS if='$IF_VALUES' expected='$EXPECTED_IF' write_if=$WRITE_IF cmd=$CMD_OK"
+    fail "hooks.json launch gate: handlers=$HANDLER_COUNT/$EXPECTED_COUNT groups=$HANDLER_GROUPS groups_off='$GROUPS_OFF' if='$IF_VALUES' expected='$EXPECTED_IF' write_if=$WRITE_IF cmd_off='$CMD_OFF'"
   fi
 else
-  fail "hooks.json launch-gate assertions need jq, $HOOKS_JSON and the script's case \"\$RAW_FILE\" pre-filter"
+  fail "hooks.json launch-gate assertions need jq, $HOOKS_JSON and agreeing case \"\$RAW_FILE\" / \"\$FILE\" gates in the script (gates=$CASE_BLOCKS gate1=(${SCRIPT_EXTS//$'\n'/ }) disagreeing:${GATES_OFF:- none})"
 fi
 
 echo

--- a/plugins/go-format/hooks/go-format.test.sh
+++ b/plugins/go-format/hooks/go-format.test.sh
@@ -505,6 +505,37 @@ else
   fail "jq-absent (rc=$RC_NOJQ out=$OUT_NOJQ)"
 fi
 
+# --- hooks.json: the if rows equal the script's own extension set (#3411) ----
+# The if rows are what keep a Write or Edit of any other file from spawning
+# this hook: Claude Code evaluates a handler's `if` at match time and drops the
+# handler without a spawn (hooks reference, `if`, re-fetched 2026-09-07; the
+# installed CLI logs "Skipping hook due to if condition ... not matching"), and
+# an Edit(...) rule is the one consulted for Write and NotebookEdit as well.
+# The script's own case filter stays as defense in depth, so the two sets must
+# be IDENTICAL: an if row the script does not handle spawns a process that
+# exits at the case, and an extension the script handles with no if row is a
+# silent regression, since the hook then never runs for it. The expected set is
+# read from the script's pre-filter line, so drift on either side fails here.
+HOOKS_JSON="$HOOK_DIR/hooks.json"
+SCRIPT_EXTS="$(sed -n '/^case "\$RAW_FILE" in$/{n;p;q;}' "$HOOK" | tr -d ' );' | tr '|' '\n' | LC_ALL=C sort)"
+EXPECTED_IF="$(printf '%s\n' "$SCRIPT_EXTS" | sed 's/.*/Edit(&)/' | tr '\n' ' ')"
+EXPECTED_IF="${EXPECTED_IF% }"
+EXPECTED_COUNT="$(printf '%s\n' "$SCRIPT_EXTS" | grep -c .)"
+if command -v jq >/dev/null 2>&1 && [[ -f "$HOOKS_JSON" && "$EXPECTED_COUNT" -gt 0 ]]; then
+  HANDLERS="$(jq -c '[.hooks.PostToolUse[]? | select(.matcher == "Write|Edit") | .hooks[]?]' "$HOOKS_JSON")"
+  HANDLER_COUNT="$(jq 'length' <<<"$HANDLERS")"
+  IF_VALUES="$(jq -r '[.[] | (.if // "(none)")] | sort | join(" ")' <<<"$HANDLERS")"
+  WRITE_IF="$(jq '[.[] | select(has("if") and (.if | startswith("Write(")))] | length' <<<"$HANDLERS")"
+  CMD_OK="$(jq '[.[] | select((.command | contains("\"${CLAUDE_PLUGIN_ROOT}\"")) and (.command | contains("go-format.sh")))] | length' <<<"$HANDLERS")"
+  if [[ "$HANDLER_COUNT" == "$EXPECTED_COUNT" && "$IF_VALUES" == "$EXPECTED_IF" && "$WRITE_IF" == "0" && "$CMD_OK" == "$EXPECTED_COUNT" ]]; then
+    ok "hooks.json launches only for $EXPECTED_IF, the script's own extension set"
+  else
+    fail "hooks.json launch gate: count=$HANDLER_COUNT/$EXPECTED_COUNT if='$IF_VALUES' expected='$EXPECTED_IF' write_if=$WRITE_IF cmd=$CMD_OK"
+  fi
+else
+  fail "hooks.json launch-gate assertions need jq, $HOOKS_JSON and the script's case \"\$RAW_FILE\" pre-filter"
+fi
+
 echo
 echo "PASS=$PASS FAIL=$FAIL"
 [[ $FAIL -eq 0 ]]

--- a/plugins/powershell-format/.claude-plugin/plugin.json
+++ b/plugins/powershell-format/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "powershell-format",
-  "version": "0.7.44",
+  "version": "0.7.45",
   "description": "Auto-format and lint PowerShell on edit via PSScriptAnalyzer, only when a PSScriptAnalyzerSettings.psd1 governs the repo \u2014 using the consuming repo's own analyzer settings.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/powershell-format/CHANGELOG.md
+++ b/plugins/powershell-format/CHANGELOG.md
@@ -12,11 +12,12 @@ All notable changes to the `powershell-format` plugin are documented here. Forma
   `if` rows are what keep a Write of any other file from spawning the hook
   (Claude Code drops a non-matching handler at match time, before a spawn);
   the script's `case` filter stays as defense in depth, and the new case
-  reads that filter's extension list and fails on drift in either direction,
-  since an extension the script handles with no `if` row is a silent
-  regression. The README's "Hook budget accounting" section carries a
-  Linux-host measurement and kernel census per hook-budget rule 1; no hook
-  behavior changes.
+  reads every arm of that filter's whole `case` block, requires every
+  handler in the manifest, under any event, to carry one of the derived
+  rows, and fails on drift in either direction, since an extension the
+  script handles with no `if` row is a silent regression. The README's
+  "Hook budget accounting" section carries a Linux-host measurement and
+  kernel census per hook-budget rule 1; no hook behavior changes.
 
 ## [0.7.44]
 

--- a/plugins/powershell-format/CHANGELOG.md
+++ b/plugins/powershell-format/CHANGELOG.md
@@ -12,10 +12,14 @@ All notable changes to the `powershell-format` plugin are documented here. Forma
   `if` rows are what keep a Write of any other file from spawning the hook
   (Claude Code drops a non-matching handler at match time, before a spawn);
   the script's `case` filter stays as defense in depth, and the new case
-  reads every arm of that filter's whole `case` block, requires every
-  handler in the manifest, under any event, to carry one of the derived
-  rows, and fails on drift in either direction, since an extension the
-  script handles with no `if` row is a silent regression. The README's
+  reads every arm of that filter's whole `case` block (each of bash's arm
+  terminators, `;;`, `;&` and `;;&`, ends an arm, and the `case "$FILE"`
+  re-check must yield the same set), requires every handler in the
+  manifest, under any event, to carry one of the derived rows and to sit in
+  a PostToolUse group whose matcher is exactly Write and Edit and whose
+  command is the plugin's own script, and fails on drift in either
+  direction, since an extension the script handles with no `if` row is a
+  silent regression, and so is a matcher narrowed to one tool. The README's
   "Hook budget accounting" section carries a Linux-host measurement and
   kernel census per hook-budget rule 1; no hook behavior changes.
 

--- a/plugins/powershell-format/CHANGELOG.md
+++ b/plugins/powershell-format/CHANGELOG.md
@@ -3,6 +3,21 @@
 All notable changes to the `powershell-format` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.7.45]
+
+### Added
+
+- **The suite pins the manifest's `if` rows to the script's own extension
+  set, and the README states the hook's measured budget share (#3411).** The
+  `if` rows are what keep a Write of any other file from spawning the hook
+  (Claude Code drops a non-matching handler at match time, before a spawn);
+  the script's `case` filter stays as defense in depth, and the new case
+  reads that filter's extension list and fails on drift in either direction,
+  since an extension the script handles with no `if` row is a silent
+  regression. The README's "Hook budget accounting" section carries a
+  Linux-host measurement and kernel census per hook-budget rule 1; no hook
+  behavior changes.
+
 ## [0.7.44]
 
 ### Changed

--- a/plugins/powershell-format/README.md
+++ b/plugins/powershell-format/README.md
@@ -87,6 +87,29 @@ The hook itself runs on Bash 3.2+. Telemetry timing uses `EPOCHREALTIME`
 (Bash 5.0+); on older bash the telemetry envelope is skipped while formatting and
 linting still run.
 
+### Hook budget accounting
+
+Per [`docs/conventions/hook-budget/README.md`](../../docs/conventions/hook-budget/README.md),
+this hook is always-on for every `Write` and `Edit` of a `.ps1`, `.psm1` or `.psd1` file (the
+three `if` rows in `hooks/hooks.json` keep every other extension from spawning it, and the
+suite pins those rows to the script's own extension set), so its cost on a clean PowerShell
+file is the figure that counts. Measured on Linux x86_64 under bash 5.2 in a container, twelve
+interleaved trials against an interleaved `bash -c :` floor S of about 2 ms, with a kernel
+census from `strace -f -e trace=clone,clone3,fork,vfork,execve` (2026-09-07, 0.7.45):
+
+| Event | Fires | Wall | Spawn-equivalents | Kernel census |
+| --- | --- | --- | --- | --- |
+| PostToolUse `Write`, clean `.ps1`, no `PSScriptAnalyzerSettings.psd1` (opt-in absent) | 1 | 37 ms | 16.7 | 16 process creations, 7 execs: four `realpath`, `git`, `jq`, the hook's own `bash` |
+| PostToolUse `Write`, clean `.ps1`, settings file present | 1 | 845 ms | 351 | 46 process creations, 12 execs: the row above plus one `pwsh` and the disclosure snapshot's `mktemp`, `cp`, `cmp`, `rm` |
+| PostToolUse `Write`, any other extension | 0 | none | 0 | no process; the `if` rows drop the handler before a spawn |
+
+The opted-in row is one `pwsh` start-up plus PSScriptAnalyzer's module load, so at a 2 ms
+floor the spawn-equivalent column measures that run time rather than spawns; the census column
+is the number that transfers to the Windows 11 Git Bash reference host the convention calls
+binding, and that host's figure for this plugin has not been taken. The residual is `pwsh` and
+PSScriptAnalyzer themselves plus the shared library's payload reader (`jq`), root resolver
+(`git`, `realpath`) and the disclosure snapshot.
+
 ## Install
 
 ```shell

--- a/plugins/powershell-format/README.md
+++ b/plugins/powershell-format/README.md
@@ -90,25 +90,26 @@ linting still run.
 ### Hook budget accounting
 
 Per [`docs/conventions/hook-budget/README.md`](../../docs/conventions/hook-budget/README.md),
-this hook is always-on for every `Write` and `Edit` of a `.ps1`, `.psm1` or `.psd1` file (the
-three `if` rows in `hooks/hooks.json` keep every other extension from spawning it, and the
-suite pins those rows to the script's own extension set), so its cost on a clean PowerShell
-file is the figure that counts. Measured on Linux x86_64 under bash 5.2 in a container, twelve
-interleaved trials against an interleaved `bash -c :` floor S of about 2 ms, with a kernel
-census from `strace -f -e trace=clone,clone3,fork,vfork,execve` (2026-09-07, 0.7.45):
+this hook is always-on for every `Write` and `Edit` of a `.ps1`, `.psm1` or `.psd1` file (every
+handler in `hooks/hooks.json` carries one of the three `if` rows, which keep every other
+extension from spawning it, and the suite pins the whole handler set to the script's own
+extension set), so its cost on a clean PowerShell file is the figure that counts. Measured on
+Linux x86_64 under bash 5.2 in a container with `HOOK_TELEMETRY_SINK` and `CLAUDE_PROJECT_DIR`
+unset, twelve interleaved trials against an interleaved `bash -c :` floor S of about 4 ms, with
+a kernel census from `strace -f -e trace=clone,clone3,fork,vfork,execve` (2026-09-07, 0.7.45):
 
 | Event | Fires | Wall | Spawn-equivalents | Kernel census |
 | --- | --- | --- | --- | --- |
-| PostToolUse `Write`, clean `.ps1`, no `PSScriptAnalyzerSettings.psd1` (opt-in absent) | 1 | 37 ms | 16.7 | 16 process creations, 7 execs: four `realpath`, `git`, `jq`, the hook's own `bash` |
-| PostToolUse `Write`, clean `.ps1`, settings file present | 1 | 845 ms | 351 | 46 process creations, 12 execs: the row above plus one `pwsh` and the disclosure snapshot's `mktemp`, `cp`, `cmp`, `rm` |
+| PostToolUse `Write`, clean `.ps1`, no `PSScriptAnalyzerSettings.psd1` (opt-in absent) | 1 | 39 ms | 9.3 | 15 process creations, 7 execs: three `realpath`, two `git rev-parse` (the working-tree probe and the root resolver), `jq`, the hook's own `bash` |
+| PostToolUse `Write`, clean `.ps1`, settings file present | 1 | 893 ms | 220 | 47 process creations, 12 execs: the row above plus one `pwsh` and the disclosure snapshot's `mktemp`, `cp`, `cmp`, `rm` |
 | PostToolUse `Write`, any other extension | 0 | none | 0 | no process; the `if` rows drop the handler before a spawn |
 
-The opted-in row is one `pwsh` start-up plus PSScriptAnalyzer's module load, so at a 2 ms
+The opted-in row is one `pwsh` start-up plus PSScriptAnalyzer's module load, so at a 4 ms
 floor the spawn-equivalent column measures that run time rather than spawns; the census column
 is the number that transfers to the Windows 11 Git Bash reference host the convention calls
 binding, and that host's figure for this plugin has not been taken. The residual is `pwsh` and
-PSScriptAnalyzer themselves plus the shared library's payload reader (`jq`), root resolver
-(`git`, `realpath`) and the disclosure snapshot.
+PSScriptAnalyzer themselves plus the shared library's payload reader (`jq`), working-tree probe
+and root resolver (`git` twice, `realpath`) and the disclosure snapshot.
 
 ## Install
 

--- a/plugins/powershell-format/hooks/powershell-format.test.sh
+++ b/plugins/powershell-format/hooks/powershell-format.test.sh
@@ -970,6 +970,37 @@ else
 fi
 rm -f "$TELS"
 
+# --- hooks.json: the if rows equal the script's own extension set (#3411) ----
+# The if rows are what keep a Write or Edit of any other file from spawning
+# this hook: Claude Code evaluates a handler's `if` at match time and drops the
+# handler without a spawn (hooks reference, `if`, re-fetched 2026-09-07; the
+# installed CLI logs "Skipping hook due to if condition ... not matching"), and
+# an Edit(...) rule is the one consulted for Write and NotebookEdit as well.
+# The script's own case filter stays as defense in depth, so the two sets must
+# be IDENTICAL: an if row the script does not handle spawns a process that
+# exits at the case, and an extension the script handles with no if row is a
+# silent regression, since the hook then never runs for it. The expected set is
+# read from the script's pre-filter line, so drift on either side fails here.
+HOOKS_JSON="$HOOK_DIR/hooks.json"
+SCRIPT_EXTS="$(sed -n '/^case "\$RAW_FILE" in$/{n;p;q;}' "$HOOK" | tr -d ' );' | tr '|' '\n' | LC_ALL=C sort)"
+EXPECTED_IF="$(printf '%s\n' "$SCRIPT_EXTS" | sed 's/.*/Edit(&)/' | tr '\n' ' ')"
+EXPECTED_IF="${EXPECTED_IF% }"
+EXPECTED_COUNT="$(printf '%s\n' "$SCRIPT_EXTS" | grep -c .)"
+if command -v jq >/dev/null 2>&1 && [[ -f "$HOOKS_JSON" && "$EXPECTED_COUNT" -gt 0 ]]; then
+  HANDLERS="$(jq -c '[.hooks.PostToolUse[]? | select(.matcher == "Write|Edit") | .hooks[]?]' "$HOOKS_JSON")"
+  HANDLER_COUNT="$(jq 'length' <<<"$HANDLERS")"
+  IF_VALUES="$(jq -r '[.[] | (.if // "(none)")] | sort | join(" ")' <<<"$HANDLERS")"
+  WRITE_IF="$(jq '[.[] | select(has("if") and (.if | startswith("Write(")))] | length' <<<"$HANDLERS")"
+  CMD_OK="$(jq '[.[] | select((.command | contains("\"${CLAUDE_PLUGIN_ROOT}\"")) and (.command | contains("powershell-format.sh")))] | length' <<<"$HANDLERS")"
+  if [[ "$HANDLER_COUNT" == "$EXPECTED_COUNT" && "$IF_VALUES" == "$EXPECTED_IF" && "$WRITE_IF" == "0" && "$CMD_OK" == "$EXPECTED_COUNT" ]]; then
+    ok "hooks.json launches only for $EXPECTED_IF, the script's own extension set"
+  else
+    fail "hooks.json launch gate: count=$HANDLER_COUNT/$EXPECTED_COUNT if='$IF_VALUES' expected='$EXPECTED_IF' write_if=$WRITE_IF cmd=$CMD_OK"
+  fi
+else
+  fail "hooks.json launch-gate assertions need jq, $HOOKS_JSON and the script's case \"\$RAW_FILE\" pre-filter"
+fi
+
 echo
 echo "PASS=$PASS FAIL=$FAIL"
 [[ $FAIL -eq 0 ]]

--- a/plugins/powershell-format/hooks/powershell-format.test.sh
+++ b/plugins/powershell-format/hooks/powershell-format.test.sh
@@ -979,23 +979,55 @@ rm -f "$TELS"
 # The script's own case filter stays as defense in depth, so the two sets must
 # be IDENTICAL: an if row the script does not handle spawns a process that
 # exits at the case, and an extension the script handles with no if row is a
-# silent regression, since the hook then never runs for it. The expected set is
-# read from the script's pre-filter line, so drift on either side fails here.
+# silent regression, since the hook then never runs for it.
+#
+# The expected set is every pattern of every arm in the script's whole
+# `case "$RAW_FILE" ... esac` block except the bare `*` catch-all, so an arm
+# added anywhere in the block counts, and an alternation wrapped across lines
+# (a backslash continuation, or `;;` on its own line) reads the same as one
+# line. On the manifest side every handler under every event and matcher
+# group is read, not only the `Write|Edit` group: the if values across all of
+# them must be exactly the derived set, one row each, so a handler with no if,
+# an if outside the set, a `Write(...)` rule, a duplicate row, an unfiltered
+# group under any event, or a command pointing elsewhere fails here. What
+# this does not reach is a registration outside hooks/hooks.json.
 HOOKS_JSON="$HOOK_DIR/hooks.json"
-SCRIPT_EXTS="$(sed -n '/^case "\$RAW_FILE" in$/{n;p;q;}' "$HOOK" | tr -d ' );' | tr '|' '\n' | LC_ALL=C sort)"
+SCRIPT_EXTS="$(awk '
+  /^case "[$]RAW_FILE" in[[:space:]]*$/ { inblock = 1; next }
+  inblock && /^esac([[:space:]]|$)/ { exit }
+  inblock {
+    sub(/#.*/, "")
+    sub(/\\$/, " ")
+    block = block " " $0
+  }
+  END {
+    n = split(block, arms, ";;")
+    for (i = 1; i <= n; i++) {
+      if (index(arms[i], ")") == 0) continue
+      pats = substr(arms[i], 1, index(arms[i], ")") - 1)
+      sub(/^[[:space:]]*\(/, "", pats)
+      m = split(pats, alts, "|")
+      for (j = 1; j <= m; j++) {
+        p = alts[j]
+        gsub(/[[:space:]]+/, "", p)
+        if (p != "" && p != "*") print p
+      }
+    }
+  }' "$HOOK" | LC_ALL=C sort -u)"
 EXPECTED_IF="$(printf '%s\n' "$SCRIPT_EXTS" | sed 's/.*/Edit(&)/' | tr '\n' ' ')"
 EXPECTED_IF="${EXPECTED_IF% }"
 EXPECTED_COUNT="$(printf '%s\n' "$SCRIPT_EXTS" | grep -c .)"
 if command -v jq >/dev/null 2>&1 && [[ -f "$HOOKS_JSON" && "$EXPECTED_COUNT" -gt 0 ]]; then
-  HANDLERS="$(jq -c '[.hooks.PostToolUse[]? | select(.matcher == "Write|Edit") | .hooks[]?]' "$HOOKS_JSON")"
+  HANDLERS="$(jq -c '[.hooks | to_entries[] | .key as $ev | .value[]? | .matcher as $m | .hooks[]? | . + {event: $ev, matcher: ($m // "(none)")}]' "$HOOKS_JSON")"
   HANDLER_COUNT="$(jq 'length' <<<"$HANDLERS")"
+  HANDLER_GROUPS="$(jq -r '[.[] | "\(.event):\(.matcher)"] | unique | join(",")' <<<"$HANDLERS")"
   IF_VALUES="$(jq -r '[.[] | (.if // "(none)")] | sort | join(" ")' <<<"$HANDLERS")"
   WRITE_IF="$(jq '[.[] | select(has("if") and (.if | startswith("Write(")))] | length' <<<"$HANDLERS")"
   CMD_OK="$(jq '[.[] | select((.command | contains("\"${CLAUDE_PLUGIN_ROOT}\"")) and (.command | contains("powershell-format.sh")))] | length' <<<"$HANDLERS")"
   if [[ "$HANDLER_COUNT" == "$EXPECTED_COUNT" && "$IF_VALUES" == "$EXPECTED_IF" && "$WRITE_IF" == "0" && "$CMD_OK" == "$EXPECTED_COUNT" ]]; then
-    ok "hooks.json launches only for $EXPECTED_IF, the script's own extension set"
+    ok "hooks.json: every handler ($HANDLER_GROUPS) carries an if row, and the rows are exactly $EXPECTED_IF, the script's own extension set"
   else
-    fail "hooks.json launch gate: count=$HANDLER_COUNT/$EXPECTED_COUNT if='$IF_VALUES' expected='$EXPECTED_IF' write_if=$WRITE_IF cmd=$CMD_OK"
+    fail "hooks.json launch gate: handlers=$HANDLER_COUNT/$EXPECTED_COUNT groups=$HANDLER_GROUPS if='$IF_VALUES' expected='$EXPECTED_IF' write_if=$WRITE_IF cmd=$CMD_OK"
   fi
 else
   fail "hooks.json launch-gate assertions need jq, $HOOKS_JSON and the script's case \"\$RAW_FILE\" pre-filter"

--- a/plugins/powershell-format/hooks/powershell-format.test.sh
+++ b/plugins/powershell-format/hooks/powershell-format.test.sh
@@ -983,25 +983,44 @@ rm -f "$TELS"
 #
 # The expected set is every pattern of every arm in the script's whole
 # `case "$RAW_FILE" ... esac` block except the bare `*` catch-all, so an arm
-# added anywhere in the block counts, and an alternation wrapped across lines
-# (a backslash continuation, or `;;` on its own line) reads the same as one
-# line. On the manifest side every handler under every event and matcher
-# group is read, not only the `Write|Edit` group: the if values across all of
-# them must be exactly the derived set, one row each, so a handler with no if,
-# an if outside the set, a `Write(...)` rule, a duplicate row, an unfiltered
-# group under any event, or a command pointing elsewhere fails here. What
-# this does not reach is a registration outside hooks/hooks.json.
+# added anywhere in the block counts. The block is read the way bash reads it:
+# a backslash continuation joins lines with nothing in between (so `;\` and a
+# following `;` is one `;;`), a comment after `in` or on any arm is dropped, a
+# one-line `case ... esac` is one block, `in` on the line after the `case`
+# word opens the block all the same, and every arm terminator bash has
+# (`;;`, the `;&` fall-through and the `;;&` continue-matching form) ends an
+# arm, so the patterns of an arm reached only by fall-through count too. What
+# the parser does not read is an arm's body, so a pattern in any arm, even one
+# after `*)` that can never match, counts as handled and must have its row.
+# The script's `case "$FILE"` re-check after path normalization (the duplicate
+# #3408 owns folding) is read the same way, and every such gate must yield the
+# same set, so an exclusion added to either gate fails here instead of sitting
+# unread; a script with one gate left passes as it is.
+#
+# On the manifest side every handler under every event and matcher group is
+# read. Two things are pinned separately, since they answer different
+# questions. The `if` rows, which paths a handler applies to: the values
+# across every handler must be exactly the derived set, one row each, so a
+# handler with no if, an if outside the set, a `Write(...)` rule, a duplicate
+# row or an unfiltered group under any event fails. The group, which tools
+# invoke the handler at all: every group must be PostToolUse with a matcher
+# whose alternation is exactly Write and Edit in either order, the two tools
+# whose payload carries a file this script formats (the rule validator folds
+# Write and NotebookEdit into an Edit(...) rule, but the matcher is the tool
+# name regex the harness consults first, and a matcher narrowed to one tool
+# is the hook silently never running for the other, which no if row can show).
+# The command must be the plugin's own script by either quoting placement,
+# with no prefix, suffix or argument. What this does not reach is a
+# registration outside hooks/hooks.json.
 HOOKS_JSON="$HOOK_DIR/hooks.json"
-SCRIPT_EXTS="$(awk '
-  /^case "[$]RAW_FILE" in[[:space:]]*$/ { inblock = 1; next }
-  inblock && /^esac([[:space:]]|$)/ { exit }
-  inblock {
-    sub(/#.*/, "")
-    sub(/\\$/, " ")
-    block = block " " $0
-  }
-  END {
-    n = split(block, arms, ";;")
+SCRIPT_GATES="$(awk '
+  function flush(   n, i, m, j, p, pats, arms, alts) {
+    inblock = 0
+    print nblocks "\t"
+    gsub(/;;&/, "\n", block)
+    gsub(/;;/, "\n", block)
+    gsub(/;&/, "\n", block)
+    n = split(block, arms, "\n")
     for (i = 1; i <= n; i++) {
       if (index(arms[i], ")") == 0) continue
       pats = substr(arms[i], 1, index(arms[i], ")") - 1)
@@ -1010,27 +1029,73 @@ SCRIPT_EXTS="$(awk '
       for (j = 1; j <= m; j++) {
         p = alts[j]
         gsub(/[[:space:]]+/, "", p)
-        if (p != "" && p != "*") print p
+        if (p != "" && p != "*") print nblocks "\t" p
       }
     }
-  }' "$HOOK" | LC_ALL=C sort -u)"
+  }
+  !inblock && !pending && $0 ~ /^case "[$](RAW_FILE|FILE)"[[:space:]]*(#.*)?$/ {
+    pending = 1
+    next
+  }
+  pending && match($0, /^[[:space:]]*in([[:space:]]|$)/) {
+    pending = 0
+    inblock = 1
+    nblocks++
+    block = ""
+    sep = ""
+    $0 = substr($0, RLENGTH + 1)
+  }
+  !inblock && match($0, /^case "[$](RAW_FILE|FILE)" in([[:space:]]|$)/) {
+    inblock = 1
+    nblocks++
+    block = ""
+    sep = ""
+    $0 = substr($0, RLENGTH + 1)
+  }
+  inblock {
+    sub(/#.*/, "")
+    if ($0 ~ /^[[:space:]]*esac([[:space:]]|$)/) {
+      flush()
+      next
+    }
+    if (match($0, /[[:space:]]esac([[:space:]]|$)/)) {
+      block = block sep substr($0, 1, RSTART - 1)
+      flush()
+      next
+    }
+    if (sub(/\\$/, "")) {
+      block = block sep $0
+      sep = ""
+    } else {
+      block = block sep $0
+      sep = " "
+    }
+  }' "$HOOK")"
+CASE_BLOCKS="$(printf '%s\n' "$SCRIPT_GATES" | cut -f1 | LC_ALL=C sort -u | grep -c .)"
+SCRIPT_EXTS="$(printf '%s\n' "$SCRIPT_GATES" | awk -F'\t' '$1 == 1 && $2 != "" { print $2 }' | LC_ALL=C sort -u)"
+GATES_OFF=""
+for ((g = 2; g <= CASE_BLOCKS; g++)); do
+  GATE_EXTS="$(printf '%s\n' "$SCRIPT_GATES" | awk -F'\t' -v g="$g" '$1 == g && $2 != "" { print $2 }' | LC_ALL=C sort -u)"
+  [[ "$GATE_EXTS" == "$SCRIPT_EXTS" ]] || GATES_OFF+=" gate$g=(${GATE_EXTS//$'\n'/ })"
+done
 EXPECTED_IF="$(printf '%s\n' "$SCRIPT_EXTS" | sed 's/.*/Edit(&)/' | tr '\n' ' ')"
 EXPECTED_IF="${EXPECTED_IF% }"
 EXPECTED_COUNT="$(printf '%s\n' "$SCRIPT_EXTS" | grep -c .)"
-if command -v jq >/dev/null 2>&1 && [[ -f "$HOOKS_JSON" && "$EXPECTED_COUNT" -gt 0 ]]; then
+if command -v jq >/dev/null 2>&1 && [[ -f "$HOOKS_JSON" && "$CASE_BLOCKS" -ge 1 && -z "$GATES_OFF" && "$EXPECTED_COUNT" -gt 0 ]]; then
   HANDLERS="$(jq -c '[.hooks | to_entries[] | .key as $ev | .value[]? | .matcher as $m | .hooks[]? | . + {event: $ev, matcher: ($m // "(none)")}]' "$HOOKS_JSON")"
   HANDLER_COUNT="$(jq 'length' <<<"$HANDLERS")"
   HANDLER_GROUPS="$(jq -r '[.[] | "\(.event):\(.matcher)"] | unique | join(",")' <<<"$HANDLERS")"
+  GROUPS_OFF="$(jq -r '[.[] | select(.event != "PostToolUse" or ((.matcher | split("|") | sort | unique) != ["Edit", "Write"])) | "\(.event):\(.matcher)"] | unique | join(",")' <<<"$HANDLERS")"
   IF_VALUES="$(jq -r '[.[] | (.if // "(none)")] | sort | join(" ")' <<<"$HANDLERS")"
   WRITE_IF="$(jq '[.[] | select(has("if") and (.if | startswith("Write(")))] | length' <<<"$HANDLERS")"
-  CMD_OK="$(jq '[.[] | select((.command | contains("\"${CLAUDE_PLUGIN_ROOT}\"")) and (.command | contains("powershell-format.sh")))] | length' <<<"$HANDLERS")"
-  if [[ "$HANDLER_COUNT" == "$EXPECTED_COUNT" && "$IF_VALUES" == "$EXPECTED_IF" && "$WRITE_IF" == "0" && "$CMD_OK" == "$EXPECTED_COUNT" ]]; then
-    ok "hooks.json: every handler ($HANDLER_GROUPS) carries an if row, and the rows are exactly $EXPECTED_IF, the script's own extension set"
+  CMD_OFF="$(jq -r '[.[] | (.command // "(none)") | select(test("^(\"[$][{]?CLAUDE_PLUGIN_ROOT[}]?\"/hooks/powershell-format[.]sh|\"[$][{]?CLAUDE_PLUGIN_ROOT[}]?/hooks/powershell-format[.]sh\")$") | not)] | unique | join(",")' <<<"$HANDLERS")"
+  if [[ "$HANDLER_COUNT" == "$EXPECTED_COUNT" && "$IF_VALUES" == "$EXPECTED_IF" && "$WRITE_IF" == "0" && -z "$GROUPS_OFF" && -z "$CMD_OFF" ]]; then
+    ok "hooks.json: every handler ($HANDLER_GROUPS) is a PostToolUse Write and Edit group running the plugin's script, and the if rows are exactly $EXPECTED_IF, the script's own extension set ($CASE_BLOCKS case gates agree)"
   else
-    fail "hooks.json launch gate: handlers=$HANDLER_COUNT/$EXPECTED_COUNT groups=$HANDLER_GROUPS if='$IF_VALUES' expected='$EXPECTED_IF' write_if=$WRITE_IF cmd=$CMD_OK"
+    fail "hooks.json launch gate: handlers=$HANDLER_COUNT/$EXPECTED_COUNT groups=$HANDLER_GROUPS groups_off='$GROUPS_OFF' if='$IF_VALUES' expected='$EXPECTED_IF' write_if=$WRITE_IF cmd_off='$CMD_OFF'"
   fi
 else
-  fail "hooks.json launch-gate assertions need jq, $HOOKS_JSON and the script's case \"\$RAW_FILE\" pre-filter"
+  fail "hooks.json launch-gate assertions need jq, $HOOKS_JSON and agreeing case \"\$RAW_FILE\" / \"\$FILE\" gates in the script (gates=$CASE_BLOCKS gate1=(${SCRIPT_EXTS//$'\n'/ }) disagreeing:${GATES_OFF:- none})"
 fi
 
 echo

--- a/plugins/ruff-format/.claude-plugin/plugin.json
+++ b/plugins/ruff-format/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "ruff-format",
-  "version": "0.6.42",
+  "version": "0.6.43",
   "description": "Auto-format and lint Python on edit via Ruff, only when a Ruff config governs the repo \u2014 using the consuming repo's own Ruff config.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/ruff-format/CHANGELOG.md
+++ b/plugins/ruff-format/CHANGELOG.md
@@ -12,10 +12,14 @@ All notable changes to the `ruff-format` plugin are documented here. Format foll
   `if` rows are what keep a Write of any other file from spawning the hook
   (Claude Code drops a non-matching handler at match time, before a spawn);
   the script's `case` filter stays as defense in depth, and the new case
-  reads every arm of that filter's whole `case` block, requires every
-  handler in the manifest, under any event, to carry one of the derived
-  rows, and fails on drift in either direction, since an extension the
-  script handles with no `if` row is a silent regression. The README's
+  reads every arm of that filter's whole `case` block (each of bash's arm
+  terminators, `;;`, `;&` and `;;&`, ends an arm, and the `case "$FILE"`
+  re-check must yield the same set), requires every handler in the
+  manifest, under any event, to carry one of the derived rows and to sit in
+  a PostToolUse group whose matcher is exactly Write and Edit and whose
+  command is the plugin's own script, and fails on drift in either
+  direction, since an extension the script handles with no `if` row is a
+  silent regression, and so is a matcher narrowed to one tool. The README's
   "Hook budget accounting" section carries a Linux-host measurement and
   kernel census per hook-budget rule 1; no hook behavior changes.
 

--- a/plugins/ruff-format/CHANGELOG.md
+++ b/plugins/ruff-format/CHANGELOG.md
@@ -12,11 +12,12 @@ All notable changes to the `ruff-format` plugin are documented here. Format foll
   `if` rows are what keep a Write of any other file from spawning the hook
   (Claude Code drops a non-matching handler at match time, before a spawn);
   the script's `case` filter stays as defense in depth, and the new case
-  reads that filter's extension list and fails on drift in either direction,
-  since an extension the script handles with no `if` row is a silent
-  regression. The README's "Hook budget accounting" section carries a
-  Linux-host measurement and kernel census per hook-budget rule 1; no hook
-  behavior changes.
+  reads every arm of that filter's whole `case` block, requires every
+  handler in the manifest, under any event, to carry one of the derived
+  rows, and fails on drift in either direction, since an extension the
+  script handles with no `if` row is a silent regression. The README's
+  "Hook budget accounting" section carries a Linux-host measurement and
+  kernel census per hook-budget rule 1; no hook behavior changes.
 
 ## [0.6.42]
 

--- a/plugins/ruff-format/CHANGELOG.md
+++ b/plugins/ruff-format/CHANGELOG.md
@@ -3,6 +3,21 @@
 All notable changes to the `ruff-format` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.6.43]
+
+### Added
+
+- **The suite pins the manifest's `if` rows to the script's own extension
+  set, and the README states the hook's measured budget share (#3411).** The
+  `if` rows are what keep a Write of any other file from spawning the hook
+  (Claude Code drops a non-matching handler at match time, before a spawn);
+  the script's `case` filter stays as defense in depth, and the new case
+  reads that filter's extension list and fails on drift in either direction,
+  since an extension the script handles with no `if` row is a silent
+  regression. The README's "Hook budget accounting" section carries a
+  Linux-host measurement and kernel census per hook-budget rule 1; no hook
+  behavior changes.
+
 ## [0.6.42]
 
 ### Changed

--- a/plugins/ruff-format/README.md
+++ b/plugins/ruff-format/README.md
@@ -67,6 +67,28 @@ The hook itself runs on Bash 3.2+. Telemetry timing uses `EPOCHREALTIME`
 (Bash 5.0+); on older bash the telemetry envelope is skipped while formatting
 and linting still run.
 
+### Hook budget accounting
+
+Per [`docs/conventions/hook-budget/README.md`](../../docs/conventions/hook-budget/README.md),
+this hook is always-on for every `Write` and `Edit` of a `.py` or `.pyi` file (the two `if`
+rows in `hooks/hooks.json` keep every other extension from spawning it, and the suite pins
+those rows to the script's own extension set), so its cost on a clean Python file is the figure
+that counts. Measured on Linux x86_64 under bash 5.2 in a container, twelve interleaved trials
+against an interleaved `bash -c :` floor S of about 2 ms, with a kernel census from
+`strace -f -e trace=clone,clone3,fork,vfork,execve` (2026-09-07, 0.6.43):
+
+| Event | Fires | Wall | Spawn-equivalents | Kernel census |
+| --- | --- | --- | --- | --- |
+| PostToolUse `Write`, clean `.py`, no Ruff config (opt-in absent) | 1 | 32 ms | 13.2 | 10 process creations, 4 execs: `git`, `jq`, `realpath`, the hook's own `bash` |
+| PostToolUse `Write`, clean `.py`, `ruff.toml` present | 1 | 79 ms | 35.4 | 44 process creations, 17 execs: the row above plus six `ruff` runs through the `.venv/bin/ruff` launcher and the disclosure snapshot's `mktemp`, `cp`, `cmp`, `rm` |
+| PostToolUse `Write`, any other extension | 0 | none | 0 | no process; the `if` rows drop the handler before a spawn |
+
+At a 2 ms floor the spawn-equivalent column mostly measures Ruff's own run time rather than
+spawns, so the census column is the number that transfers to the Windows 11 Git Bash reference
+host the convention calls binding; that host's figure for this plugin has not been taken. The
+residual is Ruff itself plus the shared library's payload reader (`jq`), root resolver (`git`,
+`realpath`) and the disclosure snapshot.
+
 ## Install
 
 ```shell

--- a/plugins/ruff-format/README.md
+++ b/plugins/ruff-format/README.md
@@ -70,24 +70,25 @@ and linting still run.
 ### Hook budget accounting
 
 Per [`docs/conventions/hook-budget/README.md`](../../docs/conventions/hook-budget/README.md),
-this hook is always-on for every `Write` and `Edit` of a `.py` or `.pyi` file (the two `if`
-rows in `hooks/hooks.json` keep every other extension from spawning it, and the suite pins
-those rows to the script's own extension set), so its cost on a clean Python file is the figure
-that counts. Measured on Linux x86_64 under bash 5.2 in a container, twelve interleaved trials
-against an interleaved `bash -c :` floor S of about 2 ms, with a kernel census from
+this hook is always-on for every `Write` and `Edit` of a `.py` or `.pyi` file (every handler in
+`hooks/hooks.json` carries one of the two `if` rows, which keep every other extension from
+spawning it, and the suite pins the whole handler set to the script's own extension set), so its
+cost on a clean Python file is the figure that counts. Measured on Linux x86_64 under bash 5.2
+in a container with `HOOK_TELEMETRY_SINK` and `CLAUDE_PROJECT_DIR` unset, twelve interleaved
+trials against an interleaved `bash -c :` floor S of about 4 ms, with a kernel census from
 `strace -f -e trace=clone,clone3,fork,vfork,execve` (2026-09-07, 0.6.43):
 
 | Event | Fires | Wall | Spawn-equivalents | Kernel census |
 | --- | --- | --- | --- | --- |
-| PostToolUse `Write`, clean `.py`, no Ruff config (opt-in absent) | 1 | 32 ms | 13.2 | 10 process creations, 4 execs: `git`, `jq`, `realpath`, the hook's own `bash` |
-| PostToolUse `Write`, clean `.py`, `ruff.toml` present | 1 | 79 ms | 35.4 | 44 process creations, 17 execs: the row above plus six `ruff` runs through the `.venv/bin/ruff` launcher and the disclosure snapshot's `mktemp`, `cp`, `cmp`, `rm` |
+| PostToolUse `Write`, clean `.py`, no Ruff config (opt-in absent) | 1 | 30 ms | 7.9 | 11 process creations, 5 execs: two `git rev-parse` (the working-tree probe and the root resolver), `jq`, `realpath`, the hook's own `bash` |
+| PostToolUse `Write`, clean `.py`, `ruff.toml` present | 1 | 65 ms | 16.3 | 45 process creations, 12 execs: the row above plus three `ruff` runs (`check --fix`, `format`, `check --no-fix`) and the disclosure snapshot's `mktemp`, `cp`, `cmp`, `rm` |
 | PostToolUse `Write`, any other extension | 0 | none | 0 | no process; the `if` rows drop the handler before a spawn |
 
-At a 2 ms floor the spawn-equivalent column mostly measures Ruff's own run time rather than
+At a 4 ms floor the spawn-equivalent column mostly measures Ruff's own run time rather than
 spawns, so the census column is the number that transfers to the Windows 11 Git Bash reference
 host the convention calls binding; that host's figure for this plugin has not been taken. The
-residual is Ruff itself plus the shared library's payload reader (`jq`), root resolver (`git`,
-`realpath`) and the disclosure snapshot.
+residual is Ruff itself plus the shared library's payload reader (`jq`), working-tree probe and
+root resolver (`git` twice, `realpath`) and the disclosure snapshot.
 
 ## Install
 

--- a/plugins/ruff-format/hooks/ruff-format.test.sh
+++ b/plugins/ruff-format/hooks/ruff-format.test.sh
@@ -551,6 +551,37 @@ else
   echo "SKIP: symlinks unavailable on this filesystem -- symlinked-root case skipped"
 fi
 
+# --- hooks.json: the if rows equal the script's own extension set (#3411) ----
+# The if rows are what keep a Write or Edit of any other file from spawning
+# this hook: Claude Code evaluates a handler's `if` at match time and drops the
+# handler without a spawn (hooks reference, `if`, re-fetched 2026-09-07; the
+# installed CLI logs "Skipping hook due to if condition ... not matching"), and
+# an Edit(...) rule is the one consulted for Write and NotebookEdit as well.
+# The script's own case filter stays as defense in depth, so the two sets must
+# be IDENTICAL: an if row the script does not handle spawns a process that
+# exits at the case, and an extension the script handles with no if row is a
+# silent regression, since the hook then never runs for it. The expected set is
+# read from the script's pre-filter line, so drift on either side fails here.
+HOOKS_JSON="$HOOK_DIR/hooks.json"
+SCRIPT_EXTS="$(sed -n '/^case "\$RAW_FILE" in$/{n;p;q;}' "$HOOK" | tr -d ' );' | tr '|' '\n' | LC_ALL=C sort)"
+EXPECTED_IF="$(printf '%s\n' "$SCRIPT_EXTS" | sed 's/.*/Edit(&)/' | tr '\n' ' ')"
+EXPECTED_IF="${EXPECTED_IF% }"
+EXPECTED_COUNT="$(printf '%s\n' "$SCRIPT_EXTS" | grep -c .)"
+if command -v jq >/dev/null 2>&1 && [[ -f "$HOOKS_JSON" && "$EXPECTED_COUNT" -gt 0 ]]; then
+  HANDLERS="$(jq -c '[.hooks.PostToolUse[]? | select(.matcher == "Write|Edit") | .hooks[]?]' "$HOOKS_JSON")"
+  HANDLER_COUNT="$(jq 'length' <<<"$HANDLERS")"
+  IF_VALUES="$(jq -r '[.[] | (.if // "(none)")] | sort | join(" ")' <<<"$HANDLERS")"
+  WRITE_IF="$(jq '[.[] | select(has("if") and (.if | startswith("Write(")))] | length' <<<"$HANDLERS")"
+  CMD_OK="$(jq '[.[] | select((.command | contains("\"${CLAUDE_PLUGIN_ROOT}\"")) and (.command | contains("ruff-format.sh")))] | length' <<<"$HANDLERS")"
+  if [[ "$HANDLER_COUNT" == "$EXPECTED_COUNT" && "$IF_VALUES" == "$EXPECTED_IF" && "$WRITE_IF" == "0" && "$CMD_OK" == "$EXPECTED_COUNT" ]]; then
+    ok "hooks.json launches only for $EXPECTED_IF, the script's own extension set"
+  else
+    fail "hooks.json launch gate: count=$HANDLER_COUNT/$EXPECTED_COUNT if='$IF_VALUES' expected='$EXPECTED_IF' write_if=$WRITE_IF cmd=$CMD_OK"
+  fi
+else
+  fail "hooks.json launch-gate assertions need jq, $HOOKS_JSON and the script's case \"\$RAW_FILE\" pre-filter"
+fi
+
 echo
 echo "PASS=$PASS FAIL=$FAIL"
 [[ $FAIL -eq 0 ]]

--- a/plugins/ruff-format/hooks/ruff-format.test.sh
+++ b/plugins/ruff-format/hooks/ruff-format.test.sh
@@ -560,23 +560,55 @@ fi
 # The script's own case filter stays as defense in depth, so the two sets must
 # be IDENTICAL: an if row the script does not handle spawns a process that
 # exits at the case, and an extension the script handles with no if row is a
-# silent regression, since the hook then never runs for it. The expected set is
-# read from the script's pre-filter line, so drift on either side fails here.
+# silent regression, since the hook then never runs for it.
+#
+# The expected set is every pattern of every arm in the script's whole
+# `case "$RAW_FILE" ... esac` block except the bare `*` catch-all, so an arm
+# added anywhere in the block counts, and an alternation wrapped across lines
+# (a backslash continuation, or `;;` on its own line) reads the same as one
+# line. On the manifest side every handler under every event and matcher
+# group is read, not only the `Write|Edit` group: the if values across all of
+# them must be exactly the derived set, one row each, so a handler with no if,
+# an if outside the set, a `Write(...)` rule, a duplicate row, an unfiltered
+# group under any event, or a command pointing elsewhere fails here. What
+# this does not reach is a registration outside hooks/hooks.json.
 HOOKS_JSON="$HOOK_DIR/hooks.json"
-SCRIPT_EXTS="$(sed -n '/^case "\$RAW_FILE" in$/{n;p;q;}' "$HOOK" | tr -d ' );' | tr '|' '\n' | LC_ALL=C sort)"
+SCRIPT_EXTS="$(awk '
+  /^case "[$]RAW_FILE" in[[:space:]]*$/ { inblock = 1; next }
+  inblock && /^esac([[:space:]]|$)/ { exit }
+  inblock {
+    sub(/#.*/, "")
+    sub(/\\$/, " ")
+    block = block " " $0
+  }
+  END {
+    n = split(block, arms, ";;")
+    for (i = 1; i <= n; i++) {
+      if (index(arms[i], ")") == 0) continue
+      pats = substr(arms[i], 1, index(arms[i], ")") - 1)
+      sub(/^[[:space:]]*\(/, "", pats)
+      m = split(pats, alts, "|")
+      for (j = 1; j <= m; j++) {
+        p = alts[j]
+        gsub(/[[:space:]]+/, "", p)
+        if (p != "" && p != "*") print p
+      }
+    }
+  }' "$HOOK" | LC_ALL=C sort -u)"
 EXPECTED_IF="$(printf '%s\n' "$SCRIPT_EXTS" | sed 's/.*/Edit(&)/' | tr '\n' ' ')"
 EXPECTED_IF="${EXPECTED_IF% }"
 EXPECTED_COUNT="$(printf '%s\n' "$SCRIPT_EXTS" | grep -c .)"
 if command -v jq >/dev/null 2>&1 && [[ -f "$HOOKS_JSON" && "$EXPECTED_COUNT" -gt 0 ]]; then
-  HANDLERS="$(jq -c '[.hooks.PostToolUse[]? | select(.matcher == "Write|Edit") | .hooks[]?]' "$HOOKS_JSON")"
+  HANDLERS="$(jq -c '[.hooks | to_entries[] | .key as $ev | .value[]? | .matcher as $m | .hooks[]? | . + {event: $ev, matcher: ($m // "(none)")}]' "$HOOKS_JSON")"
   HANDLER_COUNT="$(jq 'length' <<<"$HANDLERS")"
+  HANDLER_GROUPS="$(jq -r '[.[] | "\(.event):\(.matcher)"] | unique | join(",")' <<<"$HANDLERS")"
   IF_VALUES="$(jq -r '[.[] | (.if // "(none)")] | sort | join(" ")' <<<"$HANDLERS")"
   WRITE_IF="$(jq '[.[] | select(has("if") and (.if | startswith("Write(")))] | length' <<<"$HANDLERS")"
   CMD_OK="$(jq '[.[] | select((.command | contains("\"${CLAUDE_PLUGIN_ROOT}\"")) and (.command | contains("ruff-format.sh")))] | length' <<<"$HANDLERS")"
   if [[ "$HANDLER_COUNT" == "$EXPECTED_COUNT" && "$IF_VALUES" == "$EXPECTED_IF" && "$WRITE_IF" == "0" && "$CMD_OK" == "$EXPECTED_COUNT" ]]; then
-    ok "hooks.json launches only for $EXPECTED_IF, the script's own extension set"
+    ok "hooks.json: every handler ($HANDLER_GROUPS) carries an if row, and the rows are exactly $EXPECTED_IF, the script's own extension set"
   else
-    fail "hooks.json launch gate: count=$HANDLER_COUNT/$EXPECTED_COUNT if='$IF_VALUES' expected='$EXPECTED_IF' write_if=$WRITE_IF cmd=$CMD_OK"
+    fail "hooks.json launch gate: handlers=$HANDLER_COUNT/$EXPECTED_COUNT groups=$HANDLER_GROUPS if='$IF_VALUES' expected='$EXPECTED_IF' write_if=$WRITE_IF cmd=$CMD_OK"
   fi
 else
   fail "hooks.json launch-gate assertions need jq, $HOOKS_JSON and the script's case \"\$RAW_FILE\" pre-filter"

--- a/plugins/ruff-format/hooks/ruff-format.test.sh
+++ b/plugins/ruff-format/hooks/ruff-format.test.sh
@@ -564,25 +564,44 @@ fi
 #
 # The expected set is every pattern of every arm in the script's whole
 # `case "$RAW_FILE" ... esac` block except the bare `*` catch-all, so an arm
-# added anywhere in the block counts, and an alternation wrapped across lines
-# (a backslash continuation, or `;;` on its own line) reads the same as one
-# line. On the manifest side every handler under every event and matcher
-# group is read, not only the `Write|Edit` group: the if values across all of
-# them must be exactly the derived set, one row each, so a handler with no if,
-# an if outside the set, a `Write(...)` rule, a duplicate row, an unfiltered
-# group under any event, or a command pointing elsewhere fails here. What
-# this does not reach is a registration outside hooks/hooks.json.
+# added anywhere in the block counts. The block is read the way bash reads it:
+# a backslash continuation joins lines with nothing in between (so `;\` and a
+# following `;` is one `;;`), a comment after `in` or on any arm is dropped, a
+# one-line `case ... esac` is one block, `in` on the line after the `case`
+# word opens the block all the same, and every arm terminator bash has
+# (`;;`, the `;&` fall-through and the `;;&` continue-matching form) ends an
+# arm, so the patterns of an arm reached only by fall-through count too. What
+# the parser does not read is an arm's body, so a pattern in any arm, even one
+# after `*)` that can never match, counts as handled and must have its row.
+# The script's `case "$FILE"` re-check after path normalization (the duplicate
+# #3408 owns folding) is read the same way, and every such gate must yield the
+# same set, so an exclusion added to either gate fails here instead of sitting
+# unread; a script with one gate left passes as it is.
+#
+# On the manifest side every handler under every event and matcher group is
+# read. Two things are pinned separately, since they answer different
+# questions. The `if` rows, which paths a handler applies to: the values
+# across every handler must be exactly the derived set, one row each, so a
+# handler with no if, an if outside the set, a `Write(...)` rule, a duplicate
+# row or an unfiltered group under any event fails. The group, which tools
+# invoke the handler at all: every group must be PostToolUse with a matcher
+# whose alternation is exactly Write and Edit in either order, the two tools
+# whose payload carries a file this script formats (the rule validator folds
+# Write and NotebookEdit into an Edit(...) rule, but the matcher is the tool
+# name regex the harness consults first, and a matcher narrowed to one tool
+# is the hook silently never running for the other, which no if row can show).
+# The command must be the plugin's own script by either quoting placement,
+# with no prefix, suffix or argument. What this does not reach is a
+# registration outside hooks/hooks.json.
 HOOKS_JSON="$HOOK_DIR/hooks.json"
-SCRIPT_EXTS="$(awk '
-  /^case "[$]RAW_FILE" in[[:space:]]*$/ { inblock = 1; next }
-  inblock && /^esac([[:space:]]|$)/ { exit }
-  inblock {
-    sub(/#.*/, "")
-    sub(/\\$/, " ")
-    block = block " " $0
-  }
-  END {
-    n = split(block, arms, ";;")
+SCRIPT_GATES="$(awk '
+  function flush(   n, i, m, j, p, pats, arms, alts) {
+    inblock = 0
+    print nblocks "\t"
+    gsub(/;;&/, "\n", block)
+    gsub(/;;/, "\n", block)
+    gsub(/;&/, "\n", block)
+    n = split(block, arms, "\n")
     for (i = 1; i <= n; i++) {
       if (index(arms[i], ")") == 0) continue
       pats = substr(arms[i], 1, index(arms[i], ")") - 1)
@@ -591,27 +610,73 @@ SCRIPT_EXTS="$(awk '
       for (j = 1; j <= m; j++) {
         p = alts[j]
         gsub(/[[:space:]]+/, "", p)
-        if (p != "" && p != "*") print p
+        if (p != "" && p != "*") print nblocks "\t" p
       }
     }
-  }' "$HOOK" | LC_ALL=C sort -u)"
+  }
+  !inblock && !pending && $0 ~ /^case "[$](RAW_FILE|FILE)"[[:space:]]*(#.*)?$/ {
+    pending = 1
+    next
+  }
+  pending && match($0, /^[[:space:]]*in([[:space:]]|$)/) {
+    pending = 0
+    inblock = 1
+    nblocks++
+    block = ""
+    sep = ""
+    $0 = substr($0, RLENGTH + 1)
+  }
+  !inblock && match($0, /^case "[$](RAW_FILE|FILE)" in([[:space:]]|$)/) {
+    inblock = 1
+    nblocks++
+    block = ""
+    sep = ""
+    $0 = substr($0, RLENGTH + 1)
+  }
+  inblock {
+    sub(/#.*/, "")
+    if ($0 ~ /^[[:space:]]*esac([[:space:]]|$)/) {
+      flush()
+      next
+    }
+    if (match($0, /[[:space:]]esac([[:space:]]|$)/)) {
+      block = block sep substr($0, 1, RSTART - 1)
+      flush()
+      next
+    }
+    if (sub(/\\$/, "")) {
+      block = block sep $0
+      sep = ""
+    } else {
+      block = block sep $0
+      sep = " "
+    }
+  }' "$HOOK")"
+CASE_BLOCKS="$(printf '%s\n' "$SCRIPT_GATES" | cut -f1 | LC_ALL=C sort -u | grep -c .)"
+SCRIPT_EXTS="$(printf '%s\n' "$SCRIPT_GATES" | awk -F'\t' '$1 == 1 && $2 != "" { print $2 }' | LC_ALL=C sort -u)"
+GATES_OFF=""
+for ((g = 2; g <= CASE_BLOCKS; g++)); do
+  GATE_EXTS="$(printf '%s\n' "$SCRIPT_GATES" | awk -F'\t' -v g="$g" '$1 == g && $2 != "" { print $2 }' | LC_ALL=C sort -u)"
+  [[ "$GATE_EXTS" == "$SCRIPT_EXTS" ]] || GATES_OFF+=" gate$g=(${GATE_EXTS//$'\n'/ })"
+done
 EXPECTED_IF="$(printf '%s\n' "$SCRIPT_EXTS" | sed 's/.*/Edit(&)/' | tr '\n' ' ')"
 EXPECTED_IF="${EXPECTED_IF% }"
 EXPECTED_COUNT="$(printf '%s\n' "$SCRIPT_EXTS" | grep -c .)"
-if command -v jq >/dev/null 2>&1 && [[ -f "$HOOKS_JSON" && "$EXPECTED_COUNT" -gt 0 ]]; then
+if command -v jq >/dev/null 2>&1 && [[ -f "$HOOKS_JSON" && "$CASE_BLOCKS" -ge 1 && -z "$GATES_OFF" && "$EXPECTED_COUNT" -gt 0 ]]; then
   HANDLERS="$(jq -c '[.hooks | to_entries[] | .key as $ev | .value[]? | .matcher as $m | .hooks[]? | . + {event: $ev, matcher: ($m // "(none)")}]' "$HOOKS_JSON")"
   HANDLER_COUNT="$(jq 'length' <<<"$HANDLERS")"
   HANDLER_GROUPS="$(jq -r '[.[] | "\(.event):\(.matcher)"] | unique | join(",")' <<<"$HANDLERS")"
+  GROUPS_OFF="$(jq -r '[.[] | select(.event != "PostToolUse" or ((.matcher | split("|") | sort | unique) != ["Edit", "Write"])) | "\(.event):\(.matcher)"] | unique | join(",")' <<<"$HANDLERS")"
   IF_VALUES="$(jq -r '[.[] | (.if // "(none)")] | sort | join(" ")' <<<"$HANDLERS")"
   WRITE_IF="$(jq '[.[] | select(has("if") and (.if | startswith("Write(")))] | length' <<<"$HANDLERS")"
-  CMD_OK="$(jq '[.[] | select((.command | contains("\"${CLAUDE_PLUGIN_ROOT}\"")) and (.command | contains("ruff-format.sh")))] | length' <<<"$HANDLERS")"
-  if [[ "$HANDLER_COUNT" == "$EXPECTED_COUNT" && "$IF_VALUES" == "$EXPECTED_IF" && "$WRITE_IF" == "0" && "$CMD_OK" == "$EXPECTED_COUNT" ]]; then
-    ok "hooks.json: every handler ($HANDLER_GROUPS) carries an if row, and the rows are exactly $EXPECTED_IF, the script's own extension set"
+  CMD_OFF="$(jq -r '[.[] | (.command // "(none)") | select(test("^(\"[$][{]?CLAUDE_PLUGIN_ROOT[}]?\"/hooks/ruff-format[.]sh|\"[$][{]?CLAUDE_PLUGIN_ROOT[}]?/hooks/ruff-format[.]sh\")$") | not)] | unique | join(",")' <<<"$HANDLERS")"
+  if [[ "$HANDLER_COUNT" == "$EXPECTED_COUNT" && "$IF_VALUES" == "$EXPECTED_IF" && "$WRITE_IF" == "0" && -z "$GROUPS_OFF" && -z "$CMD_OFF" ]]; then
+    ok "hooks.json: every handler ($HANDLER_GROUPS) is a PostToolUse Write and Edit group running the plugin's script, and the if rows are exactly $EXPECTED_IF, the script's own extension set ($CASE_BLOCKS case gates agree)"
   else
-    fail "hooks.json launch gate: handlers=$HANDLER_COUNT/$EXPECTED_COUNT groups=$HANDLER_GROUPS if='$IF_VALUES' expected='$EXPECTED_IF' write_if=$WRITE_IF cmd=$CMD_OK"
+    fail "hooks.json launch gate: handlers=$HANDLER_COUNT/$EXPECTED_COUNT groups=$HANDLER_GROUPS groups_off='$GROUPS_OFF' if='$IF_VALUES' expected='$EXPECTED_IF' write_if=$WRITE_IF cmd_off='$CMD_OFF'"
   fi
 else
-  fail "hooks.json launch-gate assertions need jq, $HOOKS_JSON and the script's case \"\$RAW_FILE\" pre-filter"
+  fail "hooks.json launch-gate assertions need jq, $HOOKS_JSON and agreeing case \"\$RAW_FILE\" / \"\$FILE\" gates in the script (gates=$CASE_BLOCKS gate1=(${SCRIPT_EXTS//$'\n'/ }) disagreeing:${GATES_OFF:- none})"
 fi
 
 echo

--- a/plugins/typos-format/.claude-plugin/plugin.json
+++ b/plugins/typos-format/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "typos-format",
-  "version": "0.6.47",
+  "version": "0.6.48",
   "description": "Spell-check on edit via typos-cli, unconditionally \u2014 report-only by default, honoring the consuming repo's own typos configuration when one is present.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/typos-format/CHANGELOG.md
+++ b/plugins/typos-format/CHANGELOG.md
@@ -3,6 +3,19 @@
 All notable changes to the `typos-format` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.6.48]
+
+### Changed
+
+- **The README records why the manifest carries no `if` row (#3411).** The
+  sibling formatters filter by extension at the manifest; the read-only scan
+  here is language-agnostic, so the set a declarative file-type filter would
+  reproduce is every file and a narrower row would silently stop scanning
+  whatever it left out. The write-mode allowlist never gates the scan, and
+  `NotebookEdit` stays in the matcher. The section also records the kernel
+  census on a clean `.md` Write. Documentation only; no hook behavior
+  changes.
+
 ## [0.6.47]
 
 ### Changed

--- a/plugins/typos-format/README.md
+++ b/plugins/typos-format/README.md
@@ -110,9 +110,10 @@ read-only scan here is language-agnostic: the set a declarative file-type filter
 reproduce is every file, and a narrower row would silently stop scanning whatever it left out.
 The write-mode allowlist is a separate, later decision inside the script and never gates the
 scan, and `NotebookEdit` stays in the matcher for the same reason. The kernel census
-(`strace -f -e trace=clone,clone3,fork,vfork,execve`, Linux x86_64, 2026-09-07, 0.6.48) on a
-clean `.md` `Write` is 12 process creations and 5 execs (`typos`, `git`, `jq`, `realpath`, the
-hook's own `bash`).
+(`strace -f -e trace=clone,clone3,fork,vfork,execve`, Linux x86_64, `HOOK_TELEMETRY_SINK` and
+`CLAUDE_PROJECT_DIR` unset, 2026-09-07, 0.6.48) on a clean `.md` `Write` is 13 process
+creations and 6 execs (`typos`, `git` twice for the working-tree probe and the root resolver,
+`jq`, `realpath`, the hook's own `bash`).
 
 ## Install
 

--- a/plugins/typos-format/README.md
+++ b/plugins/typos-format/README.md
@@ -104,6 +104,16 @@ The residual is the shared library's payload reader and telemetry emitter, cut i
 vendored `hook-utils.sh` (one batched `realpath`, no jq on the envelope), and the `typos` binary
 itself.
 
+`hooks/hooks.json` carries no `if` row, and that is deliberate (#3411). The sibling formatters
+filter by extension at the manifest so a Write of any other file spawns nothing, but the
+read-only scan here is language-agnostic: the set a declarative file-type filter would have to
+reproduce is every file, and a narrower row would silently stop scanning whatever it left out.
+The write-mode allowlist is a separate, later decision inside the script and never gates the
+scan, and `NotebookEdit` stays in the matcher for the same reason. The kernel census
+(`strace -f -e trace=clone,clone3,fork,vfork,execve`, Linux x86_64, 2026-09-07, 0.6.48) on a
+clean `.md` `Write` is 12 process creations and 5 execs (`typos`, `git`, `jq`, `realpath`, the
+hook's own `bash`).
+
 ## Install
 
 ```shell


### PR DESCRIPTION
Refs: #3411
No linked issue

Two linkage lines, deliberately. `Refs: #3411` is the marker the enforcement gate actually in effect accepts for a partial: `ci-workflows/.github/actions/pr-contract@906ae7ef` (v0.22.0), invoked from `.github/workflows/ci.yml`, `linkage-mode: advisory`. The second line is required by this repo's local PreToolUse hook `plugins/source-control/hooks/pr-linkage-mcp-gate.sh`, which still enforces the shape of `.github/workflows/pr-issue-linkage.yml`, a workflow deleted in `6b6989d9a` (#3746), and which rejects the `Refs:` form on its own. Read in the gate's own vocabulary the second line is accurate, since linkage there means closure and this PR closes nothing. The stale hook and `.claude/rules/pr-body-contract.md`, which documents the same deleted workflow, both want updating; that is out of scope here.

Partial delivery of #3411. The issue body's second criterion (at most one applicability check per script) is deferred to #3408 by the triage decision recorded on #3411, and two plugins (eol-normalizer, typos-format) cannot take a file-type `if` row without a silent regression, so #3411 stays open with that residual.

## Summary

Re-verified #3411 against current `main` before changing anything. Of the nine-plugin family, seven manifests already carry declarative `if` rows (bash, biome, go, markdown, powershell, ruff, actionlint), and eol-normalizer already decides applicability before any snapshot (#3675, `1abc1b67d`). What was left: no suite except markdown-format's pinned its `if` rows to what the script actually handles (a narrowed row is a silent regression, since the hook simply never runs), six READMEs lacked the hook-budget rule 1 disclosure, and nothing recorded why the two language-agnostic hooks carry no `if` row at all.

This PR adds the launch-gate assertion to the six remaining filtered suites, adds a measured "Hook budget accounting" section to their READMEs, and records in the eol-normalizer and typos-format READMEs why no file-type filter can exist for them. No hook script or manifest changes; every plugin touched is bumped and has a CHANGELOG entry.

Second revision, after the fresh-context review of `0565110b2`: the assertion now parses the script's whole `case ... esac` block and reads every handler group in `hooks.json` (the first revision read one line and one group, and the review defeated it four ways; each is listed under Verification and now fails), the five SC2016 hits that turned the CI `lint` job red are gone, every census figure was re-taken in one pass (each was one `git rev-parse` short), and the body opens with the `Refs:` marker, the honest form for a partial, instead of the false no-issue opt-out it carried (whose `Refs #3411` in Related did not register, since the analyzer wants the colon form alone on its line).

Third revision, after the second fresh-context review of `f07b8f4e4`, which defeated the whole-block assertion two more ways: the arm splitter knew only `;;`, so `*.py | *.pyi) ;&` followed by `*.pyw) ;;` merged into one arm and `.pyw` passed the script gate with the suite still 64/64 (and `;;&` failed only through a mangled `expected='Edit(&*.pyw) ...'`), and the jq side never read the matcher, so `"matcher": "Edit"` and `"matcher": "Bash"` both passed. The parser now ends an arm at every bash terminator (`;;`, `;&`, `;;&`), joins backslash continuations the way bash does, accepts a one-line `case ... esac`, a trailing `in # comment` and `in` on the line after `case`, and reads every in-script gate (the `case "$RAW_FILE"` pre-filter and the `case "$FILE"` re-check #3408 owns folding), requiring them to agree; the manifest side pins every group to PostToolUse with a matcher whose alternation is exactly Write and Edit, asserted separately from the `if` rows, and the command to the plugin's own script with no prefix, suffix or argument. The CHANGELOG entries for the same unreleased bumps state the added pins; still no script or manifest change.

## Fix

**Derived extension sets** (read from each script's `case "$RAW_FILE"` pre-filter; the manifest's `if` rows on `main` already equal each one, so no row was added or removed):

| Plugin | Script's own set | `if` rows on main |
| --- | --- | --- |
| bash-format | `*.sh *.bash` | equal (2) |
| biome-format | `*.ts *.tsx *.js *.jsx *.mjs *.cjs *.mts *.cts *.json *.jsonc` | equal (10) |
| go-format | `*.go` | equal (1) |
| powershell-format | `*.ps1 *.psm1 *.psd1` | equal (3) |
| ruff-format | `*.py *.pyi` | equal (2) |
| actionlint | `*/.github/*workflows/*.yml`, `*.yaml` | `Edit(**/.github/workflows/*.yml)`, `.yaml` twin |
| markdown-format | `*.md *.mdc` | equal (2), already pinned by its suite since #3085 |
| eol-normalizer | no extension filter; `.gitattributes` (`git check-attr eol text`) decides | none, by design |
| typos-format | no extension filter; scan is language-agnostic, write allowlist is later and never gates the scan | none, by design; matcher keeps `NotebookEdit` |

**Tests** (six suites): a new case derives the expected `Edit(...)` set from every arm of the script's whole `case "$RAW_FILE" ... esac` pre-filter block, read the way bash reads it: every arm terminator (`;;`, `;&`, `;;&`) ends an arm, so a fall-through arm's patterns count; a backslash continuation joins lines with nothing in between (so `;\` and a following `;` is one `;;`); a comment after `in` or on an arm is dropped; a one-line `case ... esac`, `esac # comment`, and `in` on the line after the `case` word are one block; the bare `*` catch-all is excluded; arm bodies are not read, so any pattern in any arm counts as handled. The script's `case "$FILE"` re-check after path normalization (actionlint: `case "$FILE_NORM"`) is read the same way and must yield the same set, so an exclusion added to either gate fails loudly instead of sitting unread, and a script with one gate left (what #3408 will leave) passes as it is. actionlint's patterns must additionally carry the `*/.github/*workflows/*.<ext>` shape (the re-check's `*/.github/workflows/` twin included), the only shapes its manifest row is derived from. On the manifest side every handler under every event and matcher group is read and two things are pinned separately, since they answer different questions: the `if` values across all handlers (which paths) must be exactly the derived set, one row each, with no `Write(` rows; and every group (which tools) must be PostToolUse with a matcher whose alternation is exactly Write and Edit in either order, its command the plugin's own script by either quoting placement and nothing else. Drift in either direction fails, and so does an unfiltered group under any event, a matcher narrowed to one tool or widened past the two, a group moved to PreToolUse, and a command with a prefix, suffix or argument. What it does not reach is a registration outside `hooks/hooks.json`, or an arm body: a `;;&` arm followed by `*) exit 0` passes this gate and is caught by the suite's behavioral cases.

**READMEs** (six): "Hook budget accounting" section with wall time, spawn-equivalents against an interleaved `bash -c :` floor, and the `strace` kernel census per event, stated as a Linux-host measurement with the note that the Windows reference-host figure has not been taken. eol-normalizer and typos-format: a paragraph in their existing budget section stating that the derived set is every file, so a file-type `if` row would silently stop normalizing or scanning whatever it left out, plus the census on a benign Write.

**Harness semantics relied on**, verified against the hooks reference (fetched 2026-09-07) and the installed CLI 2.1.258 bundle rather than assumed: `if` holds exactly one permission rule and is evaluated at match time, dropping the handler before any spawn (the bundle logs `Skipping hook due to if condition "..." not matching`); the rule validator folds `Write`, `NotebookEdit` and `MultiEdit` rules into `Edit` and warns that a `Write(...)` rule is not matched by the file permission check, so `Edit(*.ext)` is the row that covers all three tools; the matcher is the tool-name regex consulted before any `if`, which is why it is asserted on its own; since v2.1.214 a single-segment `Edit(src/**)` matches only the working directory's own tree, which is why actionlint's rows carry the `**/` anchor.

**Versions taken** (each `main` + 1; re-validated at `819e9df7b` against `origin/main` at `39a582715` and all 34 other open PR heads: no head carries any of the eight numbers, and every head sits at or below `main` on all eight, #3740 at `4681cef11` included): actionlint 0.8.43, bash-format 0.7.44, biome-format 0.6.42, go-format 0.3.46, powershell-format 0.7.45, ruff-format 0.6.43, eol-normalizer 0.6.42, typos-format 0.6.48. #3740 will conflict textually on these CHANGELOGs whichever lands second; the numbers do not collide.

## Verification

- `bash scripts/affected-tests.sh --run` at `819e9df7b` (with `goimports` on PATH, as in CI): rc=0, all 6 selected suites passed (bash 55, biome 50, go 59, powershell 86, ruff 64, actionlint 46 assertions, 0 failures). The 24 README/CHANGELOG/plugin.json files map to the recorded no-suite allowlist.
- `scripts/check-changelog-parity.sh` `--check`, `--check-order`, `--check-bump origin/main`, `--check-preserved origin/main` (8 changelogs): all green, re-run at `819e9df7b`. `check-vendor-version-bump.sh --check-bump origin/main`: green. markdownlint-cli2 on the six re-worded CHANGELOGs: 0 issues. No em dashes in any added line.
- shellcheck 0.11.0 (`shellcheck -x` with the repository's `.shellcheckrc`, the CI lane's configuration) and `shfmt -d` on the six suites: clean at `819e9df7b`. The first revision was not: it carried five SC2016 hits on the `sed -n '/^case "\$RAW_FILE" in$/...'` line and the CI `lint` job failed on them at `0565110b2` (`shellcheck=failure`, `ci-lanes=failure`). The rewrite matches that line with `[$]RAW_FILE` inside the awk program instead of a backslash-escaped `$` in single quotes.
- **Mutations** (scratch copies of each plugin directory; the worktree was never modified; 50 shapes run against the third revision, every verdict as expected). The second review's two defeats, each now FAIL: ruff `case "$RAW_FILE"` rewritten as `*.py | *.pyi) ;&` then `*.pyw) ;;` (bash eval: `.pyw` passes the script gate; suite: `gate1=(*.py *.pyi *.pyw) disagreeing: gate2=(*.py *.pyi)`, and with both in-script gates so rewritten `handlers=2/3 ... expected='Edit(*.py) Edit(*.pyi) Edit(*.pyw)'`); the same with `;;&` (same two messages, plus 18 behavioral failures, since `;;&` sends `.py` on to `*) exit 0`); `"matcher": "Edit"` (`groups_off='PostToolUse:Edit'`); `"matcher": "Bash"` (`groups_off='PostToolUse:Bash'`). The first review's four, each still FAIL: ruff script gaining a second arm `*.pyw) ;;` before `*) exit 0` (`gate1=(*.py *.pyi *.pyw) disagreeing: gate2=(*.py *.pyi)`); actionlint script gaining `*/.github/*workflows/*.json) ;;` (`gate1=(*.json *.yaml *.yml) disagreeing: gate2=(*.yaml *.yml)`); ruff `hooks.json` gaining an unfiltered PostToolUse `"matcher":"Write"` group (`handlers=3/2 groups_off='PostToolUse:Write' if='(none) ...'`); ruff `hooks.json` gaining an unfiltered PreToolUse group (`handlers=3/2 groups_off='PreToolUse:Write|Edit'`). The first revision's five and the two further shapes, each still FAIL: `Edit(*.pyi)` row dropped (`handlers=1/2`); script `case` gaining `*.pyw` in the alternation; one handler with its `if` key deleted (`if='(none) Edit(*.py)'`); actionlint `.yaml` row dropped (`handlers=1/2`); actionlint rows without the `**/` anchor; a `Write(*.pyi)` rule (`write_if=1`); a duplicated `Edit(*.py)` row (`if='Edit(*.py) Edit(*.py)'`); plus a dead `*.pyw) ;;` arm after `*)`, `*.py[w]`, and actionlint `*.YML`. Invented for the third revision, each FAIL: `PostToolUse` renamed to `PreToolUse` with the rows intact (`groups_off='PreToolUse:Write|Edit'`; the previous revision passed it); a terminator split across a backslash, `;\` newline `; *.pyw) ;;` (bash reads it as `;;`; the previous revision's space-join did not); `*.pyi` dropped from the `case "$FILE"` re-check alone (the previous revision passed the whole suite 64/64 on it, since the ruff suite has no `.pyi` behavioral case; now `gate1=(*.py *.pyi) disagreeing: gate2=(*.py)`); a second `case "$RAW_FILE"` block excluding `*.pyi`; `in` on the line after `case` plus a `*.pyw` arm; `"matcher": "Write | Edit"` (a regex with spaces matches neither tool name); `"matcher": "Write|Edit|NotebookEdit"`; `bash -c '"${CLAUDE_PLUGIN_ROOT}"/hooks/ruff-format.sh; true'` and a `--dry` suffix on one or both rows (`cmd_off='...'`; the previous `contains()` checks passed both); `*.p[y|i]`. Legitimate shapes, each PASS with the full suite green: ruff alternation split with a backslash continuation (64/64); `;;` on its own line (64/64); `Edit|Write` matcher order (64/64); an arm-looking comment line and a trailing `# *.pyw) ;;` comment (64/64); one-line `case "$RAW_FILE" in *.py | *.pyi) ;; *) exit 0 ;; esac` (64/64, ruff and actionlint); `in # comment` (64/64, ruff and actionlint); `esac # comment` (64/64); `esac` as a word inside an arm body (64/64); `in` on the line after `case` (64/64); the whole-command quoting `"${CLAUDE_PLUGIN_ROOT}/hooks/ruff-format.sh"` (64/64); the `case "$FILE"` re-check deleted, the single-gate shape #3408 will leave (64/64 ruff, 46/46 actionlint); biome's ten-way alternation split across two lines with a backslash continuation (50/50; a bare newline after `|` is a bash syntax error, so the backslash form is the only two-line alternation shape). One shape survives this gate by design and is reported as such: `*.py | *.pyi) ;;&` followed by `*) exit 0 ;;` derives the right set (arm bodies are not read) and is caught by 18 behavioral failures in the same run.
- **Kernel census** (`strace -f -e trace=clone,clone3,fork,vfork,execve`; one benign, clean Write per row; `HOOK_TELEMETRY_SINK` and `CLAUDE_PROJECT_DIR` unset via `env -u`; the plugin's `ENABLED` option true; cwd outside any repository; Linux x86_64, bash 5.2; three traced trials per row plus twelve untraced wall trials interleaved with a `bash -c :` floor whose median was 3.8 to 4.3 ms; a process creation is a clone-family call that returned a pid, an exec an `execve` that returned 0; every row produced empty hook output). The first revision's census was one `git rev-parse --show-toplevel` short on every row (`hook::in_git_working_tree`, `hook-utils.sh:722`), exactly as the review measured, and its wall figures came from a quieter run with a 2 ms floor, so every column was re-taken in one pass: ruff-format 11 creations / 5 execs (no config; 30 ms), 45 / 12 (`ruff.toml`; 65 ms; three `ruff` runs, not the six the first revision listed); bash-format 14 / 6 (no `.editorconfig`; 45 ms), 31 to 32 / 12 (with; 55 ms); biome-format 11 / 5 (no config; 31 ms), 34 / 15 (with; 117 ms); go-format 35 to 37 / 12 (63 ms; the twelfth exec is the `go env` goimports itself runs); powershell-format 15 / 7 (no settings; 39 ms), 47 / 12 (with; 893 ms, almost all of it `pwsh` plus PSScriptAnalyzer); actionlint 14 / 5 (one trial in nine reached 15; 34 ms); eol-normalizer on an already-LF file under `eol=lf` 13 / 6 with no `mktemp` or `cp` exec; typos-format 13 / 6. The thread-heavy tools (shfmt, go, actionlint) move the creation count by one or two between trials; every exec count was identical in every trial.
- **Not demonstrated here**: the "non-matching write spawns no process" half was verified by the hooks reference and the CLI bundle's match-time skip, not by tracing the harness itself; this container has no interactive Claude Code session to strace. The Windows 11 Git Bash reference-host measurement the convention calls binding was not taken.

**Unmet or deferred, stated plainly**: (1) "at most one applicability check inside each script" is untouched, per the triage split on #3411 pending #3408; the assertion now reads both checks and requires them to agree, and passes once one is gone; (2) eol-normalizer and typos-format still register bare matchers, because their derived set is every file; (3) the six filtered manifests do not carry `shell: bash` where markdown-format's precedent does; observed, not changed here; (4) the ruff suite has no behavioral `.pyi` case, which is why a `.pyi` exclusion in the second in-script gate went unseen by the whole suite before this revision; observed, not added here.

## Related

- #3411 (partially addressed; residual listed above), #3408 (owns the in-script check reduction)
- #3085 / `af5af55b6` (markdown-format precedent), #3675 / `1abc1b67d` (eol-normalizer plan-before-snapshot), #3740 (open, touches the same eight CHANGELOGs)
- `docs/conventions/hook-budget/README.md` rule 1, `docs/conventions/hook-precision/README.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ViPsHkL3ng9xWt2GjEQJob