### PR TITLE
fix(planning): unfenced interview register example so a copied template is gradeable

### DIFF
--- a/plugins/planning/.claude-plugin/plugin.json
+++ b/plugins/planning/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "planning",
-  "version": "0.39.4",
+  "version": "0.39.5",
   "userConfig": {
     "use_ask_user_question": {
       "type": "boolean",

--- a/plugins/planning/CHANGELOG.md
+++ b/plugins/planning/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to the `planning` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.39.5]
+
+### Fixed
+
+- **`interview`:** the checklist template's open-question register now carries unfenced
+  example rows, and `check-open-questions.sh` names the fenced-block skip when it finds
+  none. The template showed the row shape only inside a fenced code block, which the gate
+  ignores by design (documentation, not data), so copying that visible shape produced an
+  empty ungradeable ledger (exit 2) with no discoverable remedy. The fenced block stays as
+  the schema illustration. `context/loop.md`'s fenced example is left as prose
+  documentation, not a copy-me template.
+
 ## [0.39.4]
 
 ### Fixed

--- a/plugins/planning/CHANGELOG.md
+++ b/plugins/planning/CHANGELOG.md
@@ -8,12 +8,13 @@ All notable changes to the `planning` plugin are documented here. Format follows
 ### Fixed
 
 - **`interview`:** the checklist template's open-question register now carries unfenced
-  example rows, and `check-open-questions.sh` names the fenced-block skip when it finds
-  none. The template showed the row shape only inside a fenced code block, which the gate
-  ignores by design (documentation, not data), so copying that visible shape produced an
-  empty ungradeable ledger (exit 2) with no discoverable remedy. The fenced block stays as
-  the schema illustration. `context/loop.md`'s fenced example is left as prose
-  documentation, not a copy-me template.
+  example rows, and `check-open-questions.sh` names the fenced-block skip when it skipped
+  a row-shaped line inside a fence. The template showed the row shape only inside a fenced
+  code block, which the gate ignores by design (documentation, not data), so copying that
+  visible shape produced an empty ungradeable ledger (exit 2) with no discoverable remedy.
+  A genuinely empty register (no fence) still gets the generic zero-rows message. The
+  fenced block stays as the schema illustration. `context/loop.md`'s fenced example is
+  left as prose documentation, not a copy-me template.
 
 ## [0.39.4]
 

--- a/plugins/planning/scripts/check-open-questions.sh
+++ b/plugins/planning/scripts/check-open-questions.sh
@@ -222,8 +222,9 @@ while IFS= read -r line; do
 done <<<"$section"
 
 if [[ "$registered" -eq 0 ]]; then
-  die_ungradeable "the register section holds no question rows in: $ledger"
+  die_ungradeable "the register section holds no question rows in: $ledger (rows inside a fenced block are ignored by design; register rows must be unfenced)"
 fi
+
 
 brief_state="unchecked"
 if [[ "$brief_named" -eq 1 ]]; then

--- a/plugins/planning/scripts/check-open-questions.sh
+++ b/plugins/planning/scripts/check-open-questions.sh
@@ -135,6 +135,7 @@ deferred_ids=""
 expected=1
 
 in_fence=0
+skipped_fenced_row=0
 while IFS= read -r line; do
   # A fenced block inside the register section is documentation (the row shape,
   # a worked example), not data. Grading it would fail a ledger for quoting its
@@ -143,7 +144,12 @@ while IFS= read -r line; do
     in_fence=$((1 - in_fence))
     continue
   fi
-  [[ "$in_fence" -eq 0 ]] || continue
+  if [[ "$in_fence" -ne 0 ]]; then
+    if [[ "$line" =~ ^[[:space:]]*-[[:space:]]+[Qq][0-9]+([^0-9]|$) ]]; then
+      skipped_fenced_row=1
+    fi
+    continue
+  fi
 
   # Any non-fenced `- Q<N>` line is a CANDIDATE row; its shape is validated
   # below. The prefilter deliberately does not require the first pipe: a row
@@ -222,7 +228,10 @@ while IFS= read -r line; do
 done <<<"$section"
 
 if [[ "$registered" -eq 0 ]]; then
-  die_ungradeable "the register section holds no question rows in: $ledger (rows inside a fenced block are ignored by design; register rows must be unfenced)"
+  if [[ "$skipped_fenced_row" -eq 1 ]]; then
+    die_ungradeable "the register section holds no question rows in: $ledger (rows inside a fenced block are ignored by design; register rows must be unfenced)"
+  fi
+  die_ungradeable "the register section holds no question rows in: $ledger"
 fi
 
 

--- a/plugins/planning/scripts/check-open-questions.test.sh
+++ b/plugins/planning/scripts/check-open-questions.test.sh
@@ -115,6 +115,12 @@ _No questions asked yet._
 EOF
 )"
 expect_exit "empty register -> 2" 2 --ledger "$empty"
+empty_err="$(bash "$SUT" --ledger "$empty" 2>&1 >/dev/null || true)"
+if [[ "$empty_err" == *"rows inside a fenced block are ignored by design"* ]]; then
+  fail "empty register without a fence keeps the generic zero-rows message (stderr: '$empty_err')"
+else
+  pass "empty register without a fence keeps the generic zero-rows message"
+fi
 
 # 10b. Rows only inside a fence are documentation, so the register is empty
 #      and the error names that cause.

--- a/plugins/planning/scripts/check-open-questions.test.sh
+++ b/plugins/planning/scripts/check-open-questions.test.sh
@@ -116,6 +116,35 @@ EOF
 )"
 expect_exit "empty register -> 2" 2 --ledger "$empty"
 
+# 10b. Rows only inside a fence are documentation, so the register is empty
+#      and the error names that cause.
+fence_only="$(
+  mkledger <<'EOF'
+```text
+- Q1 | answered | round 1 | Who writes? | admin
+```
+EOF
+)"
+expect_exit "fence-only register -> 2" 2 --ledger "$fence_only"
+fence_only_err="$(bash "$SUT" --ledger "$fence_only" 2>&1 >/dev/null || true)"
+if [[ "$fence_only_err" == *"rows inside a fenced block are ignored by design"* && "$fence_only_err" == *"register rows must be unfenced"* ]]; then
+  pass "zero-rows error names fenced-block cause"
+else
+  fail "zero-rows error names fenced-block cause (stderr: '$fence_only_err')"
+fi
+
+# 10c. Copying the checklist template's register section is gradeable: the
+#      template carries unfenced example rows, so the gate sees data (exit 0
+#      or 1), never an empty-register exit 2.
+template="$SCRIPT_DIR/../skills/interview/templates/checklist.md"
+bash "$SUT" --ledger "$template" >/dev/null 2>&1
+template_rc=$?
+if [[ "$template_rc" -eq 0 || "$template_rc" -eq 1 ]]; then
+  pass "copied checklist template is gradeable (exit $template_rc)"
+else
+  fail "copied checklist template is gradeable (want exit 0 or 1, got $template_rc)"
+fi
+
 # 11. Unknown status -> ungradeable. A typo'd status must not be counted as
 #     resolved by falling through.
 badstatus="$(

--- a/plugins/planning/skills/interview/templates/checklist.md
+++ b/plugins/planning/skills/interview/templates/checklist.md
@@ -15,6 +15,12 @@ Copy into `<memory_dir>/<topic-slug>/interview-checklist.md` (default `.work/`; 
 
 **Write a row the moment a round is ASKED — before any reply arrives.** The register is a byproduct of asking, not of resolving: a question that only lands on disk once it is answered cannot record the failure of never being answered. Statuses: `open` | `answered` | `deferred` | `withdrawn` | `blocked`. `Q<N>` matches the terminal numbering and runs continuously across rounds with no gaps.
 
+Register rows are unfenced `- Q<N>` list items. A fenced block in this section is the schema illustration, not data: the gate ignores fenced rows by design. Replace the example rows with this run's questions; keep every live row unfenced.
+
+- Q1 | answered | round 1 | Who can write comments? | enrolled + instructor + admin
+- Q2 | open | round 1 | What content format? |
+- Q3 | deferred | round 2 | Moderation model? | post-V1 — also in the Brief's Deferred questions
+
 ```text
 - Q1 | answered | round 1 | Who can write comments? | enrolled + instructor + admin
 - Q2 | open | round 1 | What content format? |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #3943

## Summary

Copying the interview checklist template's register produced an ungradeable ledger (exit 2, `registered=0`) because the only visible row shape lived inside a fenced block, which `check-open-questions.sh` ignores by design.

## Fix

- `templates/checklist.md` now carries unfenced example rows in `## Open-question register`. The fenced block remains the schema illustration.
- The zero-rows error names the fenced-block skip only when a row-shaped line was actually discarded inside a fence. A genuinely empty register keeps the generic message.
- Ignore-fenced-blocks grading is unchanged.
- `context/loop.md` was left as prose documentation, not a copy-me template.

## Verification

- Grading the template as a ledger: exit 1, `registered=3 status=open` (gradeable).
- Fence-only register: exit 2, error names the fenced-block skip.
- Empty register with no fence: exit 2, generic zero-rows message (no fenced-block hint).
- `plugins/planning/scripts/check-open-questions.test.sh` passed.
- `plugins/planning/tests/interview-defenses.test.sh` passed with no digest updates on the first commit.

## Related

Planning 0.39.5.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-749fc28c-7c3c-4e85-b625-65942d2abc6e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-749fc28c-7c3c-4e85-b625-65942d2abc6e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

