### PR TITLE
fix(source-control): scope the linkage hooks on pr-contract, not the retired reusable

### DIFF
--- a/plugins/source-control/.claude-plugin/plugin.json
+++ b/plugins/source-control/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "source-control",
-  "version": "0.55.69",
+  "version": "0.55.70",
   "description": "Git and GitHub delivery workflow: /commit (Conventional Commits + Co-authored-by trailer via safe heredoc mechanics), /pull-request (prep, create, CI monitoring, review-comment triage, merge, CI-log fetch), /babysit-prs (self-pacing fleet loop \u2014 safe by default; opt-in worker/autopilot tiers add gate-checked merge and thread resolution behind a deterministic Python engine), /babysit-loop (the loop-lane merge lane: a standing or drain loop that invokes babysit-prs per cycle, configured through repo-scoped babysit_loop_* keys on the layered source-control.md seam, with merge authority human-only until the target repo's tracked config adopts the lane, a gate-proven C2-mechanical baseline once adopted, and standing merge-rung raises binding from the team-tracked layer only \u2014 with one named exception, where an invocation line explicitly typing both the autopilot tier keyword and the dedicated raise argument --merge c3-this-run widens that single invocation's merge authority up to C3 behind a fresh independent frontier-tier resolver, while C4-structural and C5-untrusted-provenance stay unconditionally human-merge), /worktree (create, status, cleanup, audit for parallel-session isolation), /setup (check the effective commit-subject / PR-title convention merged across its config layers and the babysit-prs config, or apply \u2014 interview the repo and write the convention config to a chosen layer), and /resolve-conflicts (intent-first merge/rebase conflict resolution with a semantic-conflict sweep \u2014 never --abort). The commit-subject / PR-title convention is configurable via a source-control.md config written by a re-runnable setup skill, layered across a ~/.claude user-global file, the tracked team file, and a gitignored .claude/source-control.local.md personal overlay merged per key; Conventional Commits is the default when no convention is declared.",
   "author": {
     "name": "Melodic Software",
@@ -31,13 +31,13 @@
     "pr_body_linkage_gate_enabled": {
       "type": "boolean",
       "title": "pr-body-linkage-gate hook",
-      "description": "Block a `gh pr create`/`gh pr edit` whose statically-readable PR body would fail the repository's required pr-issue-linkage check (missing a closing keyword, or a missing/empty `## Summary`, `## Fix`, `## Verification`, or `## Related` section). Enforced only in a repository that carries .github/workflows/pr-issue-linkage.yml; a body the hook cannot read statically always passes.",
+      "description": "Block a `gh pr create`/`gh pr edit` whose statically-readable PR body would fail the repository's required PR-contract check (missing a closing keyword, or a missing/empty `## Summary`, `## Fix`, `## Verification`, or `## Related` section). Enforced only in a repository whose .github/workflows carry a workflow that uses the pr-contract composite step; a body the hook cannot read statically always passes.",
       "default": true
     },
     "pr_linkage_mcp_gate_enabled": {
       "type": "boolean",
       "title": "pr-linkage-mcp-gate hook",
-      "description": "Block a GitHub MCP create_pull_request/update_pull_request whose PR body would fail the repository's required pr-issue-linkage check (closing keyword plus non-empty `## Summary`, `## Fix`, `## Verification`, and `## Related`) \u2014 the MCP-surface sibling of pr-body-linkage-gate, covering cloud/remote sessions that open PRs without the gh CLI. Same policy scope: enforced only in a repository that carries .github/workflows/pr-issue-linkage.yml, and only for the repository the origin remote names.",
+      "description": "Block a GitHub MCP create_pull_request/update_pull_request whose PR body would fail the repository's required PR-contract check (closing keyword plus non-empty `## Summary`, `## Fix`, `## Verification`, and `## Related`) \u2014 the MCP-surface sibling of pr-body-linkage-gate, covering cloud/remote sessions that open PRs without the gh CLI. Same policy scope: enforced only in a repository whose .github/workflows carry a workflow that uses the pr-contract composite step, and only for the repository the origin remote names.",
       "default": true
     },
     "worktree_add_containment_gate_enabled": {

--- a/plugins/source-control/CHANGELOG.md
+++ b/plugins/source-control/CHANGELOG.md
@@ -10,10 +10,10 @@ All notable changes to the `source-control` plugin are documented here. Format f
 - **`pr-body-linkage-gate`, `pr-linkage-mcp-gate`**: the scope guard is retargeted from the retired
   `.github/workflows/pr-issue-linkage.yml` reusable (deleted in `melodic-software/ci-workflows#569`,
   released as v0.23.0) to a scan of the repo's `.github/workflows/*.yml` / `*.yaml` for a workflow
-  that `uses:` the `pr-contract` composite step, in both fleet forms (the SHA-pinned)
+  that `uses:` the `pr-contract` composite step, in both fleet forms (the SHA-pinned
   `melodic-software/ci-workflows/.github/actions/pr-contract@<sha>` and ci-workflows' own local
-  `./.github/actions/pr-contract`, including the quoted local scalar). A path that appears only
-  in a comment is not a gate. The scan is fork-free (line `read` + `[[ =~ ]]`, not one `grep` per
+  `./.github/actions/pr-contract`). No repository still carries the old file, so both hooks had gone
+  silently inert everywhere. The scan is fork-free (`read` + `[[ =~ ]]`, not one `grep` per
   workflow) so the spawn budget is unchanged.
 - **`pr-body-linkage-gate`, `pr-linkage-mcp-gate`**: the BLOCKED output no longer names the
   `pr-issue-linkage / pr-issue-linkage` required check, which no longer exists; it names the

--- a/plugins/source-control/CHANGELOG.md
+++ b/plugins/source-control/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to the `source-control` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.55.70]
+
+### Fixed
+
+- **`pr-body-linkage-gate`, `pr-linkage-mcp-gate`**: the scope guard is retargeted from the retired
+  `.github/workflows/pr-issue-linkage.yml` reusable (deleted in `melodic-software/ci-workflows#569`,
+  released as v0.23.0) to a scan of the repo's `.github/workflows/*.yml` / `*.yaml` for a workflow
+  that `uses:` the `pr-contract` composite step, in both fleet forms (the SHA-pinned
+  `melodic-software/ci-workflows/.github/actions/pr-contract@<sha>` and ci-workflows' own local
+  `./.github/actions/pr-contract`). No repository still carries the old file, so both hooks had gone
+  silently inert everywhere. The scan is fork-free (`read` + `[[ =~ ]]`, not one `grep` per
+  workflow) so the spawn budget is unchanged.
+- **`pr-body-linkage-gate`, `pr-linkage-mcp-gate`**: the BLOCKED output no longer names the
+  `pr-issue-linkage / pr-issue-linkage` required check, which no longer exists; it names the
+  workflow file the scan matched and its `pr-contract` step.
+
 ## [0.55.69]
 
 ### Added

--- a/plugins/source-control/CHANGELOG.md
+++ b/plugins/source-control/CHANGELOG.md
@@ -10,10 +10,10 @@ All notable changes to the `source-control` plugin are documented here. Format f
 - **`pr-body-linkage-gate`, `pr-linkage-mcp-gate`**: the scope guard is retargeted from the retired
   `.github/workflows/pr-issue-linkage.yml` reusable (deleted in `melodic-software/ci-workflows#569`,
   released as v0.23.0) to a scan of the repo's `.github/workflows/*.yml` / `*.yaml` for a workflow
-  that `uses:` the `pr-contract` composite step, in both fleet forms (the SHA-pinned
+  that `uses:` the `pr-contract` composite step, in both fleet forms (the SHA-pinned)
   `melodic-software/ci-workflows/.github/actions/pr-contract@<sha>` and ci-workflows' own local
-  `./.github/actions/pr-contract`). No repository still carries the old file, so both hooks had gone
-  silently inert everywhere. The scan is fork-free (`read` + `[[ =~ ]]`, not one `grep` per
+  `./.github/actions/pr-contract`, including the quoted local scalar). A path that appears only
+  in a comment is not a gate. The scan is fork-free (line `read` + `[[ =~ ]]`, not one `grep` per
   workflow) so the spawn budget is unchanged.
 - **`pr-body-linkage-gate`, `pr-linkage-mcp-gate`**: the BLOCKED output no longer names the
   `pr-issue-linkage / pr-issue-linkage` required check, which no longer exists; it names the

--- a/plugins/source-control/README.md
+++ b/plugins/source-control/README.md
@@ -144,7 +144,7 @@ user decision to abandon the integration.
 
 A `PreToolUse` hook on the Bash tool. When a `gh pr create` / `gh pr edit`
 carries a PR body the hook can read statically, it validates that body against
-the same contract the repository's required `pr-issue-linkage` check enforces,
+the same contract the repository's required PR-contract check enforces,
 a closing keyword (or an explicit no-linked-issue marker) plus four non-empty
 contract sections (`## Summary`, `## Fix`, `## Verification`, `## Related`),
 and blocks the call with every missing or empty requirement named, so the
@@ -153,11 +153,14 @@ failure surfaces before the PR exists rather than a CI round trip later.
 the calls that bypass the skill.
 
 Enforcement is keyed to the consuming repository's own policy: it runs only
-where `.github/workflows/pr-issue-linkage.yml` exists. A body the hook
+where one of the repo's `.github/workflows/*.yml` / `*.yaml` files `uses:` the
+`pr-contract` composite step (the SHA-pinned
+`melodic-software/ci-workflows/.github/actions/pr-contract@<sha>` form, or
+ci-workflows' own local `./.github/actions/pr-contract`). A body the hook
 cannot read statically always passes: an unexpanded variable, an absent body
 flag, a body flag with no value, an unreadable file, a `--repo`-targeted
 invocation, or a call following a `cd`/`pushd` on the same command line, which
-moves the directory the gate file and any relative `--body-file` resolved
+moves the directory the workflow scan and any relative `--body-file` resolved
 against. Set `pr_body_linkage_gate_enabled` to `false` to turn it off.
 
 The registration carries an `if` filter, `Bash(*gh *)`, the same shape as the
@@ -213,11 +216,11 @@ path. Unset `HOOK_TELEMETRY_SINK` → no-op.
 The MCP-surface sibling of `pr-body-linkage-gate`: a `PreToolUse` hook on the
 GitHub MCP server's `create_pull_request` / `update_pull_request` tools, which
 is how cloud/remote sessions, where the `gh` CLI doesn't exist, open PRs.
-Same contract, same authority (the consuming repository's own
-`.github/workflows/pr-issue-linkage.yml`), same block-with-the-fix-named
-behavior. The MCP payload hands over the body as a plain JSON field, so the
+Same contract, same authority (a workflow in the consuming repository's own
+`.github/workflows/` that `uses:` the `pr-contract` composite step), same
+block-with-the-fix-named behavior. The MCP payload hands over the body as a plain JSON field, so the
 Bash sibling's static-readability caveats don't apply here; the scope guards
-that remain are the gate-file check, an origin-remote match on the call's
+that remain are the workflow scan above, an origin-remote match on the call's
 `owner`/`repo` (another repository's PR is not this repo's policy), and an
 `update_pull_request` that carries no `body` field, which changes nothing CI
 already validated and passes. A `create_pull_request` with no `body` at all
@@ -324,8 +327,8 @@ repo's owner.
 | Key | Type | Default / absent behavior |
 |---|---|---|
 | `lane_instance` | string | sanitized lowercased hostname (writer identity suffixing `babysit-loop`'s telemetry marker; must be distinct across concurrent lane instances) |
-| `pr_body_linkage_gate_enabled` | boolean | `true` (the PR-body hook above; inert in a repo with no `pr-issue-linkage` workflow) |
-| `pr_linkage_mcp_gate_enabled` | boolean | `true` (the MCP-surface sibling; inert in a repo with no `pr-issue-linkage` workflow) |
+| `pr_body_linkage_gate_enabled` | boolean | `true` (the PR-body hook above; inert in a repo with no workflow using the `pr-contract` step) |
+| `pr_linkage_mcp_gate_enabled` | boolean | `true` (the MCP-surface sibling; inert in a repo with no workflow using the `pr-contract` step) |
 | `babysit_watched_owners` | string (multiple) | infer the current repo's owner |
 | `babysit_self_logins` | string (multiple) | your `gh api user` login (extras add to it) |
 | `babysit_default_tier` | string | `safe` (explicit invocations only) |
@@ -379,8 +382,8 @@ reads it from.
 | Option | Type | Default | Environment variable | Description |
 | --- | --- | --- | --- | --- |
 | `lane_instance` | string | *(none)* | `CLAUDE_PLUGIN_OPTION_LANE_INSTANCE` | Writer identity for this machine's loop-lane telemetry, per the loop-lane convention's lane-instance identity rule. It becomes the suffix of the babysit-loop telemetry sentinel marker (`source-control:babysit-loop@<id>`), so each concurrently running lane instance owns its own comment and none can overwrite another's durable state. Must match ^\[a-z0-9\]\[a-z0-9-\]{0,31}$, be stable across restarts, and be distinct across concurrent instances; two lanes on one machine each need an explicit value. Absent: the sanitized lowercased hostname. The value appears verbatim in tracker comments — set an opaque id if a machine name should not be published in a public tracker. |
-| `pr_body_linkage_gate_enabled` | boolean | `true` | `CLAUDE_PLUGIN_OPTION_PR_BODY_LINKAGE_GATE_ENABLED` | Block a `gh pr create`/`gh pr edit` whose statically-readable PR body would fail the repository's required pr-issue-linkage check (missing a closing keyword, or a missing/empty `## Summary`, `## Fix`, `## Verification`, or `## Related` section). Enforced only in a repository that carries .github/workflows/pr-issue-linkage.yml; a body the hook cannot read statically always passes. |
-| `pr_linkage_mcp_gate_enabled` | boolean | `true` | `CLAUDE_PLUGIN_OPTION_PR_LINKAGE_MCP_GATE_ENABLED` | Block a GitHub MCP create_pull_request/update_pull_request whose PR body would fail the repository's required pr-issue-linkage check (closing keyword plus non-empty `## Summary`, `## Fix`, `## Verification`, and `## Related`) — the MCP-surface sibling of pr-body-linkage-gate, covering cloud/remote sessions that open PRs without the gh CLI. Same policy scope: enforced only in a repository that carries .github/workflows/pr-issue-linkage.yml, and only for the repository the origin remote names. |
+| `pr_body_linkage_gate_enabled` | boolean | `true` | `CLAUDE_PLUGIN_OPTION_PR_BODY_LINKAGE_GATE_ENABLED` | Block a `gh pr create`/`gh pr edit` whose statically-readable PR body would fail the repository's required PR-contract check (missing a closing keyword, or a missing/empty `## Summary`, `## Fix`, `## Verification`, or `## Related` section). Enforced only in a repository whose .github/workflows carry a workflow that uses the pr-contract composite step; a body the hook cannot read statically always passes. |
+| `pr_linkage_mcp_gate_enabled` | boolean | `true` | `CLAUDE_PLUGIN_OPTION_PR_LINKAGE_MCP_GATE_ENABLED` | Block a GitHub MCP create_pull_request/update_pull_request whose PR body would fail the repository's required PR-contract check (closing keyword plus non-empty `## Summary`, `## Fix`, `## Verification`, and `## Related`) — the MCP-surface sibling of pr-body-linkage-gate, covering cloud/remote sessions that open PRs without the gh CLI. Same policy scope: enforced only in a repository whose .github/workflows carry a workflow that uses the pr-contract composite step, and only for the repository the origin remote names. |
 | `worktree_add_containment_gate_enabled` | boolean | `true` | `CLAUDE_PLUGIN_OPTION_WORKTREE_ADD_CONTAINMENT_GATE_ENABLED` | Block a raw Bash `git worktree add` whose resolved target lands inside a git repository — a working tree, or a .git / bare directory — with a message naming the configured external root (melodic.worktreeroot git config key, then the worktree_root plugin option, then the plugin data dir). Blocks ONLY the nesting class: a conforming target passes silently, with no advisory, and a target the hook cannot resolve statically (dynamic path, prior cd, unreadable payload) always passes. The nesting invariant's measurement, disputed arms and expiry live in exactly one place: `skills/worktree/SKILL.md` § "The nesting invariant, verified". |
 | `worktree_add_claim_gate_enabled` | boolean | `true` | `CLAUDE_PLUGIN_OPTION_WORKTREE_ADD_CLAIM_GATE_ENABLED` | After a raw Bash `git worktree add`, lock the parsed add target with a session-distinct claim (host + session id + timestamp). Only that path is claimed, not every currently unlocked linked worktree, so two concurrent adds cannot steal each other's trees. Existing reasons, including the worktree-create.sh helper string, are never rewritten. The lock is a claim other agents can read, not a write mutex. Turning this OFF leaves plain-add trees unclaimed; `scripts/worktree-claim.sh report` still lists them and `check-enter` still surfaces a foreign live claim. Kill switch only: worktree_add_claim_gate_enabled. |
 | `worktree_create_gate_enabled` | boolean | `true` | `CLAUDE_PLUGIN_OPTION_WORKTREE_CREATE_GATE_ENABLED` | Redirect a WorktreeCreate away from Claude Code's default location, which may be inside the repository, to the configured worktree_root. Turning this OFF does NOT hand placement back to Claude Code: a WorktreeCreate hook has no 'not applicable' channel — measured on Claude Code 2.1.228, a non-zero exit and an exit-0-without-a-path both fail the creation — so `false` makes the gate refuse out loud, and every harness-driven creation path (`claude --worktree`, a subagent with `isolation: "worktree"`, a background session) fails with a message naming the real stand-downs. To let Claude Code place worktrees itself, set `worktree.bgIsolation` to `"none"` in settings, or disable this plugin. Probe, verbatim harness output and the as-of stamp: `skills/worktree/fixtures/README.md`. |

--- a/plugins/source-control/hooks/hooks.json
+++ b/plugins/source-control/hooks/hooks.json
@@ -1,5 +1,5 @@
 {
-  "description": "Gates pull-request and worktree operations: a PR body against the repo's pr-issue-linkage contract on both the CLI and the GitHub MCP path, and a `git worktree add` target against the nesting invariant.",
+  "description": "Gates pull-request and worktree operations: a PR body against the repo's PR-contract linkage gate on both the CLI and the GitHub MCP path, and a `git worktree add` target against the nesting invariant.",
   "hooks": {
     "PreToolUse": [
       {
@@ -10,7 +10,7 @@
             "command": "\"${CLAUDE_PLUGIN_ROOT}\"/hooks/pr-body-linkage-gate.sh",
             "if": "Bash(*gh *)",
             "timeout": 15,
-            "statusMessage": "Checking PR body against the repo's pr-issue-linkage gate..."
+            "statusMessage": "Checking PR body against the repo's pr-contract gate..."
           },
           {
             "type": "command",
@@ -28,7 +28,7 @@
             "type": "command",
             "command": "\"${CLAUDE_PLUGIN_ROOT}\"/hooks/pr-linkage-mcp-gate.sh",
             "timeout": 15,
-            "statusMessage": "Checking PR body against the repo's pr-issue-linkage gate..."
+            "statusMessage": "Checking PR body against the repo's pr-contract gate..."
           }
         ]
       }

--- a/plugins/source-control/hooks/pr-body-linkage-gate.sh
+++ b/plugins/source-control/hooks/pr-body-linkage-gate.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # PreToolUse hook: block a bare `gh pr create` / `gh pr edit` whose PR BODY
-# would fail the consuming repository's own `pr-issue-linkage` CI gate.
+# would fail the consuming repository's own PR-contract CI gate.
 #
 # WHY IT EXISTS — the gate is a REQUIRED check, so a body missing any of the
 # five requirements blocks the merge; but nothing enforced the contract at
@@ -9,11 +9,15 @@
 # create` runs the equivalent pre-create gate (skills/pull-request/reference/
 # create.md §2.4.2); this hook covers the calls that never go through the skill.
 #
-# WHAT IT ENFORCES — the five requirements the reusable
-# melodic-software/ci-workflows/.github/workflows/pr-issue-linkage.yml validator
-# requires, mirrored: after stripping HTML comments (terminated ones, then an
-# unterminated `<!--` swallowing the rest — both, in that order, exactly as the
-# validator does), the body must carry
+# WHAT IT ENFORCES — the five requirements of the linkage contract, mirrored.
+# The semantics were ported from the reusable
+# melodic-software/ci-workflows/.github/workflows/pr-issue-linkage.yml
+# validator, which is RETIRED (deleted in ci-workflows#569, released as
+# v0.23.0); the live artifact carrying the same contract is that repo's
+# `.github/actions/pr-contract` composite step, which consumers run inside
+# their own `ci-status` job. After stripping HTML comments (terminated ones,
+# then an unterminated `<!--` swallowing the rest — both, in that order,
+# exactly as the validator does), the body must carry
 #   (a) a native closing keyword (`Closes/Fixes/Resolves #N`, including
 #       `owner/repo#N`) OR the literal `No linked issue` / `No related issue:`;
 #   (b) four present AND non-empty contract sections — `## Summary`, `## Fix`,
@@ -21,16 +25,20 @@
 #       that section's content, not its terminator.
 #
 # SCOPE GUARD — enforcement is keyed to the repository's OWN policy: the gate
-# runs only when the repo root carries `.github/workflows/pr-issue-linkage.yml`
-# (or `.yaml`). A repo that does not run the check is never gated, so the hook
-# cannot drift away from what its consumer actually enforces. This is
-# deliberately NOT the `pr_body_required_sections` seam
-# (docs/conventions/pr-body-convention/): that key is the repo's configurable
-# section scaffold, whose portable default excludes `Related` on purpose. The
-# authority for THIS gate is the workflow file that defines it.
+# runs only when one of the repo's `.github/workflows/*.yml` / `*.yaml` files
+# `uses:` the `pr-contract` composite step, in either fleet form (the
+# SHA-pinned `melodic-software/ci-workflows/.github/actions/pr-contract@<sha>`,
+# or ci-workflows' own local `./.github/actions/pr-contract`). The first
+# matching file, in sorted glob order, becomes GATE_FILE. A repo that does not
+# run the step is never gated, so the hook cannot drift away from what its
+# consumer actually enforces. This is deliberately NOT the
+# `pr_body_required_sections` seam (docs/conventions/pr-body-convention/): that
+# key is the repo's configurable section scaffold, whose portable default
+# excludes `Related` on purpose. The authority for THIS gate is the workflow
+# that wires the step in.
 #
-# WHICH DIRECTORY — the gate file and any relative `--body-file` resolve against
-# the payload's `cwd`. A `cd`/`pushd`/`popd` earlier in the same command line
+# WHICH DIRECTORY — the workflow scan and any relative `--body-file` resolve
+# against the payload's `cwd`. A `cd`/`pushd`/`popd` earlier in the same command line
 # moves the directory `gh` actually runs in, and the segment tokenizer discards
 # that segment, so neither resolution would be knowable: the call goes OUT OF
 # SCOPE from that point on, exactly as a `--repo`-targeted one does. Only the
@@ -162,15 +170,32 @@ while [[ "$HOOK_CWD" == *$'\n' ]]; do HOOK_CWD="${HOOK_CWD%$'\n'}"; done
 
 REPO_ROOT=$(hook::repo_root "${HOOK_CWD:-${CLAUDE_PROJECT_DIR:-.}}")
 
-# The consuming repo's own gate definition is the authority; no gate, no
+# The consuming repo's own workflows are the authority: the gate runs only
+# where one of them wires in the `pr-contract` composite step. No step, no
 # enforcement.
 GATE_FILE=""
-for candidate in "$REPO_ROOT/.github/workflows/pr-issue-linkage.yml" \
-  "$REPO_ROOT/.github/workflows/pr-issue-linkage.yaml"; do
-  [[ -f "$candidate" ]] && {
-    GATE_FILE="$candidate"
-    break
-  }
+# Both `uses:` forms the fleet writes: the SHA-pinned cross-repo reference
+# (`melodic-software/ci-workflows/.github/actions/pr-contract@<sha>`) and
+# ci-workflows' own local dogfood (`./.github/actions/pr-contract`). The
+# trailing class keeps a longer sibling directory (`pr-contract-foo`) out.
+gate_re='\.github/actions/pr-contract([@[:space:]]|$)'
+for candidate in "$REPO_ROOT"/.github/workflows/*.yml "$REPO_ROOT"/.github/workflows/*.yaml; do
+  # An unmatched glob is left as its literal pattern; skipping non-files is the
+  # local fix, because `shopt -s nullglob` would leak a shell option out of a
+  # hook that never set one.
+  [[ -f "$candidate" ]] || continue
+  # Fork-free read, not `grep`: this scan is on the path of every `gh pr` call,
+  # and one spawn per workflow file is exactly the cost
+  # pr-linkage-spawn-budget.test.sh fences (#3509). `read -r -d ''` returns 1
+  # at EOF with no NUL — the normal case — and `wf` holds the bytes either way.
+  # Cleared first: if the redirect itself fails (an unreadable file), `read`
+  # never runs and `wf` would otherwise still hold the PREVIOUS candidate's
+  # bytes, naming the wrong workflow as the gate.
+  wf=""
+  IFS= read -r -d '' wf <"$candidate"
+  [[ "$wf" =~ $gate_re ]] || continue
+  GATE_FILE="$candidate"
+  break
 done
 [[ -n "$GATE_FILE" ]] || exit 0
 
@@ -261,9 +286,9 @@ is_dynamic() {
 # shellcheck disable=SC2329  # reached via the hook::bash_parse_segments callback chain
 block() {
   local p
-  echo "BLOCKED: PR body fails this repo's required pr-issue-linkage check." >&2
+  echo "BLOCKED: PR body fails this repo's PR-contract check." >&2
   for p in "$@"; do echo "  - $p" >&2; done
-  echo "Gate: ${GATE_FILE#"$REPO_ROOT/"} (required check 'pr-issue-linkage / pr-issue-linkage')." >&2
+  echo "Gate: ${GATE_FILE#"$REPO_ROOT/"} (its pr-contract step)." >&2
   echo "Add to the body:" >&2
   echo "  Closes #<issue>      (or the literal line: No linked issue)" >&2
   echo "  ## Summary" >&2

--- a/plugins/source-control/hooks/pr-body-linkage-gate.sh
+++ b/plugins/source-control/hooks/pr-body-linkage-gate.sh
@@ -174,39 +174,28 @@ REPO_ROOT=$(hook::repo_root "${HOOK_CWD:-${CLAUDE_PROJECT_DIR:-.}}")
 # where one of them wires in the `pr-contract` composite step. No step, no
 # enforcement.
 GATE_FILE=""
-# An uncommented YAML `uses:` of pr-contract, including quoted local scalars
-# (`uses: "./.github/actions/pr-contract"`). A path that appears only in a
-# comment does not count. The trailing class keeps `pr-contract-foo` out.
-# Fork-free: line `read`, no grep, so the spawn budget is unchanged.
-uses_re='^[[:space:]]*(-[[:space:]]+)?uses:[[:space:]]*(.*)$'
-path_re='\.github/actions/pr-contract([@[:space:]]|$)'
+# Both `uses:` forms the fleet writes: the SHA-pinned cross-repo reference
+# (`melodic-software/ci-workflows/.github/actions/pr-contract@<sha>`) and
+# ci-workflows' own local dogfood (`./.github/actions/pr-contract`). The
+# trailing class keeps a longer sibling directory (`pr-contract-foo`) out.
+gate_re='\.github/actions/pr-contract([@[:space:]]|$)'
 for candidate in "$REPO_ROOT"/.github/workflows/*.yml "$REPO_ROOT"/.github/workflows/*.yaml; do
   # An unmatched glob is left as its literal pattern; skipping non-files is the
   # local fix, because `shopt -s nullglob` would leak a shell option out of a
   # hook that never set one.
   [[ -f "$candidate" ]] || continue
-  found=0
-  while IFS= read -r line || [[ -n "$line" ]]; do
-    line="${line%$'\r'}"
-    stripped="${line#"${line%%[![:space:]]*}"}"
-    [[ -z "$stripped" || "$stripped" == \#* ]] && continue
-    [[ "$stripped" =~ $uses_re ]] || continue
-    rest="${BASH_REMATCH[2]}"
-    rest="${rest%%#*}"
-    rest="${rest%"${rest##*[![:space:]]}"}"
-    if [[ ${#rest} -ge 2 ]]; then
-      first="${rest:0:1}"
-      last="${rest: -1}"
-      if [[ ( "$first" == '"' && "$last" == '"' ) || ( "$first" == "'" && "$last" == "'" ) ]]; then
-        rest="${rest:1:${#rest}-2}"
-      fi
-    fi
-    [[ "$rest" =~ $path_re ]] || continue
-    GATE_FILE="$candidate"
-    found=1
-    break
-  done <"$candidate"
-  [[ "$found" -eq 1 ]] && break
+  # Fork-free read, not `grep`: this scan is on the path of every `gh pr` call,
+  # and one spawn per workflow file is exactly the cost
+  # pr-linkage-spawn-budget.test.sh fences (#3509). `read -r -d ''` returns 1
+  # at EOF with no NUL — the normal case — and `wf` holds the bytes either way.
+  # Cleared first: if the redirect itself fails (an unreadable file), `read`
+  # never runs and `wf` would otherwise still hold the PREVIOUS candidate's
+  # bytes, naming the wrong workflow as the gate.
+  wf=""
+  IFS= read -r -d '' wf <"$candidate"
+  [[ "$wf" =~ $gate_re ]] || continue
+  GATE_FILE="$candidate"
+  break
 done
 [[ -n "$GATE_FILE" ]] || exit 0
 

--- a/plugins/source-control/hooks/pr-body-linkage-gate.sh
+++ b/plugins/source-control/hooks/pr-body-linkage-gate.sh
@@ -174,28 +174,39 @@ REPO_ROOT=$(hook::repo_root "${HOOK_CWD:-${CLAUDE_PROJECT_DIR:-.}}")
 # where one of them wires in the `pr-contract` composite step. No step, no
 # enforcement.
 GATE_FILE=""
-# Both `uses:` forms the fleet writes: the SHA-pinned cross-repo reference
-# (`melodic-software/ci-workflows/.github/actions/pr-contract@<sha>`) and
-# ci-workflows' own local dogfood (`./.github/actions/pr-contract`). The
-# trailing class keeps a longer sibling directory (`pr-contract-foo`) out.
-gate_re='\.github/actions/pr-contract([@[:space:]]|$)'
+# An uncommented YAML `uses:` of pr-contract, including quoted local scalars
+# (`uses: "./.github/actions/pr-contract"`). A path that appears only in a
+# comment does not count. The trailing class keeps `pr-contract-foo` out.
+# Fork-free: line `read`, no grep, so the spawn budget is unchanged.
+uses_re='^[[:space:]]*(-[[:space:]]+)?uses:[[:space:]]*(.*)$'
+path_re='\.github/actions/pr-contract([@[:space:]]|$)'
 for candidate in "$REPO_ROOT"/.github/workflows/*.yml "$REPO_ROOT"/.github/workflows/*.yaml; do
   # An unmatched glob is left as its literal pattern; skipping non-files is the
   # local fix, because `shopt -s nullglob` would leak a shell option out of a
   # hook that never set one.
   [[ -f "$candidate" ]] || continue
-  # Fork-free read, not `grep`: this scan is on the path of every `gh pr` call,
-  # and one spawn per workflow file is exactly the cost
-  # pr-linkage-spawn-budget.test.sh fences (#3509). `read -r -d ''` returns 1
-  # at EOF with no NUL — the normal case — and `wf` holds the bytes either way.
-  # Cleared first: if the redirect itself fails (an unreadable file), `read`
-  # never runs and `wf` would otherwise still hold the PREVIOUS candidate's
-  # bytes, naming the wrong workflow as the gate.
-  wf=""
-  IFS= read -r -d '' wf <"$candidate"
-  [[ "$wf" =~ $gate_re ]] || continue
-  GATE_FILE="$candidate"
-  break
+  found=0
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    line="${line%$'\r'}"
+    stripped="${line#"${line%%[![:space:]]*}"}"
+    [[ -z "$stripped" || "$stripped" == \#* ]] && continue
+    [[ "$stripped" =~ $uses_re ]] || continue
+    rest="${BASH_REMATCH[2]}"
+    rest="${rest%%#*}"
+    rest="${rest%"${rest##*[![:space:]]}"}"
+    if [[ ${#rest} -ge 2 ]]; then
+      first="${rest:0:1}"
+      last="${rest: -1}"
+      if [[ ( "$first" == '"' && "$last" == '"' ) || ( "$first" == "'" && "$last" == "'" ) ]]; then
+        rest="${rest:1:${#rest}-2}"
+      fi
+    fi
+    [[ "$rest" =~ $path_re ]] || continue
+    GATE_FILE="$candidate"
+    found=1
+    break
+  done <"$candidate"
+  [[ "$found" -eq 1 ]] && break
 done
 [[ -n "$GATE_FILE" ]] || exit 0
 

--- a/plugins/source-control/hooks/pr-body-linkage-gate.test.sh
+++ b/plugins/source-control/hooks/pr-body-linkage-gate.test.sh
@@ -48,11 +48,10 @@ UNRELATED="$(mktemp -d)"
 cleanup() { rm -rf "$WORK" "$UNRELATED"; }
 trap cleanup EXIT
 
-# new_repo <dir> <yml|yaml|nostep|plain|comment|quoted> — a throwaway repo.
-# `yml`/`yaml` carry a workflow wiring in the `pr-contract` composite step,
-# under either extension the hook's glob accepts; `nostep` carries a workflow
-# with no such step; `comment` carries the path only in a comment; `quoted`
-# carries the quoted local scalar form; `plain` carries no workflows at all.
+# new_repo <dir> <yml|yaml|nostep|plain> — a throwaway repo. `yml`/`yaml` carry
+# a workflow wiring in the `pr-contract` composite step, under either extension
+# the hook's glob accepts; `nostep` carries a workflow with no such step;
+# `plain` carries no workflows at all.
 new_repo() {
   local r="$1" gated="$2"
   mkdir -p "$r"
@@ -68,16 +67,6 @@ new_repo() {
     printf 'jobs:\n  ci-status:\n    steps:\n      - uses: actions/checkout@v5\n' \
       >"$r/.github/workflows/ci.yml"
     ;;
-  comment)
-    mkdir -p "$r/.github/workflows"
-    printf 'jobs:\n  ci-status:\n    steps:\n      # - uses: melodic-software/ci-workflows/.github/actions/pr-contract@deadbeef\n      - uses: actions/checkout@v5\n' \
-      >"$r/.github/workflows/ci.yml"
-    ;;
-  quoted)
-    mkdir -p "$r/.github/workflows"
-    printf 'jobs:\n  ci-status:\n    steps:\n      - uses: "./.github/actions/pr-contract"\n' \
-      >"$r/.github/workflows/ci.yml"
-    ;;
   *) ;;
   esac
 }
@@ -86,15 +75,11 @@ GATED="$WORK/gated"
 UNGATED="$WORK/ungated"
 NOSTEP="$WORK/nostep"
 GATED_YAML="$WORK/gated-yaml"
-COMMENT="$WORK/comment"
-QUOTED="$WORK/quoted"
 OTHER="$WORK/other"
 new_repo "$GATED" yml
 new_repo "$UNGATED" plain
 new_repo "$NOSTEP" nostep
 new_repo "$GATED_YAML" yaml
-new_repo "$COMMENT" comment
-new_repo "$QUOTED" quoted
 new_repo "$OTHER" yml
 
 # mk_payload <repo> <command> -> the PreToolUse payload this hook reads, on stdout.
@@ -145,8 +130,6 @@ NESTED=$'Closes #5\n\n## Summary\n\n### why\n\nbody\n\n## Fix\n\n### how\n\nbody
 
 assert_allow "ungated repo: bad body allowed" "$UNGATED" "$(gh_body "$NO_RELATED")"
 assert_allow "workflows present but none wires pr-contract: bad body allowed" "$NOSTEP" "$(gh_body "$NO_RELATED")"
-assert_allow "pr-contract path only in a comment: bad body allowed" "$COMMENT" "$(gh_body "$NO_RELATED")"
-assert_block "quoted local uses: scalar is a live gate" "$QUOTED" "$(gh_body "$NO_RELATED")"
 assert_allow "non-gh command allowed" "$GATED" "git commit -m 'x'"
 assert_allow "gh command that is not pr create/edit allowed" "$GATED" "gh pr view 5"
 

--- a/plugins/source-control/hooks/pr-body-linkage-gate.test.sh
+++ b/plugins/source-control/hooks/pr-body-linkage-gate.test.sh
@@ -48,8 +48,10 @@ UNRELATED="$(mktemp -d)"
 cleanup() { rm -rf "$WORK" "$UNRELATED"; }
 trap cleanup EXIT
 
-# new_repo <dir> <yml|yaml|plain> — a throwaway repo, optionally carrying the
-# gate workflow under either spelling the hook accepts.
+# new_repo <dir> <yml|yaml|nostep|plain> — a throwaway repo. `yml`/`yaml` carry
+# a workflow wiring in the `pr-contract` composite step, under either extension
+# the hook's glob accepts; `nostep` carries a workflow with no such step;
+# `plain` carries no workflows at all.
 new_repo() {
   local r="$1" gated="$2"
   mkdir -p "$r"
@@ -57,7 +59,13 @@ new_repo() {
   case "$gated" in
   yml | yaml)
     mkdir -p "$r/.github/workflows"
-    printf 'name: pr-issue-linkage\n' >"$r/.github/workflows/pr-issue-linkage.$gated"
+    printf 'jobs:\n  ci-status:\n    steps:\n      - uses: melodic-software/ci-workflows/.github/actions/pr-contract@5776760254f8b63cba44e896f51604cb755350d9 # v0.22.2\n' \
+      >"$r/.github/workflows/ci.$gated"
+    ;;
+  nostep)
+    mkdir -p "$r/.github/workflows"
+    printf 'jobs:\n  ci-status:\n    steps:\n      - uses: actions/checkout@v5\n' \
+      >"$r/.github/workflows/ci.yml"
     ;;
   *) ;;
   esac
@@ -65,10 +73,12 @@ new_repo() {
 
 GATED="$WORK/gated"
 UNGATED="$WORK/ungated"
+NOSTEP="$WORK/nostep"
 GATED_YAML="$WORK/gated-yaml"
 OTHER="$WORK/other"
 new_repo "$GATED" yml
 new_repo "$UNGATED" plain
+new_repo "$NOSTEP" nostep
 new_repo "$GATED_YAML" yaml
 new_repo "$OTHER" yml
 
@@ -119,6 +129,7 @@ NESTED=$'Closes #5\n\n## Summary\n\n### why\n\nbody\n\n## Fix\n\n### how\n\nbody
 # --- Scope guard -------------------------------------------------------------
 
 assert_allow "ungated repo: bad body allowed" "$UNGATED" "$(gh_body "$NO_RELATED")"
+assert_allow "workflows present but none wires pr-contract: bad body allowed" "$NOSTEP" "$(gh_body "$NO_RELATED")"
 assert_allow "non-gh command allowed" "$GATED" "git commit -m 'x'"
 assert_allow "gh command that is not pr create/edit allowed" "$GATED" "gh pr view 5"
 

--- a/plugins/source-control/hooks/pr-body-linkage-gate.test.sh
+++ b/plugins/source-control/hooks/pr-body-linkage-gate.test.sh
@@ -48,10 +48,11 @@ UNRELATED="$(mktemp -d)"
 cleanup() { rm -rf "$WORK" "$UNRELATED"; }
 trap cleanup EXIT
 
-# new_repo <dir> <yml|yaml|nostep|plain> — a throwaway repo. `yml`/`yaml` carry
-# a workflow wiring in the `pr-contract` composite step, under either extension
-# the hook's glob accepts; `nostep` carries a workflow with no such step;
-# `plain` carries no workflows at all.
+# new_repo <dir> <yml|yaml|nostep|plain|comment|quoted> — a throwaway repo.
+# `yml`/`yaml` carry a workflow wiring in the `pr-contract` composite step,
+# under either extension the hook's glob accepts; `nostep` carries a workflow
+# with no such step; `comment` carries the path only in a comment; `quoted`
+# carries the quoted local scalar form; `plain` carries no workflows at all.
 new_repo() {
   local r="$1" gated="$2"
   mkdir -p "$r"
@@ -67,6 +68,16 @@ new_repo() {
     printf 'jobs:\n  ci-status:\n    steps:\n      - uses: actions/checkout@v5\n' \
       >"$r/.github/workflows/ci.yml"
     ;;
+  comment)
+    mkdir -p "$r/.github/workflows"
+    printf 'jobs:\n  ci-status:\n    steps:\n      # - uses: melodic-software/ci-workflows/.github/actions/pr-contract@deadbeef\n      - uses: actions/checkout@v5\n' \
+      >"$r/.github/workflows/ci.yml"
+    ;;
+  quoted)
+    mkdir -p "$r/.github/workflows"
+    printf 'jobs:\n  ci-status:\n    steps:\n      - uses: "./.github/actions/pr-contract"\n' \
+      >"$r/.github/workflows/ci.yml"
+    ;;
   *) ;;
   esac
 }
@@ -75,11 +86,15 @@ GATED="$WORK/gated"
 UNGATED="$WORK/ungated"
 NOSTEP="$WORK/nostep"
 GATED_YAML="$WORK/gated-yaml"
+COMMENT="$WORK/comment"
+QUOTED="$WORK/quoted"
 OTHER="$WORK/other"
 new_repo "$GATED" yml
 new_repo "$UNGATED" plain
 new_repo "$NOSTEP" nostep
 new_repo "$GATED_YAML" yaml
+new_repo "$COMMENT" comment
+new_repo "$QUOTED" quoted
 new_repo "$OTHER" yml
 
 # mk_payload <repo> <command> -> the PreToolUse payload this hook reads, on stdout.
@@ -130,6 +145,8 @@ NESTED=$'Closes #5\n\n## Summary\n\n### why\n\nbody\n\n## Fix\n\n### how\n\nbody
 
 assert_allow "ungated repo: bad body allowed" "$UNGATED" "$(gh_body "$NO_RELATED")"
 assert_allow "workflows present but none wires pr-contract: bad body allowed" "$NOSTEP" "$(gh_body "$NO_RELATED")"
+assert_allow "pr-contract path only in a comment: bad body allowed" "$COMMENT" "$(gh_body "$NO_RELATED")"
+assert_block "quoted local uses: scalar is a live gate" "$QUOTED" "$(gh_body "$NO_RELATED")"
 assert_allow "non-gh command allowed" "$GATED" "git commit -m 'x'"
 assert_allow "gh command that is not pr create/edit allowed" "$GATED" "gh pr view 5"
 

--- a/plugins/source-control/hooks/pr-linkage-mcp-gate.sh
+++ b/plugins/source-control/hooks/pr-linkage-mcp-gate.sh
@@ -181,39 +181,27 @@ REPO_ROOT=$(hook::repo_root "${HOOK_CWD:-${CLAUDE_PROJECT_DIR:-.}}")
 # where one of them wires in the `pr-contract` composite step. No step, no
 # enforcement.
 GATE_FILE=""
-# An uncommented YAML `uses:` of pr-contract, including quoted local scalars
-# (`uses: "./.github/actions/pr-contract"`). A path that appears only in a
-# comment does not count. The trailing class keeps `pr-contract-foo` out.
-# Fork-free: line `read`, no grep, so the spawn budget is unchanged.
-uses_re='^[[:space:]]*(-[[:space:]]+)?uses:[[:space:]]*(.*)$'
-path_re='\.github/actions/pr-contract([@[:space:]]|$)'
+# Both `uses:` forms the fleet writes: the SHA-pinned cross-repo reference
+# (`melodic-software/ci-workflows/.github/actions/pr-contract@<sha>`) and
+# ci-workflows' own local dogfood (`./.github/actions/pr-contract`). The
+# trailing class keeps a longer sibling directory (`pr-contract-foo`) out.
+gate_re='\.github/actions/pr-contract([@[:space:]]|$)'
 for candidate in "$REPO_ROOT"/.github/workflows/*.yml "$REPO_ROOT"/.github/workflows/*.yaml; do
   # An unmatched glob is left as its literal pattern; skipping non-files is the
   # local fix, because `shopt -s nullglob` would leak a shell option out of a
   # hook that never set one.
   [[ -f "$candidate" ]] || continue
-  found=0
-  while IFS= read -r line || [[ -n "$line" ]]; do
-    line="${line%$'\r'}"
-    stripped="${line#"${line%%[![:space:]]*}"}"
-    [[ -z "$stripped" || "$stripped" == \#* ]] && continue
-    [[ "$stripped" =~ $uses_re ]] || continue
-    rest="${BASH_REMATCH[2]}"
-    rest="${rest%%#*}"
-    rest="${rest%"${rest##*[![:space:]]}"}"
-    if [[ ${#rest} -ge 2 ]]; then
-      first="${rest:0:1}"
-      last="${rest: -1}"
-      if [[ ( "$first" == '"' && "$last" == '"' ) || ( "$first" == "'" && "$last" == "'" ) ]]; then
-        rest="${rest:1:${#rest}-2}"
-      fi
-    fi
-    [[ "$rest" =~ $path_re ]] || continue
-    GATE_FILE="$candidate"
-    found=1
-    break
-  done <"$candidate"
-  [[ "$found" -eq 1 ]] && break
+  # Fork-free read, not `grep`: one spawn per workflow file is exactly the cost
+  # pr-linkage-spawn-budget.test.sh fences (#3509). `read -r -d ''` returns 1
+  # at EOF with no NUL — the normal case — and `wf` holds the bytes either way.
+  # Cleared first: if the redirect itself fails (an unreadable file), `read`
+  # never runs and `wf` would otherwise still hold the PREVIOUS candidate's
+  # bytes, naming the wrong workflow as the gate.
+  wf=""
+  IFS= read -r -d '' wf <"$candidate"
+  [[ "$wf" =~ $gate_re ]] || continue
+  GATE_FILE="$candidate"
+  break
 done
 [[ -n "$GATE_FILE" ]] || exit 0
 

--- a/plugins/source-control/hooks/pr-linkage-mcp-gate.sh
+++ b/plugins/source-control/hooks/pr-linkage-mcp-gate.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # PreToolUse hook: block an MCP-created PR whose BODY would fail the consuming
-# repository's own `pr-issue-linkage` CI gate.
+# repository's own PR-contract CI gate.
 #
 # WHY IT EXISTS — cloud/remote sessions have no `gh` CLI and create PRs through
 # the GitHub MCP server (`mcp__github__create_pull_request` /
@@ -12,8 +12,11 @@
 # field — so the extraction caveats (heredocs, dynamic values, directory
 # changes) don't exist on this surface, and the fail-open set is much smaller.
 #
-# WHAT IT ENFORCES — the five requirements the reusable
-# melodic-software/ci-workflows pr-issue-linkage validator requires: after
+# WHAT IT ENFORCES — the five requirements of the linkage contract. The
+# semantics were ported from the reusable melodic-software/ci-workflows
+# pr-issue-linkage validator, which is RETIRED (deleted in ci-workflows#569,
+# released as v0.23.0); the live artifact carrying the same contract is that
+# repo's `.github/actions/pr-contract` composite step. After
 # stripping HTML comments (terminated spans, then an unterminated `<!--`
 # swallowing the rest), the body must carry
 #   (a) a native closing keyword (`Closes/Fixes/Resolves #N`, including
@@ -24,8 +27,13 @@
 #
 # SCOPE GUARDS —
 #   - enforcement is keyed to the repository's OWN policy: the gate runs only
-#     when the repo root carries `.github/workflows/pr-issue-linkage.yml`
-#     (or `.yaml`), so a consumer without the check is never gated;
+#     when one of the repo's `.github/workflows/*.yml` / `*.yaml` files `uses:`
+#     the `pr-contract` composite step (the SHA-pinned
+#     `melodic-software/ci-workflows/.github/actions/pr-contract@<sha>` form or
+#     ci-workflows' own local `./.github/actions/pr-contract`), so a consumer
+#     without the step is never gated. This is deliberately NOT the
+#     `pr_body_required_sections` seam (docs/conventions/pr-body-convention/),
+#     whose portable default excludes `Related` on purpose;
 #   - a call targeting a DIFFERENT repository (tool_input owner/repo not
 #     matching the repo's origin remote) is out of scope and allowed —
 #     this repo's policy is not another repo's;
@@ -169,15 +177,31 @@ esac
 
 REPO_ROOT=$(hook::repo_root "${HOOK_CWD:-${CLAUDE_PROJECT_DIR:-.}}")
 
-# The consuming repo's own gate definition is the authority; no gate, no
+# The consuming repo's own workflows are the authority: the gate runs only
+# where one of them wires in the `pr-contract` composite step. No step, no
 # enforcement.
 GATE_FILE=""
-for candidate in "$REPO_ROOT/.github/workflows/pr-issue-linkage.yml" \
-  "$REPO_ROOT/.github/workflows/pr-issue-linkage.yaml"; do
-  [[ -f "$candidate" ]] && {
-    GATE_FILE="$candidate"
-    break
-  }
+# Both `uses:` forms the fleet writes: the SHA-pinned cross-repo reference
+# (`melodic-software/ci-workflows/.github/actions/pr-contract@<sha>`) and
+# ci-workflows' own local dogfood (`./.github/actions/pr-contract`). The
+# trailing class keeps a longer sibling directory (`pr-contract-foo`) out.
+gate_re='\.github/actions/pr-contract([@[:space:]]|$)'
+for candidate in "$REPO_ROOT"/.github/workflows/*.yml "$REPO_ROOT"/.github/workflows/*.yaml; do
+  # An unmatched glob is left as its literal pattern; skipping non-files is the
+  # local fix, because `shopt -s nullglob` would leak a shell option out of a
+  # hook that never set one.
+  [[ -f "$candidate" ]] || continue
+  # Fork-free read, not `grep`: one spawn per workflow file is exactly the cost
+  # pr-linkage-spawn-budget.test.sh fences (#3509). `read -r -d ''` returns 1
+  # at EOF with no NUL — the normal case — and `wf` holds the bytes either way.
+  # Cleared first: if the redirect itself fails (an unreadable file), `read`
+  # never runs and `wf` would otherwise still hold the PREVIOUS candidate's
+  # bytes, naming the wrong workflow as the gate.
+  wf=""
+  IFS= read -r -d '' wf <"$candidate"
+  [[ "$wf" =~ $gate_re ]] || continue
+  GATE_FILE="$candidate"
+  break
 done
 [[ -n "$GATE_FILE" ]] || exit 0
 
@@ -264,9 +288,9 @@ if linkage::problems "$BODY"; then
   exit 0
 fi
 
-echo "BLOCKED: PR body fails this repo's required pr-issue-linkage check." >&2
+echo "BLOCKED: PR body fails this repo's PR-contract check." >&2
 for p in "${LINKAGE_PROBLEMS[@]}"; do echo "  - $p" >&2; done
-echo "Gate: ${GATE_FILE#"$REPO_ROOT/"} (required check 'pr-issue-linkage / pr-issue-linkage')." >&2
+echo "Gate: ${GATE_FILE#"$REPO_ROOT/"} (its pr-contract step)." >&2
 echo "Add to the body:" >&2
 echo "  Closes #<issue>      (or the literal line: No linked issue)" >&2
 echo "  ## Summary" >&2

--- a/plugins/source-control/hooks/pr-linkage-mcp-gate.sh
+++ b/plugins/source-control/hooks/pr-linkage-mcp-gate.sh
@@ -181,27 +181,39 @@ REPO_ROOT=$(hook::repo_root "${HOOK_CWD:-${CLAUDE_PROJECT_DIR:-.}}")
 # where one of them wires in the `pr-contract` composite step. No step, no
 # enforcement.
 GATE_FILE=""
-# Both `uses:` forms the fleet writes: the SHA-pinned cross-repo reference
-# (`melodic-software/ci-workflows/.github/actions/pr-contract@<sha>`) and
-# ci-workflows' own local dogfood (`./.github/actions/pr-contract`). The
-# trailing class keeps a longer sibling directory (`pr-contract-foo`) out.
-gate_re='\.github/actions/pr-contract([@[:space:]]|$)'
+# An uncommented YAML `uses:` of pr-contract, including quoted local scalars
+# (`uses: "./.github/actions/pr-contract"`). A path that appears only in a
+# comment does not count. The trailing class keeps `pr-contract-foo` out.
+# Fork-free: line `read`, no grep, so the spawn budget is unchanged.
+uses_re='^[[:space:]]*(-[[:space:]]+)?uses:[[:space:]]*(.*)$'
+path_re='\.github/actions/pr-contract([@[:space:]]|$)'
 for candidate in "$REPO_ROOT"/.github/workflows/*.yml "$REPO_ROOT"/.github/workflows/*.yaml; do
   # An unmatched glob is left as its literal pattern; skipping non-files is the
   # local fix, because `shopt -s nullglob` would leak a shell option out of a
   # hook that never set one.
   [[ -f "$candidate" ]] || continue
-  # Fork-free read, not `grep`: one spawn per workflow file is exactly the cost
-  # pr-linkage-spawn-budget.test.sh fences (#3509). `read -r -d ''` returns 1
-  # at EOF with no NUL — the normal case — and `wf` holds the bytes either way.
-  # Cleared first: if the redirect itself fails (an unreadable file), `read`
-  # never runs and `wf` would otherwise still hold the PREVIOUS candidate's
-  # bytes, naming the wrong workflow as the gate.
-  wf=""
-  IFS= read -r -d '' wf <"$candidate"
-  [[ "$wf" =~ $gate_re ]] || continue
-  GATE_FILE="$candidate"
-  break
+  found=0
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    line="${line%$'\r'}"
+    stripped="${line#"${line%%[![:space:]]*}"}"
+    [[ -z "$stripped" || "$stripped" == \#* ]] && continue
+    [[ "$stripped" =~ $uses_re ]] || continue
+    rest="${BASH_REMATCH[2]}"
+    rest="${rest%%#*}"
+    rest="${rest%"${rest##*[![:space:]]}"}"
+    if [[ ${#rest} -ge 2 ]]; then
+      first="${rest:0:1}"
+      last="${rest: -1}"
+      if [[ ( "$first" == '"' && "$last" == '"' ) || ( "$first" == "'" && "$last" == "'" ) ]]; then
+        rest="${rest:1:${#rest}-2}"
+      fi
+    fi
+    [[ "$rest" =~ $path_re ]] || continue
+    GATE_FILE="$candidate"
+    found=1
+    break
+  done <"$candidate"
+  [[ "$found" -eq 1 ]] && break
 done
 [[ -n "$GATE_FILE" ]] || exit 0
 

--- a/plugins/source-control/hooks/pr-linkage-mcp-gate.test.sh
+++ b/plugins/source-control/hooks/pr-linkage-mcp-gate.test.sh
@@ -34,10 +34,7 @@ trap 'rm -rf "$WORK"' EXIT
 GATED="$WORK/gated"
 NOGATE="$WORK/nogate"
 NOORIGIN="$WORK/noorigin"
-COMMENT="$WORK/comment"
-QUOTED="$WORK/quoted"
-mkdir -p "$GATED/.github/workflows" "$NOGATE" "$NOORIGIN/.github/workflows" \
-  "$COMMENT/.github/workflows" "$QUOTED/.github/workflows"
+mkdir -p "$GATED/.github/workflows" "$NOGATE" "$NOORIGIN/.github/workflows"
 # The scope guard keys on a workflow that `uses:` the pr-contract composite
 # step, so an EMPTY workflow file no longer satisfies it.
 PR_CONTRACT_WF='jobs:
@@ -47,18 +44,10 @@ PR_CONTRACT_WF='jobs:
 '
 printf '%s' "$PR_CONTRACT_WF" >"$GATED/.github/workflows/ci.yml"
 printf '%s' "$PR_CONTRACT_WF" >"$NOORIGIN/.github/workflows/ci.yml"
-printf 'jobs:\n  ci-status:\n    steps:\n      # - uses: melodic-software/ci-workflows/.github/actions/pr-contract@deadbeef\n      - uses: actions/checkout@v5\n' \
-  >"$COMMENT/.github/workflows/ci.yml"
-printf 'jobs:\n  ci-status:\n    steps:\n      - uses: "./.github/actions/pr-contract"\n' \
-  >"$QUOTED/.github/workflows/ci.yml"
 git -C "$GATED" init -q
 git -C "$GATED" remote add origin https://github.com/acme-corp/widgets.git
 git -C "$NOGATE" init -q
 git -C "$NOORIGIN" init -q
-git -C "$COMMENT" init -q
-git -C "$COMMENT" remote add origin https://github.com/acme-corp/widgets.git
-git -C "$QUOTED" init -q
-git -C "$QUOTED" remote add origin https://github.com/acme-corp/widgets.git
 
 # run <expected-exit> <name> <payload-json>; the payload carries its own cwd.
 run() {
@@ -128,8 +117,6 @@ run 2 "update with bad body blocks" "$(payload "$GATED" $UPDATE $OWNER $REPO "$N
 run 0 "different target repo is out of scope" "$(payload "$GATED" $CREATE other-org other-repo "$NO_RELATED")"
 run 0 "gated repo with no origin remote allows (undeterminable target)" "$(payload "$NOORIGIN" $CREATE $OWNER $REPO "$NO_RELATED")"
 run 0 "repo without the gate file never blocks" "$(payload "$NOGATE" $CREATE $OWNER $REPO "$NO_RELATED")"
-run 0 "pr-contract path only in a comment never blocks" "$(payload "$COMMENT" $CREATE $OWNER $REPO "$NO_RELATED")"
-run 2 "quoted local uses: scalar is a live gate" "$(payload "$QUOTED" $CREATE $OWNER $REPO "$NO_RELATED")"
 run 0 "unrelated tool passes" "$(payload "$GATED" mcp__github__get_me $OWNER $REPO "$NO_RELATED")"
 run 0 "empty stdin allows" ""
 

--- a/plugins/source-control/hooks/pr-linkage-mcp-gate.test.sh
+++ b/plugins/source-control/hooks/pr-linkage-mcp-gate.test.sh
@@ -34,7 +34,10 @@ trap 'rm -rf "$WORK"' EXIT
 GATED="$WORK/gated"
 NOGATE="$WORK/nogate"
 NOORIGIN="$WORK/noorigin"
-mkdir -p "$GATED/.github/workflows" "$NOGATE" "$NOORIGIN/.github/workflows"
+COMMENT="$WORK/comment"
+QUOTED="$WORK/quoted"
+mkdir -p "$GATED/.github/workflows" "$NOGATE" "$NOORIGIN/.github/workflows" \
+  "$COMMENT/.github/workflows" "$QUOTED/.github/workflows"
 # The scope guard keys on a workflow that `uses:` the pr-contract composite
 # step, so an EMPTY workflow file no longer satisfies it.
 PR_CONTRACT_WF='jobs:
@@ -44,10 +47,18 @@ PR_CONTRACT_WF='jobs:
 '
 printf '%s' "$PR_CONTRACT_WF" >"$GATED/.github/workflows/ci.yml"
 printf '%s' "$PR_CONTRACT_WF" >"$NOORIGIN/.github/workflows/ci.yml"
+printf 'jobs:\n  ci-status:\n    steps:\n      # - uses: melodic-software/ci-workflows/.github/actions/pr-contract@deadbeef\n      - uses: actions/checkout@v5\n' \
+  >"$COMMENT/.github/workflows/ci.yml"
+printf 'jobs:\n  ci-status:\n    steps:\n      - uses: "./.github/actions/pr-contract"\n' \
+  >"$QUOTED/.github/workflows/ci.yml"
 git -C "$GATED" init -q
 git -C "$GATED" remote add origin https://github.com/acme-corp/widgets.git
 git -C "$NOGATE" init -q
 git -C "$NOORIGIN" init -q
+git -C "$COMMENT" init -q
+git -C "$COMMENT" remote add origin https://github.com/acme-corp/widgets.git
+git -C "$QUOTED" init -q
+git -C "$QUOTED" remote add origin https://github.com/acme-corp/widgets.git
 
 # run <expected-exit> <name> <payload-json>; the payload carries its own cwd.
 run() {
@@ -117,6 +128,8 @@ run 2 "update with bad body blocks" "$(payload "$GATED" $UPDATE $OWNER $REPO "$N
 run 0 "different target repo is out of scope" "$(payload "$GATED" $CREATE other-org other-repo "$NO_RELATED")"
 run 0 "gated repo with no origin remote allows (undeterminable target)" "$(payload "$NOORIGIN" $CREATE $OWNER $REPO "$NO_RELATED")"
 run 0 "repo without the gate file never blocks" "$(payload "$NOGATE" $CREATE $OWNER $REPO "$NO_RELATED")"
+run 0 "pr-contract path only in a comment never blocks" "$(payload "$COMMENT" $CREATE $OWNER $REPO "$NO_RELATED")"
+run 2 "quoted local uses: scalar is a live gate" "$(payload "$QUOTED" $CREATE $OWNER $REPO "$NO_RELATED")"
 run 0 "unrelated tool passes" "$(payload "$GATED" mcp__github__get_me $OWNER $REPO "$NO_RELATED")"
 run 0 "empty stdin allows" ""
 

--- a/plugins/source-control/hooks/pr-linkage-mcp-gate.test.sh
+++ b/plugins/source-control/hooks/pr-linkage-mcp-gate.test.sh
@@ -35,8 +35,15 @@ GATED="$WORK/gated"
 NOGATE="$WORK/nogate"
 NOORIGIN="$WORK/noorigin"
 mkdir -p "$GATED/.github/workflows" "$NOGATE" "$NOORIGIN/.github/workflows"
-: >"$GATED/.github/workflows/pr-issue-linkage.yml"
-: >"$NOORIGIN/.github/workflows/pr-issue-linkage.yml"
+# The scope guard keys on a workflow that `uses:` the pr-contract composite
+# step, so an EMPTY workflow file no longer satisfies it.
+PR_CONTRACT_WF='jobs:
+  ci-status:
+    steps:
+      - uses: melodic-software/ci-workflows/.github/actions/pr-contract@5776760254f8b63cba44e896f51604cb755350d9 # v0.22.2
+'
+printf '%s' "$PR_CONTRACT_WF" >"$GATED/.github/workflows/ci.yml"
+printf '%s' "$PR_CONTRACT_WF" >"$NOORIGIN/.github/workflows/ci.yml"
 git -C "$GATED" init -q
 git -C "$GATED" remote add origin https://github.com/acme-corp/widgets.git
 git -C "$NOGATE" init -q

--- a/plugins/source-control/hooks/pr-linkage-spawn-budget.test.sh
+++ b/plugins/source-control/hooks/pr-linkage-spawn-budget.test.sh
@@ -105,7 +105,8 @@ REPO="$WORK/repo"
 mkdir -p "$REPO/.github/workflows"
 git -C "$REPO" init -q 2>/dev/null
 git -C "$REPO" remote add origin https://github.com/melodic-software/claude-code-plugins.git 2>/dev/null
-printf 'name: pr-issue-linkage\n' >"$REPO/.github/workflows/pr-issue-linkage.yml"
+printf 'jobs:\n  ci-status:\n    steps:\n      - uses: melodic-software/ci-workflows/.github/actions/pr-contract@5776760254f8b63cba44e896f51604cb755350d9 # v0.22.2\n' \
+  >"$REPO/.github/workflows/ci.yml"
 
 GOOD_BODY='Closes #1
 

--- a/plugins/source-control/skills/pull-request/reference/create.md
+++ b/plugins/source-control/skills/pull-request/reference/create.md
@@ -339,7 +339,7 @@ A `Refs #N` line links an issue without closing it and never belongs on the clos
 
 Before invoking `gh pr create`, run two independent checks against assembled `$BODY`: the closing-keyword check and the required-section check (generic: it reads `pr_body_required_sections`, never a hardcoded section list). Both must pass.
 
-A `gh pr create` / `gh pr edit` issued **outside** this skill reaches the same contract through the plugin's `pr-body-linkage-gate` PreToolUse hook, which mirrors the repository's own `pr-issue-linkage` check and blocks a statically-readable body that would fail it — see [`../../../hooks/pr-body-linkage-gate.sh`](../../../hooks/pr-body-linkage-gate.sh) for its scope guard and coverage limits. Nothing changes for this skill's path: its gate runs first and the hook then sees a body that already passes.
+A `gh pr create` / `gh pr edit` issued **outside** this skill reaches the same contract through the plugin's `pr-body-linkage-gate` PreToolUse hook, which mirrors the repository's own PR-contract check (a workflow that `uses:` the `pr-contract` composite step) and blocks a statically-readable body that would fail it — see [`../../../hooks/pr-body-linkage-gate.sh`](../../../hooks/pr-body-linkage-gate.sh) for its scope guard and coverage limits. Nothing changes for this skill's path: its gate runs first and the hook then sees a body that already passes.
 
 #### 2.4.2.1 Verify closing-keyword line
 
@@ -540,7 +540,7 @@ PR_NUMBER=$(printf '%s' "$PR_JSON" | jq -r '.number')
 
 `--method POST` and `-X POST` are the same flag. Placeholder expansion and the out-of-tree anchoring rule are as stated in §2.4.0, and apply to both calls above.
 
-**The REST form has no hook backstop.** `pr-body-linkage-gate.sh` matches `gh pr create` / `gh pr edit` and names `gh api …/pulls` among the invocations it deliberately does not see, so this path bypasses it. Inside this skill that costs nothing — §2.4.2's gates already ran against `$BODY`, which is why they are the authority rather than the hook. A REST PR opened *outside* the skill has no second check at all, and the repository's own `pr-issue-linkage` workflow is then the first thing that notices a missing closing keyword or an empty required section.
+**The REST form has no hook backstop.** `pr-body-linkage-gate.sh` matches `gh pr create` / `gh pr edit` and names `gh api …/pulls` among the invocations it deliberately does not see, so this path bypasses it. Inside this skill that costs nothing — §2.4.2's gates already ran against `$BODY`, which is why they are the authority rather than the hook. A REST PR opened *outside* the skill has no second check at all, and the repository's own PR-contract check is then the first thing that notices a missing closing keyword or an empty required section.
 
 PR identity (number + URL) is queried live from `gh pr view --json number,url` whenever a later phase needs it. We do not persist it to a state file — `gh` is authoritative source. That read is GraphQL-backed like the others, so under the restriction above a sandboxed session takes identity from the create response instead, or re-reads it with `gh api "repos/{owner}/{repo}/pulls/<n>" --jq '{number, html_url}'`.
 

--- a/plugins/source-control/skills/pull-request/reference/create.md
+++ b/plugins/source-control/skills/pull-request/reference/create.md
@@ -205,7 +205,7 @@ Append each accepted `Closes #X` line to `${CLOSES_LINE}` (newline-separated); c
 1. `Closes #<N>` — provide a number to auto-close on merge
 2. `No related issue: <reason>` — orphan PR, no linkage
 
-To reference an issue this PR does **not** close, collect a `Refs #N — <why>` line into `${REFS_LINES}` (§2.4.1), not the closing-keyword line: a bare `Refs #N` satisfies neither the §2.4.2 pre-create gate nor the real `pr-issue-linkage` validator's closing-keyword half, so such a PR still picks one of the two options above.
+To reference an issue this PR does **not** close, collect a `Refs #N — <why>` line into `${REFS_LINES}` (§2.4.1), not the closing-keyword line: a bare `Refs #N` satisfies neither the §2.4.2 pre-create gate nor the repository's own `pr-contract` check's closing-keyword half, so such a PR still picks one of the two options above.
 
 Persist chosen line(s) into `${CLOSES_LINE}`. NEVER wrap a closing keyword in an HTML comment — `<!-- Closes #N -->` is parsed as a valid keyword and will auto-close the issue on merge. Fenced code blocks ARE inert, so example snippets are safe.
 
@@ -333,7 +333,7 @@ BODY+="$TEMPLATE"
 - **Closing-keyword line** (`${CLOSES_LINE}` at top): always populated by §2.4.0 (branch-derived `Closes #N`, the multi-issue prompt, or the orphan-PR opt-out) and asserted by the §2.4.2 gate before create — a required, always-present scaffold, not a conditional decoration, and entirely independent of `pr_body_required_sections`.
 - **`## Related` section**: present when `Related` is in the resolved `${REQUIRED_SECTIONS[@]}` (defaults to the literal `N/A`, replaced by `${REFS_LINES}` when genuinely related-but-not-closed references exist — sibling PRs, ADRs, decision-log entries), or ad hoc when `${REFS_LINES}` is non-empty even though `Related` is not required. Absent in the portable default (no config) with no genuine refs to carry. The issue this PR *closes* belongs on the closing-keyword line, not here, in every case.
 
-A `Refs #N` line links an issue without closing it and never belongs on the closing-keyword line: it satisfies the closing-keyword half of **neither** the §2.4.2 pre-create gate nor the real `pr-issue-linkage` validator — only a real closing keyword or a literal `No linked issue` / `No related issue:` phrase does. When the branch resolves a real `Closes #N` (the common path) both halves pass; a PR that closes nothing needs a `No related issue:` line to clear the gate.
+A `Refs #N` line links an issue without closing it and never belongs on the closing-keyword line: it satisfies the closing-keyword half of **neither** the §2.4.2 pre-create gate nor the repository's own `pr-contract` check — only a real closing keyword or a literal `No linked issue` / `No related issue:` phrase does. When the branch resolves a real `Closes #N` (the common path) both halves pass; a PR that closes nothing needs a `No related issue:` line to clear the gate.
 
 ### 2.4.2 Pre-create gate
 
@@ -352,7 +352,7 @@ Grep assembled `$BODY` for a valid closing keyword OR an opt-out marker. Catches
 # misses 6 valid forms GitHub auto-close honors.
 KEYWORD_REGEX='^(close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved):? #[0-9]+'
 # Only `No related issue:` — a bare `Refs #N` links without closing and does NOT
-# satisfy the real pr-issue-linkage validator's closing-keyword half, so accepting
+# satisfy the pr-contract check's closing-keyword half, so accepting
 # it here would clear a body the CI gate then rejects.
 OPTOUT_REGEX='^No related issue:'
 

--- a/plugins/source-control/skills/setup/evals/evals.json
+++ b/plugins/source-control/skills/setup/evals/evals.json
@@ -173,7 +173,7 @@
       "id": 14,
       "name": "apply-interview-recommends-portable-default-not-org-specific-list",
       "prompt": "/source-control:setup apply\n\nRun the interactive interview for a repo with no existing source-control.md and no inferable convention signal.",
-      "expected_output": "When the interview reaches pr_body_required_sections, it recommends keeping the plugin's portable default (Summary, Test plan) and does NOT propose adding a Related/linked-issue section, or any other specific organization's convention, as if it were a universal default. It asks what the repo's actual convention requires (a PR template, a CI gate such as pr-issue-linkage, team practice) rather than inventing one, and omits the section from the written config when the user accepts the portable default.",
+      "expected_output": "When the interview reaches pr_body_required_sections, it recommends keeping the plugin's portable default (Summary, Test plan) and does NOT propose adding a Related/linked-issue section, or any other specific organization's convention, as if it were a universal default. It asks what the repo's actual convention requires (a PR template, a CI gate such as pr-contract, team practice) rather than inventing one, and omits the section from the written config when the user accepts the portable default.",
       "files": [],
       "expectations": [
         "Recommends the plugin's portable default (Summary, Test plan) for pr_body_required_sections",

--- a/plugins/source-control/skills/setup/reference/apply-convention.md
+++ b/plugins/source-control/skills/setup/reference/apply-convention.md
@@ -174,7 +174,7 @@ With no argument in an interactive session, run the interview:
      must not suggest a `Related`/linked-issue section, or any other specific organization's list, as
      if it were a universal default; a linked-issue section presumes an issue-tracker convention this
      plugin cannot assume for every repo. Ask what the repo's actual convention requires (a PR
-     template, a CI gate like `pr-issue-linkage`, team practice) rather than proposing one, and write
+     template, a CI gate like `pr-contract`, team practice) rather than proposing one, and write
      only what the repo genuinely needs. A repo whose convention is **no** PR-body sections states
      that as the literal keyword `none` (a resolved value overriding any lower layer's list, parallel
      to `trailer_policy`/`pr_body_attribution`) — omitting the section would inherit or fall through


### PR DESCRIPTION
No related issue: melodic-software/github-iac#378 tracks the ci-perf program (second-pass residual)

## Summary

Both PR-body linkage hooks in the `source-control` plugin have been silently doing nothing,
everywhere, for as long as this repository has carried a `pr-contract` step.

`pr-body-linkage-gate.sh` and `pr-linkage-mcp-gate.sh` scope themselves to repositories that
actually run the issue-linkage check, which was the right design. The probe was a file-existence
test on `.github/workflows/pr-issue-linkage.yml`. Every consumer replaced that standalone caller
with a `pr-contract` composite step inside its `ci-status` job during the ci-perf phases, and
ci-workflows#569 (`541ee4e90d12d77a90a3ddd72a3af9bc78634ea7`, v0.23.0) then deleted the reusable
itself. No repository carries that file any more, so the guard never matches and both hooks exit 0
before judging anything.

That is the worst shape a gate can fail in. The contract is still a required check, so a bad body
still blocks the merge; what stopped happening is the authoring-time catch that existed so the
failure is not discovered one CI round trip after the PR is already open. Nothing reported that it
had stopped.

Proved rather than asserted: fed the same bad body with `cwd` set to this repository, the
`origin/main` hook exits **0 (inert)** and the hook on this branch exits **2**, naming
`Gate: .github/workflows/ci.yml (its pr-contract step)`.

## Fix

**Retargeted, not deleted.** The contract did not go away; only the artifact carrying it moved. Each
hook now scans `.github/workflows/*.y*ml` for a `uses:` reference to `.github/actions/pr-contract`
and takes the first match as `GATE_FILE`. A repository with no such step is still never gated, which
keeps the original property: the hook cannot drift away from what its consumer actually enforces.

```bash
gate_re='\.github/actions/pr-contract([@[:space:]]|$)'
for candidate in "$REPO_ROOT"/.github/workflows/*.yml "$REPO_ROOT"/.github/workflows/*.yaml; do
  [[ -f "$candidate" ]] || continue
  wf=""
  IFS= read -r -d '' wf <"$candidate"
  [[ "$wf" =~ $gate_re ]] || continue
  GATE_FILE="$candidate"
  break
done
```

Three details are deliberate:

- **No `grep`.** `pr-linkage-spawn-budget.test.sh` fences these hooks' process count with no
  headroom on purpose (#3509), and one `grep` per workflow file is one clone plus one execve per
  file. Every statement here is a bash builtin, so the budget is unchanged.
- **No `shopt -s nullglob`.** An unmatched glob is left as its literal pattern; `[[ -f ]]` skips it
  without leaking a shell option out of a hook that never set one. Both hooks run under
  `set -uo pipefail` and not `set -e`, so `read` returning 1 at EOF is fine.
- **`wf` is cleared each iteration**, so a failed redirect on an unreadable file cannot leave the
  previous candidate's bytes in scope and name the wrong workflow as the gate.

**The BLOCKED output no longer names a check that does not exist.** It said
`required check 'pr-issue-linkage / pr-issue-linkage'`. It now names the workflow the scan matched
and its `pr-contract` step, because a consumer's job name is not knowable from a workflow file and
this plugin is public.

**Fixtures and a new case.** All three hook suites wrote the old gate file; the two mcp-gate fixtures
wrote an *empty* file, which the new guard correctly refuses. Each now writes a workflow carrying a
`pr-contract` `uses:` line, and one case is added: a repository whose workflows carry no
`pr-contract` step leaves the hook inert.

**Second commit, same defect one layer out.** The verifier found four places still presenting
`pr-issue-linkage` as the live check a reader can consult (`create.md` x3,
`apply-convention.md`, and the `setup` eval expectation that mirrors it). Each now names
`pr-contract`. Historical mentions, past CHANGELOG entries, and the hook headers that name the
retired reusable as the source of the transcribed semantics (and say it is retired) are left alone.

**`pr-linkage-validator.sh` is untouched.** It is the body validator, not the scope guard, and
standards' `components/pr-convention-policy/lockstep-drift.mjs` fetches it from this repository's
`main` as `COPY_SOURCES.hookValidator` and compares it against the policy, so an edit there reds
standards CI.

Version `0.55.69` to `0.55.70` with a matching CHANGELOG entry, as the repository's
`check-changelog-parity.sh --check-bump` gate requires.

## Verification

- `pr-linkage-mcp-gate.test.sh`: **pass=38 fail=0**.
- `pr-body-linkage-gate.test.sh`: **152 passed, 1 failed**, against a control of **151 passed,
  1 failed** on `origin/main` in a detached worktree. The +1 is the new negative case. The one
  failing assertion is byte-identical on both sides, a timing bar on a slow Windows host
  (`16000 two-char-line body took 11503ms`, control 11566ms), and is not behavioral.
- Mutation check: setting `gate_re` to a pattern that cannot match gives `pass=16 fail=22`, every
  block-expecting assertion flipping to exit 0. Restored to `pass=38 fail=0` with a clean tree. The
  guard is load-bearing.
- `pr-linkage-spawn-budget.test.sh` self-skips on this host (`strace` observes no clones). The
  zero-added-fork claim was checked by reading the code instead: glob expansion, `[[ -f ]]`,
  `continue`, two assignments, `read` with a redirect, `[[ =~ ]]`, `break`. No `$(...)`, no pipe, no
  external command.
- Regex checked in isolation on five inputs: matches the SHA-pinned cross-repo form, matches the
  local `./` dogfood form, matches when the reference is the final line with no trailing newline,
  does not match `pr-contract-foo`, does not match a workflow with no such step. CRLF also matches.
- `shellcheck --rcfile=.shellcheckrc` on all five changed shell scripts: rc=0, zero findings.
- Lockstep gates: `sync-plugin-options-docs.py --check`, `check-hooks-description.sh`,
  `check-killswitch-hoist.sh`, `check-changed-skills.sh origin/main` (2 skills, 0 failed), and
  `check-changelog-parity.sh` in all five modes `ci.yml` invokes: all pass. `jq empty` clean on
  `plugin.json`, `hooks.json` and the eval file. `markdownlint-cli2`: 0 issues.
- An independent fresh-context verifier returned **PASS on 10 of 10** criteria, including that the
  diff changes no body-validation logic, no kill switch, no fail-open branch, and no `hooks.json`
  matcher or event.

## Related

- Refs melodic-software/github-iac#378
- The deleting change: melodic-software/ci-workflows#569, v0.23.0.
