### PR TITLE
fix(review): ask the filesystem, not the string, whether a stub home is fenced

### DIFF
--- a/plugins/review/.claude-plugin/plugin.json
+++ b/plugins/review/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "review",
-  "version": "0.27.0",
+  "version": "0.27.1",
   "description": "Code-review toolkit: six read-only reviewer agents (code, security, architecture, doc drift, build/test/lint, CI-log audit) plus orchestration skills \u2014 quality gate, fan-out, enforceability audit (/review:audit-enforceability), and CI lane commands (/review:code-review, /review:security-review) for org reusable workflows.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/review/CHANGELOG.md
+++ b/plugins/review/CHANGELOG.md
@@ -3,6 +3,27 @@
 All notable changes to the `review` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.27.1]
+
+### Fixed
+
+- **`audit-enforceability`:** the stub-home fence asks the filesystem rather than the string.
+  Comparing spellings folds ASCII only when no locale is set, while the filesystem folds all of
+  Unicode, so a non-ASCII case variant of a fenced path (`RÉVIEWS` against `réviews`) was one
+  directory the comparison called two, and stubs landed inside the fix action's scan directory at
+  exit 0. The string compare is now the fast path; when it does not match, a walk up the
+  candidate's chain compares device and inode for the part of the path that exists.
+- **`audit-enforceability`:** the post-write marker check treats a bare CR as a line terminator and
+  strips leading whitespace, so a marker that any universal-newline reader would see cannot reach a
+  stub behind one space or one CR.
+- **`audit-enforceability`:** the exit-4 rollback removes the stub home only when the run created
+  it, instead of deleting a pre-existing empty home the caller had prepared.
+- **`audit-enforceability`:** a path segment ending in a dot or a space is refused. Such a
+  directory exists but ordinary path APIs cannot address it, so a stub home there is invisible to
+  every consumer and compares unequal to the same name without the suffix.
+- **`audit-enforceability`:** a row whose `Rank` cell is empty is stubbed under a placeholder
+  rather than dropped by an invalid array subscript while the summary counted only what it wrote.
+
 ## [0.27.0]
 
 ### Added

--- a/plugins/review/skills/audit-enforceability/scripts/emit-stubs.sh
+++ b/plugins/review/skills/audit-enforceability/scripts/emit-stubs.sh
@@ -258,15 +258,36 @@ canonicalize_dir() {
 # refusal of a genuinely distinct sibling that differs only in case, which the
 # operator sees and can rename around. A visible false refusal is recoverable;
 # a silent write into the fix action's scan directory is not.
+# A string compare cannot settle it alone. `nocasematch` folds ASCII only when
+# no locale is set, which is the common state, while the filesystem folds all of
+# Unicode: `RÉVIEWS` and `réviews` are then one directory that the string
+# compare calls two. So the string compare is the FAST PATH, and a walk that
+# asks the filesystem itself (`-ef`, which compares device and inode rather than
+# spelling) is the authority for the part of the path that exists.
 is_within() {
-  local candidate="$1" ancestor="$2" had_nocase=0 rc=1
+  local candidate="$1" ancestor="$2" had_nocase=0 rc=1 probe prev
   shopt -q nocasematch && had_nocase=1
   shopt -s nocasematch
   if [[ "$candidate" == "$ancestor" || "$candidate" == "${ancestor%/}"/* ]]; then
     rc=0
   fi
   [[ $had_nocase -eq 1 ]] || shopt -u nocasematch
-  return $rc
+  [[ $rc -eq 0 ]] && return 0
+
+  # The filesystem's own answer, for the existing part of the chain. Walks UP
+  # from the candidate, so nothing is created to decide it.
+  [[ -e "$ancestor" ]] || return 1
+  probe="$candidate"
+  while :; do
+    if [[ -e "$probe" ]] && [[ "$probe" -ef "$ancestor" ]]; then
+      return 0
+    fi
+    prev="$probe"
+    probe="${probe%/*}"
+    [[ "$probe" =~ ^[A-Za-z]:$ ]] && probe="$probe/"
+    [[ -n "$probe" ]] || probe="/"
+    [[ "$probe" != "$prev" ]] || return 1
+  done
 }
 
 # has_dotdot_segment <path>: true when the path AS GIVEN carries a `..`
@@ -279,6 +300,23 @@ has_dotdot_segment() {
   # A trailing `.` names the parent as the home. No binding resolves one, and a
   # slug of `.` that survived the charset rule is how it appears.
   [[ "$p" == "." || "$p" == *"/." ]]
+}
+
+# has_unaddressable_segment <dir>: true when a segment ends in a dot or a space.
+# Such a directory exists but Win32 path APIs cannot address it, so a stub home
+# there is invisible to every consumer that is not this shell; it also compares
+# unequal to the same name without the suffix, which is how it slips a fence.
+# Directory arguments only: a file name legitimately ends in `.md`.
+has_unaddressable_segment() {
+  local p="${1//\\//}" seg rest
+  rest="$p"
+  while [[ -n "$rest" ]]; do
+    seg="${rest%%/*}"
+    if [[ "$rest" == */* ]]; then rest="${rest#*/}"; else rest=""; fi
+    [[ -z "$seg" || "$seg" == "." || "$seg" == ".." ]] && continue
+    [[ "$seg" == *[.\ ] ]] && return 0
+  done
+  return 1
 }
 
 # is_unc_path <path>: true for a path whose leading double separator makes it a
@@ -430,6 +468,13 @@ if has_dotdot_segment "$findings"; then
     "$findings" >&2
   exit 3
 fi
+for dir_candidate in "$out" "$scan_dir" ${memory_root:+"$memory_root"}; do
+  if has_unaddressable_segment "$dir_candidate"; then
+    printf 'refusing: %s has a path segment ending in a dot or a space. That directory exists but is unaddressable by ordinary path APIs, so a stub home there is invisible to every consumer, and it compares unequal to the same name without the suffix.\n' \
+      "$dir_candidate" >&2
+    exit 3
+  fi
+done
 for unc_candidate in "$out" "$scan_dir" "$findings" ${memory_root:+"$memory_root"}; do
   if is_unc_path "$unc_candidate"; then
     printf 'refusing: %s is a network-share path. The fence normalizes it to a path that does not exist while the operating system still resolves the raw argument, so the two would not describe the same directory.\n' \
@@ -574,6 +619,7 @@ count=0
 malformed=0
 
 mkdir_done=0
+created_home=0
 
 while IFS= read -r record; do
   [[ -n "$record" ]] || continue
@@ -582,6 +628,11 @@ while IFS= read -r record; do
     continue
   fi
   IFS=$'\002' read -r r_rank r_tier r_conf r_loc r_surf r_find r_act <<<"$record"
+  # An empty Rank cell is a row, not a reason to lose one. It cannot key the
+  # classification map (an empty array subscript is an error that would drop the
+  # row while the summary still counted only what it wrote), so it takes a
+  # placeholder and falls through to the unclassified defaults.
+  [[ -n "$r_rank" ]] || r_rank="unranked"
   table_ranks+=("$r_rank")
   seen_rank["$r_rank"]=1
 
@@ -622,6 +673,7 @@ while IFS= read -r record; do
   fi
 
   if [[ $mkdir_done -eq 0 ]]; then
+    [[ -d "$out" ]] || created_home=1
     if ! mkdir -p "$out"; then
       printf 'refusing: could not create the stub home %s.\n' "$out" >&2
       exit 2
@@ -697,16 +749,27 @@ fi
 # the four markers. Read in-shell rather than with grep: the markers are
 # line-anchored literals, and a spawn per stub is the dominant cost on a
 # spawn-bound host.
+# The line model is deliberately WIDER than this script's own writer uses. A
+# reader downstream may split on a bare CR as well as LF (every
+# universal-newline reader does), and may tolerate leading whitespace before a
+# key. A check that modelled only LF-terminated, column-0 markers would pass a
+# stub that such a reader still sees as declaring one, so CR is treated as a
+# terminator too and leading whitespace is stripped before the compare.
 has_forbidden_marker() {
-  local line
-  while IFS= read -r line || [[ -n "$line" ]]; do
-    line="${line%$'\r'}"
-    case "$line" in
-    'type: review-findings'* | 'type: fix-pass-record'* | 'branch:'* | '## Findings'*)
-      return 0
-      ;;
-    *) ;;
-    esac
+  local chunk line
+  while IFS= read -r chunk || [[ -n "$chunk" ]]; do
+    while [[ -n "$chunk" || -n "${chunk+x}" ]]; do
+      line="${chunk%%$'\r'*}"
+      line="${line#"${line%%[![:space:]]*}"}"
+      case "$line" in
+      'type: review-findings'* | 'type: fix-pass-record'* | 'branch:'* | '## Findings'*)
+        return 0
+        ;;
+      *) ;;
+      esac
+      [[ "$chunk" == *$'\r'* ]] || break
+      chunk="${chunk#*$'\r'}"
+    done
   done <"$1"
   return 1
 }
@@ -724,10 +787,12 @@ if [[ -n "$violation" ]]; then
   # option, `rm` refuses the lot, and the rollback this refusal promises would
   # silently leave the marker-bearing stubs on disk.
   rm -f -- ${written[@]+"${written[@]}"}
-  # A home this run created and then emptied is not left behind as evidence of
-  # a write that was taken back. rmdir refuses a directory that still holds
-  # anything, so a pre-existing home with other files in it survives.
-  rmdir "$out" 2>/dev/null || :
+  # Only a home THIS RUN created is removed. `rmdir` alone would also delete a
+  # pre-existing empty home the caller had prepared, which is state the run did
+  # not create and has no business destroying.
+  if [[ $created_home -eq 1 ]]; then
+    rmdir -- "$out" 2>/dev/null || :
+  fi
   printf 'refusing: %s carried a findings-file marker, which would offer it to the fix pass. Every stub this run wrote has been removed.\n' \
     "$violation" >&2
   exit 4

--- a/plugins/review/skills/audit-enforceability/scripts/emit-stubs.test.sh
+++ b/plugins/review/skills/audit-enforceability/scripts/emit-stubs.test.sh
@@ -505,6 +505,79 @@ bash "$EMIT" --findings "$FINDINGS" --classes "$CLASSES" --out "$CHARSET_OK" \
   --scan-dir "$SCAN_DIR" --memory-root "$CHARSET_ROOT" >/dev/null 2>&1
 assert_eq "case 21: a last segment inside the charset still writes" "0" "$?"
 assert_eq "case 21: the charset-ok home got its seven stubs" "7" "$(count_files "$CHARSET_OK")"
+# --- Case 22: a NON-ASCII case-variant spelling ------------------------------
+#
+# A string compare folds ASCII only when no locale is set, while the filesystem
+# folds all of Unicode, so a non-ASCII segment spelled two ways is one directory
+# the string compare calls two. This is the arm case 17 cannot cover.
+UNI="$TEST_TMPDIR/uni"
+if mkdir -p "$UNI/réviews/feat-x" 2>/dev/null && [[ -d "$UNI/réviews/feat-x" ]]; then
+  cp "$FINDINGS" "$UNI/réviews/feat-x/review-findings.md"
+  bash "$EMIT" --findings "$UNI/réviews/feat-x/review-findings.md" --classes "$CLASSES" \
+    --out "$UNI/RÉVIEWS/feat-x/stubs" --scan-dir "$UNI/réviews/feat-x" >/dev/null 2>&1
+  uni_exit=$?
+  uni_landed=0
+  for f in "$UNI/réviews/feat-x/stubs"/*.md; do
+    [[ -f "$f" ]] && uni_landed=$((uni_landed + 1))
+  done
+  if [[ "$uni_landed" -gt 0 ]]; then
+    fail "case 22: a non-ASCII case variant is fenced" "no stub inside --scan-dir" "$uni_landed stubs landed there"
+  elif [[ "$uni_exit" -eq 3 ]]; then
+    pass "case 22: a non-ASCII case variant of --scan-dir is refused"
+  else
+    # On a case-SENSITIVE volume the two spellings are genuinely two
+    # directories, so writing is correct and nothing landed in the scan dir.
+    pass "case 22: the non-ASCII spellings are distinct directories on this volume, and nothing landed in --scan-dir"
+  fi
+else
+  skip_case "case 22: this filesystem does not accept a non-ASCII path segment"
+fi
+
+# --- Case 23: whitespace and bare CR before a forbidden marker ---------------
+#
+# A reader downstream may split on a bare CR and may tolerate leading space, so
+# a check modelling only LF-terminated column-0 markers would pass a stub such a
+# reader still sees as declaring one.
+OUT22="$TEST_TMPDIR/out22"
+printf '1\tstyle\tjudgment\teditorconfig-severity\t branch: evil\n' >"$TEST_TMPDIR/classes-ws.tsv"
+bash "$EMIT" --findings "$FINDINGS" --classes - --out "$OUT22" --scan-dir "$SCAN_DIR" \
+  <"$TEST_TMPDIR/classes-ws.tsv" >/dev/null 2>&1
+assert_eq "case 23: a marker behind leading whitespace still exits 4" "4" "$?"
+assert_eq "case 23: the whitespace-marker run left no stub" "0" "$(count_files "$OUT22")"
+
+OUT22B="$TEST_TMPDIR/out22b"
+printf '1\tstyle\tjudgment\teditorconfig-severity\tpre\rbranch: evil\n' >"$TEST_TMPDIR/classes-cr.tsv"
+bash "$EMIT" --findings "$FINDINGS" --classes - --out "$OUT22B" --scan-dir "$SCAN_DIR" \
+  <"$TEST_TMPDIR/classes-cr.tsv" >/dev/null 2>&1
+assert_eq "case 23: a marker after an embedded bare CR still exits 4" "4" "$?"
+assert_eq "case 23: the CR-marker run left no stub" "0" "$(count_files "$OUT22B")"
+
+# --- Case 24: a segment ending in a dot or a space is refused ----------------
+bash "$EMIT" --findings "$FINDINGS" --classes "$CLASSES" --out "$SCAN_DIR." \
+  --scan-dir "$SCAN_DIR" >/dev/null 2>&1
+assert_eq "case 24: a home whose segment ends in a dot is refused" "3" "$?"
+bash "$EMIT" --findings "$FINDINGS" --classes "$CLASSES" --out "$TEST_TMPDIR/out23 " \
+  --scan-dir "$SCAN_DIR" >/dev/null 2>&1
+assert_eq "case 24: a home whose segment ends in a space is refused" "3" "$?"
+
+# --- Case 25: the rollback leaves pre-existing state alone -------------------
+OUT24="$TEST_TMPDIR/out24"
+mkdir -p "$OUT24"
+bash "$EMIT" --findings "$FINDINGS" --classes - --out "$OUT24" --scan-dir "$SCAN_DIR" \
+  <"$TEST_TMPDIR/classes-poison.tsv" >/dev/null 2>&1
+assert_eq "case 25: the marker refusal still exits 4" "4" "$?"
+assert_eq "case 25: a home the run did NOT create survives its rollback" "1" \
+  "$([[ -d "$OUT24" ]] && echo 1 || echo 0)"
+assert_eq "case 25: but it holds no stub" "0" "$(count_files "$OUT24")"
+
+# --- Case 26: a row with an empty Rank is stubbed, not lost ------------------
+EMPTY_RANK="$TEST_TMPDIR/input/empty-rank.md"
+awk '/^\| 7 \|/ { sub(/^\| 7 \|/, "|  |") } { print }' "$FINDINGS" >"$EMPTY_RANK"
+OUT25="$TEST_TMPDIR/out25"
+bash "$EMIT" --findings "$EMPTY_RANK" --classes "$CLASSES" --out "$OUT25" \
+  --scan-dir "$SCAN_DIR" >/dev/null 2>&1
+assert_eq "case 26: an empty Rank cell does not fail the run" "0" "$?"
+assert_eq "case 26: the empty-Rank row still produced a stub" "7" "$(count_files "$OUT25")"
 
 # --- Dry run ------------------------------------------------------------------
 


### PR DESCRIPTION
Follow-up to #3902 (issue #3815), which merged while an adversarial pass was still running against it. The safety property that slice exists to hold, that an enforceability stub cannot land where the review fan-out's `fix` pass will consume it, was breakable on the merged code.

## The escape

A fresh-context attacker landed **seven stubs inside the fix action's `--scan-dir`, at exit 0**, and seven more beside the findings file, using a non-ASCII case variant of the fenced path:

```bash
mkdir -p "$S/root/réviews/feat-x"
emit-stubs.sh --findings "$S/root/réviews/feat-x/review-findings.md" \
  --out "$S/root/RÉVIEWS/feat-x/stubs" --scan-dir "$S/root/réviews/feat-x"
# 7 findings → 7 stubs ...   EXIT 0, and they are physically inside --scan-dir
```

`is_within` compared with `shopt -s nocasematch`, which folds **ASCII only** when no locale is set, the deployed state. The filesystem folds all of Unicode, so `RÉVIEWS` and `réviews` are one directory the comparison called two. `pwd -P` does not fold segment case, so canonicalization could not close it. This is the same defect class the case-insensitive compare was added for, still open for every non-ASCII letter.

**Fix:** the string compare is now the fast path only. When it does not match, a walk up the candidate's chain asks the filesystem itself, `-ef`, which compares device and inode rather than spelling, for the part of the path that exists. Nothing is created to decide it.

## Four more from the same pass

- **The marker self-check modelled only LF-terminated, column-0 markers.** One leading space, or one embedded bare CR, carried `branch: evil` into a stub at exit 0. Every universal-newline reader splits on that CR and sees a line beginning `branch:`. The check now treats CR as a terminator and strips leading whitespace.
- **The exit-4 rollback deleted a pre-existing empty stub home** the run had not created. It now removes the home only when it created it.
- **A segment ending in a dot or a space** names a directory ordinary path APIs cannot address, invisible to every consumer and unequal to the same name without the suffix, which is how it slipped the fence. Refused.
- **An empty `Rank` cell was an invalid array subscript**, so the row was silently dropped while the summary counted only what it wrote and the run exited 0. It takes a placeholder and falls through to the unclassified defaults.

## Pinned

Cases 22 to 26 cover all five; case 22 degrades honestly on a case-sensitive volume rather than asserting a refusal that would be wrong there. The suite passes at **113 checks, 1 skipped** (the skip is case 16, which cannot force a write failure on a host that writes into read-only directories). `shellcheck --rcfile .shellcheckrc -x` is clean on both files.

Every attack that still exits 3 or 2 was snapshotted before and after: a refused run creates nothing. The name-prefix sibling (`reviews-archive` beside `reviews`) and a correctly composed home under `--memory-root` both still exit 0 and write, so the refusals are pinned in both directions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
