### PR TITLE
fix(disk-hygiene): branch Bash denial text on engine-gate vs belt

### DIFF
--- a/plugins/disk-hygiene/.claude-plugin/plugin.json
+++ b/plugins/disk-hygiene/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "disk-hygiene",
-  "version": "0.23.3",
+  "version": "0.23.4",
   "description": "Context-aware disk hygiene for arbitrary directory trees: inventories orphaned and temporary artifacts, classifies evidence into review tiers, and offers exact-path cleanup only after a fresh safety preview and explicit per-tier approval. The target is read-only by default; OS-managed paths, links and mount points, VCS-tracked content without the complete checkout evidence bundle, changed entries, and live-handle uncertainty fail closed.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/disk-hygiene/CHANGELOG.md
+++ b/plugins/disk-hygiene/CHANGELOG.md
@@ -3,6 +3,20 @@
 All notable changes to the `disk-hygiene` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.23.4]
+
+### Fixed
+
+- **Bash denial text names the guard that issued it (#3348).** The always-on engine
+  gate and the session belt previously shared one `_bash_denial_guidance` body, so a
+  session that never invoked `/disk-hygiene:clean` was told its Bash lane was
+  restricted to the skill's scan/preview/handoff-verify/apply shapes. Each mode now
+  explains its own scope: the engine gate says this invocation is gated and the rest
+  of the Bash lane is unaffected; the belt says the skill was invoked, that the belt
+  persists until the session ends, and names recovery (a new session; subagent
+  non-inheritance caveated as undocumented and build-specific). Allow/deny decisions
+  and the classifier allow-list disclosure are unchanged.
+
 ## [0.23.3]
 
 ### Changed

--- a/plugins/disk-hygiene/CHANGELOG.md
+++ b/plugins/disk-hygiene/CHANGELOG.md
@@ -13,9 +13,10 @@ All notable changes to the `disk-hygiene` plugin are documented here. Format fol
   restricted to the skill's scan/preview/handoff-verify/apply shapes. Each mode now
   explains its own scope: the engine gate says this invocation is gated and the rest
   of the Bash lane is unaffected; the belt says the skill was invoked, that the belt
-  persists until the session ends, and names recovery (a new session; subagent
-  non-inheritance caveated as undocumented and build-specific). Allow/deny decisions
-  and the classifier allow-list disclosure are unchanged.
+  persists until the session ends, and names recovery as a new session). Skill
+  frontmatter hooks stay registered for the rest of the session and plugin hooks
+  run inside subagents, so the belt is not a subagent-escape hatch. Allow/deny
+  decisions and the classifier allow-list disclosure are unchanged.
 
 ## [0.23.3]
 

--- a/plugins/disk-hygiene/skills/clean/scripts/destructive_guard.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/destructive_guard.py
@@ -1605,7 +1605,13 @@ def _powershell_mutation_verdict(enabled: bool, flagged: str) -> tuple[str, str]
     )
 
 
-def _bash_denial_guidance(authority: str | None) -> str:
+def _bash_allowlist_disclosure(authority: str | None) -> str:
+    """The classifier allow-list both denial bodies teach, named once.
+
+    ``_bash_denial_guidance`` prefixes this with each surface's own scope. The
+    shapes, paths, and supporting heads stay here so a subcommand added to one
+    body and not the other cannot drift (#1806).
+    """
     data_root = _display_data_root(authority)
     data_sentence = (
         f' Pass --data-root "{data_root}" so generated state lands in the plugin data directory.'
@@ -1620,12 +1626,12 @@ def _bash_denial_guidance(authority: str | None) -> str:
     subcommands = ", ".join(_ALLOWED_ENGINE_SUBCOMMANDS[:-1])
     supporting = ", ".join(sorted(_READONLY_SUPPORTING_BASH_HEADS | {"["}))
     return (
-        "Disk-hygiene fails closed: Bash is restricted to exact bundled "
-        f"{subcommands}, and {_ALLOWED_ENGINE_SUBCOMMANDS[-1]} invocations of "
-        f'"{_display_path(_engine_script_path())}", plus the argument-free '
-        f'read-only kill-switch probe "{_display_path(_probe_script_path())}", '
-        f"plus literal-form read-only supporting commands ({supporting}; find "
-        "without -delete/-exec/-ok/-fprint side-effect primaries; [ only as an "
+        f"exact bundled {subcommands}, and {_ALLOWED_ENGINE_SUBCOMMANDS[-1]} "
+        f'invocations of "{_display_path(_engine_script_path())}", plus the '
+        "argument-free read-only kill-switch probe "
+        f'"{_display_path(_probe_script_path())}", plus literal-form read-only '
+        f"supporting commands ({supporting}; find without "
+        "-delete/-exec/-ok/-fprint side-effect primaries; [ only as an "
         "absolute-path complete /usr/bin/[ ... ] expression with the closing ] "
         "bookend; every head, [ included, only as an absolute path under a "
         "trusted system directory — bare names are denied because exported "
@@ -1634,8 +1640,44 @@ def _bash_denial_guidance(authority: str | None) -> str:
         f'"{_display_python()}" for engine/probe shapes. Bare python/python3 '
         "commands are denied because shell functions and aliases can replace them."
         + data_sentence
-        + " Supporting inspection may use that small Bash allowlist or non-Bash "
-        "read-only tools; everything else stays denied."
+    )
+
+
+def _bash_denial_guidance(authority: str | None, mode: str | None = None) -> str:
+    """Explain a Bash deny in the words of the surface that issued it.
+
+    ``engine-gate`` (the plugin-level always-on hook) gates this engine
+    invocation only: the rest of the Bash lane is unaffected, and
+    ``/disk-hygiene:clean`` need not have been invoked. ``belt`` (the
+    skill-frontmatter registration, and the default) is session-wide after
+    that skill is invoked, and names how it clears. Both bodies disclose the
+    same classifier allow-list so the denial cannot teach a grammar the
+    classifier does not implement. Unrecognized ``mode`` values fall back to
+    ``belt``, matching ``resolve_mode``.
+    """
+    resolved = resolve_mode() if mode is None else mode
+    grammar = _bash_allowlist_disclosure(authority)
+    if resolved == _MODE_ENGINE_GATE:
+        return (
+            "Disk-hygiene engine gate: this specific engine invocation is "
+            "gated. The rest of the Bash lane is unaffected, and "
+            "/disk-hygiene:clean need not have been invoked for this to fire. "
+            "Allowed shapes for this invocation are "
+            + grammar
+            + " Supporting inspection of this invocation may use that small "
+            "Bash allowlist or non-Bash read-only tools; any other shape of "
+            "this engine invocation stays denied."
+        )
+    return (
+        "Disk-hygiene session belt: /disk-hygiene:clean was invoked in this "
+        "session, and this belt persists until the session ends. Bash is "
+        "restricted to "
+        + grammar
+        + " Supporting inspection may use that small Bash allowlist or "
+        "non-Bash read-only tools; everything else stays denied. Recovery: "
+        "start a new session. A subagent does not inherit this belt; that "
+        "non-inheritance is undocumented and build-specific, so it is not a "
+        "reliable recovery lane."
     )
 
 

--- a/plugins/disk-hygiene/skills/clean/scripts/destructive_guard.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/destructive_guard.py
@@ -1675,9 +1675,7 @@ def _bash_denial_guidance(authority: str | None, mode: str | None = None) -> str
         + grammar
         + " Supporting inspection may use that small Bash allowlist or "
         "non-Bash read-only tools; everything else stays denied. Recovery: "
-        "start a new session. A subagent does not inherit this belt; that "
-        "non-inheritance is undocumented and build-specific, so it is not a "
-        "reliable recovery lane."
+        "start a new session."
     )
 
 

--- a/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
@@ -5706,10 +5706,7 @@ class GuardTests(unittest.TestCase):
         self.assertIn("persists until the session ends", belt)
         self.assertIn("Bash is restricted", belt)
         self.assertIn("start a new session", belt)
-        self.assertIn("subagent does not inherit", belt)
-        self.assertIn("undocumented", belt)
-        self.assertIn("build-specific", belt)
-        self.assertIn("not a reliable recovery", belt)
+        self.assertNotIn("subagent does not inherit", belt)
         self.assertNotIn("this specific engine invocation", belt)
         self.assertNotIn("need not have been invoked", belt)
 

--- a/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
@@ -5236,7 +5236,7 @@ class GuardTests(unittest.TestCase):
         recorded = entry["reason"]
         self.assertTrue(recorded.endswith("..."), recorded)
         self.assertTrue(host_reason.startswith(recorded[:-3]), recorded)
-        self.assertIn("fails closed", recorded)
+        self.assertIn("this specific engine invocation", recorded)
         self.assertTrue(entry["timestamp"].endswith("Z"), entry["timestamp"])
 
     def test_allow_and_ask_verdicts_are_recorded_with_distinct_rules(self) -> None:
@@ -5664,20 +5664,76 @@ class GuardTests(unittest.TestCase):
         # reaches the classifier — so a consumer learning the allow-list from
         # the denial never learned the probe is permitted, and the probe is the
         # step that lets the model state the kill-switch value honestly instead
-        # of assuming the default.
-        guidance = guard._bash_denial_guidance("/data/root")
-        for subcommand in guard._ALLOWED_ENGINE_SUBCOMMANDS:
-            self.assertIn(subcommand, guidance, subcommand)
-        self.assertIn("kill_switch_probe.py", guidance)
-        # The engine's own path: without it, a body whose ${CLAUDE_PLUGIN_ROOT}
-        # arrived unexpanded leaves no disclosed route to the engine, and the
-        # exact-path identity check denies every guess.
-        self.assertIn(guard._display_path(guard._engine_script_path()), guidance)
-        for head in guard._READONLY_SUPPORTING_BASH_HEADS:
-            self.assertIn(head, guidance, head)
-        self.assertIn("[", guidance)
-        self.assertIn("absolute path", guidance)
-        self.assertIn("bare names are denied", guidance)
+        # of assuming the default. Both surfaces share that list; only the
+        # scope framing differs (#3348).
+        for mode in (guard._MODE_BELT, guard._MODE_ENGINE_GATE):
+            with self.subTest(mode=mode):
+                guidance = guard._bash_denial_guidance("/data/root", mode=mode)
+                for subcommand in guard._ALLOWED_ENGINE_SUBCOMMANDS:
+                    self.assertIn(subcommand, guidance, subcommand)
+                self.assertIn("kill_switch_probe.py", guidance)
+                # The engine's own path: without it, a body whose
+                # ${CLAUDE_PLUGIN_ROOT} arrived unexpanded leaves no disclosed
+                # route to the engine, and the exact-path identity check denies
+                # every guess.
+                self.assertIn(
+                    guard._display_path(guard._engine_script_path()), guidance
+                )
+                for head in guard._READONLY_SUPPORTING_BASH_HEADS:
+                    self.assertIn(head, guidance, head)
+                self.assertIn("[", guidance)
+                self.assertIn("absolute path", guidance)
+                self.assertIn("bare names are denied", guidance)
+
+    def test_bash_denial_modes_frame_opposite_scopes(self) -> None:
+        """Each guard explains itself; the always-on gate does not claim the belt's lockout."""
+        belt = guard._bash_denial_guidance("/data/root", mode=guard._MODE_BELT)
+        gated = guard._bash_denial_guidance(
+            "/data/root", mode=guard._MODE_ENGINE_GATE
+        )
+        self.assertNotEqual(belt, gated)
+        self.assertEqual(
+            belt, guard._bash_denial_guidance("/data/root"), "default is belt"
+        )
+
+        self.assertIn("this specific engine invocation", gated)
+        self.assertIn("rest of the Bash lane is unaffected", gated)
+        self.assertIn("/disk-hygiene:clean need not have been invoked", gated)
+        self.assertNotIn("Bash is restricted", gated)
+        self.assertNotIn("was invoked in this session", gated)
+
+        self.assertIn("/disk-hygiene:clean was invoked in this session", belt)
+        self.assertIn("persists until the session ends", belt)
+        self.assertIn("Bash is restricted", belt)
+        self.assertIn("start a new session", belt)
+        self.assertIn("subagent does not inherit", belt)
+        self.assertIn("undocumented", belt)
+        self.assertIn("build-specific", belt)
+        self.assertIn("not a reliable recovery", belt)
+        self.assertNotIn("this specific engine invocation", belt)
+        self.assertNotIn("need not have been invoked", belt)
+
+        script = (SCRIPT_DIR / "hygiene.py").resolve().as_posix()
+        command = f'python "{script}" scan --target t --output s'
+        belt_result = self.run_guard(command)
+        gated_result = self.run_guard_engine_gate(command)
+        assert gated_result is not None
+        self.assertEqual(
+            "deny", belt_result["hookSpecificOutput"]["permissionDecision"]
+        )
+        self.assertEqual(
+            "deny", gated_result["hookSpecificOutput"]["permissionDecision"]
+        )
+        belt_reason = belt_result["hookSpecificOutput"]["permissionDecisionReason"]
+        gated_reason = gated_result["hookSpecificOutput"][
+            "permissionDecisionReason"
+        ]
+        self.assertNotEqual(belt_reason, gated_reason)
+        self.assertIn(
+            "/disk-hygiene:clean was invoked in this session", belt_reason
+        )
+        self.assertIn("this specific engine invocation", gated_reason)
+        self.assertNotIn("Bash is restricted", gated_reason)
 
     def test_guard_allows_literal_readonly_supporting_bash_commands(self) -> None:
         """Belt inspection allowlist (#2591): read-only shapes pass; mutations stay denied.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #3348

## Summary

The always-on engine gate and the session belt share a classifier but have opposite scopes. They previously emitted the same `_bash_denial_guidance` body, so a session that never invoked `/disk-hygiene:clean` was told its Bash lane was restricted to the skill's scan/preview/handoff-verify/apply shapes.

## Fix

Denial text now branches on `resolve_mode()`:

- engine-gate: this engine invocation is gated; the rest of the Bash lane is unaffected; the skill need not have been invoked.
- belt: `/disk-hygiene:clean` was invoked; the belt persists until the session ends; recovery is a new session. Subagent non-inheritance is named as undocumented and build-specific, not a reliable recovery lane.

The classifier allow-list disclosure stays one shared list. No allow/deny or scope change. Plugin patch `0.23.3` to `0.23.4`.

## Verification

- `python3 -m unittest` on the denial tests in `test_hygiene.py`: 4 passed
- `hygiene.test.sh`: 374 tests OK
- `scripts/run-ruff.sh check` on the edited Python files: pass
- Directly owned Python suites `test_hook_telemetry.py` + `test_guard_launch_monitor.py`: 31 tests OK
- `scripts/affected-tests.sh --run` selected a large fan-out from `test_hygiene.py`; disk-hygiene suites passed. One unrelated `block-hook-bypass.test.sh` symlink case failed on this host and is byte-identical to `origin/main`.

## Related

Refs #3347. F9.3/F9.4 (belt escape hatch and over-broad scope, #3856) are out of scope.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-749fc28c-7c3c-4e85-b625-65942d2abc6e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-749fc28c-7c3c-4e85-b625-65942d2abc6e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

