### PR TITLE
fix(cloud): verify plugin refreshes against the marketplace the installs resolve from

### DIFF
--- a/.claude/cloud-bootstrap.sh
+++ b/.claude/cloud-bootstrap.sh
@@ -163,6 +163,33 @@ if [[ -x "$claude_bin" ]] && command -v jq >/dev/null 2>&1; then
       echo "cloud-bootstrap: warning: could not register the $marketplace_name marketplace" >&2
   fi
 
+  # Where installs actually resolve from. The registration above runs only
+  # when no marketplace of this name exists, and a cloud snapshot arrives with
+  # one of the same name registered from GitHub and tracking main. `plugin
+  # install` then pulls THAT clone and records its commit as gitCommitSha, so
+  # the checkout's HEAD is the wrong reference for both the refresh decision
+  # and the verification below: a branch ahead of main, or a checkout behind
+  # it, scored every healthy install as failed and re-ran the refresh on every
+  # resume. The reference is therefore the repository the installs come from.
+  # When that is not this checkout, bring it current first (the CLI-sanctioned
+  # pull, the one `plugin install` performs anyway) and say so once: the
+  # session then runs that clone's plugin code and not this branch's, which is
+  # the property the directory source exists for and the one thing an operator
+  # on a branch that changed a plugin needs to hear. A location that is not a
+  # git repository (a copied directory source) keeps the checkout.
+  source_repo="$repo_root"
+  marketplace_entry="$("$claude_bin" plugin marketplace list --json 2>/dev/null |
+    jq -c --arg n "$marketplace_name" 'first(.[]? | select(.name == $n)) // {}' 2>/dev/null || true)"
+  [[ -n "$marketplace_entry" ]] || marketplace_entry='{}'
+  marketplace_location="$(jq -r '.installLocation // ""' <<<"$marketplace_entry" 2>/dev/null | tr -d '\r')"
+  if [[ -n "$marketplace_location" ]] &&
+    git -C "$marketplace_location" rev-parse --verify HEAD >/dev/null 2>&1 &&
+    [[ "$(cd -P -- "$marketplace_location" && pwd)" != "$(cd -P -- "$repo_root" && pwd)" ]]; then
+    "$claude_bin" plugin marketplace update "$marketplace_name" >/dev/null 2>&1 || true
+    source_repo="$marketplace_location"
+    echo "cloud-bootstrap: warning: marketplace $marketplace_name is registered from $(jq -r '.source // "an unknown source"' <<<"$marketplace_entry" | tr -d '\r') at $marketplace_location, not this checkout; plugins serve that clone at $(git -C "$source_repo" rev-parse --short HEAD 2>/dev/null), not $(git branch --show-current 2>/dev/null || echo detached) at $(git rev-parse --short HEAD 2>/dev/null)" >&2
+  fi
+
   # Enabled set: the fleet list the shared environment baked into the snapshot
   # (standards cloud-environment component), overlaid with the tracked
   # settings file, so a repo entry set to false opts out of a fleet entry and
@@ -211,12 +238,13 @@ if [[ -x "$claude_bin" ]] && command -v jq >/dev/null 2>&1; then
   # disabled by default", and `plugin list --json` showing scope=user with
   # enabled=false. So DISABLED is the EXPECTED end state for these ids, and
   # scoring it as a failed install printed a standing failure count on every
-  # fresh snapshot — the shape that teaches operators to skip the log. This
-  # checkout is the registered marketplace (`marketplace add "$repo_root"`
-  # above), so the catalog reads off disk at no CLI or network cost.
+  # fresh snapshot — the shape that teaches operators to skip the log. The
+  # catalog is read from the repository the installs resolve against (this
+  # checkout, or the clone found above), so it reads off disk at no CLI or
+  # network cost.
   mapfile -t default_disabled < <(
     jq -r '.plugins[]? | select(.defaultEnabled == false) | .name' \
-      .claude-plugin/marketplace.json 2>/dev/null | tr -d '\r'
+      "$source_repo/.claude-plugin/marketplace.json" 2>/dev/null | tr -d '\r'
   )
 
   # A directory-source install cache is keyed by the semver in plugin.json, not
@@ -233,7 +261,7 @@ if [[ -x "$claude_bin" ]] && command -v jq >/dev/null 2>&1; then
   # playbook's answer for that loop is `claude --plugin-dir ./plugins/<name>`,
   # which takes session precedence over the cached install.
   plugins_registry="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/plugins/installed_plugins.json"
-  head_sha="$(git rev-parse HEAD 2>/dev/null || true)"
+  head_sha="$(git -C "$source_repo" rev-parse HEAD 2>/dev/null || true)"
   needs_refresh() {
     # needs_refresh <plugin-id> — true when the cached snapshot predates a
     # change to that plugin's directory in this checkout.
@@ -245,8 +273,8 @@ if [[ -x "$claude_bin" ]] && command -v jq >/dev/null 2>&1; then
     [[ -n "$recorded" && "$recorded" != "$head_sha" ]] || return 1
     # A commit this clone doesn't have (shallow fetch, force-push): refresh
     # rather than guess that the snapshot is current.
-    git cat-file -e "${recorded}^{commit}" 2>/dev/null || return 0
-    ! git diff --quiet "$recorded" HEAD -- "plugins/$name" 2>/dev/null
+    git -C "$source_repo" cat-file -e "${recorded}^{commit}" 2>/dev/null || return 0
+    ! git -C "$source_repo" diff --quiet "$recorded" HEAD -- "plugins/$name" 2>/dev/null
   }
 
   # snapshot_problem <plugin-id> — the VERIFICATION counterpart of
@@ -283,12 +311,12 @@ if [[ -x "$claude_bin" ]] && command -v jq >/dev/null 2>&1; then
       return 0
     fi
     [[ "$recorded" != "$head_sha" ]] || return 0
-    if ! git cat-file -e "${recorded}^{commit}" 2>/dev/null; then
+    if ! git -C "$source_repo" cat-file -e "${recorded}^{commit}" 2>/dev/null; then
       printf 'cannot verify snapshot: installed from commit %s, which this clone does not have' \
         "$recorded"
       return 0
     fi
-    if ! git diff --quiet "$recorded" HEAD -- "plugins/$name" 2>/dev/null; then
+    if ! git -C "$source_repo" diff --quiet "$recorded" HEAD -- "plugins/$name" 2>/dev/null; then
       printf 'plugins/%s changed between the installed commit %s and HEAD' "$name" "$recorded"
     fi
     return 0

--- a/.claude/cloud-bootstrap.sh
+++ b/.claude/cloud-bootstrap.sh
@@ -185,9 +185,20 @@ if [[ -x "$claude_bin" ]] && command -v jq >/dev/null 2>&1; then
   if [[ -n "$marketplace_location" ]] &&
     git -C "$marketplace_location" rev-parse --verify HEAD >/dev/null 2>&1 &&
     [[ "$(cd -P -- "$marketplace_location" && pwd)" != "$(cd -P -- "$repo_root" && pwd)" ]]; then
-    "$claude_bin" plugin marketplace update "$marketplace_name" >/dev/null 2>&1 || true
+    # A pull that fails (no network, a clone the CLI refuses to fast-forward)
+    # leaves the clone as it stands, which is still what the installs serve,
+    # so the verdict below stays truthful about serving; what it cannot claim
+    # is currency, and that is said here rather than swallowed.
+    if ! "$claude_bin" plugin marketplace update "$marketplace_name" >/dev/null 2>&1; then
+      echo "cloud-bootstrap: warning: could not bring the $marketplace_name marketplace clone current (\`plugin marketplace update\` failed); verifying against the clone as it stands" >&2
+    fi
     source_repo="$marketplace_location"
-    echo "cloud-bootstrap: warning: marketplace $marketplace_name is registered from $(jq -r '.source // "an unknown source"' <<<"$marketplace_entry" | tr -d '\r') at $marketplace_location, not this checkout; plugins serve that clone at $(git -C "$source_repo" rev-parse --short HEAD 2>/dev/null), not $(git branch --show-current 2>/dev/null || echo detached) at $(git rev-parse --short HEAD 2>/dev/null)" >&2
+    # `plugin marketplace list --json` reports `source` as a plain string
+    # (claude 2.1.263: "github"), while known_marketplaces.json nests it as an
+    # object with a `repo`; `jq -r` pretty-prints an object over several
+    # lines, so the one-line warning below takes either shape.
+    marketplace_source="$(jq -r 'if (.source | type) == "object" then (.source.repo // .source.source // "an unknown source") else (.source // "an unknown source") end' <<<"$marketplace_entry" 2>/dev/null | tr -d '\r')"
+    echo "cloud-bootstrap: warning: marketplace $marketplace_name is registered from ${marketplace_source:-an unknown source} at $marketplace_location, not this checkout; plugins serve that clone at $(git -C "$source_repo" rev-parse --short HEAD 2>/dev/null), not $(git branch --show-current 2>/dev/null || echo detached) at $(git rev-parse --short HEAD 2>/dev/null)" >&2
   fi
 
   # Enabled set: the fleet list the shared environment baked into the snapshot

--- a/.claude/hooks/cloud-bootstrap-plugins.test.sh
+++ b/.claude/hooks/cloud-bootstrap-plugins.test.sh
@@ -291,7 +291,7 @@ case "$*" in
   ;;
 *"marketplace update"*)
   printf '%s\n' "$*" >>"$fx/calls.log"
-  [[ -f "$fx/update-fails" ]] && exit 1
+  if [[ -f "$fx/update-fails" ]]; then exit 1; fi
   ;;
 *"plugin list --json"*)
   if [[ -f "$fx/.listed" ]]; then

--- a/.claude/hooks/cloud-bootstrap-plugins.test.sh
+++ b/.claude/hooks/cloud-bootstrap-plugins.test.sh
@@ -248,8 +248,20 @@ run_case() {
       fi
       clone_head="$(git_test_config "$location" rev-parse HEAD)"
     fi
-    printf '[{"name":"melodic-software","source":"github","installLocation":"%s"}]\n' "$location" \
-      >"$fx/marketplace-entry.json"
+    # `plugin marketplace list --json` reports `source` as a plain string
+    # (claude 2.1.263); CASE_SOURCE_SHAPE=object reports the nested object
+    # known_marketplaces.json carries, which `jq -r` would pretty-print over
+    # several lines if the block read it naively.
+    if [[ "${CASE_SOURCE_SHAPE:-}" == object ]]; then
+      printf '[{"name":"melodic-software","source":{"source":"github","repo":"melodic-software/claude-code-plugins"},"installLocation":"%s"}]\n' "$location" \
+        >"$fx/marketplace-entry.json"
+    else
+      printf '[{"name":"melodic-software","source":"github","installLocation":"%s"}]\n' "$location" \
+        >"$fx/marketplace-entry.json"
+    fi
+    # CASE_UPDATE_FAILS makes the stub's `marketplace update` exit 1: the
+    # no-network / refused-fast-forward shape.
+    [[ -z "${CASE_UPDATE_FAILS:-}" ]] || : >"$fx/update-fails"
   fi
 
   local subst="s/@HEAD@/$head/g; s/@FIRST@/$first/g; s/@CLONE@/$clone_head/g"
@@ -277,7 +289,10 @@ case "$*" in
     printf '[{"name":"melodic-software"}]\n'
   fi
   ;;
-*"marketplace update"*) printf '%s\n' "$*" >>"$fx/calls.log" ;;
+*"marketplace update"*)
+  printf '%s\n' "$*" >>"$fx/calls.log"
+  [[ -f "$fx/update-fails" ]] && exit 1
+  ;;
 *"plugin list --json"*)
   if [[ -f "$fx/.listed" ]]; then
     cat "$fx/list-after.json"
@@ -523,6 +538,26 @@ expect "and brings the clone current first" \
   "calls: plugin marketplace update melodic-software"
 refute "and no plugin is called stale" \
   "failed verification"
+refute "and a pull that worked is not reported as failed" \
+  "could not bring the melodic-software marketplace clone current"
+
+# The pull can fail (no network, a clone the CLI refuses to fast-forward).
+# The clone as it stands is still what the installs serve, so the verdict
+# stays truthful about serving; what the block may not do is claim currency
+# or swallow the failure.
+CASE_CLONE=behind CASE_UPDATE_FAILS=1 \
+  run_case github_update_fails "$BOTH_USER" "$BOTH_USER" "$REG_BOTH_FIRST" NONE
+expect "a failed marketplace pull is surfaced, not swallowed" \
+  "could not bring the melodic-software marketplace clone current (\`plugin marketplace update\` failed); verifying against the clone as it stands"
+expect "and the verdict is still measured against the clone as it stands" \
+  "plugins 2 declared, 0 newly installed, 0 refreshed, 0 failed"
+
+CASE_CLONE=behind CASE_SOURCE_SHAPE=object \
+  run_case github_nested_source "$BOTH_USER" "$BOTH_USER" "$REG_BOTH_FIRST" NONE
+expect "a nested source object still yields a one-line warning naming the repo" \
+  "is registered from melodic-software/claude-code-plugins at"
+expect "and the verdict is unchanged" \
+  "plugins 2 declared, 0 newly installed, 0 refreshed, 0 failed"
 
 CASE_CLONE=ahead \
   run_case github_clone_ahead "$BOTH_USER" "$BOTH_USER" "$REG_BOTH_HEAD" "$REG_ALPHA_CLONE"

--- a/.claude/hooks/cloud-bootstrap-plugins.test.sh
+++ b/.claude/hooks/cloud-bootstrap-plugins.test.sh
@@ -226,7 +226,33 @@ run_case() {
   git_test_config "$fx" commit -qm two
   head="$(git_test_config "$fx" rev-parse HEAD)"
 
-  local subst="s/@HEAD@/$head/g; s/@FIRST@/$first/g"
+  # The marketplace the stub reports. Absent by default (the pre-existing
+  # shape: a name and nothing else, so the checkout stays the reference).
+  # CASE_CLONE builds a clone of the fixture and reports it as a GitHub-sourced
+  # marketplace's install location: `behind` leaves the clone at the first
+  # commit (a branch that changed a plugin, main untouched), `ahead` adds a
+  # third commit to the clone that changes plugins/alpha again (main moved),
+  # `self` reports the checkout itself (the directory-source shape).
+  local clone_head=""
+  if [[ -n "${CASE_CLONE:-}" ]]; then
+    local location="$fx"
+    if [[ "$CASE_CLONE" != self ]]; then
+      location="$TMP/$name-clone"
+      git_test_config "$fx" clone -q "$fx" "$location"
+      if [[ "$CASE_CLONE" == behind ]]; then
+        git_test_config "$location" reset -q --hard "$first"
+      else
+        printf 'a3\n' >>"$location/plugins/alpha/f.txt"
+        git_test_config "$location" add -A
+        git_test_config "$location" commit -qm three
+      fi
+      clone_head="$(git_test_config "$location" rev-parse HEAD)"
+    fi
+    printf '[{"name":"melodic-software","source":"github","installLocation":"%s"}]\n' "$location" \
+      >"$fx/marketplace-entry.json"
+  fi
+
+  local subst="s/@HEAD@/$head/g; s/@FIRST@/$first/g; s/@CLONE@/$clone_head/g"
   if [[ "$registry" != "MISSING" ]]; then
     printf '%s\n' "$registry" | sed "$subst" >"$fx/cfg/plugins/installed_plugins.json"
   fi
@@ -244,7 +270,14 @@ run_case() {
 #!/usr/bin/env bash
 fx="$(cd -- "$(dirname -- "$0")/../.." && pwd)"
 case "$*" in
-*"marketplace list"*) printf '[{"name":"melodic-software"}]\n' ;;
+*"marketplace list"*)
+  if [[ -f "$fx/marketplace-entry.json" ]]; then
+    cat "$fx/marketplace-entry.json"
+  else
+    printf '[{"name":"melodic-software"}]\n'
+  fi
+  ;;
+*"marketplace update"*) printf '%s\n' "$*" >>"$fx/calls.log" ;;
 *"plugin list --json"*)
   if [[ -f "$fx/.listed" ]]; then
     cat "$fx/list-after.json"
@@ -268,6 +301,11 @@ STUB
   OUT="$(env "${fleet_env[@]}" CLAUDE_CONFIG_DIR="$fx/cfg" bash "$BLOCK" "$fx" 2>&1)"
   RC=$?
   set -e
+  # The stub's mutation log rides along so a case can assert which CLI
+  # mutations the block asked for, not only what it printed.
+  if [[ -f "$fx/calls.log" ]]; then
+    OUT+=$'\n'"calls: $(tr '\n' ';' <"$fx/calls.log")"
+  fi
 
   if [[ "$RC" -eq 0 ]]; then
     ok "$name: the block exits 0, so the rest of the bootstrap still runs"
@@ -460,6 +498,47 @@ CASE_SETTINGS='{"enabledPlugins":{"alpha@melodic-software":true}}' \
   run_case fleet_array "$BOTH_USER" "$BOTH_USER" "$REG_BOTH_HEAD" NONE
 expect "a fleet list that is a bare array degrades to the settings block" \
   "plugins 1 declared, 0 newly installed, 0 refreshed, 0 failed"
+
+# --- the marketplace a snapshot pre-registers is not this checkout -----------
+# A cloud snapshot arrives with a marketplace of this name registered from
+# GitHub, so the checkout is never registered and every install resolves
+# against that clone, which records ITS commit as gitCommitSha. The reference
+# for the refresh decision and the verification is therefore the clone, not
+# the checkout, and the block says so once. Three shapes: the clone behind the
+# checkout (a branch that changed a plugin, main untouched), the clone ahead of
+# it (main moved while the checkout stayed), and a location that IS the
+# checkout (the directory-source shape, whose behaviour must not change).
+
+REG_ALPHA_CLONE='{"plugins":{
+  "alpha@melodic-software":[{"scope":"user","gitCommitSha":"@CLONE@"}],
+  "beta@melodic-software":[{"scope":"user","gitCommitSha":"@HEAD@"}]}}'
+
+CASE_CLONE=behind \
+  run_case github_branch_ahead "$BOTH_USER" "$BOTH_USER" "$REG_BOTH_FIRST" NONE
+expect "a branch ahead of the marketplace clone is healthy against the clone, not stale against itself" \
+  "plugins 2 declared, 0 newly installed, 0 refreshed, 0 failed"
+expect "and the block names the clone the session actually serves" \
+  "is registered from github at"
+expect "and brings the clone current first" \
+  "calls: plugin marketplace update melodic-software"
+refute "and no plugin is called stale" \
+  "failed verification"
+
+CASE_CLONE=ahead \
+  run_case github_clone_ahead "$BOTH_USER" "$BOTH_USER" "$REG_BOTH_HEAD" "$REG_ALPHA_CLONE"
+expect "a reinstall from a clone ahead of the checkout counts as refreshed, not failed" \
+  "plugins 2 declared, 0 newly installed, 1 refreshed, 0 failed"
+refute "and a plugin whose directory the clone did not change is not refreshed" \
+  "beta@melodic-software failed verification"
+
+CASE_CLONE=self \
+  run_case directory_source "$BOTH_USER" "$BOTH_USER" "$REG_BOTH_HEAD" NONE
+expect "a marketplace whose location is the checkout keeps the checkout as the reference" \
+  "plugins 2 declared, 0 newly installed, 0 refreshed, 0 failed"
+refute "with no warning about a foreign clone" \
+  "is registered from"
+refute "and no marketplace update" \
+  "marketplace update"
 
 # --- report -------------------------------------------------------------------
 echo

--- a/docs/CLOUD-SESSIONS.md
+++ b/docs/CLOUD-SESSIONS.md
@@ -214,7 +214,14 @@ catalog on, and the cloud bootstrap installs from the two together (see
 
 - `extraKnownMarketplaces` declares this repo as its own marketplace via a `directory` source
   with a relative path, so a session exercises the plugin code on the current branch rather than
-  published `main`. Local collaborators are prompted once they trust the folder.
+  published `main`. Local collaborators are prompted once they trust the folder. A cloud
+  snapshot can already carry a marketplace of the same name registered from GitHub and tracking
+  `main`; the bootstrap then never registers the checkout, every install resolves against that
+  clone, and the session runs `main`'s plugin code. The bootstrap detects this from
+  `plugin marketplace list --json`, brings the clone current, measures the refresh decision and
+  the health verdict against the clone's HEAD rather than the checkout's, and prints one
+  warning naming both commits, so a branch that changed a plugin knows its copy is not the one
+  being served.
 - **`skillListingBudgetFraction` is set to `0.05`, and what that buys depends entirely on the
   live model's context window.** Claude Code loads every enabled skill's name and description
   each turn and caps the total at


### PR DESCRIPTION
Closes #4026

## Summary

Cloud sessions on this repo scored healthy plugin refreshes as failures on every resume (`0 refreshed, 1 failed: claude-ops` on a branch that changed one plugin; `0 refreshed, 11 failed` on `main` after `origin/main` moved) and burned an uninstall/install cycle each time. The snapshot pre-registers a marketplace named `melodic-software` from GitHub tracking `main`, so the bootstrap never registers the checkout, every install resolves against that clone, and the recorded `gitCommitSha` is the clone's commit. Comparing it against the checkout's HEAD fails whenever the two diverge.

## Fix

- `.claude/cloud-bootstrap.sh`: read the registered marketplace's `installLocation` from `plugin marketplace list --json`. When it is a git repository other than this checkout, run `plugin marketplace update` so the clone is current, take the clone as the reference for `needs_refresh` and `snapshot_problem` (HEAD, `cat-file`, per-plugin `diff`) and for the default-disabled catalog, and print one warning naming the marketplace source, the clone's commit, and the checkout's branch and commit. A location that is the checkout, absent, or not a git repository keeps the previous behaviour.
- A pull that fails (no network, a clone the CLI refuses to fast-forward) is reported with its own warning and the verdict is measured against the clone as it stands, which is still what the installs serve; currency is never claimed. The warning renders `source` on one line whether the CLI reports it as a string (the observed shape on claude 2.1.263) or as the nested object `known_marketplaces.json` carries.
- `.claude/hooks/cloud-bootstrap-plugins.test.sh`: the stub reports a GitHub-sourced marketplace when a case asks for one, logs `marketplace update` calls into the case output, and can stage a failed pull or a nested `source` object. Five cases cover the clone behind the checkout (healthy, not refreshed again, warning printed, update requested), a failed pull (surfaced, verdict unchanged), a nested source (one-line warning naming the repo), the clone ahead of the checkout (a reinstall counts as refreshed), and a directory-source location (unchanged, no warning, no update).
- `docs/CLOUD-SESSIONS.md`: the plugins paragraph states what happens when the snapshot's marketplace wins.

Out of scope, as the issue records: making the session serve the branch's plugin code. That needs the CLI-owned clone re-pointed at the checkout or `claude --plugin-dir`, and is a separate decision.

## Verification

- `bash .claude/hooks/cloud-bootstrap-plugins.test.sh`: 74 of 74 against this branch. Against the pre-fix script (`CLOUD_BOOTSTRAP_SCRIPT` pointed at `origin/main`'s copy) the new marketplace-shape assertions fail and the directory-source case passes, so the discriminator is the marketplace shape and nothing else.
- `scripts/affected-tests.sh --run --explain`: five selected suites pass (the bootstrap contract, `affected-tests`, `check-plugin-catalog-enablement`, and the two the docs map to).
- `shellcheck` clean on the bootstrap and its suite; `markdownlint-cli2` 0 issues on `docs/CLOUD-SESSIONS.md`.
- Not exercised live: a cloud resume on this branch. The bootstrap runs from the snapshot's cached copy of `main`, so the fix takes effect for sessions started after it merges.

## Related

Observed during #3977; the refresh accounting was last changed in #3487 and #3972. The `main`-side symptom (`11 failed`) was recorded on this session's resume at 22:20 UTC on 2026-09-09. Review findings from Codex and the Claude review lane are addressed on the second and third commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KkYQhYA2meJ1gcc9ZgzVQE