### PR TITLE
feat(discovery): scale research source breadth with CLAUDE_EFFORT

### DIFF
--- a/plugins/discovery/.claude-plugin/plugin.json
+++ b/plugins/discovery/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "discovery",
-  "version": "0.19.7",
+  "version": "0.19.8",
   "description": "Structured discovery before changes: explore the local codebase, run disciplined multi-source external research, and reconstruct why a past decision was made from evidence outside the code \u2014 each dispatching a purpose-built subagent by default so the reading stays out of the main conversation, with source tiers, falsification, recency gates, an intent-evidence tier, and a corpus-coverage ledger \u2014 persisting EXPLORE.md / RESEARCH.md / INTENT.md index-plus-sidecar handoff artifacts.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/discovery/CHANGELOG.md
+++ b/plugins/discovery/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog — discovery plugin
 
+## [0.19.8]
+
+### Added
+
+- **`research`:** an Effort subsection that reads the caller's effort level through the
+  `${CLAUDE_EFFORT}` substitution and uses it to scale source breadth. `low` runs Phase 0 when
+  the corpus is bounded, Phase 1 at the existing floors, and Phase 2 as the mandatory falsification
+  query only, skipping Phase 3 and Phase 4. `medium` runs Phase 0 through Phase 2 in full and
+  skips Phase 3 and Phase 4. `high` and above keep the current full workflow, so behavior at the
+  default is unchanged. Outcome-gate criteria that require a skipped phase are N/A; criteria that
+  still apply still bite, including the coverage-ledger script verdict and the Phase 2
+  falsification query. A narrower run names the skipped phases in the artifact.
+
 ## [0.19.7]
 
 ### Added

--- a/plugins/discovery/CHANGELOG.md
+++ b/plugins/discovery/CHANGELOG.md
@@ -9,9 +9,15 @@
   the corpus is bounded, Phase 1 at the existing floors, and Phase 2 as the mandatory falsification
   query only, skipping Phase 3 and Phase 4. `medium` runs Phase 0 through Phase 2 in full and
   skips Phase 3 and Phase 4. `high` and above keep the current full workflow, so behavior at the
-  default is unchanged. Outcome-gate criteria that require a skipped phase are N/A; criteria that
-  still apply still bite, including the coverage-ledger script verdict and the Phase 2
-  falsification query. A narrower run names the skipped phases in the artifact.
+  default is unchanged. On the default dispatch path the parent writes `Source breadth:` from its
+  own `${CLAUDE_EFFORT}` load, because `discovery:researcher` is pinned `high` for reasoning and a
+  disk fallback of the skill body is unsubstituted. The substitution claim, and the frontmatter
+  `effort` pin overriding the session, live as a dated record in `reference/parent-contract.md`.
+  The Effort row is the ceiling over discipline 8's doubled floors: skipped phases stay skipped,
+  and Phase 2 at `low` stays the one falsification query. Outcome-gate criteria that require a
+  skipped phase are N/A; criteria that still apply still bite, including the coverage-ledger
+  script verdict and the Phase 2 falsification query. A narrower run names the skipped phases
+  in the artifact.
 
 ## [0.19.7]
 

--- a/plugins/discovery/agents/researcher.md
+++ b/plugins/discovery/agents/researcher.md
@@ -58,6 +58,14 @@ load-time machinery, no user turn, no unresolved scope.
   well-formed, and neither side learns it answered the wrong question. Intent is what decides which
   of several defensible readings of a topic is the one wanted.
 - **The budget** — how much depth the parent authorized.
+- **Source breadth** — `low`, `medium`, `high`, `xhigh`, or `max`. This is the *caller's*
+  effort, written by the parent. Your frontmatter pin is `high` so reasoning does not
+  degrade; that pin is why a substituted effort in a preloaded skill body is not this
+  value. Follow the envelope line for the source-breadth table in the research skill.
+  If the line is absent, treat the run as `high`, name that default in the artifact,
+  and mention the omission in `open_questions`. Dated record:
+  [`${CLAUDE_PLUGIN_ROOT}/reference/parent-contract.md`](${CLAUDE_PLUGIN_ROOT}/reference/parent-contract.md),
+  "Harness facts the dispatch design rests on".
 - **Capability flags** the parent probed. `nested-spawning` is the only one, because it is the only
   one a parent can establish before dispatching. In particular **your own ability to write is not a
   flag** — the parent's pre-dispatch `mkdir`/baseline proves the *parent* can write there, not you.

--- a/plugins/discovery/reference/parent-contract.md
+++ b/plugins/discovery/reference/parent-contract.md
@@ -30,7 +30,7 @@ Adding a second copy is the defect this file removes.
 
 ## The pre-dispatch envelope
 
-Six fields. The agent refuses to guess any of them, which is what makes the envelope safe to
+Six shared fields. The agent refuses to guess any of them, which is what makes the envelope safe to
 mandate: an unresolved field surfaces as a failed dispatch instead of a confident answer to a
 question nobody asked.
 
@@ -46,6 +46,20 @@ Memory root: <memory_dir>
 Budget: <the depth this session authorized>
 Capability flags: nested spawning <available|unavailable>
 ```
+
+**Research adds one more labelled line**, because source breadth is the caller's level and
+the researcher lane is pinned `high` for reasoning:
+
+```text
+Source breadth: <low|medium|high|xhigh|max>
+```
+
+The parent resolves that value from `${CLAUDE_EFFORT}` in the parent skill load before
+dispatch (a literal placeholder means the body was read from disk: write `high`). Explore
+and trace-intent do not write this line. A research worker that does not receive it treats
+the run as `high` and names that default in the artifact, the same fallback as an
+unsubstituted body. Dated record: [Harness facts the dispatch design rests on](#harness-facts-the-dispatch-design-rests-on),
+"`${CLAUDE_EFFORT}` is the loading context's level".
 
 Those labels are the ones `/discovery:research-deep` already ships in its literal dispatch block;
 they are reproduced here rather than reinvented, so the two cannot drift.
@@ -180,16 +194,18 @@ claim, not a fact — say so rather than repeating it.
 
 ## Harness facts the dispatch design rests on
 
-Six harness behaviors this plugin's dispatch design depends on, each with one dated record here
+Seven harness behaviors this plugin's dispatch design depends on, each with one dated record here
 instead of an undated restatement at every site that relies on it. A skill, context file, or agent
 definition keeps its own one-sentence operative rule and cites this section by heading; none of
-them repeats a basis. Every record below was verified against Claude Code 2.1.263 with the pages
-named, fetched 2026-09-06.
+them repeats a basis. Records 1-6 were verified against Claude Code 2.1.263 with the pages
+named, fetched 2026-09-06. Record 7 was verified against the skills and sub-agents pages
+fetched 2026-09-08.
 
-**One shared recheck trigger covers all six:** any of the named pages stops carrying the quoted
-span, a release note names subagent tool filtering, skill preloading, background execution, or
-subagent spawn permissions, or the CLI major version moves. On any of those, re-fetch the page
-before restating the record, and re-date this section rather than editing a claim in place.
+**One shared recheck trigger covers all seven:** any of the named pages stops carrying the quoted
+span, a release note names subagent tool filtering, skill preloading, background execution,
+subagent spawn permissions, or effort substitution, or the CLI major version moves. On any of
+those, re-fetch the page before restating the record, and re-date this section rather than
+editing a claim in place.
 
 ### A preloaded skill that fails to resolve is skipped silently
 
@@ -244,6 +260,24 @@ tool to call rather than a call that comes back denied, while "A fork at the lim
 its inherited tool list, but the tool returns an error instead of spawning." *One bound worth
 carrying:* in a subagent definition, listing `Agent` permits nesting while the depth limit allows
 it, but "any type list inside the parentheses is ignored".
+
+### `${CLAUDE_EFFORT}` is the loading context's level
+
+*Claim.* `${CLAUDE_EFFORT}` substitutes the effort level of the context that loaded the skill
+(`low`, `medium`, `high`, `xhigh`, or `max`; Ultracode reports as `xhigh`). A skill or
+subagent frontmatter `effort` pin overrides the session level while that lane is active, so a
+skill preloaded into a pinned worker expands the pin, not the parent's session level. A body
+Read from disk is unsubstituted: the placeholder remains the literal characters. *Basis.*
+[Skills: available string substitutions](https://code.claude.com/docs/en/skills#available-string-substitutions):
+"`${CLAUDE_EFFORT}` | The current effort level: `low`, `medium`, `high`, `xhigh`, or `max`.
+Ultracode is not a distinct level and reports as `xhigh`." [Skills: frontmatter
+reference](https://code.claude.com/docs/en/skills#frontmatter-reference): `effort` "Overrides
+the session effort level." [Create custom subagents](https://code.claude.com/docs/en/sub-agents):
+the agent-frontmatter `effort` field "Overrides the session effort level. Default: inherits
+from session." *Why the plugin cares.* `/discovery:research` scales source breadth by caller
+effort, and `discovery:researcher` is pinned `high` so reasoning does not degrade inside a
+session tuned down for cost. The worker's substituted value is therefore the pin. The parent
+writes `Source breadth:` from its own load so the table still follows the caller.
 
 ## Running the acceptance gate
 

--- a/plugins/discovery/scripts/contract.test.sh
+++ b/plugins/discovery/scripts/contract.test.sh
@@ -135,6 +135,10 @@ assert_present 'the research parent-obligation table carries a Memory root row' 
   'skills/research/context/dispatch.md' '^\| Memory root \|'
 assert_present 'the parent contract ships a literal envelope template' \
   'reference/parent-contract.md' 'Memory root:'
+assert_present 'the parent contract ships a research Source breadth line' \
+  'reference/parent-contract.md' 'Source breadth:'
+assert_present 'the research parent-obligation table carries a Source breadth row' \
+  'skills/research/context/dispatch.md' '^\| Source breadth \|'
 
 # ---------------------------------------------------------------------------
 # 6. No inert permission grant (#2267 B-F11) + un-run gate is a halt (#2616)

--- a/plugins/discovery/skills/research-deep/SKILL.md
+++ b/plugins/discovery/skills/research-deep/SKILL.md
@@ -65,11 +65,12 @@ Agent({
            Memory slice: <memory_dir>/<slug>/ — on the N-topic path, the <topic-slug>/ sub-slice assigned to THIS topic
            Memory root: <memory_dir>
            Budget: <the depth this session authorized>
-           Capability flags: nested spawning <available|unavailable>"
+           Capability flags: nested spawning <available|unavailable>
+           Source breadth: <low|medium|high|xhigh|max, resolved from this session's caller effort; write high if the substitution is a literal placeholder>"
 })
 ```
 
-**Envelope fields only.** The agent arrives with `/discovery:research` preloaded and with its effort and turn budget already calibrated to that discipline, so the mandatory disciplines, the citation rule, the outcome gate, including the split that hands its verifier-owned rows to a fresh-context verifier rather than letting the producer grade them, and the shape of its return payload are all its own standing contract. Restating them in the prompt copies a contract that lives in the parent skill and drifts from it the moment that skill changes. One bound to know when filling `Budget`: the researcher's `maxTurns: 40` is fixed in its definition, so the budget field can narrow depth within that ceiling but never widen past it, a task that genuinely needs more belongs to Tier 1's workflow engine. The labels above are the plugin's one envelope template ([`${CLAUDE_PLUGIN_ROOT}/reference/parent-contract.md`](${CLAUDE_PLUGIN_ROOT}/reference/parent-contract.md)); field-by-field rationale for all six, `Memory root` included, is [`${CLAUDE_PLUGIN_ROOT}/skills/research/context/dispatch.md`](${CLAUDE_PLUGIN_ROOT}/skills/research/context/dispatch.md).
+**Envelope fields only.** The agent arrives with `/discovery:research` preloaded and with its effort and turn budget already calibrated to that discipline, so the mandatory disciplines, the citation rule, the outcome gate, including the split that hands its verifier-owned rows to a fresh-context verifier rather than letting the producer grade them, and the shape of its return payload are all its own standing contract. Restating them in the prompt copies a contract that lives in the parent skill and drifts from it the moment that skill changes. One bound to know when filling `Budget`: the researcher's `maxTurns: 40` is fixed in its definition, so the budget field can narrow depth within that ceiling but never widen past it, a task that genuinely needs more belongs to Tier 1's workflow engine. The labels above are the plugin's one envelope template ([`${CLAUDE_PLUGIN_ROOT}/reference/parent-contract.md`](${CLAUDE_PLUGIN_ROOT}/reference/parent-contract.md)); field-by-field rationale for the six shared fields plus `Source breadth`, `Memory root` included, is [`${CLAUDE_PLUGIN_ROOT}/skills/research/context/dispatch.md`](${CLAUDE_PLUGIN_ROOT}/skills/research/context/dispatch.md).
 
 ### Tier 1. Workflow engine (preferred)
 

--- a/plugins/discovery/skills/research-deep/evals/evals.json
+++ b/plugins/discovery/skills/research-deep/evals/evals.json
@@ -12,7 +12,7 @@
         "Output dispatches one discovery:researcher agent per topic in parallel rather than running one engine over the combined blob, and does not spawn a bare general-purpose agent carrying a hand-written copy of the research discipline",
         "Each topic agent runs the full research discipline and writes a normal RESEARCH.md plus its sidecars and checklist inside its OWN sub-slice directory, not a sibling research-<topic>.md at the slice root",
         "The sub-slice path for each topic is assigned by the dispatching session rather than chosen by the worker",
-        "Each dispatch carries a resolved envelope — the topic, the reason it is being researched, the assigned memory-slice path, the memory root as its own field, the authorized budget, and the nested-spawning capability flag",
+        "Each dispatch carries a resolved envelope — the topic, the reason it is being researched, the assigned memory-slice path, the memory root as its own field, the authorized budget, the nested-spawning capability flag, and Source breadth from this session's caller effort",
         "The main session dispatches the sibling verifier and applies project fit per topic, writing both results back into that topic's index before synthesizing",
         "The main session synthesizes a combined slice-root RESEARCH.md from the per-topic indexes"
       ]
@@ -34,12 +34,12 @@
       "id": 3,
       "name": "isolated-agent-fallback-no-engine",
       "prompt": "Deep-research the tradeoffs between gRPC and REST for our internal service-to-service calls. Note: no Workflow tool / deep-research workflow is available this session.",
-      "expected_output": "With no workflow-engine path and a heavy task, falls back to dispatching one discovery:researcher — the plugin's purpose-built worker, which arrives with the /research discipline preloaded and its effort and turn budget calibrated to it — rather than a bare general-purpose spawn carrying a hand-written copy of that discipline. The dispatch prompt is the envelope only (topic, reason, memory-slice path, memory root, budget, capability flags). The main session then dispatches the sibling verifier against the written artifact and applies project fit, writing both back into the index before surfacing the result — the same post-dispatch boundary the multi-topic path owns.",
+      "expected_output": "With no workflow-engine path and a heavy task, falls back to dispatching one discovery:researcher — the plugin's purpose-built worker, which arrives with the /research discipline preloaded and its effort and turn budget calibrated to it — rather than a bare general-purpose spawn carrying a hand-written copy of that discipline. The dispatch prompt is the envelope only (topic, reason, memory-slice path, memory root, budget, capability flags, Source breadth). The main session then dispatches the sibling verifier against the written artifact and applies project fit, writing both back into the index before surfacing the result — the same post-dispatch boundary the multi-topic path owns.",
       "files": [],
       "expectations": [
         "Output falls back to an isolated subagent when no workflow engine is available",
         "The subagent is discovery:researcher rather than a bare general-purpose spawn, and is not a read-only Explore agent",
-        "The dispatch prompt carries the resolved envelope (topic, reason, memory-slice path, memory root, budget, capability flags) rather than restating the research discipline, the citation rule, the outcome gate, or the return-payload shape the agent already carries",
+        "The dispatch prompt carries the resolved envelope (topic, reason, memory-slice path, memory root, budget, capability flags, Source breadth) rather than restating the research discipline, the citation rule, the outcome gate, or the return-payload shape the agent already carries",
         "The main session dispatches the sibling verifier against the returned artifact and applies project fit rather than presenting the worker's summary and artifact path directly",
         "The verifier and project-fit results are written back into the artifact index before the result is surfaced"
       ]

--- a/plugins/discovery/skills/research/SKILL.md
+++ b/plugins/discovery/skills/research/SKILL.md
@@ -103,6 +103,27 @@ Full recipes and rationale: `${CLAUDE_PLUGIN_ROOT}/skills/research/context/disci
 13. **Outcome gate before presenting**, the run self-checks its own evidence table + written gap lists + fetch log against binary criteria; any FAIL returns to the named phase (see "Outcome gate")
 14. **Bounded corpora are enumerated before they are searched**, when the topic has a finite, knowable set of things to cover, Phase 0 writes `research-checklist.md` naming every item and its per-item depth criterion BEFORE any query runs, and the gate fails on any unmarked row. Distinct from discipline 9: the gap list chases *unknowns* surfaced by searching, this enforces exhaustive coverage of a set that was knowable up front. Recipe: the discipline file's "Corpus enumeration"
 
+### Effort, source breadth
+
+Caller effort for this run is `${CLAUDE_EFFORT}`. If that reads as a literal placeholder rather than
+one of `low`, `medium`, `high`, `xhigh`, or `max`, this body was read directly instead of
+skill-loaded, so the substitution never ran: treat the run as `high` and run every phase below.
+
+Effort scales **source breadth**, not outcome-gate honesty. Default `high` (and `xhigh` / `max`)
+is the current full Phase 0 through Phase 3 workflow, plus conditional Phase 4. Task size never
+trims phases; only this table does.
+
+| Effort | Source breadth |
+|---|---|
+| `low` | Phase 0 if bounded, Phase 1 at existing floors, Phase 2 as the mandatory falsification query only (no per-gap expansion). Skip Phase 3 and Phase 4 |
+| `medium` | Phase 0 through 2 in full (per-gap Phase 2 queries plus falsification). Skip Phase 3 and Phase 4 |
+| `high`, `xhigh`, `max` | Current full workflow |
+
+Criteria that need a skipped phase are N/A at that effort. Criteria that still apply still bite,
+including the coverage-ledger script verdict when Phase 0 wrote a ledger, and Phase 2
+falsification at every level that runs Phase 2. Name skipped phases in the artifact and report so
+a narrower run is not mistaken for a complete one.
+
 ## Phase 0: Corpus enumeration (before any query)
 
 **Ask first: is the corpus bounded?** Bounded means finite and enumerable *before* the first query. Every skill in a plugin, every endpoint in an API reference, every release between two versions. An unbounded topic ("is this approach sound?") has no such set; record that verdict in one line and go to Phase 1. When it IS bounded, **enumerate from a surface that is exhaustive by construction**, never from search results or a curated index that is partial by design. Write `research-checklist.md` into the artifact's memory slice **in exactly this shape**. Criterion 11's gate parses it and fails closed on a table it cannot read, so a renamed column or a prose status is a FAIL:
@@ -214,7 +235,7 @@ Present research findings as, and if invoked standalone present them directly, w
 5. **Gaps**. Claims not at ≥1 primary + 2 independent corroborators, OR LOW confidence (flagged for follow-up). A gap asserting absence names the sources checked AND the sources left unchecked, never a bare "not found"
 6. **Recency status**. Primary-source age per tool/library claim
 7. **Project fit**. How findings align with the consuming project's conventions and stated direction
-8. **Outcome gate result**. Pass, or which criterion failed and what was re-run
+8. **Outcome gate result**. Pass, or which criterion failed and what was re-run, plus effort and any skipped phases
 
 ## Final step: persist artifact for handoff
 
@@ -232,7 +253,7 @@ Write the research output to `<memory_dir>/<slug>/RESEARCH.md`, a memory-tier ar
 
 - **Does not make decisions**. Presents verified evidence; the planning step (or user) decides
 - **Does not write code**. Researches only; execution is a separate step
-- **Does not skip phases for "simple" topics**. Task size does not reduce depth; all phases run
+- **Does not skip phases for "simple" topics**. Task size does not reduce depth; only the Effort table may skip later phases
 - **Does not present training-data knowledge as current fact**. Tier 3 recall must be promoted to Tier 0/1 before claim acceptance
 
 ## See also

--- a/plugins/discovery/skills/research/SKILL.md
+++ b/plugins/discovery/skills/research/SKILL.md
@@ -30,7 +30,7 @@ Local counterpart: `/discovery:explore` (what IS in the repo); this skill covers
 
 ## Routing. Dispatch by default
 
-**From the main conversation, this skill dispatches the `discovery:researcher` subagent.** Research reads a lot; keeping that out of the orchestrator's context window is the point. The agent runs Phase 0 through the gate's mechanical criteria, writes the artifact set, and returns a file pointer plus a short summary, not the transcript. The parent resolves the **pre-dispatch envelope** first, six fields (topic, reason, memory-slice path, memory root, budget, capability flags), written into the dispatch prompt as the labelled template in [`${CLAUDE_PLUGIN_ROOT}/reference/parent-contract.md`](${CLAUDE_PLUGIN_ROOT}/reference/parent-contract.md), not as prose the agent has to parse, and owns the **post-dispatch boundary** after: re-surfacing `open_questions`, dispatching the sibling verifier, applying project fit itself, and **writing both results back into the index**, because `verification: pending` says the producer may not self-grade, not that the question is permanently open.
+**From the main conversation, this skill dispatches the `discovery:researcher` subagent.** Research reads a lot; keeping that out of the orchestrator's context window is the point. The agent runs Phase 0 through the gate's mechanical criteria, writes the artifact set, and returns a file pointer plus a short summary, not the transcript. The parent resolves the **pre-dispatch envelope** first, six shared fields (topic, reason, memory-slice path, memory root, budget, capability flags) plus research-only `Source breadth:`, written into the dispatch prompt as the labelled template in [`${CLAUDE_PLUGIN_ROOT}/reference/parent-contract.md`](${CLAUDE_PLUGIN_ROOT}/reference/parent-contract.md), not as prose the agent has to parse, and owns the **post-dispatch boundary** after: re-surfacing `open_questions`, dispatching the sibling verifier, applying project fit itself, and **writing both results back into the index**, because `verification: pending` says the producer may not self-grade, not that the question is permanently open.
 
 **Run inline instead when any of these holds**, and inline runs the identical discipline; the escape hatch relaxes nothing below:
 
@@ -108,10 +108,9 @@ Full recipes and rationale: `${CLAUDE_PLUGIN_ROOT}/skills/research/context/disci
 Caller effort for this run is `${CLAUDE_EFFORT}`. If that reads as a literal placeholder rather than
 one of `low`, `medium`, `high`, `xhigh`, or `max`, this body was read directly instead of
 skill-loaded, so the substitution never ran: treat the run as `high` and run every phase below.
-
-Effort scales **source breadth**, not outcome-gate honesty. Default `high` (and `xhigh` / `max`)
-is the current full Phase 0 through Phase 3 workflow, plus conditional Phase 4. Task size never
-trims phases; only this table does.
+Dated record: [`${CLAUDE_PLUGIN_ROOT}/reference/parent-contract.md`](${CLAUDE_PLUGIN_ROOT}/reference/parent-contract.md),
+"Harness facts the dispatch design rests on". A dispatched run follows envelope `Source breadth:`
+from this load, not the researcher pin. Missing line: `high`, named in the artifact.
 
 | Effort | Source breadth |
 |---|---|
@@ -119,10 +118,8 @@ trims phases; only this table does.
 | `medium` | Phase 0 through 2 in full (per-gap Phase 2 queries plus falsification). Skip Phase 3 and Phase 4 |
 | `high`, `xhigh`, `max` | Current full workflow |
 
-Criteria that need a skipped phase are N/A at that effort. Criteria that still apply still bite,
-including the coverage-ledger script verdict when Phase 0 wrote a ledger, and Phase 2
-falsification at every level that runs Phase 2. Name skipped phases in the artifact and report so
-a narrower run is not mistaken for a complete one.
+The Effort row is the ceiling over discipline 8. Rationale and skipped-phase N/A: the discipline
+file's "Effort, source breadth".
 
 ## Phase 0: Corpus enumeration (before any query)
 
@@ -258,4 +255,4 @@ Write the research output to `<memory_dir>/<slug>/RESEARCH.md`, a memory-tier ar
 
 ## See also
 
-- `${CLAUDE_PLUGIN_ROOT}/skills/research/context/discipline.md`. Source tiers, recency gates, broad-topic recipe, falsification recipe, tool-ecosystem fallback, confidence calibration, source-quality red flags, observed failure patterns
+- `${CLAUDE_PLUGIN_ROOT}/skills/research/context/discipline.md`. Source tiers, recency gates, broad-topic recipe, effort ceiling over that doubling, falsification recipe, tool-ecosystem fallback, confidence calibration, source-quality red flags, observed failure patterns

--- a/plugins/discovery/skills/research/context/discipline.md
+++ b/plugins/discovery/skills/research/context/discipline.md
@@ -65,6 +65,23 @@ When the research topic matches any trigger below, double all phase minimums:
 
 **Why:** multi-vendor topics have N times more drift surface. Each vendor ships its own changelog cadence, docs site, and naming-convention shifts. Single-vendor minimums under-cover the cross-vendor edges where hallucinations concentrate.
 
+## Effort, source breadth
+
+Effort scales **source breadth**, not outcome-gate honesty. Default `high` (and `xhigh` / `max`)
+is the current full Phase 0 through Phase 3 workflow, plus conditional Phase 4. Task size never
+trims phases; only the Effort table in the skill body does.
+
+Criteria that need a skipped phase are N/A at that effort. Criteria that still apply still bite,
+including the coverage-ledger script verdict when Phase 0 wrote a ledger, and Phase 2
+falsification at every level that runs Phase 2. Name skipped phases in the artifact and report so
+a narrower run is not mistaken for a complete one.
+
+**The Effort row is the ceiling over [Broad-topic auto-detect](#broad-topic-auto-detect).**
+Doubling still applies to a phase the table actually runs at its floor (Phase 1 at every
+level that runs it; Phase 2 at `medium` and above). Skipped phases stay skipped, and Phase 2
+at `low` stays the one falsification query, even when the topic would otherwise double every
+phase to 6+ queries.
+
 ## Query scaling — floors are not targets
 
 The per-phase minimums (3+ standard, 6+ broad-topic) are floors to start from, not targets to stop at. The query count is a function of the open-question count: a flat per-phase number would stop a run while numbered gaps are still open.

--- a/plugins/discovery/skills/research/context/dispatch.md
+++ b/plugins/discovery/skills/research/context/dispatch.md
@@ -5,11 +5,12 @@ dispatched run **that is specific to research**, and why each obligation exists.
 is [`${CLAUDE_PLUGIN_ROOT}/agents/researcher.md`](${CLAUDE_PLUGIN_ROOT}/agents/researcher.md).
 
 Everything the parent owes that is **identical for exploration and research** — the envelope's six
-fields as a literal template, the pre-dispatch baseline in both shell forms, what is and is not
+shared fields as a literal template, the pre-dispatch baseline in both shell forms, what is and is not
 documented about argument substitution on the preload path, why the gate ships no permission grant
 and what to do when it cannot run, and the resume-before-discard ordering — is stated once in
 [`${CLAUDE_PLUGIN_ROOT}/reference/parent-contract.md`](${CLAUDE_PLUGIN_ROOT}/reference/parent-contract.md).
-This file does not restate it.
+Research also writes `Source breadth:` on that same template. This file does not restate the shared
+six.
 
 ## The orchestration boundary
 
@@ -19,8 +20,8 @@ that surrounds the reading, and the failures worth guarding against are all at t
 **The parent owns the pre-dispatch envelope** — everything that must be resolved in main context
 before the agent starts, because the agent cannot resolve it once started:
 
-The literal envelope template is in the parent contract. All six fields are owed; this table says
-why each is the parent's to supply.
+The literal envelope template is in the parent contract. All six shared fields are owed; research
+also owes `Source breadth:`. This table says why each is the parent's to supply.
 
 | Field | Why the agent cannot supply it |
 |---|---|
@@ -29,6 +30,7 @@ why each is the parent's to supply.
 | Memory-slice path | Resolved against the consuming repo's topic-docs binding, which is a parent-side lookup |
 | Memory root | **Not derivable from the slice path.** On a fan-out the slice is a sub-slice, and no one can tell from the path alone which ancestor is the configured root — but the root is where the self-ignoring `.gitignore` guard belongs. It is owed as its own labelled line. It is also the one field whose absence is **degradable**: the agent derives, flags in `open_questions`, and continues, rather than stopping |
 | Budget | How much depth was authorized is the caller's decision, never the worker's |
+| Source breadth | The caller effort that scales the phase table. The researcher lane is pinned `high` for reasoning, so the worker's own `${CLAUDE_EFFORT}` is the pin (or a literal placeholder on disk fallback). The parent writes this line from its own load |
 | Capability flags | Whether nested spawning is available is a session property the parent probed. It is the only flag — the agent's own **write** capability is not probeable before dispatch, and the parent's `mkdir`/baseline proves only that the parent can write there. That question is answered afterwards by `persistence:` in the payload |
 
 The agent **refuses to guess** any of these rather than inventing one — memory root excepted above —

--- a/plugins/discovery/skills/research/evals/evals.json
+++ b/plugins/discovery/skills/research/evals/evals.json
@@ -277,6 +277,21 @@
         "A payload that echoed the token but omitted preload: is an out-of-date agent definition, not a pass, the same class as a missing topic_as_received",
         "check-coverage-complete.sh is NOT run — the recovered index records the corpus as unbounded, so no ledger is owed"
       ]
+    },
+    {
+      "id": 20,
+      "name": "low-effort-skips-phase-3",
+      "prompt": "Research the current connection-pooling defaults in Npgsql 8. [Caller effort for this run is low.]",
+      "expected_output": "Reads caller effort as low and scales source breadth: Phase 0 if the corpus is bounded, Phase 1 at the existing floors, and Phase 2 only the mandatory falsification query. It skips Phase 3 preferred-sources / tool-ecosystem fallback and Phase 4. It names those skipped phases in the artifact so the narrower run is not mistaken for a complete one. Outcome-gate criteria that require a skipped phase are N/A; the Phase 2 falsification criterion still applies, as does the coverage-ledger script verdict when Phase 0 wrote a ledger.",
+      "files": [],
+      "expectations": [
+        "Treats caller effort as low rather than running the default full workflow",
+        "Runs Phase 1 at the existing floors and Phase 2 only as the mandatory falsification query, without one-query-per-gap expansion",
+        "Does NOT run Phase 3 preferred-sources / tool-ecosystem fallback",
+        "Does NOT run Phase 4",
+        "Names the skipped phases in the artifact or report",
+        "Still records the Phase 2 falsification query and still cites the coverage-ledger script verdict when Phase 0 wrote a ledger"
+      ]
     }
   ]
 }

--- a/plugins/discovery/skills/research/evals/evals.json
+++ b/plugins/discovery/skills/research/evals/evals.json
@@ -282,15 +282,30 @@
       "id": 20,
       "name": "low-effort-skips-phase-3",
       "prompt": "Research the current connection-pooling defaults in Npgsql 8. [Caller effort for this run is low.]",
-      "expected_output": "Reads caller effort as low and scales source breadth: Phase 0 if the corpus is bounded, Phase 1 at the existing floors, and Phase 2 only the mandatory falsification query. It skips Phase 3 preferred-sources / tool-ecosystem fallback and Phase 4. It names those skipped phases in the artifact so the narrower run is not mistaken for a complete one. Outcome-gate criteria that require a skipped phase are N/A; the Phase 2 falsification criterion still applies, as does the coverage-ledger script verdict when Phase 0 wrote a ledger.",
+      "expected_output": "On an inline run, reads caller effort as low and scales source breadth. On the default dispatch path, does NOT use the researcher's substituted effort (that lane is pinned high, and a disk fallback is unsubstituted): the parent writes Source breadth: low in the envelope and the worker follows that line. Either path runs Phase 0 if the corpus is bounded, Phase 1 at the existing floors, and Phase 2 only the mandatory falsification query. It skips Phase 3 preferred-sources / tool-ecosystem fallback and Phase 4. It names those skipped phases in the artifact so the narrower run is not mistaken for a complete one. Outcome-gate criteria that require a skipped phase are N/A; the Phase 2 falsification criterion still applies, as does the coverage-ledger script verdict when Phase 0 wrote a ledger.",
       "files": [],
       "expectations": [
         "Treats caller effort as low rather than running the default full workflow",
+        "On a dispatched run, writes Source breadth: low in the envelope and does not take the researcher lane's high pin as source breadth",
         "Runs Phase 1 at the existing floors and Phase 2 only as the mandatory falsification query, without one-query-per-gap expansion",
         "Does NOT run Phase 3 preferred-sources / tool-ecosystem fallback",
         "Does NOT run Phase 4",
         "Names the skipped phases in the artifact or report",
         "Still records the Phase 2 falsification query and still cites the coverage-ledger script verdict when Phase 0 wrote a ledger"
+      ]
+    },
+    {
+      "id": 21,
+      "name": "low-effort-is-ceiling-over-broad-topic-doubling",
+      "prompt": "Research Dapper vs EF Core vs ADO.NET connection-pooling defaults. [Caller effort for this run is low.]",
+      "files": [],
+      "expected_output": "Broad-topic auto-detect fires (comparison, three tools named) but the Effort row is the ceiling: Phase 1 uses the doubled floor, Phase 2 is only the mandatory falsification query (not 6+ per-gap queries), and Phase 3 and Phase 4 are skipped. On a dispatched run the parent still writes Source breadth: low rather than following the researcher pin. Names the skipped phases. Does not treat discipline 8 as a licence to run a full doubled workflow at low.",
+      "expectations": [
+        "Treats caller effort as low rather than running the default full workflow",
+        "Recognizes a broad comparison topic so Phase 1 uses the doubled floor",
+        "Does NOT expand Phase 2 to 6+ queries: Phase 2 is the one falsification query",
+        "Does NOT run Phase 3 or Phase 4, even though discipline 8 would otherwise double every phase",
+        "Names the skipped phases in the artifact or report"
       ]
     }
   ]

--- a/plugins/discovery/skills/research/evals/evals.json
+++ b/plugins/discovery/skills/research/evals/evals.json
@@ -299,7 +299,7 @@
       "name": "low-effort-is-ceiling-over-broad-topic-doubling",
       "prompt": "Research Dapper vs EF Core vs ADO.NET connection-pooling defaults. [Caller effort for this run is low.]",
       "files": [],
-      "expected_output": "Broad-topic auto-detect fires (comparison, three tools named) but the Effort row is the ceiling: Phase 1 uses the doubled floor, Phase 2 is only the mandatory falsification query (not 6+ per-gap queries), and Phase 3 and Phase 4 are skipped. On a dispatched run the parent still writes Source breadth: low rather than following the researcher pin. Names the skipped phases. Does not treat discipline 8 as a licence to run a full doubled workflow at low.",
+      "expected_output": "Broad-topic auto-detect fires (comparison, three tools named) but the Effort row is the ceiling: Phase 1 uses the doubled floor, Phase 2 is only the mandatory falsification query (not 6+ per-gap queries), and Phase 3 and Phase 4 are skipped. On a dispatched run the parent still writes Source breadth: low rather than following the researcher pin. Names the skipped phases. Does not treat discipline 8 as a license to run a full doubled workflow at low.",
       "expectations": [
         "Treats caller effort as low rather than running the default full workflow",
         "Recognizes a broad comparison topic so Phase 1 uses the doubled floor",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #3548

## Summary

Adopt `${CLAUDE_EFFORT}` in `/discovery:research` so source breadth follows caller effort. This is the remaining slice of #3548; the other four skills already landed on main.

## Fix

`low` and `medium` skip later research phases; `high` / `xhigh` / `max` keep the current full workflow. Outcome-gate criteria that still apply still bite; skipped phases are named in the artifact. No `!` pre-compute.

On the default dispatch path the researcher lane stays pinned `high` for reasoning. The parent writes `Source breadth:` from its own load into the envelope; the worker follows that line rather than the pin. Substitution, the frontmatter `effort` override, and disk-fallback unsubstituted placeholders are a dated record in `reference/parent-contract.md` (as-of 2026-09-08, skills and sub-agents pages). The Effort row is the ceiling over discipline 8: skipped phases stay skipped, and Phase 2 at `low` stays the one falsification query.

discovery 0.19.7 to 0.19.8. Eval 20 pins that `low` skips Phase 3 and that dispatch writes `Source breadth: low`. Eval 21 pins the discipline-8 ceiling.

## Verification

- `python3 -m json.tool` on both research evals files
- discovery `contract.test.sh` passed (hub 5217 words &lt; spoke 5417)
- `check-changed-skills.sh origin/main`: research and research-deep PASS
- `check-evals-quality.sh` PASS
- `tool-honesty.test.sh` and `check-dispatch-artifact.test.sh` passed

## Related

#3548. Already on main: `bugs:scan`, `codebase-health:audit`, `plugin-quality:audit`, `mutation-testing:audit`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-749fc28c-7c3c-4e85-b625-65942d2abc6e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-749fc28c-7c3c-4e85-b625-65942d2abc6e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

