### PR TITLE
docs(cloud): retire the residual union wording and restore the refresh enable step

### DIFF
--- a/docs/CLOUD-FLEET-SETUP.md
+++ b/docs/CLOUD-FLEET-SETUP.md
@@ -15,8 +15,12 @@ recorded in [CLOUD-SESSIONS.md](CLOUD-SESSIONS.md); the environment itself was v
 [#2654](https://github.com/melodic-software/claude-code-plugins/issues/2654), folded in below.
 Recheck trigger, per the [upstream-drift convention](conventions/upstream-drift/README.md): a
 repo changes its toolchain pins (`global.json`, `.node-version`, `.python-version`, lockfiles)
-or its `.claude/` config, or a verification session (see [checklist](#verification-checklist))
-contradicts a claim here.
+or its `.claude/` config; or `melodic-software/standards`
+`components/cloud-environment/setup.sh` changes (that file owns
+`DOTNET_FALLBACK_VERSIONS` and `NODE_FALLBACK_VERSION`, the numbers copied into the
+inventory below); or a verification session (see [checklist](#verification-checklist))
+contradicts a claim here. The .NET and Node fallback numbers were re-read from that
+setup.sh on 2026-09-08 (`origin/main` at `3ea3e96`; the file last touched by `1cafb61`).
 
 ## The design in one paragraph
 

--- a/docs/CLOUD-FLEET-SETUP.md
+++ b/docs/CLOUD-FLEET-SETUP.md
@@ -23,8 +23,10 @@ contradicts a claim here.
 Cloud environments are account-scoped and repo-agnostic, and each environment's setup script
 result is cached as a filesystem snapshot (the "warm boot": script runs once, later sessions boot
 from the snapshot; rebuilds only on script/network edits or ~7-day expiry). So the fleet uses
-**one shared environment** whose setup script installs the *union* of static toolchains the
-repos pin — .NET SDKs, Node 24, `gh`, PowerShell — inside the ~5-minute cache-build budget, while
+**one shared environment** whose setup script installs the static toolchains the repos pin —
+.NET SDK and Node at whatever the checked-out repo pins, with fleet fallbacks for whichever of
+those two lanes the repo does not pin, plus `gh` and PowerShell — inside the ~5-minute
+cache-build budget, while
 **each repo carries its own bootstrap**: a committed, idempotent, `CLAUDE_CODE_REMOTE`-guarded
 `.claude/cloud-bootstrap.sh` that installs manifest-driven dependencies (`npm ci`, repo-local
 .NET, `uv sync`), run by the environment's setup script pre-launch (the call that gets the repo's
@@ -34,13 +36,17 @@ and a repo's own steps live beside it in `.claude/cloud-bootstrap.local.sh`.
 
 ## Fleet toolchain inventory (2026-08-13)
 
-The union the shared environment's setup script installs — the one input to
-[Step 1](#step-1--the-shared-environment-claudeai-ui-one-time) that lives nowhere else.
+The pins found across the fleet — the one input to
+[Step 1](#step-1--the-shared-environment-claudeai-ui-one-time) that lives nowhere else. The .NET
+and Node numbers below are what the setup script carries as fleet *fallbacks*; a checked-out repo
+that pins a version in `global.json` or `.node-version` replaces that lane's fallback for the
+cache build rather than adding to it, so a snapshot need not hold all of them at once.
 
 Pinned toolchains found: **.NET SDK 10.0.302** (medley, github-iac — `rollForward: disable`, so
-the exact patch is required) and **10.0.400** (ci-workflows); **Node 24.18.0**
-(medley, github-iac, provisioning, standards, dotfiles; codex-plugins pins major 24) — the cloud
-VM ships Node 20/21/22 only, so this is always an install; **Python 3.14** (medley,
+the exact patch is required) and **10.0.400** (ci-workflows) — the two fleet fallback SDKs;
+**Node 24.20.0**, the fleet fallback the setup script installs when the checked-out repo pins no
+`.node-version` (codex-plugins pins major 24) — the cloud VM ships Node 20/21/22 only, so this
+is always an install; **Python 3.14** (medley,
 claude-code-proxy — the VM has `uv`, see the caveat below); **Go 1.26.6** (ci-runner — the VM's
 Go plus the module `toolchain` mechanism covers this); **PowerShell** (`pwsh` — six repos carry
 `PSScriptAnalyzerSettings.psd1`; ci-workflows also runs Pester) — not pre-installed.
@@ -257,8 +263,9 @@ session on this repo in the new environment and ask Claude to verify:
    script's pinned-tarball step actually failed (`grep gh /var/log/melodic-env-setup.log` for
    its `WARN`), leaving scripts that shell out to `gh` running against a CLI 53 minor versions
    behind the other two lanes.
-   Then `pwsh --version`, `dotnet --list-sdks` (expect 10.0.302 and 10.0.400),
-   `node --version` (expect the `.node-version` pin), `check-tools` for the VM inventory.
+   Then `pwsh --version`, `dotnet --list-sdks` (expect the repo's `global.json` pin, or both
+   fleet fallbacks when the repo declares none — this repo declares none), `node --version`
+   (expect the `.node-version` pin), `check-tools` for the VM inventory.
 2. The repo's bootstrap ran: `node_modules/.bin` populated, pinned lint tools present (`typos`,
    `actionlint`), and re-running the bootstrap is a fast no-op.
 3. `echo $GH_TOKEN` prints `proxy-injected` (GitHub proxy is authenticating).

--- a/docs/CLOUD-FLEET-SETUP.md
+++ b/docs/CLOUD-FLEET-SETUP.md
@@ -19,8 +19,7 @@ or its `.claude/` config; or `melodic-software/standards`
 `components/cloud-environment/setup.sh` changes (that file owns
 `DOTNET_FALLBACK_VERSIONS` and `NODE_FALLBACK_VERSION`, the numbers copied into the
 inventory below); or a verification session (see [checklist](#verification-checklist))
-contradicts a claim here. The .NET and Node fallback numbers were re-read from that
-setup.sh on 2026-09-08 (`origin/main` at `3ea3e96`; the file last touched by `1cafb61`).
+contradicts a claim here.
 
 ## The design in one paragraph
 
@@ -42,7 +41,9 @@ and a repo's own steps live beside it in `.claude/cloud-bootstrap.local.sh`.
 
 The pins found across the fleet — the one input to
 [Step 1](#step-1--the-shared-environment-claudeai-ui-one-time) that lives nowhere else. The .NET
-and Node numbers below are what the setup script carries as fleet *fallbacks*; a checked-out repo
+and Node numbers below are fleet *fallbacks* owned by `DOTNET_FALLBACK_VERSIONS` and
+`NODE_FALLBACK_VERSION` in standards `components/cloud-environment/setup.sh` (values as read
+2026-09-08 — that script, not this list, is the source of truth); a checked-out repo
 that pins a version in `global.json` or `.node-version` replaces that lane's fallback for the
 cache build rather than adding to it, so a snapshot need not hold all of them at once.
 
@@ -267,9 +268,12 @@ session on this repo in the new environment and ask Claude to verify:
    script's pinned-tarball step actually failed (`grep gh /var/log/melodic-env-setup.log` for
    its `WARN`), leaving scripts that shell out to `gh` running against a CLI 53 minor versions
    behind the other two lanes.
-   Then `pwsh --version`, `dotnet --list-sdks` (expect the repo's `global.json` pin, or both
-   fleet fallbacks when the repo declares none — this repo declares none), `node --version`
-   (expect the `.node-version` pin), `check-tools` for the VM inventory.
+   Then `pwsh --version`, `dotnet --list-sdks` (expect the repo's `global.json` pin, or, when it
+   declares none — as this repo does — the SDKs `DOTNET_FALLBACK_VERSIONS` lists), `node
+   --version` (expect the `.node-version` pin, or `NODE_FALLBACK_VERSION` when the repo declares
+   none). Read both variables from standards `components/cloud-environment/setup.sh` at check
+   time rather than expecting the numbers recorded above. Then `check-tools` for the VM
+   inventory.
 2. The repo's bootstrap ran: `node_modules/.bin` populated, pinned lint tools present (`typos`,
    `actionlint`), and re-running the bootstrap is a fast no-op.
 3. `echo $GH_TOKEN` prints `proxy-injected` (GitHub proxy is authenticating).

--- a/docs/CLOUD-SESSIONS.md
+++ b/docs/CLOUD-SESSIONS.md
@@ -400,6 +400,9 @@ catalog on, and the cloud bootstrap installs from the two together (see
   honors that flag, so a raw install leaves them disabled. They still appear as `true` on the
   fleet list, so this repo's cloud bootstrap includes them in its wanted set and treats an
   explicit JSON-`false` disabled install as the expected end state, not a verification failure.
+  A source-changing refresh does enable them: its chain is
+  `plugin uninstall --keep-data`, then `plugin install --scope user -y`, then
+  `plugin enable --scope user`, and that first step drops enabled state.
   Operator opt-in outside that path is `/plugin enable`. That covers the two whose bundled MCP
   servers need `userConfig` credentials this environment has no reason to hold — `miro`
   (`miro_api_token`) and `dometrain` (`dometrain_api_key`), set with `/plugin configure` —


### PR DESCRIPTION
No related issue: residual wording drift after PR #3970 and PR #3972

## Summary

Two merged PRs left their own docs contradicting themselves.

PR #3970 (1023424dc) rewrote the Step 1 paragraph of `docs/CLOUD-FLEET-SETUP.md` to say a repo's
own pin **replaces** the matching fleet fallback. It did not touch three earlier lines that still
described the shared environment as installing the *union* of the fleet's pins and told the reader
to expect both fallback SDKs from `dotnet --list-sdks`. A reader hitting the design paragraph or
the verification checklist got the claim the same document later denies. The inventory also listed
Node **24.18.0**, which is not the version the setup script installs.

PR #3972 (dd367e7e7) rewrote the enablement contract bullet in `docs/CLOUD-SESSIONS.md` so a
catalog-`defaultEnabled: false` plugin's disabled install reads as the expected end state rather
than a verification failure. That rewrite is correct, but it dropped the clause stating that a
source-changing refresh runs `plugin enable` for the plugin — behavior `.claude/cloud-bootstrap.sh`
still has. The bullet then read as if nothing in the automatic path ever enables those plugins, and
the following sentence's "outside that path" lost its antecedent.

## Fix

Source of truth for the toolchain claims is `components/cloud-environment/setup.sh` on
`origin/main` of `melodic-software/standards` (`3ea3e96`; the file was last touched by `1cafb61`,
its PR #555). Source of truth for the refresh claim is this repo's `.claude/cloud-bootstrap.sh` on
`origin/main` (`dd367e7e7`).

`docs/CLOUD-FLEET-SETUP.md`:

- **Design paragraph** — dropped "installs the *union* of static toolchains the repos pin". The two
  lanes resolve independently and by replacement: `dotnet_versions="$DOTNET_FALLBACK_VERSIONS"`
  (setup.sh:172) is overwritten by `dotnet_versions="$repo_sdk"` (setup.sh:179) when the repo's
  `global.json` declares `.sdk.version`, and `node_version="$NODE_FALLBACK_VERSION"`
  (setup.sh:186) by `node_version="$repo_node"` (setup.sh:191) when the repo declares
  `.node-version`. Neither assignment appends. The text now says fleet fallbacks cover whichever of
  the two lanes the repo does not pin — deliberately *not* "when it pins neither", since a repo
  pinning only Node still receives both .NET fallbacks.
- **Inventory lead-in** — "The union the shared environment's setup script installs" replaced with
  the replace-not-add statement, scoped to the .NET and Node numbers, which are the only two lanes
  setup.sh carries a fallback pin for (setup.sh:170-171). Python, Go, `gh` and PowerShell have no
  such fallback/repo-pin split.
- **Inventory entry** — Node **24.18.0** corrected to **24.20.0** and described as the fleet
  fallback, per `NODE_FALLBACK_VERSION='24.20.0'` (setup.sh:171). The per-repo attribution list was
  dropped rather than renumbered: it could only be checked against possibly-stale local clones,
  while the fallback is citable. The .NET entry keeps 10.0.302 and 10.0.400 unchanged — those match
  `DOTNET_FALLBACK_VERSIONS='10.0.302 10.0.400'` (setup.sh:170) — and is now labelled as the two
  fallback SDKs.
- **Verification checklist** — `dotnet --list-sdks` no longer says "expect 10.0.302 and 10.0.400"
  unconditionally. It now expects the repo's `global.json` pin, or both fallbacks when the repo
  declares none, and notes this repo declares none (no `global.json` at the repo root on
  `origin/main`, so setup.sh:173 `[[ -n "$REPO_ROOT" && -f "$REPO_ROOT/global.json" ]]` is false
  here and the fallback list stands).

The Step 1 paragraph #3970 already corrected is untouched.

`docs/CLOUD-SESSIONS.md`: one sentence restored, stating that a source-changing refresh does enable
those plugins and naming the chain — `plugin uninstall --keep-data`, `plugin install --scope user
-y`, `plugin enable --scope user` (`.claude/cloud-bootstrap.sh` lines 321, 322, 323), the enable
being required because "`uninstall` drops enabled state" (comment at line 317). The
default-disabled end-state wording #3972 added is unchanged, and the restored sentence gives
"Operator opt-in outside that path" its antecedent back.

Wording only. No script logic changed, and no file outside these two docs is touched.

## Verification

```
$ npx markdownlint-cli2 --config .markdownlint-cli2.jsonc docs/CLOUD-FLEET-SETUP.md docs/CLOUD-SESSIONS.md
markdownlint-cli2 v0.23.2 (markdownlint v0.41.1)
Linting: 2 files
Summary: 0 issues in 0 files

$ typos docs/CLOUD-FLEET-SETUP.md docs/CLOUD-SESSIONS.md
(no output, exit 0)

$ bash scripts/check-purged-em-dashes.sh
check-purged-em-dashes: 98 declared paths, 130 files scanned, no em dashes.
(exit 0)
```

Neither cloud doc is in `scripts/em-dash-purged-paths.txt`, so the gate does not scan them; the
existing em-dash prose style in both files is preserved.

Claim-by-claim re-read against `origin/main` of standards:

```
$ git show origin/main:components/cloud-environment/setup.sh | grep -n "FALLBACK\|dotnet_versions=\|node_version=\|repo_sdk=\|repo_node="
170:DOTNET_FALLBACK_VERSIONS='10.0.302 10.0.400'
171:NODE_FALLBACK_VERSION='24.20.0'
172:dotnet_versions="$DOTNET_FALLBACK_VERSIONS"
177:    repo_sdk="$(jq -r '.sdk.version // empty' "$REPO_ROOT/global.json" 2>/dev/null)"
179:      dotnet_versions="$repo_sdk"
186:node_version="$NODE_FALLBACK_VERSION"
188:  repo_node="$(tr -d '[:space:]' <"$REPO_ROOT/.node-version")"
189:  repo_node="${repo_node#v}"
191:    node_version="$repo_node"
```

and against this repo's bootstrap:

```
$ git show 'origin/main:./.claude/cloud-bootstrap.sh' | sed -n '317,323p'
      # `uninstall` drops enabled state, so re-enable explicitly or the plugin
      # goes silently absent instead of silently stale. `--keep-data` preserves
      # the plugin's persistent data directory. It does not preserve
      # pluginConfigs -- uninstall still drops stored userConfig.
      "$claude_bin" plugin uninstall "$id" --keep-data >/dev/null 2>&1 || true
      "$claude_bin" plugin install "$id" --scope user -y >/dev/null 2>&1 || true
      "$claude_bin" plugin enable "$id" --scope user >/dev/null 2>&1 || true
```

Also confirmed no `global.json` exists at the repo root on this branch, which is what the
verification-checklist parenthetical asserts.

Provenance note: the doc edits started from a `git cherry-pick` of `31074a5cf` (an abandoned
branch, deleted on origin). It did **not** apply clean. The design, inventory, and
verification-checklist hunks merged; the Step 1 hunk conflicted with #3970's replacement text, and
a hunk against `scripts/check-plugin-catalog-enablement.sh` conflicted with the rewording #3970
already landed there. The conflict was resolved by keeping main's Step 1 text verbatim and
restoring that script from `HEAD` — this PR touches no script. The surviving wording was then
corrected against setup.sh, which is where the "when it pins neither" and "no single snapshot holds
all of them" claims in the picked commit were found wrong and rewritten.

## Related

- #3970 — corrected the Step 1 pin-resolution text this PR reconciles the rest of the document with.
- #3972 — rewrote the enablement contract whose `plugin enable` clause this PR restores.
- #3688 — the plugin-sync cluster this follow-up belongs to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L5ZJnwTRCgc31bmfrdugyU
