### PR TITLE
docs: correct the routing doc for the retired selector (ci-perf Phase 9b)

### DIFF
--- a/docs/CI-RUNNER-ROUTING.md
+++ b/docs/CI-RUNNER-ROUTING.md
@@ -1,10 +1,21 @@
 # CI runner routing
 
 This repository is public, so every lane runs on GitHub-hosted
-`ubuntu-24.04` — free for public repositories — and the organization's
-runner-policy engine forbids local-runner selector routing here outright
-(`public-self-hosted-routing`). There is no selector preflight, no observer
-credential, and no self-hosted exception inventory in this repository.
+`ubuntu-24.04`, free for public repositories, and the organization's
+runner-policy engine refuses a governed fleet label here outright, reporting
+`public-self-hosted-routing`. There is no observer credential and no
+self-hosted exception inventory in this repository.
+
+There is no selector preflight anywhere in the organization any more. ci-perf
+Phase 7 deleted the `select-runner` reusable workflow (ci-workflows#569, merged
+as `541ee4e90d12d77a90a3ddd72a3af9bc78634ea7`, released as v0.23.0) and
+melodic-software/standards#556 (merged as
+`771a796628f325c3c418c7b397d09fb7211e2972`) removed its grammar from the
+`runner-policy` component. Private repositories now name the governed fleet
+label as a literal and nothing routes at run time; this repository is
+unaffected, because it was never eligible for the fleet in the first place.
+The decision is recorded in melodic-software/github-iac#466, which adds
+`docs/adr/0014-fleet-first-ci-for-private-repositories.md`.
 
 ## Configuration contract
 

--- a/docs/CI-RUNNER-ROUTING.md
+++ b/docs/CI-RUNNER-ROUTING.md
@@ -1,7 +1,9 @@
 # CI runner routing
 
-This repository is public, so every lane runs on GitHub-hosted
-`ubuntu-24.04`, free for public repositories, and the organization's
+This repository is public, so every lane runs on GitHub-hosted runners, free for
+public repositories: `ubuntu-24.04` for all of them except the two informational
+Windows lanes, `test-windows` in `ci.yml` and `windows` in
+`hook-utils-timing.yml`, which run `windows-2025`. The organization's
 runner-policy engine refuses a governed fleet label here outright, reporting
 `public-self-hosted-routing`. There is no observer credential and no
 self-hosted exception inventory in this repository.
@@ -36,10 +38,13 @@ reviewed pull request.
 
 ## Routing and failure behavior
 
-The `ci-status` required check depends on every workload lane and requires
+The `ci-status` required check depends on every **required** workload lane
+(`changes`, `lint`, `test-linux`, `hook-utils`) and requires
 each result to be `success`, failing closed through execution
 (`!cancelled()`, never a success-guard, so a skipped lane cannot report
-success to branch protection). The metadata checks (Conventional Commits title,
+success to branch protection). `test-windows` is deliberately outside that
+aggregate, as an informational platform lane; `ci.yml` says so at the job and
+warns against adding it to `ci-status.needs`. The metadata checks (Conventional Commits title,
 `do-not-merge` label, issue linkage) run as the `pr-contract` composite step
 inside the same `ci-status` job on the same hosted runner, so they no longer
 carry status contexts of their own. Fork pull requests receive no secrets and


### PR DESCRIPTION
No related issue: melodic-software/github-iac#378 tracks the ci-perf program (Phase 9b). Draft until Phase 7 steps 5 and 7 land.

## Summary

This repository's CI posture has not changed and this PR does not change it. It is public, every lane runs on GitHub-hosted `ubuntu-24.04` (free for public repositories), and the organization's runner-policy engine refuses a governed fleet label here outright. What changed is the machinery `docs/CI-RUNNER-ROUTING.md` described around that posture.

The document said the engine "forbids local-runner **selector** routing here outright" and that "there is no **selector preflight**". Both presumed a selector that still existed elsewhere in the organization. ci-perf Phase 7 deleted it: ci-workflows#569 removed the `select-runner` reusable workflow and melodic-software/standards#556 removed its grammar from the `runner-policy` component. Left as written, the document tells a reader this repository is carved out of a mechanism that no longer runs anywhere.

## Fix

`docs/CI-RUNNER-ROUTING.md`, the opening section only:

- The refusal is stated as what the engine actually does: it refuses a governed fleet label and reports `public-self-hosted-routing`. That identifier is still current; it survives standards#556 and is emitted by the analyzer today.
- "No selector preflight" is replaced by the retirement itself, with its two SHAs, plus the one sentence a reader of this repository needs: private repositories now name the fleet label as a literal, and this repository is unaffected because it was never eligible for the fleet.
- The em-dash pair in the first sentence is replaced with commas, per the program's prose convention.

`.github/runner-policy.json` needs no change and is not touched: it declares `visibility: "public"`, `selfHostedCi: false` and an empty `exceptions` object, and carries no prose to correct.

**Two Windows-lane corrections, found on review.** The document treated this repository as if its two `windows-2025` lanes did not exist, and the first commit re-asserted that on a line it edited:

- "Every lane runs on GitHub-hosted `ubuntu-24.04`" was false. `test-windows` (`ci.yml:1941`) and `windows` (`hook-utils-timing.yml:39`) both run `windows-2025`. The posture argument is unaffected, since `windows-2025` is also GitHub-hosted and free for public repositories, so only the phrasing changed.
- "The `ci-status` required check depends on every workload lane" was false for the same reason. `ci.yml:2008` lists `changes`, `lint`, `test-linux`, `hook-utils` and excludes `test-windows` by design, with a comment at that job warning against adding it. The section now names the four and records the exclusion.

The configuration contract, toolchain integrity and local-ruff sections were checked against the actual workflows and are accurate as written.

## Verification

- `npx markdownlint-cli2 docs/CI-RUNNER-ROUTING.md`: 0 issues.
- No em-dashes in added lines; the diff removes one and adds none.
- `grep -rn "select-runner\|governed selector\|CI_RUNNER_POLICY"` across `docs/` and root markdown: the only surviving hits are the two lines of deliberate retirement prose added here.
- The `public-self-hosted-routing` identifier was confirmed current in melodic-software/standards `components/runner-policy/runner-policy.mjs` at `771a796628f325c3c418c7b397d09fb7211e2972`, and is held by the test "a fleet literal on a public repository is refused as public-self-hosted-routing".
- The claim that `select-runner.yml` is gone was checked against ci-workflows `origin/main`, where it is absent from `.github/workflows/`.

## Related

- melodic-software/github-iac#378, the ci-perf program; github-iac#466, the Phase 9b PR carrying ADR 0014 and the completed `POSTURE.md`.
- ci-workflows#569, merged as `541ee4e90d12d77a90a3ddd72a3af9bc78634ea7`, released as v0.23.0.
- melodic-software/standards#556, merged as `771a796628f325c3c418c7b397d09fb7211e2972`; standards#558, the matching onboarding-doc correction.
- claude-code-plugins#3948, this repository's Phase 7 step 2 sync.
