### PR TITLE
docs(cloud): correct the off-switch, overlay, and setup-step wording left by #3963

### DIFF
--- a/docs/CLOUD-FLEET-SETUP.md
+++ b/docs/CLOUD-FLEET-SETUP.md
@@ -121,10 +121,14 @@ What the canonical script does (details and lifecycle in the
 [component README](https://github.com/melodic-software/standards/blob/main/components/cloud-environment/README.md)):
 parallel tracks install `gh` (the pinned, checksum-verified `linux_amd64` release tarball from
 `github.com/cli/cli`, at the same version and SHA-256 the CI runner image and dotfiles' mise pin
-carry — Ubuntu's archive `gh` is years stale) and PowerShell (apt), the fleet's exact .NET SDK pins into
-`/opt/dotnet`, and Node 24.18.0 via the VM's nvm; it then runs the checked-out repo's own
-`.claude/cloud-bootstrap.sh` — baking its results into the snapshot, and, because it runs before
-the session process launches, making the repo's plugins live at turn one. Every step logs with a timestamp to
+carry — Ubuntu's archive `gh` is years stale) and PowerShell (apt), the .NET SDK into
+`/opt/dotnet` and Node via the VM's nvm at the versions the checked-out repo pins in `global.json`
+and `.node-version` (the fleet pins cover whichever of the two the repo does not pin); it then runs
+that repo's own `.claude/cloud-bootstrap.sh`, baking its results into the snapshot; and then it
+fetches the standards fleet plugin list to `/opt/melodic-fleet-plugins.json` and installs every
+`true` entry in it at user scope. That plugin install is what makes the fleet's plugins live at
+turn one, because it runs before the session process launches and the plugin registry is read at
+process start. Every step logs with a timestamp to
 `/var/log/melodic-env-setup.log`, and `/opt/melodic-env-setup.done` (version + timestamp) is
 written strictly last — so a missing stamp is the signature of an interrupted cache build
 ([#2654](https://github.com/melodic-software/claude-code-plugins/issues/2654) Blocker 2), fixed
@@ -176,9 +180,11 @@ fleet list
 ([`components/cloud-environment/fleet-plugins.json`](https://github.com/melodic-software/standards/blob/main/components/cloud-environment/fleet-plugins.json))
 into every snapshot, and the bootstrap reads that list overlaid with the repo's own block. So a
 repo's `enabledPlugins` carries only deltas: an explicit `false` to opt out of a fleet entry, or
-a `true` for a plugin beyond the fleet. A block that mirrors the whole catalog still works (the
-overlay is a union) but writes one project-scope install record per entry per checkout on every
-local session start, which is the accumulation #3688 removed.
+a `true` for a plugin beyond the fleet. The overlay is settings-wins: where both files name the
+same plugin the repo's value takes precedence, which is what makes the `false` an opt-out. A
+block that mirrors the whole catalog still works — a repeated `true` agrees with the fleet
+entry it overrides — but writes one project-scope install record per entry per checkout
+on every local session start, which is the accumulation #3688 removed.
 
 **`.claude/cloud-bootstrap.sh`** — do not author one. The canonical script is generic and
 manifest-driven (it carries no repo names, no marketplace identifiers, and no pinned versions),

--- a/docs/CLOUD-FLEET-SETUP.md
+++ b/docs/CLOUD-FLEET-SETUP.md
@@ -122,13 +122,16 @@ What the canonical script does (details and lifecycle in the
 parallel tracks install `gh` (the pinned, checksum-verified `linux_amd64` release tarball from
 `github.com/cli/cli`, at the same version and SHA-256 the CI runner image and dotfiles' mise pin
 carry — Ubuntu's archive `gh` is years stale) and PowerShell (apt), the .NET SDK into
-`/opt/dotnet` and Node via the VM's nvm at the versions the checked-out repo pins in `global.json`
-and `.node-version` (the fleet pins cover whichever of the two the repo does not pin); it then runs
-that repo's own `.claude/cloud-bootstrap.sh`, baking its results into the snapshot; and then it
-fetches the standards fleet plugin list to `/opt/melodic-fleet-plugins.json` and installs every
-`true` entry in it at user scope. That plugin install is what makes the fleet's plugins live at
-turn one, because it runs before the session process launches and the plugin registry is read at
-process start. Every step logs with a timestamp to
+`/opt/dotnet` and Node via the VM's nvm. When the checked-out repo pins a version in
+`global.json` or `.node-version`, that pin replaces the matching fleet fallback for this
+cache build rather than unioning with it, so a repo that pins one .NET SDK does not also
+receive the other fallback SDK. The fleet pins cover whichever of those two the repo does
+not pin. The env copy is still a warm cache: each repo's bootstrap installs its exact pins
+repo-locally. The script then runs that repo's own `.claude/cloud-bootstrap.sh`, baking its
+results into the snapshot; and then it fetches the standards fleet plugin list to
+`/opt/melodic-fleet-plugins.json` and installs every `true` entry in it at user scope. That
+plugin install is what makes the fleet's plugins live at turn one, because it runs before
+the session process launches and the plugin registry is read at process start. Every step logs with a timestamp to
 `/var/log/melodic-env-setup.log`, and `/opt/melodic-env-setup.done` (version + timestamp) is
 written strictly last — so a missing stamp is the signature of an interrupted cache build
 ([#2654](https://github.com/melodic-software/claude-code-plugins/issues/2654) Blocker 2), fixed

--- a/scripts/check-plugin-catalog-enablement.sh
+++ b/scripts/check-plugin-catalog-enablement.sh
@@ -51,11 +51,13 @@
 #      plugin can be flipped to `false` without disturbing the rest, and an
 #      insertion at the wrong point is how a duplicate-looking near-miss hides.
 #
-# A key set to `false` PASSES. An explicit `false` is a recorded opt-out that
-# the bootstrap honors: its enabled-set merge overlays this file on the fleet
-# list, so a `false` here drops a plugin the fleet list enables. An absent key
-# is the drift this gate exists to name. The two are different states and only
-# one of them is silent.
+# A key set to `false` PASSES. An explicit `false` is a recorded decision:
+# the gate treats every matching settings key as coverage regardless of
+# value, so a disable of a plugin the fleet list never enabled still
+# passes. When the fleet list does enable that plugin, the bootstrap's
+# overlay honors the `false` as an opt-out (settings-wins). An absent key
+# is the drift this gate exists to name. The two are different states and
+# only one of them is silent.
 #
 # Exit codes: 0 clean, 1 drift, 2 fatal (inputs missing or unreadable).
 #

--- a/scripts/check-plugin-catalog-enablement.sh
+++ b/scripts/check-plugin-catalog-enablement.sh
@@ -51,11 +51,11 @@
 #      plugin can be flipped to `false` without disturbing the rest, and an
 #      insertion at the wrong point is how a duplicate-looking near-miss hides.
 #
-# A key set to `false` PASSES. An explicit `false` is a recorded decision --
-# the documented off switch for the two entries whose MCP servers need
-# credentials this environment has no reason to hold (`miro`, `dometrain`) --
-# whereas an absent key is the drift this gate exists to name. The two are
-# different states and only one of them is silent.
+# A key set to `false` PASSES. An explicit `false` is a recorded opt-out that
+# the bootstrap honors: its enabled-set merge overlays this file on the fleet
+# list, so a `false` here drops a plugin the fleet list enables. An absent key
+# is the drift this gate exists to name. The two are different states and only
+# one of them is silent.
 #
 # Exit codes: 0 clean, 1 drift, 2 fatal (inputs missing or unreadable).
 #


### PR DESCRIPTION
No related issue: wording drift flagged during PR #3963

## Summary

PR #3963 rewrote `docs/CLOUD-SESSIONS.md` and `docs/CLOUD-FLEET-SETUP.md` for the fleet-list
declaration model, and its worker flagged three claims it did not fix. All three send a reader
to behavior that no longer exists: an off switch named after two settings keys this repo dropped,
a merge described as symmetric when it is not, and a setup-script description missing the step
that actually installs the fleet's plugins.

Comment and prose only. No logic changed in the gate script, and no file outside the two below
was touched.

## Fix

**`scripts/check-plugin-catalog-enablement.sh`** (header, lines 54-58 on `origin/main`)

The paragraph explaining why a `false` key passes called an explicit `false` "the documented off
switch for the two entries whose MCP servers need credentials this environment has no reason to
hold (`miro`, `dometrain`)". Neither key exists in `.claude/settings.json` on `origin/main` — it
carries `fleet@melodic-software: true` and `playgrounds@melodic-software: false`. Both plugins now
ride the fleet list, and #3963 already corrected the matching bullet in `docs/CLOUD-SESSIONS.md`.

The paragraph now states the mechanism instead of the retired example: an explicit `false` is a
recorded opt-out the bootstrap honors, because its enabled-set merge overlays the settings file on
the fleet list. It deliberately names no plugin — a comment naming settings keys is exactly the
drift class this correction is repairing.

The gate's logic was NOT touched, and does not depend on those names. `enabled=` (lines 141-147 on
`origin/main`) is built from every `enabledPlugins` key whose suffix matches the marketplace,
regardless of its value, so a `false` key counts as covered by construction; no plugin name appears
anywhere in the script.

**`docs/CLOUD-FLEET-SETUP.md`, Step 2 (line 180 on `origin/main`)**

"A block that mirrors the whole catalog still works (the overlay is a union)". It is not a union.
`.claude/cloud-bootstrap.sh` line 200 on `origin/main` merges with jq object addition,
`(($f[0].enabledPlugins // {}) + (.enabledPlugins // {}))`, with the fleet list on the LEFT and the
repo's settings on the RIGHT, then selects `.value == true`. jq's `+` gives the right operand
precedence on a key collision, so a settings `false` overrides a fleet `true` and the plugin never
reaches `wanted`. A union would enable it.

The sentence now says the overlay is settings-wins and names the precedence, which is also what
makes the `false` in the preceding sentence an opt-out at all.

The same outcome holds for fleet repos on the canonical script, by a different mechanism worth
recording here: `components/cloud-bootstrap/cloud-bootstrap.sh` in `melodic-software/standards`
(at `c06e8d9`) does not merge — it calls `install_plugins_from` once per source, lines 314-315 —
and its own comment at line 204 states that a repo `false` entry "is native project-scope
precedence over the user-scope install and needs nothing here". Repo value wins either way, so the
doc's wording is mechanism-neutral and true for both.

**`docs/CLOUD-FLEET-SETUP.md`, Step 1 "What the canonical script does" (lines 122-127 on
`origin/main`)**

Two steps were wrong against `components/cloud-environment/setup.sh` in
`melodic-software/standards` (at `c06e8d9`, `SCRIPT_VERSION='2026-09-07.2'`, line 39):

- The fleet plugin install was missing entirely. After running the repo's bootstrap, the script
  fetches the standards fleet list to `/opt/melodic-fleet-plugins.json` (`FLEET_PLUGINS`, line 51)
  and installs every `true` entry at user scope (`install_plugins_from "$fleet_file" fleet`,
  line 377). That call, not the repo bootstrap, is what puts the fleet's plugins on disk before the
  session process launches. The paragraph now lists it as the last step and attributes "live at
  turn one" to it.
- The toolchain versions were stated as fixed fleet pins ("the fleet's exact .NET SDK pins",
  "Node 24.18.0"). The script prefers the checked-out repo's own manifests — `global.json` `.sdk.version`
  (line 180 logs `dotnet pin ... read from repo global.json`) and `.node-version` — and falls back to
  `DOTNET_FALLBACK_VERSIONS='10.0.302 10.0.400'` (line 170) and `NODE_FALLBACK_VERSION='24.20.0'`
  (line 171) only when the repo declares none. The hardcoded `24.18.0` was already stale against
  that fallback. The paragraph now names the manifests and the fallback rather than a number that
  drifts.

Step 2's "generic and manifest-driven (it carries no repo names, no marketplace identifiers, and no
pinned versions)" was checked and left alone: it matches the canonical `cloud-bootstrap.sh`'s own
header line 27 at `c06e8d9` verbatim.

No plugin version bump or CHANGELOG entry: `scripts/` and `docs/` at the repo root are not plugin
surfaces, and both files sit outside every `plugins/<name>/` tree.

## Verification

Run in `D:/worktrees/ccp-fleet-doc-wording` after `npm ci`.

- `bash scripts/check-plugin-catalog-enablement.test.sh` — 16 `ok` lines, 0 `FAIL`
  (`grep -c '^ok'` = 16), including `a plugin explicitly disabled (false) still passes` and
  `a catalog the fleet list enables passes with a deltas-only settings block`. Output ends
  `All check-plugin-catalog-enablement.sh contract checks passed.`
- `shellcheck -S info scripts/check-plugin-catalog-enablement.sh` — exit 0, no output.
- `bash scripts/affected-tests.sh --explain` selected `scripts/affected-tests.test.sh` and
  `scripts/check-plugin-catalog-enablement.test.sh`; `docs/CLOUD-FLEET-SETUP.md` is a recorded
  `no-suite` path. `bash scripts/affected-tests.test.sh` reported `PASS=76 FAIL=0`.
- `npx markdownlint-cli2 --config .markdownlint-cli2.jsonc docs/CLOUD-FLEET-SETUP.md` —
  `Summary: 0 issues in 0 files` (markdownlint-cli2 v0.23.2, the repo devDependency and the config
  `.github/workflows/ci.yml` line 330 passes).
- `typos docs/CLOUD-FLEET-SETUP.md scripts/check-plugin-catalog-enablement.sh` — exit 0.
- `editorconfig-checker docs/CLOUD-FLEET-SETUP.md scripts/check-plugin-catalog-enablement.sh` —
  exit 0, no output (binary resolved, not skipped).
- `bash scripts/check-purged-em-dashes.sh` — `98 declared paths, 130 files scanned, no em dashes`
  (neither changed file is on the purged list; the doc's surrounding prose uses em dashes already).
- Claim sources were read at `origin/main` for this repo (`git show 'origin/main:./.claude/...'`)
  and fetched from `raw.githubusercontent.com/melodic-software/standards/main/...` for the two
  standards components, with `gh api repos/melodic-software/standards/commits/main` resolving main
  to `c06e8d970831e56cb96063b305201a7eefc47d6a`.

## Related

- PR #3963 (`43b72bfb`) — the fleet-list doc rewrite whose worker flagged these three claims.
- PR #3949 — flipped `firecrawl` and `x` to `defaultEnabled: true`; the `miro`/`dometrain`
  `defaultEnabled: false` context behind the corrected script comment.
- Issue #3688 — the plugin-declaration migration these sentences lagged. Context only; this PR
  closes nothing.
- melodic-software/standards#542, #552, #555 — the fleet list, the `/opt`-only shape-gated read,
  and the removal of the `enabledPlugins` fallback.
