### PR TITLE
feat(autonomy): add the drift-delta-sweep v1 routine class and its leaf

### DIFF
--- a/plugins/autonomy/.claude-plugin/plugin.json
+++ b/plugins/autonomy/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "autonomy",
-  "version": "0.22.32",
+  "version": "0.23.0",
   "description": "Governed autonomous agent operation: role-topology, binding-seam, wiring-vs-advisor, telemetry, return-accounting, trigger-dispatch, per-work-class guardrail-matrix, standing-routine-catalog, and design-only runner-charter contracts for climbing the AI-adoption ladder, plus a guided-setup skill that discovers an adopting org's state, writes its schema-versioned binding, wires standards-pinned OTLP emission with a zero-cost file-artifact default, wires human-attested return capture at the task boundary, wires signal adapters with one governed dispatch entrypoint, binds the five-class guardrail matrix to an org's isolation substrates with an in-boundary live-validation probe before recording each fail-closed binding, and stands up standing-routine-catalog classes as scheduled temporal signal adapters behind the one governed queue with free scheduling defaults wired as reviewable changes and each routine's work-class mapping homed on the security surface.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/autonomy/CHANGELOG.md
+++ b/plugins/autonomy/CHANGELOG.md
@@ -3,6 +3,28 @@
 All notable changes to the `autonomy` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.23.0]
+
+### Added
+
+- **`drift-delta-sweep`, an eleventh `v1` routine class, with its own definition leaf
+  (#3819).** The catalog gains a sibling row under Code quality / knowledge
+  (`AGT | R + WI | repo | C1 | v1`) and the leaf
+  `reference/routines/drift-delta-sweep.md` carries its instruction content: a cadence pass
+  that runs the repository's installed drift lanes and reports what moved, fanning out to the
+  instruction-placement delta lane, the enforcement-surface delta lane (two layers rotating on
+  the ISO week), and the repository drift audit lane (one dimension rotating on the same week,
+  never with `--fix`). Each invocation is presence-gated on its owning plugin and states its
+  fallback; a missing lane is recorded as not run rather than silently skipped. The row is a
+  sibling of `doc-freshness-sweep`, not an extension of it: `doc-freshness-sweep/advisory` is
+  a ratified admission identity on org security bindings, and broadening its substance would
+  change what a ratified entry authorizes without an org re-reviewing it. A class parameter
+  records the one dimension the two classes overlap on, and that the class's substantive
+  prerequisites (three optional sibling plugins, plus a run resolving a branch identity whose
+  memory-tier home persists across cycles) are not representable in the generated prerequisite
+  emission, so a `supported` verdict for this identity over-reports. The generated
+  `generated/identity-prerequisites.json` goes from thirteen identities to fourteen.
+
 ## [0.22.32]
 
 ### Changed

--- a/plugins/autonomy/generated/identity-prerequisites.json
+++ b/plugins/autonomy/generated/identity-prerequisites.json
@@ -198,6 +198,32 @@
       ]
     },
     {
+      "identity": "drift-delta-sweep",
+      "class": "drift-delta-sweep",
+      "posture": null,
+      "leaf": "reference/routines/drift-delta-sweep.md",
+      "access_class": "repo",
+      "isolation_floor": "L2",
+      "connector_entitlements": [],
+      "connector_entitlement_rung": null,
+      "executor_class_merge_cap": "security-binding",
+      "needs": [
+        {
+          "id": "documentation_corpus",
+          "probe_class": "repo-file"
+        },
+        {
+          "id": "source_tree",
+          "probe_class": "repo-file"
+        },
+        {
+          "id": "tracker",
+          "probe_class": "repo-file",
+          "seam": "work-item-tracker"
+        }
+      ]
+    },
+    {
       "identity": "duplicate-detection-sweep",
       "class": "duplicate-detection-sweep",
       "posture": null,

--- a/plugins/autonomy/reference/routines.md
+++ b/plugins/autonomy/reference/routines.md
@@ -237,6 +237,7 @@ prepares, human decides · hybrid rows show the split. Output: `R` report · `WI
 | abstraction-flattening | AGT | DC (PR) | repo | C4 (structural surface) | join (external): a validated detector is published |
 | gui-crash-fuzzing | DET (fuzzer) | R + WI | repo | n/a — no agent session; the GUI-actuation rule still requires L3 | not-a-routine |
 | doc-freshness-sweep | AGT | R + DC (optional docs PR) | repo | C1 (report); optional gated docs-PR portion C3 | v1 |
+| drift-delta-sweep | AGT | R + WI | repo | C1 | v1 |
 | coverage-mutation-watch | DET | R (digest/gate) | repo | n/a — no agent session | not-a-routine |
 | release-notes-generation | hybrid: DET cut mechanics (no agent session); AGT narrative is the routine | DC (draft) | repo | C3 (narrative truth not mechanically checkable) | join: proven recurring manual pattern |
 | eng-metrics-digest | AGT | R | repo | C1 | v1 |
@@ -330,10 +331,19 @@ commentary, and a leaf that contradicts one is non-conforming.
   no-agent-session property per the portion-split mapping rule; the repair judgment, the routine
   itself, is not, so the join trigger stays open and the class gains no leaf. A detector proves
   detection, never the repair pattern `v1` requires.
+- **`drift-delta-sweep` and `doc-freshness-sweep` are distinct classes.** `doc-freshness-sweep`
+  judges whether prose still describes its subject; `drift-delta-sweep` runs the repository's
+  installed drift lanes and reports their movement. Its repository-drift-audit lane is a full pass
+  whose documentation dimension overlaps `doc-freshness-sweep`; an org enabling both accepts that
+  one dimension is covered twice. The class's substantive prerequisites, three optional sibling
+  plugins present and a run that resolves a branch identity and persists its memory-tier home
+  across cycles, are not representable in the generated prerequisite emission, so a `supported`
+  verdict for this identity over-reports; the leaf states the predicate and the routine binding
+  owns satisfying it.
 
 ### v1 leaves
 
-Leaf-level definition depth for the ten `v1` classes only — every leaf derives its guardrail
+Leaf-level definition depth for the eleven `v1` classes only — every leaf derives its guardrail
 row through the mapping rules above, never by hand. The class parameters above are the other
 depth tier and bind whether or not a class has a leaf:
 
@@ -342,6 +352,7 @@ depth tier and bind whether or not a class has a leaf:
 - [backlog-readiness-check](routines/backlog-readiness-check.md)
 - [pr-queue-tending](routines/pr-queue-tending.md)
 - [doc-freshness-sweep](routines/doc-freshness-sweep.md)
+- [drift-delta-sweep](routines/drift-delta-sweep.md)
 - [dependency-update-wave](routines/dependency-update-wave.md)
 - [advisory-cve-triage](routines/advisory-cve-triage.md)
 - [tech-debt-sweep](routines/tech-debt-sweep.md)

--- a/plugins/autonomy/reference/routines/drift-delta-sweep.md
+++ b/plugins/autonomy/reference/routines/drift-delta-sweep.md
@@ -1,0 +1,166 @@
+# Drift-delta sweep
+
+Normative leaf of the [routine catalog](../routines.md): the `drift-delta-sweep` v1 class
+definition — a standing sweep that runs the repository's installed drift lanes on a cadence
+and reports what moved since the previous cycle.
+
+## Purpose
+
+The toil addressed is a coverage gap rather than a detection gap. The drift lanes a
+repository already installs are read-only and cheap to run, but they run only when a human
+remembers to invoke them, so movement between one invocation and the next is noticed late or
+not at all. `drift-delta-sweep` runs those lanes on a cadence and reports their movement, so
+drift coverage is a standing property of the repository rather than a habit somebody has to
+keep.
+
+## Trigger and cadence
+
+Trigger-taxonomy slot: **schedule**. The routine enters work as a `temporal`-class signal
+through the [trigger-dispatch contract](../trigger-dispatch.md)'s temporal adapter — a
+scheduled trigger behind the governed queue, never a private execution or merge path.
+Suggested cadence default: **weekly** — an org-bindable value set in the org's routine
+binding, never contract-fixed.
+
+The run predicate is a fact of the class, not a requirement the class imposes on a binding.
+The two delta lanes compare against their previous cycle, and capture a comparison point for
+the next one, only when the executing session resolves a **branch identity** — a branch
+checkout, or a logical ref the runner supplies — and finds its memory-tier home
+**persisted across** runs. A run that resolves neither still executes and still reports: it
+compares nothing, captures nothing, and says so.
+
+One illustrative binding, not a fixed requirement: a scheduled job on the org's
+CI-orchestration home, whose runner restores that home and checks out the branch before the
+run, which guided setup records as the `ci-cron` scheduler class.
+No vendor scheduling surface is named here; guided setup researches scheduling surfaces live.
+
+## Access scope
+
+Repo — the sweep reads the repository tree and writes through the governed queue and tracker
+only. No merge path: the repository drift audit lane runs without `--fix`, and no lane in the
+fan-out prepares or applies a repository change. No production, product, org, or external-web
+access, so the connector-prerequisite branch of the mapping rules never applies. Per the
+catalog mapping rules' access axis, repo scope sets the `L2` unattended floor as the class
+prerequisite ([guardrail contract](../guardrails.md)).
+
+## Output contract
+
+- **Advisory report** — one report per run, carrying one section per lane, a **coverage line**
+  naming which enforcement-surface layers and which audit dimension this cycle walked, and a
+  "lanes not run" section naming each absent or blocked lane and why it did not run.
+- **Work items** — filed through the governed queue for movement whose correction needs
+  authorial judgment.
+
+The report is also the evidence with which this class keeps its own place on the enforcement
+surface. A catalog routine's handler runs no work itself and enqueues one signal onto a
+tracker-held governed queue item, so the durable record of the class is that queue item — the
+recurring-work-item shape the enforcement-surface lane's own guidance prefers — minted by a
+scheduled tick. That queue item is itself an item on the enforcement surface, and the report
+is what has to justify it.
+
+## Fan-out
+
+The class's instruction content: three lanes, invoked in this order. Each names the plugin
+that owns it, is gated on that plugin's presence at the point of invocation, and states its
+fallback in the same sentence.
+
+1. **The instruction-placement delta lane.** Invoke `/instruction-placement:delta` when the
+   `instruction-placement` plugin is installed; where it is absent, record the lane as not run
+   and continue. The lane owns what moved in the instruction-placement findings since its own
+   last run. Bootstrap rule: where the lane reports no prior artifact to compare against,
+   invoke `/instruction-placement:audit` instead — read-only, its only write being its own
+   findings artifact — so the next cycle has a baseline, and record the cycle as a bootstrap
+   in the coverage line.
+
+2. **The enforcement-surface delta lane.** Invoke `/overengineering:delta` with `unattended`
+   and the cycle's two layers when the `overengineering` plugin is installed; where it is
+   absent, record the lane as not run and continue. The lane owns what moved in the
+   enforcement surface since its own last run. The layer pair rotates on the ISO week number,
+   read with `date -u +%V`; the pair index is (ISO week − 1) mod 5:
+
+   | Pair index | Layers |
+   |---|---|
+   | 0 | `agent-hooks agent-instructions` |
+   | 1 | `repo-hooks vcs-hooks` |
+   | 2 | `ci-lanes gate-scripts` |
+   | 3 | `satellite-workflows branch-protection` |
+   | 4 | `forge-apps external-integrations` |
+
+   The rotation is stateless — a function of the week alone — so a 53-week year repeats one
+   pair, which the coverage line records. The report carries the lane's own coverage line.
+
+3. **The repository drift audit lane.** Invoke `/codebase-health:audit` without `--fix` and
+   with exactly one dimension flag when the `codebase-health` plugin is installed; where it is
+   absent, record the lane as not run and continue. The lane owns the full drift pass over
+   documentation, configuration, code, and architecture claims; it is a full pass every cycle
+   and never a delta. The dimension rotates on the same ISO week number; the dimension index
+   is (ISO week − 1) mod 4:
+
+   | Dimension index | Flag |
+   |---|---|
+   | 0 | `--docs-only` |
+   | 1 | `--config-only` |
+   | 2 | `--code-only` |
+   | 3 | `--arch-only` |
+
+   Before invoking, read the lane's own tracked configuration and expand that dimension's
+   `primary-sources` globs. Where the configuration resolves no targets for the dimension, or
+   the expanded list exceeds twenty files — the lane's confirm threshold, which an unattended
+   session cannot answer — do not invoke the lane, and record it as not run with the dimension
+   and the file count. Keep the lane's checklist in-response and take no persist offer.
+
+## Derived guardrail row
+
+The row is derived through the catalog's mapping rules, never hand-assigned:
+
+1. **Judgment axis.** Which movement matters, and which of it needs authorial judgment, is
+   semantic judgment no rule engine resolves — agent judgment (`AGT`). Detection belongs to
+   the lanes; the sweep's judgment is over what they returned.
+2. **Output axes.** The advisory report derives `C1` through the `AGT` + report rule, and the
+   filed work items derive `C1` through the `AGT` + work-item rule: governed-queue and tracker
+   writes with no repository mutation, scoped as permitted `C1` output by the
+   [work-classes leaf](../guardrails/work-classes.md).
+3. **Risk-raising axes.** No portion of the class makes a direct change, so no structural or
+   configuration surface is the target of one and the `C4` axis does not fire. Access is
+   `repo` and every input is repository content the org already governs, so the
+   input-provenance axis does not fire and the class is not `C5`.
+4. **Access axis → prerequisite.** Repo scope sets the `L2` unattended floor as the dispatch
+   prerequisite; the `C1` matrix row keeps the floor at `L2`.
+
+Derived row: `C1`, with the `L2` unattended floor — in the
+[guardrail matrix](../guardrails.md).
+
+## Prerequisites
+
+Per-identity needs under
+[routine prerequisite resolution](../prerequisite-resolution.md). Axes derive through the
+catalog mapping rules; the isolation floor and `executor_class` merge cap are cited from the
+guardrail slice, never re-derived. Resolution verdicts use `supported` | `conditional` |
+`unsupported` | `unknown`.
+
+Single-posture identity: `drift-delta-sweep` (bare class token). The class has one output
+shape, so no posture-qualified identity is minted.
+
+| Axis | Value |
+|---|---|
+| Access class | `repo` |
+| Isolation floor | `L2` — cited from the [matrix](../guardrails.md#the-matrix) `C1` row and the [unattended floor](../guardrails/isolation-ladder.md#unattended-floor) |
+| Connector entitlements | none — `repo` access; the connector branch of [Access to prerequisites](../routines.md#access-to-prerequisites) does not apply |
+| Connector entitlement rung | n/a (no connector). For `prod` / `product` / `org` / `ext`, entitlement binds at the [Org binding layer](../binding-seam.md#resolution-ladder) |
+| `executor_class` merge cap | cited from [executor surface classes](../trigger-dispatch.md#executor-surface-classes) — security-binding `executor_class`; `vendor-hosted` caps every class at human-gated merge; never repo-derivable. Merge policy for this identity is n/a (`C1`) |
+| Repo needs | repository source tree; documentation corpus; tracker binding when filing work items through the work-item tracker seam. The class's substantive prerequisites, three optional sibling plugins present and a run that resolves a branch identity and persists its memory-tier home, are not representable in the generated emission |
+
+## Admission and escalation
+
+Admission disposition and fan-out caps for the derived class come from the
+[admission policy](../guardrails/admission-policy.md), evaluated over the stamped
+`signal.work_class`; escalation follows the [guardrail matrix](../guardrails.md)'s
+escalation column for the derived row. This leaf adds no routine-specific admission or
+escalation rules.
+
+## Precedent
+
+The proven manual pattern at class level is the operator-run cadence pass over report-only
+drift detectors: report-only drift-watch rows already carried in a consumer's recurring
+schedule, and the recurring-wiring guidance the enforcement-surface lane gives for its own
+repeat runs. Said plainly: no run record exists yet for these three lanes together. The `v1`
+status rests on the class-level pattern, not on a logged run of this fan-out.

--- a/plugins/autonomy/skills/setup/scripts/generate-identity-prerequisites.mjs
+++ b/plugins/autonomy/skills/setup/scripts/generate-identity-prerequisites.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 // Generates the machine-readable identity-and-prerequisite emission from the
-// ten v1 routine definition leaves. Leaves stay the authored single home; this
+// eleven v1 routine definition leaves. Leaves stay the authored single home; this
 // file is derived output the resolver and CI consume. Run with no argument to
 // rewrite the emission; run with --check to fail on drift (CI gate).
 //


### PR DESCRIPTION
Closes #3819

## What

Adds an eleventh `v1` routine class, `drift-delta-sweep`, to the autonomy routine catalog, with its own tracked definition leaf carrying the fan-out as instruction content.

| Path | Change |
|---|---|
| `plugins/autonomy/reference/routines/drift-delta-sweep.md` | New leaf. |
| `plugins/autonomy/reference/routines.md` | Catalog row after `doc-freshness-sweep`, class-parameter bullet, v1-leaves link, count `ten` → `eleven`. |
| `plugins/autonomy/skills/setup/scripts/generate-identity-prerequisites.mjs` | Header comment `ten` → `eleven` v1 leaves. No logic change. |
| `plugins/autonomy/generated/identity-prerequisites.json` | Regenerated (never hand-edited). Thirteen identities → fourteen. |
| `plugins/autonomy/CHANGELOG.md` | New `## [0.23.0]` `### Added`. |
| `plugins/autonomy/.claude-plugin/plugin.json` | `version` → `0.23.0`. |

The leaf fans out, in order, to `/instruction-placement:delta` (with the `/instruction-placement:audit` bootstrap), `/overengineering:delta` with `unattended` and a two-layer pair rotating on the ISO week, and `/codebase-health:audit` without `--fix` with one dimension rotating on the same week. Each invocation is presence-gated on its owning plugin and states its fallback in the same sentence; an absent or blocked lane is recorded as not run rather than silently skipped. Lanes are named by slash invocation only, with no file paths, so a relocation of any of them cannot contradict this leaf.

## Sibling, not an extension

The row ships as a **sibling** of `doc-freshness-sweep` with its own leaf, not as a broadening of that class. `doc-freshness-sweep/advisory` is ratified admission data on org security bindings; broadening its substance would change what a ratified entry authorizes without an org re-reviewing it, and two of the three lanes are not doc freshness. The one dimension the two classes overlap on is recorded as a class parameter.

Routine instructions live in the tracked leaf, never a stored prompt, per the catalog's Instruction provenance rule.

## Open question for review: the `v1` status

Recorded by the planning slice (#3809) as a PR-review switch condition, carried here rather than decided:

The row ships as `v1` on the class-level pattern (operators re-run report-only drift detectors on a cadence) with all three lanes built, and because the container Brief requires a leaf, which only a `v1` row ships. **No run record exists for these three lanes together**, and the leaf says so plainly in its `Precedent` section. CHANGELOG `[0.19.1]` refused `v1` for `cant-fail-test-repair` because its judgment portion was unbuilt; here it is built.

If review rules `v1` unearned until a lane-specific run record exists, the row instead files as `join: proven recurring manual pattern` with **no leaf**, which makes this slice's leaf criteria and the container's criterion 2 unsatisfiable as written; the slice then returns to decompose, and the cheapest run record is a recurring-schedule row for this repository.

## Notes

- **The autonomy README needs no change**: it enumerates no leaves (it refers only to the `reference/routines/` directory), so it is untouched.
- **No path under `docs/topics/`.** The plan document lives on the contract-tier branch `plan/3809-drift-delta-routine` and never merges.
- **Nothing registers a surface, binding, schedule, or workflow.** `.github/recurring-schedule.json` is untouched. The leaf names one illustrative `ci-cron` binding and excludes no scheduling surface.
- **`lychee` is installed** and passes on the leaf and the catalog (52 links, 52 OK, 0 errors).
- **Version start point**: the issue's files table says `0.22.30` → `0.23.0`. The real base carried `0.22.32` (main moved). The landing version `0.23.0` is unchanged and is still the correct next minor, strictly greater than the base.

## Verification

Every line of the issue's Sanity Checks block passes, plus:

- `node plugins/autonomy/skills/setup/scripts/generate-identity-prerequisites.mjs --check` → in sync; emission holds 14 identities and `drift-delta-sweep` needs exactly `documentation_corpus`, `source_tree`, `tracker`.
- `bash plugins/autonomy/skills/setup/scripts/generate-identity-prerequisites.test.sh` → Passed: 6, Failed: 0.
- `node plugins/autonomy/skills/setup/scripts/resolve-prerequisites.fixtures.test.mjs` → All 22 checks passed.
- `node scripts/validate-plugin-contracts.mjs` → 53 setup skills, 3 retirement manifests, 3345 plugin files checked.
- `npx markdownlint-cli2` on the changed markdown → 0 issues.
- `bash scripts/check-changelog-parity.sh --check-bump origin/main`, `--check`, `--check-preserved origin/main`, `--check-order` → all green; 92 changelogs read newest-first, 81 headings preserved.
- `bash scripts/check-stale-base-overlap.sh --check origin/main` → no overlapping paths.
- `bash scripts/check-purged-em-dashes.sh` → 91 declared paths, 122 files, no em dashes.

Two independent fresh-context verifiers reviewed the change against the issue with the author's reasoning withheld. The first found one MAJOR (the mandated verbatim trigger-section sentence was soft-wrapped, so the contract's own `grep` failed under `set -e`); it was fixed by a reflow with no content change. The second, run on the rebased commit, returned no CRITICAL, MAJOR, or MINOR findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012jiwedVq2GxuzN7siXQbr4
