### PR TITLE
fix(code-tidying): count pygments String.Doc in comment-census

### DIFF
--- a/plugins/code-tidying/.claude-plugin/plugin.json
+++ b/plugins/code-tidying/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "code-tidying",
-  "version": "0.18.1",
+  "version": "0.18.2",
   "description": "Code tidying and comment hygiene: /code-tidying:tidy proactively hunts a rotated, glob-scoped lane for Beck-style tidyings under a research-backed scope budget and ships one tight PR; /code-tidying:batch-simplify sweeps a time window, a branch, or an entire repository through grouped, dependency-ordered simplification waves with a fix-first deferral contract that resolves deferrals in the same run instead of filing issues; /code-tidying:dissolve-comments enforces self-describing expressive code over a diff or target, widening to the branch diff and then the whole repository when the tree is clean \u2014 deletes zero-information comments, dissolves code-expressible ones into names and structure behind a tests gate (safe mode restricts applied edits to removals), and keeps only terse load-bearing comments code cannot express; /code-tidying:audit-comment-residue is a read-only classifier that flags history, plan, conversational, and ticket/PR residue in code comments for author-applied deletion; /code-tidying:audit-dead-code is a read-only whole-repo dead-code hunter running four labelled lanes of unequal confidence (knip for TS/JS, vulture for Python, gopls for Go, and a portable grep lane for shell and other symbol languages), adjudicating every candidate against dynamic-usage evidence into a dead, uncertain, or alive verdict. Project-specific tidy lanes are scaffolded into a tracked .claude/tidy-lanes/ config folder by a re-runnable setup skill.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/code-tidying/CHANGELOG.md
+++ b/plugins/code-tidying/CHANGELOG.md
@@ -3,6 +3,20 @@
 All notable changes to the `code-tidying` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.18.2]
+
+### Fixed
+
+- **`comment-census.py` counts documentation strings.** Pygments lexes Python
+  docstrings as `String.Doc`, not `Comment`, so a file whose prose is mostly
+  docstrings reported hash comments only and a dissolve-comments pass that
+  rewrote every private docstring could still print `comment_lines +0`. The
+  pygments layer now counts `String.Doc` as comment lines and bytes for any
+  lexer that emits it, and still ignores ordinary `String` / `String.Double` /
+  `String.Single` tokens. `dissolve-comments` steps 4 and 7 and
+  `rank-comment-targets.py` read this figure, so a docstring-heavy Python file
+  is no longer under-counted or under-ranked.
+
 ## [0.18.1]
 
 ### Changed

--- a/plugins/code-tidying/CHANGELOG.md
+++ b/plugins/code-tidying/CHANGELOG.md
@@ -15,7 +15,10 @@ All notable changes to the `code-tidying` plugin are documented here. Format fol
   lexer that emits it, and still ignores ordinary `String` / `String.Double` /
   `String.Single` tokens. `dissolve-comments` steps 4 and 7 and
   `rank-comment-targets.py` read this figure, so a docstring-heavy Python file
-  is no longer under-counted or under-ranked.
+  is no longer under-counted or under-ranked. The ranker's drift extraction
+  (`comment_line_numbers`) uses the same `is_comment_token` predicate, so a
+  mixed file does not treat docstrings as code when computing
+  `comment_age_vs_code_days`.
 
 ## [0.18.1]
 

--- a/plugins/code-tidying/scripts/comment-census.py
+++ b/plugins/code-tidying/scripts/comment-census.py
@@ -176,11 +176,25 @@ def scc_available() -> bool:
     return shutil.which("scc") is not None
 
 
+def is_comment_token(tok) -> bool:
+    """True for pygments tokens the census counts as comment burden.
+
+    Comment subtypes except Hashbang and Preproc, plus String.Doc (documentation
+    strings, including Python docstrings). Ordinary String / String.Double /
+    String.Single tokens are data. rank-comment-targets.comment_line_numbers
+    uses this same predicate so drift extraction cannot drift from the census.
+    """
+    from pygments.token import Comment, String
+
+    if tok in Comment and tok not in (Comment.Hashbang, Comment.Preproc):
+        return True
+    return tok in String.Doc
+
+
 def pygments_counts(path: Path) -> dict | None:
     try:
         from pygments import lex
         from pygments.lexers import get_lexer_for_filename
-        from pygments.token import Comment, String
         from pygments.util import ClassNotFound
     except ImportError:
         return None
@@ -199,11 +213,7 @@ def pygments_counts(path: Path) -> dict | None:
     comment_lines: set[int] = set()
     comment_bytes = 0
     for tok, text in lex(src, lexer):
-        # Comment subtypes stay comments. String.Doc is documentation (Python
-        # docstrings, and any other lexer that emits it). Ordinary String,
-        # String.Double, and String.Single tokens are data, not comments.
-        is_comment = tok in Comment and tok not in (Comment.Hashbang, Comment.Preproc)
-        if is_comment or tok in String.Doc:
+        if is_comment_token(tok):
             body = text.strip("\n")
             if body.strip():
                 comment_bytes += len(body.encode("utf-8"))

--- a/plugins/code-tidying/scripts/comment-census.py
+++ b/plugins/code-tidying/scripts/comment-census.py
@@ -12,7 +12,9 @@ was made:
             pass over 300+ languages. No byte counts.
   pygments  per-file comment BYTES and lines from the token stream, so the
             token estimate is real text, not a line-count multiplied by a
-            guess. Correct on heredocs, trailing comments and block comments.
+            guess. Correct on heredocs, trailing comments, block comments, and
+            documentation strings (`String.Doc`, including Python docstrings).
+            Ordinary string literals are not comments.
 
 Both present: lines and complexity from scc, bytes from pygments. Neither
 present: exit 3 naming what to install. A line-prefix grep is never used,
@@ -178,7 +180,7 @@ def pygments_counts(path: Path) -> dict | None:
     try:
         from pygments import lex
         from pygments.lexers import get_lexer_for_filename
-        from pygments.token import Comment
+        from pygments.token import Comment, String
         from pygments.util import ClassNotFound
     except ImportError:
         return None
@@ -197,7 +199,11 @@ def pygments_counts(path: Path) -> dict | None:
     comment_lines: set[int] = set()
     comment_bytes = 0
     for tok, text in lex(src, lexer):
-        if tok in Comment and tok not in (Comment.Hashbang, Comment.Preproc):
+        # Comment subtypes stay comments. String.Doc is documentation (Python
+        # docstrings, and any other lexer that emits it). Ordinary String,
+        # String.Double, and String.Single tokens are data, not comments.
+        is_comment = tok in Comment and tok not in (Comment.Hashbang, Comment.Preproc)
+        if is_comment or tok in String.Doc:
             body = text.strip("\n")
             if body.strip():
                 comment_bytes += len(body.encode("utf-8"))

--- a/plugins/code-tidying/scripts/comment-census.py
+++ b/plugins/code-tidying/scripts/comment-census.py
@@ -273,7 +273,9 @@ def census(files: list[Path], layer: str) -> tuple[list[dict], dict]:
     # and `scc_counts` returns None on an empty file list even when the binary is
     # present, so using either as the proxy reports an installed analyser as
     # missing and turns an empty scope into a false hard stop.
-    have_layer = (use_scc and scc_available()) or (use_pygments and pygments_available())
+    have_layer = (use_scc and scc_available()) or (
+        use_pygments and pygments_available()
+    )
     if sources["lines"] is None and not have_layer:
         return [], {
             "error": "neither scc nor pygments is available (install scc, or pip install pygments)"

--- a/plugins/code-tidying/scripts/rank-comment-targets.py
+++ b/plugins/code-tidying/scripts/rank-comment-targets.py
@@ -235,13 +235,34 @@ def fan_in(paths: list[str]) -> dict[str, int]:
     return out
 
 
+def _census_is_comment_token():
+    """Load comment-census.is_comment_token once so drift lines match the census."""
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location("_comment_census", CENSUS)
+    if spec is None or spec.loader is None:
+        raise ImportError("comment-census.py")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod.is_comment_token
+
+
+_IS_COMMENT_TOKEN = None
+
+
 def comment_line_numbers(path: str) -> set[int]:
+    global _IS_COMMENT_TOKEN
     try:
         from pygments import lex
         from pygments.lexers import get_lexer_for_filename
-        from pygments.token import Comment
     except ImportError:
         return set()
+    if _IS_COMMENT_TOKEN is None:
+        try:
+            _IS_COMMENT_TOKEN = _census_is_comment_token()
+        except Exception:  # noqa: BLE001 - census import failed; no comment lines to report
+            return set()
+    is_comment = _IS_COMMENT_TOKEN
     try:
         lexer = get_lexer_for_filename(path, stripnl=False)
     except Exception:  # noqa: BLE001 - unknown extension means no comment lines to report
@@ -249,7 +270,7 @@ def comment_line_numbers(path: str) -> set[int]:
     src = Path(path).read_text(encoding="utf-8", errors="replace")
     line, out = 1, set()
     for tok, text in lex(src, lexer):
-        if tok in Comment and tok is not Comment.Hashbang and text.strip():
+        if is_comment(tok) and text.strip():
             out.update(range(line, line + text.count("\n") + 1))
         line += text.count("\n")
     return out

--- a/plugins/code-tidying/scripts/test_comment_census.py
+++ b/plugins/code-tidying/scripts/test_comment_census.py
@@ -37,9 +37,22 @@ x=1  # trailing comment
 y="${v#prefix}"
 """
 
-MOD_PY = '''"""Docstring is a string, not a comment."""
-# a comment
+MOD_PY = """# a comment
 x = 1
+"""
+
+# Hash-comment-free: every prose line is a Python docstring (String.Doc). On a
+# census that only counts pygments Comment tokens this file reports 0.
+DOCSTRING_ONLY_PY = '''"""Module docstring the census must count."""
+
+def _watchdog_fire():
+    """Private function docstring spanning
+    a second line of prose.
+    """
+    x = "ordinary double is not a comment"
+    y = 'ordinary single is not a comment'
+    z = """assigned triple quote is not a comment"""
+    return 1
 '''
 
 
@@ -93,10 +106,20 @@ class PygmentsLayer(unittest.TestCase):
         self.assertEqual(sh["comment_lines"], 2, sh)
         self.assertGreater(sh["comment_bytes"], 0)
 
-    def test_docstring_is_not_a_comment(self):
+    def test_hash_comment_in_python_is_still_counted(self):
         rep = self.report()
         py = next(r for r in rep["files"] if r["path"].endswith("m.py"))
         self.assertEqual(py["comment_lines"], 1, py)
+
+    def test_python_docstring_only_file_is_counted(self):
+        (self.tmp / "docs_only.py").write_text(DOCSTRING_ONLY_PY)
+        py = next(
+            r for r in self.report()["files"] if r["path"].endswith("docs_only.py")
+        )
+        # Module docstring (1) plus the three-line function docstring. Ordinary
+        # String / String.Double / String.Single on later lines are not comments.
+        self.assertEqual(py["comment_lines"], 4, py)
+        self.assertGreater(py["comment_bytes"], 0)
 
     def test_markdown_is_never_counted(self):
         rep = self.report()

--- a/plugins/code-tidying/scripts/test_rank_comment_targets.py
+++ b/plugins/code-tidying/scripts/test_rank_comment_targets.py
@@ -304,5 +304,28 @@ class RankNormalisation(unittest.TestCase):
         )
 
 
+class CommentLineNumbers(unittest.TestCase):
+    """Drift extraction must use the census comment predicate, including String.Doc."""
+
+    @unittest.skipUnless(pygments_present(), "pygments not installed")
+    def test_docstring_lines_count_ordinary_strings_do_not(self):
+        import importlib.util
+
+        spec = importlib.util.spec_from_file_location("rank_targets", SCRIPT)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        tmp = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, tmp, ignore_errors=True)
+        src = tmp / "mixed.py"
+        src.write_text(
+            'x = "not a comment"\n"""doc line"""\ndef f():\n    pass\n',
+            encoding="utf-8",
+        )
+        lines = mod.comment_line_numbers(str(src))
+        self.assertIn(2, lines)
+        self.assertNotIn(1, lines)
+        self.assertNotIn(3, lines)
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #3960

## Summary

`comment-census.py` only counted pygments `Comment` tokens. Python docstrings lex as `String.Doc`, so dissolve-comments used an under-count for the step 4 before-figure and the step 7 delta. A Python file that is almost all docstrings could rewrite every private docstring and still print `comment_lines +0`.

## Fix

The pygments layer now treats `String.Doc` as comment lines and bytes via a shared `is_comment_token` predicate. `Comment` subtypes stay comments. Ordinary `String` / `String.Double` / `String.Single` tokens are not counted. `rank-comment-targets.py` drift extraction (`comment_line_numbers`) uses the same predicate, so a mixed file does not treat docstrings as code in `comment_age_vs_code_days`. Plugin patch 0.18.1 to 0.18.2.

Authoritative token: Pygments builtin tokens document `String.Doc` as the token type for documentation strings (for example Python). https://pygments.org/docs/tokens/

## Verification

- `test_python_docstring_only_file_is_counted` fails on main (`comment_lines=0`) and passes here
- `test_docstring_lines_count_ordinary_strings_do_not` pins ranker drift extraction
- `python3 -m pytest plugins/code-tidying/scripts/test_comment_census.py plugins/code-tidying/scripts/test_rank_comment_targets.py` — 28 passed, 2 skipped
- `scripts/run-ruff.sh check` / `format` on the touched Python files — pass

## Related

N/A

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-749fc28c-7c3c-4e85-b625-65942d2abc6e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-749fc28c-7c3c-4e85-b625-65942d2abc6e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

