### PR TITLE
docs(cloud): state the fleet-list plugin declaration model in both cloud docs

### DIFF
--- a/docs/CLOUD-FLEET-SETUP.md
+++ b/docs/CLOUD-FLEET-SETUP.md
@@ -49,9 +49,11 @@ Go plus the module `toolchain` mechanism covers this); **PowerShell** (`pwsh` â€
 
 Adoption is complete and no longer a per-repo decision surface: all fifteen non-archived
 melodic-software repositories (`gh repo list melodic-software --json name,isArchived`) carry
-`.claude/cloud-bootstrap.sh`, register it as a `startup|resume` SessionStart hook, declare the
-`melodic-software` marketplace, and enable the catalog. Read adoption state from the repos
-rather than from a table here; a per-repo enumeration in this doc can only lag them.
+`.claude/cloud-bootstrap.sh`, register it as a `startup|resume` SessionStart hook, and declare the
+`melodic-software` marketplace. Enabling the catalog is not among the per-repo steps: the standards
+fleet list does that for every repo, and a repo's own block carries only deltas
+([Step 2](#step-2--per-repo-wiring)). Read adoption state from the repos rather than from a table
+here; a per-repo enumeration in this doc can only lag them.
 
 The script is owned upstream, not per repo: standards
 [`components/cloud-bootstrap`](https://github.com/melodic-software/standards/blob/main/components/cloud-bootstrap/README.md)

--- a/docs/CLOUD-SESSIONS.md
+++ b/docs/CLOUD-SESSIONS.md
@@ -358,8 +358,9 @@ catalog on, and the cloud bootstrap installs from the two together (see
   cloud session; verify in a fresh session and add the same bootstrap-plus-hook setup if the
   catalog does not load.
 - The whole catalog is installed here, so this repo dogfoods everything it publishes and a
-  regression in any plugin surfaces here first — bar what a repo delta opts out of and what the
-  catalog ships `defaultEnabled: false`, which installs without being enabled (below). The enabling
+  regression in any plugin surfaces here first — bar what a repo delta opts out of. Catalog
+  entries that ship `defaultEnabled: false` install disabled on a raw `claude plugin install`;
+  this repo's cloud bootstrap still treats fleet-list `true` as wanted (below). The enabling
   list is the fleet cloud plugin list in standards
   ([`components/cloud-environment/fleet-plugins.json`](https://github.com/melodic-software/standards/blob/main/components/cloud-environment/fleet-plugins.json)),
   which the shared environment fetches at cache build, writes into the snapshot at
@@ -390,12 +391,14 @@ catalog on, and the cloud bootstrap installs from the two together (see
 - Entries are sorted alphabetically, one per line, so a single plugin can be flipped to `false`
   without disturbing the rest — a state the gate accepts, since an explicit `false` is a recorded
   decision where an absent key is drift. The entries that should not start on their own are not
-  keyed here at all: the catalog ships them `defaultEnabled: false` and `claude plugin install`
-  honors that flag, so the fleet list's `true` installs them without enabling them and they stay
-  off until someone opts in with `/plugin enable`. That covers the two whose bundled MCP servers
-  need `userConfig` credentials this environment has no reason to hold — `miro` (`miro_api_token`)
-  and `dometrain` (`dometrain_api_key`), set with `/plugin configure` — alongside `songwriting`,
-  `kindle-dedrm`, and `ai-briefing`.
+  keyed here at all: the catalog ships them `defaultEnabled: false`, and `claude plugin install`
+  honors that flag, so a raw install leaves them disabled. They still appear as `true` on the
+  fleet list, so this repo's cloud bootstrap includes them in its wanted set, treats a disabled
+  install as a verification failure, and runs `plugin enable` on a source-changing refresh.
+  Operator opt-in outside that path is `/plugin enable`. That covers the two whose bundled MCP
+  servers need `userConfig` credentials this environment has no reason to hold — `miro`
+  (`miro_api_token`) and `dometrain` (`dometrain_api_key`), set with `/plugin configure` —
+  alongside `songwriting`, `kindle-dedrm`, and `ai-briefing`.
 
 ### GitHub MCP tools vs the gh CLI
 

--- a/docs/CLOUD-SESSIONS.md
+++ b/docs/CLOUD-SESSIONS.md
@@ -325,15 +325,15 @@ catalog on, and the cloud bootstrap installs from the two together (see
   `claude --plugin-dir ./plugins/<name>`, which takes session precedence over the cached install.
 - **Reading the summary line's `failed` count (corrected 2026-08-28).** That count used to be the
   exit status of the refresh chain, and the chain's tail step is nonzero on the healthy path:
-  `claude plugin install --scope user` already leaves the plugin enabled, so the following
+  `claude plugin install --scope user` already leaves the plugin enabled — unless the catalog entry
+  sets `defaultEnabled: false`, which the install honors — so the following
   `claude plugin enable --scope user` exits 1 with `Plugin "<id>" is already enabled at user
   scope`. Startup lines like `plugins 71 enabled, 5 newly installed, 0 refreshed, 65 failed` were
   therefore false alarms, and dozens of them per session start buried the only health signal this
   block emits. The script now runs the chain for effect and verifies the end state once per run,
   over every plugin the fleet list plus this repo's `enabledPlugins` deltas turn on rather than only
   the ones that run touched, since the plugins most likely to be wrong are the ones it decided to
-  skip. A plugin counts as failed
-  when any of these holds:
+  skip. A plugin counts as failed when any of these holds:
   - `claude plugin list --json` does not list it at user scope, or lists it there with `enabled`
     anything other than the JSON boolean `true`;
   - its own directory under `plugins/` changed between the `gitCommitSha` recorded for the

--- a/docs/CLOUD-SESSIONS.md
+++ b/docs/CLOUD-SESSIONS.md
@@ -180,7 +180,7 @@ The environment side stays generic (Default environment, **All** network access,
 | shellcheck, actionlint, typos, editorconfig-checker, gitleaks | pinned in the bootstrap (GitHub release binaries → `~/.local/bin`) | best effort — warns and continues |
 | check-jsonschema | pinned in the bootstrap (uv tool / pip `--user`) | best effort |
 | full git history + `origin/main` | `git fetch` | best effort — the base-ref diff gates need it |
-| the enabled plugin catalog | `enabledPlugins` in `.claude/settings.json` | best effort — a plugin that fails to install costs its skills, not the session |
+| the enabled plugin catalog | the snapshot's fleet list (`/opt/melodic-fleet-plugins.json`) overlaid with `enabledPlugins` in `.claude/settings.json` | best effort — a plugin that fails to install costs its skills, not the session |
 
 The bootstrap's startup `report_tool` resolves each binary under a **hook-safe PATH**
 (the process PATH with the nvm prefix stripped) and prints the resolved path, so an
@@ -206,8 +206,9 @@ Playwright. `gh`, `pwsh`, and `lychee` are likewise on-demand.
 ### Plugins in sessions on this repo
 
 Being the marketplace doesn't make this repo's plugins active in a session — plugins load only
-when a marketplace is declared, enabled, **and installed**. `.claude/settings.json` declares and
-enables; the cloud bootstrap installs (see
+when a marketplace is declared, enabled, **and installed**. `.claude/settings.json` declares the
+marketplace and carries this repo's deltas, the fleet list baked into the snapshot turns the
+catalog on, and the cloud bootstrap installs from the two together (see
 [Discover and install plugins](https://code.claude.com/docs/en/discover-plugins) and
 [extraKnownMarketplaces / enabledPlugins](https://code.claude.com/docs/en/settings#plugin-settings)):
 
@@ -329,8 +330,9 @@ enables; the cloud bootstrap installs (see
   scope`. Startup lines like `plugins 71 enabled, 5 newly installed, 0 refreshed, 65 failed` were
   therefore false alarms, and dozens of them per session start buried the only health signal this
   block emits. The script now runs the chain for effect and verifies the end state once per run,
-  over every plugin `enabledPlugins` turns on rather than only the ones that run touched, since
-  the plugins most likely to be wrong are the ones it decided to skip. A plugin counts as failed
+  over every plugin the fleet list plus this repo's `enabledPlugins` deltas turn on rather than only
+  the ones that run touched, since the plugins most likely to be wrong are the ones it decided to
+  skip. A plugin counts as failed
   when any of these holds:
   - `claude plugin list --json` does not list it at user scope, or lists it there with `enabled`
     anything other than the JSON boolean `true`;
@@ -355,9 +357,10 @@ enables; the cloud bootstrap installs (see
   plugin changes. Declaring it is necessary but, per the trust gate above, not sufficient in a
   cloud session; verify in a fresh session and add the same bootstrap-plus-hook setup if the
   catalog does not load.
-- The whole catalog is enabled here, so this repo dogfoods everything it publishes and a
-  regression in any plugin surfaces here first. The enabling list is the fleet cloud plugin list
-  in standards
+- The whole catalog is installed here, so this repo dogfoods everything it publishes and a
+  regression in any plugin surfaces here first — bar what a repo delta opts out of and what the
+  catalog ships `defaultEnabled: false`, which installs without being enabled (below). The enabling
+  list is the fleet cloud plugin list in standards
   ([`components/cloud-environment/fleet-plugins.json`](https://github.com/melodic-software/standards/blob/main/components/cloud-environment/fleet-plugins.json)),
   which the shared environment fetches at cache build, writes into the snapshot at
   `/opt/melodic-fleet-plugins.json`, and installs at user scope; `cloud-bootstrap.sh` reads that
@@ -386,10 +389,13 @@ enables; the cloud bootstrap installs (see
   is precisely this repo's relative `directory` source.
 - Entries are sorted alphabetically, one per line, so a single plugin can be flipped to `false`
   without disturbing the rest — a state the gate accepts, since an explicit `false` is a recorded
-  decision where an absent key is drift. Two entries carry required `userConfig` credentials that are unset
-  here — `miro` (`miro_api_token`) and `dometrain` (`dometrain_api_key`) — so their bundled MCP
-  servers exit at startup until configured; set them with `/plugin configure`, or flip those two
-  to `false` if a session shouldn't try.
+  decision where an absent key is drift. The entries that should not start on their own are not
+  keyed here at all: the catalog ships them `defaultEnabled: false` and `claude plugin install`
+  honors that flag, so the fleet list's `true` installs them without enabling them and they stay
+  off until someone opts in with `/plugin enable`. That covers the two whose bundled MCP servers
+  need `userConfig` credentials this environment has no reason to hold — `miro` (`miro_api_token`)
+  and `dometrain` (`dometrain_api_key`), set with `/plugin configure` — alongside `songwriting`,
+  `kindle-dedrm`, and `ai-briefing`.
 
 ### GitHub MCP tools vs the gh CLI
 


### PR DESCRIPTION
No related issue: docs follow-up to #3688

## Summary

`docs/CLOUD-FLEET-SETUP.md` and `docs/CLOUD-SESSIONS.md` still carried
sentences from the pre-#3688 declaration model, where every repo committed an
`enabledPlugins` block mirroring the whole catalog and that block was what
enabled it. Anyone setting up a cloud repo from these docs would have
reproduced the per-checkout project-scope pin accumulation #3688 exists to
stop, and would have been told to flip settings keys this repo no longer
carries.

## Fix

Only the stale sentences changed; no restructuring, no new sections, and no
content about a `fleet@` plugin.

`docs/CLOUD-SESSIONS.md`

- Bootstrap pin-source table: the plugin catalog's pin source is the
  snapshot's fleet list (`/opt/melodic-fleet-plugins.json`) overlaid with
  `enabledPlugins`, not `enabledPlugins` alone.
- "`.claude/settings.json` declares and enables" becomes: settings declares
  the marketplace and carries this repo's deltas, the snapshot's fleet list
  turns the catalog on, and the bootstrap installs from the two together.
- The `failed`-count description now names the verification set as the fleet
  list plus this repo's deltas, and its "install already leaves the plugin
  enabled" measurement is scoped to entries whose catalog record does not set
  `defaultEnabled: false`.
- "The whole catalog is enabled here" becomes "installed here", with the
  exceptions stated: a repo delta opting out, and the catalog's
  `defaultEnabled: false` entries, which a raw install leaves disabled.
- The `miro` / `dometrain` bullet no longer says to "flip those two to
  `false`" — neither key exists in this repo's settings. Both ride the fleet
  list, the catalog ships them `defaultEnabled: false` so a raw install leaves
  them disabled, and the bullet now states what this repo's bootstrap does with
  them from there. Same for `songwriting`, `kindle-dedrm`, and `ai-briefing`.

`docs/CLOUD-FLEET-SETUP.md`

- Bootstrap adoption no longer lists "enable the catalog" among the per-repo
  steps; the standards fleet list does that for every repo and a repo's block
  carries only deltas.

Step 2's per-repo wiring section and the deltas paragraph in CLOUD-SESSIONS.md
were already correct (#3917) and are untouched.

## Verification

Each changed claim against the source it was read from:

- **Canonical fleet list exists and is the install set.** `git show
  origin/main:components/cloud-environment/fleet-plugins.json` in
  `melodic-software/standards` (at `3fbc009`): a settings-shaped object,
  76 `enabledPlugins` entries, all `true`, none `false`. Set-differenced
  against this repo's `.claude-plugin/marketplace.json` at `origin/main`
  (77 entries): the fleet list covers the catalog exactly bar the one entry
  this repo's own delta block enables.
- **Cloud bootstrap reads `/opt` only and gates on shape.** standards
  `components/cloud-bootstrap/cloud-bootstrap.sh` at `origin/main`
  (`fleet_plugins="${CLOUD_BOOTSTRAP_FLEET_LIST:-/opt/melodic-fleet-plugins.json}"`,
  then a `jq -e 'type == "object" and ((.enabledPlugins // {}) | type ==
  "object")'` gate that exits the plugin stage on failure), landed by
  standards#552. This repo's own `.claude/cloud-bootstrap.sh` at `origin/main`
  reads the same `/opt` path with the same shape gate and merges
  `(fleet.enabledPlugins + settings.enabledPlugins)` into its `wanted` set,
  which is the set the end-state verification iterates — the source for the
  table row and the `failed`-count sentence.
- **Consumer repos carry deltas only.** This repo's `.claude/settings.json` at
  `origin/main` carries two `enabledPlugins` entries, not a mirrored list
  (#3917). `scripts/check-plugin-catalog-enablement.sh`'s header states the
  same rule ("this file no longer mirrors the whole catalog").
- **The `enabledPlugins` fallback loop is gone from standards.**
  `components/cloud-environment/setup.sh` at `origin/main`
  (`SCRIPT_VERSION='2026-09-07.2'`) calls `install_plugins_from` exactly once,
  with the fleet file; a failed fetch logs `no plugins install this build`
  rather than falling back. The canonical `cloud-bootstrap.sh` exits the
  plugin stage when the fleet list is absent or wrong-shaped. Removal landed
  in standards#555 on top of standards#542 and standards#552.
- **`firecrawl` and `x` are `defaultEnabled: true`.** `.claude-plugin/marketplace.json`
  at `origin/main`: `defaultEnabled: true` for exactly `firecrawl` and `x`
  (#3949), `false` for exactly `songwriting`, `kindle-dedrm`, `ai-briefing`,
  `miro`, `dometrain`, and unset for the other 70 — which is the list the
  rewritten bullet names.
- **`claude plugin install` honors `defaultEnabled`, so the paragraph's older
  "install already leaves the plugin enabled" measurement needed scoping.**
  #3949's body ("a post-migration cloud verification found both plugins
  installed but disabled") and `README.md` ("install disabled ... until the
  user opts in with `/plugin enable`"). What this repo's bootstrap then does
  with such an entry — keeps it in `wanted`, counts a disabled install as a
  verification failure, and runs `plugin enable` on a source-changing refresh —
  is read from `.claude/cloud-bootstrap.sh` at `origin/main`.

Tooling, run in the worktree:

- `npx markdownlint-cli2 docs/CLOUD-SESSIONS.md docs/CLOUD-FLEET-SETUP.md` —
  `0 issues in 0 files` (repo `.markdownlint-cli2.jsonc`).
- `typos docs/` — clean (repo `_typos.toml`).
- `scripts/affected-tests.sh --explain` selected five suites.
  `plugins/provenance/skills/audit/scripts/extract-breadcrumbs.test.sh`
  reported `Passed: 64  Failed: 0`, and
  `scripts/check-plugin-catalog-enablement.test.sh` reported "All
  check-plugin-catalog-enablement.sh contract checks passed" (exit 0).
  `docs/CLOUD-FLEET-SETUP.md` is a recorded `no-suite` path.
- A fresh-context verifier re-checked the first commit's diff against those
  same sources and returned PASS on all four acceptance criteria, flagging two
  defects the follow-up commits fix: the `defaultEnabled` exception attached to
  the installation claim instead of the enablement claim, and the unscoped
  install-already-enables measurement.
- No plugin version bump or CHANGELOG entry: `docs/` at the repo root is not a
  plugin surface, and both files sit outside every `plugins/<name>/` tree.

## Related

- #3688 — the plugin-declaration migration these docs lagged. Context only;
  this PR closes nothing.
- #3917 — reduced this repo's `enabledPlugins` to deltas.
- #3949 — flipped `firecrawl` and `x` to `defaultEnabled: true`.
- melodic-software/standards#542, #552, #555 — the fleet list, the `/opt`-only
  shape-gated read, and the removal of the `enabledPlugins` fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L5ZJnwTRCgc31bmfrdugyU
