### PR TITLE
feat(code-metrics): bind the config reference key table to the defaults file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -706,6 +706,22 @@ jobs:
         continue-on-error: true
         run: python3 scripts/sync-plugin-options-docs.py --check
 
+      # code-metrics resolves every tunable from one defaults file and restates
+      # every key in a reference table with its default. The setup template is
+      # pinned to that defaults file leaf for leaf by a test; the reference
+      # table was pinned to nothing, and a stale default in a reference reads
+      # exactly like a current one (#3841). The gate is ungated on purpose: a
+      # change that edits only the reference is docs-only, and that is exactly
+      # the edit that can walk the table away from the defaults. Self-test
+      # first so a broken detector cannot mask a regression.
+      - name: Test the code-metrics config reference gate
+        if: needs.changes.outputs.run_shell == 'true'
+        run: bash scripts/check-code-metrics-config-reference.test.sh
+      - name: Check the code-metrics config reference against its defaults file
+        id: code_metrics_config_reference
+        continue-on-error: true
+        run: python3 scripts/check-code-metrics-config-reference.py
+
       - name: Check hook entry scripts for silent prerequisite skips
         id: silent_skips
         continue-on-error: true
@@ -1259,6 +1275,7 @@ jobs:
             hooks-description=${{ steps.hooks_description.outcome }}
             summary-reader-parity=${{ steps.summary_reader_parity.outcome }}
             plugin-options-docs=${{ steps.plugin_options_docs.outcome }}
+            code-metrics-config-reference=${{ steps.code_metrics_config_reference.outcome }}
             silent-skips=${{ steps.silent_skips.outcome }}
             discriminating-test-skips=${{ steps.discriminating_test_skips.outcome }}
             plugin-manifest-presence=${{ steps.plugin_manifest_presence.outcome }}

--- a/plugins/code-metrics/.claude-plugin/plugin.json
+++ b/plugins/code-metrics/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "code-metrics",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Read-only code measures for a change, with cited references and no verdict: lines per file (audit-size), cyclomatic, cognitive, and Halstead complexity (audit-complexity), duplication with sanctioned-replication exclusions (audit-duplication), coverage per function with CRAP from existing lcov, Cobertura, coverage.py, or Go artifacts (audit-coverage), type debt for TypeScript and Python (audit-type-debt), the literacy router for what each number can and cannot say (principles), and a setup skill for the consumer's .claude/code-metrics.yaml. Runs external collectors only when they already resolve, never installs, never runs tests, never emits a finding.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/code-metrics/CHANGELOG.md
+++ b/plugins/code-metrics/CHANGELOG.md
@@ -3,6 +3,23 @@
 All notable changes to the `code-metrics` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.1.7]
+
+### Changed
+
+- **The configuration reference's key table can no longer disagree with the bundled defaults.**
+  `reference/config.md` restated every key from `scripts/config-defaults.json` as hand-maintained
+  prose, and nothing checked the two against each other, so a key added, removed, or given a
+  different default left a stale reference that reads exactly like a current one. A repository gate
+  (`scripts/check-code-metrics-config-reference.py`, run on every change) now pins the table's key
+  column and default column to that file: every non-reserved defaults leaf must be documented by
+  exactly one row, every row must document a key that exists (or be marked `absent`), and each
+  row's default must equal the canonical rendering of the value, pipes escaped and backtick fences
+  widened so a value carrying markdown-significant characters cannot produce a broken table that
+  still passes. The third column stays hand written; the document's prose is unchanged apart from
+  a paragraph saying what the gate covers. The prose copies of default values in the skill bodies
+  remain unbound and are now recorded in the README's known gaps.
+
 ## [0.1.6]
 
 ### Fixed

--- a/plugins/code-metrics/README.md
+++ b/plugins/code-metrics/README.md
@@ -114,6 +114,13 @@ figure for a live session.
   complexity; those rows report `unavailable` with the validation date rather than a number.
 - C# is counted and its duplication measured, but its complexity lane is deferred to a native
   collector and its type debt is reported as not applicable.
+- The skill bodies restate some default values in prose, and those copies are not bound to
+  `scripts/config-defaults.json`. The setup template and the `reference/config.md` key table both
+  are, by a test and by `scripts/check-code-metrics-config-reference.py`; what remains unbound is
+  the number written into a sentence or a small illustrative table, currently `coverage.reference`
+  in `audit-coverage`, `duplication.min_tokens` and `duplication.min_lines` in `audit-duplication`,
+  `type_debt.reference` in `audit-type-debt`, and the cyclomatic reference in `setup`. Those drift
+  silently until someone reads them.
 
 ## License
 

--- a/plugins/code-metrics/reference/config.md
+++ b/plugins/code-metrics/reference/config.md
@@ -46,6 +46,14 @@ scalar, and the resolver refuses it by key and layer (exit 2, and a FAIL `config
 
 ## Keys
 
+The key column and the default column of this table are checked against
+`scripts/config-defaults.json` on every change by
+`scripts/check-code-metrics-config-reference.py`, so the two cannot disagree: a key added to,
+removed from, or given a different default in that file fails the check until this table follows.
+The third column is written by hand and is not derived from anything. A row whose key carries a
+`<placeholder>` segment covers every key matching it, and a default written as the bare word
+`absent` marks a key the defaults file deliberately does not default.
+
 | Key | Default | Meaning and provenance |
 |---|---|---|
 | `scope.default` | `change` | `change` (the merge-base diff plus uncommitted and untracked files) or `all` |

--- a/scripts/check-code-metrics-config-reference.py
+++ b/scripts/check-code-metrics-config-reference.py
@@ -1,0 +1,341 @@
+#!/usr/bin/env python3
+"""Bind the code-metrics config reference table to the bundled defaults file.
+
+`plugins/code-metrics/scripts/config-defaults.json` is the single source of
+truth the resolver reads at run time. `plugins/code-metrics/reference/config.md`
+restates every key in a `## Keys` table with its default and its provenance.
+The setup template is already pinned to the defaults leaf for leaf by
+`plugins/code-metrics/skills/setup/scripts/test_setup_apply.py`; the reference
+table was not pinned to anything, so it drifts the first time a key is added,
+removed, renamed, or given a different default, and a stale default in a
+reference reads exactly like a current one.
+
+WHY VERIFY RATHER THAN GENERATE. Generating the table would need every column
+to be derivable from the defaults file, and the third column is not: for 12 of
+the table's 20 rows the "meaning and provenance" prose exists nowhere but the
+document, and the 8 rows with a `thresholds[].provenance` string in the defaults
+are reworded there for a reader rather than quoted. Generating would therefore
+mean moving documentation prose into the JSON the resolver loads at run time.
+The two columns that ARE derivable -- the key set and the default value -- are
+pinned here instead, byte for byte against a canonical rendering, so the
+mechanically checkable half cannot disagree while the prose half stays hand
+written and readable. That is the shape the issue calls "verify" (#3841).
+
+WHAT IS PINNED, exactly:
+
+  * Every non-reserved leaf of the defaults file is documented by exactly one
+    table row. A leaf documented by no row fails; a leaf documented by two
+    rows fails, because then it is unclear which row states its default.
+  * Every table row documents at least one defaults leaf, unless its default
+    cell is the bare word `absent`, which is how the document marks a key that
+    has no bundled default (`lanes.<lane>.collectors.<measure>`). A row that
+    stops matching any leaf -- the shape of a key REMOVED from the defaults --
+    fails and names the key.
+  * Each row's default cell equals the canonical rendering of the value, which
+    is exact: `20`, `null`, `[]`, `true`, and a string as itself, each inside a
+    code span, with a `|` backslash-escaped (a raw pipe ends the cell even
+    inside a code span) and the fence widened past any backtick run in the
+    value. A value carrying a newline is NOT representable in a table cell and
+    is reported as such rather than silently flattened.
+
+Row ORDER is deliberately not pinned. The document groups keys for a reader and
+the defaults file groups them for the resolver; requiring the two orders to
+agree would fail a harmless reformat of either while preventing no drift.
+
+Usage:
+
+    scripts/check-code-metrics-config-reference.py
+    scripts/check-code-metrics-config-reference.py --defaults FILE --doc FILE
+
+Exit codes: 0 clean, 1 the two surfaces disagree, 2 the gate could not run
+(fail closed: a missing file, unparseable JSON, or no table under `## Keys`).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+# `from __future__ import annotations` is a SyntaxError below 3.7, before any
+# runtime check here could run, so the sibling .test.sh parses this tuple as
+# text to pick a qualifying interpreter BEFORE invoking this file.
+MIN_PYTHON = (3, 7)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_DEFAULTS = REPO_ROOT / "plugins" / "code-metrics" / "scripts" / "config-defaults.json"
+DEFAULT_DOC = REPO_ROOT / "plugins" / "code-metrics" / "reference" / "config.md"
+
+# Top-level defaults members that are not consumer configuration. The document
+# says so itself, under "Reserved keys": `thresholds` and anything starting
+# with `_` belong to the bundled defaults and the resolver's output.
+RESERVED_PREFIX = "_"
+RESERVED_KEYS = frozenset({"thresholds"})
+
+# The heading whose first table is the key contract, and the literal a row uses
+# for a documented key that the defaults file deliberately does not default.
+SECTION_HEADING = "## Keys"
+NO_DEFAULT = "absent"
+
+# A `<name>` segment in a documented key stands for exactly one path segment,
+# which is how one row documents `lanes.<lane>.enabled` for all five lanes.
+WILDCARD = re.compile(r"^<[A-Za-z_][A-Za-z0-9_]*>$")
+
+# A cell boundary is a pipe that is not backslash-escaped.
+CELL_SPLIT = re.compile(r"(?<!\\)\|")
+
+# A code span: a run of backticks, optional one-space padding, then the content.
+CODE_SPAN = re.compile(r"^(?P<fence>`+)(?P<body>.*)(?P=fence)$", re.DOTALL)
+
+
+class GateError(Exception):
+    """The gate cannot run and must fail closed rather than clear the file."""
+
+
+class Unrepresentable(Exception):
+    """A default value that no markdown table cell can carry."""
+
+
+def leaves(node, prefix: str = ""):
+    """Yield (dotted path, value) for every non-mapping value in the tree.
+
+    A list is a leaf, not a branch: the document and the resolver both treat
+    `scope.exclude` as one closed value, never as indexed sub-keys.
+    """
+    if isinstance(node, dict):
+        for key, value in node.items():
+            yield from leaves(value, f"{prefix}{key}.")
+    else:
+        yield prefix[:-1], node
+
+
+def default_leaves(defaults: dict) -> "dict[str, object]":
+    """The consumer-configurable leaves, reserved members dropped at the root."""
+    out = {}
+    for key, value in defaults.items():
+        if key in RESERVED_KEYS or key.startswith(RESERVED_PREFIX):
+            continue
+        for path, leaf in leaves(value, f"{key}."):
+            out[path] = leaf
+    return out
+
+
+def render_default(value) -> str:
+    """The exact cell text that documents `value`, code span included.
+
+    A string renders as itself (the document writes `change`, not `"change"`);
+    everything else renders as JSON, which gives `null`, `true`, `[]` and bare
+    numbers. Then two markdown hazards are handled rather than hoped away:
+
+      * a `|` ends the table cell even inside a code span, so it is escaped;
+      * a backtick inside the value needs a longer fence than the longest run
+        it contains, plus a space of padding when the value starts or ends
+        with one, which is CommonMark's own rule for a code span.
+    """
+    text = value if isinstance(value, str) else json.dumps(value)
+    if "\n" in text or "\r" in text:
+        raise Unrepresentable(text)
+    escaped = text.replace("|", "\\|")
+    longest = max((len(run) for run in re.findall(r"`+", escaped)), default=0)
+    fence = "`" * (longest + 1)
+    pad = " " if escaped.startswith("`") or escaped.endswith("`") else ""
+    return f"{fence}{pad}{escaped}{pad}{fence}"
+
+
+def read_code_span(cell: str) -> "str | None":
+    """The content of a code-span cell with `\\|` unescaped, or None."""
+    match = CODE_SPAN.match(cell.strip())
+    if match is None or not match.group("body"):
+        return None
+    body = match.group("body")
+    if body.startswith(" ") and body.endswith(" ") and body.strip():
+        body = body[1:-1]
+    return body.replace("\\|", "|")
+
+
+def split_row(line: str) -> "list[str]":
+    """The cells of a markdown table row, outer pipes discarded."""
+    cells = CELL_SPLIT.split(line.strip())
+    if cells and not cells[0].strip():
+        cells = cells[1:]
+    if cells and not cells[-1].strip():
+        cells = cells[:-1]
+    return [cell.strip() for cell in cells]
+
+
+def key_table(doc_text: str) -> "list[tuple[int, list[str]]]":
+    """The first table under `## Keys`, as (1-based line number, cells) rows."""
+    lines = doc_text.splitlines()
+    start = None
+    for index, line in enumerate(lines):
+        if line.strip() == SECTION_HEADING:
+            start = index + 1
+            break
+    if start is None:
+        raise GateError(f"no {SECTION_HEADING!r} heading in the reference document")
+
+    rows: "list[tuple[int, list[str]]]" = []
+    seen_table = False
+    for index in range(start, len(lines)):
+        line = lines[index]
+        if line.startswith("## "):
+            break
+        if not line.strip().startswith("|"):
+            if seen_table:
+                break
+            continue
+        seen_table = True
+        cells = split_row(line)
+        # The delimiter row (`|---|---|---|`) carries no content.
+        if cells and all(re.fullmatch(r":?-{2,}:?", cell) for cell in cells):
+            continue
+        rows.append((index + 1, cells))
+
+    if not rows:
+        raise GateError(f"no table under {SECTION_HEADING!r} in the reference document")
+    # Drop the header row, whose first cell names the column rather than a key.
+    header = rows[0][1]
+    if not header or read_code_span(header[0]) is not None:
+        raise GateError(
+            f"the first row under {SECTION_HEADING!r} is not a header row: {header!r}"
+        )
+    return rows[1:]
+
+
+def matches(pattern: str, path: str) -> bool:
+    """Does a documented key, wildcards included, name this defaults leaf?"""
+    want = pattern.split(".")
+    have = path.split(".")
+    if len(want) != len(have):
+        return False
+    return all(WILDCARD.match(w) or w == h for w, h in zip(want, have))
+
+
+def check(defaults: dict, doc_text: str, doc_name: str) -> "list[str]":
+    """Every disagreement between the two surfaces, each naming its key."""
+    problems: "list[str]" = []
+    expected = default_leaves(defaults)
+    rows = key_table(doc_text)
+
+    documented: "dict[str, list[str]]" = {path: [] for path in expected}
+    for lineno, cells in rows:
+        if len(cells) < 2:
+            problems.append(f"{doc_name}:{lineno}: table row has fewer than two cells")
+            continue
+        key = read_code_span(cells[0])
+        if key is None:
+            problems.append(
+                f"{doc_name}:{lineno}: the key cell {cells[0]!r} is not a code span; "
+                "every documented key is written as `a.b.c`"
+            )
+            continue
+        cell = cells[1].strip()
+        hits = [path for path in expected if matches(key, path)]
+        for path in hits:
+            documented[path].append(key)
+
+        if not hits:
+            if cell != NO_DEFAULT:
+                problems.append(
+                    f"{doc_name}:{lineno}: `{key}` is documented here but the defaults file "
+                    "defines no such key. Remove the row, or write its default cell as the "
+                    f"bare word `{NO_DEFAULT}` if the key deliberately has no bundled default."
+                )
+            continue
+        if cell == NO_DEFAULT:
+            problems.append(
+                f"{doc_name}:{lineno}: `{key}` is documented as having no default, but the "
+                f"defaults file now defines it ({', '.join(sorted(hits))}). "
+                "State the default instead."
+            )
+            continue
+
+        distinct = {json.dumps(expected[path], sort_keys=True) for path in hits}
+        if len(distinct) > 1:
+            problems.append(
+                f"{doc_name}:{lineno}: `{key}` covers {', '.join(sorted(hits))}, which no "
+                "longer share one default, so a single row cannot state it. Split the row."
+            )
+            continue
+        try:
+            want = render_default(expected[hits[0]])
+        except Unrepresentable:
+            problems.append(
+                f"{doc_name}:{lineno}: the default for `{key}` contains a line break, which "
+                "no markdown table cell can carry. Give the key a single-line default, or "
+                "move the key out of this table."
+            )
+            continue
+        if cell != want:
+            problems.append(
+                f"{doc_name}:{lineno}: `{key}` documents its default as {cell} but the "
+                f"defaults file says {want}."
+            )
+
+    for path in sorted(expected):
+        rows_for_path = documented[path]
+        if not rows_for_path:
+            problems.append(
+                f"{doc_name}: the defaults file defines `{path}` and no row under "
+                f"{SECTION_HEADING!r} documents it. Add a row for it."
+            )
+        elif len(rows_for_path) > 1:
+            named = ", ".join(f"`{row}`" for row in rows_for_path)
+            problems.append(
+                f"{doc_name}: `{path}` is documented by more than one row ({named}), so "
+                "which row states its default is ambiguous."
+            )
+    return problems
+
+
+def main(argv: "list[str]") -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--defaults", type=Path, default=DEFAULT_DEFAULTS)
+    parser.add_argument("--doc", type=Path, default=DEFAULT_DOC)
+    args = parser.parse_args(argv)
+
+    try:
+        defaults_text = args.defaults.read_text(encoding="utf-8")
+    except OSError as error:
+        print(f"CANNOT RUN: {args.defaults}: {error}", file=sys.stderr)
+        return 2
+    try:
+        doc_text = args.doc.read_text(encoding="utf-8")
+    except OSError as error:
+        print(f"CANNOT RUN: {args.doc}: {error}", file=sys.stderr)
+        return 2
+    try:
+        defaults = json.loads(defaults_text)
+    except json.JSONDecodeError as error:
+        print(f"CANNOT RUN: {args.defaults}: {error}", file=sys.stderr)
+        return 2
+    if not isinstance(defaults, dict):
+        print(f"CANNOT RUN: {args.defaults}: top level is not a JSON object", file=sys.stderr)
+        return 2
+
+    try:
+        problems = check(defaults, doc_text, args.doc.name)
+    except GateError as error:
+        print(f"CANNOT RUN: {args.doc}: {error}", file=sys.stderr)
+        return 2
+
+    if problems:
+        for problem in problems:
+            print(f"CONFIG REFERENCE DRIFT: {problem}", file=sys.stderr)
+        print(
+            f"{len(problems)} disagreement(s) between {args.defaults.name} and "
+            f"{args.doc.name}. The defaults file is the source of truth; the reference "
+            "table follows it.",
+            file=sys.stderr,
+        )
+        return 1
+
+    count = len(default_leaves(defaults))
+    print(f"{args.doc.name} documents all {count} key(s) in {args.defaults.name}.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/check-code-metrics-config-reference.py
+++ b/scripts/check-code-metrics-config-reference.py
@@ -48,7 +48,7 @@ Usage:
     scripts/check-code-metrics-config-reference.py --defaults FILE --doc FILE
 
 Exit codes: 0 clean, 1 the two surfaces disagree, 2 the gate could not run
-(fail closed: a missing file, unparseable JSON, or no table under `## Keys`).
+(fail closed: a missing file, unparsable JSON, or no table under `## Keys`).
 """
 
 from __future__ import annotations

--- a/scripts/check-code-metrics-config-reference.py
+++ b/scripts/check-code-metrics-config-reference.py
@@ -65,7 +65,9 @@ from pathlib import Path
 MIN_PYTHON = (3, 7)
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
-DEFAULT_DEFAULTS = REPO_ROOT / "plugins" / "code-metrics" / "scripts" / "config-defaults.json"
+DEFAULT_DEFAULTS = (
+    REPO_ROOT / "plugins" / "code-metrics" / "scripts" / "config-defaults.json"
+)
 DEFAULT_DOC = REPO_ROOT / "plugins" / "code-metrics" / "reference" / "config.md"
 
 # Top-level defaults members that are not consumer configuration. The document
@@ -312,7 +314,10 @@ def main(argv: "list[str]") -> int:
         print(f"CANNOT RUN: {args.defaults}: {error}", file=sys.stderr)
         return 2
     if not isinstance(defaults, dict):
-        print(f"CANNOT RUN: {args.defaults}: top level is not a JSON object", file=sys.stderr)
+        print(
+            f"CANNOT RUN: {args.defaults}: top level is not a JSON object",
+            file=sys.stderr,
+        )
         return 2
 
     try:

--- a/scripts/check-code-metrics-config-reference.test.sh
+++ b/scripts/check-code-metrics-config-reference.test.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Cross-platform contract wrapper for the code-metrics config reference gate's
+# test suite.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# The Python floor has one origin: MIN_PYTHON in the gate itself (needed
+# because `from __future__ import annotations` requires 3.7+). Parse it rather
+# than restating the number here, same convention as
+# scripts/check-manifest-duplicate-keys.test.sh.
+ENGINE="$SCRIPT_DIR/check-code-metrics-config-reference.py"
+FLOOR="$(sed -n 's/^MIN_PYTHON = (\([0-9]*\), \([0-9]*\)).*/\1.\2/p' "$ENGINE")"
+if [[ -z "$FLOOR" ]]; then
+  echo "FAIL: could not parse MIN_PYTHON from $ENGINE" >&2
+  exit 1
+fi
+
+# A zero-length candidate under a WindowsApps path component is the Store's
+# App Execution Alias stub -- executing it opens the Microsoft Store (or hangs)
+# instead of running an interpreter, so each candidate is inspected before
+# anything executes it. A candidate that is real but below the floor does not
+# end the search: the next candidate may satisfy it.
+PYTHON=""
+for candidate in python3 python; do
+  resolved="$(command -v "$candidate" 2>/dev/null)" || continue
+  lower="$(printf '%s' "$resolved" | tr '[:upper:]' '[:lower:]')"
+  if [[ "$lower" == *windowsapps* && ! -s "$resolved" ]]; then
+    continue
+  fi
+  if "$candidate" -c "import sys; floor = tuple(int(part) for part in '$FLOOR'.split('.')); raise SystemExit(0 if sys.version_info >= floor else 1)"; then
+    PYTHON="$candidate"
+    break
+  fi
+done
+if [[ -z "$PYTHON" ]]; then
+  echo "SKIP: Python ${FLOOR}+ not found" >&2
+  exit 0
+fi
+
+# Execute the test file directly (its unittest.main() guard) rather than via
+# `-m unittest <abs path>`, which resolves the path as a module name relative
+# to the caller's cwd and breaks when invoked from outside the checkout.
+"$PYTHON" "$SCRIPT_DIR/test_check_code_metrics_config_reference.py" -v

--- a/scripts/test_check_code_metrics_config_reference.py
+++ b/scripts/test_check_code_metrics_config_reference.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python3
+"""Tests for the code-metrics config reference gate.
+
+Every case runs the gate at its command line against a mutated COPY of the
+shipped pair, so what is asserted is the exit code and the message an author
+would actually see. The point of the gate is that drift is impossible, so the
+suite is written as drift injections: each one must FAIL, and the message must
+name the key, or the gate is decorative.
+"""
+
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+GATE = SCRIPT_DIR / "check-code-metrics-config-reference.py"
+REPO_ROOT = SCRIPT_DIR.parent
+SHIPPED_DEFAULTS = (
+    REPO_ROOT / "plugins" / "code-metrics" / "scripts" / "config-defaults.json"
+)
+SHIPPED_DOC = REPO_ROOT / "plugins" / "code-metrics" / "reference" / "config.md"
+
+_spec = importlib.util.spec_from_file_location("cm_config_reference_gate", GATE)
+assert _spec is not None and _spec.loader is not None
+gate = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(gate)
+
+
+def run(defaults: Path, doc: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(GATE), "--defaults", str(defaults), "--doc", str(doc)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+class GateHarness(unittest.TestCase):
+    """A scratch copy of the shipped pair that each case mutates."""
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.dir = Path(self._tmp.name)
+        self.defaults_path = self.dir / "config-defaults.json"
+        self.doc_path = self.dir / "config.md"
+        self.defaults = json.loads(SHIPPED_DEFAULTS.read_text(encoding="utf-8"))
+        self.doc = SHIPPED_DOC.read_text(encoding="utf-8")
+
+    def write(self) -> subprocess.CompletedProcess:
+        self.defaults_path.write_text(
+            json.dumps(self.defaults, indent=2) + "\n", encoding="utf-8"
+        )
+        self.doc_path.write_text(self.doc, encoding="utf-8")
+        return run(self.defaults_path, self.doc_path)
+
+    def assert_clean(self, result: subprocess.CompletedProcess) -> None:
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def assert_drift(
+        self, result: subprocess.CompletedProcess, *must_name: str
+    ) -> None:
+        self.assertEqual(
+            result.returncode, 1, f"stdout={result.stdout} stderr={result.stderr}"
+        )
+        for token in must_name:
+            self.assertIn(token, result.stderr)
+
+
+class ShippedPairTests(GateHarness):
+    def test_the_shipped_pair_agrees(self) -> None:
+        result = run(SHIPPED_DEFAULTS, SHIPPED_DOC)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("documents all", result.stdout)
+
+    def test_the_unmutated_copy_agrees(self) -> None:
+        # The harness itself must clear the gate, or every "this fails" case
+        # below would pass for the wrong reason.
+        self.assert_clean(self.write())
+
+
+class DriftFailsTests(GateHarness):
+    def test_a_new_defaults_key_fails_and_names_it(self) -> None:
+        self.defaults["size"]["max_params"] = 7
+        self.assert_drift(self.write(), "size.max_params")
+
+    def test_a_new_top_level_defaults_section_fails_and_names_it(self) -> None:
+        self.defaults["churn"] = {"window_days": 30}
+        self.assert_drift(self.write(), "churn.window_days")
+
+    def test_a_changed_default_value_fails_and_names_both_values(self) -> None:
+        self.defaults["size"]["file_lines"] = 500
+        self.assert_drift(self.write(), "size.file_lines", "`1000`", "`500`")
+
+    def test_a_changed_default_type_fails(self) -> None:
+        self.defaults["complexity"]["cyclomatic"]["reference"] = None
+        self.assert_drift(self.write(), "complexity.cyclomatic.reference", "`null`")
+
+    def test_a_removed_defaults_key_still_documented_fails(self) -> None:
+        del self.defaults["duplication"]["min_lines"]
+        self.assert_drift(self.write(), "duplication.min_lines")
+
+    def test_a_row_deleted_from_the_document_fails(self) -> None:
+        self.doc = "\n".join(
+            line
+            for line in self.doc.splitlines()
+            if not line.startswith("| `duplication.min_lines`")
+        )
+        self.assert_drift(self.write(), "duplication.min_lines")
+
+    def test_a_key_documented_by_two_rows_fails_as_ambiguous(self) -> None:
+        self.doc = self.doc.replace(
+            "| `type_debt.reference` | `null` |",
+            "| `type_debt.reference` | `null` | a second row |\n"
+            "| `type_debt.reference` | `null` |",
+        )
+        self.assert_drift(self.write(), "type_debt.reference", "ambiguous")
+
+    def test_a_wildcard_row_whose_leaves_stop_agreeing_fails(self) -> None:
+        self.defaults["lanes"]["go"]["enabled"] = False
+        result = self.write()
+        self.assert_drift(result, "lanes.<lane>.enabled", "lanes.go.enabled")
+
+    def test_a_documented_undefaulted_key_that_gains_a_default_fails(self) -> None:
+        self.defaults["lanes"]["python"]["collectors"] = {"cyclomatic": ["lizard"]}
+        self.assert_drift(
+            self.write(),
+            "lanes.<lane>.collectors.<measure>",
+            "lanes.python.collectors.cyclomatic",
+        )
+
+    def test_a_key_cell_that_is_not_a_code_span_fails(self) -> None:
+        self.doc = self.doc.replace(
+            "| `type_debt.reference` | `null` |", "| type_debt.reference | `null` |"
+        )
+        self.assert_drift(self.write(), "code span")
+
+
+class MarkdownSignificantValueTests(GateHarness):
+    """A default carrying `|`, a backtick, or a newline.
+
+    A pipe ends a table cell even inside a code span, so a gate that compared
+    a naively written cell would either mis-read the row or clear a document
+    that renders broken. Each case is pinned here.
+    """
+
+    def test_a_pipe_in_a_value_must_be_escaped_and_then_passes(self) -> None:
+        self.defaults["scope"]["base"] = "auto|HEAD"
+        self.doc = self.doc.replace(
+            "| `scope.base` | `auto` |", "| `scope.base` | `auto\\|HEAD` |"
+        )
+        self.assert_clean(self.write())
+
+    def test_a_pipe_written_raw_in_the_cell_fails(self) -> None:
+        self.defaults["scope"]["base"] = "auto|HEAD"
+        self.doc = self.doc.replace(
+            "| `scope.base` | `auto` |", "| `scope.base` | `auto|HEAD` |"
+        )
+        result = self.write()
+        self.assert_drift(result, "scope.base", "auto\\|HEAD")
+
+    def test_a_pipe_value_left_undocumented_fails(self) -> None:
+        self.defaults["scope"]["base"] = "auto|HEAD"
+        self.assert_drift(self.write(), "scope.base", "auto\\|HEAD")
+
+    def test_a_backtick_in_a_value_needs_a_widened_fence(self) -> None:
+        self.defaults["scope"]["base"] = "`HEAD`"
+        self.assert_drift(self.write(), "scope.base")
+        self.doc = self.doc.replace(
+            "| `scope.base` | `auto` |", "| `scope.base` | `` `HEAD` `` |"
+        )
+        self.assert_clean(self.write())
+
+    def test_a_newline_in_a_value_is_reported_as_unrepresentable(self) -> None:
+        self.defaults["scope"]["base"] = "auto\nHEAD"
+        result = self.write()
+        self.assert_drift(result, "scope.base", "line break")
+
+    def test_render_default_covers_every_shipped_value_shape(self) -> None:
+        self.assertEqual(gate.render_default("change"), "`change`")
+        self.assertEqual(gate.render_default(20), "`20`")
+        self.assertEqual(gate.render_default(None), "`null`")
+        self.assertEqual(gate.render_default(True), "`true`")
+        self.assertEqual(gate.render_default([]), "`[]`")
+        self.assertEqual(gate.render_default(["a", "b"]), '`["a", "b"]`')
+        self.assertEqual(gate.render_default("a|b"), "`a\\|b`")
+        self.assertEqual(gate.render_default("a`b"), "``a`b``")
+        self.assertEqual(gate.render_default("`b`"), "`` `b` ``")
+        self.assertEqual(gate.render_default("a``b"), "```a``b```")
+        with self.assertRaises(gate.Unrepresentable):
+            gate.render_default("a\nb")
+
+
+class ToleratedTests(GateHarness):
+    """What the gate deliberately does NOT fail on."""
+
+    def test_reordering_the_defaults_file_is_not_drift(self) -> None:
+        # The document orders keys for a reader and the defaults file orders
+        # them for the resolver. Pinning the two orders together would fail a
+        # harmless reformat while preventing no disagreement.
+        self.defaults = dict(reversed(list(self.defaults.items())))
+        self.defaults["size"] = dict(reversed(list(self.defaults["size"].items())))
+        self.assert_clean(self.write())
+
+    def test_reserved_members_need_no_row(self) -> None:
+        # `thresholds` and any `_`-prefixed member belong to the bundled
+        # defaults and the resolver's output, not to the consumer surface.
+        self.defaults["_generated_at"] = "2026-01-01"
+        self.defaults["thresholds"] = copy.deepcopy(self.defaults["thresholds"])
+        self.defaults["thresholds"].append(
+            {"measure": "invented", "config_key": "nope.nope", "value_key": "x"}
+        )
+        self.assert_clean(self.write())
+
+    def test_prose_outside_the_keys_table_is_ignored(self) -> None:
+        self.doc = self.doc.replace(
+            "## Example",
+            "## Example\n\nAn added paragraph mentioning `size.file_lines`.\n",
+        )
+        self.assert_clean(self.write())
+
+
+class FailClosedTests(GateHarness):
+    def test_a_missing_defaults_file_cannot_clear_the_gate(self) -> None:
+        self.write()
+        self.defaults_path.unlink()
+        result = run(self.defaults_path, self.doc_path)
+        self.assertEqual(result.returncode, 2, result.stderr)
+        self.assertIn("CANNOT RUN", result.stderr)
+
+    def test_malformed_defaults_json_cannot_clear_the_gate(self) -> None:
+        self.write()
+        self.defaults_path.write_text("{not json", encoding="utf-8")
+        result = run(self.defaults_path, self.doc_path)
+        self.assertEqual(result.returncode, 2, result.stderr)
+
+    def test_a_document_without_the_keys_section_cannot_clear_the_gate(self) -> None:
+        self.doc = self.doc.replace("## Keys", "## Configuration keys")
+        result = self.write()
+        self.assertEqual(result.returncode, 2, result.stderr)
+        self.assertIn("CANNOT RUN", result.stderr)
+
+    def test_a_keys_section_without_a_table_cannot_clear_the_gate(self) -> None:
+        head, _, tail = self.doc.partition("## Keys")
+        self.doc = (
+            head
+            + "## Keys\n\nNo table here.\n\n## Example"
+            + tail.split("## Example", 1)[1]
+        )
+        result = self.write()
+        self.assertEqual(result.returncode, 2, result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_check_code_metrics_config_reference.py
+++ b/scripts/test_check_code_metrics_config_reference.py
@@ -147,7 +147,7 @@ class MarkdownSignificantValueTests(GateHarness):
     """A default carrying `|`, a backtick, or a newline.
 
     A pipe ends a table cell even inside a code span, so a gate that compared
-    a naively written cell would either mis-read the row or clear a document
+    a naively written cell would either misread the row or clear a document
     that renders broken. Each case is pinned here.
     """
 


### PR DESCRIPTION
Closes #3841

## Summary

`plugins/code-metrics/reference/config.md` restated every key in
`plugins/code-metrics/scripts/config-defaults.json` as a hand-maintained table, and nothing checked
the two agreed. The setup template is already pinned to that defaults file leaf for leaf by
`plugins/code-metrics/skills/setup/scripts/test_setup_apply.py`; the reference table was pinned to
nothing, so it drifts the first time a key is added, removed, or given a different default, and a
stale default in a reference reads exactly like a current one.

**Verify, not generate, and here is why.** Generating the table needs every column to be derivable
from the defaults file, and the third column is not. For 12 of the table's 20 rows the "meaning and
provenance" prose exists nowhere but the document; the 8 rows that have a
`thresholds[].provenance` string in the defaults are reworded there for a reader rather than
quoted. Generating would therefore mean relocating documentation prose into the JSON the resolver
loads at run time, which enlarges a runtime artifact for a documentation concern and is the kind of
defaults-file change #3841 puts out of scope. What is derivable is the key set and the default
value, and those two columns are now pinned byte for byte against a canonical rendering, so the
mechanically checkable half cannot disagree while the prose half stays hand written and readable.
That is the shape the issue calls "verify".

**Why a new gate rather than an existing one.** Three existing seams were checked and none fits.
`scripts/sync-plugin-options-docs.py --check` binds `plugin.json` `userConfig` to a delimited
generated block in a plugin README; different source file, different target, different key model
(flat option specs, not a nested tree with wildcard rows), and generalizing it would mean rewriting
a script with a very specific contract. `scripts/check-contract-clause-coverage.py` with its
`contract-clause-registry.json` canonical/restates/qualifiers model matches prose vocabulary inside
declared markdown spans; it has no notion of a key or a value and its own header defers the
prose-versus-code direction. `scripts/check-changelog-parity.sh` is unrelated. The new gate follows
the house shape for a plugin-specific repository gate exactly: engine in `scripts/`, shell wrapper
self-test, wired into the `lint` job with the self-test step first.

## Fix

- `scripts/check-code-metrics-config-reference.py` (new, `100755`). Every non-reserved leaf of the
  defaults file must be documented by exactly one table row under `## Keys`; every row must
  document a key that exists, or carry the bare word `absent` for a key the defaults deliberately
  does not default (`lanes.<lane>.collectors.<measure>`); each row's default cell must equal the
  canonical rendering of the value. A row key may carry a `<placeholder>` segment, which is how one
  row covers all five `lanes.<lane>.enabled` leaves, and those leaves must then agree on one value.
  Exit 0 clean, 1 disagreement (every message names the key), 2 the gate could not run.
- Rendering handles markdown-significant characters rather than hoping they never appear: a `|` is
  backslash-escaped because a raw pipe ends the cell even inside a code span, a backtick widens the
  fence past the longest run in the value with CommonMark's space padding, and a value containing a
  newline is reported as unrepresentable in a table cell instead of being flattened into a document
  that renders broken while the gate stays green.
- Row order is deliberately NOT pinned. The document groups keys for a reader and the defaults file
  groups them for the resolver; requiring the two orders to agree would fail a harmless reformat of
  either while preventing no disagreement. Tested as a tolerated case, not left implicit.
- `scripts/check-code-metrics-config-reference.test.sh` (new, `100755`) and
  `scripts/test_check_code_metrics_config_reference.py` (new, `100755`): 25 cases, each a drift
  injection run at the gate's command line against a mutated copy of the shipped pair.
- `.github/workflows/ci.yml`: self-test step (gated on `run_shell`, matching its neighbours) then
  the gate itself, ungated and `continue-on-error` with its outcome added to `CHECK_RESULTS` as
  `code-metrics-config-reference`. Ungated on purpose: a change that edits only the reference is
  docs-only, and that is exactly the edit that can walk the table away from the defaults.
- `plugins/code-metrics/reference/config.md`: one paragraph under `## Keys` saying what is checked
  and what is not. The table and every other paragraph are unchanged.
- `plugins/code-metrics/README.md`: the residue #3841 asks to record. The prose copies of default
  values in the skill bodies stay unbound, named individually (`coverage.reference` in
  `audit-coverage`, `duplication.min_tokens` and `duplication.min_lines` in `audit-duplication`,
  `type_debt.reference` in `audit-type-debt`, the cyclomatic reference in `setup`).
- Version `0.1.5` with its changelog entry. `0.1.2`, `0.1.3` and `0.1.4` are held by the open
  #3877, #3885 and #3907; verified against current `main` (`0.1.1`, at `6db96637d`) and against
  every open code-metrics PR head immediately before opening this.

## Verification

Everything below was run locally in the foreground on `72b684c67`, branched from `6db96637d`.
Draft CI is not cited as test evidence: the `test-linux` lanes short-circuit on a draft.

- Gate on the shipped pair: `config.md documents all 23 key(s) in config-defaults.json`, exit 0.
- **Non-vacuity, at the gate's command line.** Each injection was run against a copy of the shipped
  pair and each FAILED with a message naming the key: add a key (`size.max_params`), change a value
  (`size.file_lines` 1000 to 500), change a type (`complexity.cyclomatic.reference` 20 to null),
  remove a key from the defaults while the row remains, delete the row from the document, document
  one key from two rows, a wildcard row whose leaves stop agreeing, and an `absent` row whose key
  gains a default. Reordering the defaults file passes, which is the intended behavior.
- **Markdown-significant characters, each tested.** Value `auto|HEAD` documented as `auto\|HEAD`
  passes; the same value written raw in the cell FAILS (the raw pipe truncates the cell to
  `` `auto ``, and the gate prints the correctly escaped form it wants); the same value left
  undocumented FAILS. Value `` `HEAD` `` FAILS until the cell uses a widened `` `` `` fence, then
  passes. A value containing a newline FAILS with "contains a line break, which no markdown table
  cell can carry". `render_default` is also unit-tested across `change`, `20`, `null`, `true`, `[]`,
  `["a", "b"]`, `a|b`, `` a`b ``, `` `b` ``, ``a``b`` and the newline rejection.
- **The suite itself was mutation-checked**, because a vacuous assertion is the failure mode here.
  Neutering `check()` to return no problems turns 16 of the 25 cases red (the 9 survivors are the
  clean, tolerated and fail-closed cases, which is correct). Removing only the pipe escaping from
  `render_default` turns exactly the 4 pipe/rendering cases red. Gate restored and re-verified
  green after each.
- Fail-closed: missing defaults file, malformed JSON, a document with no `## Keys` heading, and a
  `## Keys` section with no table each exit 2 rather than clearing the file.
- `bash scripts/affected-tests.sh --run --base origin/main`, sharded 0..3/4: shards 1, 2, 3 exit 3
  (success plus non-shell suites the runner declines). Shard 0 exits 1 on
  `plugins/claude-ops/skills/plugins/scripts/cache-content-check.test.sh` (2 of 24 cases, the two
  process-budget cases), reproduced identically on a clean `git archive origin/main` export, so it
  is pre-existing and not from this change.
- The 11 selected Python suites under the pinned pytest: 654 passed, 2 skipped, 138 subtests, and
  one failure, `plugins/session-flow/scripts/tests/test_save_point.py::test_new_origin_falls_back_to_directory_name`,
  also reproduced on the clean `origin/main` export. Pre-existing, unrelated to this change.
- `bash scripts/affected-tests.sh --run plugins/code-metrics/scripts/config-defaults.json` selects
  and passes `scripts/check-code-metrics-config-reference.test.sh` (exit 3). A change to
  `plugins/code-metrics/reference/config.md` selects it too.
- `scripts/check-code-metrics-config-reference.test.sh`: 25 tests, OK.
- All four parity modes green: `--check`, `--check-order`, `--check-bump origin/main`,
  `--check-preserved origin/main` (1 changed changelog, 2 headings compared).
- `scripts/run-ruff.sh check` and `format --check` clean on both new Python files.
  `shellcheck -x` and `shfmt -d` clean on the wrapper. `check-shell-portability.sh --paths` clean.
- `actionlint .github/workflows/ci.yml` exit 0. `scripts/check-docs-only-gate.sh --check` and
  `scripts/check-lane-coverage.sh --check` both green after the workflow edit.
- `markdownlint-cli2` clean on the three changed markdown files. `typos` clean on every file this
  change touches. No em dashes on any added line. All three new files committed `100755`, verified
  with `git ls-tree`.

## Related

- Closes #3841. Parent #3768 (code-metrics 0.1.0 follow-ups, from #3766).
- Version neighbours, all open at the time of writing: #3877 (0.1.2), #3885 (0.1.3), #3907 (0.1.4).
- Prior art for the shape: `scripts/sync-plugin-options-docs.py` (generated block plus `--check`),
  `scripts/check-manifest-duplicate-keys.py` with its `.test.sh` wrapper (the engine plus
  self-test convention this follows), and `test_setup_apply.py`'s existing template-to-defaults
  binding, which this extends to the second surface.

## Unmet or deferred

- The skill-body prose copies of default values remain unbound, which #3841 explicitly allows;
  they are recorded in the README's known gaps instead.
- The table's third column (meaning and provenance) is not checked against anything. No mechanical
  shape can check it, and this PR does not claim to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ViPsHkL3ng9xWt2GjEQJob


---
_Generated by [Claude Code](https://claude.ai/code/session_01ViPsHkL3ng9xWt2GjEQJob)_