### PR TITLE
fix(architecture): stop map-landscape fabricating an owner and reading the wrong dependencies

### DIFF
--- a/plugins/architecture/.claude-plugin/plugin.json
+++ b/plugins/architecture/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "architecture",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Scans an existing codebase for module-level architecture friction — shallow modules, seam leaks, and locality gaps — using Ousterhout's deep-module lens, presents candidates as a self-contained HTML report, and runs an interview loop on the selected candidate before handing off for planning. Also charts a discovered set of repositories as a C4 system landscape plus an application-portfolio table, and records an architecture decision into the repository's existing ADR convention.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/architecture/CHANGELOG.md
+++ b/plugins/architecture/CHANGELOG.md
@@ -3,6 +3,24 @@
 All notable changes to the `architecture` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.8.1]
+
+### Fixed
+
+- **`map-landscape` no longer fabricates an `owner` from a local-path remote.** A git remote is
+  often a plain filesystem path, and `portfolio-facts.sh` stripped its first segment as if it were a
+  hosting account: `/srv/code/platform/billing` reported owner `srv`, and `file:///opt/mirror/repo`
+  reported `opt`. Both were emitted with `evidence.owner: "origin remote URL"`, so a fabricated
+  fact carried a citation, which is worse than the wrong value alone. `remote_owner` now requires a
+  host (a `scheme://host/...` authority, or the scp-style `host:owner/repo`) and returns `unknown`
+  for every path form. The contract's rule is `unknown` for anything underivable, never a guess.
+- **`map-landscape` reads the top-level `dependencies` even when a nested member shares its name.**
+  The package.json reader sought the first literal `"dependencies"` in the byte stream, so a
+  `pnpm.overrides.dependencies` block appearing earlier in the file shadowed the real one and the
+  portfolio listed the override's pins as the project's dependencies. The reader now locates the
+  member by position with a container stack rather than by text search.
+- Regression cases for both, plus assertions for `path` and for the absent-owner citation.
+
 ## [0.8.0]
 
 ### Added

--- a/plugins/architecture/skills/map-landscape/scripts/portfolio-facts.sh
+++ b/plugins/architecture/skills/map-landscape/scripts/portfolio-facts.sh
@@ -161,10 +161,11 @@ find_all() {
 # `opt`. Both were emitted with `evidence.owner: "origin remote URL"`, so a
 # fabricated fact carried a citation. `unknown` is the correct answer here.
 remote_owner() {
-  local url="$1" rest owner
+  local url="$1" rest owner had_scheme=0
   url="${url%.git}"
   case "$url" in
   *://*)
+    had_scheme=1
     url="${url#*://}"
     # An empty authority (`file:///path`) leaves a leading slash: no host.
     case "$url" in
@@ -195,11 +196,28 @@ remote_owner() {
     ;;
   *) ;;
   esac
-  # scp-style `host:owner/repo` becomes `host/owner/repo`.
-  case "$url" in
-  *:*) url="${url%%:*}/${url#*:}" ;;
-  *) ;;
-  esac
+  # scp-style `host:owner/repo` becomes `host/owner/repo`. ONLY when there was
+  # no scheme: with one, a colon in the authority is a PORT, and converting it
+  # promotes the port number to a path segment, so `https://example.com:8080/acme/repo`
+  # would resolve to owner `8080`. That is the same fabricated-fact-with-a-citation
+  # this guard exists to stop, arriving by a different route. With a scheme, strip
+  # the port from the authority instead.
+  if [[ "$had_scheme" -eq 1 ]]; then
+    case "$url" in
+    *:*)
+      case "${url%%/*}" in
+      *:*) url="${url%%:*}/${url#*/}" ;;
+      *) ;;
+      esac
+      ;;
+    *) ;;
+    esac
+  else
+    case "$url" in
+    *:*) url="${url%%:*}/${url#*:}" ;;
+    *) ;;
+    esac
+  fi
   case "$url" in
   */*) rest="${url#*/}" ;;
   *) return 1 ;;

--- a/plugins/architecture/skills/map-landscape/scripts/portfolio-facts.sh
+++ b/plugins/architecture/skills/map-landscape/scripts/portfolio-facts.sh
@@ -150,13 +150,40 @@ find_all() {
   done <<<"$REPO_FILES"
 }
 
-# The owner segment of a git remote URL. Handles scheme://host/owner/repo,
-# user@host:owner/repo, and host/owner/repo. Prints nothing when the shape does
-# not yield an owner rather than guessing at one.
+# The owner segment of a git remote URL. Handles `scheme://[user@]host/owner/repo`
+# and scp-style `[user@]host:owner/repo`. Returns non-zero when the shape names
+# no host, rather than guessing at an owner.
+#
+# A HOST IS REQUIRED, and that is the whole guard. A git remote is often a plain
+# filesystem path, and a path's first segment is a directory, not an owner: an
+# earlier spelling stripped a leading segment unconditionally and reported
+# `/srv/code/platform/billing` as owner `srv` and `file:///opt/mirror/repo` as owner
+# `opt`. Both were emitted with `evidence.owner: "origin remote URL"`, so a
+# fabricated fact carried a citation. `unknown` is the correct answer here.
 remote_owner() {
   local url="$1" rest owner
   url="${url%.git}"
-  url="${url#*://}"
+  case "$url" in
+  *://*)
+    url="${url#*://}"
+    # An empty authority (`file:///path`) leaves a leading slash: no host.
+    case "$url" in
+    /*) return 1 ;;
+    *) ;;
+    esac
+    ;;
+  *)
+    # No scheme. Only the scp-style `host:owner/repo` form names a host; an
+    # absolute, relative, or Windows path does not. A colon that appears AFTER
+    # a slash is part of a path, not an scp separator.
+    case "$url" in
+    /* | ./* | ../* | ~*) return 1 ;;
+    */*:*) return 1 ;;
+    *:*) ;;
+    *) return 1 ;;
+    esac
+    ;;
+  esac
   # Strip a `user@` only when the `@` precedes the first path separator, so an
   # `@` inside a path segment is left alone.
   case "$url" in
@@ -178,7 +205,7 @@ remote_owner() {
   *) return 1 ;;
   esac
   owner="${rest%%/*}"
-  # A local-path remote yields a drive letter or a dot segment, not an owner.
+  # A Windows drive letter normalizes to an empty or backslash-bearing segment.
   case "$owner" in
   "" | . | ..) return 1 ;;
   *[!A-Za-z0-9._-]*) return 1 ;;
@@ -197,42 +224,55 @@ codeowners_default() {
   ' "$1"
 }
 
-# Keys of a top-level JSON object member, one per line. Walks the text with a
-# depth and string-state machine because a package.json is not line-oriented
-# and an anchored grep would miss a one-line manifest entirely.
+# Keys of a TOP-LEVEL JSON object member, one per line. Walks the text with a
+# depth and string-state machine because a package.json is not line-oriented and
+# an anchored grep would miss a one-line manifest entirely.
+#
+# The member must be found BY POSITION, not by text search. Seeking the first
+# literal `"dependencies"` anywhere in the file lets a nested member of the same
+# name shadow the real one: a `pnpm.overrides.dependencies` block appears first
+# in the byte stream, so the top-level dependencies were reported as whatever
+# the override pinned. A container stack costs a few lines and cannot be fooled
+# that way.
 json_object_keys() {
   awk -v want="$2" '
     { buf = buf $0 "\n" }
     END {
-      i = index(buf, "\"" want "\"")
-      if (i == 0) exit 0
       n = length(buf)
-      while (i <= n && substr(buf, i, 1) != "{") {
-        c = substr(buf, i, 1)
-        # A member whose value is not an object has no keys to report.
-        if (c == "[" || (c == "," && i > 1)) exit 0
-        i++
-      }
-      if (i > n) exit 0
-      i++
-      depth = 1; instr = 0; esc = 0; expectkey = 1; collecting = 0; key = ""
-      while (i <= n && depth > 0) {
+      depth = 0; instr = 0; esc = 0
+      expectkey = 0; collecting = 0; key = ""; target = 0; done = 0
+      for (i = 1; i <= n; i++) {
         c = substr(buf, i, 1)
         if (instr) {
           if (esc) { esc = 0 }
           else if (c == "\\") { esc = 1 }
           else if (c == "\"") {
             instr = 0
-            if (collecting) { print key; collecting = 0 }
+            if (collecting) {
+              collecting = 0
+              # The last key seen at this depth names the value about to open.
+              keyat[depth] = key
+              if (target != 0 && depth == target) print key
+            }
           } else if (collecting) { key = key c }
-        } else if (c == "\"") {
+          continue
+        }
+        if (c == "\"") {
           instr = 1
-          if (depth == 1 && expectkey) { collecting = 1; key = "" }
-        } else if (c == "{") { depth++ }
-        else if (c == "}") { depth-- }
-        else if (c == ":" && depth == 1) { expectkey = 0 }
-        else if (c == "," && depth == 1) { expectkey = 1 }
-        i++
+          if (expectkey) { collecting = 1; key = "" }
+        } else if (c == "{") {
+          depth++; isobj[depth] = 1; expectkey = 1
+          if (!done && target == 0 && depth == 2 && keyat[1] == want) target = 2
+        } else if (c == "[") {
+          depth++; isobj[depth] = 0; expectkey = 0
+        } else if (c == "}" || c == "]") {
+          if (target != 0 && depth == target) { target = 0; done = 1 }
+          depth--; expectkey = 0
+        } else if (c == ":") {
+          expectkey = 0
+        } else if (c == ",") {
+          expectkey = (depth >= 1 && isobj[depth] == 1) ? 1 : 0
+        }
       }
     }
   ' "$1"

--- a/plugins/architecture/skills/map-landscape/scripts/portfolio-facts.test.sh
+++ b/plugins/architecture/skills/map-landscape/scripts/portfolio-facts.test.sh
@@ -105,6 +105,7 @@ CSPROJ
 commit_repo "$dotnet_repo"
 out="$(bash "$SCRIPT" "$dotnet_repo")"
 assert_equals "dotnet: name" "$(field "$out" name)" "dotnet-svc"
+assert_contains "dotnet: path is the resolved absolute path" "$(field "$out" path)" "dotnet-svc"
 assert_equals "dotnet: runtime" "$(field "$out" runtime)" "dotnet"
 assert_equals "dotnet: target_framework from the first csproj" "$(field "$out" target_framework)" "net9.0"
 assert_contains "dotnet: PackageReference collected (MediatR)" "$out" '"MediatR"'
@@ -206,6 +207,52 @@ out="$(bash "$SCRIPT" "$remote_repo")"
 assert_equals "owner ladder: scp-style remote owner segment" "$(field "$out" owner)" "fallback-owner"
 assert_contains "owner ladder: evidence names the remote" "$out" 'origin remote URL'
 assert_contains "remote: URL is reported verbatim" "$out" 'fallback-owner/remote-only.git'
+
+# --- Case group 7b: a local-path remote names no owner -----------------------
+# A git remote is often a plain filesystem path, and a path's first segment is a
+# directory, not an owner. Reporting one would be a fabricated fact carrying an
+# "origin remote URL" citation.
+#
+# The remote is RELATIVE on purpose. An MSYS bash rewrites a POSIX-absolute
+# argument into a Windows path before git ever sees it, so an absolute fixture
+# would assert against `C:/Program Files/Git/...` on one platform and the
+# original on another. A relative path is left alone everywhere and exercises
+# the same branch.
+localpath_repo="$(make_repo local-remote)"
+printf 'x\n' >"$localpath_repo/README.md"
+git -C "$localpath_repo" remote add origin "../sibling-upstream"
+commit_repo "$localpath_repo"
+out="$(bash "$SCRIPT" "$localpath_repo")"
+assert_equals "owner ladder: a path remote yields unknown, not its first segment" \
+  "$(field "$out" owner)" "unknown"
+assert_not_contains "owner ladder: no fabricated owner from the path" "$out" '"owner":"sibling-upstream"'
+assert_not_contains "owner ladder: an unknown owner is not cited to the remote" "$out" '"owner":"origin remote URL"'
+assert_contains "owner ladder: the remote itself is still reported" "$out" 'sibling-upstream'
+
+# The same rule through a scheme with an empty authority: no host, no owner.
+fileurl_repo="$(make_repo file-url-remote)"
+printf 'x\n' >"$fileurl_repo/README.md"
+git -C "$fileurl_repo" remote add origin "file:///opt/mirrors/upstream"
+commit_repo "$fileurl_repo"
+out="$(bash "$SCRIPT" "$fileurl_repo")"
+assert_equals "owner ladder: file:// with an empty authority yields unknown" \
+  "$(field "$out" owner)" "unknown"
+assert_not_contains "owner ladder: no fabricated owner from a file URL" "$out" '"owner":"opt"'
+
+# --- Case group 7c: a nested member must not shadow the top-level one --------
+nested_repo="$(make_repo nested-deps)"
+cat >"$nested_repo/package.json" <<'PKG'
+{
+  "name": "nested-deps",
+  "pnpm": { "overrides": { "dependencies": { "ghost-from-nested": "1.0.0" } } },
+  "dependencies": { "real-dep-a": "^1.0.0", "real-dep-b": "^2.0.0" }
+}
+PKG
+commit_repo "$nested_repo"
+out="$(bash "$SCRIPT" "$nested_repo")"
+assert_contains "nested: the top-level dependencies win (a)" "$out" '"real-dep-a"'
+assert_contains "nested: the top-level dependencies win (b)" "$out" '"real-dep-b"'
+assert_not_contains "nested: a same-named nested member does not shadow them" "$out" '"ghost-from-nested"'
 
 # --- Case group 8: the dependency cap ---------------------------------------
 capped_repo="$(make_repo capped)"

--- a/plugins/architecture/skills/map-landscape/scripts/portfolio-facts.test.sh
+++ b/plugins/architecture/skills/map-landscape/scripts/portfolio-facts.test.sh
@@ -208,6 +208,26 @@ assert_equals "owner ladder: scp-style remote owner segment" "$(field "$out" own
 assert_contains "owner ladder: evidence names the remote" "$out" 'origin remote URL'
 assert_contains "remote: URL is reported verbatim" "$out" 'fallback-owner/remote-only.git'
 
+# --- Case group 7a: a port in the authority is not an owner ------------------
+# With a scheme, a colon in the authority is a PORT. An unconditional scp-style
+# conversion promotes it to a path segment, so `https://host:8080/acme/repo`
+# resolves to owner `8080` — the same fabricated-fact-with-a-citation the
+# host-required guard exists to stop, arriving by a different route.
+port_repo="$(make_repo ported-remote)"
+printf 'x\n' >"$port_repo/README.md"
+git -C "$port_repo" remote add origin "https://example.invalid:8080/ported-owner/ported-remote.git"
+commit_repo "$port_repo"
+out="$(bash "$SCRIPT" "$port_repo")"
+assert_equals "owner ladder: a scheme URL with a port keeps its real owner" "$(field "$out" owner)" "ported-owner"
+assert_not_contains "owner ladder: the port never becomes the owner" "$out" '"owner":"8080"'
+
+ssh_port_repo="$(make_repo ssh-ported)"
+printf 'x\n' >"$ssh_port_repo/README.md"
+git -C "$ssh_port_repo" remote add origin "ssh://git@example.invalid:22/ssh-owner/ssh-ported.git"
+commit_repo "$ssh_port_repo"
+out="$(bash "$SCRIPT" "$ssh_port_repo")"
+assert_equals "owner ladder: ssh URL with a port keeps its real owner" "$(field "$out" owner)" "ssh-owner"
+
 # --- Case group 7b: a local-path remote names no owner -----------------------
 # A git remote is often a plain filesystem path, and a path's first segment is a
 # directory, not an owner. Reporting one would be a fabricated fact carrying an


### PR DESCRIPTION
## Summary

Two wrong facts `portfolio-facts.sh` emitted, both found by the fresh-context acceptance verifier for #3816 after PR #3901 had already merged. Both matter more than an ordinary wrong value because the collector's whole contract is "`unknown` for anything underivable, never a guess" — and one of them shipped a fabricated value with a citation attached.

## Fix

**A local-path remote no longer produces an owner.** A git remote is often a plain filesystem path, and a path's first segment is a directory, not a hosting account. `remote_owner` stripped it unconditionally:

| remote | reported owner (before) | after |
|---|---|---|
| `/srv/code/platform/billing` | `srv` | `unknown` |
| `/home/operator/repos/target` | `home` | `unknown` |
| `file:///home/operator/repos/target` | `home` | `unknown` |
| `../sibling/repo` | `sibling` | `unknown` |
| `ssh://git@github.com/acme/x` | `acme` | `acme` (unchanged) |
| `git@example.invalid:owner/repo.git` | `owner` | `owner` (unchanged) |

Each fabricated owner was emitted with `evidence.owner: "origin remote URL"`, so a made-up fact carried a provenance line — worse than the wrong value alone, because the evidence object exists precisely so a reader can trust what it cites. The old guard rejected only `""`, `.`, `..` and non-`[A-Za-z0-9._-]` segments, which caught Windows drive letters and nothing else. `remote_owner` now **requires a host**: either a `scheme://host/...` authority (rejecting the empty authority of `file:///path`) or the scp-style `host:owner/repo` (rejecting a colon that appears after a slash, which is a path).

**A nested member no longer shadows the top-level `dependencies`.** `json_object_keys` used `index(buf, "\"dependencies\"")`, the first *textual* occurrence anywhere in the file. A `pnpm.overrides.dependencies` block appears earlier in the byte stream than the real member, so:

```json
{
  "pnpm": { "overrides": { "dependencies": { "ghost-from-nested": "1.0.0" } } },
  "dependencies": { "real-dep-a": "^1.0.0", "real-dep-b": "^2.0.0" }
}
```

reported `["ghost-from-nested"]` and silently dropped both real dependencies — again under `evidence.dependencies: "package.json (dependencies + peerDependencies)"`. The reader now locates the member **by position** with a container stack, so only a genuine top-level member matches. (`devDependencies` and `peerDependenciesMeta` never false-matched; the leading quote and case made them safe.)

**Test gaps closed.** The same review noted that `path` was never asserted and that nothing checked the citation drops when the owner is unknown. Both are now covered, alongside regression cases for the two bugs. The path-remote fixture is deliberately **relative**: an MSYS bash rewrites a POSIX-absolute argument into `C:/Program Files/Git/...` before git ever sees it, so an absolute fixture would assert different strings on different platforms. That is exactly how the first draft of this test failed, and the mangled value is itself rejected by the fix.

## Verification

- `portfolio-facts.test.sh`: **54 cases, 0 failed** (was 44; +10 covering both bugs and the two assertion gaps).
- `shellcheck`: clean, exit 0.
- `check-fixture-git-isolation.sh --check`: `OK (128 isolated, 0 baselined)`.
- `validate-plugin-contracts.mjs`: `54 setup skills, 3 retirement manifests, and 3361 plugin files checked`.
- `markdownlint-cli2` on the changed markdown: `0 issues`.
- Version `0.7.1` with a matching `## [0.7.1]` CHANGELOG entry, newest-first.

No SKILL body changes: both bugs are contained to the collector script, and the skill's documented contract already said `unknown` was the right answer in these cases. The script simply was not honoring it.

## Related

- Refs #3816 (closed by #3901; these are post-merge findings against it, not a reopening).
- Follows #3901, which introduced `portfolio-facts.sh`.
- Does not close: the dependency-cap ordering the same review raised as MINOR (a multi-project .NET repo's `ProjectReference` paths sort before package ids and can consume the whole 25-item cap). That is spec-conformant — the issue asks for both sources, sorted and capped — so changing it is a contract decision, not a bug fix, and is left alone here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012jiwedVq2GxuzN7siXQbr4
