### PR TITLE
chore(marketplace): enable firecrawl and x by default

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -200,7 +200,7 @@
       "source": "./plugins/firecrawl",
       "category": "discovery",
       "tags": ["firecrawl", "scraping", "web-search", "crawling", "parsing", "skill"],
-      "defaultEnabled": false,
+      "defaultEnabled": true,
       "relevance": {
         "topic": "Firecrawl",
         "signals": {
@@ -523,7 +523,7 @@
       "source": "./plugins/x",
       "category": "discovery",
       "tags": ["x", "twitter", "markdown", "social", "content-extraction", "skill"],
-      "defaultEnabled": false,
+      "defaultEnabled": true,
       "relevance": {
         "topic": "X (Twitter) content",
         "signals": {


### PR DESCRIPTION
No related issue: operator request to enable firecrawl and x by default fleet-wide (surfaced by the post-#3688 cloud verification)

## Summary

The `firecrawl` and `x` catalog entries in `.claude-plugin/marketplace.json`
carried `"defaultEnabled": false`. `claude plugin install` honors that flag, so
a post-migration cloud verification found both plugins installed but disabled:
their skills were absent from sessions that had every reason to reach for them.
The operator wants both enabled by default fleet-wide.

## Fix

Flip `"defaultEnabled"` from `false` to `true` for exactly those two entries.
Two lines, one file, nothing else touched. The five other entries that record a
deliberate `false` (`songwriting`, `kindle-dedrm`, `ai-briefing`, `miro`,
`dometrain`) are unchanged.

## Verification

Run in the worktree against this diff:

- `git diff --stat` — one file, 2 insertions, 2 deletions.
- `jq '.plugins[]|select(.name=="firecrawl" or .name=="x")|.defaultEnabled'` — `true` twice.
- `jq -r '.plugins[]|select(.defaultEnabled==false)|.name'` — the five intended
  entries only, confirming no collateral flip.
- `claude plugin validate .` — passed (marketplace manifest).
- `scripts/check-manifest-duplicate-keys.py` — passed, 78 manifests.
- `scripts/check-plugin-catalog-enablement.sh` — passed, 77 catalogued plugins.
- `scripts/check-plugin-manifest-presence.sh` — passed.

No plugin version bump or CHANGELOG entry: this is the repo-root marketplace
manifest, not a plugin's own surface. Nothing under `scripts/`, `.github/`, or
`lib/` reads `defaultEnabled`, so no generated artifact tracks this value.

## Related

- #3688 — the migration whose cloud verification surfaced the disabled state.
  Context only; this PR closes nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016e6sBmnTGcidwvSrM86NYp
