### PR TITLE
docs(adr): amend the CI posture records for the fleet-first decision (Phase 9a)

### DIFF
--- a/docs/adr/0002-default-on-ai-review-advisory-with-earned-promotion.md
+++ b/docs/adr/0002-default-on-ai-review-advisory-with-earned-promotion.md
@@ -342,10 +342,13 @@ a bare draft comparison would never run the review an operator asked for.
 the shared Claude seat instead of contending for it; the security caller queues per pull request
 with `cancel-in-progress: false`. This is a deliberate exception to the cancel-in-progress posture
 `ci.yml` applies to every other pull-request lane, and it is affordable only because these lanes are
-advisory: a queued review blocks no merge. Two mechanics constrain the shape. `queue` and
-`cancel-in-progress` cannot be combined on one group
+advisory: a queued review blocks no merge. The two lanes are deliberately not normalized to each
+other, and two mechanics constrain the code-review shape. `queue: max` and `cancel-in-progress:
+true` cannot be combined on one group; that pairing is a workflow validation error
 (<https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idconcurrency>),
-so the queue is a job-level group beside the workflow-level cancel group rather than a change to it;
+while `cancel-in-progress: false` beside a `queue` key is legal, which is the shape the security
+lane uses. So the queue is a job-level group beside the workflow-level cancel group rather than a
+change to it;
 and the group is deliberately distinct from the reusable workflow's own inner group, which is keyed
 per pull request and head SHA, because a caller group sharing that name would deadlock the call
 against itself. Anthropic's documented behaviour for its own review product is the same: a second

--- a/docs/adr/0002-default-on-ai-review-advisory-with-earned-promotion.md
+++ b/docs/adr/0002-default-on-ai-review-advisory-with-earned-promotion.md
@@ -9,6 +9,7 @@
 - [Addendum (2026-07-21): step 3 applied — required check live; skip-actor exception](#addendum-2026-07-21-step-3-applied--required-check-live-skip-actor-exception)
 - [Addendum (2026-08-03): mechanism correction — the exception moved to a reusable default](#addendum-2026-08-03-mechanism-correction--the-exception-moved-to-a-reusable-default)
 - [Addendum (2026-08-04): operator decision — Branch A ratified, four actors](#addendum-2026-08-04-operator-decision--branch-a-ratified-four-actors)
+- [Addendum (2026-09-07): once per pull request, drafts filtered, reviews queued](#addendum-2026-09-07-once-per-pull-request-drafts-filtered-reviews-queued)
 - [Revisit triggers](#revisit-triggers)
 
 - Status: accepted
@@ -307,6 +308,53 @@ Four is now the ratified baseline the `skip-actors` trigger measures additions a
 actor widens a deliberated exception and warrants the same deliberation. Unchanged by this
 decision — the review lane's inherited default stays deferred with its own trigger, and the
 caller-tamper gap recorded above stays open pending ci-workflows#345.
+
+## Addendum (2026-09-07): once per pull request, drafts filtered, reviews queued
+
+Recorded by the ci-perf program (melodic-software/github-iac#378, Phase 9). The decision above is
+unchanged: both lanes stay default-on and advisory, and promotion is still earned. What changed is
+that the lane triggers now match that posture instead of running as if a blocking gate might return.
+Landed in claude-code-plugins#3696 (`31dc91ded6cc51cac47c6cb27c49788ba9cde449`, merged
+2026-09-04), the same change that collapsed `ci.yml` into six jobs.
+
+**The trigger set.** Both callers now run on `opened`, `ready_for_review` and `reopened` only. A
+push to an open pull request no longer re-triggers either lane. `synchronize` bought a duplicate
+advisory report per push: it only ever earned its cost against a gate certifying execution against
+the latest head, and neither lane is one here. A finding on an older head is a finding to
+disposition, which is what advisory already meant.
+
+There are exactly three ways to get a review of a newer head, and the caller comments name them:
+reopen the pull request, flip it to draft and back to ready, or, on the code-review lane,
+`workflow_dispatch` with the pull request's number. Re-running the job is not one of them; a re-run
+replays the original event payload and the reusable workflow's freshness guard retires it as
+superseded. The security caller carries no `workflow_dispatch` re-entry, because its skip-actors job
+reads the ratified list from the pull request's base branch and a dispatch has no base ref to read
+it from.
+
+**The draft filter.** A draft is work in progress and does not spend a review; the
+`ready_for_review` trigger is what delivers one when it is ready. The code-review job's condition is
+`github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false`, and the
+`event_name` clause is load-bearing: a dispatched run has no `github.event.pull_request` at all, so
+a bare draft comparison would never run the review an operator asked for.
+
+**Queued, not cancelled.** The code-review job takes a second, repository-wide concurrency group
+(`claude-review-${{ github.repository }}`) with `queue: max`, so parallel pull requests queue for
+the shared Claude seat instead of contending for it; the security caller queues per pull request
+with `cancel-in-progress: false`. This is a deliberate exception to the cancel-in-progress posture
+`ci.yml` applies to every other pull-request lane, and it is affordable only because these lanes are
+advisory: a queued review blocks no merge. Two mechanics constrain the shape. `queue` and
+`cancel-in-progress` cannot be combined on one group
+(<https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idconcurrency>),
+so the queue is a job-level group beside the workflow-level cancel group rather than a change to it;
+and the group is deliberately distinct from the reusable workflow's own inner group, which is keyed
+per pull request and head SHA, because a caller group sharing that name would deadlock the call
+against itself. Anthropic's documented behaviour for its own review product is the same: a second
+request while one runs is queued until the in-progress review completes
+(<https://code.claude.com/docs/en/code-review>).
+
+The organization-wide statement of this posture, with its evidence, is in github-iac
+`docs/topics/ci-perf/POSTURE.md` under "Advisory AI review", and the org record that the lanes are
+advisory at all is github-iac ADR 0011.
 
 ## Revisit triggers
 

--- a/docs/adr/0002-default-on-ai-review-advisory-with-earned-promotion.md
+++ b/docs/adr/0002-default-on-ai-review-advisory-with-earned-promotion.md
@@ -347,9 +347,9 @@ other, and two mechanics constrain the code-review shape. `queue: max` and `canc
 true` cannot be combined on one group; that pairing is a workflow validation error
 (<https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idconcurrency>),
 while `cancel-in-progress: false` beside a `queue` key is legal, which is the shape the security
-lane uses. So the queue is a job-level group beside the workflow-level cancel group rather than a
-change to it;
-and the group is deliberately distinct from the reusable workflow's own inner group, which is keyed
+lane uses. The queue therefore lives in a job-level group; the code-review caller declares no
+workflow-level group of its own, so there is nothing at that level to change. The group is also
+deliberately distinct from the reusable workflow's own inner group, which is keyed
 per pull request and head SHA, because a caller group sharing that name would deadlock the call
 against itself. Anthropic's documented behaviour for its own review product is the same: a second
 request while one runs is queued until the in-progress review completes

--- a/docs/adr/0002-default-on-ai-review-advisory-with-earned-promotion.md
+++ b/docs/adr/0002-default-on-ai-review-advisory-with-earned-promotion.md
@@ -320,8 +320,20 @@ Landed in claude-code-plugins#3696 (`31dc91ded6cc51cac47c6cb27c49788ba9cde449`, 
 **The trigger set.** Both callers now run on `opened`, `ready_for_review` and `reopened` only. A
 push to an open pull request no longer re-triggers either lane. `synchronize` bought a duplicate
 advisory report per push: it only ever earned its cost against a gate certifying execution against
-the latest head, and neither lane is one here. A finding on an older head is a finding to
-disposition, which is what advisory already meant.
+the latest head. A finding on an older head is a finding to disposition, which is what advisory
+already meant.
+
+**This retires the 2026-07-21 required-execution ruling for this repository, and says so rather
+than leaving the two records to contradict each other.** That addendum promoted execution evidence
+to a required status check on the protected base, and the security caller's own header still warns
+that without the push trigger the required check can certify a head the branch has since moved past.
+That warning is written against a base where the evidence check is required. Here it no longer is:
+the ci-perf required-check contract (Phase 3, melodic-software/github-iac#378) made `ci-status` the
+single required context, and `gh api repos/melodic-software/claude-code-plugins/rules/branches/main`
+read on 2026-09-07 returns exactly `[{"context": "ci-status", "integration_id": 15368}]`. No
+security-evidence context is required, so dropping `synchronize` gives up no certification the
+ruleset asks for. Reinstating a required execution check is a new decision, and it would have to
+restore the push trigger with it; the revisit triggers below already say so.
 
 There are exactly three ways to get a review of a newer head, and the caller comments name them:
 reopen the pull request, flip it to draft and back to ready, or, on the code-review lane,
@@ -348,8 +360,13 @@ true` cannot be combined on one group; that pairing is a workflow validation err
 (<https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idconcurrency>).
 The queue therefore lives in a job-level group; the code-review caller declares no workflow-level
 group of its own, so there is nothing at that level to change. The security lane needs no `queue`
-key at all: it groups per pull request with `cancel-in-progress: false`, so its reviews neither
-cancel nor contend. The code-review group is also
+key: it groups per pull request with `cancel-in-progress: false`, which keeps the running review
+alive rather than cancelling it when a second event arrives. That is weaker than a queue and the
+difference is worth knowing. Without `queue`, a group holds one pending run, so a third
+review-triggering event on the same pull request evicts the pending second one rather than lining up
+behind it. On an advisory lane running once per pull request that is an acceptable loss; on the
+repository-wide code-review group, where several pull requests contend for one seat, it is not,
+which is what `queue: max` is there for. The code-review group is also
 deliberately distinct from the reusable workflow's own inner group, which is keyed
 per pull request and head SHA, because a caller group sharing that name would deadlock the call
 against itself. Anthropic's documented behaviour for its own review product is the same: a second

--- a/docs/adr/0002-default-on-ai-review-advisory-with-earned-promotion.md
+++ b/docs/adr/0002-default-on-ai-review-advisory-with-earned-promotion.md
@@ -345,10 +345,11 @@ with `cancel-in-progress: false`. This is a deliberate exception to the cancel-i
 advisory: a queued review blocks no merge. The two lanes are deliberately not normalized to each
 other, and two mechanics constrain the code-review shape. `queue: max` and `cancel-in-progress:
 true` cannot be combined on one group; that pairing is a workflow validation error
-(<https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idconcurrency>),
-while `cancel-in-progress: false` beside a `queue` key is legal, which is the shape the security
-lane uses. The queue therefore lives in a job-level group; the code-review caller declares no
-workflow-level group of its own, so there is nothing at that level to change. The group is also
+(<https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idconcurrency>).
+The queue therefore lives in a job-level group; the code-review caller declares no workflow-level
+group of its own, so there is nothing at that level to change. The security lane needs no `queue`
+key at all: it groups per pull request with `cancel-in-progress: false`, so its reviews neither
+cancel nor contend. The code-review group is also
 deliberately distinct from the reusable workflow's own inner group, which is keyed
 per pull request and head SHA, because a caller group sharing that name would deadlock the call
 against itself. Anthropic's documented behaviour for its own review product is the same: a second

--- a/docs/adr/0019-share-code-across-plugins-by-vendoring-with-a-sync-gate.md
+++ b/docs/adr/0019-share-code-across-plugins-by-vendoring-with-a-sync-gate.md
@@ -90,12 +90,19 @@ Each shared source used to get **its own CI job**. Before claude-code-plugins#36
 `check-retirements-sync`, `legacy-statusline-detect-sync`, `unwrap-before-compose-sync`,
 `resolve-convention-home-sync`, `resolve-convention-pattern-sync`, `index-regen-sync` and
 `standards-contract-sync`. Each was a runner, a pinned `actions/checkout`, a
-`checkout-with-base` deepen to full history plus a base fetch, and then the `--check` and
-`--check-bump` steps themselves. No toolchain install: these are shell scripts, and the toolchains
-belong to `test-linux`. The overhead was the runner, the checkout and the unshallow, and GitHub
-rounds every job up to a whole minute
-(<https://docs.github.com/en/billing/reference/actions-runner-pricing>), so thirteen jobs bought
-thirteen billed minutes at a floor for work measured in seconds.
+`checkout-with-base` deepen to full history plus a base fetch, the `--check` and `--check-bump`
+steps, and in eleven of the thirteen a per-library test step as well. No toolchain install: these
+are shell scripts, and the toolchains belong to `test-linux`. The cost was the runner, the checkout
+and the unshallow, paid thirteen times over.
+
+**The cost is latency here and money on the fleet.** This repository is public and the jobs ran on
+`ubuntu-24.04`, a standard runner, so nothing was billed: what thirteen jobs bought was thirteen
+runner startups and thirteen unshallows on the critical path, and thirteen concurrency slots taken
+from every other lane in the run. In the private repositories the same ci-perf program covers, the
+identical shape does cost money, because GitHub rounds the minutes and partial minutes each job uses
+up to the nearest whole minute
+(<https://docs.github.com/en/billing/reference/actions-runner-pricing>), so a per-library job floor
+is a per-library billed minute there.
 
 **They are now steps, not jobs.** Twelve of the thirteen run as steps of `test-linux`, which
 already performs that same deepen and base fetch for its own `--check-bump` steps;

--- a/docs/adr/0019-share-code-across-plugins-by-vendoring-with-a-sync-gate.md
+++ b/docs/adr/0019-share-code-across-plugins-by-vendoring-with-a-sync-gate.md
@@ -75,3 +75,33 @@ obligates a plugin `version` bump, since the version is the update cache key. (`
 `repo-analysis` + `video-digestion`, shared by its `video-digest` and `course-digest` skills, is the
 reference instance.) Reach for the cross-plugin shape above only once a *second plugin* genuinely
 needs the same source.
+
+## Addendum (2026-09-07): one sync lane with N steps, not one lane per library
+
+Recorded by the ci-perf program (melodic-software/github-iac#378, Phase 9). The decision above is
+unchanged: a shared source still has one canonical copy, a `sync-*.sh` script still propagates it,
+and CI still fails a pull request when a copy drifts or when the lib changed without a plugin
+version bump. What changed is where that gate runs.
+
+Each shared source used to get **its own CI job**. Before claude-code-plugins#3696
+(`31dc91ded6cc51cac47c6cb27c49788ba9cde449`, merged 2026-09-04) `ci.yml` carried thirteen
+`*-sync` jobs, one per library: `hook-utils-sync`, `rewrite-guard-sync`,
+`parse-concern-value-sync`, `managed-scope-sync`, `state-key-sync`, `spawn-noise-sync`,
+`check-retirements-sync`, `legacy-statusline-detect-sync`, `unwrap-before-compose-sync`,
+`resolve-convention-home-sync`, `resolve-convention-pattern-sync`, `index-regen-sync` and
+`standards-contract-sync`. Each paid a fresh runner, a fresh checkout and a fresh toolchain install
+to run a few seconds of `--check`, and GitHub bills a job by whole minutes, so the per-job overhead
+dominated the work by an order of magnitude.
+
+**They are now steps, not jobs.** Twelve of the thirteen run as steps of `test-linux`, which is
+where the `--check-bump` steps' base history already lives; `sync-hook-utils.sh` runs in the
+`hook-utils` job beside the hook contract tests it covers. Every step keeps the name it had, so a
+failure still says which library drifted. Adding a fourteenth shared source therefore adds a step to
+an existing job, and adding a job is the thing to justify rather than the default.
+
+Nothing about the invariant moved: byte-drift is still fatal, the `--check-bump` half still fails a
+lib change whose carrying plugin's manifest version did not move, and the intra-plugin `vendor/`
+shape above still replaces the byte-drift gate with delivery-by-version
+(`check-vendor-version-bump.sh`, its own gate). **Recheck trigger:** a sync gate that needs a
+different runner, a different toolchain, or an isolation the consolidated job cannot give it earns
+its own job again; say which of the three when adding one.

--- a/docs/adr/0019-share-code-across-plugins-by-vendoring-with-a-sync-gate.md
+++ b/docs/adr/0019-share-code-across-plugins-by-vendoring-with-a-sync-gate.md
@@ -99,10 +99,12 @@ and the unshallow, paid thirteen times over.
 `ubuntu-24.04`, a standard runner, so nothing was billed: what thirteen jobs bought was thirteen
 runner startups and thirteen unshallows on the critical path, and thirteen concurrency slots taken
 from every other lane in the run. In the private repositories the same ci-perf program covers, the
-identical shape does cost money, because GitHub rounds the minutes and partial minutes each job uses
-up to the nearest whole minute
+identical shape spends the metered minute pool instead, because GitHub rounds the minutes and
+partial minutes each job uses up to the nearest whole minute
 (<https://docs.github.com/en/billing/reference/actions-runner-pricing>), so a per-library job floor
-is a per-library billed minute there.
+is a per-library pooled minute there. That organization caps Actions spend at `$0` with
+`prevent_further_usage` (melodic-software/github-iac ADR 0008), so the failure mode is not a line
+item but a hard stop on every private repository's hosted CI once the pool is gone.
 
 **They are now steps, not jobs.** Twelve of the thirteen run as steps of `test-linux`, which
 already performs that same deepen and base fetch for its own `--check-bump` steps;

--- a/docs/adr/0019-share-code-across-plugins-by-vendoring-with-a-sync-gate.md
+++ b/docs/adr/0019-share-code-across-plugins-by-vendoring-with-a-sync-gate.md
@@ -89,15 +89,28 @@ Each shared source used to get **its own CI job**. Before claude-code-plugins#36
 `parse-concern-value-sync`, `managed-scope-sync`, `state-key-sync`, `spawn-noise-sync`,
 `check-retirements-sync`, `legacy-statusline-detect-sync`, `unwrap-before-compose-sync`,
 `resolve-convention-home-sync`, `resolve-convention-pattern-sync`, `index-regen-sync` and
-`standards-contract-sync`. Each paid a fresh runner, a fresh checkout and a fresh toolchain install
-to run a few seconds of `--check`, and GitHub bills a job by whole minutes, so the per-job overhead
-dominated the work by an order of magnitude.
+`standards-contract-sync`. Each was a runner, a pinned `actions/checkout`, a
+`checkout-with-base` deepen to full history plus a base fetch, and then the `--check` and
+`--check-bump` steps themselves. No toolchain install: these are shell scripts, and the toolchains
+belong to `test-linux`. The overhead was the runner, the checkout and the unshallow, and GitHub
+rounds every job up to a whole minute
+(<https://docs.github.com/en/billing/reference/actions-runner-pricing>), so thirteen jobs bought
+thirteen billed minutes at a floor for work measured in seconds.
 
-**They are now steps, not jobs.** Twelve of the thirteen run as steps of `test-linux`, which is
-where the `--check-bump` steps' base history already lives; `sync-hook-utils.sh` runs in the
-`hook-utils` job beside the hook contract tests it covers. Every step keeps the name it had, so a
-failure still says which library drifted. Adding a fourteenth shared source therefore adds a step to
-an existing job, and adding a job is the thing to justify rather than the default.
+**They are now steps, not jobs.** Twelve of the thirteen run as steps of `test-linux`, which
+already performs that same deepen and base fetch for its own `--check-bump` steps;
+`sync-hook-utils.sh` runs in the `hook-utils` job beside the hook contract tests it covers, on the
+shell-only diff that job exists to keep off the heavier lanes. Adding a fourteenth shared source
+therefore adds a step to an existing job, and adding a job is the thing to justify rather than the
+default.
+
+One thing was lost and is worth naming rather than glossing. The old **job** name
+(`state-key-sync`, `index-regen-sync`) was the discriminator that said which library failed. Every
+step kept the name it had, but those names were never carrying that load: seven of the twelve drift
+checks name their library and five do not, and none of the `--check-bump` steps do, seven of them
+sharing the string "Verify carrying plugins bumped when canonical changed". So a red bump check now
+needs its log read to say which library it was. That is the price paid for the consolidation, and a
+new sync step should name its library in its step name so the price stops growing.
 
 Nothing about the invariant moved: byte-drift is still fatal, the `--check-bump` half still fails a
 lib change whose carrying plugin's manifest version did not move, and the intra-plugin `vendor/`


### PR DESCRIPTION
No related issue: melodic-software/github-iac#378 tracks the ci-perf program (Phase 9a)

## Summary

Phase 9 of the ci-perf program codifies what the earlier phases settled. This is the
claude-code-plugins half of its startable-now part: two ADR amendments recording shapes this
repository already ships. Neither decision changes; both records were describing a world that moved
on without them.

The github-iac half of the phase (ADR 0001, ADR 0011 and a new `docs/topics/ci-perf/POSTURE.md`) is
a sibling pull request. Not merged by this worker.

## Fix

**ADR 0002, addendum.** The record kept its default-on advisory posture while the lane triggers
still ran as if a blocking gate might return. Since #3696 both callers run once per pull request, on
`opened`, `ready_for_review` and `reopened`, with a draft filter whose `event_name` clause exists so
a dispatched review is not filtered out by a payload that is not there, and with three named ways to
get a review of a newer head. The addendum also records what the file never stated at all: the
code-review job queues repository-wide with `queue: max` rather than cancelling in progress, which
is a deliberate exception to the cancel posture every other lane in `ci.yml` follows, and is
affordable only because a queued advisory review blocks no merge. The security caller takes the
exception differently, grouping per pull request with `cancel-in-progress: false` and no `queue` key,
and the two are deliberately not normalized to each other.

**ADR 0019, addendum.** The record said a shared source gets a sync script and a CI gate. The shape
that grew from it was one CI job per library, thirteen of them, each a runner, a checkout, a
full-history unshallow and a base fetch for a few shell scripts. #3696 made them steps: twelve in
`test-linux`, which already does that unshallow for its own `--check-bump` steps, and
`sync-hook-utils.sh` in `hook-utils` beside the contract tests it covers. The invariant is
untouched, so the addendum records the placement, the cost that was actually paid (runner startups,
unshallows and concurrency slots here; the metered private minute pool on the fleet), the one thing
the consolidation lost, and the recheck trigger that says when a sync gate earns a job of its own
again.

**What the consolidation lost, recorded rather than glossed.** The old job name was the
discriminator that said which library failed. The step names were never carrying that load: seven of
the twelve drift checks name their library, none of the `--check-bump` steps do, and seven of those
share one string. So a red bump check now needs its log read. The addendum says so and asks a new
sync step to name its library.

## Verification

A fresh-context verifier (no access to the reasoning that produced the change) audited the diff
against six criteria and returned **PASS on all six** after three fix rounds. It found five real
defects, every one of them mine, and confirmed each fix against the files rather than against my
description of the fix:

1. "A fresh toolchain install" was factually inverted. None of the thirteen retired jobs installed a
   toolchain; the toolchains belong to `test-linux`, the job the twelve steps moved into.
2. "Every step keeps the name it had, so a failure still says which library drifted" was a non
   sequitur. The verifier ran a job-attributing pass over the old and new `ci.yml` and produced the
   7-of-12 and 0-of-12 counts now in the record.
3. ADR 0002 claimed a workflow-level cancel group that `claude-review.yml` does not declare.
4. My fix for (3) introduced a new false claim, that `cancel-in-progress: false` beside a `queue`
   key is what the security lane uses. It has no `queue` key at all, and the legality half rested on
   the docs page saying nothing about that pairing rather than on it saying anything. Deleted
   outright; nothing depended on it. The same inference was in the sibling github-iac records and is
   dropped there too, so the two repositories stay consistent.
5. The billing conclusion was wrong for this repository: it is public and the jobs ran on a standard
   runner, so nothing was billed. Split into the cost that is real here (runner startups, unshallows
   and concurrency slots) and the metered pool the same shape spends on the private repositories the
   program covers, where the organization caps spend at `$0` and the failure mode is a hard stop.

The verifier also checked the trigger set, the draft filter, both concurrency blocks and the
attribution SHA against the workflow files line by line, verified both external citations live, and
confirmed the repository has no ADR index needing a row.

**Two disclosures.**

The commit at `2a9a79ee4` carries the wrong toolchain claim in its message. Correcting it needs a
force-push, which this task forbids, so the correction is written into the message of the commit
that fixed it and repeated here. The verifier was asked whether that disposition is adequate and
said yes: the history stays honest.

The brief specified `git diff origin/main | grep -c $'—'` printing 0. That form counts unchanged
context and git's own hunk headers, and ADR 0002's pre-existing Contents entries contain em-dashes,
so it cannot reach 0 without rewriting text this change does not touch. The added-line form is the
one that measures authored prose and it prints 0. The verifier ran both, classified all six
whole-diff hits (four unchanged context lines, two synthesized hunk headers), and confirmed none is
in new prose.

## Related

- melodic-software/github-iac#378, the ci-perf program (Phase 9).
- melodic-software/github-iac#450, the sibling pull request amending ADR 0001 and ADR 0011 and
  adding `docs/topics/ci-perf/POSTURE.md`.
- #3696, the change both addenda record.
