### PR TITLE
fix: stop counting catalog-disabled plugins as failed cloud installs

### DIFF
--- a/.claude/cloud-bootstrap.sh
+++ b/.claude/cloud-bootstrap.sh
@@ -152,7 +152,8 @@ fi
 # skills, not the session. Idempotent — installed plugins are skipped, so a
 # resume re-run costs two `claude plugin list` calls: one to see what is
 # installed, one to verify the end state afterwards. Measured on this VM with
-# nothing to do: 72 enabled, 0 installed, 0 refreshed, 0 failed.
+# nothing to do: 72 declared, 0 installed, 0 refreshed, 0 failed. The counts are
+# that measurement; only the first label changed with the summary line below.
 claude_bin="$repo_root/node_modules/.bin/claude"
 marketplace_name="melodic-software"
 if [[ -x "$claude_bin" ]] && command -v jq >/dev/null 2>&1; then
@@ -202,6 +203,21 @@ if [[ -x "$claude_bin" ]] && command -v jq >/dev/null 2>&1; then
       .claude/settings.json 2>/dev/null | tr -d '\r'
   )
   mapfile -t have < <("$claude_bin" plugin list --json 2>/dev/null | jq -r '.[].id' 2>/dev/null | tr -d '\r')
+
+  # Catalog entries this marketplace marks `defaultEnabled: false`. The two
+  # sources above answer INSTALL; enablement is the catalog's separate axis, and
+  # `plugin install --scope user -y` honours it — measured on claude 2.1.263
+  # against a throwaway marketplace: exit 0, the CLI printing "This plugin is
+  # disabled by default", and `plugin list --json` showing scope=user with
+  # enabled=false. So DISABLED is the EXPECTED end state for these ids, and
+  # scoring it as a failed install printed a standing failure count on every
+  # fresh snapshot — the shape that teaches operators to skip the log. This
+  # checkout is the registered marketplace (`marketplace add "$repo_root"`
+  # above), so the catalog reads off disk at no CLI or network cost.
+  mapfile -t default_disabled < <(
+    jq -r '.plugins[]? | select(.defaultEnabled == false) | .name' \
+      .claude-plugin/marketplace.json 2>/dev/null | tr -d '\r'
+  )
 
   # A directory-source install cache is keyed by the semver in plugin.json, not
   # by commit, so a later commit under the same version never replaces the
@@ -325,8 +341,13 @@ if [[ -x "$claude_bin" ]] && command -v jq >/dev/null 2>&1; then
   #
   # A plugin passes only when it is installed at user scope, enabled there
   # (enabled must be the JSON boolean true, so a string "true" is rejected), and
-  # snapshot_problem finds nothing. Failures are NAMED, not just counted,
-  # because a bare count cannot be acted on.
+  # snapshot_problem finds nothing. The one exception is an id the catalog marks
+  # `defaultEnabled: false`, for which disabled IS the pass state; it is still
+  # held to the install and snapshot checks. The exception is deliberately keyed
+  # on the catalog rather than on the disabled state itself, so a plugin that is
+  # disabled and NOT default-disabled still fails, which is the fail-closed
+  # signal this block was given in the first place. Failures are NAMED, not just
+  # counted, because a bare count cannot be acted on.
   failed_ids=()
   end_state="$("$claude_bin" plugin list --json 2>/dev/null || true)"
   listed=1
@@ -347,7 +368,8 @@ if [[ -x "$claude_bin" ]] && command -v jq >/dev/null 2>&1; then
       reason="not installed at user scope"
     elif ! jq -e --arg id "$id" \
       'any(.[]?; .id == $id and .scope == "user" and .enabled == true)' \
-      <<<"$end_state" >/dev/null 2>&1; then
+      <<<"$end_state" >/dev/null 2>&1 &&
+      [[ " ${default_disabled[*]} " != *" ${id%@*} "* ]]; then
       reason="installed at user scope but not enabled"
     else
       reason="$(snapshot_problem "$id")"
@@ -363,7 +385,10 @@ if [[ -x "$claude_bin" ]] && command -v jq >/dev/null 2>&1; then
     fi
   done
 
-  plugin_summary="cloud-bootstrap: plugins ${#wanted[@]} enabled, $installed newly installed, $refreshed refreshed, ${#failed_ids[@]} failed"
+  # "declared", not "enabled": the count is of ids the two sources declare, and
+  # a catalog entry marked `defaultEnabled: false` is declared and installed
+  # without ever being enabled.
+  plugin_summary="cloud-bootstrap: plugins ${#wanted[@]} declared, $installed newly installed, $refreshed refreshed, ${#failed_ids[@]} failed"
   if [[ "$listed" -eq 0 ]]; then
     plugin_summary="$plugin_summary: none could be verified, see the warning above"
   elif ((${#failed_ids[@]} > 0)); then

--- a/.claude/cloud-bootstrap.sh
+++ b/.claude/cloud-bootstrap.sh
@@ -342,9 +342,10 @@ if [[ -x "$claude_bin" ]] && command -v jq >/dev/null 2>&1; then
   # A plugin passes only when it is installed at user scope, enabled there
   # (enabled must be the JSON boolean true, so a string "true" is rejected), and
   # snapshot_problem finds nothing. The one exception is an id the catalog marks
-  # `defaultEnabled: false`, for which disabled IS the pass state; it is still
-  # held to the install and snapshot checks. The exception is deliberately keyed
-  # on the catalog rather than on the disabled state itself, so a plugin that is
+  # `defaultEnabled: false` whose user-scope record has enabled as the JSON
+  # boolean false; a missing, null, or string enabled value still fails. It is
+  # still held to the install and snapshot checks. The exception is keyed on
+  # the catalog rather than on the disabled state itself, so a plugin that is
   # disabled and NOT default-disabled still fails, which is the fail-closed
   # signal this block was given in the first place. Failures are NAMED, not just
   # counted, because a bare count cannot be acted on.
@@ -369,7 +370,10 @@ if [[ -x "$claude_bin" ]] && command -v jq >/dev/null 2>&1; then
     elif ! jq -e --arg id "$id" \
       'any(.[]?; .id == $id and .scope == "user" and .enabled == true)' \
       <<<"$end_state" >/dev/null 2>&1 &&
-      [[ " ${default_disabled[*]} " != *" ${id%@*} "* ]]; then
+      ! { jq -e --arg id "$id" \
+            'any(.[]?; .id == $id and .scope == "user" and .enabled == false)' \
+            <<<"$end_state" >/dev/null 2>&1 &&
+          [[ " ${default_disabled[*]} " == *" ${id%@*} "* ]]; }; then
       reason="installed at user scope but not enabled"
     else
       reason="$(snapshot_problem "$id")"

--- a/.claude/hooks/cloud-bootstrap-plugins.test.sh
+++ b/.claude/hooks/cloud-bootstrap-plugins.test.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Contract test for the plugin accounting in .claude/cloud-bootstrap.sh: the
 # block that installs/refreshes this repo's own catalog on a cloud VM and prints
-# `cloud-bootstrap: plugins N enabled, X newly installed, Y refreshed, Z failed`.
+# `cloud-bootstrap: plugins N declared, X newly installed, Y refreshed, Z failed`.
 #
 # That summary is the ONLY health signal a cloud session start emits for
 # plugins, and it has failed in both directions. It over-reported first: the
@@ -155,6 +155,8 @@ BETA_DISABLED='[{"id":"alpha@melodic-software","scope":"user","enabled":true},
                 {"id":"beta@melodic-software","scope":"user","enabled":false}]'
 BETA_ENABLED_STRING='[{"id":"alpha@melodic-software","scope":"user","enabled":true},
                       {"id":"beta@melodic-software","scope":"user","enabled":"true"}]'
+BETA_DISABLED_STRING='[{"id":"alpha@melodic-software","scope":"user","enabled":true},
+                       {"id":"beta@melodic-software","scope":"user","enabled":"false"}]'
 NONE='[]'
 
 REG_BOTH_HEAD='{"plugins":{
@@ -361,6 +363,14 @@ CASE_MARKETPLACE="$BETA_DEFAULT_DISABLED" \
   run_case default_disabled_stale "$BETA_DISABLED" "$BETA_DISABLED" "$REG_BETA_SHA_NULL" NONE
 expect "a catalog-disabled plugin is still snapshot-verified" \
   "beta@melodic-software failed verification after no action: cannot verify snapshot: no user-scope gitCommitSha recorded"
+
+# The exemption requires JSON boolean false. A string "false" is the same
+# malformed-output class as the string "true" case below, even when the
+# catalog marks the plugin default-disabled.
+CASE_MARKETPLACE="$BETA_DEFAULT_DISABLED" \
+  run_case default_disabled_enabled_string "$BETA_DISABLED_STRING" "$BETA_DISABLED_STRING" "$REG_BOTH_HEAD" NONE
+expect "a catalog-disabled plugin with enabled as the string \"false\" still fails" \
+  "beta@melodic-software failed verification after no action: installed at user scope but not enabled"
 
 # --- broken end states must be named and counted, continued ------------------
 

--- a/.claude/hooks/cloud-bootstrap-plugins.test.sh
+++ b/.claude/hooks/cloud-bootstrap-plugins.test.sh
@@ -204,6 +204,13 @@ run_case() {
     printf '%s\n' "$CASE_FLEET" >"$fx/fleet.json"
     fleet_env=(CLOUD_BOOTSTRAP_FLEET_LIST="$fx/fleet.json")
   fi
+  # The catalog the block reads for `defaultEnabled`. Absent by default, which
+  # is the pre-existing shape every case below was written against: no catalog
+  # means no default-disabled ids, so disabled stays a failure.
+  if [[ -n "${CASE_MARKETPLACE:-}" ]]; then
+    mkdir -p "$fx/.claude-plugin"
+    printf '%s\n' "$CASE_MARKETPLACE" >"$fx/.claude-plugin/marketplace.json"
+  fi
   printf 'a\n' >"$fx/plugins/alpha/f.txt"
   printf 'b\n' >"$fx/plugins/beta/f.txt"
 
@@ -292,21 +299,21 @@ refute() {
 
 run_case steady "$BOTH_USER" "$BOTH_USER" "$REG_BOTH_HEAD" NONE
 expect "a settled catalog reports no work and no failures" \
-  "plugins 2 enabled, 0 newly installed, 0 refreshed, 0 failed"
+  "plugins 2 declared, 0 newly installed, 0 refreshed, 0 failed"
 
 run_case duplicated "$BOTH_DUPLICATED" "$BOTH_DUPLICATED" "$REG_BOTH_HEAD" NONE
 expect "the real project+user duplicate listing passes" \
-  "plugins 2 enabled, 0 newly installed, 0 refreshed, 0 failed"
+  "plugins 2 declared, 0 newly installed, 0 refreshed, 0 failed"
 
 run_case fresh "$NONE" "$BOTH_USER" "$REG_BOTH_HEAD" NONE
 expect "a first-run install counts as installed, not failed" \
-  "plugins 2 enabled, 2 newly installed, 0 refreshed, 0 failed"
+  "plugins 2 declared, 2 newly installed, 0 refreshed, 0 failed"
 
 # The regression this whole change set exists for: the refresh chain's trailing
 # `plugin enable` exits 1 on the healthy path, and the stub reproduces that.
 run_case refreshed "$BOTH_USER" "$BOTH_USER" "$REG_BOTH_FIRST" "$REG_BOTH_HEAD"
 expect "a healthy refresh is not a failure even though \`plugin enable\` exits 1" \
-  "plugins 2 enabled, 0 newly installed, 1 refreshed, 0 failed"
+  "plugins 2 declared, 0 newly installed, 1 refreshed, 0 failed"
 
 # --- broken end states must be named and counted -----------------------------
 
@@ -319,6 +326,43 @@ expect "and is named in the summary" \
 run_case disabled "$BETA_DISABLED" "$BETA_DISABLED" "$REG_BOTH_HEAD" NONE
 expect "a plugin installed at user scope but disabled is a failure" \
   "beta@melodic-software failed verification after no action: installed at user scope but not enabled"
+
+# --- a catalog `defaultEnabled: false` makes disabled the EXPECTED end state --
+# The fleet list and the settings block answer INSTALL; the catalog owns
+# enablement, and `plugin install --scope user -y` honours it (claude 2.1.263:
+# exit 0, "This plugin is disabled by default", `plugin list --json` reporting
+# scope=user with enabled=false). Scoring that as a failed install put a
+# standing nonzero failure count in every fresh snapshot's log. The pair below
+# is the point: the SAME disabled end state passes with the catalog entry and
+# fails without it, which pins the discriminator on the catalog rather than on
+# the disabled state.
+
+BETA_DEFAULT_DISABLED='{"plugins":[{"name":"alpha"},{"name":"beta","defaultEnabled":false}]}'
+
+CASE_MARKETPLACE="$BETA_DEFAULT_DISABLED" \
+  run_case default_disabled_fresh "$NONE" "$BETA_DISABLED" "$REG_BOTH_HEAD" NONE
+expect "a fresh install left disabled by the catalog counts as installed, not failed" \
+  "plugins 2 declared, 2 newly installed, 0 refreshed, 0 failed"
+refute "and is not named as a failure" \
+  "beta@melodic-software failed verification"
+
+CASE_MARKETPLACE="$BETA_DEFAULT_DISABLED" \
+  run_case default_disabled_steady "$BETA_DISABLED" "$BETA_DISABLED" "$REG_BOTH_HEAD" NONE
+expect "a settled catalog-disabled plugin reports no work and no failures" \
+  "plugins 2 declared, 0 newly installed, 0 refreshed, 0 failed"
+
+# Still held to the other two checks, so the exception cannot hide a real break.
+CASE_MARKETPLACE="$BETA_DEFAULT_DISABLED" \
+  run_case default_disabled_project_only "$BETA_PROJECT_ONLY" "$BETA_PROJECT_ONLY" "$REG_BOTH_HEAD" NONE
+expect "a catalog-disabled plugin missing from user scope is still a failure" \
+  "beta@melodic-software failed verification after no action: not installed at user scope"
+
+CASE_MARKETPLACE="$BETA_DEFAULT_DISABLED" \
+  run_case default_disabled_stale "$BETA_DISABLED" "$BETA_DISABLED" "$REG_BETA_SHA_NULL" NONE
+expect "a catalog-disabled plugin is still snapshot-verified" \
+  "beta@melodic-software failed verification after no action: cannot verify snapshot: no user-scope gitCommitSha recorded"
+
+# --- broken end states must be named and counted, continued ------------------
 
 run_case enabled_string "$BETA_ENABLED_STRING" "$BETA_ENABLED_STRING" "$REG_BOTH_HEAD" NONE
 expect "enabled as the string \"true\" is rejected, not accepted" \
@@ -354,7 +398,7 @@ refute "and a plugin whose own directory did not change is not called stale" \
 # one that can catch an id credited to `refreshed` (or `installed`) and to
 # `failed` at the same time. The counts must partition, not overlap.
 expect "an attempted plugin that failed is counted once, as failed only" \
-  "plugins 2 enabled, 0 newly installed, 0 refreshed, 1 failed: alpha@melodic-software"
+  "plugins 2 declared, 0 newly installed, 0 refreshed, 1 failed: alpha@melodic-software"
 
 run_case unreadable "$BOTH_USER" 'not json at all' "$REG_BOTH_HEAD" NONE
 expect "an unreadable plugin list fails the whole batch" \
@@ -374,24 +418,24 @@ CASE_SETTINGS='{"enabledPlugins":{"alpha@melodic-software":true}}' \
   CASE_FLEET='{"enabledPlugins":{"alpha@melodic-software":true,"beta@melodic-software":true,"gamma@elsewhere":true}}' \
   run_case fleet_union "$BOTH_USER" "$BOTH_USER" "$REG_BOTH_HEAD" NONE
 expect "a fleet entry beyond the settings block counts as enabled" \
-  "plugins 2 enabled, 0 newly installed, 0 refreshed, 0 failed"
+  "plugins 2 declared, 0 newly installed, 0 refreshed, 0 failed"
 
 CASE_SETTINGS='{"enabledPlugins":{"alpha@melodic-software":true,"beta@melodic-software":false}}' \
   CASE_FLEET='{"enabledPlugins":{"alpha@melodic-software":true,"beta@melodic-software":true}}' \
   run_case fleet_opt_out "$BOTH_USER" "$BOTH_USER" "$REG_BOTH_HEAD" NONE
 expect "a settings false opts out of a fleet entry" \
-  "plugins 1 enabled, 0 newly installed, 0 refreshed, 0 failed"
+  "plugins 1 declared, 0 newly installed, 0 refreshed, 0 failed"
 
 CASE_SETTINGS='{"enabledPlugins":{"alpha@melodic-software":true}}' \
   run_case fleet_absent "$BOTH_USER" "$BOTH_USER" "$REG_BOTH_HEAD" NONE
 expect "without a fleet list the settings block is the only source" \
-  "plugins 1 enabled, 0 newly installed, 0 refreshed, 0 failed"
+  "plugins 1 declared, 0 newly installed, 0 refreshed, 0 failed"
 
 CASE_SETTINGS='{"enabledPlugins":{"alpha@melodic-software":true}}' \
   CASE_FLEET='not json at all' \
   run_case fleet_malformed "$BOTH_USER" "$BOTH_USER" "$REG_BOTH_HEAD" NONE
 expect "a malformed fleet list degrades to the settings block, not to an empty set" \
-  "plugins 1 enabled, 0 newly installed, 0 refreshed, 0 failed"
+  "plugins 1 declared, 0 newly installed, 0 refreshed, 0 failed"
 
 # Valid JSON of the wrong shape (an error body, an array where the object
 # should be) would break the merge the same way a parse failure does.
@@ -399,13 +443,13 @@ CASE_SETTINGS='{"enabledPlugins":{"alpha@melodic-software":true}}' \
   CASE_FLEET='{"enabledPlugins":["alpha@melodic-software"]}' \
   run_case fleet_wrong_shape "$BOTH_USER" "$BOTH_USER" "$REG_BOTH_HEAD" NONE
 expect "a wrong-shaped fleet list degrades to the settings block, not to an empty set" \
-  "plugins 1 enabled, 0 newly installed, 0 refreshed, 0 failed"
+  "plugins 1 declared, 0 newly installed, 0 refreshed, 0 failed"
 
 CASE_SETTINGS='{"enabledPlugins":{"alpha@melodic-software":true}}' \
   CASE_FLEET='[]' \
   run_case fleet_array "$BOTH_USER" "$BOTH_USER" "$REG_BOTH_HEAD" NONE
 expect "a fleet list that is a bare array degrades to the settings block" \
-  "plugins 1 enabled, 0 newly installed, 0 refreshed, 0 failed"
+  "plugins 1 declared, 0 newly installed, 0 refreshed, 0 failed"
 
 # --- report -------------------------------------------------------------------
 echo

--- a/docs/CLOUD-SESSIONS.md
+++ b/docs/CLOUD-SESSIONS.md
@@ -335,7 +335,9 @@ catalog on, and the cloud bootstrap installs from the two together (see
   the ones that run touched, since the plugins most likely to be wrong are the ones it decided to
   skip. A plugin counts as failed when any of these holds:
   - `claude plugin list --json` does not list it at user scope, or lists it there with `enabled`
-    anything other than the JSON boolean `true`;
+    anything other than the JSON boolean `true`, except a catalog entry marked
+    `defaultEnabled: false` whose user-scope record has `enabled` as the JSON boolean
+    `false` (a missing, null, or string `enabled` value still fails);
   - its own directory under `plugins/` changed between the `gitCommitSha` recorded for the
     user-scope install and `HEAD`, so the session would serve that plugin's older sources. A
     recorded sha that merely differs from `HEAD` is NOT a failure: the check is
@@ -347,10 +349,13 @@ catalog on, and the cloud bootstrap installs from the two together (see
     the same inputs and skips what it cannot judge.
 
   Each failure is named on stderr with its reason and the summary line appends the failing ids
-  after the count. So `0 failed` means every enabled plugin was checked and each one is installed
-  at user scope, enabled there, and serving sources that match `HEAD`; the one case where nothing
-  can be claimed, `claude plugin list --json` itself being unreadable, counts every plugin as
-  failed and says so in one line rather than one per plugin.
+  after the count. The leading count is `N declared` (ids the fleet list plus settings deltas
+  turn on), not `N enabled`, because a catalog `defaultEnabled: false` entry is declared and
+  installed without ever being enabled. So `0 failed` means every declared plugin was checked
+  and each one is installed at user scope, serving sources that match `HEAD`, and either enabled
+  there or (for a catalog-default-disabled id) explicitly JSON-`false` disabled; the one case
+  where nothing can be claimed, `claude plugin list --json` itself being unreadable, counts
+  every plugin as failed and says so in one line rather than one per plugin.
 - **Consumer repos** should declare the marketplace with a `github` source —
   `{"source": "github", "repo": "melodic-software/claude-code-plugins"}` — since the relative
   `directory` source is specific to this repo, whose reason to exist is validating in-flight
@@ -393,8 +398,8 @@ catalog on, and the cloud bootstrap installs from the two together (see
   decision where an absent key is drift. The entries that should not start on their own are not
   keyed here at all: the catalog ships them `defaultEnabled: false`, and `claude plugin install`
   honors that flag, so a raw install leaves them disabled. They still appear as `true` on the
-  fleet list, so this repo's cloud bootstrap includes them in its wanted set, treats a disabled
-  install as a verification failure, and runs `plugin enable` on a source-changing refresh.
+  fleet list, so this repo's cloud bootstrap includes them in its wanted set and treats an
+  explicit JSON-`false` disabled install as the expected end state, not a verification failure.
   Operator opt-in outside that path is `/plugin enable`. That covers the two whose bundled MCP
   servers need `userConfig` credentials this environment has no reason to hold — `miro`
   (`miro_api_token`) and `dometrain` (`dometrain_api_key`), set with `/plugin configure` —


### PR DESCRIPTION
No related issue: bootstrap failure-count semantics flagged during PR #3963

## Summary

Every fresh cloud snapshot's bootstrap log reported five failed plugin
installs that were not failures.

`.claude/cloud-bootstrap.sh` builds its `wanted` set from the fleet list
(`/opt/melodic-fleet-plugins.json`) overlaid with `.claude/settings.json`,
taking every `enabledPlugins` entry set to `true` for the `melodic-software`
marketplace. Five of those entries name plugins this repo's
`.claude-plugin/marketplace.json` deliberately marks `defaultEnabled: false` —
`songwriting`, `kindle-dedrm`, `ai-briefing`, `miro`, `dometrain`.

The end-state verification then required each declared id to be enabled:

```bash
    elif ! jq -e --arg id "$id" \
      'any(.[]?; .id == $id and .scope == "user" and .enabled == true)' \
      <<<"$end_state" >/dev/null 2>&1; then
      reason="installed at user scope but not enabled"
```

Those five hit that branch, were pushed onto `failed_ids`, and were printed
as `N failed: <ids>` in the summary plus one warning line each — on every
fresh snapshot, forever. A standing false failure count is how a log teaches
its readers to stop reading it.

The two sources answer INSTALL. Enablement is the catalog's separate axis, and
the CLI honours it. Measured on claude 2.1.263 against a throwaway marketplace
in an isolated `CLAUDE_CONFIG_DIR`:

```
$ claude plugin install poff@probe-mp --scope user -y
Installing plugin "poff@probe-mp"...✔ Successfully installed plugin:
poff@probe-mp (scope: user). This plugin is disabled by default — enable it
with: claude plugin enable poff@probe-mp
exit=0

$ claude plugin list --json
  { "id": "poff@probe-mp", "scope": "user", "enabled": false, ... }
  { "id": "pon@probe-mp",  "scope": "user", "enabled": true,  ... }
```

Install succeeds; the plugin is correctly left disabled. Nothing failed.

## Fix

Read the catalog's `defaultEnabled: false` names off disk (this checkout is
the registered marketplace, so no CLI call and no network), and exempt exactly
those ids from the enablement check:

```bash
      <<<"$end_state" >/dev/null 2>&1 &&
      [[ " ${default_disabled[*]} " != *" ${id%@*} "* ]]; then
```

The exemption is keyed on the catalog, not on the disabled state itself. A
plugin that is disabled *without* being default-disabled still fails, which
preserves the fail-closed signal this block was given in the first place: the
pre-existing `disabled` case still asserts that failure, unchanged.
Default-disabled ids also stay held to the user-scope install check and to
`snapshot_problem`, so the exemption cannot hide a real break.

The summary line's leading count is relabelled from `N enabled` to
`N declared`: a default-disabled entry is declared and installed without ever
being enabled, so `enabled` was the untrue word.

Deliberately NOT done: enabling those five. The fleet list says install; the
marketplace's `defaultEnabled: false` is the deliberate choice about
enablement, and the bootstrap has no business overriding it.

## Verification

`bash .claude/hooks/cloud-bootstrap-plugins.test.sh` — PASS=53 FAIL=0.
Four new cases, all with a `CASE_MARKETPLACE` fixture marking `beta`
`defaultEnabled: false`:

- `default_disabled_fresh` — a fresh install left disabled by the catalog
  reports `plugins 2 declared, 2 newly installed, 0 refreshed, 0 failed`, and
  refutes `beta@melodic-software failed verification`.
- `default_disabled_steady` — the settled state reports `0 failed`.
- `default_disabled_project_only` — still fails with
  `not installed at user scope`.
- `default_disabled_stale` — still fails with
  `cannot verify snapshot: no user-scope gitCommitSha recorded`.

Negative control, the same suite against the unfixed script
(`CLOUD_BOOTSTRAP_SCRIPT=<origin/main copy> bash .claude/hooks/cloud-bootstrap-plugins.test.sh`)
— PASS=38 FAIL=15, including:

```
not ok - a fresh install left disabled by the catalog counts as installed, not failed
not ok - and is not named as a failure (unexpected: beta@melodic-software failed verification)
```

That pair is the bug reproduced. The existing `disabled` case (no catalog
fixture) passes on both sides, which pins the discriminator on the catalog
rather than on the disabled state.

Lint, both touched files:

- `shellcheck --rcfile=.shellcheckrc -S info .claude/cloud-bootstrap.sh .claude/hooks/cloud-bootstrap-plugins.test.sh` — rc=0 (ShellCheck 0.11.0).
- `typos` — rc=0.
- `editorconfig-checker` — rc=0.
- Added lines carry no machine-specific paths and no `#NNNN` comment citations.

The probe ran in a throwaway `CLAUDE_CONFIG_DIR` under `%TEMP%` with a
throwaway local marketplace; `~/.claude/plugins/installed_plugins.json` is
byte-identical before and after (md5 `d32515d2ec132ddcc4eaf83f59e09d36`), and
no real plugin state was touched.

Scope: this repo's bootstrap only. `.claude/cloud-bootstrap.sh` here is
`locally-owned` in the standards sync manifest
(`distribution/sync-manifest.yml`, under
`melodic-software/claude-code-plugins:` → `locally-owned:` → `cloud-bootstrap`,
"Directory-source dogfooding: this repo's bootstrap carries same-version
commit-drift repair the canonical github-source script must not"), so it is an
independent script and not a drifted copy of the standards component. The
canonical `components/cloud-bootstrap/cloud-bootstrap.sh` does not carry this
bug: it has no enablement check at all, its only failure branch is a nonzero
`claude plugin install`, and its skip set comes from `plugin list --json`
`.[].id`, which includes disabled entries. No standards change is needed.

## Related

- Follows from PR #3963, where the failure-count semantics were flagged.
- PR #3949 flipped `firecrawl` and `x` to `defaultEnabled: true`; the five
  plugins above remain deliberately `false`.
- Issue #3688 (plugin-sync cluster).
- melodic-software/standards PR #559.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L5ZJnwTRCgc31bmfrdugyU
