### PR TITLE
fix(skill-quality): stop the evals-warrant walk at a filesystem root

### DIFF
--- a/plugins/skill-quality/.claude-plugin/plugin.json
+++ b/plugins/skill-quality/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "skill-quality",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "description": "Skill-authoring QA tooling: a static contract checker that runs twenty-five deterministic checks over a Claude Code skill (frontmatter, explicit invocation mode, description/verb-contract polarity, per-skill listing-entry cap, trigger-keyword preservation, line caps, broken internal refs, markdownlint, gotchas surface, evals presence, precompute opportunity, completion-criteria signal, injection shell-declaration, fresh-eyes declaration conformance), a shared skill-listing budget reporter across a set of skills, and a bundled evals.json schema plus a deterministic eval-quality lint (duplicate case identities, missing fixtures, empty or vague grading criteria, set-coverage warnings). Runs against any repo's skills directory via the convention-resolution ladder \u2014 no baked layout.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/skill-quality/CHANGELOG.md
+++ b/plugins/skill-quality/CHANGELOG.md
@@ -14,13 +14,18 @@ All notable changes to the `skill-quality` plugin are documented here. Format fo
   `git rev-parse --show-toplevel` returns on Git Bash (`dirname C:` is `C:`), and a relative
   path, which is what a non-git run anchored on a relative root produces (`dirname .` is `.`).
   With no exemptions file anywhere up the chain the loop never exited, forking `dirname` each
-  iteration, so the run produced no further output and no CPU worth noticing.
+  iteration, so the run produced no further output. The cost sits in short-lived child
+  processes rather than in the shell itself, so it does not accumulate against the parent's own
+  CPU accounting and reads as an idle hang, though it does hold most of a core.
 
-  Real checkouts never saw it because the file sits at the repo root and the walk returns on
-  its first iteration. Only fixture trees without the file reached the fixed point, which is
-  why `scripts/check-changed-skills.test.sh` hung on Windows while Linux CI stayed green: on
-  Linux the walk does reach `/` and stops. The loop now breaks when `dirname` stops changing
-  the path, the same guard the format hooks in this marketplace already carry.
+  This repository does not hit it in ordinary use, because the file sits at its root and the
+  walk returns on the first iteration; the trees that reached the fixed point were the test
+  suites' fixture repos, which is why `scripts/check-changed-skills.test.sh` hung on Windows
+  while Linux CI stayed green, since on Linux the walk does reach `/` and stops. A consumer
+  repo carrying no exemptions file is exposed the same way on Git Bash, because the checker
+  resolves a skills root against any layout and walks from `REPO_ROOT`, or from the skill dir
+  when there is no git repo. The loop now breaks when `dirname` stops changing the path, the
+  same guard the format hooks in this marketplace already carry.
 
 ## [0.21.1]
 

--- a/plugins/skill-quality/CHANGELOG.md
+++ b/plugins/skill-quality/CHANGELOG.md
@@ -3,6 +3,25 @@
 All notable changes to the `skill-quality` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.21.2]
+
+### Fixed
+
+- **`check`: the evals-warrant exemptions walk now stops at a filesystem root instead of
+  spinning forever.** The walk looking for `scripts/evals-warrant-exemptions.txt` terminated
+  only on `/`, but `dirname` is a fixed point at every root, so that condition is unreachable
+  from the two path shapes the checker actually receives: a drive-letter path, which is what
+  `git rev-parse --show-toplevel` returns on Git Bash (`dirname C:` is `C:`), and a relative
+  path, which is what a non-git run anchored on a relative root produces (`dirname .` is `.`).
+  With no exemptions file anywhere up the chain the loop never exited, forking `dirname` each
+  iteration, so the run produced no further output and no CPU worth noticing.
+
+  Real checkouts never saw it because the file sits at the repo root and the walk returns on
+  its first iteration. Only fixture trees without the file reached the fixed point, which is
+  why `scripts/check-changed-skills.test.sh` hung on Windows while Linux CI stayed green: on
+  Linux the walk does reach `/` and stops. The loop now breaks when `dirname` stops changing
+  the path, the same guard the format hooks in this marketplace already carry.
+
 ## [0.21.1]
 
 ### Changed

--- a/plugins/skill-quality/scripts/check-skill.sh
+++ b/plugins/skill-quality/scripts/check-skill.sh
@@ -826,13 +826,15 @@ fi
 # must ship evals/evals.json unless a recorded skip exists (#3135).
 
 evals_warrant_exemptions_file() {
-  local d="${1:-}"
+  local d="${1:-}" parent
   while [[ -n "$d" && "$d" != "/" ]]; do
     if [[ -f "$d/scripts/evals-warrant-exemptions.txt" ]]; then
       printf '%s\n' "$d/scripts/evals-warrant-exemptions.txt"
       return 0
     fi
-    d="$(dirname "$d")"
+    parent="$(dirname -- "$d")"
+    [[ "$parent" == "$d" ]] && break # reached a root: dirname is a fixed point
+    d="$parent"
   done
   return 1
 }

--- a/plugins/skill-quality/scripts/check-skill.test.sh
+++ b/plugins/skill-quality/scripts/check-skill.test.sh
@@ -3684,6 +3684,44 @@ else
   fail "unlisted skill should still fail --require-evals (rc=$rc): $out"
 fi
 
+# 49. The evals-warrant walk stops at a filesystem root instead of spinning.
+# `dirname` is a fixed point at every root: `.` for a relative path on any
+# platform, and `<drive>:` on Git Bash, where `git rev-parse --show-toplevel`
+# hands back a drive-letter path. A walk that only stops on `/` never reaches
+# it from either, so the whole run hangs with no output. The fixture is
+# deliberately outside a git repo and anchored on a relative root, which is the
+# shape that reproduces the fixed point on Linux as well as Windows.
+WALK_TMP="$(mktemp -d)"
+# Nested trap: remove the walk fixture alongside the dirs the outer traps own.
+trap 'rm -rf "$TMP" "$CACHE_TMP" "$WALK_TMP"' EXIT
+mkdir -p "$WALK_TMP/plugins/p1/skills/walkroot"
+cat >"$WALK_TMP/plugins/p1/skills/walkroot/SKILL.md" <<'EOF'
+---
+description: "A walk fixture. Use when: 'testing exemptions-walk termination'."
+disable-model-invocation: false
+---
+
+## Purpose
+
+Fixture for the exemptions-walk termination check.
+
+## Gotchas
+
+None known.
+EOF
+if ! command -v timeout >/dev/null 2>&1; then
+  pass "timeout unavailable; skip exemptions-walk termination case"
+else
+  (cd "$WALK_TMP" && CLAUDE_PROJECT_DIR=. CHECK_SKILL_SKILLS_ROOT=plugins/p1/skills \
+    CHECK_SKILL_SKIP_MARKDOWNLINT=1 timeout 60 bash "$SUT" --require-evals walkroot) >/dev/null 2>&1
+  rc=$?
+  if [[ $rc -ne 124 ]]; then
+    pass "the evals-warrant walk terminates at a filesystem root"
+  else
+    fail "the evals-warrant walk never terminated (timed out at a dirname fixed point)"
+  fi
+fi
+
 if [[ $fails -ne 0 ]]; then
   printf '%d assertion(s) failed\n' "$fails" >&2
   exit 1


### PR DESCRIPTION
Closes #3797

## Summary

`scripts/affected-tests.sh --run` hung on this Windows 11 Git Bash host whenever it reached
`scripts/check-changed-skills.test.sh`, with no output after the suite name and no CPU worth
noticing. The same suite was green on Linux CI every time.

The blocking call is `evals_warrant_exemptions_file` in
`plugins/skill-quality/scripts/check-skill.sh`. It walks up from the repo root looking for
`scripts/evals-warrant-exemptions.txt` and its loop terminated only on `/`:

```bash
while [[ -n "$d" && "$d" != "/" ]]; do
  ...
  d="$(dirname "$d")"
done
```

`dirname` is a fixed point at every root, so `/` is unreachable from either path shape the
checker actually receives. Measured on the affected host:

```
dirname /tmp  -> /
dirname C:/   -> C:
dirname C:    -> C:      <-- fixed point
dirname .     -> .       <-- fixed point (GNU coreutils too)
```

`git rev-parse --show-toplevel` returns a drive-letter path on Git Bash, so `REPO_ROOT` enters
the walk as `C:/...`. Tracing the loop from that value reaches `C:` on iteration 7 and is still
`C:` at iteration 400. Each iteration forks a short-lived external `dirname`. Measured, that is
about 1.55s of CPU per 200 iterations, roughly 78% of a core held continuously; because the cost
sits in child processes rather than the shell itself it does not accumulate against the parent's
own CPU accounting, which is why the stall reads as idle.

This repository does not hit it in ordinary use: `scripts/evals-warrant-exemptions.txt` sits at
its root and the walk returns on the first iteration. The trees that exhaust the walk are the
test suites' fixture repos. On Linux the walk does reach `/` and stops, which is exactly why CI
stayed green while the local validator did not. Note the exposure is not limited to fixtures: the
checker resolves a skills root against any layout, and walks from `REPO_ROOT` or from the skill
dir when there is no git repo, so a consumer repo carrying no exemptions file reaches the same
fixed point on Git Bash.

## Fix

One guard in the loop. `plugins/markdown-format/hooks/markdown-format.sh:559-561` already carries
it in exactly this `dirname` form; `plugins/bash-format/hooks/bash-format.sh:178-180`,
`plugins/ruff-format/hooks/ruff-format.sh:186-188`, and
`plugins/biome-format/hooks/biome-format.sh:168` carry the same fixed-point guard via `${dir%/*}`
instead. Same guard, two primitives:

```bash
parent="$(dirname -- "$d")"
[[ "$parent" == "$d" ]] && break # reached a root: dirname is a fixed point
d="$parent"
```

This is the root cause, not a wrapper timeout. No `timeout` was added to any script under
`scripts/` or `plugins/`; the only `timeout` introduced is inside the new test assertion.

Regression case 49 in `plugins/skill-quality/scripts/check-skill.test.sh` drives the checker from
a non-git fixture on a relative skills root, which reaches the `.` fixed point on Linux as well
as Windows, and asserts the run does not exit 124. So it fails without the fix on Linux CI, not
only on the affected host.

One honest limit on that: the case is guarded by `command -v timeout`, in line with the existing
precedent in `plugins/claude-ops/skills/plugins/scripts/fleet-state.test.sh` and
`plugins/claude-ops/skills/lanes/scripts/telemetry-upsert.test.sh`. Stock macOS ships `gtimeout`
rather than `timeout`, so on that host the case skips and reports green rather than running. The
fixed-point shape it constructs is platform-independent; whether it actually executes is not.

`plugins/skill-quality` is bumped 0.21.1 -> 0.21.2 with a matching CHANGELOG entry, since the
changed files live inside that plugin.

## Verification

All on the affected host, Windows 11 Pro 10.0.26200, Git Bash.

A fresh-context verifier, given the diff and the criteria but not this rationale, returned PASS on
all five: repro terminates and discriminates, both suites pass, shellcheck clean, no tracker refs
in added comments, and the fix is the in-loop guard rather than a wrapper timeout. The CPU,
blast-radius, and macOS-skip wording above is corrected per its findings.

- **The test discriminates.** With the fix stashed, case 49's exact invocation exits `124`. With
  the fix applied it exits `1`, the correct missing-evals verdict rather than a hang. The verifier
  reproduced this independently against `97ccd44ff^` staged to a temp path (`OLD rc=124` at 60s,
  `NEW rc=1` at 1s), and confirmed the old loop body standalone never terminates within 2000
  iterations from either `C:/Users/x` or `.`.
- **The originally hanging suite finishes.** `scripts/check-changed-skills.test.sh` reached the
  120s outer timeout before the fix (exit 124, stalled after case 10, which is the first case
  that runs the real checker via `stage_checker`). After the fix: `PASS=19 FAIL=0` in 4m47s under
  an outer `timeout` this change did not add to the script. The wall time is markdownlint and
  node startup on Windows, roughly 30s per real checker call across five such cases, not the
  defect.
- **`scripts/affected-tests.sh --run`** is in flight on this host at the time of writing and this
  line will be updated with its exit code and wall time. Note that with this change set it is not
  the narrow run the issue describes: `check-skill.sh` is referenced from roughly forty test
  files, so `--explain` selects nearly every suite in the repo and the wall time is volume rather
  than the defect. The issue's original scenario was a claude-ops-only change set, whose selected
  suite `scripts/check-changed-skills.test.sh` is proven above. `--explain` records `plugin.json`
  and `CHANGELOG.md` as no-suite entries via `scripts/affected-tests-no-suite.txt`, the documented
  allowlist, not an unmapped-file error.
- `shellcheck -S info` clean on both changed shell files; `typos` clean; changelog parity clean
  on `--check`, `--check-bump origin/main`, and `--check-preserved origin/main`.

## Related

- Closes #3797.
- Cross-platform hazard inventory. Grepping by termination condition rather than variable name,
  `check-skill.sh` was the only `dirname` walk-up in the repo that stopped on `/` with no
  fixed-point guard. Two siblings are latent but not reached today, and are deliberately left
  alone rather than widened into this change:
  - `plugins/claude-ops/hooks/claude-ops-paths.sh:32` has no guard. A prior note held it safe
    because `-e "C:"` terminates it; on this host `[[ -e "C:" ]]` is in fact **false**, so that
    reasoning does not hold. It is safe only because `$project_dir` always exists up the chain,
    so the walk stops at an existing ancestor before any root.
  - `plugins/guardrails/hooks/block-hook-bypass.sh:1033` is the same class via `${p%/*}`, which
    is also a fixed point on `C:`. Likewise reached only when no ancestor exists.
- The prior process-substitution hypothesis on this issue is refuted: neither
  `scripts/check-changed-skills.test.sh` nor `scripts/check-changed-skills.sh` contains a process
  substitution, and nothing in this chain reads inherited stdin.
- Separable hardening still worth doing, not on this fix's critical path: a per-suite timeout in
  the runner so a stall names its suite, and invoking suites with stdin detached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L5ZJnwTRCgc31bmfrdugyU
