### PR TITLE
feat(rendered-views): loop-closure and export snippets for interactive views (#3607)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1470,6 +1470,13 @@ jobs:
       - name: Check rendered-view HTML assets
         if: needs.changes.outputs.run_tests == 'true'
         run: scripts/check-html-assets.sh
+      # The loop-closure snippet reference is copied verbatim by every adopting
+      # lane, so its shared helpers get a behavioral suite on top of the markup
+      # lint above: markup linting cannot tell whether esc still escapes the
+      # single quote or whether safeHref still refuses a javascript: URL.
+      - name: Test the loop-closure snippet helpers
+        if: needs.changes.outputs.run_tests == 'true'
+        run: bash scripts/check-loop-closure-helpers.test.sh
       # scripts/lib/changed-files.sh is the base-ref and changed-file resolver
       # the checker gates share. Its NUL-safety cases are the invariant four of
       # those gates had diverged on (#2914), and no caller suite exercises a

--- a/docs/conventions/rendered-views/README.md
+++ b/docs/conventions/rendered-views/README.md
@@ -140,9 +140,20 @@ escaping, so this baseline is authoring discipline until the deterministic helpe
   repo's files) MUST NOT ship on this skeleton alone: it is gated on the checked-in
   deterministic escape helper with a generator-marker a validator can check (tracked as
   the wave-2 issue; the review-plugin PR explainer is the first gated lane).
+- Escaping reaches text and quoted-attribute positions and nothing else. A value that
+  lands in URL position (`href`, `src`, `action`, `formaction`, SVG `xlink:href`) is
+  checked against a scheme allowlist BEFORE it is escaped: `javascript:` and `data:`
+  carry none of the escaped characters, so they pass through escaping unchanged and
+  still execute. An export builds a `Blob` and an object URL rather than concatenating
+  content into a `data:` URL, and reduces any filename it puts in a `download`
+  attribute to an allowlisted character set. Working helpers for all three positions
+  are in the loop-closure snippet reference below.
 
 Checked-in `.html` assets are validated by `scripts/check-html-assets.sh` (registration
-manifest plus pinned htmlhint), wired into CI.
+manifest plus pinned htmlhint), wired into CI. Markup linting still validates syntax
+rather than escaping, so an asset whose job is to carry copied helpers also carries a
+behavioral suite: `scripts/check-loop-closure-helpers.test.sh` executes the shipped
+helpers of the loop-closure reference and fails on a dropped case that lints clean.
 
 ## Accessibility floor
 
@@ -151,6 +162,49 @@ keyboard reach) lives in the shared chrome reference and is provisional until th
 design-system vertical revisits it cross-genre. Accessibility is a named, sanctioned
 reason to prefer markdown over a rendered view: when a reader's tooling or needs make the
 markdown record the better deliverable, flipping back is conformant, not a deviation.
+
+## Loop closure and the export obligation
+
+A rendered view that only shows things is a dead end: the reader has to retype what they
+picked. Loop closure is the family of patterns that hands the reader a terse payload to
+give back; export is the pattern that gets live page state off the page.
+
+**When a view owes an export.** A custom editor always ends with one: a view that lets a
+person change state and then offers no way to get that state out has thrown the work
+away. A view that asks the reader to choose, rank, accept, or correct owes a loop-closure
+payload for the same reason. A view that only presents owes neither.
+
+**Where the family belongs.** Editors, explorations and option spreads, and
+unknowns-lifecycle pages. It is excluded from the writeup and report genre by design,
+which is a decision the corpus already made, not an omission: a report is read, not
+answered, and a lane that bolts a resonate token onto a post-mortem is contradicting the
+genre rather than improving it. A dual-audience report whose markdown record is the
+deliverable stays on that record.
+
+**Why the payloads stay terse.** The artifact is still on screen while the reader
+answers, so the agent re-anchors by number or token rather than by a restated body. A
+payload that repeats the page's content back is not a richer loop closure, it is the
+pattern broken.
+
+The five escalating payload shapes, cheapest first: numbered resonate tokens;
+chip-assembled replies; generated follow-up prompts; accept-and-correct sign-off tokens;
+live-state exports. A view may carry more than one, and adding a rung the reader did not
+need is overproduction: this section names an obligation, not a floor to hit on every
+page.
+
+## The loop-closure and export snippet reference
+
+Canonical copy: `plugins/visualization/reference/html-loop-closure.html`, carried and
+shared on the same terms as the chrome reference below (byte-identical copy at
+`reference/html-loop-closure.html` in a second adopting plugin, registered in
+`scripts/cross-plugin-source-registry.txt` in that same change; unregistered while only
+one plugin carries it). It holds the four shared helpers every pattern is built from,
+including the clipboard boilerplate each interactive page otherwise duplicates, and one
+runnable demo per payload shape.
+
+It is reference material, not a skill: it owns no page shape, and each adopting lane
+keeps its own layout, vocabulary, and genre. Adopting it is a per-lane change, and this
+convention's instruction-size budget applies to the lines a lane adds for it.
 
 ## The shared chrome reference
 

--- a/plugins/visualization/.claude-plugin/plugin.json
+++ b/plugins/visualization/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "visualization",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "On-demand visualization router: infers what in the current conversation should be shown visually, then decides the best FORM (a mermaid diagram, a markdown table, a hand-authored SVG/CSS chart, ASCII/Unicode art, a rich rendered page — or, where the bundled design skill is available, a hand-editable design canvas) and the best MEDIUM (inline terminal, a local HTML file, or a published Artifact) via a decision matrix over content shape, complexity, and a configurable medium preference. Renders good defaults and asks only when the target is genuinely ambiguous and no form was named. A form-and-medium decision layer in front of the craft capabilities — it routes chart craft and artifact-design fundamentals to those capabilities when installed and never restates them.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/visualization/CHANGELOG.md
+++ b/plugins/visualization/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to the `visualization` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.5.2]
+
+### Added
+
+- **Loop-closure and export snippet reference**, `reference/html-loop-closure.html`, the
+  second shared rendered-view piece this plugin carries beside the chrome reference. It
+  holds four shared helpers (`esc` for the convention's escape set in text and attribute
+  positions; `copyText`, the clipboard write-fallback-flash boilerplate every interactive
+  page otherwise duplicates; `safeHref` for URL position, which refuses `javascript:`,
+  `data:`, and relative URLs; `safeFilename` for a `download` attribute) plus
+  `downloadText`, which exports through a `Blob` and an object URL rather than a `data:`
+  URL. Five runnable demos cover the escalating loop-closure payload shapes: numbered
+  resonate tokens, chip-assembled replies, generated follow-up prompts,
+  accept-and-correct sign-off, and live-state export. The page is reference material and
+  owns no page shape; `visualize` itself is unchanged and adopts nothing here.
+
 ## [0.5.1]
 
 ### Changed

--- a/plugins/visualization/CHANGELOG.md
+++ b/plugins/visualization/CHANGELOG.md
@@ -12,7 +12,8 @@ All notable changes to the `visualization` plugin are documented here. Format fo
   holds four shared helpers (`esc` for the convention's escape set in text and attribute
   positions; `copyText`, the clipboard write-fallback-flash boilerplate every interactive
   page otherwise duplicates; `safeHref` for URL position, which refuses `javascript:`,
-  `data:`, and relative URLs; `safeFilename` for a `download` attribute) plus
+  `data:`, and relative URLs, and HTML-escapes a bare `#fragment` so a quote cannot
+  break out of a quoted `href` attribute; `safeFilename` for a `download` attribute) plus
   `downloadText`, which exports through a `Blob` and an object URL rather than a `data:`
   URL. Five runnable demos cover the escalating loop-closure payload shapes: numbered
   resonate tokens, chip-assembled replies, generated follow-up prompts,

--- a/plugins/visualization/reference/html-loop-closure.html
+++ b/plugins/visualization/reference/html-loop-closure.html
@@ -1,0 +1,598 @@
+<!doctype html>
+<!--
+  html-loop-closure.html: the marketplace's loop-closure and export snippet
+  reference for interactive rendered HTML views (the rendered-views
+  convention's second sanctioned shared piece, beside html-chrome.html).
+
+  What it is for. A rendered view that only shows things is a dead end: the
+  reader has to retype what they picked. Loop closure is the family of patterns
+  that gives the reader a terse payload to hand back, and export is the pattern
+  that gets live page state off the page. Skills that emit an interactive view
+  copy the helpers and one or more patterns from here and shape the page
+  themselves; this file owns no page shape, and adopting it is a per-lane
+  change.
+
+  Doctrine. The rendered-views convention owns when a view owes an export and
+  which genres this family is excluded from: docs/conventions/rendered-views/
+  README.md, "Loop closure and the export obligation".
+
+  Security. The rendered-views convention's "Security baseline" owns the
+  escaping and self-containment rules; this file does not restate them, it
+  demonstrates them. Two positions that rule's character set does not reach are
+  handled by the safeHref and safeFilename helpers below, and are called out in
+  the "Positions escaping does not reach" panel.
+
+  Provenance. The pattern family is the one the rendered-views convention's
+  corpus distillate names (item 3 of the nine cross-cutting families) plus the
+  clipboard boilerplate (item 4). The helpers and demos here are written for
+  this repository; no working loop-closure or export code existed in it to
+  extract.
+
+  Accessibility floor and tokens: taken from html-chrome.html, which stays the
+  canonical copy of both. The token block below is the subset this page needs
+  so it renders standalone; html-chrome.html governs any disagreement.
+
+  Sharing contract: this is the canonical copy. A second plugin adopting it
+  copies the file byte-identical to the same path within its own plugin root
+  (reference/html-loop-closure.html) and registers the cluster in
+  scripts/cross-plugin-source-registry.txt; the drift checker rejects a
+  registration while only one plugin carries it.
+-->
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Rendered-views loop-closure and export reference</title>
+<style>
+  :root {
+    --ivory: #FAF9F5;
+    --slate: #141413;
+    --clay: #D97757;
+    --oat: #E3DACC;
+    --olive: #788C5D;
+    --white: #FFFFFF;
+    --gray-100: #F0EEE6;
+    --gray-300: #D1CFC5;
+    --gray-500: #87867F;
+    --gray-700: #3D3D3A;
+    --serif: ui-serif, Georgia, serif;
+    --sans: system-ui, -apple-system, sans-serif;
+    --mono: ui-monospace, 'SF Mono', Menlo, monospace;
+    --clay-deep: #A0512E;
+    --clay-soft: #E89B7E;
+    --radius-panel: 12px;
+    --radius-row: 8px;
+    --border: 1.5px solid var(--gray-300);
+    --bg: var(--ivory);
+    --fg: var(--slate);
+    --panel: var(--white);
+    --muted: var(--gray-500);
+    --link: var(--clay-deep);
+    --focus: var(--clay-deep);
+    --code-bg: var(--gray-100);
+    --code-fg: var(--slate);
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --bg: var(--slate);
+      --fg: var(--ivory);
+      --panel: var(--gray-700);
+      --muted: var(--gray-300);
+      --border: 1.5px solid var(--gray-500);
+      --link: var(--clay-soft);
+      --focus: var(--clay-soft);
+      --code-bg: #23231F;
+      --code-fg: var(--ivory);
+    }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    * { animation: none !important; transition: none !important; }
+  }
+  html { color-scheme: light dark; }
+  body {
+    margin: 0 auto; max-width: 880px; padding: 2rem 1.25rem 4rem;
+    background: var(--bg); color: var(--fg);
+    font-family: var(--sans); line-height: 1.55;
+  }
+  h1, h2, h3 { font-family: var(--serif); font-weight: 600; }
+  h1 { font-size: 1.7rem; margin-bottom: .25rem; }
+  h2 { font-size: 1.2rem; margin-top: 2.4rem; border-bottom: var(--border); padding-bottom: .3rem; }
+  h3 { font-size: 1rem; margin-top: 1.6rem; margin-bottom: .4rem; }
+  p.lead { color: var(--muted); margin-top: 0; }
+  .panel {
+    background: var(--panel); border: var(--border);
+    border-radius: var(--radius-panel); padding: 1rem 1.25rem; margin: 1rem 0;
+  }
+  .demo { border-left: 4px solid var(--olive); }
+  .note { border-left: 4px solid var(--clay); }
+  code, .mono { font-family: var(--mono); font-size: .9em; }
+  pre {
+    font-family: var(--mono); font-size: .82rem; line-height: 1.5;
+    background: var(--code-bg); color: var(--code-fg);
+    border: var(--border); border-radius: var(--radius-row);
+    padding: .8rem .9rem; overflow-x: auto; margin: .6rem 0 0;
+  }
+  a { color: var(--link); }
+  a:focus-visible, button:focus-visible, input:focus-visible,
+  textarea:focus-visible, [tabindex]:focus-visible {
+    outline: 3px solid var(--focus); outline-offset: 2px; border-radius: 2px;
+  }
+  button {
+    font: inherit; font-size: .85rem; cursor: pointer;
+    background: var(--panel); color: var(--fg);
+    border: var(--border); border-radius: var(--radius-row);
+    padding: .3rem .7rem;
+  }
+  button[aria-pressed="true"] {
+    background: var(--oat); color: var(--slate); border-color: var(--clay-deep);
+  }
+  input[type="text"] {
+    font: inherit; font-size: .85rem; background: var(--panel); color: var(--fg);
+    border: var(--border); border-radius: var(--radius-row); padding: .25rem .5rem;
+  }
+  .row { display: flex; flex-wrap: wrap; gap: .5rem; align-items: center; margin: .5rem 0; }
+  .flash { font-size: .82rem; color: var(--olive); font-weight: 600; min-height: 1.2em; }
+  .payload {
+    font-family: var(--mono); font-size: .85rem; word-break: break-word;
+    background: var(--code-bg); color: var(--code-fg);
+    border: var(--border); border-radius: var(--radius-row); padding: .5rem .6rem;
+  }
+  ol.numbered { padding-left: 1.4rem; }
+  ol.numbered li { margin: .3rem 0; }
+  textarea {
+    font: inherit; font-size: .85rem; width: 100%; box-sizing: border-box;
+    background: var(--panel); color: var(--fg); border: var(--border);
+    border-radius: var(--radius-row); padding: .4rem .5rem;
+  }
+  table { border-collapse: collapse; width: 100%; font-size: .92rem; }
+  th, td { text-align: left; border-bottom: 1px solid var(--gray-300); padding: .45rem .5rem; vertical-align: top; }
+  th { font-family: var(--sans); font-weight: 600; }
+</style>
+</head>
+<body>
+<h1>Loop-closure and export reference</h1>
+<p class="lead">Snippets an interactive rendered view copies so the reader can hand something back, and so live page state can leave the page. Self-contained: no external links, scripts, fonts, or images. Every demo below runs from this file alone.</p>
+
+<div class="panel note">
+  <p><strong>Doctrine lives in the convention, not here.</strong> When a view owes an export, which genres this family is excluded from, and why payloads stay terse are stated in <code>docs/conventions/rendered-views/README.md</code>, section &quot;Loop closure and the export obligation&quot;. The escaping and self-containment rules are that document's &quot;Security baseline&quot;. This file demonstrates both and owns neither.</p>
+  <p><strong>These snippets own no page shape.</strong> Each adopting lane keeps its own layout, vocabulary, and genre. Copy a helper and a pattern; do not copy this page.</p>
+</div>
+
+<h2>The four shared helpers</h2>
+<p>Every pattern below is built from these four and nothing else. Copy all four, or the subset a pattern names. The snippet blocks in this section are printed from the live functions this page is running, so what you read is what executes.</p>
+
+<h3>esc: the one interpolation path</h3>
+<p>Use it for every value that reaches markup, in text and in a quoted attribute alike. <code>&amp;</code> is replaced first, so an already-escaped entity is not double-decoded. The safer path is still not to interpolate at all: <code>node.textContent = value</code> needs no escaping, and the patterns below prefer it wherever the value is a whole text node.</p>
+<pre id="src-esc"></pre>
+
+<h3>copyText: the clipboard boilerplate</h3>
+<p>One copy of the write-then-fall-back-then-flash sequence that every interactive page otherwise reinvents. The flash element is written with <code>textContent</code>, never <code>innerHTML</code>. It returns whether the copy landed, so a caller reports a failure instead of showing a false confirmation.</p>
+<pre id="src-copy"></pre>
+
+<h3>safeHref: URL position, which esc does not cover</h3>
+<p>Escaping keeps a value inside its attribute; it does not make the value safe to <em>navigate to</em>. <code>javascript:alert(1)</code> contains none of the characters the baseline escapes, so it survives <code>esc</code> unchanged and still runs on click. Any value that lands in <code>href</code>, <code>src</code>, <code>action</code>, <code>formaction</code>, or SVG <code>xlink:href</code> is scheme-checked first and escaped second. A relative URL is rejected too: a self-contained view has nothing to resolve it against.</p>
+<pre id="src-href"></pre>
+
+<h3>downloadText: export without a data URL</h3>
+<p>Exports build a <code>Blob</code> and an object URL rather than concatenating content into a <code>data:</code> URL. A data URL puts the payload in URL position, where it needs percent-encoding rather than HTML escaping, and <code>data:text/html</code> in particular runs script. The object URL is minted by the browser from bytes, so no input reaches the URL string, and it is revoked once the click is dispatched. The download filename is reader-reachable too, so it is reduced to an allowlisted character set before it becomes an attribute.</p>
+<pre id="src-download"></pre>
+<pre id="src-filename"></pre>
+
+<div class="panel note">
+  <p><strong>Positions escaping does not reach.</strong> The convention's character-escape rule covers text and quoted-attribute positions. It does not cover URL position (use <code>safeHref</code>), a download filename (use <code>safeFilename</code>), an unquoted attribute (always quote), a value inside <code>&lt;script&gt;</code> or <code>&lt;style&gt;</code> (never interpolate there, per the baseline), or a CSS <code>url()</code>. A view that needs one of those and has no helper for it emits the value as visible text instead.</p>
+</div>
+
+<h2>Pattern 1: numbered resonate tokens</h2>
+<p>The cheapest rung. Items carry stable visible numbers; the reader names the numbers back in chat. The page needs no state and no script beyond the render. Reach for this when the reader is picking from a list you already had to show.</p>
+<div class="panel demo">
+  <ol class="numbered" id="p1-list"></ol>
+  <p class="lead">Reply with the numbers that resonate, for example <code>2, 4</code>.</p>
+</div>
+<pre id="src-p1"></pre>
+
+<h2>Pattern 2: chip-assembled reply</h2>
+<p>The reader toggles chips and the page assembles the terse payload for them. Use it when the reply has a fixed vocabulary the reader should not have to spell. The payload stays short on purpose: the page is still on screen, so the agent re-anchors by token rather than by a restated body.</p>
+<div class="panel demo">
+  <div class="row" id="p2-chips"></div>
+  <div class="payload" id="p2-payload"></div>
+  <div class="row">
+    <button type="button" id="p2-copy">Copy reply</button>
+    <span class="flash" id="p2-flash" role="status" aria-live="polite"></span>
+  </div>
+</div>
+<pre id="src-p2"></pre>
+
+<h2>Pattern 3: generated follow-up prompts</h2>
+<p>The page writes the next prompt for the reader, one button per branch. Use it when the useful next moves are known at render time and typing them is the only friction. Each prompt is a whole text node, so it is set with <code>textContent</code> and never interpolated.</p>
+<div class="panel demo">
+  <div id="p3-list"></div>
+  <span class="flash" id="p3-flash" role="status" aria-live="polite"></span>
+</div>
+<pre id="src-p3"></pre>
+
+<h2>Pattern 4: accept and correct sign-off</h2>
+<p>The escalation for a view the reader approves rather than picks from. Every row is accepted or corrected; a correction carries free text, which is the first payload in this family that is not a token, and so the first that is untrusted on the way back out.</p>
+<div class="panel demo">
+  <div id="p4-rows"></div>
+  <div class="payload" id="p4-payload"></div>
+  <div class="row">
+    <button type="button" id="p4-copy">Copy sign-off</button>
+    <span class="flash" id="p4-flash" role="status" aria-live="polite"></span>
+  </div>
+</div>
+<pre id="src-p4"></pre>
+
+<h2>Pattern 5: live-state export</h2>
+<p>The top rung, and the one a custom editor always owes. The page holds state the reader changed, so the export reads that state and rebuilds the record: markdown, a diff, or plain text. Build the string from state, never by scraping <code>innerHTML</code>, and offer both rungs: the clipboard for a payload the reader pastes into chat, a file download for a payload that is a document.</p>
+<div class="panel demo">
+  <div id="p5-rows"></div>
+  <div class="row">
+    <button type="button" id="p5-copy">Copy markdown</button>
+    <button type="button" id="p5-download">Download .md</button>
+    <span class="flash" id="p5-flash" role="status" aria-live="polite"></span>
+  </div>
+  <pre id="p5-preview"></pre>
+</div>
+<pre id="src-p5"></pre>
+
+<h2>Choosing a rung</h2>
+<div class="panel">
+  <table>
+    <tr><th>The view asks the reader to</th><th>Pattern</th><th>Payload shape</th></tr>
+    <tr><td>Pick from things already listed</td><td>1, numbered tokens</td><td>Numbers typed in chat, no script</td></tr>
+    <tr><td>Answer with a fixed vocabulary</td><td>2, chips</td><td>One assembled line, copied</td></tr>
+    <tr><td>Choose a next move</td><td>3, follow-up prompts</td><td>A whole prompt, copied</td></tr>
+    <tr><td>Approve or amend a proposal</td><td>4, accept and correct</td><td>Tokens plus free-text corrections</td></tr>
+    <tr><td>Edit state the page holds</td><td>5, live-state export</td><td>A rebuilt record, copied or downloaded</td></tr>
+  </table>
+  <p>A view may carry more than one rung, and a custom editor carries rung 5 whatever else it carries. Adding a rung the reader did not need is overproduction: the convention's doctrine section names an obligation, not a floor to hit on every page.</p>
+</div>
+
+<script>
+"use strict";
+
+/* ---- the four shared helpers ---- */
+
+function esc(value) {
+  return String(value)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+async function copyText(text, flashEl) {
+  var ok = false;
+  try {
+    if (navigator.clipboard && window.isSecureContext) {
+      await navigator.clipboard.writeText(text);
+      ok = true;
+    }
+  } catch (err) {
+    ok = false;
+  }
+  if (!ok) {
+    var ta = document.createElement("textarea");
+    ta.value = text;
+    ta.setAttribute("readonly", "");
+    ta.style.position = "fixed";
+    ta.style.top = "-1000px";
+    document.body.appendChild(ta);
+    ta.select();
+    try {
+      ok = document.execCommand("copy");
+    } catch (err2) {
+      ok = false;
+    }
+    ta.remove();
+  }
+  if (flashEl) {
+    flashEl.textContent = ok ? "Copied" : "Copy failed. Select the payload and copy it.";
+    setTimeout(function () { flashEl.textContent = ""; }, 1600);
+  }
+  return ok;
+}
+
+function safeHref(value) {
+  var raw = String(value).trim();
+  if (raw.charAt(0) === "#") { return raw; }
+  var parsed;
+  try {
+    parsed = new URL(raw);
+  } catch (err) {
+    return "#";
+  }
+  var allowed = ["https:", "http:", "mailto:"];
+  return allowed.indexOf(parsed.protocol) === -1 ? "#" : parsed.href;
+}
+
+function safeFilename(name, fallback) {
+  var cleaned = String(name)
+    .replace(/[^A-Za-z0-9._-]+/g, "-")
+    .replace(/^[.-]+/, "")
+    .slice(0, 100);
+  return cleaned || fallback || "export.txt";
+}
+
+function downloadText(name, text, mime) {
+  var blob = new Blob([text], { type: (mime || "text/plain") + ";charset=utf-8" });
+  var url = URL.createObjectURL(blob);
+  var link = document.createElement("a");
+  link.href = url;
+  link.download = safeFilename(name, "export.txt");
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+  setTimeout(function () { URL.revokeObjectURL(url); }, 0);
+}
+
+/* ---- pattern snippets, printed into their pre blocks as text ---- */
+
+var SNIPPETS = {
+  "src-p1": [
+    "// Pattern 1: numbered resonate tokens. No state, no handlers.",
+    "// esc() guards the label; the number is the reader's handle.",
+    "var items = [",
+    "  { n: 1, label: 'Split the reader out of the parser' },",
+    "  { n: 2, label: 'Cache the resolved config per run' }",
+    "];",
+    "list.innerHTML = items.map(function (it) {",
+    "  return '<li value=\"' + esc(it.n) + '\">' + esc(it.label) + '<\\/li>';",
+    "}).join('');",
+    "// Then tell the reader how to answer, in the page:",
+    "//   \"Reply with the numbers that resonate, for example 2, 4.\""
+  ].join("\n"),
+  "src-p2": [
+    "// Pattern 2: chip-assembled reply. Chips are native buttons with",
+    "// aria-pressed, so keyboard reach and state come for free.",
+    "var chosen = [];",
+    "function render() {",
+    "  payloadEl.textContent = chosen.length",
+    "    ? 'focus: ' + chosen.join(', ')",
+    "    : 'focus: (nothing selected)';",
+    "}",
+    "vocab.forEach(function (token) {",
+    "  var b = document.createElement('button');",
+    "  b.type = 'button';",
+    "  b.textContent = token;               // no interpolation needed",
+    "  b.setAttribute('aria-pressed', 'false');",
+    "  b.addEventListener('click', function () {",
+    "    var at = chosen.indexOf(token);",
+    "    if (at === -1) { chosen.push(token); } else { chosen.splice(at, 1); }",
+    "    b.setAttribute('aria-pressed', String(at === -1));",
+    "    render();",
+    "  });",
+    "  chipRow.appendChild(b);",
+    "});",
+    "copyBtn.addEventListener('click', function () {",
+    "  copyText(payloadEl.textContent, flashEl);",
+    "});"
+  ].join("\n"),
+  "src-p3": [
+    "// Pattern 3: generated follow-up prompts. One button per branch.",
+    "// The prompt is a whole text node, so textContent replaces esc().",
+    "prompts.forEach(function (prompt) {",
+    "  var row = document.createElement('div');",
+    "  row.className = 'row';",
+    "  var text = document.createElement('span');",
+    "  text.className = 'mono';",
+    "  text.textContent = prompt;",
+    "  var btn = document.createElement('button');",
+    "  btn.type = 'button';",
+    "  btn.textContent = 'Copy';",
+    "  btn.addEventListener('click', function () { copyText(prompt, flashEl); });",
+    "  row.appendChild(btn);",
+    "  row.appendChild(text);",
+    "  listEl.appendChild(row);",
+    "});"
+  ].join("\n"),
+  "src-p4": [
+    "// Pattern 4: accept and correct sign-off. The correction text is",
+    "// reader input on the way back out: it is a text node here, and it",
+    "// would need esc() if it were ever interpolated into markup.",
+    "function payload() {",
+    "  var accepted = rows.filter(function (r) { return r.state === 'accept'; })",
+    "    .map(function (r) { return r.n; });",
+    "  var parts = [];",
+    "  if (accepted.length) { parts.push('ACCEPT ' + accepted.join(',')); }",
+    "  rows.filter(function (r) { return r.state === 'correct'; })",
+    "    .forEach(function (r) {",
+    "      parts.push('CORRECT ' + r.n + ': ' + (r.text || '(no text)'));",
+    "    });",
+    "  return parts.length ? parts.join(' | ') : '(nothing signed off)';",
+    "}",
+    "payloadEl.textContent = payload();"
+  ].join("\n"),
+  "src-p5": [
+    "// Pattern 5: live-state export. Build the record from STATE, never",
+    "// by scraping innerHTML, and offer both rungs.",
+    "function buildMarkdown() {",
+    "  return ['# Review notes', ''].concat(rows.map(function (r) {",
+    "    return '- [' + (r.done ? 'x' : ' ') + '] ' + r.title +",
+    "           (r.note ? ' -- ' + r.note : '');",
+    "  })).join('\\n') + '\\n';",
+    "}",
+    "copyBtn.addEventListener('click', function () {",
+    "  copyText(buildMarkdown(), flashEl);",
+    "});",
+    "downloadBtn.addEventListener('click', function () {",
+    "  downloadText('review-notes.md', buildMarkdown(), 'text/markdown');",
+    "});"
+  ].join("\n")
+};
+
+/* ---- render the helper sources and the pattern snippets ---- */
+
+function printSource(id, fn) {
+  document.getElementById(id).textContent = fn.toString();
+}
+
+printSource("src-esc", esc);
+printSource("src-copy", copyText);
+printSource("src-href", safeHref);
+printSource("src-download", downloadText);
+printSource("src-filename", safeFilename);
+
+Object.keys(SNIPPETS).forEach(function (id) {
+  document.getElementById(id).textContent = SNIPPETS[id];
+});
+
+/* ---- live demos ---- */
+
+// Pattern 1. The labels carry markup-ish and quote characters on purpose:
+// that is what a real repo-derived label looks like, and esc() is what keeps
+// them visible text.
+var p1Items = [
+  { n: 1, label: "Split the reader out of the parser" },
+  { n: 2, label: "Cache the resolved config per run" },
+  { n: 3, label: "Name the <timeout> knob in one place" },
+  { n: 4, label: "Drop the \"legacy\" branch in loader's fallback" }
+];
+document.getElementById("p1-list").innerHTML = p1Items.map(function (it) {
+  return '<li value="' + esc(it.n) + '">' + esc(it.label) + '<\/li>';
+}).join("");
+
+// Pattern 2.
+var p2Chosen = [];
+var p2Payload = document.getElementById("p2-payload");
+function p2Render() {
+  p2Payload.textContent = p2Chosen.length
+    ? "focus: " + p2Chosen.join(", ")
+    : "focus: (nothing selected)";
+}
+["perf", "api-shape", "tests", "naming", "docs"].forEach(function (token) {
+  var b = document.createElement("button");
+  b.type = "button";
+  b.textContent = token;
+  b.setAttribute("aria-pressed", "false");
+  b.addEventListener("click", function () {
+    var at = p2Chosen.indexOf(token);
+    if (at === -1) { p2Chosen.push(token); } else { p2Chosen.splice(at, 1); }
+    b.setAttribute("aria-pressed", String(at === -1));
+    p2Render();
+  });
+  document.getElementById("p2-chips").appendChild(b);
+});
+p2Render();
+document.getElementById("p2-copy").addEventListener("click", function () {
+  copyText(p2Payload.textContent, document.getElementById("p2-flash"));
+});
+
+// Pattern 3.
+var p3Flash = document.getElementById("p3-flash");
+[
+  "Take option 2 and sketch the interface twice.",
+  "Show me what breaks if the cache is per process.",
+  "Write the failing test for the timeout knob first."
+].forEach(function (prompt) {
+  var row = document.createElement("div");
+  row.className = "row";
+  var text = document.createElement("span");
+  text.className = "mono";
+  text.textContent = prompt;
+  var btn = document.createElement("button");
+  btn.type = "button";
+  btn.textContent = "Copy";
+  btn.addEventListener("click", function () { copyText(prompt, p3Flash); });
+  row.appendChild(btn);
+  row.appendChild(text);
+  document.getElementById("p3-list").appendChild(row);
+});
+
+// Pattern 4.
+var p4Rows = [
+  { n: 1, title: "Extract the resolver", state: "accept", text: "" },
+  { n: 2, title: "Inline the two-line wrapper", state: "accept", text: "" }
+];
+var p4Payload = document.getElementById("p4-payload");
+function p4Build() {
+  var accepted = p4Rows.filter(function (r) { return r.state === "accept"; })
+    .map(function (r) { return r.n; });
+  var parts = [];
+  if (accepted.length) { parts.push("ACCEPT " + accepted.join(",")); }
+  p4Rows.filter(function (r) { return r.state === "correct"; })
+    .forEach(function (r) {
+      parts.push("CORRECT " + r.n + ": " + (r.text || "(no text)"));
+    });
+  p4Payload.textContent = parts.length ? parts.join(" | ") : "(nothing signed off)";
+}
+p4Rows.forEach(function (r) {
+  var wrap = document.createElement("div");
+  var row = document.createElement("div");
+  row.className = "row";
+  var label = document.createElement("span");
+  label.textContent = r.n + ". " + r.title;
+  var accept = document.createElement("button");
+  accept.type = "button";
+  accept.textContent = "Accept";
+  var correct = document.createElement("button");
+  correct.type = "button";
+  correct.textContent = "Correct";
+  var box = document.createElement("textarea");
+  box.rows = 2;
+  box.hidden = true;
+  box.setAttribute("aria-label", "Correction for item " + r.n);
+  function sync() {
+    accept.setAttribute("aria-pressed", String(r.state === "accept"));
+    correct.setAttribute("aria-pressed", String(r.state === "correct"));
+    box.hidden = r.state !== "correct";
+    p4Build();
+  }
+  accept.addEventListener("click", function () { r.state = "accept"; sync(); });
+  correct.addEventListener("click", function () { r.state = "correct"; sync(); });
+  box.addEventListener("input", function () { r.text = box.value; p4Build(); });
+  row.appendChild(label);
+  row.appendChild(accept);
+  row.appendChild(correct);
+  wrap.appendChild(row);
+  wrap.appendChild(box);
+  document.getElementById("p4-rows").appendChild(wrap);
+  sync();
+});
+
+// Pattern 5.
+var p5Rows = [
+  { title: "Resolver extracted", note: "", done: true },
+  { title: "Timeout knob named once", note: "", done: false }
+];
+var p5Preview = document.getElementById("p5-preview");
+function p5BuildMarkdown() {
+  return ["# Review notes", ""].concat(p5Rows.map(function (r) {
+    return "- [" + (r.done ? "x" : " ") + "] " + r.title +
+      (r.note ? " -- " + r.note : "");
+  })).join("\n") + "\n";
+}
+function p5Sync() { p5Preview.textContent = p5BuildMarkdown(); }
+p5Rows.forEach(function (r, index) {
+  var row = document.createElement("div");
+  row.className = "row";
+  var box = document.createElement("input");
+  box.type = "checkbox";
+  box.checked = r.done;
+  box.id = "p5-done-" + index;
+  var label = document.createElement("label");
+  label.setAttribute("for", box.id);
+  label.textContent = r.title;
+  var note = document.createElement("input");
+  note.type = "text";
+  note.placeholder = "note";
+  note.setAttribute("aria-label", "Note for " + r.title);
+  box.addEventListener("change", function () { r.done = box.checked; p5Sync(); });
+  note.addEventListener("input", function () { r.note = note.value; p5Sync(); });
+  row.appendChild(box);
+  row.appendChild(label);
+  row.appendChild(note);
+  document.getElementById("p5-rows").appendChild(row);
+});
+p5Sync();
+var p5Flash = document.getElementById("p5-flash");
+document.getElementById("p5-copy").addEventListener("click", function () {
+  copyText(p5BuildMarkdown(), p5Flash);
+});
+document.getElementById("p5-download").addEventListener("click", function () {
+  downloadText("review-notes.md", p5BuildMarkdown(), "text/markdown");
+});
+</script>
+</body>
+</html>

--- a/plugins/visualization/reference/html-loop-closure.html
+++ b/plugins/visualization/reference/html-loop-closure.html
@@ -296,7 +296,8 @@ async function copyText(text, flashEl) {
 
 function safeHref(value) {
   var raw = String(value).trim();
-  if (raw.charAt(0) === "#") { return raw; }
+  // Bare fragments skip new URL(); esc so a quote cannot close a quoted href.
+  if (raw.charAt(0) === "#") { return esc(raw); }
   var parsed;
   try {
     parsed = new URL(raw);

--- a/scripts/check-html-assets.sh
+++ b/scripts/check-html-assets.sh
@@ -44,6 +44,7 @@ if [[ -n "${HTML_ASSETS_MANIFEST:-}" ]]; then
 else
   assets=(
     plugins/visualization/reference/html-chrome.html
+    plugins/visualization/reference/html-loop-closure.html
   )
 fi
 

--- a/scripts/check-loop-closure-helpers.test.sh
+++ b/scripts/check-loop-closure-helpers.test.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# Behavioral tests for the shared helpers carried by the loop-closure snippet
+# reference, plugins/visualization/reference/html-loop-closure.html.
+#
+#   bash scripts/check-loop-closure-helpers.test.sh
+#
+# WHY THIS EXISTS. That asset is a SNIPPET surface: every skill that adopts a
+# loop-closure or export pattern copies its helpers verbatim, so a helper that
+# silently loses a case is inherited by every copy and caught by nothing. The
+# html-assets gate lints the file's MARKUP; markup linting says nothing about
+# whether esc still escapes the single quote or whether safeHref still refuses
+# a javascript: URL. This suite is the discriminating check on the behavior.
+#
+# The helpers are extracted from the live asset between the two comment
+# markers the file uses to bound them, so this suite tests the shipped text
+# rather than a copy. Losing a marker fails the suite loudly.
+#
+# Exit 0 clean, 1 findings, 2 environment (node missing, markers missing).
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 2
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)" || exit 2
+ASSET="$REPO_ROOT/plugins/visualization/reference/html-loop-closure.html"
+
+if ! command -v node >/dev/null 2>&1; then
+  echo "check-loop-closure-helpers: node not found on PATH" >&2
+  exit 2
+fi
+if [[ ! -f "$ASSET" ]]; then
+  echo "check-loop-closure-helpers: asset missing at $ASSET" >&2
+  exit 2
+fi
+
+work="$(mktemp -d)" || exit 2
+trap 'rm -rf "$work"' EXIT
+
+cat >"$work/driver.mjs" <<'NODE'
+import { readFileSync } from "node:fs";
+
+const asset = process.argv[2];
+const src = readFileSync(asset, "utf8");
+
+let pass = 0;
+let fail = 0;
+const ok = (label) => { pass += 1; console.log(`ok: ${label}`); };
+const bad = (label) => { fail += 1; console.error(`FAIL: ${label}`); };
+const check = (cond, label) => (cond ? ok(label) : bad(label));
+
+// --- extract the helper block from the shipped asset ---------------------
+const OPEN = "/* ---- the four shared helpers ---- */";
+const CLOSE = "/* ---- pattern snippets, printed into their pre blocks as text ---- */";
+const from = src.indexOf(OPEN);
+const to = src.indexOf(CLOSE);
+if (from === -1 || to === -1 || to <= from) {
+  console.error("check-loop-closure-helpers: helper block markers not found in the asset");
+  process.exit(2);
+}
+const helpers = src.slice(from + OPEN.length, to);
+
+// esc, safeHref and safeFilename are pure; copyText and downloadText touch the
+// DOM, so they are asserted at source level below rather than executed.
+const factory = new Function(`${helpers}\nreturn { esc, safeHref, safeFilename, copyText, downloadText };`);
+const { esc, safeHref, safeFilename, copyText, downloadText } = factory();
+
+// --- esc: every character the convention's baseline names ----------------
+const escaped = {
+  "&": "&amp;",
+  "<": "&lt;",
+  ">": "&gt;",
+  '"': "&quot;",
+  "'": "&#39;",
+};
+for (const [raw, want] of Object.entries(escaped)) {
+  check(esc(raw) === want, `esc escapes ${JSON.stringify(raw)} to ${want}`);
+}
+check(esc("&lt;") === "&amp;lt;", "esc replaces & first, so an entity is not double-decoded");
+check(esc(null) === "null", "esc coerces a non-string rather than throwing");
+// The single-quote case is the one an attribute breakout needs: a value
+// dropped into a single-quoted attribute must not be able to close it.
+check(
+  !esc("' onclick='alert(1)").includes("'"),
+  "esc leaves no raw single quote that could close a single-quoted attribute",
+);
+check(
+  !esc('" onclick="alert(1)').includes('"'),
+  "esc leaves no raw double quote that could close a double-quoted attribute",
+);
+
+// --- safeHref: scheme hazards escaping cannot reach ----------------------
+const rejected = [
+  "javascript:alert(1)",
+  "JavaScript:alert(1)",
+  "  javascript:alert(1)  ",
+  "java\tscript:alert(1)",
+  "data:text/html,<script>alert(1)</" + "script>",
+  "vbscript:msgbox(1)",
+  "file:///etc/passwd",
+  "relative/page.html",
+];
+for (const value of rejected) {
+  check(safeHref(value) === "#", `safeHref refuses ${JSON.stringify(value)}`);
+}
+check(safeHref("#section-2") === "#section-2", "safeHref passes a fragment through");
+check(safeHref("https://example.com/x").startsWith("https://"), "safeHref allows https");
+check(safeHref("mailto:a@example.com").startsWith("mailto:"), "safeHref allows mailto");
+// A rejected scheme must also survive the escape pass without reappearing.
+check(esc(safeHref("javascript:alert(1)")) === "#", "a refused URL stays refused after esc");
+
+// --- safeFilename: the download attribute --------------------------------
+check(!safeFilename("../../etc/passwd").includes("/"), "safeFilename drops path separators");
+check(!safeFilename("a\\b.md").includes("\\"), "safeFilename drops backslashes");
+check(!safeFilename('x" onfocus="y.md').includes('"'), "safeFilename drops quotes");
+check(safeFilename("") === "export.txt", "safeFilename falls back when nothing survives");
+check(safeFilename("...").startsWith("export"), "safeFilename refuses a leading-dot-only name");
+check(safeFilename("review-notes.md") === "review-notes.md", "safeFilename keeps an ordinary name");
+check(safeFilename("x".repeat(500)).length <= 100, "safeFilename caps the length");
+
+// --- source-level assertions on the two DOM helpers ----------------------
+const copySrc = copyText.toString();
+check(copySrc.includes("navigator.clipboard"), "copyText uses the async clipboard write");
+check(copySrc.includes("execCommand"), "copyText keeps the execCommand fallback");
+check(copySrc.includes("textContent"), "copyText writes its flash with textContent");
+check(!copySrc.includes("innerHTML"), "copyText never writes its flash with innerHTML");
+
+const downloadSrc = downloadText.toString();
+check(downloadSrc.includes("new Blob("), "downloadText builds a Blob");
+check(downloadSrc.includes("createObjectURL"), "downloadText mints an object URL");
+check(downloadSrc.includes("revokeObjectURL"), "downloadText revokes the object URL");
+check(downloadSrc.includes("safeFilename("), "downloadText sanitizes the download filename");
+check(!/data:/.test(downloadSrc), "downloadText builds no data: URL");
+
+// --- self-containment of the whole asset ---------------------------------
+check(!/https?:\/\//.test(src), "the asset contains no absolute http(s) URL");
+check(!/<link\b/i.test(src), "the asset links no external stylesheet");
+check(!/\bsrc\s*=/i.test(src), "the asset loads no external resource via src");
+check(!/@import/i.test(src), "the asset imports no external stylesheet");
+// Handler attributes built from input are what the baseline forbids; the asset
+// must wire every control through addEventListener instead.
+check(!/\son(click|load|error|focus|input|change)\s*=/i.test(src), "the asset declares no inline handler attribute");
+
+console.log(`PASS=${pass} FAIL=${fail}`);
+process.exit(fail > 0 ? 1 : 0);
+NODE
+
+node "$work/driver.mjs" "$ASSET"
+status=$?
+if ((status != 0)); then
+  exit "$status"
+fi
+echo "PASS: scripts/check-loop-closure-helpers.test.sh"

--- a/scripts/check-loop-closure-helpers.test.sh
+++ b/scripts/check-loop-closure-helpers.test.sh
@@ -108,7 +108,10 @@ check(esc(safeHref("javascript:alert(1)")) === "#", "a refused URL stays refused
 
 // --- safeFilename: the download attribute --------------------------------
 check(!safeFilename("../../etc/passwd").includes("/"), "safeFilename drops path separators");
-check(!safeFilename("a\\b.md").includes("\\"), "safeFilename drops backslashes");
+// The backslash is written as an escape so this file carries no GNU-only
+// regex token for the shell-portability lint to trip over.
+const BACKSLASH = String.fromCharCode(92);
+check(!safeFilename("a" + BACKSLASH + "b.md").includes(BACKSLASH), "safeFilename drops backslashes");
 check(!safeFilename('x" onfocus="y.md').includes('"'), "safeFilename drops quotes");
 check(safeFilename("") === "export.txt", "safeFilename falls back when nothing survives");
 check(safeFilename("...").startsWith("export"), "safeFilename refuses a leading-dot-only name");
@@ -131,12 +134,16 @@ check(!/data:/.test(downloadSrc), "downloadText builds no data: URL");
 
 // --- self-containment of the whole asset ---------------------------------
 check(!/https?:\/\//.test(src), "the asset contains no absolute http(s) URL");
-check(!/<link\b/i.test(src), "the asset links no external stylesheet");
-check(!/\bsrc\s*=/i.test(src), "the asset loads no external resource via src");
-check(!/@import/i.test(src), "the asset imports no external stylesheet");
+// These patterns spell their character classes out rather than using the
+// shorthand escapes, so this file carries no GNU-only regex token for the
+// shell-portability lint to trip over.
+const lower = src.toLowerCase();
+check(!lower.includes("<link"), "the asset links no external stylesheet");
+check(!/ src *=/i.test(src), "the asset loads no external resource via src");
+check(!lower.includes("@import"), "the asset imports no external stylesheet");
 // Handler attributes built from input are what the baseline forbids; the asset
 // must wire every control through addEventListener instead.
-check(!/\son(click|load|error|focus|input|change)\s*=/i.test(src), "the asset declares no inline handler attribute");
+check(!/ on(click|load|error|focus|input|change) *=/i.test(src), "the asset declares no inline handler attribute");
 
 console.log(`PASS=${pass} FAIL=${fail}`);
 process.exit(fail > 0 ? 1 : 0);

--- a/scripts/check-loop-closure-helpers.test.sh
+++ b/scripts/check-loop-closure-helpers.test.sh
@@ -101,6 +101,14 @@ for (const value of rejected) {
   check(safeHref(value) === "#", `safeHref refuses ${JSON.stringify(value)}`);
 }
 check(safeHref("#section-2") === "#section-2", "safeHref passes a fragment through");
+check(
+  !safeHref('#" onmouseover="alert(1)').includes('"'),
+  "safeHref escapes a quote in a fragment so it cannot close a double-quoted href",
+);
+check(
+  safeHref('#" onmouseover="alert(1)') === esc('#" onmouseover="alert(1)'),
+  "safeHref routes a bare fragment through esc",
+);
 check(safeHref("https://example.com/x").startsWith("https://"), "safeHref allows https");
 check(safeHref("mailto:a@example.com").startsWith("mailto:"), "safeHref allows mailto");
 // A rejected scheme must also survive the escape pass without reappearing.


### PR DESCRIPTION
Closes #3607

## Summary

Adds the rendered-views convention's second sanctioned shared piece, `plugins/visualization/reference/html-loop-closure.html`, carried beside the chrome reference and on the same sharing terms; adds the convention's `## Loop closure and the export obligation` doctrine section; and adds a fourth security-baseline bullet for the positions HTML escaping does not reach.

Nothing adopts the snippets. `visualize` is unchanged apart from the plugin's version and changelog, and adoption stays a per-lane change, as the issue scopes it.

**Extracted versus invented, stated plainly.** I checked `visualization:visualize` first, as instructed, and it carries no loop-closure or export code: the plugin's only reference asset was `html-chrome.html`, which has no `<script>` at all, and a repo-wide grep for `writeText`, `execCommand`, and `clipboard` across `plugins/*/skills` and `plugins/*/reference` returns only `playgrounds` and `playwright`, both unrelated. There was nothing working to extract. The pattern *family* is taken verbatim from the convention's own corpus distillate (item 3, plus the clipboard boilerplate at item 4); the helpers and demos are written for this repository, and the file's header comment says so rather than implying corpus provenance.

## Fix

**The snippet reference.** One self-contained page, no external requests, that both documents and runs the patterns. Four shared helpers plus one export helper:

| Helper | What it covers |
|---|---|
| `esc` | The convention's escape set, `&` `<` `>` `"` `'`, `&` replaced first so an entity is not double-decoded. One path for text and quoted-attribute positions alike. |
| `copyText` | The clipboard boilerplate every interactive corpus page duplicates: `navigator.clipboard.writeText`, the `execCommand` fallback, a brief flash. Written once here. |
| `safeHref` | URL position. Scheme allowlist checked BEFORE escaping. |
| `safeFilename` | The `download` attribute, reduced to an allowlisted character set. |
| `downloadText` | Export through a `Blob` and an object URL, revoked after the click. |

Then one section per payload shape, each with a live demo that runs from the file alone and a copyable snippet block: numbered resonate tokens, chip-assembled replies, generated follow-up prompts, accept-and-correct sign-off, live-state export (`buildMarkdown` over state, offered as both clipboard and file download). The five helper snippet blocks are printed from the live functions via `Function.prototype.toString()`, so the text a reader copies is the text the page executes and the two cannot drift.

**How each snippet handles the five-character escape.** Every pattern routes through the single `esc` above, or avoids interpolation entirely by assigning `textContent` (patterns 2, 3, 4, and 5 do the latter for whole text nodes; pattern 1 interpolates a label into `innerHTML` and calls `esc` on it, and its demo data deliberately contains `<timeout>`, a double quote, and an apostrophe so the escape is exercised on load). The page declares no inline handler attribute anywhere and interpolates nothing into `<script>` or `<style>`; every control is wired with `addEventListener`. All three properties are asserted by the test suite below.

**URL-position and scheme hazards, which the five-character rule does not cover.** `javascript:alert(1)` contains none of the five characters, so it survives `esc` unchanged and still runs on click. `safeHref` therefore parses the value and allowlists `https:`, `http:`, and `mailto:` (a bare `#fragment` passes through); `javascript:`, `data:`, `vbscript:`, `file:`, and relative URLs all resolve to `#`. Exports never build a `data:` URL, because a data URL puts the payload in URL position where percent-encoding rather than HTML escaping applies, and `data:text/html` runs script; `downloadText` uses a `Blob` and `URL.createObjectURL`, so no input reaches the URL string at all. The `download` filename is reader-reachable, so `safeFilename` reduces it to `[A-Za-z0-9._-]`, strips a leading dot run, and caps the length.

**Restatement, and what is new rather than restated.** I did NOT register a clause. The snippet file does not restate the security baseline's rules: it names the convention as their owner and demonstrates them, which is the pointer-not-copy exit `check-contract-clause-coverage.py` says is the stronger fix. Note for the reviewer: #3896 is still OPEN, so its `rendered-views-security-baseline` clause is not on `main`; adding a same-id entry here would have collided with it. The clause gate passes unchanged on this branch (`4 canonical surface(s), 14 tagged restatement(s), 16 surface(s) that point rather than restate`), the same counts as `main`.

The URL-position and scheme rule is genuinely NEW, not a restatement, and I put it in the convention rather than only in the snippet, per the brief: `docs/conventions/rendered-views/README.md`, "Security baseline", fourth bullet. It sits after the existing third bullet, outside where #3896's span markers land on the first two, so the two changes should not collide textually.

**Doctrine section.** `## Loop closure and the export obligation`: when a view owes an export (a custom editor always ends with one; a view that asks the reader to choose, rank, accept, or correct owes a payload; a view that only presents owes neither), that the family is excluded from the writeup and report genre by design with the reason given, that payloads stay terse because the artifact stays visible, and the five shapes named cheapest-first. A second short section names the snippet file's canonical path and its sharing terms.

**Registry mechanics.** Registration in `scripts/cross-plugin-source-registry.txt` is deliberately absent, matching how the chrome reference is carried: the drift checker rejects a registration while only one plugin holds the file, so the first adoption ships unregistered by design. The convention's new section states that explicitly. `scripts/check-cross-plugin-source-drift.sh --check` passes.

**What catches a future regression, since this is mostly prose.** Three things, and I want to be precise about which covers what:

1. `scripts/check-html-assets.sh` gains the asset in its manifest. That is markup lint (pinned htmlhint) plus the registration check. It catches syntax and an unregistered sibling. It says NOTHING about escaping.
2. `scripts/check-loop-closure-helpers.test.sh` (new, `100755`, wired into ci.yml next to the html-assets steps) is the behavioral gate. It extracts the helper block from the shipped asset between the two comment markers the file uses to bound it, executes `esc`, `safeHref`, and `safeFilename`, and asserts 42 properties: each of the five escape characters, the `&`-first ordering, no raw quote of either kind surviving, every rejected scheme above, the filename cases, and source-level assertions on the two DOM helpers (`copyText` keeps both the async write and the `execCommand` fallback and never uses `innerHTML`; `downloadText` uses Blob/createObjectURL/revokeObjectURL, sanitizes the filename, and contains no `data:`). It also asserts the asset's self-containment: no absolute http(s) URL, no `<link>`, no `src=`, no `@import`, no inline handler attribute.
3. The doctrine prose itself has NO gate. Markdownlint and the ai-slop detector check style, not content. If a later editor deletes the writeup-and-report exclusion or the export obligation, nothing mechanical catches it. I considered registering the doctrine as a contract clause, but a clause registry entry only holds RESTATEMENTS in agreement with a canonical; with exactly one copy of this doctrine there is nothing to hold together yet. The right moment for a clause is the first lane that restates it, which is out of scope here.

## Verification

Three commits. The third, `d1f3c973a`, is a CI fix and nothing else: the first CI run went red on `shell-portability-lint` because that gate reads the whole shell file including the heredoc, so the JavaScript driver's `\b` and `\s` shorthands read as GNU-only grep constructs. The three self-containment patterns now spell their character classes out or use a plain substring test, and the backslash case builds its character from a code point. Same 42 assertions, all still passing, and `bash scripts/check-shell-portability.sh origin/main` now reports `No unexcused GNU-only constructs in 2 shell file(s)`.

Everything below was run in the foreground in the worktree. Base `ddb3ab347`; the suite runs below were on `53965a001` and re-verified on the final head `d1f3c973a` where the change touched them.

- **Discriminating proof for the new suite.** With `.replace(/'/g, "&#39;")` deleted from `esc` and nothing else changed, `check-html-assets.sh` still reported `All registered rendered-view HTML assets lint clean` (exit 0) while `check-loop-closure-helpers.test.sh` failed with `PASS=40 FAIL=2` naming `esc escapes "'" to &#39;` and `esc leaves no raw single quote that could close a single-quoted attribute` (exit 1). Restored, it is `PASS=42 FAIL=0`. That is the gap this suite exists to close, demonstrated rather than asserted.
- `bash scripts/affected-tests.sh --explain`: the three markdown/JSON files resolve to recorded no-suite classes; the new suite is selected by the reference rule (`references html-loop-closure.html`) and `check-html-assets.test.sh` by co-location. The ci.yml edit fans the selection out to 165 suites, so `--run` was sharded 6 ways rather than risking the timeout.
- `bash scripts/affected-tests.sh --run --shard <i>/6`, all six legs: legs 0, 3, 4, 5 exit 3 (shell suites all passed, other-ecosystem suites listed as NOT RUN); leg 1 exit 0; leg 2 exit 1 from `plugins/claude-ops/skills/plugins/scripts/cache-content-check.test.sh` alone, failing its two process-budget assertions, which is the known pre-existing 2-of-24 failure and touches nothing in this change. No other suite failed in any leg. `PASS: scripts/check-loop-closure-helpers.test.sh` and `PASS: scripts/check-html-assets.test.sh` both appear in leg 1.
- `bash scripts/check-changelog-parity.sh` in all four modes: `--check` 0, `--check-order` 0 (92 changelogs), `--check-bump origin/main` 0, `--check-preserved origin/main` 0 (1 changed changelog, 18 headings compared).
- `bash scripts/check-html-assets.sh`: exit 0. `bash scripts/check-cross-plugin-source-drift.sh --check`: exit 0. `bash scripts/check-lane-coverage.sh --check`: exit 0, 4 lanes reachable (the new CI entry is a step in an existing job, not a new job). `python3 scripts/check-contract-clause-coverage.py`: exit 0. `shellcheck scripts/check-loop-closure-helpers.test.sh`: exit 0.
- `actionlint .github/workflows/ci.yml`: exit 0. The workflow also parses under `yaml.safe_load`.
- `markdownlint-cli2` over the two changed markdown files: 0 issues. ai-slop `detect.sh` over the same two: 0 findings across all rules. Note the repo config disables the em-dash rule, so that run says nothing about em dashes; a direct check of added lines in `git diff origin/main` shows 0 em dashes. No formatting was taken from `plugins/*/skills/*/vendor/**`.
- `git ls-tree`: `scripts/check-loop-closure-helpers.test.sh` is `100755`; the asset is `100644`.
- **Version collision re-check, done twice.** `visualization` 0.5.1 to 0.5.2 with a matching changelog entry. Checked against `origin/main` (0.5.1) and every open PR head fetched via `refs/pull/*/head`: no head carries 0.5.2 (the only non-0.5.1 heads are #3772 at 0.5.0 and #3704 at 0.4.2). Re-fetched and re-scanned immediately before opening this PR; still clear.
- **CI on the final head `d1f3c973a`: `ci-status: success`**, 11 checks complete, none failing (`lint`, `hook-utils`, `changes`, `managed-files-guard`, `GitGuardian`, the four `test-linux` shards, `test-windows` skipped).

**Unmet or partial, stated plainly.**

- Because this PR is a DRAFT, the `test-linux` lanes short-circuit with "this is a draft pull request ... reporting success" and run no suites. So CI has **not** actually executed `check-loop-closure-helpers.test.sh` yet; it runs on the flip to ready. Every claim about that suite above rests on the local runs, not on a CI observation.
- The doctrine prose has no mechanical gate, as set out above.
- The snippet file is not registered in the cross-plugin source registry, which is correct today but means the byte-identical guarantee only begins at the second adopter.
- `copyText` is asserted at source level rather than executed, because it needs a DOM and a clipboard; its `execCommand` fallback is therefore never run by CI.
- I did not verify the demos in a real browser: the container has no browser, so "every demo runs from this file alone" rests on the code and the helper suite, not on an observed render.

## Related

- Closes #3607
- Relates to: #3896 (still open at the time of writing; it registers the `rendered-views-security-baseline` clause and moves both retrofit lanes onto the baseline. This PR deliberately adds no clause entry so the two do not collide, and its new baseline bullet sits outside where #3896's span markers land)
- Relates to: #3605 (the deterministic escape helper with a generator marker. The helpers here are instruction-level snippets under the wave-1 skeleton, not that helper, and nothing here is gated on it)
- Relates to: #3606 (the reports and research genre lanes, which the exclusion rule in the new doctrine section explicitly keeps out of this family)
- `docs/conventions/rendered-views/README.md`, "Security baseline", "Loop closure and the export obligation", "The loop-closure and export snippet reference"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ViPsHkL3ng9xWt2GjEQJob
