### PR TITLE
ci: move the claude lanes to ci-workflows v0.22.2

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -58,7 +58,7 @@ jobs:
     concurrency:
       group: claude-review-${{ github.repository }}
       queue: max
-    uses: melodic-software/ci-workflows/.github/workflows/claude-review.yml@cd2f4e6d500e7923c0db521b4d10034d36331ed3 # v0.22.1
+    uses: melodic-software/ci-workflows/.github/workflows/claude-review.yml@5776760254f8b63cba44e896f51604cb755350d9 # v0.22.2
     with:
       runner: ubuntu-24.04
       # Empty on a pull_request event, where the payload supplies the number

--- a/.github/workflows/claude-security-review.yml
+++ b/.github/workflows/claude-security-review.yml
@@ -105,7 +105,7 @@ jobs:
       contents: read         # checkout + read the diff
       pull-requests: write   # post the security review
       id-token: write        # OIDC — mints the Claude GitHub App token
-    uses: melodic-software/ci-workflows/.github/workflows/claude-security-review.yml@cd2f4e6d500e7923c0db521b4d10034d36331ed3 # v0.22.1
+    uses: melodic-software/ci-workflows/.github/workflows/claude-security-review.yml@5776760254f8b63cba44e896f51604cb755350d9 # v0.22.2
     with:
       runner: ubuntu-24.04
       paths-file: .github/claude-security-paths


### PR DESCRIPTION
No related issue: melodic-software/github-iac#378 tracks the ci-perf program (Phase 6b-ii item K).

## Summary

Moves the two locally owned claude-lane callers in this repo from
`ci-workflows` v0.22.1 to v0.22.2:

- `.github/workflows/claude-review.yml`
- `.github/workflows/claude-security-review.yml`

## Fix

Both callers reference `melodic-software/ci-workflows` reusable workflows by
pinned commit SHA with a version comment. Neither carries a `SYNC-MANAGED`
header, so this bump is manual rather than an automated sync. The change is
exactly two lines: the `uses:` SHA and trailing version comment on each
caller, from `@cd2f4e6d500e7923c0db521b4d10034d36331ed3 # v0.22.1` to
`@5776760254f8b63cba44e896f51604cb755350d9 # v0.22.2`.

Before bumping, confirmed both v0.22.2 contracts already exist in
`.github/standards/runner-policy/policy.json`, and diffed each reusable
workflow's `on.workflow_call` block between the old and new SHA via the
GitHub contents API — both are byte-identical, so no other input/permission
surface changed underneath these callers.

**Expected red on this PR:** `claude-code-action` refuses to run when a PR
edits its own caller workflow (`Workflow validation failed ... must have
identical content to the version on the repository's default branch`), so
the `claude-security-review` lane is expected to fail closed on this PR with
`class=skipped-validation`. That lane is non-required and self-heals once
this PR merges to the default branch. This is expected and not something
this PR attempts to fix.

## Verification

Local gates run in the worktree, all green:

- `actionlint -shellcheck= -pyflakes=` — passed, no findings.
- `scripts/check-docs-only-gate.sh --check` — passed.
- `.github/standards/runner-policy/runner-policy.mjs --root .` (with
  `CI_REPOSITORY_VISIBILITY=public GITHUB_REPOSITORY=melodic-software/claude-code-plugins`)
  — "Runner policy passed."

A fresh-context verifier subagent independently checked the diff before this
PR was opened. Verdict: **PASS** on all four criteria —

- Only the two expected lines changed (`git diff --stat` / `git diff`).
- The new SHA `5776760254f8b63cba44e896f51604cb755350d9` appears in
  `policy.json` for both `claude-review.yml` and `claude-security-review.yml`
  contracts.
- Both reusable workflows' `on.workflow_call` blocks are byte-identical
  between the old and new SHA.
- `git grep -hoE "ci-workflows/[^@ ]+@[0-9a-f]{40}" -- .github/workflows | sed -E 's/.*@//' | sort -u`
  prints only `5776760254f8b63cba44e896f51604cb755350d9`.

## Related

Refs melodic-software/github-iac#378
