### PR TITLE
feat(review): pattern column on the close-out acceptance-criteria rollup

### DIFF
--- a/plugins/review/.claude-plugin/plugin.json
+++ b/plugins/review/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "review",
-  "version": "0.26.19",
+  "version": "0.26.20",
   "description": "Code-review toolkit: six read-only reviewer agents (code, security, architecture, doc drift, build/test/lint, CI-log audit) plus orchestration skills \u2014 quality gate, fan-out, and CI lane commands (/review:code-review, /review:security-review) for org reusable workflows.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/review/CHANGELOG.md
+++ b/plugins/review/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to the `review` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.26.20]
+
+### Added
+
+- **`quality-gate`:** close-out mode's acceptance-criteria rollup gains a requirement-pattern
+  column when any of the container's retrieved criteria opens with a bracketed EARS tag. The cell
+  carries one of exactly five names, `ubiquitous`, `event-driven`, `state-driven`,
+  `unwanted-behaviour`, `optional-feature`, matching what the planning surfaces emit; a bracket
+  holding anything else leaves the cell empty rather than echoing raw text. Detection is that
+  bracket's presence, so no flag, lever, or convention key is read. Every criterion still gets a
+  row, so a partially tagged set shows its untagged rows with an empty pattern cell, and a set
+  with no tag renders exactly as before with no extra column. Step 2's extraction bullet now says
+  to keep the criterion line whole so the tag survives the read. The verdict vocabulary
+  (`delivered` / `partial` / `missing` / `unverifiable`) and the blocking rule (`missing` or
+  `wrong` keeps the container open) are unchanged.
+
 ## [0.26.19]
 
 ### Changed

--- a/plugins/review/CHANGELOG.md
+++ b/plugins/review/CHANGELOG.md
@@ -11,8 +11,9 @@ All notable changes to the `review` plugin are documented here. Format follows
   column when any of the container's retrieved criteria opens with a bracketed EARS tag. The cell
   carries one of exactly five names, `ubiquitous`, `event-driven`, `state-driven`,
   `unwanted-behaviour`, `optional-feature`, matching what the planning surfaces emit; a bracket
-  holding anything else leaves the cell empty rather than echoing raw text. Detection is that
-  bracket's presence, so no flag, lever, or convention key is read. Every criterion still gets a
+  holding anything else leaves the cell empty rather than echoing raw text. Detection is a leading
+  bracket holding one of those names, so a checklist marker (`- [ ]`) is not read as a tag and no
+  flag, lever, or convention key is read at all. Every criterion still gets a
   row, so a partially tagged set shows its untagged rows with an empty pattern cell, and a set
   with no tag renders exactly as before with no extra column. Step 2's extraction bullet now says
   to keep the criterion line whole so the tag survives the read. The verdict vocabulary

--- a/plugins/review/README.md
+++ b/plugins/review/README.md
@@ -30,7 +30,9 @@ Invoke via `@review:<agent>` or let Claude delegate.
   `security`, `spec` (spec-fidelity: did the change deliver what the originating item, plan, or
   brief asked for), `close-out` (the same fidelity lens at spec-container scale, one cumulative
   pass over everything a container shipped, across however many PRs, against the container's own
-  body; derives its own diff basis per execution shape), `downstream` (what the change breaks
+  body; derives its own diff basis per execution shape, and its acceptance-criteria rollup gains a
+  requirement-pattern column when the container's criteria carry bracketed EARS tags),
+  `downstream` (what the change breaks
   outside its own diff: callers, serialization boundaries, cross-service consumers), `pr`,
   `criteria`, `slice <name>`, `restatement`.
 - **`/review:fanout [mode]`**. Breadth review: fans out across the

--- a/plugins/review/skills/quality-gate/context/close-out.md
+++ b/plugins/review/skills/quality-gate/context/close-out.md
@@ -378,8 +378,9 @@ plus, above it:
   alone cannot show. The pattern cell carries one of exactly five names, `ubiquitous`,
   `event-driven`, `state-driven`, `unwanted-behaviour`, `optional-feature`, or nothing at all; a
   bracket holding anything else is an untagged criterion that looks tagged, so the cell stays empty
-  rather than echoing the raw text. Detection is that bracket's presence in the criteria as
-  retrieved, nothing else: no flag, no lever, and no convention key is read here. **Every criterion
+  rather than echoing the raw text. Detection is a leading bracket holding one of those five names
+  in the criteria as retrieved, nothing else: a checklist marker (`- [ ]`) is a bracket and not a
+  tag, and no flag, no lever, and no convention key is read here. **Every criterion
   still gets a row.** A partially tagged set leaves the untagged rows' pattern cell empty rather
   than dropping them, which is the invisibility this rollup exists to remove; a set carrying no tag
   at all renders exactly as it does today, with no pattern column. The column names the pattern and

--- a/plugins/review/skills/quality-gate/context/close-out.md
+++ b/plugins/review/skills/quality-gate/context/close-out.md
@@ -93,7 +93,9 @@ inside the verbatim fence [spec.md](spec.md) "Step 2" specifies.
 
 From the body, extract the three things the rest of this mode needs:
 
-- the **acceptance criteria** — the checklist the cumulative verdict is rendered against
+- the **acceptance criteria** — the checklist the cumulative verdict is rendered against. Keep each
+  criterion line whole rather than stripping it to prose: a leading bracketed tag is part of the
+  line, and Step 6 reads it
 - any **scope statement** (an `## Out of scope` section, an acceptance-criteria list read as
   exhaustive) — without one, `scope-creep` is not reachable at all, per [spec.md](spec.md)
   "Finding classes"
@@ -369,7 +371,19 @@ plus, above it:
   `sub-item → PR → oid`, so the basis is auditable rather than asserted; name the rung, and say
   outright when it was the heuristic scan
 - the **acceptance-criteria rollup** — every criterion with its `delivered` / `partial` /
-  `missing` / `unverifiable` verdict
+  `missing` / `unverifiable` verdict, and, **when any criterion retrieved in Step 2 opens with a
+  bracketed EARS tag, one more column naming that criterion's requirement pattern**. That column is
+  what makes the shape of a tagged set legible: that every `unwanted-behaviour` criterion came back
+  `unverifiable` while the `event-driven` ones were all `delivered` is a fact the verdict column
+  alone cannot show. The pattern cell carries one of exactly five names, `ubiquitous`,
+  `event-driven`, `state-driven`, `unwanted-behaviour`, `optional-feature`, or nothing at all; a
+  bracket holding anything else is an untagged criterion that looks tagged, so the cell stays empty
+  rather than echoing the raw text. Detection is that bracket's presence in the criteria as
+  retrieved, nothing else: no flag, no lever, and no convention key is read here. **Every criterion
+  still gets a row.** A partially tagged set leaves the untagged rows' pattern cell empty rather
+  than dropping them, which is the invisibility this rollup exists to remove; a set carrying no tag
+  at all renders exactly as it does today, with no pattern column. The column names the pattern and
+  changes no verdict
 - the **`no-code` sub-items** — those the provider confirms closed without a PR, each with the
   closing comment its criteria were judged against. These are journey coverage, not gaps.
 - any sub-item whose shipping commit could not be resolved (`unresolved`), listed as a coverage gap


### PR DESCRIPTION
Closes #3824

## What changed

Close-out mode's acceptance-criteria rollup already anchors the pass on the container's criteria,
already gives every criterion a verdict of `delivered` / `partial` / `missing` / `unverifiable`,
and already renders unconditionally. What it lacked was any awareness of a criterion's requirement
pattern, so the shape of a tagged set (every `unwanted-behaviour` criterion `unverifiable` while
the `event-driven` ones were all `delivered`) was discarded.

The rollup now gains **one conditional column** naming each criterion's requirement pattern when
any criterion retrieved in Step 2 opens with a bracketed EARS tag.

- The cell carries one of exactly five names, `ubiquitous`, `event-driven`, `state-driven`,
  `unwanted-behaviour`, `optional-feature`, the vocabulary the writing side (#3821 / #3882) emits.
  A bracket holding anything else leaves the cell empty rather than echoing raw text.
- Detection is a leading bracket holding one of those names, nothing more. No flag, no lever, no
  convention key, and no resolution ladder. A checklist marker (`- [ ]`) is named explicitly as the
  bracket that is not a tag, because the repo's own Agent Brief template emits criteria that way.
- **Every criterion still gets a row.** A partially tagged set shows its untagged rows with an
  empty pattern cell rather than dropping them, which is the invisibility the rollup exists to
  remove. A set carrying no tag renders exactly as it does today, with no extra column.
- Step 2's extraction bullet now says to keep the criterion line whole, so the tag survives the
  read.

## What deliberately did not change

- **No second verdict vocabulary.** The existing four values stay; no `met`, no `not-met`.
- **The blocking rule is untouched.** Only a `missing` or `wrong` finding keeps the container open.
  That rule is co-owned by the work-items container lifecycle and changing it is a container-level
  decision, not a side effect of adding a column. `plugins/work-items/` is not in this diff.

## Verification

A fresh-context verifier that did not write the change confirmed all nine checked points with no
CRITICALs: no second verdict vocabulary, blocking rule unchanged, `plugins/work-items/` untouched,
one row per criterion on a partially tagged set, the five names verbatim (including British
`-behaviour`), unchanged rendering with no tags, no flag/lever/convention key, scope held to one
column, and house mechanics (em-dash purge on the README, changelog order, version parity). Its one
non-blocking tightening (the checklist-marker ambiguity) is applied as the second commit.

Gates run locally: `check-changelog-parity.sh --check-bump main` (pass),
`check-purged-em-dashes.sh` (pass), `validate-plugin-contracts.mjs` (pass),
`markdownlint-cli2` on the changed markdown (0 issues).

Review plugin bumped 0.26.19 to 0.26.20.

Note: #3821 / #3882 (the writing side that emits the tags) is still open, so this reader lands
before its writer. The vocabulary is pinned to that PR's stated contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012jiwedVq2GxuzN7siXQbr4
