### PR TITLE
fix(code-tidying): self-parse before triage, grant workflow scripts, SSOT cost rule

### DIFF
--- a/plugins/code-tidying/.claude-plugin/plugin.json
+++ b/plugins/code-tidying/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "code-tidying",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "description": "Code tidying and comment hygiene: /code-tidying:tidy proactively hunts a rotated, glob-scoped lane for Beck-style tidyings under a research-backed scope budget and ships one tight PR; /code-tidying:batch-simplify sweeps a time window, a branch, or an entire repository through grouped, dependency-ordered simplification waves with a fix-first deferral contract that resolves deferrals in the same run instead of filing issues; /code-tidying:dissolve-comments enforces self-describing expressive code over a diff or target, widening to the branch diff and then the whole repository when the tree is clean \u2014 deletes zero-information comments, dissolves code-expressible ones into names and structure behind a tests gate (safe mode restricts applied edits to removals), and keeps only terse load-bearing comments code cannot express; /code-tidying:audit-comment-residue is a read-only classifier that flags history, plan, conversational, and ticket/PR residue in code comments for author-applied deletion; /code-tidying:audit-dead-code is a read-only whole-repo dead-code hunter running four labelled lanes of unequal confidence (knip for TS/JS, vulture for Python, gopls for Go, and a portable grep lane for shell and other symbol languages), adjudicating every candidate against dynamic-usage evidence into a dead, uncertain, or alive verdict. Project-specific tidy lanes are scaffolded into a tracked .claude/tidy-lanes/ config folder by a re-runnable setup skill.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/code-tidying/CHANGELOG.md
+++ b/plugins/code-tidying/CHANGELOG.md
@@ -12,9 +12,12 @@ All notable changes to the `code-tidying` plugin are documented here. Format fol
   against itself carries a construct its grammar rejects, so no deletion or rename anywhere in it
   can ever carry a proof. Those files are named and counted in the report up front and triaged as
   proposals only, instead of the closed gate surfacing one comment at a time at step 6.
-- **`allowed-tools` grants every script the workflow runs**: `change-shape.py`,
-  `comment-census.py`, `commented-out-code.py`, and `rank-comment-targets.py` under
-  `${CLAUDE_PLUGIN_ROOT}/scripts/`, alongside the two skill-directory scripts it already granted.
+- **`allowed-tools` grants every script the workflow runs** through skill-local
+  exec wrappers (`change-shape.sh`, `comment-census.sh`, `commented-out-code.sh`,
+  `rank-comment-targets.sh` under `${CLAUDE_SKILL_DIR}/scripts/`), alongside the
+  two skill-directory scripts it already granted. The implementations stay
+  single-source at the plugin root; the wrappers exist so the grants use the
+  skill-local path whose runtime matching is already exercised.
 - **The census temp path falls back as `${TEMP:-${TMPDIR:-/tmp}}`.** Git Bash on Windows sets
   `TMPDIR=/tmp`, which resolves to the drive root rather than the platform temp directory and
   accumulates there silently, so `TEMP` is consulted first.

--- a/plugins/code-tidying/CHANGELOG.md
+++ b/plugins/code-tidying/CHANGELOG.md
@@ -3,6 +3,50 @@
 All notable changes to the `code-tidying` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.18.1]
+
+### Changed
+
+- **`dissolve-comments` step 4 self-parses before it counts.** Each scoped file is run through
+  `change-shape.py <file> <file>` ahead of the census; a file that cannot prove itself unchanged
+  against itself carries a construct its grammar rejects, so no deletion or rename anywhere in it
+  can ever carry a proof. Those files are named and counted in the report up front and triaged as
+  proposals only, instead of the closed gate surfacing one comment at a time at step 6.
+- **`allowed-tools` grants every script the workflow runs**: `change-shape.py`,
+  `comment-census.py`, `commented-out-code.py`, and `rank-comment-targets.py` under
+  `${CLAUDE_PLUGIN_ROOT}/scripts/`, alongside the two skill-directory scripts it already granted.
+- **The census temp path falls back as `${TEMP:-${TMPDIR:-/tmp}}`.** Git Bash on Windows sets
+  `TMPDIR=/tmp`, which resolves to the drive root rather than the platform temp directory and
+  accumulates there silently, so `TEMP` is consulted first.
+- **Step 1 states the SSOT propagation cost.** Where a source has synced copies, the run reports
+  how many and whether the sync gate demands a version bump per consuming plugin; a comment-only
+  edit that would force those bumps is proposed, never applied, unless the user named the source
+  as the target.
+- **Step 5 settles the indented usage example.** A line demonstrating how to call the thing a
+  documentation block documents is prose whatever it parses as, so `commented-out-code.py` calling
+  it a statement does not make it a class-A deletion.
+- **Step 7 groups keeps under a whole-file verdict.** Class-C keeps are reported as a count per
+  reason group rather than a line each; the per-keep criterion-2 evidence line is owed only for
+  keeps the run actually searched.
+- **`dissolving-moves.md` keeps a file-level divider as navigation.** A divider between top-level
+  groups restates nothing and has nothing to dissolve into, so it stays class C without a
+  criterion-2 search, which asks whether rationale is recoverable elsewhere and has no rationale
+  to ask about.
+- **`tooling.md` records the grammar limit behind the self-parse**: tree-sitter-bash 0.25.1
+  rejects base-N arithmetic (`N#$var` inside `$(( ))`), producing ERROR nodes that make
+  `change-shape.py` return UNPROVABLE for the whole file.
+
+### Fixed
+
+- **`dissolve-comments` workflow step 1 names the ranker flag the action router names.** It passes
+  `--allow-path <glob>` per lifted path and reserves `--override-exclusions` for
+  `hard_exclusions=advisory`, matching the ranker's own argument surface.
+- **`exclusions.md` states that the enumeration gate reaches only argument-lifted paths**, so a
+  path lifted by the repository overrides file or by `hard_exclusions=advisory` proceeds without a
+  go-ahead, and drops the last release-narration phrase from the precedence list.
+- **`rank-comment-targets.py` and `test_rank_comment_targets.py` pass `ruff format --check`.** Two
+  lines shipped in 0.18.0 were not formatter-clean.
+
 ## [0.18.0]
 
 ### Added

--- a/plugins/code-tidying/scripts/allowed-tools-pairing.test.sh
+++ b/plugins/code-tidying/scripts/allowed-tools-pairing.test.sh
@@ -22,7 +22,10 @@
 # runtime on every host, and this repo does not ship a grant on docs alone
 # (`plugins/discovery/reference/parent-contract.md`). Until a runtime check
 # exists, the skill-local path is the exercised shape — reachable from a shared
-# `scripts/` location through a thin exec wrapper.
+# `scripts/` location through a thin exec wrapper. dissolve-comments ships four
+# of those wrappers beside the skill, named so this suite covers them:
+# change-shape.sh, comment-census.sh, commented-out-code.sh,
+# rank-comment-targets.sh.
 #
 # SC2016 is disabled file-wide on purpose. Every single-quoted `${…}` here is a
 # fixed string searched for VERBATIM in markdown and frontmatter, where those

--- a/plugins/code-tidying/scripts/rank-comment-targets.py
+++ b/plugins/code-tidying/scripts/rank-comment-targets.py
@@ -283,9 +283,7 @@ def admin_gate_lifted(path: str, allow: list[str], lift_all: bool) -> bool:
         pat = raw.replace(os.sep, "/").lstrip("./")
         if posix == pat or fnmatch.fnmatch(posix, pat):
             return True
-        if pat.endswith("/**") and (
-            posix == pat[:-3] or posix.startswith(pat[:-2])
-        ):
+        if pat.endswith("/**") and (posix == pat[:-3] or posix.startswith(pat[:-2])):
             return True
     return False
 

--- a/plugins/code-tidying/scripts/test_commented_out_code.py
+++ b/plugins/code-tidying/scripts/test_commented_out_code.py
@@ -151,6 +151,20 @@ class Toml(unittest.TestCase):
         self.assertEqual(lines(rows), {3}, rows)
         self.assertEqual(rows[0]["end"], 4)
 
+    def test_prose_vs_pair(self):
+        # The bare-word comment is the third case: TOML parses a lone key as an
+        # ERROR, so it must stay unflagged even though it is one token, not prose.
+        src = (
+            "# retries are capped at 3\n"
+            "timeout = 30\n"
+            "# retries = 3\n"
+            "verbose = true\n"
+            "# enabled\n"
+        )
+        code, rows, err = scan(src, ".toml")
+        self.assertEqual(code, 0, err)
+        self.assertEqual(lines(rows), {3}, rows)
+
 
 class Degradation(unittest.TestCase):
     def test_missing_tree_sitter_exits_3(self):

--- a/plugins/code-tidying/scripts/test_rank_comment_targets.py
+++ b/plugins/code-tidying/scripts/test_rank_comment_targets.py
@@ -185,7 +185,10 @@ class Ranking(unittest.TestCase):
         self.assertNotIn(guard, default_paths)
         self.assertNotIn(other, default_paths)
 
-        named = [r["path"] for r in json.loads(self.run_rank("--allow-path", guard).stdout)["rows"]]
+        named = [
+            r["path"]
+            for r in json.loads(self.run_rank("--allow-path", guard).stdout)["rows"]
+        ]
         self.assertIn(guard, named)
         self.assertNotIn(other, named)
         self.assertNotIn("gen.sh", named)

--- a/plugins/code-tidying/skills/dissolve-comments/SKILL.md
+++ b/plugins/code-tidying/skills/dissolve-comments/SKILL.md
@@ -1,7 +1,7 @@
 ---
 description: "Enforce self-describing code over a diff, branch, or ranked repository: a three-way comment triage that deletes zero-information comments, dissolves code-expressible ones into names and structure by behavior-preserving refactoring, and keeps only terse, load-bearing comments code cannot express. Deletions and local renames apply behind a token-level proof, other refactors behind a test net, else proposed; 'safe' mode restricts applied edits to removals. Use when: 'dissolve comments', 'remove comments', 'strip agent comments', 'too many comments', 'make it self-documenting', 'make the code expressive', 'comments must earn their keep', after an agent wrote over-commented code. Skip when: read-only residue classification (audit-comment-residue), structural tidyings (tidy), simplification waves (batch-simplify), markdown noise (docs-hygiene audit-noise), adding why-comments (tidy #14). Never touches public-API doc comments, license headers, or machine-read directives."
 argument-hint: "[safe] [override] [target]"
-allowed-tools: ["Bash(${CLAUDE_SKILL_DIR}/scripts/scope-code-files.sh:*)", "Bash(${CLAUDE_SKILL_DIR}/scripts/comment-tooling-probe.sh:*)", "Bash(${CLAUDE_PLUGIN_ROOT}/scripts/change-shape.py:*)", "Bash(${CLAUDE_PLUGIN_ROOT}/scripts/comment-census.py:*)", "Bash(${CLAUDE_PLUGIN_ROOT}/scripts/commented-out-code.py:*)", "Bash(${CLAUDE_PLUGIN_ROOT}/scripts/rank-comment-targets.py:*)", "Bash(git branch:*)", "Bash(git log:*)", "Bash(grep:*)", "Bash(echo:*)"]
+allowed-tools: ["Bash(${CLAUDE_SKILL_DIR}/scripts/scope-code-files.sh:*)", "Bash(${CLAUDE_SKILL_DIR}/scripts/comment-tooling-probe.sh:*)", "Bash(${CLAUDE_SKILL_DIR}/scripts/change-shape.sh:*)", "Bash(${CLAUDE_SKILL_DIR}/scripts/comment-census.sh:*)", "Bash(${CLAUDE_SKILL_DIR}/scripts/commented-out-code.sh:*)", "Bash(${CLAUDE_SKILL_DIR}/scripts/rank-comment-targets.sh:*)", "Bash(git branch:*)", "Bash(git log:*)", "Bash(grep:*)", "Bash(echo:*)"]
 disable-model-invocation: false
 user-invocable: true
 shell: bash
@@ -116,7 +116,7 @@ from them.
   output as a proposed commit-message block for `/source-control:commit`. Text is never silently
   destroyed.
 - **Every applied edit passes the gate its tier names; lint never opens one.** Deletions and
-  function-local renames are certified by `${CLAUDE_PLUGIN_ROOT}/scripts/change-shape.py`
+  function-local renames are certified by `${CLAUDE_SKILL_DIR}/scripts/change-shape.sh`
   (COMMENT-ONLY, RENAME-ONLY); additive and interface-creating moves need a discovered test net.
   Any other verdict reverts the edit and demotes it to a proposal.
 - **RENAME-ONLY is a shape claim, not a safety claim.** It rejects a rename that misses a
@@ -150,7 +150,7 @@ from them.
    the pre-computed scope line is void, `scope-code-files.sh` is not run, and no file outside the
    target is triaged or reported. Empty argument: run `scope-code-files.sh` (never the truncated
    preview), confirm a widening to the repository rung interactively, and take any widened rung in
-   safe mode when non-interactive. On the repository rung, run `rank-comment-targets.py` and triage
+   safe mode when non-interactive. On the repository rung, run `${CLAUDE_SKILL_DIR}/scripts/rank-comment-targets.sh` and triage
    in its order. When an override channel is active, hand its resolved reach to the ranker so the
    administrative gate does not re-drop a lifted path: `--allow-path <glob>` per path the `override`
    argument or the repository overrides file lifted, and `--override-exclusions` only for
@@ -184,12 +184,12 @@ from them.
    deletion or rename carries a proof, and the 12 extensions no grammar covers stay proposals even
    when it is present ([reference/safety.md](reference/safety.md)). Name each absent layer's lost
    capability as the probe phrases it. Done when it is in the report.
-4. **Self-parse, then baseline the census.** First run `change-shape.py <file> <file>` on each
+4. **Self-parse, then baseline the census.** First run `${CLAUDE_SKILL_DIR}/scripts/change-shape.sh <file> <file>` on each
    scoped file. A file that cannot prove itself unchanged against itself (exit 21, UNPROVABLE) has a
    construct the grammar rejects, so no deletion or rename anywhere in it can ever carry a proof.
    Name those files and their count in the report **now**, and triage them as proposals only, rather
-   than discovering the closed gate one comment at a time at step 6. Then run `comment-census.py
-   --json` over the scope, writing it to
+   than discovering the closed gate one comment at a time at step 6. Then run
+   `${CLAUDE_SKILL_DIR}/scripts/comment-census.sh --json` over the scope, writing it to
    `${TEMP:-${TMPDIR:-/tmp}}/dissolve-comments/<run-id>/baseline.json` with `<run-id>` unique per
    run; step 7 reads that exact path back. `TEMP` comes first because Git Bash on Windows sets
    `TMPDIR=/tmp`, which resolves to the drive root rather than the platform temp directory and
@@ -198,7 +198,7 @@ from them.
    quote the script's install hint, and stop; an all-zero baseline reports every later count as an
    improvement. Done when the file exists, or the run has stopped with the missing layer named.
 5. **Triage.** Classify every remaining comment A/B/C per [reference/triage.md](reference/triage.md).
-   Run `commented-out-code.py` (and Ruff ERA001 on Python, via the repository's pinned wrapper where
+   Run `${CLAUDE_SKILL_DIR}/scripts/commented-out-code.sh` (and Ruff ERA001 on Python, via the repository's pinned wrapper where
    one exists) for **candidates, each verified by reading it before deletion**, never as settled
    class-A input: it calls a comment code whenever the body reparses, so prose carrying
    backtick-quoted identifiers hits. A hit whose text is a sentence, not a statement, is prose. That

--- a/plugins/code-tidying/skills/dissolve-comments/SKILL.md
+++ b/plugins/code-tidying/skills/dissolve-comments/SKILL.md
@@ -1,7 +1,7 @@
 ---
 description: "Enforce self-describing code over a diff, branch, or ranked repository: a three-way comment triage that deletes zero-information comments, dissolves code-expressible ones into names and structure by behavior-preserving refactoring, and keeps only terse, load-bearing comments code cannot express. Deletions and local renames apply behind a token-level proof, other refactors behind a test net, else proposed; 'safe' mode restricts applied edits to removals. Use when: 'dissolve comments', 'remove comments', 'strip agent comments', 'too many comments', 'make it self-documenting', 'make the code expressive', 'comments must earn their keep', after an agent wrote over-commented code. Skip when: read-only residue classification (audit-comment-residue), structural tidyings (tidy), simplification waves (batch-simplify), markdown noise (docs-hygiene audit-noise), adding why-comments (tidy #14). Never touches public-API doc comments, license headers, or machine-read directives."
 argument-hint: "[safe] [override] [target]"
-allowed-tools: ["Bash(${CLAUDE_SKILL_DIR}/scripts/scope-code-files.sh:*)", "Bash(${CLAUDE_SKILL_DIR}/scripts/comment-tooling-probe.sh:*)", "Bash(git branch:*)", "Bash(git log:*)", "Bash(grep:*)", "Bash(echo:*)"]
+allowed-tools: ["Bash(${CLAUDE_SKILL_DIR}/scripts/scope-code-files.sh:*)", "Bash(${CLAUDE_SKILL_DIR}/scripts/comment-tooling-probe.sh:*)", "Bash(${CLAUDE_PLUGIN_ROOT}/scripts/change-shape.py:*)", "Bash(${CLAUDE_PLUGIN_ROOT}/scripts/comment-census.py:*)", "Bash(${CLAUDE_PLUGIN_ROOT}/scripts/commented-out-code.py:*)", "Bash(${CLAUDE_PLUGIN_ROOT}/scripts/rank-comment-targets.py:*)", "Bash(git branch:*)", "Bash(git log:*)", "Bash(grep:*)", "Bash(echo:*)"]
 disable-model-invocation: false
 user-invocable: true
 shell: bash
@@ -150,14 +150,23 @@ from them.
    the pre-computed scope line is void, `scope-code-files.sh` is not run, and no file outside the
    target is triaged or reported. Empty argument: run `scope-code-files.sh` (never the truncated
    preview), confirm a widening to the repository rung interactively, and take any widened rung in
-   safe mode when non-interactive. On the repository rung, run `rank-comment-targets.py` (adding
-   `--override-exclusions` when any override channel is active) and triage in its order; **exit 3
+   safe mode when non-interactive. On the repository rung, run `rank-comment-targets.py` and triage
+   in its order. When an override channel is active, hand its resolved reach to the ranker so the
+   administrative gate does not re-drop a lifted path: `--allow-path <glob>` per path the `override`
+   argument or the repository overrides file lifted, and `--override-exclusions` only for
+   `hard_exclusions=advisory`, whose reach genuinely is every path. The all-paths flag for a
+   specific lift lets the whole administrative tree compete for the `--top` cutoff against the one
+   file the operator named. **Exit 3
    from it or from the census means the analysis layer is missing, never that there is nothing to
    rank** — relay the script's stderr, which names the install command, and stop rather than
    proceeding on an empty ranking. Resolve the section 4 override channels first, then drop excluded
    paths and exempt surfaces, listing **every dropped path with its reason**, not only a per-reason
    tally: a silently dropped file is indistinguishable from one triaged and kept. Check survivors for
-   SSOT/materialized-copy declarations (triage the source, run its sync, never touch a copy). Done
+   SSOT/materialized-copy declarations (triage the source, run its sync, never touch a copy). Where
+   a source has synced copies, report how many and whether the sync gate demands a version bump per
+   consuming plugin; a comment-only edit that would force version bumps on consumers is **proposed,
+   never applied**, unless the user named the source as the target. The propagation cost is the
+   decision, and it is the user's, not the run's. Done
    when the file list, the per-path drop list, the tally, and the lifted set with each entry's
    channel are written down. A lifted file outside both grammar tables (`.json`) is neither scanned
    for commented-out code nor certified for deletion.
@@ -175,17 +184,28 @@ from them.
    deletion or rename carries a proof, and the 12 extensions no grammar covers stay proposals even
    when it is present ([reference/safety.md](reference/safety.md)). Name each absent layer's lost
    capability as the probe phrases it. Done when it is in the report.
-4. **Baseline the census.** Run `comment-census.py --json` over the scope, writing it to
-   `${TMPDIR:-${TEMP:-/tmp}}/dissolve-comments/<run-id>/baseline.json` with `<run-id>` unique per
-   run; step 7 reads that exact path back. **Exit 3 is a stop, not a zero:** neither `scc` nor
-   pygments resolved, so there is no baseline and step 7's delta is unobtainable. Report the layer,
+4. **Self-parse, then baseline the census.** First run `change-shape.py <file> <file>` on each
+   scoped file. A file that cannot prove itself unchanged against itself (exit 21, UNPROVABLE) has a
+   construct the grammar rejects, so no deletion or rename anywhere in it can ever carry a proof.
+   Name those files and their count in the report **now**, and triage them as proposals only, rather
+   than discovering the closed gate one comment at a time at step 6. Then run `comment-census.py
+   --json` over the scope, writing it to
+   `${TEMP:-${TMPDIR:-/tmp}}/dissolve-comments/<run-id>/baseline.json` with `<run-id>` unique per
+   run; step 7 reads that exact path back. `TEMP` comes first because Git Bash on Windows sets
+   `TMPDIR=/tmp`, which resolves to the drive root rather than the platform temp directory and
+   accumulates there silently. **Exit 3 is a stop, not a zero:** neither `scc` nor pygments
+   resolved, so there is no baseline and step 7's delta is unobtainable. Report the layer,
    quote the script's install hint, and stop; an all-zero baseline reports every later count as an
    improvement. Done when the file exists, or the run has stopped with the missing layer named.
 5. **Triage.** Classify every remaining comment A/B/C per [reference/triage.md](reference/triage.md).
    Run `commented-out-code.py` (and Ruff ERA001 on Python, via the repository's pinned wrapper where
    one exists) for **candidates, each verified by reading it before deletion**, never as settled
    class-A input: it calls a comment code whenever the body reparses, so prose carrying
-   backtick-quoted identifiers hits. A hit whose text is a sentence, not a statement, is prose.
+   backtick-quoted identifiers hits. A hit whose text is a sentence, not a statement, is prose. That
+   test does not settle an indented usage example under a documentation block
+   (`#   hook::require_jq PostToolUse my-plugin "$INPUT"`), which is a statement and still
+   documentation. Reading decides: a line demonstrating how to call the thing the block documents is
+   prose, whatever it parses as.
    **Criterion 2 is decided on evidence, never on impression.** For every class-C candidate whose
    content is rationale, run `git log -L <start>,<end>:<file>` over its own lines and check the
    repo's ADR or decision-log directory where one is declared; recoverable there **fails** the
@@ -211,7 +231,9 @@ from them.
    versus proposed with each applied item's verdict (and the mapping for every RENAME-ONLY), the
    staged commit-message block, the class-C keeps and rewrites with one-line reasons (grouped where
    several share one, every member still named) and **each keep naming its criterion-2 evidence**
-   from step 5, plus any whole-file budget suspension; then the census delta, `comment-census.py
+   from step 5, plus any whole-file budget suspension. Under a whole-file verdict, report that
+   file's class-C keeps as a count per reason group rather than a line each; the per-keep evidence
+   line is owed only for keeps the run actually searched. Then the census delta, `comment-census.py
    --baseline` pointed at the exact `baseline.json` step 4 wrote, in lines, bytes and estimated
    tokens. A scope whose every file was dropped reports the tally rather than exiting silently. When
    the census could not run, say so in place of the delta line and name the missing layer — an

--- a/plugins/code-tidying/skills/dissolve-comments/reference/dissolving-moves.md
+++ b/plugins/code-tidying/skills/dissolve-comments/reference/dissolving-moves.md
@@ -31,6 +31,11 @@ net; interface-creating moves need a test net and stay proposals in non-interact
 
 ## Cautions
 
+- **A file-level divider is not a section marker.** The row above is about markers segmenting one
+  long function, which Extract Function dissolves. A divider between top-level groups
+  (`# --- Builtin JSON helpers ---`) restates nothing and there is nothing to dissolve it into: it
+  is navigation in a file too long to scan. Keep it as class C without running the criterion-2
+  search, which asks whether rationale is recoverable elsewhere and has no rationale to ask about.
 - **Extraction has a cost curve.** Each extraction adds an interface. A name that must grow
   megasyllabic to stay honest (`isLeastRelevantMultipleOfLargerPrimeFactor`) signals the
   information did not fit the name channel — short name + terse class-C comment, or Inline

--- a/plugins/code-tidying/skills/dissolve-comments/reference/tooling.md
+++ b/plugins/code-tidying/skills/dissolve-comments/reference/tooling.md
@@ -50,6 +50,7 @@ pass.
 | `tree-sitter-language-pack` first-use download behind the cloud proxy | HTTP 502; per-language wheels unaffected | 2026-09-04 |
 | Both `sg` binaries present on the cloud image | `/usr/bin/sg -> newgrp` and `/usr/local/bin/sg` (ast-grep shim) | 2026-09-04 |
 | Versions pinned for CI | tree-sitter 0.26.0; grammars python 0.25.0, c-sharp 0.23.5, typescript 0.23.2, bash 0.25.1, javascript 0.25.0, yaml 0.7.2, toml 0.7.0 | 2026-09-07 |
+| tree-sitter-bash 0.25.1 rejects base-N arithmetic (`N#$var` inside `$(( ))`) | ERROR nodes, one spanning a third of `lib/hook-utils.sh`, so `change-shape.py` returns UNPROVABLE for the file against itself and no deletion or rename in it can carry a proof; 35 `.sh` files in this tree carry the form | 2026-09-08 |
 
 ## What no tool covers
 

--- a/plugins/code-tidying/skills/dissolve-comments/scripts/change-shape.sh
+++ b/plugins/code-tidying/skills/dissolve-comments/scripts/change-shape.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Skill-local entry point for ../../../scripts/change-shape.py.
+#
+# The grant that covers this script names ${CLAUDE_SKILL_DIR}, not the shared
+# plugin-root path. ${CLAUDE_PLUGIN_ROOT} does substitute in a plugin skill's
+# `allowed-tools` Bash rules (<https://code.claude.com/docs/en/skills>, fetched
+# 2026-09-07: "In a plugin skill, Claude Code substitutes ${CLAUDE_PLUGIN_ROOT}
+# and ${CLAUDE_PLUGIN_DATA} in the same two places"), so the token is not the
+# obstacle it once was. What the docs do not establish is that such a rule
+# matches at runtime on every host, and this repo's standing position is not to
+# ship a grant on docs alone (plugins/discovery/reference/parent-contract.md).
+# The skill-local path is the shape whose matching is already exercised here, so
+# it is what the grant names, while the implementation stays single-source at
+# the plugin root — one file to change, and no copy to drift.
+set -euo pipefail
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec python3 "$here/../../../scripts/change-shape.py" "$@"

--- a/plugins/code-tidying/skills/dissolve-comments/scripts/comment-census.sh
+++ b/plugins/code-tidying/skills/dissolve-comments/scripts/comment-census.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Skill-local entry point for ../../../scripts/comment-census.py.
+#
+# Same reason as the sibling wrappers: the grant names ${CLAUDE_SKILL_DIR}
+# because that shape's runtime matching is already exercised here, not because
+# ${CLAUDE_PLUGIN_ROOT} fails to substitute — it does substitute in a plugin
+# skill's `allowed-tools`. See change-shape.sh for the citation.
+set -euo pipefail
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec python3 "$here/../../../scripts/comment-census.py" "$@"

--- a/plugins/code-tidying/skills/dissolve-comments/scripts/commented-out-code.sh
+++ b/plugins/code-tidying/skills/dissolve-comments/scripts/commented-out-code.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Skill-local entry point for ../../../scripts/commented-out-code.py.
+#
+# Same reason as the sibling wrappers: the grant names ${CLAUDE_SKILL_DIR}
+# because that shape's runtime matching is already exercised here, not because
+# ${CLAUDE_PLUGIN_ROOT} fails to substitute — it does substitute in a plugin
+# skill's `allowed-tools`. See change-shape.sh for the citation.
+set -euo pipefail
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec python3 "$here/../../../scripts/commented-out-code.py" "$@"

--- a/plugins/code-tidying/skills/dissolve-comments/scripts/rank-comment-targets.sh
+++ b/plugins/code-tidying/skills/dissolve-comments/scripts/rank-comment-targets.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Skill-local entry point for ../../../scripts/rank-comment-targets.py.
+#
+# Same reason as the sibling wrappers: the grant names ${CLAUDE_SKILL_DIR}
+# because that shape's runtime matching is already exercised here, not because
+# ${CLAUDE_PLUGIN_ROOT} fails to substitute — it does substitute in a plugin
+# skill's `allowed-tools`. See change-shape.sh for the citation.
+set -euo pipefail
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec python3 "$here/../../../scripts/rank-comment-targets.py" "$@"

--- a/plugins/code-tidying/skills/tidy/reference/exclusions.md
+++ b/plugins/code-tidying/skills/tidy/reference/exclusions.md
@@ -114,6 +114,8 @@ Its reach is the run's target, and the three skills' targets are not the same si
 
 That difference gets a gate rather than a caveat. On `tidy`, `override` **enumerates before it edits**: after Phase D's hunt, the run lists the specific HARD paths it now intends to touch and takes a go-ahead on that list, exactly as `batch-simplify`'s repo mode confirms its inventory. An interactive user answers. A non-interactive run has nobody to answer, so it does not proceed on a blanket token: it reports the enumerated list and continues with those candidates dropped, leaving the rest of the lane's tidyings to ship normally. The operator then re-runs interactively or puts the durable entries in the repository overrides file, which is the channel built for a standing decision. Combining `override` with `dry-run` produces that enumeration and nothing else, which is the cheap way to see the list first.
 
+The gate reaches only the paths this argument lifted. A path lifted by the repository overrides file or by `hard_exclusions=advisory` is already a standing decision the operator recorded outside the run, so it proceeds without a go-ahead in an interactive and a non-interactive run alike, and is named in the Phase H lifted table like every other lifted path. A non-interactive `tidy` therefore drops argument-lifted candidates and nothing else.
+
 The other two skills need no such gate: their target is already the enumeration.
 
 To operate on a directory genuinely named `override`, spell it `./override`.
@@ -152,7 +154,7 @@ The three channels only ever loosen, so precedence resolves per path rather than
 1. The `override` argument named this run's target → **lifted**.
 2. A glob in the repository overrides file matches → **lifted**, unless a consumer-declared protection also matches.
 3. `hard_exclusions` is `advisory` → **lifted, and reported as advisory**.
-4. Otherwise → **enforced**, dropped before triage exactly as before.
+4. Otherwise → **enforced**, dropped before triage.
 
 Argument beats repository file beats userConfig. Nothing here reaches a path that was never on the section 1 path list; every channel is subtraction from one fixed set.
 


### PR DESCRIPTION
No related issue: follow-up findings from a fourth dissolve-comments test run, on top of #3962.

## Summary

Running the 0.18.0 dissolve-comments skill on `lib/hook-utils.sh` (1350 comment lines, the repo's rank-1 comment target) produced zero edits, and the reason surfaced only at step 6: tree-sitter-bash 0.25.1 cannot parse base-N arithmetic (`10#$var` inside `$(( ))`), so `change-shape.py` returns UNPROVABLE for the file against itself. The run had already triaged every comment before it learned its proof gate was closed. Six more contract gaps came out of the same run.

## Fix

code-tidying 0.18.1:

- Step 4 self-parses each scoped file with `change-shape.py <file> <file>` before the census; an UNPROVABLE file is named up front and triages as proposals only. `tooling.md` records the grammar limit with a recheck trigger (35 shell files in this tree carry the form).
- `allowed-tools` grants the four workflow scripts, so a user-invoked run does not permission-prompt on every proof.
- The census baseline path takes `TEMP` before `TMPDIR`; Git Bash sets `TMPDIR=/tmp`, which resolves to the drive root on Windows.
- A comment-only edit to a synced SSOT source that would force version bumps on consuming plugins is proposed, never applied, unless the user named the source; the run reports the copy count first. (hook-utils.sh has 17 copies and its sync gate demands a bump per consumer.)
- Indented usage examples under a doc block are prose; file-level section dividers are kept as navigation; under a whole-file verdict, class-C keeps report as counts per reason group.
- Step 1 names the shipped `--allow-path` ranker flag; `exclusions.md` drops its last release-narration phrase; two lines 0.18.0 shipped unformatted are reformatted.

Resolved against the parallel fixes #3962 merged with: main's `--allow-path` and TOML evidence set are kept as is; the one addition there is a bare-word TOML test case.

## Verification

- `pytest` on `test_rank_comment_targets.py`, `test_commented_out_code.py`, `test_change_shape.py`: 48 passed, 1 error (the pre-existing Windows `rmtree` teardown `PermissionError` in the shallow-clone test).
- `run-ruff.sh check`: clean. `format --check`: only the pre-existing `comment-census.py` hit remains.
- `check-skill.sh` dissolve-comments, tidy, setup: PASS, 0 errors (line-count and Gotchas warnings pre-existing).
- `check-purged-em-dashes.sh`: exit 0. `plugin.json` parses at 0.18.1.
- `affected-tests.sh` and `check-changelog-parity.sh` not run locally (#3716); CI covers both.

## Related

- #3962: the 0.18.0 override contract this builds on.
- #3716: local test and gate wall clock.
- #3960: census blind to Python docstrings, still open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
