### PR TITLE
ci: converge ci-workflows references on v0.22.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,7 +163,7 @@ jobs:
       - name: Match the changed files against the filter groups
         id: match
         continue-on-error: true
-        uses: melodic-software/ci-workflows/.github/actions/change-detection@906ae7ef379ea4d2b8497f64475dce1d3d8715c4 # v0.22.0
+        uses: melodic-software/ci-workflows/.github/actions/change-detection@5776760254f8b63cba44e896f51604cb755350d9 # v0.22.2
         with:
           filters: |
             shell:
@@ -325,21 +325,21 @@ jobs:
       - name: Lint markdown
         id: markdown
         continue-on-error: true
-        uses: melodic-software/ci-workflows/.github/actions/markdown@906ae7ef379ea4d2b8497f64475dce1d3d8715c4 # v0.22.0
+        uses: melodic-software/ci-workflows/.github/actions/markdown@5776760254f8b63cba44e896f51604cb755350d9 # v0.22.2
         with:
           config: .markdownlint-cli2.jsonc
 
       - name: Spell-check
         id: typos
         continue-on-error: true
-        uses: melodic-software/ci-workflows/.github/actions/typos@906ae7ef379ea4d2b8497f64475dce1d3d8715c4 # v0.22.0
+        uses: melodic-software/ci-workflows/.github/actions/typos@5776760254f8b63cba44e896f51604cb755350d9 # v0.22.2
         with:
           config: _typos.toml
 
       - name: Scan for secrets
         id: gitleaks
         continue-on-error: true
-        uses: melodic-software/ci-workflows/.github/actions/gitleaks@906ae7ef379ea4d2b8497f64475dce1d3d8715c4 # v0.22.0
+        uses: melodic-software/ci-workflows/.github/actions/gitleaks@5776760254f8b63cba44e896f51604cb755350d9 # v0.22.2
         with:
           config: .gitleaks.toml
           scan-mode: git
@@ -348,7 +348,7 @@ jobs:
       - name: Check editorconfig conformance
         id: editorconfig
         continue-on-error: true
-        uses: melodic-software/ci-workflows/.github/actions/editorconfig@906ae7ef379ea4d2b8497f64475dce1d3d8715c4 # v0.22.0
+        uses: melodic-software/ci-workflows/.github/actions/editorconfig@5776760254f8b63cba44e896f51604cb755350d9 # v0.22.2
         with:
           config: .editorconfig-checker.json
 
@@ -392,7 +392,7 @@ jobs:
       - name: Lint shell scripts
         id: shellcheck
         continue-on-error: true
-        uses: melodic-software/ci-workflows/.github/actions/shellcheck@906ae7ef379ea4d2b8497f64475dce1d3d8715c4 # v0.22.0
+        uses: melodic-software/ci-workflows/.github/actions/shellcheck@5776760254f8b63cba44e896f51604cb755350d9 # v0.22.2
         with:
           files: ${{ steps.changed_shell.outputs.files }}
           rcfile: .shellcheckrc
@@ -401,13 +401,13 @@ jobs:
         id: actionlint
         if: needs.changes.outputs.run_full == 'true'
         continue-on-error: true
-        uses: melodic-software/ci-workflows/.github/actions/actionlint@906ae7ef379ea4d2b8497f64475dce1d3d8715c4 # v0.22.0
+        uses: melodic-software/ci-workflows/.github/actions/actionlint@5776760254f8b63cba44e896f51604cb755350d9 # v0.22.2
 
       - name: Validate marketplace manifest
         id: marketplace_schema
         if: needs.changes.outputs.run_full == 'true'
         continue-on-error: true
-        uses: melodic-software/ci-workflows/.github/actions/check-jsonschema@906ae7ef379ea4d2b8497f64475dce1d3d8715c4 # v0.22.0
+        uses: melodic-software/ci-workflows/.github/actions/check-jsonschema@5776760254f8b63cba44e896f51604cb755350d9 # v0.22.2
         with:
           schemafile: https://json.schemastore.org/claude-code-marketplace.json
           files: .claude-plugin/marketplace.json
@@ -415,7 +415,7 @@ jobs:
         id: plugin_schema
         if: needs.changes.outputs.run_full == 'true'
         continue-on-error: true
-        uses: melodic-software/ci-workflows/.github/actions/check-jsonschema@906ae7ef379ea4d2b8497f64475dce1d3d8715c4 # v0.22.0
+        uses: melodic-software/ci-workflows/.github/actions/check-jsonschema@5776760254f8b63cba44e896f51604cb755350d9 # v0.22.2
         with:
           schemafile: https://json.schemastore.org/claude-code-plugin-manifest.json
           files: plugins/*/.claude-plugin/plugin.json
@@ -455,7 +455,7 @@ jobs:
         id: dependabot_schema
         if: needs.changes.outputs.run_full == 'true'
         continue-on-error: true
-        uses: melodic-software/ci-workflows/.github/actions/check-jsonschema@906ae7ef379ea4d2b8497f64475dce1d3d8715c4 # v0.22.0
+        uses: melodic-software/ci-workflows/.github/actions/check-jsonschema@5776760254f8b63cba44e896f51604cb755350d9 # v0.22.2
         with:
           builtin-schema: vendor.dependabot
           files: .github/dependabot.yml
@@ -463,7 +463,7 @@ jobs:
         id: workflow_schema
         if: needs.changes.outputs.run_full == 'true'
         continue-on-error: true
-        uses: melodic-software/ci-workflows/.github/actions/check-jsonschema@906ae7ef379ea4d2b8497f64475dce1d3d8715c4 # v0.22.0
+        uses: melodic-software/ci-workflows/.github/actions/check-jsonschema@5776760254f8b63cba44e896f51604cb755350d9 # v0.22.2
         with:
           builtin-schema: vendor.github-workflows
           files: >-
@@ -478,12 +478,12 @@ jobs:
       - name: Verify shebang files are executable
         id: exec_bit
         continue-on-error: true
-        uses: melodic-software/ci-workflows/.github/actions/exec-bit@906ae7ef379ea4d2b8497f64475dce1d3d8715c4 # v0.22.0
+        uses: melodic-software/ci-workflows/.github/actions/exec-bit@5776760254f8b63cba44e896f51604cb755350d9 # v0.22.2
 
       - name: Check for machine-specific paths
         id: machine_paths
         continue-on-error: true
-        uses: melodic-software/ci-workflows/.github/actions/machine-specific-paths@906ae7ef379ea4d2b8497f64475dce1d3d8715c4 # v0.22.0
+        uses: melodic-software/ci-workflows/.github/actions/machine-specific-paths@5776760254f8b63cba44e896f51604cb755350d9 # v0.22.2
         with:
           # The guardrails plugin bundles a path-detection pattern lib whose
           # regex bodies self-match this lane's own detector. The autonomy
@@ -516,12 +516,12 @@ jobs:
       - name: Check index-level EOL drift
         id: eol
         continue-on-error: true
-        uses: melodic-software/ci-workflows/.github/actions/eol-renormalize@906ae7ef379ea4d2b8497f64475dce1d3d8715c4 # v0.22.0
+        uses: melodic-software/ci-workflows/.github/actions/eol-renormalize@5776760254f8b63cba44e896f51604cb755350d9 # v0.22.2
 
       - name: Scan comment hygiene
         id: comment_hygiene
         continue-on-error: true
-        uses: melodic-software/ci-workflows/.github/actions/comment-hygiene@906ae7ef379ea4d2b8497f64475dce1d3d8715c4 # v0.22.0
+        uses: melodic-software/ci-workflows/.github/actions/comment-hygiene@5776760254f8b63cba44e896f51604cb755350d9 # v0.22.2
         with:
           # The audit-comment-residue skill IS a code-comment linter: its detector
           # fixtures and shape library necessarily contain the markers this policy
@@ -1064,7 +1064,7 @@ jobs:
       - name: Validate every eval set against the bundled schema
         id: evals_schema
         continue-on-error: true
-        uses: melodic-software/ci-workflows/.github/actions/check-jsonschema@906ae7ef379ea4d2b8497f64475dce1d3d8715c4 # v0.22.0
+        uses: melodic-software/ci-workflows/.github/actions/check-jsonschema@5776760254f8b63cba44e896f51604cb755350d9 # v0.22.2
         with:
           schemafile: plugins/skill-quality/reference/evals.schema.json
           files: plugins/*/skills/*/evals/evals.json
@@ -1327,7 +1327,7 @@ jobs:
         if: needs.changes.outputs.run_tests == 'true'
         # This canonical action also makes the exact ShellCheck version
         # available to the later bash-format contract tests in this same job.
-        uses: melodic-software/ci-workflows/.github/actions/shellcheck@906ae7ef379ea4d2b8497f64475dce1d3d8715c4 # v0.22.0
+        uses: melodic-software/ci-workflows/.github/actions/shellcheck@5776760254f8b63cba44e896f51604cb755350d9 # v0.22.2
         with:
           paths: plugins/bash-format
           rcfile: .shellcheckrc
@@ -1962,7 +1962,7 @@ jobs:
       statuses: write
     steps:
       - name: Check the pull-request contract
-        uses: melodic-software/ci-workflows/.github/actions/pr-contract@906ae7ef379ea4d2b8497f64475dce1d3d8715c4 # v0.22.0
+        uses: melodic-software/ci-workflows/.github/actions/pr-contract@5776760254f8b63cba44e896f51604cb755350d9 # v0.22.2
         with:
           token: ${{ github.token }}
           # Carried over verbatim from `pr-issue-linkage.yml`, the caller this

--- a/.github/workflows/issue-triage-label.yml
+++ b/.github/workflows/issue-triage-label.yml
@@ -18,6 +18,6 @@ jobs:
   issue-triage-label:
     permissions:
       issues: write # passed to the reusable, which reads and adds issue labels
-    uses: melodic-software/ci-workflows/.github/workflows/issue-triage-label.yml@906ae7ef379ea4d2b8497f64475dce1d3d8715c4 # v0.22.0
+    uses: melodic-software/ci-workflows/.github/workflows/issue-triage-label.yml@5776760254f8b63cba44e896f51604cb755350d9 # v0.22.2
     with:
       runner: ubuntu-24.04

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -20,7 +20,7 @@ jobs:
     permissions:
       contents: read
       issues: write
-    uses: melodic-software/ci-workflows/.github/workflows/link-check.yml@906ae7ef379ea4d2b8497f64475dce1d3d8715c4 # v0.22.0
+    uses: melodic-software/ci-workflows/.github/workflows/link-check.yml@5776760254f8b63cba44e896f51604cb755350d9 # v0.22.2
     with:
       runner: ubuntu-24.04
       args: >-


### PR DESCRIPTION
No related issue: melodic-software/github-iac#378 tracks the ci-perf program (Phase 6b-ii convergence)

## Summary

Every `melodic-software/ci-workflows/...` reference this repository owns now sits on v0.22.2 (`5776760254f8b63cba44e896f51604cb755350d9`). Before this change the repository carried twenty pins at `906ae7ef379ea4d2b8497f64475dce1d3d8715c4` (v0.22.0), two already at v0.22.2 from the standards sync (#3908), and two at `cd2f4e6d500e7923c0db521b4d10034d36331ed3` (v0.22.1) in standards-managed callers.

## Fix

Moved to `5776760254f8b63cba44e896f51604cb755350d9 # v0.22.2` (20 lines, 3 files):

`.github/workflows/ci.yml`, eighteen composite pins across thirteen distinct composites:

- `.github/actions/change-detection` (line 166)
- `.github/actions/markdown` (line 328)
- `.github/actions/typos` (line 335)
- `.github/actions/gitleaks` (line 342)
- `.github/actions/editorconfig` (line 351)
- `.github/actions/shellcheck` (lines 395 and 1330)
- `.github/actions/actionlint` (line 404)
- `.github/actions/check-jsonschema` (lines 410, 418, 458, 466 and 1067)
- `.github/actions/exec-bit` (line 481)
- `.github/actions/machine-specific-paths` (line 486)
- `.github/actions/eol-renormalize` (line 519)
- `.github/actions/comment-hygiene` (line 524)
- `.github/actions/pr-contract` (line 1965)

`.github/workflows/issue-triage-label.yml` line 21 and `.github/workflows/link-check.yml` line 23, the two reusable callers.

No caller input was adjusted. Each of the thirteen composites' `action.yml` is byte-identical between `906ae7ef379ea4d2b8497f64475dce1d3d8715c4` and `5776760254f8b63cba44e896f51604cb755350d9`; the compare between those two SHAs touches only `ci-status` (`action.yml`, `run.sh`, `run.test.sh`), `checks.yml`, `ci.yml`, `issue-triage-label-self.yml`, `.github/actionlint.yaml`, `.claude/cloud-bootstrap.sh` and `README.md`. Both reusables have an approved contract at v0.22.2 in `.github/standards/runner-policy/policy.json`, and each carries the same `allowedInputs`, `allowedSecrets` and `allowedCallerPermissions` as its v0.22.0 contract, so the callers moved unchanged.

`machine-specific-paths` moved with the rest rather than being held. The Phase 6b-i hold at `c2654182bc2d78f7909795df78304d482aa69226` was already released in #3790 (`7069bf57fae1b0644138dc17684dde031340ce22`, merged 2026-09-05), which adopted the v0.22.0 patterns and fixed the flagged paths. On `main` the pin read `906ae7ef379ea4d2b8497f64475dce1d3d8715c4 # v0.22.0` with no hold comment, so nothing held it back.

Left unchanged:

- `.github/workflows/ci.yml` line 1979, `.github/actions/ci-status`: already at v0.22.2 (#3875).
- `.github/workflows/managed-files-guard.yml` line 61, `.github/actions/managed-files-guard`: already at v0.22.2, and the file is `SYNC-MANAGED`.
- `.github/workflows/claude-review.yml` line 61 and `.github/workflows/claude-security-review.yml` line 108, both at `cd2f4e6d500e7923c0db521b4d10034d36331ed3` (v0.22.1): standards-managed callers whose ref is owned upstream in `melodic-software/standards`. A v0.22.2 contract exists for both paths in `policy.json`, so the bump is available whenever the next sync carries it; it is not this repository's to make.

## Verification

SHA census over `.github/workflows` and `.github/actions` on this branch:

```
$ grep -rhoE "ci-workflows/[^@ ]+@[0-9a-f]{40}" .github/workflows .github/actions | sed -E 's/.*@//' | sort | uniq -c
     22 5776760254f8b63cba44e896f51604cb755350d9
      2 cd2f4e6d500e7923c0db521b4d10034d36331ed3
```

`cd2f4e6d500e7923c0db521b4d10034d36331ed3` is the only non-v0.22.2 SHA left: the two standards-managed AI review callers named above. No deliberate holds, no missing contracts, and no Phase 7 exclusions remain in this repository.

Run locally in the worktree, all green:

- `bash scripts/check-docs-only-gate.sh --check`: scope resolved once in `changes`, 124 references across 4 consumer jobs, all in the sanctioned form.
- `npm ci --prefix .github/standards/runner-policy && node .github/standards/runner-policy/runner-policy.mjs --root .`: `Runner policy passed.` This is the same command the `Enforce runner policy` step runs in `ci.yml`.
- `actionlint -shellcheck= -pyflakes=`: clean. The external linters are covered by this pull request's own shellcheck lane.

This repository has no pin-convention test of its own; `pin-comment-convention` lives in `melodic-software/standards`.

## Related

Refs melodic-software/github-iac#378
