### PR TITLE
docs(agents): regenerate the rules index row for the successor-section rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@ context, read the file directly.
 | `.claude/rules/catalog-taxonomy.md` | `.claude-plugin/marketplace.json` | Where the marketplace category taxonomy lives; read before adding or changing a plugin's category |
 | `.claude/rules/hook-budget.md` | `plugins/*/hooks/**` | Marketplace-wide latency budget for always-on hooks; read before adding or widening a hook |
 | `.claude/rules/ruff-pin.md` | `**/*.py` | Python linting runs through the pinned ruff wrapper, never a bare ruff on PATH |
-| `.claude/rules/skill-bodies-state-current-rules.md` | `plugins/*/skills/**, plugins/*/agents/**` | Skill and agent bodies state the current rule and its reason, never the incident, PR, or model that motivated it; read before editing any skill body |
+| `.claude/rules/skill-bodies-state-current-rules.md` | `plugins/*/skills/**, plugins/*/agents/**` | Skill and agent bodies state the current rule and its reason, never the incident, PR, or model that motivated it, and name their successor in a `## Next` section; read before editing any skill body |
 | `.claude/rules/worktree-base-ref.md` | `.claude/settings.json, .claude/settings.local.json` | This repository sets no worktree.baseRef and never adds one back, even when a review says a merge dropped it; read before editing either settings file |
 | `plugins/autonomy/AGENTS.md` | `plugins/autonomy/**` | autonomy plugin: contributor conventions |
 | `plugins/machine-health/skills/audit/AGENTS.md` | `plugins/machine-health/skills/audit/**` | machine-health audit skill: contributor conventions |


### PR DESCRIPTION
No related issue: follow-through on #3961, whose merge landed before the index regeneration commit was pushed.

## Summary

`.claude/rules/skill-bodies-state-current-rules.md` gained the successor-section clause in its
frontmatter description in #3961. The generated instruction-placement index in `AGENTS.md` still
carries the previous wording, so the row a subagent reads does not say the rule covers `## Next`
sections.

## Fix

Re-run `plugins/instruction-placement/scripts/render-index.sh write --file AGENTS.md`. One row
changes inside the generated region; nothing else.

## Verification

- `bash plugins/instruction-placement/scripts/render-index.sh write --file AGENTS.md` on this
  branch is a no-op (index in sync).
- `npx markdownlint-cli2 AGENTS.md`: 0 issues.

## Related

- #3961 (the rule change and the 29 `## Next` sections)
- #3959 (follow-up: advisory WARN for stage-bearing skills missing `## Next`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vs1MSE5S5dj4avrVm89Uj8
