### PR TITLE
fix(knowledge): honor videoPlayerSelector and key hotmart interceptors per Page

### DIFF
--- a/plugins/knowledge/.claude-plugin/plugin.json
+++ b/plugins/knowledge/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "knowledge",
-  "version": "0.13.46",
+  "version": "0.13.47",
   "description": "Ingest external knowledge into durable, synthesized artifacts. Ships a book-distillation pipeline (PDF/EPUB into concept-organized, author-attributed skill reference files), a video-digest pipeline (watch a single public video from YouTube or X, formerly Twitter: transcript, link harvest, and repo-applicability synthesis), a course-digest pipeline (extract and synthesize online video courses \u2014 Dometrain, Teachable \u2014 into repo-applicable recommendations), a docpage-digest pipeline (single online documentation page into a verified knowledge slice with dual verification \u2014 one cross-vendor verifier \u2014 and an interview handoff), and a map-corpus pipeline (multi-resource corpus into a classified link map, deterministic node manifests, gate-verified relevance inventory, and an approved queue of docpage-digest runs), plus a re-runnable setup action; a configurable library directory governs where synthesized artifacts land in the consuming repo.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/knowledge/CHANGELOG.md
+++ b/plugins/knowledge/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to the `knowledge` plugin are recorded here. The `version` i
 `.claude-plugin/plugin.json` is the delivery vehicle — a consumer receives a change
 only after that version increases.
 
+## [0.13.47]
+
+### Fixed
+
+- **course-digest:** an adapter's `videoPlayerSelector` override now reaches every place that
+  queries for the player. `.hotmart_video_player` was hardcoded inside the `page.evaluate` calls in
+  `detectResources` and `preflight` (Teachable adapter) and in `hasHotmartPlayer` (Hotmart player
+  module), so an override validated and was then ignored, and detection failed as though no player
+  were present. The selector is passed as an evaluate argument, not closed over, because the
+  callback is serialized into the browser context.
+- **course-digest:** the Hotmart interceptor guard is keyed to the Page instead of the module. A
+  second Page in the same process was short-circuited by a module-level flag and captured no HLS
+  master URL or subtitle manifest. Repeat installs on one Page remain a no-op. The test helper
+  `isInterceptorsInstalled` now takes the Page to check and throws when called without one.
+
 ## [0.13.46]
 
 ### Changed

--- a/plugins/knowledge/CHANGELOG.md
+++ b/plugins/knowledge/CHANGELOG.md
@@ -18,6 +18,11 @@ only after that version increases.
   second Page in the same process was short-circuited by a module-level flag and captured no HLS
   master URL or subtitle manifest. Repeat installs on one Page remain a no-op. The test helper
   `isInterceptorsInstalled` now takes the Page to check and throws when called without one.
+- **course-digest:** Hotmart captured HLS and subtitle data is keyed to the Page instead of
+  `page.url()`. Two Pages on the same lesson URL each keep their own master URL and subtitle
+  manifest; previously the second Page overwrote (and `preparePage` deleted) the first Page's
+  entry. `getHlsUrl`, `getTranscript`, and `preparePage` look up by Page. The test helper
+  `clearCapturedData` takes the Page to clear.
 
 ## [0.13.46]
 

--- a/plugins/knowledge/skills/course-digest/extraction/adapters/teachable.js
+++ b/plugins/knowledge/skills/course-digest/extraction/adapters/teachable.js
@@ -160,8 +160,9 @@ export async function prepareLessonPage(page, platformCfg, lesson) {
   return timed("prepare-lesson-page", { lesson: lesson?.title }, async () => {
     const subtitleLang = platformCfg.subtitleLanguage ?? defaults.subtitleLanguage;
     const manifestTimeout = platformCfg.manifestTimeoutMs ?? defaults.manifestTimeoutMs;
+    const videoSelector = resolveVideoPlayerSelector(platformCfg);
 
-    return preparePage(page, subtitleLang, manifestTimeout, resolveVideoPlayerSelector(platformCfg));
+    return preparePage(page, subtitleLang, manifestTimeout, videoSelector);
   });
 }
 

--- a/plugins/knowledge/skills/course-digest/extraction/adapters/teachable.js
+++ b/plugins/knowledge/skills/course-digest/extraction/adapters/teachable.js
@@ -23,6 +23,7 @@ import { loginOrPromptManual } from "../lib/auth/manual-login.js";
 import { login as teachableLogin } from "../lib/auth/teachable-sso.js";
 import { fetchMetaTags } from "../lib/meta-tags.js";
 import {
+  DEFAULT_VIDEO_PLAYER_SELECTOR,
   extractFrames as extractHotmartFrames,
   getHlsUrl,
   getTranscript,
@@ -40,7 +41,7 @@ const COURSE_SLUG_PATH = /\/courses\/([^/]+)/;
 // ---------------------------------------------------------------------------
 
 export const defaults = {
-  videoPlayerSelector: ".hotmart_video_player",
+  videoPlayerSelector: DEFAULT_VIDEO_PLAYER_SELECTOR,
   authWarnDays: 14,
   authProvider: "teachable",
   subtitleLanguage: "eng",
@@ -86,6 +87,11 @@ function resolveResourceSelectors(platformCfg) {
   return { ...defaults.resourceSelectors, ...platformCfg.resourceSelectors };
 }
 
+/** The configured video-player selector, falling back to the adapter default. */
+export function resolveVideoPlayerSelector(platformCfg) {
+  return platformCfg?.videoPlayerSelector ?? defaults.videoPlayerSelector;
+}
+
 /**
  * Detect available resources on the current Teachable lesson page.
  * Reads .lecture-attachment-type-* CSS classes from the DOM.
@@ -93,14 +99,15 @@ function resolveResourceSelectors(platformCfg) {
 export async function detectResources(page, platformCfg) {
   return timed("detect-resources", null, async () => {
     const selectors = resolveResourceSelectors(platformCfg);
+    const videoPlayerSelector = resolveVideoPlayerSelector(platformCfg);
 
     return page.evaluate(
-      ({ sel, attachmentTypeSource }) => {
+      ({ sel, attachmentTypeSource, videoSel }) => {
         const has = (s) => !!document.querySelector(s);
         const attachmentTypePattern = new RegExp(attachmentTypeSource);
 
         return {
-          hasVideo: has(".hotmart_video_player"),
+          hasVideo: has(videoSel),
           hasTranscript: false,
           hasDownload: has(sel.file),
           hasLessonNotes: false,
@@ -115,7 +122,11 @@ export async function detectResources(page, platformCfg) {
           ),
         };
       },
-      { sel: selectors, attachmentTypeSource: LECTURE_ATTACHMENT_TYPE_SOURCE },
+      {
+        sel: selectors,
+        attachmentTypeSource: LECTURE_ATTACHMENT_TYPE_SOURCE,
+        videoSel: videoPlayerSelector,
+      },
     );
   });
 }
@@ -150,7 +161,7 @@ export async function prepareLessonPage(page, platformCfg, lesson) {
     const subtitleLang = platformCfg.subtitleLanguage ?? defaults.subtitleLanguage;
     const manifestTimeout = platformCfg.manifestTimeoutMs ?? defaults.manifestTimeoutMs;
 
-    return preparePage(page, subtitleLang, manifestTimeout);
+    return preparePage(page, subtitleLang, manifestTimeout, resolveVideoPlayerSelector(platformCfg));
   });
 }
 
@@ -243,13 +254,13 @@ export async function extractFramesCanvas({ page, duration, outputDir, options =
 /**
  * Pre-flight check: verify Hotmart iframe loads and Teachable API responds.
  */
-export async function preflight(page, _platformCfg) {
-  const checks = await page.evaluate(() => {
-    const hotmartEl = !!document.querySelector(".hotmart_video_player");
+export async function preflight(page, platformCfg) {
+  const checks = await page.evaluate((videoSel) => {
+    const hotmartEl = !!document.querySelector(videoSel);
     const lectureContent = !!document.querySelector(".lecture-content");
     const attachments = document.querySelectorAll(".lecture-attachment").length;
     return { hotmart: hotmartEl, lectureContent, attachments };
-  });
+  }, resolveVideoPlayerSelector(platformCfg));
 
   const failures = Object.entries(checks)
     .filter(([key, val]) => key !== "attachments" && !val)
@@ -273,7 +284,7 @@ export async function preflight(page, _platformCfg) {
  * @param {import('./auth-session.js').AuthSessionInput} input
  */
 export async function authenticate({ context, page, course, storageStatePath, platformCfg }) {
-  const videoSelector = platformCfg.videoPlayerSelector ?? defaults.videoPlayerSelector;
+  const videoSelector = resolveVideoPlayerSelector(platformCfg);
   const envPrefix = platformCfg.authEnvPrefix ?? "TEACHABLE";
 
   const firstVideoLesson = course.modules.flatMap((m) => m.lessons).find((l) => l.duration);

--- a/plugins/knowledge/skills/course-digest/extraction/adapters/teachable.test.js
+++ b/plugins/knowledge/skills/course-digest/extraction/adapters/teachable.test.js
@@ -186,7 +186,7 @@ describe("preflight video-player selector", () => {
     expect(page.lastArg).toBe(".skin-v2-player");
   });
 
-  it("should fail when only the hardcoded literal is present and an override is configured", async () => {
+  it("should fail when only the default selector is present and an override is set", async () => {
     const page = makeDomPage([defaults.videoPlayerSelector, ".lecture-content"]);
 
     const result = await preflight(page, { videoPlayerSelector: ".skin-v2-player" });

--- a/plugins/knowledge/skills/course-digest/extraction/adapters/teachable.test.js
+++ b/plugins/knowledge/skills/course-digest/extraction/adapters/teachable.test.js
@@ -1,6 +1,34 @@
 import { describe, expect, it } from "vitest";
 
-import { buildLessonUrl, defaults, deriveLandingUrl } from "./teachable.js";
+import {
+  buildLessonUrl,
+  defaults,
+  deriveLandingUrl,
+  detectResources,
+  preflight,
+  resolveVideoPlayerSelector,
+} from "./teachable.js";
+
+/**
+ * Page stand-in whose `evaluate` rebuilds the callback from source, so the
+ * callback can only see the argument that crossed the serialization boundary,
+ * and answers `querySelector` from a fixed set of present selectors.
+ */
+function makeDomPage(presentSelectors) {
+  const present = new Set(presentSelectors);
+  return {
+    lastArg: undefined,
+    async evaluate(fn, arg) {
+      this.lastArg = arg;
+      const detached = new Function("document", "arg", `return (${fn.toString()})(arg);`);
+      const document = {
+        querySelector: (s) => (present.has(s) ? { tag: "div", textContent: "" } : null),
+        querySelectorAll: () => [],
+      };
+      return detached(document, structuredClone(arg));
+    },
+  };
+}
 
 describe("defaults", () => {
   it("should have hotmart video player selector", () => {
@@ -102,5 +130,76 @@ describe("buildLessonUrl", () => {
     expect(buildLessonUrl(courseWithSlug, lesson, platformCfg)).toBe(
       "https://www.courses.example.com/courses/modular-monolith/lectures/456",
     );
+  });
+});
+
+describe("resolveVideoPlayerSelector", () => {
+  it("should return the adapter default when platformConfig omits it", () => {
+    expect(resolveVideoPlayerSelector({})).toBe(defaults.videoPlayerSelector);
+  });
+
+  it("should return the configured override", () => {
+    expect(resolveVideoPlayerSelector({ videoPlayerSelector: ".skin-v2-player" })).toBe(
+      ".skin-v2-player",
+    );
+  });
+});
+
+describe("detectResources video-player selector", () => {
+  it("should report a video when the default selector matches", async () => {
+    const page = makeDomPage([defaults.videoPlayerSelector]);
+
+    const result = await detectResources(page, {});
+
+    expect(result.success).toBe(true);
+    expect(result.data.hasVideo).toBe(true);
+  });
+
+  it("should query the configured selector in the browser context", async () => {
+    const page = makeDomPage([".skin-v2-player"]);
+
+    const result = await detectResources(page, { videoPlayerSelector: ".skin-v2-player" });
+
+    expect(result.success).toBe(true);
+    expect(result.data.hasVideo).toBe(true);
+    expect(page.lastArg.videoSel).toBe(".skin-v2-player");
+  });
+
+  it("should not match the hardcoded literal when an override is configured", async () => {
+    const page = makeDomPage([defaults.videoPlayerSelector]);
+
+    const result = await detectResources(page, { videoPlayerSelector: ".skin-v2-player" });
+
+    expect(result.success).toBe(true);
+    expect(result.data.hasVideo).toBe(false);
+  });
+});
+
+describe("preflight video-player selector", () => {
+  it("should pass when the configured selector and lecture content are present", async () => {
+    const page = makeDomPage([".skin-v2-player", ".lecture-content"]);
+
+    const result = await preflight(page, { videoPlayerSelector: ".skin-v2-player" });
+
+    expect(result.success).toBe(true);
+    expect(result.data.hotmart).toBe(true);
+    expect(page.lastArg).toBe(".skin-v2-player");
+  });
+
+  it("should fail when only the hardcoded literal is present and an override is configured", async () => {
+    const page = makeDomPage([defaults.videoPlayerSelector, ".lecture-content"]);
+
+    const result = await preflight(page, { videoPlayerSelector: ".skin-v2-player" });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("hotmart");
+  });
+
+  it("should pass with the default selector when no override is configured", async () => {
+    const page = makeDomPage([defaults.videoPlayerSelector, ".lecture-content"]);
+
+    const result = await preflight(page, {});
+
+    expect(result.success).toBe(true);
   });
 });

--- a/plugins/knowledge/skills/course-digest/extraction/lib/players/hotmart.js
+++ b/plugins/knowledge/skills/course-digest/extraction/lib/players/hotmart.js
@@ -20,6 +20,13 @@ import {
   processSubtitleSegments,
 } from "@melodic/video-digestion/transcript/vtt-parser";
 
+/**
+ * Selector for the Hotmart player element as Teachable renders it by default.
+ * Callers override it through `platformConfig.videoPlayerSelector`; this is the
+ * fallback used when a caller supplies nothing.
+ */
+export const DEFAULT_VIDEO_PLAYER_SELECTOR = ".hotmart_video_player";
+
 const VIDEO_ID_PREFIX = /^(\w+)-\d+-/;
 const PNG_DATA_URL_PREFIX = /^data:image\/png;base64,/;
 const SUBTITLE_BATCH_SIZE = 15;
@@ -33,13 +40,23 @@ const HLS_FIELDS = [
 ];
 
 // ---------------------------------------------------------------------------
-// Module-level state (per-session singleton)
+// Module-level state
 // ---------------------------------------------------------------------------
 
 /** @type {Map<string, { hlsMasterUrl: string|null, subtitleManifestBody: string|null }>} */
 const capturedData = new Map();
 
-let interceptorsInstalled = false;
+/**
+ * Pages that already carry this module's request/response listeners.
+ *
+ * Keyed by Page rather than by module: the listeners are attached with
+ * `page.on`, so the double-install hazard this guard exists to prevent is per
+ * Page, and a second Page in the same process needs its own listeners. A
+ * WeakSet lets a closed Page be collected without a deregistration step.
+ *
+ * @type {WeakSet<import('playwright').Page>}
+ */
+let pagesWithInterceptors = new WeakSet();
 
 function getOrCreateEntry(pageUrl) {
   const existing = capturedData.get(pageUrl);
@@ -317,13 +334,16 @@ async function storeSubtitleManifest(hotmartFrame, hlsData, currentUrl) {
  * Install page.on("request") and page.on("response") interceptors for
  * HLS master URL and subtitle manifest capture.
  *
- * Safe to call multiple times — installs only once per module lifetime.
+ * Semantics are PER PAGE: repeat calls for the same Page are a no-op, and each
+ * new Page in the process gets its own listeners. The listeners are registered
+ * on the Page, so installing twice on one Page would double-handle every
+ * request, while skipping a second Page would leave it capturing nothing.
  *
  * @param {import('playwright').Page} page
  * @param {string} subtitleLang — e.g. "eng"
  */
 export function installInterceptors(page, subtitleLang) {
-  if (interceptorsInstalled) return;
+  if (pagesWithInterceptors.has(page)) return;
 
   page.on("request", (request) => {
     captureMasterUrl(page, request.url());
@@ -345,7 +365,7 @@ export function installInterceptors(page, subtitleLang) {
     }
   });
 
-  interceptorsInstalled = true;
+  pagesWithInterceptors.add(page);
 }
 
 /**
@@ -355,14 +375,20 @@ export function installInterceptors(page, subtitleLang) {
  * @param {import('playwright').Page} page
  * @param {string} subtitleLang — e.g. "eng"
  * @param {number} _manifestTimeoutMs
+ * @param {string} [videoPlayerSelector] — defaults to {@link DEFAULT_VIDEO_PLAYER_SELECTOR}
  * @returns {Promise<{ hasVideo: boolean, hotmartFrame?: object, hlsMasterUrl?: string, subtitleSegments?: number, warning?: string }>}
  */
-export async function preparePage(page, subtitleLang, _manifestTimeoutMs) {
+export async function preparePage(
+  page,
+  subtitleLang,
+  _manifestTimeoutMs,
+  videoPlayerSelector = DEFAULT_VIDEO_PLAYER_SELECTOR,
+) {
   const currentUrl = page.url();
 
   capturedData.delete(currentUrl);
 
-  const hasHotmart = await hasHotmartPlayer(page);
+  const hasHotmart = await hasHotmartPlayer(page, videoPlayerSelector);
 
   writeStdout(`    hasHotmart: ${hasHotmart}`);
 
@@ -558,21 +584,35 @@ export function clearCapturedData(url) {
 }
 
 /**
- * Check if the Hotmart video player element exists on the page.
+ * Check if the video player element exists on the page.
+ *
+ * `videoPlayerSelector` is handed to `page.evaluate` as an argument rather than
+ * closed over: the callback is serialized into the browser context, where this
+ * module's bindings do not exist.
+ *
  * @param {import('playwright').Page} page
+ * @param {string} [videoPlayerSelector] — defaults to {@link DEFAULT_VIDEO_PLAYER_SELECTOR}
  * @returns {Promise<boolean>}
  */
-export async function hasHotmartPlayer(page) {
-  return page.evaluate(() => !!document.querySelector(".hotmart_video_player")).catch(() => false);
+export async function hasHotmartPlayer(page, videoPlayerSelector = DEFAULT_VIDEO_PLAYER_SELECTOR) {
+  return page
+    .evaluate((selector) => !!document.querySelector(selector), videoPlayerSelector)
+    .catch(() => false);
 }
 
 // ---------------------------------------------------------------------------
 // Test helpers (exported for unit tests only)
 // ---------------------------------------------------------------------------
 
-/** @returns {boolean} */
-export function isInterceptorsInstalled() {
-  return interceptorsInstalled;
+/**
+ * @param {import('playwright').Page} page
+ * @returns {boolean}
+ */
+export function isInterceptorsInstalled(page) {
+  if (!page || typeof page !== "object") {
+    throw new TypeError("isInterceptorsInstalled(page) requires the Page to check.");
+  }
+  return pagesWithInterceptors.has(page);
 }
 
 /** @returns {Map} */
@@ -585,5 +625,5 @@ export function getCapturedData() {
  */
 export function resetState() {
   capturedData.clear();
-  interceptorsInstalled = false;
+  pagesWithInterceptors = new WeakSet();
 }

--- a/plugins/knowledge/skills/course-digest/extraction/lib/players/hotmart.js
+++ b/plugins/knowledge/skills/course-digest/extraction/lib/players/hotmart.js
@@ -375,7 +375,7 @@ export function installInterceptors(page, subtitleLang) {
  * @param {import('playwright').Page} page
  * @param {string} subtitleLang — e.g. "eng"
  * @param {number} _manifestTimeoutMs
- * @param {string} [videoPlayerSelector] — defaults to {@link DEFAULT_VIDEO_PLAYER_SELECTOR}
+ * @param {string} [videoPlayerSelector] defaults to {@link DEFAULT_VIDEO_PLAYER_SELECTOR}
  * @returns {Promise<{ hasVideo: boolean, hotmartFrame?: object, hlsMasterUrl?: string, subtitleSegments?: number, warning?: string }>}
  */
 export async function preparePage(
@@ -591,7 +591,7 @@ export function clearCapturedData(url) {
  * module's bindings do not exist.
  *
  * @param {import('playwright').Page} page
- * @param {string} [videoPlayerSelector] — defaults to {@link DEFAULT_VIDEO_PLAYER_SELECTOR}
+ * @param {string} [videoPlayerSelector] defaults to {@link DEFAULT_VIDEO_PLAYER_SELECTOR}
  * @returns {Promise<boolean>}
  */
 export async function hasHotmartPlayer(page, videoPlayerSelector = DEFAULT_VIDEO_PLAYER_SELECTOR) {

--- a/plugins/knowledge/skills/course-digest/extraction/lib/players/hotmart.js
+++ b/plugins/knowledge/skills/course-digest/extraction/lib/players/hotmart.js
@@ -43,8 +43,20 @@ const HLS_FIELDS = [
 // Module-level state
 // ---------------------------------------------------------------------------
 
-/** @type {Map<string, { hlsMasterUrl: string|null, subtitleManifestBody: string|null }>} */
-const capturedData = new Map();
+/**
+ * Captured HLS master URL and subtitle manifest, keyed by Page.
+ *
+ * Keyed by Page rather than by URL: two Pages on the same lesson URL must not
+ * overwrite each other's capture, and `preparePage` must not delete another
+ * Page's entry. A WeakMap lets a closed Page be collected without a
+ * deregistration step.
+ *
+ * @type {WeakMap<import('playwright').Page, {
+ *   hlsMasterUrl: string|null,
+ *   subtitleManifestBody: string|null,
+ * }>}
+ */
+let capturedData = new WeakMap();
 
 /**
  * Pages that already carry this module's request/response listeners.
@@ -58,11 +70,11 @@ const capturedData = new Map();
  */
 let pagesWithInterceptors = new WeakSet();
 
-function getOrCreateEntry(pageUrl) {
-  const existing = capturedData.get(pageUrl);
+function getOrCreateEntry(page) {
+  const existing = capturedData.get(page);
   if (existing) return existing;
   const entry = { hlsMasterUrl: null, subtitleManifestBody: null };
-  capturedData.set(pageUrl, entry);
+  capturedData.set(page, entry);
   return entry;
 }
 
@@ -73,7 +85,7 @@ function findHotmartFrame(page) {
 /** Record `url` as the page's HLS master when it matches the packaged-master pattern. */
 function captureMasterUrl(page, url) {
   if (url.includes("master-pkg-t-") && url.includes(".m3u8")) {
-    getOrCreateEntry(page.url()).hlsMasterUrl = url;
+    getOrCreateEntry(page).hlsMasterUrl = url;
   }
 }
 
@@ -305,7 +317,7 @@ async function readHlsDataFromFrame(hotmartFrame, subtitleLang) {
   }
 }
 
-async function storeSubtitleManifest(hotmartFrame, hlsData, currentUrl) {
+async function storeSubtitleManifest(hotmartFrame, hlsData, page) {
   if (!hlsData.subtitlePlaylistUrlFull) return null;
 
   const manifestBody = await hotmartFrame.evaluate(async (url) => {
@@ -319,7 +331,7 @@ async function storeSubtitleManifest(hotmartFrame, hlsData, currentUrl) {
   const segCount = parseSubtitleManifest(manifestBody).length;
   writeStdout(`    ✓ Subtitle manifest fetched: ${segCount} segments`);
 
-  const entry = getOrCreateEntry(currentUrl);
+  const entry = getOrCreateEntry(page);
   entry.hlsMasterUrl = hlsData.masterUrlFull;
   entry.subtitleManifestBody = manifestBody;
 
@@ -358,7 +370,7 @@ export function installInterceptors(page, subtitleLang) {
 
       if (url.includes(`textstream_${subtitleLang}`) && url.includes(".m3u8")) {
         const body = await response.text();
-        getOrCreateEntry(page.url()).subtitleManifestBody = body;
+        getOrCreateEntry(page).subtitleManifestBody = body;
       }
     } catch {
       // Response body may not be available for all intercepted responses
@@ -384,9 +396,7 @@ export async function preparePage(
   _manifestTimeoutMs,
   videoPlayerSelector = DEFAULT_VIDEO_PLAYER_SELECTOR,
 ) {
-  const currentUrl = page.url();
-
-  capturedData.delete(currentUrl);
+  capturedData.delete(page);
 
   const hasHotmart = await hasHotmartPlayer(page, videoPlayerSelector);
 
@@ -428,7 +438,7 @@ export async function preparePage(
     `    HLS data: master=${hlsData.masterUrl ? "found" : "none"}, sub=${hlsData.subtitlePlaylistUrl ? "found" : "none"}, vjs=${hlsData.hasVjs}`,
   );
 
-  const subtitleSegments = await storeSubtitleManifest(hotmartFrame, hlsData, currentUrl);
+  const subtitleSegments = await storeSubtitleManifest(hotmartFrame, hlsData, page);
   if (subtitleSegments !== null) {
     return {
       hasVideo: true,
@@ -439,7 +449,7 @@ export async function preparePage(
   }
 
   if (hlsData.masterUrlFull) {
-    getOrCreateEntry(currentUrl).hlsMasterUrl = hlsData.masterUrlFull;
+    getOrCreateEntry(page).hlsMasterUrl = hlsData.masterUrlFull;
   }
 
   return {
@@ -460,8 +470,7 @@ export async function preparePage(
  * @returns {Promise<string>} — formatted transcript text
  */
 export async function getTranscript(page) {
-  const currentUrl = page.url();
-  const captured = capturedData.get(currentUrl);
+  const captured = capturedData.get(page);
 
   if (!captured?.subtitleManifestBody) {
     throw new Error("No subtitle manifest captured. Ensure preparePage() ran and video played.");
@@ -522,13 +531,13 @@ export async function getTranscript(page) {
 }
 
 /**
- * Get the captured HLS master URL for the current page.
+ * Get the captured HLS master URL for this Page.
  *
  * @param {import('playwright').Page} page
  * @returns {string}
  */
 export function getHlsUrl(page) {
-  const captured = capturedData.get(page.url());
+  const captured = capturedData.get(page);
 
   if (!captured?.hlsMasterUrl) {
     throw new Error("No HLS master URL captured. Ensure preparePage() ran and video played.");
@@ -576,11 +585,11 @@ export async function extractFrames(page, duration, outputDir, options = {}) {
 }
 
 /**
- * Clear captured data for a specific URL.
- * @param {string} url
+ * Clear captured data for a specific Page.
+ * @param {import('playwright').Page} page
  */
-export function clearCapturedData(url) {
-  capturedData.delete(url);
+export function clearCapturedData(page) {
+  capturedData.delete(page);
 }
 
 /**
@@ -615,7 +624,7 @@ export function isInterceptorsInstalled(page) {
   return pagesWithInterceptors.has(page);
 }
 
-/** @returns {Map} */
+/** @returns {WeakMap} */
 export function getCapturedData() {
   return capturedData;
 }
@@ -624,6 +633,6 @@ export function getCapturedData() {
  * Reset module state — for tests only.
  */
 export function resetState() {
-  capturedData.clear();
+  capturedData = new WeakMap();
   pagesWithInterceptors = new WeakSet();
 }

--- a/plugins/knowledge/skills/course-digest/extraction/lib/players/hotmart.test.js
+++ b/plugins/knowledge/skills/course-digest/extraction/lib/players/hotmart.test.js
@@ -2,13 +2,35 @@ import { beforeEach, describe, expect, it } from "vitest";
 
 import {
   clearCapturedData,
+  DEFAULT_VIDEO_PLAYER_SELECTOR,
   getCapturedData,
   getHlsUrl,
   hasHotmartPlayer,
   installInterceptors,
   isInterceptorsInstalled,
+  preparePage,
   resetState,
 } from "./hotmart.js";
+
+/**
+ * Minimal Page stand-in that records `page.on` registrations and can replay
+ * them, so a test can watch what a given Page actually received.
+ */
+function makeMockPage(url = "https://example.com") {
+  const listeners = [];
+  return {
+    listeners,
+    url: () => url,
+    on: (event, handler) => {
+      listeners.push({ event, handler });
+    },
+    async emit(event, payload) {
+      for (const l of listeners.filter((x) => x.event === event)) {
+        await l.handler(payload);
+      }
+    },
+  };
+}
 
 describe("hotmart player module", () => {
   beforeEach(() => {
@@ -34,53 +56,73 @@ describe("hotmart player module", () => {
   });
 
   describe("isInterceptorsInstalled", () => {
-    it("should return false initially", () => {
-      expect(isInterceptorsInstalled()).toBe(false);
+    it("should return false for a page that has not been set up", () => {
+      expect(isInterceptorsInstalled(makeMockPage())).toBe(false);
+    });
+
+    it("should throw when no page is supplied", () => {
+      expect(() => isInterceptorsInstalled()).toThrow(TypeError);
     });
   });
 
   describe("installInterceptors", () => {
-    it("should set interceptorsInstalled to true after first call", () => {
-      const mockPage = {
-        on: () => {},
-        url: () => "https://example.com",
-      };
+    it("should mark the page as installed after first call", () => {
+      const mockPage = makeMockPage();
 
       installInterceptors(mockPage, "eng");
-      expect(isInterceptorsInstalled()).toBe(true);
+      expect(isInterceptorsInstalled(mockPage)).toBe(true);
     });
 
-    it("should not install twice (idempotent)", () => {
-      let callCount = 0;
-      const mockPage = {
-        on: () => {
-          callCount++;
-        },
-        url: () => "https://example.com",
-      };
+    it("should not install twice on the same page (idempotent)", () => {
+      const mockPage = makeMockPage();
 
       installInterceptors(mockPage, "eng");
-      const firstCount = callCount;
+      const firstCount = mockPage.listeners.length;
       installInterceptors(mockPage, "eng");
-      expect(callCount).toBe(firstCount);
+      expect(mockPage.listeners.length).toBe(firstCount);
+    });
+
+    it("should install on a second page in the same process", () => {
+      const firstPage = makeMockPage("https://example.com/lesson/1");
+      const secondPage = makeMockPage("https://example.com/lesson/2");
+
+      installInterceptors(firstPage, "eng");
+      installInterceptors(secondPage, "eng");
+
+      expect(isInterceptorsInstalled(secondPage)).toBe(true);
+      expect(secondPage.listeners.map((l) => l.event).sort()).toEqual(["request", "response"]);
+      expect(secondPage.listeners.length).toBe(firstPage.listeners.length);
+    });
+
+    it("should capture the HLS master URL for a second page", async () => {
+      const firstPage = makeMockPage("https://example.com/lesson/1");
+      const secondPage = makeMockPage("https://example.com/lesson/2");
+      const masterUrl = "https://cdn.hotmart.com/master-pkg-t-xyz.m3u8?token=abc";
+
+      installInterceptors(firstPage, "eng");
+      installInterceptors(secondPage, "eng");
+
+      await secondPage.emit("request", { url: () => masterUrl });
+
+      expect(getHlsUrl(secondPage)).toBe(masterUrl);
     });
   });
 
   describe("resetState", () => {
-    it("should clear captured data and reset interceptors flag", () => {
+    it("should clear captured data and forget installed pages", () => {
       const data = getCapturedData();
       data.set("url1", { hlsMasterUrl: "x", subtitleManifestBody: null });
 
-      const mockPage = { on: () => {}, url: () => "" };
+      const mockPage = makeMockPage("");
       installInterceptors(mockPage, "eng");
 
       expect(data.size).toBe(1);
-      expect(isInterceptorsInstalled()).toBe(true);
+      expect(isInterceptorsInstalled(mockPage)).toBe(true);
 
       resetState();
 
       expect(data.size).toBe(0);
-      expect(isInterceptorsInstalled()).toBe(false);
+      expect(isInterceptorsInstalled(mockPage)).toBe(false);
     });
   });
 
@@ -108,18 +150,58 @@ describe("hotmart player module", () => {
   });
 
   describe("hasHotmartPlayer", () => {
-    it("should return true when page has .hotmart_video_player", async () => {
-      const mockPage = {
-        evaluate: async () => true,
+    /**
+     * Runs the evaluate callback the way Playwright does — serialized, with the
+     * argument handed across the boundary — against a fake `document` whose
+     * only matching selector is `presentSelector`.
+     */
+    function makeDomPage(presentSelector) {
+      return {
+        evaluate: async (fn, arg) => {
+          // Rebuild the callback from source so it cannot reach any binding in
+          // this module — the same isolation page.evaluate imposes.
+          const detached = new Function("document", "arg", `return (${fn.toString()})(arg);`);
+          const document = {
+            querySelector: (s) => (s === presentSelector ? { tag: "div" } : null),
+          };
+          return detached(document, structuredClone(arg));
+        },
       };
-      expect(await hasHotmartPlayer(mockPage)).toBe(true);
+    }
+
+    it("should return true when the default selector matches", async () => {
+      expect(await hasHotmartPlayer(makeDomPage(DEFAULT_VIDEO_PLAYER_SELECTOR))).toBe(true);
     });
 
-    it("should return false when page lacks .hotmart_video_player", async () => {
+    it("should return false when the default selector does not match", async () => {
+      expect(await hasHotmartPlayer(makeDomPage(".something-else"))).toBe(false);
+    });
+
+    it("should query the configured selector inside the browser context", async () => {
+      const customSelector = ".custom-player-shell";
+
+      expect(await hasHotmartPlayer(makeDomPage(customSelector), customSelector)).toBe(true);
+    });
+
+    it("should not fall back to the hardcoded literal when a selector is configured", async () => {
+      expect(
+        await hasHotmartPlayer(makeDomPage(DEFAULT_VIDEO_PLAYER_SELECTOR), ".custom-player-shell"),
+      ).toBe(false);
+    });
+
+    it("should pass the selector as an evaluate argument, not a closure", async () => {
+      let receivedArg;
       const mockPage = {
-        evaluate: async () => false,
+        evaluate: async (fn, arg) => {
+          receivedArg = arg;
+          expect(fn.toString()).not.toContain("custom-player-shell");
+          return true;
+        },
       };
-      expect(await hasHotmartPlayer(mockPage)).toBe(false);
+
+      await hasHotmartPlayer(mockPage, ".custom-player-shell");
+
+      expect(receivedArg).toBe(".custom-player-shell");
     });
 
     it("should return false on evaluate error", async () => {
@@ -129,6 +211,41 @@ describe("hotmart player module", () => {
         },
       };
       expect(await hasHotmartPlayer(mockPage)).toBe(false);
+    });
+  });
+
+  describe("preparePage selector threading", () => {
+    function makeDetectionPage(presentSelector) {
+      return {
+        url: () => "https://example.com/lesson/1",
+        evaluate: async (fn, arg) => {
+          const detached = new Function("document", "arg", `return (${fn.toString()})(arg);`);
+          const document = {
+            querySelector: (s) => (s === presentSelector ? { tag: "div" } : null),
+          };
+          return detached(document, structuredClone(arg));
+        },
+        frames: () => [],
+      };
+    }
+
+    it("should detect no video when the configured selector is absent", async () => {
+      const page = makeDetectionPage(DEFAULT_VIDEO_PLAYER_SELECTOR);
+
+      const result = await preparePage(page, "eng", 15000, ".skin-v2-player");
+
+      expect(result).toEqual({ hasVideo: false, hotmartFrame: null });
+    });
+
+    it("should fail past detection when the configured selector matches", async () => {
+      const page = makeDetectionPage(".skin-v2-player");
+
+      // Detection passes, so preparePage moves on to iframe lookup and throws
+      // because this stand-in exposes no Hotmart frame. That throw is the proof
+      // the custom selector matched.
+      await expect(preparePage(page, "eng", 15000, ".skin-v2-player")).rejects.toThrow(
+        "iframe not accessible",
+      );
     });
   });
 });

--- a/plugins/knowledge/skills/course-digest/extraction/lib/players/hotmart.test.js
+++ b/plugins/knowledge/skills/course-digest/extraction/lib/players/hotmart.test.js
@@ -5,6 +5,7 @@ import {
   DEFAULT_VIDEO_PLAYER_SELECTOR,
   getCapturedData,
   getHlsUrl,
+  getTranscript,
   hasHotmartPlayer,
   installInterceptors,
   isInterceptorsInstalled,
@@ -29,6 +30,8 @@ function makeMockPage(url = "https://example.com") {
         await l.handler(payload);
       }
     },
+    evaluate: async () => false,
+    frames: () => [],
   };
 }
 
@@ -38,20 +41,36 @@ describe("hotmart player module", () => {
   });
 
   describe("clearCapturedData", () => {
-    it("should remove entry for a specific URL", () => {
+    it("should remove entry for a specific Page", () => {
+      const page = makeMockPage("https://example.com/lesson/1");
       const data = getCapturedData();
-      data.set("https://example.com/lesson/1", {
+      data.set(page, {
         hlsMasterUrl: "https://cdn.hotmart.com/master.m3u8",
         subtitleManifestBody: null,
       });
-      expect(data.has("https://example.com/lesson/1")).toBe(true);
+      expect(data.has(page)).toBe(true);
 
-      clearCapturedData("https://example.com/lesson/1");
-      expect(data.has("https://example.com/lesson/1")).toBe(false);
+      clearCapturedData(page);
+      expect(data.has(page)).toBe(false);
     });
 
-    it("should not throw when URL does not exist", () => {
-      expect(() => clearCapturedData("https://nonexistent.com")).not.toThrow();
+    it("should not throw when the Page has no entry", () => {
+      expect(() => clearCapturedData(makeMockPage("https://nonexistent.com"))).not.toThrow();
+    });
+
+    it("should not clear another Page on the same URL", () => {
+      const lessonUrl = "https://example.com/lesson/1";
+      const firstPage = makeMockPage(lessonUrl);
+      const secondPage = makeMockPage(lessonUrl);
+      const data = getCapturedData();
+      data.set(firstPage, { hlsMasterUrl: "first", subtitleManifestBody: null });
+      data.set(secondPage, { hlsMasterUrl: "second", subtitleManifestBody: null });
+
+      clearCapturedData(secondPage);
+
+      expect(data.has(firstPage)).toBe(true);
+      expect(data.has(secondPage)).toBe(false);
+      expect(getHlsUrl(firstPage)).toBe("first");
     });
   });
 
@@ -106,46 +125,112 @@ describe("hotmart player module", () => {
 
       expect(getHlsUrl(secondPage)).toBe(masterUrl);
     });
+
+    it("should keep each Page's HLS capture when both sit on the same URL", async () => {
+      const lessonUrl = "https://example.com/lesson/1";
+      const firstPage = makeMockPage(lessonUrl);
+      const secondPage = makeMockPage(lessonUrl);
+      const firstMaster = "https://cdn.hotmart.com/master-pkg-t-first.m3u8";
+      const secondMaster = "https://cdn.hotmart.com/master-pkg-t-second.m3u8";
+
+      installInterceptors(firstPage, "eng");
+      installInterceptors(secondPage, "eng");
+
+      await firstPage.emit("request", { url: () => firstMaster });
+      await secondPage.emit("request", { url: () => secondMaster });
+
+      expect(getHlsUrl(firstPage)).toBe(firstMaster);
+      expect(getHlsUrl(secondPage)).toBe(secondMaster);
+    });
+
+    it("should not let a same-URL Page read another Page's HLS capture", async () => {
+      const lessonUrl = "https://example.com/lesson/1";
+      const firstPage = makeMockPage(lessonUrl);
+      const secondPage = makeMockPage(lessonUrl);
+      const firstMaster = "https://cdn.hotmart.com/master-pkg-t-first.m3u8";
+
+      installInterceptors(firstPage, "eng");
+      installInterceptors(secondPage, "eng");
+
+      await firstPage.emit("request", { url: () => firstMaster });
+
+      expect(getHlsUrl(firstPage)).toBe(firstMaster);
+      expect(() => getHlsUrl(secondPage)).toThrow("No HLS master URL captured");
+    });
+
+    it("should keep each Page's subtitle capture when both sit on the same URL", async () => {
+      const lessonUrl = "https://example.com/lesson/1";
+      const firstPage = makeMockPage(lessonUrl);
+      const secondPage = makeMockPage(lessonUrl);
+
+      installInterceptors(firstPage, "eng");
+      installInterceptors(secondPage, "eng");
+
+      await firstPage.emit("response", {
+        url: () => "https://cdn.hotmart.com/textstream_eng.m3u8",
+        status: () => 200,
+        text: async () => "manifest-first",
+      });
+      await secondPage.emit("response", {
+        url: () => "https://cdn.hotmart.com/textstream_eng.m3u8",
+        status: () => 200,
+        text: async () => "manifest-second",
+      });
+
+      expect(getCapturedData().get(firstPage).subtitleManifestBody).toBe("manifest-first");
+      expect(getCapturedData().get(secondPage).subtitleManifestBody).toBe("manifest-second");
+    });
   });
 
   describe("resetState", () => {
     it("should clear captured data and forget installed pages", () => {
-      const data = getCapturedData();
-      data.set("url1", { hlsMasterUrl: "x", subtitleManifestBody: null });
-
       const mockPage = makeMockPage("");
+      getCapturedData().set(mockPage, { hlsMasterUrl: "x", subtitleManifestBody: null });
       installInterceptors(mockPage, "eng");
 
-      expect(data.size).toBe(1);
+      expect(getCapturedData().has(mockPage)).toBe(true);
       expect(isInterceptorsInstalled(mockPage)).toBe(true);
 
       resetState();
 
-      expect(data.size).toBe(0);
+      expect(getCapturedData().has(mockPage)).toBe(false);
       expect(isInterceptorsInstalled(mockPage)).toBe(false);
     });
   });
 
   describe("getHlsUrl", () => {
     it("should return the captured HLS master URL", () => {
-      const data = getCapturedData();
       const testUrl = "https://example.com/lesson/1";
       const cdnBase = "https://cdn.hotmart.com/";
       const masterPath = "master-pkg-t-xyz.m3u8";
       const tokenQuery = "?token=abc";
       const hlsMasterUrl = `${cdnBase}${masterPath}${tokenQuery}`;
-      data.set(testUrl, {
+      const mockPage = { url: () => testUrl };
+      getCapturedData().set(mockPage, {
         hlsMasterUrl,
         subtitleManifestBody: null,
       });
 
-      const mockPage = { url: () => testUrl };
       expect(getHlsUrl(mockPage)).toBe(hlsMasterUrl);
     });
 
     it("should throw when no HLS URL captured", () => {
       const mockPage = { url: () => "https://example.com/no-data" };
       expect(() => getHlsUrl(mockPage)).toThrow("No HLS master URL captured");
+    });
+  });
+
+  describe("getTranscript", () => {
+    it("should not let a same-URL Page read another Page's subtitle capture", async () => {
+      const lessonUrl = "https://example.com/lesson/1";
+      const firstPage = makeMockPage(lessonUrl);
+      const secondPage = makeMockPage(lessonUrl);
+      getCapturedData().set(firstPage, {
+        hlsMasterUrl: "https://cdn.hotmart.com/master-pkg-t-first.m3u8",
+        subtitleManifestBody: "WEBVTT\n\n00:00:00.000 --> 00:00:01.000\nHello",
+      });
+
+      await expect(getTranscript(secondPage)).rejects.toThrow("No subtitle manifest captured");
     });
   });
 
@@ -215,9 +300,9 @@ describe("hotmart player module", () => {
   });
 
   describe("preparePage selector threading", () => {
-    function makeDetectionPage(presentSelector) {
+    function makeDetectionPage(presentSelector, url = "https://example.com/lesson/1") {
       return {
-        url: () => "https://example.com/lesson/1",
+        url: () => url,
         evaluate: async (fn, arg) => {
           const detached = new Function("document", "arg", `return (${fn.toString()})(arg);`);
           const document = {
@@ -246,6 +331,39 @@ describe("hotmart player module", () => {
       await expect(preparePage(page, "eng", 15000, ".skin-v2-player")).rejects.toThrow(
         "iframe not accessible",
       );
+    });
+
+    it("should not clear another Page's capture when preparing a same-URL Page", async () => {
+      const lessonUrl = "https://example.com/lesson/1";
+      const firstPage = makeMockPage(lessonUrl);
+      const firstMaster = "https://cdn.hotmart.com/master-pkg-t-first.m3u8";
+      installInterceptors(firstPage, "eng");
+      await firstPage.emit("request", { url: () => firstMaster });
+
+      const secondPage = makeDetectionPage(DEFAULT_VIDEO_PLAYER_SELECTOR, lessonUrl);
+      const result = await preparePage(secondPage, "eng", 15000, ".skin-v2-player");
+
+      expect(result).toEqual({ hasVideo: false, hotmartFrame: null });
+      expect(getHlsUrl(firstPage)).toBe(firstMaster);
+    });
+
+    it("should clear only this Page's capture at the start of preparePage", async () => {
+      const lessonUrl = "https://example.com/lesson/1";
+      const page = makeMockPage(lessonUrl);
+      const otherPage = makeMockPage(lessonUrl);
+      const pageMaster = "https://cdn.hotmart.com/master-pkg-t-page.m3u8";
+      const otherMaster = "https://cdn.hotmart.com/master-pkg-t-other.m3u8";
+
+      installInterceptors(page, "eng");
+      installInterceptors(otherPage, "eng");
+      await page.emit("request", { url: () => pageMaster });
+      await otherPage.emit("request", { url: () => otherMaster });
+
+      const result = await preparePage(page, "eng", 15000, ".skin-v2-player");
+
+      expect(result).toEqual({ hasVideo: false, hotmartFrame: null });
+      expect(() => getHlsUrl(page)).toThrow("No HLS master URL captured");
+      expect(getHlsUrl(otherPage)).toBe(otherMaster);
     });
   });
 });


### PR DESCRIPTION
Closes #3432

## Summary

Two latent course-digest extraction defects, both requiring a non-default selector or a second
Page to surface.

1. `videoPlayerSelector` was silently ignored. The config surface defines it and
   `lib/config.js` validates it as a required field, but `.hotmart_video_player` was hardcoded
   inside three `page.evaluate` callbacks. An operator overriding the selector for a
   differently-skinned Teachable course had the value accepted and then never used, and detection
   failed as though no player were present.
2. `interceptorsInstalled` was a module-level boolean. The first Page in a process installed the
   HLS and subtitle listeners; every later Page was short-circuited by the guard and captured
   nothing.

## Fix

**Selector threading.** Every hardcoded occurrence of the literal, found by grepping the whole
repo for `hotmart_video_player`, not only the three the issue named:

| Site | Status |
|---|---|
| `extraction/lib/players/hotmart.js:566` `hasHotmartPlayer` | fixed: takes `videoPlayerSelector`, passed as an evaluate argument |
| `extraction/adapters/teachable.js:103` `detectResources` | fixed: `videoSel` added to the existing evaluate arg object |
| `extraction/adapters/teachable.js:248` `preflight` | fixed: selector passed as the evaluate argument; the parameter was `_platformCfg` and is now read |
| `extraction/lib/players/hotmart.js` `preparePage` | fixed: threads the selector into `hasHotmartPlayer`; `prepareLessonPage` supplies it |
| `extraction/adapters/teachable.js:43` `defaults.videoPlayerSelector` | not a defect: the adapter default. Now references the new exported `DEFAULT_VIDEO_PLAYER_SELECTOR` so the string has one definition |
| `extraction/build-course-json.js:206` | not a defect: this writes the generated `platformConfig`, so it is the producer of the config value, not a consumer that ignores it |
| `reference/adapters/teachable.md:108`, `reference/adapters/discovery-checklist.md:68` | not a defect: human-facing manual discovery steps, no code path |

`extraction/adapters/teachable.js:276` (`authenticate`) already honored the config and was left
alone apart from routing through the new `resolveVideoPlayerSelector` helper.

Selectors cross into the browser context as `page.evaluate` **arguments**, never closed over,
matching what this codebase already does everywhere else (`scrapeCodeSnippets`,
`scrapeAttachmentLinks`, `extractMetadata`, `captureCanvasFrame`).

**Interceptor semantics: PER PAGE.** The guard is now a `WeakSet` keyed on the Page, and the
docstring states that scope. The reasoning, since the issue records the intent as ambiguous:

- The hazard the guard exists to prevent is a duplicate `page.on` registration, and that hazard is
  per Page by construction. Two different Pages cannot double-register each other's listeners.
- The module's other state is already keyed per target rather than per module: `capturedData` is a
  `Map` keyed by page URL. Per-module keying for the guard was the odd one out.
- Nothing in the tree creates a second Page today. `lib/browser.js:67` holds the only
  `context.newPage()` call, `launchBrowser` is called once each by `extract-course.js`,
  `discover-resources.js`, and `build-course-json.js`, and those are separate CLI processes. So
  no existing caller can observe the change: for a single Page, per-page keying behaves exactly as
  the module-global did. The behavior change is confined to a case that is broken today.
- Per-module would have meant weakening the docstring to bless a silent failure. Per-page makes
  the second Page work, and the new `isInterceptorsInstalled(page)` throws a `TypeError` when
  called without a Page rather than quietly answering `false`.

`resetState()` replaces the WeakSet (a WeakSet cannot be iterated to clear).

Known limitation this PR does not close, stated rather than implied: `capturedData` is still keyed
by page URL (verbatim on `main` at lines 59, 341, 363, and 505), so two Pages sitting on the *same*
URL at the same time share one entry. That keying is pre-existing and unchanged by this PR, but the
per-Page interceptor fix makes it newly reachable rather than merely latent. Before this fix, a
second Page had no listeners at all and could never write into the Map, the module-global guard
blocked it. After this fix, two Pages on one URL both write through `captureMasterUrl`
(hotmart.js:74-76) and both read through `getHlsUrl` (hotmart.js:531), so they can now collide.
Verified against real Chromium: after a third Page on `https://lesson.test/2` captured
`master-pkg-t-p3.m3u8`, `getHlsUrl(p2)` returned p3's URL. Separately, `preparePage`
(hotmart.js:389) calls `capturedData.delete(currentUrl)`, so Page B opening the same URL wipes
Page A's capture. Neither failure is observable today because nothing in this tree opens a second
Page; each becomes reachable only once a caller does. Orthogonal to the interceptor guard and out
of scope for this PR.

Version: `knowledge` 0.13.46 to 0.13.47, with a matching CHANGELOG entry.

## Verification

Everything below was run in the foreground in a dedicated worktree off `origin/main` at
`bf24e0e56bc5cebc1e8916b6a4ef60676c2629e3`.

- `bash scripts/affected-tests.sh --run` exits **3**, which is a pass. It selects both co-located
  vitest suites and reports them `NOT RUN` because vitest is an ecosystem that runner does not
  execute; no file in the change is unmapped (`plugin.json` and `CHANGELOG.md` are recorded
  `no-suite` entries).
- Those two suites run directly: `npx vitest run` in
  `plugins/knowledge/skills/course-digest/extraction` gives **10 files / 107 tests passed**.
- `npm run build` (`tsc --noEmit`) clean. It was briefly not clean: an em dash placed directly
  after a bracketed optional `@param` name is `TS1127 Invalid character`. Confirmed against a
  `git archive origin/main` export, which typechecks clean, so that was mine and is fixed.
- Changelog parity, all four modes green: `--check`, `--check-order`,
  `--check-bump origin/main`, `--check-preserved origin/main` (109 headings compared).
- Version 0.13.47 validated against current `origin/main` (0.13.46) and against the fetched head
  of all 29 open PRs: none bumps `knowledge` above 0.13.46. Re-checked immediately before opening
  this PR.

**Non-vacuity.** Four mutations applied, each confirmed to fail, then reverted:

| Mutation | Tests killed |
|---|---|
| `hasHotmartPlayer` evaluate callback back to the hardcoded literal | 4 |
| `hasHotmartPlayer` closes over the selector instead of passing it as an argument | 4 |
| Interceptor guard back to a module-global flag | 2 (`should install on a second page in the same process`, `should capture the HLS master URL for a second page`) |
| `detectResources` `hasVideo` back to the literal | 2 |
| `preflight` back to the literal | 2 |

The selector tests are not vacuous config reads. `makeDomPage` rebuilds the evaluate callback from
its own source with `new Function` and passes the argument through `structuredClone`, so the
callback can only see what actually crossed the serialization boundary and cannot reach any module
binding; that is what kills the closure mutation. The second-Page test drives a `request` event
through the recorded listeners and asserts `getHlsUrl(secondPage)` returns the captured URL.

**Scope of testing, stated plainly:** unit level only. No real browser, no Playwright Page, no live
Teachable or Hotmart course was exercised. The Page and DOM stand-ins model the serialization
boundary and the `page.on` registration, not Chromium. The behavior against a real course page is
unverified by this PR.

## Related

- Closes #3432. Both triage acceptance criteria are addressed. The criterion "opening a second page
  in the same process installs interceptors for it" is proven at the unit level as described above,
  not against a real browser.
- Sibling issue #3421 (Node CLIs calling `main()` at import) is visible in these same files and was
  deliberately left alone as a separate structural item.
- Triage recommended per-page keying and flagged it as reversible and confined to the guard's key;
  this PR takes that option and records the reasoning above so a maintainer who knows the
  interceptors are genuinely process-wide can veto with the argument in front of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ViPsHkL3ng9xWt2GjEQJob

---
_Generated by [Claude Code](https://claude.ai/code/session_01ViPsHkL3ng9xWt2GjEQJob)_