### PR TITLE
fix: chomp a trailing CR from settings option values, declare --run a Linux gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,17 @@ scripts/affected-tests.sh --explain       # ... and say why each one was selecte
 scripts/affected-tests.sh path/to/file.sh # explicit paths instead of a diff
 ```
 
+`--run` is a Linux gate. On a Windows Git Bash host a standing set of suites
+fails for reasons that belong to the host rather than to the tree: text-mode
+CRLF translation (a native jq and Git Bash line-ending handling), no
+unprivileged symlink right, MSYS drive-letter paths against the POSIX form in
+fixture assertions, and a missing `scc`. Its exit code there reports host
+capability, not whether your change is good, so Windows is not a supported host
+for the full `--run` gate ([#3966](https://github.com/melodic-software/claude-code-plugins/issues/3966)).
+Selection itself is host-neutral: on Windows, use the listing forms above to see
+what your change affects and run individual suites by hand. CI's Linux lanes are
+the gate that decides.
+
 It maps a changed file to its co-located suite, to any suite that names it, and
 to its dependents transitively, and it fans a shared-lib change out to every
 carrying plugin by reading the `copies=(...)` array out of that lib's

--- a/plugins/autonomy/.claude-plugin/plugin.json
+++ b/plugins/autonomy/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "autonomy",
-  "version": "0.23.4",
+  "version": "0.23.5",
   "description": "Governed autonomous agent operation: role-topology, binding-seam, wiring-vs-advisor, telemetry, return-accounting, trigger-dispatch, per-work-class guardrail-matrix, standing-routine-catalog, and design-only runner-charter contracts for climbing the AI-adoption ladder, plus a guided-setup skill that discovers an adopting org's state, writes its schema-versioned binding, wires standards-pinned OTLP emission with a zero-cost file-artifact default, wires human-attested return capture at the task boundary, wires signal adapters with one governed dispatch entrypoint, binds the five-class guardrail matrix to an org's isolation substrates with an in-boundary live-validation probe before recording each fail-closed binding, and stands up standing-routine-catalog classes as scheduled temporal signal adapters behind the one governed queue with free scheduling defaults wired as reviewable changes and each routine's work-class mapping homed on the security surface.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/autonomy/CHANGELOG.md
+++ b/plugins/autonomy/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to the `autonomy` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.23.5]
+
+### Fixed
+
+- **The multi-key settings reader chomps a trailing CR as well as a trailing
+  newline.** A jq that writes stdout in text mode (the native Windows build)
+  turns every LF inside a string value into CRLF, so a string option whose value
+  carries a newline came back with a CR left embedded on the end. Both the
+  multi-key and the single-key print form read through this one reader, so both
+  are corrected.
+
 ## [0.23.4]
 
 ### Changed

--- a/plugins/autonomy/hooks/lane-stop-gate-lib.sh
+++ b/plugins/autonomy/hooks/lane-stop-gate-lib.sh
@@ -276,7 +276,9 @@ gate_managed_settings_files() {
 # redirections left to right, so an existing-but-unreadable settings file would
 # otherwise print "Permission denied" before stderr is silenced.
 # Trailing newlines are removed from each value as the former `$(jq -r …)`
-# capture removed them, so a value reads the same on either path.
+# capture removed them, so a value reads the same on either path. A trailing CR
+# goes with them: a jq that writes stdout in text mode turns every LF inside a
+# value into CRLF, which would otherwise leave a CR embedded in the value.
 #   gate_settings_options_to <file> <key>...
 # shellcheck disable=SC2034 # result arrays are consumed by the sourcing hook
 gate_settings_options_to() {
@@ -303,7 +305,7 @@ gate_settings_options_to() {
   local rec
   {
     while IFS= read -r -d '' rec; do
-      while [[ "$rec" == *$'\n' ]]; do rec="${rec%$'\n'}"; done
+      while [[ "$rec" == *[$'\r\n'] ]]; do rec="${rec%?}"; done
       recs+=("$rec")
     done < <(jq -j --arg id "$GATE_PLUGIN_ID" --arg n "$GATE_PLUGIN_NAME" --argjson keys "[$keys]" '
       [ (.pluginConfigs // {}) | to_entries[]

--- a/plugins/autonomy/hooks/lane-stop-gate.test.sh
+++ b/plugins/autonomy/hooks/lane-stop-gate.test.sh
@@ -936,6 +936,7 @@ else
   fail "gate_settings_options_to disagrees with the per-key reader (#3515)"
 fi
 
+# --- Case 49b: a CRLF-terminated option value chomps to the bare string -----
 # A value whose trailing whitespace is CRLF chomps to the bare string too. A jq
 # that writes stdout in text mode turns every LF inside a value into CRLF, so a
 # reader that chomps LF alone hands back a value with a CR still on the end.

--- a/plugins/autonomy/hooks/lane-stop-gate.test.sh
+++ b/plugins/autonomy/hooks/lane-stop-gate.test.sh
@@ -936,6 +936,23 @@ else
   fail "gate_settings_options_to disagrees with the per-key reader (#3515)"
 fi
 
+# A value whose trailing whitespace is CRLF chomps to the bare string too. A jq
+# that writes stdout in text mode turns every LF inside a value into CRLF, so a
+# reader that chomps LF alone hands back a value with a CR still on the end.
+if (
+  # shellcheck source=lane-stop-gate-lib.sh
+  source "$STAGED_DIR/lane-stop-gate-lib.sh"
+  gate_resolve_install "$STAGED_DIR/.." || exit 1
+  printf '{"pluginConfigs":{"autonomy@melodic":{"options":{"lane_stop_gate_sentinel":"Y\\r\\n"}}}}\n' >"$OPTS_STUB"
+  gate_settings_options_to "$OPTS_STUB" lane_stop_gate_sentinel || exit 1
+  [[ "${GATE_FILE_OPT_VALUE[0]}" == "Y" ]] || exit 1
+  exit 0
+); then
+  ok "a CRLF-terminated option value chomps to the bare string"
+else
+  fail "gate_settings_options_to left a trailing CR on a CRLF-terminated value"
+fi
+
 # --- Case 50: a sentinel that holds a newline matches only as a whole block --
 # The shell's regex match replaced `grep -qE` over a here-string. grep read a
 # newline inside the configured token as a PATTERN SEPARATOR and authorized a

--- a/scripts/affected-tests.sh
+++ b/scripts/affected-tests.sh
@@ -35,6 +35,16 @@
 # suite it selected but ALSO selected suites in other ecosystems, whose runner
 # it deliberately will not guess (see the --run note at the foot of this file).
 #
+# HOST: --run IS A LINUX GATE. On a Windows Git Bash host a standing set of
+# suites fails for reasons that belong to the host and not to the tree: text-mode
+# CRLF translation (a native jq and Git Bash line-ending handling), no
+# unprivileged symlink right, MSYS drive-letter paths against the POSIX form in
+# fixture assertions, and a missing `scc`. Its exit code there reports host
+# capability, so it cannot say whether a change is good, and the repo does not
+# support it as a local gate on Windows. Selection itself is host-neutral: use
+# the listing forms to see what a change affects and run individual suites by
+# hand. CI's Linux lanes are the gate that decides.
+#
 # DIRECTION: over-selection is safe, under-selection is not. Every rule below is
 # deliberately generous — a basename match counts even when it lands in a
 # comment — because a suite that runs needlessly costs seconds, while a suite


### PR DESCRIPTION
Closes #3966

## Summary

The issue recorded 23 test suites failing under `scripts/affected-tests.sh --run` on a Windows Git
Bash host, all attributed to four host-environment families (CRLF translation, no unprivileged
symlink right, MSYS drive-letter path form, missing `scc`), and parked at `needs-human` on one
policy call: per-family skips, fixture hardening, or declaring Windows unsupported for the local
gate.

The operator's call: **the local full `--run` is a Linux gate.** No per-suite skips and no fixture
hardening. CI's Linux lanes are what decides whether a tree is good. This PR records that decision
where a developer running the gate will meet it, and fixes the one genuine robustness gap the
investigation surfaced along the way.

## Fix

**1. A trailing CR is chomped like a trailing newline** (`plugins/autonomy/hooks/lane-stop-gate-lib.sh`).

`gate_settings_options_to` chomped trailing newlines only:

```bash
while [[ "$rec" == *$'\n' ]]; do rec="${rec%$'\n'}"; done
```

```bash
while [[ "$rec" == *[$'\r\n'] ]]; do rec="${rec%?}"; done
```

A jq that writes stdout in text mode (the WinGet native build measured in the issue) turns every LF
inside a string value into CRLF, so a string option whose value carries a newline came back with a
CR left embedded on the end. This is the single settings reader: `gate_settings_option`,
`gate_managed_options_to`, and `gate_managed_option` all route through it, so one guard corrects
every caller. The bracket-glob plus `${var%?}` idiom is the one `hook-utils.sh` already uses for the
same job.

**2. The gate decision is documented** in the header of `scripts/affected-tests.sh` and in the
README's validate-a-change section: on a Windows Git Bash host `--run`'s exit code reports host
capability rather than the tree, so Windows is not a supported host for the full gate; selection
itself stays host-neutral, and CI's Linux lanes are the gate. No `affected-tests.sh` logic changed.

## Verification

Baseline, unmodified `origin/main` (dd367e7e7) in a scratch worktree on the reporting Windows host:

```
FAIL: gate_settings_options_to disagrees with the per-key reader (#3515)
FAIL: LANE-STOP\r-OK authorized — LAST must preserve CR:
PASS=97 FAIL=2
```

Same host, this branch:

```
ok: one settings pass answers every key with the single-key verdicts
ok: a CRLF-terminated option value chomps to the bare string
FAIL: LANE-STOP\r-OK authorized — LAST must preserve CR:
PASS=99 FAIL=1
```

Case 49 failed on this host before the fix and passes after it, so the change removes a real
host-observed failure rather than only satisfying a new assertion. The remaining failure is case 52,
which exercises the payload path in `lane-stop-gate.sh` (untouched here) and is one of the
pre-existing host-family failures the issue catalogues; it fails identically on unmodified
`origin/main` above.

The new assertion is a regression check in its own right: it fails against the old chomp on Linux
too, since jq emits the configured `"Y\r\n"` value verbatim.

Other checks, all in `D:/worktrees/ccp-3966-windows-gate`:

- `shellcheck -S info` on `lane-stop-gate-lib.sh`, `lane-stop-gate.test.sh`, `affected-tests.sh`: rc 0
- `scripts/check-changelog-parity.sh --check`, `--check-bump origin/main`, `--check-order`: all pass
- `scripts/check-purged-em-dashes.sh`: 98 declared paths, 130 files scanned, no em dashes (root
  `README.md` is on the purged list, so the new paragraph is em-dash free)
- `markdownlint-cli2 README.md plugins/autonomy/CHANGELOG.md`: 0 issues

`autonomy` bumped 0.23.4 -> 0.23.5 with a matching `## [0.23.5]` CHANGELOG entry.

## Related

- Follows #3966 (this closes it) and the four-family triage recorded in its comment 5586518670.
- Adjacent, not addressed here: #3797 (MSYS walk-up defect, same hazard class as the path family)
  and #3964.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L5ZJnwTRCgc31bmfrdugyU
