### PR TITLE
fix(code-metrics): derive tool-free PATH from the collector ladder

### DIFF
--- a/plugins/code-metrics/.claude-plugin/plugin.json
+++ b/plugins/code-metrics/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "code-metrics",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Read-only code measures for a change, with cited references and no verdict: lines per file (audit-size), cyclomatic, cognitive, and Halstead complexity (audit-complexity), duplication with sanctioned-replication exclusions (audit-duplication), coverage per function with CRAP from existing lcov, Cobertura, coverage.py, or Go artifacts (audit-coverage), type debt for TypeScript and Python (audit-type-debt), the literacy router for what each number can and cannot say (principles), and a setup skill for the consumer's .claude/code-metrics.yaml. Runs external collectors only when they already resolve, never installs, never runs tests, never emits a finding.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/code-metrics/CHANGELOG.md
+++ b/plugins/code-metrics/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to the `code-metrics` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.1.9]
+
+### Fixed
+
+- **The tool-free PATH in the audit suites is derived from the collector ladder.** Each suite
+  that builds an environment with collectors removed used to keep a second, hardcoded list of
+  tool names off PATH. A collector added to `scripts/collector-ladder.tsv` stayed reachable
+  and the no-collector case stopped being tool-free. The excluded set is now the ladder's tool
+  column (skipping the reserved `none`, `n/a`, and `deferred` rungs) plus the PATH binaries those
+  adapters look up, and after that environment is built the suite asserts that none of those
+  collectors still resolves.
+
 ## [0.1.8]
 
 ### Added

--- a/plugins/code-metrics/CHANGELOG.md
+++ b/plugins/code-metrics/CHANGELOG.md
@@ -13,7 +13,8 @@ All notable changes to the `code-metrics` plugin are documented here. Format fol
   and the no-collector case stopped being tool-free. The excluded set is now the ladder's tool
   column (skipping the reserved `none`, `n/a`, and `deferred` rungs) plus the PATH binaries those
   adapters look up, and after that environment is built the suite asserts that none of those
-  collectors still resolves.
+  collectors still resolves. Python interpreters on that PATH are resolved to a non-mutating
+  executable so a pyenv (or similar) shim cannot prepend skipped collectors back onto PATH.
 
 ## [0.1.8]
 

--- a/plugins/code-metrics/scripts/dispatch.test.sh
+++ b/plugins/code-metrics/scripts/dispatch.test.sh
@@ -51,19 +51,19 @@ cat "$CAPTURE"
 EOF
 chmod +x "$STUBS/scc"
 # EMPTY_PATH is the caller's PATH with every collector removed: a directory of
-# symlinks to each executable on PATH except the tools the ladder names, so
-# the coreutils, git, and the interpreter stay reachable while `scc` does not.
-COLLECTOR_NAMES=" scc lizard radon multimetric jscpd gocyclo gocognit dupl shellmetrics type-coverage mypy pmd eslint "
-IFS=':' read -r -a path_dirs <<<"$PATH"
-for dir in "${path_dirs[@]}"; do
-  [[ -d "$dir" ]] || continue
-  for exe in "$dir"/*; do
-    [[ -f "$exe" && -x "$exe" ]] || continue
-    name="${exe##*/}"
-    [[ "$COLLECTOR_NAMES" == *" $name "* ]] && continue
-    [[ -e "$EMPTY_PATH/$name" ]] || ln -s "$exe" "$EMPTY_PATH/$name"
-  done
-done
+# symlinks to each executable on PATH except the tools the ladder names (and
+# the binaries those adapters look up), so the coreutils, git, and the
+# interpreter stay reachable while `scc` does not.
+# shellcheck source=tool-free-path.sh
+source "$SCRIPT_DIR/tool-free-path.sh"
+cm_fill_tool_free_path "$EMPTY_PATH"
+leftover="$(cm_resolvable_ladder_collectors "$EMPTY_PATH" | sort -u | tr '\n' ' ')"
+leftover="${leftover% }"
+if [[ -z "$leftover" ]]; then
+  pass "no ladder collector is resolvable on the tool-free PATH"
+else
+  fail "no ladder collector is resolvable on the tool-free PATH" "none" "$leftover"
+fi
 unset CODE_METRICS_DISABLE_BUNDLED
 
 # 1. scc absent: the bundled counter is used and the run row names it.

--- a/plugins/code-metrics/scripts/tool-free-path.sh
+++ b/plugins/code-metrics/scripts/tool-free-path.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# Sourced by code-metrics shell suites: build a PATH directory that keeps
+# every collector the ladder names unreachable, so a machine with those
+# tools installed still exercises the no-collector path.
+#
+# The excluded names come from scripts/collector-ladder.tsv (column 3,
+# skipping the reserved rungs `none`, `n/a`, and `deferred`) plus the PATH
+# binaries those collectors' adapters look up with shutil.which, so a new
+# ladder rung stays off the tool-free PATH with no suite edit. A bundled
+# adapter that never looks up a binary (line-counter) is not a PATH tool
+# and is not treated as a leak.
+#
+#   source "$PLUGIN_ROOT/scripts/tool-free-path.sh"
+#   cm_fill_tool_free_path "$EMPTY_PATH"
+#   leftover="$(cm_resolvable_ladder_collectors "$EMPTY_PATH")"
+#
+# shellcheck shell=bash
+
+_CM_SCRIPTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+_CM_LADDER="${_CM_SCRIPTS_DIR}/collector-ladder.tsv"
+_CM_COLLECTORS="${_CM_SCRIPTS_DIR}/collectors"
+
+# Unique non-reserved tool names from the ladder, same column and skip rules
+# dispatch.sh uses when it walks a lane/measure.
+cm_ladder_tools() {
+  awk -F'\t' '
+    !/^#/ && NF >= 3 && $3 != "none" && $3 != "n/a" && $3 != "deferred" && !seen[$3]++ {
+      print $3
+    }
+  ' "$_CM_LADDER"
+}
+
+# PATH basenames to keep off the tool-free directory: each ladder tool plus
+# every shutil.which argument in that tool's adapter (a string literal, or a
+# module-level NAME/TOOL constant).
+cm_ladder_path_bins() {
+  local py=python3
+  command -v python3 >/dev/null 2>&1 || py=python
+  "$py" - "$_CM_LADDER" "$_CM_COLLECTORS" <<'PY'
+import ast
+import os
+import sys
+
+RESERVED = {"none", "n/a", "deferred"}
+ladder, collectors_dir = sys.argv[1], sys.argv[2]
+tools = []
+seen = set()
+with open(ladder, encoding="utf-8") as handle:
+    for raw in handle:
+        if raw.startswith("#") or not raw.strip():
+            continue
+        parts = raw.rstrip("\n").split("\t")
+        if len(parts) < 3:
+            continue
+        tool = parts[2]
+        if tool in RESERVED or tool in seen:
+            continue
+        seen.add(tool)
+        tools.append(tool)
+
+bins = set(tools)
+for tool in tools:
+    adapter = os.path.join(collectors_dir, f"{tool}.py")
+    if not os.path.isfile(adapter):
+        continue
+    with open(adapter, encoding="utf-8") as handle:
+        tree = ast.parse(handle.read(), filename=adapter)
+    constants = {}
+    for node in tree.body:
+        if isinstance(node, ast.Assign) and len(node.targets) == 1:
+            target = node.targets[0]
+            if (
+                isinstance(target, ast.Name)
+                and isinstance(node.value, ast.Constant)
+                and isinstance(node.value.value, str)
+            ):
+                constants[target.id] = node.value.value
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if not (isinstance(func, ast.Attribute) and func.attr == "which"):
+            continue
+        if not node.args:
+            continue
+        arg = node.args[0]
+        if isinstance(arg, ast.Constant) and isinstance(arg.value, str):
+            bins.add(arg.value)
+        elif isinstance(arg, ast.Name) and arg.id in constants:
+            bins.add(constants[arg.id])
+for name in sorted(bins):
+    print(name)
+PY
+}
+
+# Fill dest with symlinks to every PATH executable except the ladder's
+# collectors, so git, the coreutils, and the interpreter stay reachable.
+cm_fill_tool_free_path() {
+  local dest="$1"
+  local name dir exe
+  mkdir -p "$dest"
+  declare -A skip=()
+  while IFS= read -r name; do
+    [[ -n "$name" ]] || continue
+    skip["$name"]=1
+  done < <(cm_ladder_path_bins)
+  local IFS=':'
+  local -a path_dirs
+  read -r -a path_dirs <<<"$PATH"
+  for dir in "${path_dirs[@]}"; do
+    [[ -d "$dir" ]] || continue
+    for exe in "$dir"/*; do
+      [[ -f "$exe" && -x "$exe" ]] || continue
+      name="${exe##*/}"
+      [[ -n "${skip[$name]:-}" ]] && continue
+      [[ -e "$dest/$name" ]] || ln -s "$exe" "$dest/$name"
+    done
+  done
+}
+
+# Print ladder collectors that still resolve on dest: a PATH lookup of the
+# derived bins, or an adapter probe that succeeds. A bundled adapter with no
+# shutil.which is skipped. Non-empty output means the environment is not
+# tool-free.
+cm_resolvable_ladder_collectors() {
+  local dest="$1"
+  local py=python3
+  command -v python3 >/dev/null 2>&1 || py=python
+  local name tool adapter
+  while IFS= read -r name; do
+    [[ -n "$name" ]] || continue
+    PATH="$dest" command -v "$name" >/dev/null 2>&1 && printf '%s\n' "$name"
+  done < <(cm_ladder_path_bins)
+  while IFS= read -r tool; do
+    [[ -n "$tool" ]] || continue
+    adapter="$_CM_COLLECTORS/$tool.py"
+    [[ -f "$adapter" ]] || continue
+    grep -q 'shutil.which' "$adapter" || continue
+    if PATH="$dest" "$py" "$adapter" probe >/dev/null 2>&1; then
+      printf '%s\n' "$tool"
+    fi
+  done < <(cm_ladder_tools)
+}

--- a/plugins/code-metrics/scripts/tool-free-path.sh
+++ b/plugins/code-metrics/scripts/tool-free-path.sh
@@ -101,8 +101,8 @@ PY
 _cm_is_python_interp() {
   case "$1" in
     python|python[0-9]|python[0-9].*|python3|python3.*|pypy|pypy3|pypy3.*) return 0 ;;
+    *) return 1 ;;
   esac
-  return 1
 }
 
 _cm_nonmutating_python() {

--- a/plugins/code-metrics/scripts/tool-free-path.sh
+++ b/plugins/code-metrics/scripts/tool-free-path.sh
@@ -95,9 +95,26 @@ PY
 
 # Fill dest with symlinks to every PATH executable except the ladder's
 # collectors, so git, the coreutils, and the interpreter stay reachable.
+# Python interpreters are resolved to a non-mutating executable: a pyenv
+# (or similar) shim that prepends its version bin would put skipped
+# collectors back on PATH when the adapter probe runs.
+_cm_is_python_interp() {
+  case "$1" in
+    python|python[0-9]|python[0-9].*|python3|python3.*|pypy|pypy3|pypy3.*) return 0 ;;
+  esac
+  return 1
+}
+
+_cm_nonmutating_python() {
+  local exe="$1" resolved
+  resolved="$("$exe" -c 'import os, sys; print(os.path.realpath(sys.executable))' 2>/dev/null)" || return 1
+  [[ -n "$resolved" && -f "$resolved" && -x "$resolved" ]] || return 1
+  printf '%s\n' "$resolved"
+}
+
 cm_fill_tool_free_path() {
   local dest="$1"
-  local name dir exe
+  local name dir exe target resolved
   mkdir -p "$dest"
   declare -A skip=()
   while IFS= read -r name; do
@@ -113,7 +130,12 @@ cm_fill_tool_free_path() {
       [[ -f "$exe" && -x "$exe" ]] || continue
       name="${exe##*/}"
       [[ -n "${skip[$name]:-}" ]] && continue
-      [[ -e "$dest/$name" ]] || ln -s "$exe" "$dest/$name"
+      [[ -e "$dest/$name" ]] && continue
+      target="$exe"
+      if _cm_is_python_interp "$name"; then
+        resolved="$(_cm_nonmutating_python "$exe")" && target="$resolved"
+      fi
+      ln -s "$target" "$dest/$name"
     done
   done
 }

--- a/plugins/code-metrics/scripts/tool-free-path.test.sh
+++ b/plugins/code-metrics/scripts/tool-free-path.test.sh
@@ -89,5 +89,34 @@ case " $leaked " in
   ;;
 esac
 
+# 5. A python shim that prepends a directory containing mypy must not make
+#    mypy-report resolvable. pyenv shims do this; the filled PATH must point
+#    at a non-mutating interpreter instead.
+REAL_PY="$(command -v python3 || command -v python)"
+REAL_PY="$("$REAL_PY" -c 'import os, sys; print(os.path.realpath(sys.executable))')"
+mkdir -p "$WORK/shimdir" "$WORK/version-bin"
+cat >"$WORK/version-bin/mypy" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+chmod +x "$WORK/version-bin/mypy"
+cat >"$WORK/shimdir/python3" <<EOF
+#!/usr/bin/env bash
+export PATH="$WORK/version-bin:\$PATH"
+exec "$REAL_PY" "\$@"
+EOF
+chmod +x "$WORK/shimdir/python3"
+EMPTY_SHIM="$WORK/empty-shim"
+PATH="$WORK/shimdir:$PATH" cm_fill_tool_free_path "$EMPTY_SHIM"
+shim_target="$(readlink "$EMPTY_SHIM/python3" 2>/dev/null || true)"
+if [[ "$shim_target" == "$REAL_PY" ]]; then
+  pass "python3 on the tool-free PATH is the non-mutating interpreter"
+else
+  fail "python3 on the tool-free PATH is the non-mutating interpreter" "$REAL_PY" "$shim_target"
+fi
+leftover_shim="$(cm_resolvable_ladder_collectors "$EMPTY_SHIM" | sort -u | tr '\n' ' ')"
+leftover_shim="${leftover_shim% }"
+assert_eq "a PATH-mutating python3 shim does not restore mypy-report" "" "$leftover_shim"
+
 printf '%d cases, %d failed\n' "$CASE_NUM" "$FAILED"
 exit $((FAILED > 0 ? 1 : 0))

--- a/plugins/code-metrics/scripts/tool-free-path.test.sh
+++ b/plugins/code-metrics/scripts/tool-free-path.test.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Regression tests for tool-free-path.sh: the excluded set is derived from
+# the collector ladder, the filled directory keeps those collectors off PATH,
+# and the resolvable-collector check fails when one is put back.
+set -uo pipefail
+unset GIT_DIR GIT_WORK_TREE GIT_CONFIG
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=tool-free-path.sh
+source "$SCRIPT_DIR/tool-free-path.sh"
+
+FAILED=0
+CASE_NUM=0
+pass() {
+  CASE_NUM=$((CASE_NUM + 1))
+  printf 'PASS: %s\n' "$1"
+}
+fail() {
+  CASE_NUM=$((CASE_NUM + 1))
+  FAILED=$((FAILED + 1))
+  printf 'FAIL: %s\n  expected: %s\n  actual:   %s\n' "$1" "$2" "$3" >&2
+}
+assert_eq() {
+  if [[ "$2" == "$3" ]]; then pass "$1"; else fail "$1" "$2" "$3"; fi
+}
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# 1. The ladder names the shipped adapters (skipping reserved rungs).
+tools="$(cm_ladder_tools | tr '\n' ' ')"
+tools="${tools% }"
+case " $tools " in
+*" lizard "* | *" type-coverage "* | *" mypy-report "* | *" cpd "* | *" line-counter "*)
+  pass "the ladder lists shipped collectors"
+  ;;
+*)
+  fail "the ladder lists shipped collectors" "lizard type-coverage mypy-report cpd line-counter" "$tools"
+  ;;
+esac
+case " $tools " in
+*" none "* | *" n/a "* | *" deferred "*)
+  fail "reserved rungs are not collectors" "no none/n/a/deferred" "$tools"
+  ;;
+*)
+  pass "reserved rungs are not collectors"
+  ;;
+esac
+
+# 2. Adapter PATH names that differ from the ladder tool name are in the
+#    excluded set (mypy-report looks up mypy, cpd looks up pmd).
+bins="$(cm_ladder_path_bins | tr '\n' ' ')"
+bins="${bins% }"
+case " $bins " in
+*" mypy "* | *" pmd "* | *" eslint "*)
+  pass "adapter PATH names that differ from the ladder tool are excluded"
+  ;;
+*)
+  fail "adapter PATH names that differ from the ladder tool are excluded" \
+    "mypy pmd eslint among the bins" "$bins"
+  ;;
+esac
+
+# 3. A filled directory has none of those names resolvable, and no adapter
+#    that looks up a binary probes successfully.
+EMPTY="$WORK/empty"
+cm_fill_tool_free_path "$EMPTY"
+leftover="$(cm_resolvable_ladder_collectors "$EMPTY" | sort -u | tr '\n' ' ')"
+leftover="${leftover% }"
+assert_eq "no ladder collector is resolvable on the tool-free PATH" "" "$leftover"
+
+# 4. Putting a ladder collector back on that directory makes the check fail.
+mkdir -p "$WORK/leak"
+cp -a "$EMPTY/." "$WORK/leak/"
+cat >"$WORK/leak/lizard" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "--version" ]]; then printf '1.24.0\n'; exit 0; fi
+exit 0
+EOF
+chmod +x "$WORK/leak/lizard"
+leaked="$(cm_resolvable_ladder_collectors "$WORK/leak" | sort -u | tr '\n' ' ')"
+leaked="${leaked% }"
+case " $leaked " in
+*" lizard "*)
+  pass "a collector put back on the path is reported as resolvable"
+  ;;
+*)
+  fail "a collector put back on the path is reported as resolvable" "lizard among: $leaked" "$leaked"
+  ;;
+esac
+
+printf '%d cases, %d failed\n' "$CASE_NUM" "$FAILED"
+exit $((FAILED > 0 ? 1 : 0))

--- a/plugins/code-metrics/skills/audit-complexity/scripts/audit-complexity.test.sh
+++ b/plugins/code-metrics/skills/audit-complexity/scripts/audit-complexity.test.sh
@@ -84,20 +84,20 @@ EOF
 chmod +x "$STUBS"/*
 
 # EMPTY_PATH is the caller's PATH with every collector removed: a directory of
-# symlinks to each executable on PATH except the tools the ladder names, so the
-# coreutils, git and the interpreter stay reachable while a real lizard, radon,
-# eslint or gocyclo on this machine cannot shadow the stubs or the assertions.
-COLLECTOR_NAMES=" scc lizard radon multimetric jscpd gocyclo gocognit dupl shellmetrics eslint type-coverage mypy pmd "
-IFS=':' read -r -a path_dirs <<<"$PATH"
-for dir in "${path_dirs[@]}"; do
-  [[ -d "$dir" ]] || continue
-  for exe in "$dir"/*; do
-    [[ -f "$exe" && -x "$exe" ]] || continue
-    name="${exe##*/}"
-    [[ "$COLLECTOR_NAMES" == *" $name "* ]] && continue
-    [[ -e "$EMPTY_PATH/$name" ]] || ln -s "$exe" "$EMPTY_PATH/$name"
-  done
-done
+# symlinks to each executable on PATH except the tools the ladder names (and
+# the binaries those adapters look up), so the coreutils, git and the
+# interpreter stay reachable while a real lizard, radon, eslint or gocyclo on
+# this machine cannot shadow the stubs or the assertions.
+# shellcheck source=../../../scripts/tool-free-path.sh
+source "$PLUGIN_ROOT/scripts/tool-free-path.sh"
+cm_fill_tool_free_path "$EMPTY_PATH"
+leftover="$(cm_resolvable_ladder_collectors "$EMPTY_PATH" | sort -u | tr '\n' ' ')"
+leftover="${leftover% }"
+if [[ -z "$leftover" ]]; then
+  pass "no ladder collector is resolvable on the tool-free PATH"
+else
+  fail "no ladder collector is resolvable on the tool-free PATH" "none" "$leftover"
+fi
 unset CODE_METRICS_DISABLE_BUNDLED
 
 # 1. Every stub resolves: the document, its references, and its run table.

--- a/plugins/code-metrics/skills/audit-coverage/scripts/audit-coverage.test.sh
+++ b/plugins/code-metrics/skills/audit-coverage/scripts/audit-coverage.test.sh
@@ -85,18 +85,17 @@ chmod +x "$STUBS"/*
 
 # EMPTY_PATH is the caller's PATH with every collector removed, so a real
 # lizard, radon or multimetric on this machine cannot change the rows the
-# assertions read.
-COLLECTOR_NAMES=" scc lizard radon multimetric jscpd gocyclo gocognit dupl shellmetrics eslint type-coverage mypy pmd "
-IFS=':' read -r -a path_dirs <<<"$PATH"
-for dir in "${path_dirs[@]}"; do
-  [[ -d "$dir" ]] || continue
-  for exe in "$dir"/*; do
-    [[ -f "$exe" && -x "$exe" ]] || continue
-    name="${exe##*/}"
-    [[ "$COLLECTOR_NAMES" == *" $name "* ]] && continue
-    [[ -e "$EMPTY_PATH/$name" ]] || ln -s "$exe" "$EMPTY_PATH/$name"
-  done
-done
+# assertions read. The excluded set is the ladder, not a second list.
+# shellcheck source=../../../scripts/tool-free-path.sh
+source "$PLUGIN_ROOT/scripts/tool-free-path.sh"
+cm_fill_tool_free_path "$EMPTY_PATH"
+leftover="$(cm_resolvable_ladder_collectors "$EMPTY_PATH" | sort -u | tr '\n' ' ')"
+leftover="${leftover% }"
+if [[ -z "$leftover" ]]; then
+  pass "no ladder collector is resolvable on the tool-free PATH"
+else
+  fail "no ladder collector is resolvable on the tool-free PATH" "none" "$leftover"
+fi
 unset CODE_METRICS_DISABLE_BUNDLED
 
 run_json() {

--- a/plugins/code-metrics/skills/audit-duplication/scripts/audit-duplication.test.sh
+++ b/plugins/code-metrics/skills/audit-duplication/scripts/audit-duplication.test.sh
@@ -81,21 +81,20 @@ exit 1
 STUB
 chmod +x "$STUBS/jscpd"
 export CM_TEST_CAPTURE="$CAPTURE"
-# EMPTY_PATH is the caller's PATH with every duplication collector removed: a
-# directory of symlinks to each executable on PATH except those tools, so the
-# coreutils, git, and the interpreter stay reachable while the collectors do
-# not.
-COLLECTOR_NAMES=" jscpd pmd dupl "
-IFS=':' read -r -a path_dirs <<<"$PATH"
-for dir in "${path_dirs[@]}"; do
-  [[ -d "$dir" ]] || continue
-  for exe in "$dir"/*; do
-    [[ -f "$exe" && -x "$exe" ]] || continue
-    name="${exe##*/}"
-    [[ "$COLLECTOR_NAMES" == *" $name "* ]] && continue
-    [[ -e "$EMPTY_PATH/$name" ]] || ln -s "$exe" "$EMPTY_PATH/$name"
-  done
-done
+# EMPTY_PATH is the caller's PATH with every collector removed: a directory of
+# symlinks to each executable on PATH except the tools the ladder names (and
+# the binaries those adapters look up), so the coreutils, git, and the
+# interpreter stay reachable while the collectors do not.
+# shellcheck source=../../../scripts/tool-free-path.sh
+source "$PLUGIN_ROOT/scripts/tool-free-path.sh"
+cm_fill_tool_free_path "$EMPTY_PATH"
+leftover="$(cm_resolvable_ladder_collectors "$EMPTY_PATH" | sort -u | tr '\n' ' ')"
+leftover="${leftover% }"
+if [[ -z "$leftover" ]]; then
+  pass "no ladder collector is resolvable on the tool-free PATH"
+else
+  fail "no ladder collector is resolvable on the tool-free PATH" "none" "$leftover"
+fi
 
 # 1. The declared cluster is excluded, not counted as debt.
 out="$(PATH="$STUBS:$EMPTY_PATH" bash "$SCRIPT" --json --all "$CLUSTER" --registry "$CLUSTER_REGISTRY")"

--- a/plugins/code-metrics/skills/audit-type-debt/scripts/audit-type-debt.test.sh
+++ b/plugins/code-metrics/skills/audit-type-debt/scripts/audit-type-debt.test.sh
@@ -62,20 +62,20 @@ mkdir -p "$STUBS" "$EMPTY_PATH" "$HOME_DIR"
 trap 'rm -rf "$WORK"' EXIT
 
 # EMPTY_PATH is the caller's PATH with every collector removed: a directory of
-# symlinks to each executable on PATH except the tools the ladder names, so
-# git, the coreutils, and the interpreter stay reachable while `mypy` and
-# `type-coverage` do not (this machine may have either installed).
-COLLECTOR_NAMES=" scc lizard radon multimetric jscpd gocyclo gocognit dupl shellmetrics type-coverage mypy pmd "
-IFS=':' read -r -a path_dirs <<<"$PATH"
-for dir in "${path_dirs[@]}"; do
-  [[ -d "$dir" ]] || continue
-  for exe in "$dir"/*; do
-    [[ -f "$exe" && -x "$exe" ]] || continue
-    name="${exe##*/}"
-    [[ "$COLLECTOR_NAMES" == *" $name "* ]] && continue
-    [[ -e "$EMPTY_PATH/$name" ]] || ln -s "$exe" "$EMPTY_PATH/$name"
-  done
-done
+# symlinks to each executable on PATH except the tools the ladder names (and
+# the binaries those adapters look up), so git, the coreutils, and the
+# interpreter stay reachable while `mypy` and `type-coverage` do not (this
+# machine may have either installed).
+# shellcheck source=../../../scripts/tool-free-path.sh
+source "$PLUGIN_ROOT/scripts/tool-free-path.sh"
+cm_fill_tool_free_path "$EMPTY_PATH"
+leftover="$(cm_resolvable_ladder_collectors "$EMPTY_PATH" | sort -u | tr '\n' ' ')"
+leftover="${leftover% }"
+if [[ -z "$leftover" ]]; then
+  pass "no ladder collector is resolvable on the tool-free PATH"
+else
+  fail "no ladder collector is resolvable on the tool-free PATH" "none" "$leftover"
+fi
 
 cat >"$STUBS/type-coverage" <<EOF
 #!/usr/bin/env bash


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #3844

## Summary

The type-debt (and sibling) suites built a tool-free PATH from a hardcoded collector-name list. That list was a second copy of the ladder and went stale when a collector was added, so the no-collector case stopped being tool-free.

## Fix

- New `plugins/code-metrics/scripts/tool-free-path.sh` derives the excluded set from `scripts/collector-ladder.tsv` (skipping reserved `none` / `n/a` / `deferred` rungs) plus adapter `shutil.which` lookups.
- After the environment is built, the suite fails if any of those collectors still resolve.
- Adding a collector to the ladder needs no suite edit for the tool-free case.
- Existing type-debt no-collector cases are unchanged in what they report.
- Sibling suites with the same hardcoded-list pattern now share the helper: `audit-complexity`, `audit-coverage`, `audit-duplication`, and `dispatch`. `audit-size` does not build that PATH filter and was left unchanged.

code-metrics 0.1.9.

## Verification

- `scripts/affected-tests.sh --run`: six shell suites passed (dispatch, tool-free-path, audit-complexity, audit-coverage, audit-duplication, audit-type-debt). Each prints `PASS: no ladder collector is resolvable on the tool-free PATH`.
- `--run` also selected `test_cobertura.py` (reference to `audit-duplication.test.sh`) and exited 3 as `NOT RUN`, which is the documented contract.

## Related

Refs #3768

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-749fc28c-7c3c-4e85-b625-65942d2abc6e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-749fc28c-7c3c-4e85-b625-65942d2abc6e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

