### PR TITLE
fix(skill-quality,playbooks): correct the reserved-word basis and severity, record the load probes, anchor every record

### DIFF
--- a/plugins/playbooks/.claude-plugin/plugin.json
+++ b/plugins/playbooks/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "playbooks",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Doctrine and knowledge playbooks as on-demand skills, plus a maintainer-facing update skill. boris — Boris Cherny's Claude Code workflow tips (howborisusesclaudecode.com); skill-authoring — Anthropic's internal skill-authoring playbook; fable-5 — Claude Fable 5's operating doctrine (self-authored, no upstream). The boris and skill-authoring packs vendor a verbatim upstream baseline; /playbooks:update drift-checks and syncs those baselines centrally (maintainers).",
   "author": {
     "name": "Melodic Software",

--- a/plugins/playbooks/CHANGELOG.md
+++ b/plugins/playbooks/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to the `playbooks` plugin are recorded here. The `version` i
 `.claude-plugin/plugin.json` is the delivery vehicle — a consumer receives a change
 only after that version increases.
 
+## [0.10.1]
+
+### Fixed
+
+- **`skill-authoring`**: `reference/authoring-guidance.md` corrections after an independent audit
+  of its claims against the official pages. The 1,024-character description cap is stated as the
+  Agent Skills specification's, enforced by its `skills-ref` validator and stated as a Skills API
+  upload requirement (the earlier "enforced on upload paths (claude.ai, the Skills API)" named a
+  surface no source documents); the dependency paragraph carries the platform overview's second
+  Claude Code bullet (installs stay local to the project, never global) and scopes its example
+  accordingly; the network sentence separates the Claude API sandbox (no network, no runtime
+  installs, pre-installed list only) from claude.ai (varies with admin settings) instead of one
+  "platform sandbox"; the `/skill-doctor` mention is presence-gated with its version floor stated
+  as "v2.1.252 or later" and its feature-flag and terminal conditions, per the native-references
+  convention; the 500-line rule's "advisory on every surface" now rests on a recorded
+  `--plugin-dir` load probe (Claude Code 2.1.263, 2026-09-11, a 608-line SKILL.md loaded and
+  invoked) as well as the docs; and every Record line cites its basis by anchored URL rather than a
+  quoted section name, with the spoke's intro tightened to match the upstream-drift record form.
+  `evals/evals.json` case 3 follows the cap wording.
+- **`skill-authoring`**: `reference/authoring-checklist.md` gains the presence-gated skill-creator
+  row in its Testing group (attestation), which the guidance spoke carried but the checklist did not.
+
 ## [0.10.0]
 
 ### Added

--- a/plugins/playbooks/skills/skill-authoring/evals/evals.json
+++ b/plugins/playbooks/skills/skill-authoring/evals/evals.json
@@ -29,7 +29,7 @@
       "id": 3,
       "name": "description-caps-and-their-sources",
       "prompt": "What length limits apply to a skill description and where does the 1,024 number come from?",
-      "expected_output": "Names both caps with their sources: 1,024 characters is the Agent Skills specification's validation limit on the description field, enforced on upload paths and not by Claude Code; 1,536 characters is Claude Code's skill-listing truncation of description plus when_to_use (skillListingMaxDescChars), under a listing budget of 1% of the context window that shortens least-invoked skills first. States that when_to_use extends the one description in the listing and that the key use case goes first because truncation is tail-first. Serves reference/authoring-guidance.md rather than restating the page as an instruction.",
+      "expected_output": "Names both caps with their sources: 1,024 characters is the Agent Skills specification's validation limit on the description field, enforced by the spec's skills-ref validator and stated as a Skills API upload requirement, not by Claude Code; 1,536 characters is Claude Code's skill-listing truncation of description plus when_to_use (skillListingMaxDescChars), under a listing budget of 1% of the context window that shortens least-invoked skills first. States that when_to_use extends the one description in the listing and that the key use case goes first because truncation is tail-first. Serves reference/authoring-guidance.md rather than restating the page as an instruction.",
       "files": [],
       "expectations": [
         "Output names 1,024 as the Agent Skills specification validation cap on the description field alone and says Claude Code does not validate it",

--- a/plugins/playbooks/skills/skill-authoring/reference/authoring-checklist.md
+++ b/plugins/playbooks/skills/skill-authoring/reference/authoring-checklist.md
@@ -60,6 +60,7 @@ have checked a judgment row is misreporting.
 | `evals/evals.json` is present | mechanical (check 14) |
 | `evals/evals.json` validates against the schema and passes the eval-quality lint | mechanical (`/skill-quality:check validate-evals <skill>`) |
 | Three or more eval cases | mechanical (advisory) |
+| Where the bundled skill-creator plugin is installed, its eval modes ran the cases with a subagent per case; otherwise the fresh-session loop below stands in | attestation |
 | Fresh-session baseline captured with the skill disabled, then enabled | attestation |
 | Tested on real tasks, not contrived scenarios | attestation |
 | Models exercised: which of `haiku`, `sonnet`, `opus`, `fable` | attestation |

--- a/plugins/playbooks/skills/skill-authoring/reference/authoring-guidance.md
+++ b/plugins/playbooks/skills/skill-authoring/reference/authoring-guidance.md
@@ -18,7 +18,7 @@ Locally-owned Melodic Software guidance (not part of the upstream playbook). Ant
 page is cross-product writing guidance; the Claude Code [Skills](https://code.claude.com/docs/en/skills)
 page owns the harness mechanics. Each section states what the page says, what Claude Code enforces
 or does differently, and the rule this marketplace applies, and ends in a **Record** line: basis
-URL with anchor or section, as-of date, recheck trigger. A stamped date is a ceiling on how current
+URL with anchor, as-of date, recheck trigger. A stamped date is a ceiling on how current
 a claim can be, never authority; re-fetch the basis before acting on a number. The page is quoted
 as guidance, not as an instruction to the reader.
 
@@ -35,7 +35,7 @@ Two caps apply at two layers:
 
 | Cap | Layer | Over the cap |
 |---|---|---|
-| 1,024 characters, `description` alone | Agent Skills specification validation, enforced on upload paths (claude.ai, the Skills API); Claude Code does not validate it | Fails validation outside Claude Code; `skill-quality:check` check 2b FAILs it here for portability |
+| 1,024 characters, `description` alone | Agent Skills specification validation, enforced by the spec's `skills-ref` validator and stated as a Skills API upload requirement; Claude Code does not validate it | Fails validation outside Claude Code; `skill-quality:check` check 2b FAILs it here for portability |
 | 1,536 characters, `description` plus `when_to_use` | Claude Code's skill listing (`skillListingMaxDescChars`) | The entry is cut at the cap; the skill still loads |
 
 Beneath both sits the listing budget: the listing scales at 1% of the context window
@@ -43,12 +43,15 @@ Beneath both sits the listing budget: the listing scales at 1% of the context wi
 least-invoked skills while keeping every name. A short, specific description survives that
 pressure; a long, vague one loses its trigger words first.
 
-**Record.** 1,024: <https://agentskills.io/specification> (the `description` field). 1,536 and the
-1% budget: <https://code.claude.com/docs/en/skills#skill-descriptions-are-cut-short> and the
-frontmatter reference on the same page (`description` and `when_to_use` rows), which is also where
-"key use case first" comes from. Third person: the page, "Writing effective descriptions". Verified
-2026-09-10. Recheck: either number changes on its owning page, or the Claude Code page begins
-stating a validation cap of its own.
+**Record.** 1,024: <https://agentskills.io/specification> (the `description` field) and
+<https://platform.claude.com/docs/en/build-with-claude/skills-guide#creating-a-skill> (the
+upload requirement). 1,536 and the 1% budget:
+<https://code.claude.com/docs/en/skills#skill-descriptions-are-cut-short> and
+<https://code.claude.com/docs/en/skills#frontmatter-reference> (`description` and `when_to_use`
+rows), which is also where "key use case first" comes from. Third person:
+<https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices#writing-effective-descriptions>.
+Verified 2026-09-10. Recheck: either number changes on its owning page, or the Claude Code page
+begins stating a validation cap of its own.
 
 ## Conciseness and the listing budget
 
@@ -61,9 +64,10 @@ explanation?", "Can I assume Claude knows this?", "Does this paragraph justify i
 bite hardest on the body, and the truncation rule above governs the description: conciseness there
 is what keeps the trigger inside the budget.
 
-**Record.** Public good and the challenge questions: the page, "Concise is key". Cost shape:
-<https://code.claude.com/docs/en/skills>, "Skill content lifecycle" and "Skill descriptions are cut
-short". Verified 2026-09-10. Recheck: the lifecycle section stops saying the body persists across
+**Record.** Public good and the challenge questions:
+<https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices#concise-is-key>.
+Cost shape: <https://code.claude.com/docs/en/skills#skill-content-lifecycle> and
+<https://code.claude.com/docs/en/skills#skill-descriptions-are-cut-short>. Verified 2026-09-10. Recheck: the lifecycle section stops saying the body persists across
 turns, or the listing section changes its truncation rule.
 
 ## Degrees of freedom
@@ -87,14 +91,17 @@ cost of a skipped gate is high, a hook is the escalation: deterministic, indepen
 model read, and charged to the marketplace's hook budget (`.claude/rules/hook-budget.md`), which
 is why it is the exception rather than the default.
 
-**Record.** Levels: the page, "Set appropriate degrees of freedom". The exact-command
-`allowed-tools` pattern: <https://code.claude.com/docs/en/skills#frontmatter-reference>. Verified
+**Record.** Levels:
+<https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices#set-appropriate-degrees-of-freedom>.
+The exact-command `allowed-tools` pattern:
+<https://code.claude.com/docs/en/skills#frontmatter-reference>. Verified
 2026-09-10. Recheck: the page renames the levels, or the frontmatter reference drops the example.
 
 ## Progressive disclosure
 
 - **500 lines.** Advisory on every surface: the page says body, the Claude Code Tip says the whole
-  file, the Agent Skills specification recommends under 500 lines and under 5,000 tokens. This
+  file, the Agent Skills specification recommends under 500 lines and under 5,000 tokens, and a
+  `--plugin-dir` load probe on Claude Code 2.1.263 loaded and invoked a 608-line SKILL.md. This
   marketplace FAILs at 500 whole-file lines through `skill-quality:check` (check 4), the stricter
   reading, and WARNs above 200 (check 10). Split when approaching the cap, not at it.
 - **One level deep.** Every reference file links directly from SKILL.md. The basis is the Agent
@@ -110,11 +117,16 @@ is why it is the exception rather than the default.
 - **Pointer shape.** Each spoke pointer says what the file holds and when to read it. A bare "see
   X" link is the missed-connection signal the evaluation section watches for.
 
-**Record.** 500: the page, "Progressive disclosure patterns" and "Token budgets";
-<https://code.claude.com/docs/en/skills#add-supporting-files> (Tip); <https://agentskills.io/specification>.
-One level deep: <https://agentskills.io/specification>. TOC over 300: the skill-creator SKILL.md in
-<https://github.com/anthropics/skills>. 5,000 and 25,000: <https://code.claude.com/docs/en/skills>,
-"Skill content lifecycle". Verified 2026-09-10. Recheck: any number changes on its owning surface.
+**Record.** 500:
+<https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices#progressive-disclosure-patterns>
+and the same page at `#token-budgets`; <https://code.claude.com/docs/en/skills#add-supporting-files>
+(Tip); <https://agentskills.io/specification>; load probe run 2026-09-11 (`claude -p` with
+`--plugin-dir`, Claude Code 2.1.263). One level deep: <https://agentskills.io/specification>. TOC
+over 300: <https://github.com/anthropics/skills/blob/main/skills/skill-creator/SKILL.md>; over
+100: the best-practices page at `#structure-longer-reference-files-with-table-of-contents`.
+5,000 and 25,000: <https://code.claude.com/docs/en/skills#skill-content-lifecycle>. Verified
+2026-09-10. Recheck: any number changes on its owning surface, or a Claude Code release rejects a
+long file.
 
 ## Runtime model
 
@@ -133,18 +145,25 @@ it resolves at personal, project, and plugin scope, and state the intent with th
 backslash in a plugin component path is rejected at load on macOS and Linux, and
 `skill-quality:check` FAILs one in a skill-internal pointer (check 5).
 
-Dependencies: state the install command and check before use ("Install with `pip install pypdf`;
-the script exits 2 with an install hint when it is missing"), never "use the pdf library". Claude
-Code skills have full network access and install packages on the user's machine, so there is no
-pre-installed list to verify against; the platform sandbox has no network at all, which is why the
-page tells authors to list packages explicitly.
+Dependencies: state the install command and check before use ("Install into the project
+environment with `pip install pypdf` inside its virtualenv; the script exits 2 with an install hint
+when it is missing"), never "use the pdf library". Claude Code skills have full network access and
+install packages on the user's machine, so there is no pre-installed list to verify against, and the
+install must stay local to the project (a virtualenv, a project `node_modules`, a `--user` install),
+never global, so the skill does not alter the user's computer. The other surfaces differ: the Claude
+API sandbox has no network and no runtime installs, so a package must be on the code execution
+tool's pre-installed list, and claude.ai's network access varies with admin settings. That is why
+the page tells authors to list packages explicitly.
 
-**Record.** Inject-once lifecycle: <https://code.claude.com/docs/en/skills>, "Skill content
-lifecycle"; `${CLAUDE_SKILL_DIR}` and `allowed-tools`: same page, "Frontmatter reference".
-Backslash rejection: <https://code.claude.com/docs/en/plugins-reference>, "Path traversal
-limitations". Network and local installs: <https://platform.claude.com/docs/en/agents-and-tools/agent-skills/overview>
-(the Claude Code row of the runtime table). Verified 2026-09-10. Recheck: the lifecycle section
-changes the inject-once claim, or the overview's runtime table changes the Claude Code row.
+**Record.** Inject-once lifecycle: <https://code.claude.com/docs/en/skills#skill-content-lifecycle>;
+`${CLAUDE_SKILL_DIR}` and `allowed-tools`: <https://code.claude.com/docs/en/skills#frontmatter-reference>.
+Backslash rejection: <https://code.claude.com/docs/en/plugins-reference#path-traversal-limitations>.
+Network, local-not-global installs, and the per-surface table:
+<https://platform.claude.com/docs/en/agents-and-tools/agent-skills/overview#runtime-environment-constraints>
+(the Claude Code row, both bullets). Package listing:
+<https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices#package-dependencies>.
+Verified 2026-09-10 (overview table re-read 2026-09-11). Recheck: the lifecycle section changes
+the inject-once claim, or the overview's runtime table changes any row.
 
 ## MCP tool names
 
@@ -156,9 +175,11 @@ server the user or project configured (for example `mcp__github__get_me`), and
 colon form matches no Claude Code tool. `docs-hygiene:audit-progressive-disclosure` carries the
 same two forms as a pointer-quality criterion, where installed.
 
-**Record.** <https://code.claude.com/docs/en/mcp>, "Plugin-provided MCP servers";
-<https://code.claude.com/docs/en/permissions>, "MCP"; the page, "MCP tool references" (the
-`ServerName:tool_name` form). Verified 2026-09-10. Recheck: any of the three changes the name form.
+**Record.** <https://code.claude.com/docs/en/mcp#plugin-provided-mcp-servers>;
+<https://code.claude.com/docs/en/permissions#mcp>;
+<https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices#mcp-tool-references>
+(the `ServerName:tool_name` form). Verified 2026-09-10. Recheck: any of the three changes the name
+form.
 
 ## Output templates and examples
 
@@ -178,8 +199,10 @@ the model has to make mid-task. The page's "unless necessary" means environment-
 availability: a real menu is justified when the right choice depends on something discoverable
 only at run time, and the body then says what that something is.
 
-**Record.** The page, "Common patterns" and "Anti-patterns to avoid". Verified 2026-09-10.
-Recheck: the page changes either framing sentence or drops the escape-hatch example.
+**Record.**
+<https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices#common-patterns>
+and the same page at `#anti-patterns-to-avoid`. Verified 2026-09-10. Recheck: the page changes
+either framing sentence or drops the escape-hatch example.
 
 ## Time-sensitive content
 
@@ -192,8 +215,9 @@ collapsed block is still tokens on every turn after invocation, while a separate
 free until read, so history that must travel with the skill goes in a spoke. The owning rule is
 `.claude/rules/skill-bodies-state-current-rules.md`.
 
-**Record.** The page, "Content guidelines" (the "Old patterns" example). Verified 2026-09-10.
-Recheck: the page drops or changes that section.
+**Record.**
+<https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices#avoid-time-sensitive-information>
+(the "Old patterns" example). Verified 2026-09-10. Recheck: the page drops or changes that section.
 
 ## Evaluation and iteration
 
@@ -217,20 +241,25 @@ loaded, carry specific observed failures (not impressions) back to the authoring
 the test transcript for four navigation signals: files read in an unexpected order, a reference
 never followed, one file read repeatedly (promote it into the body), a bundled file never read (cut
 it or signal it better). Where the bundled skill-creator plugin is installed, its eval modes run
-this loop with a subagent per case. `/skill-doctor` (documented at v2.1.252) answers "does it
-activate" from usage data, not "is the output right". A `claude plugin eval` subcommand exists in
-the binary but is undocumented, so nothing here depends on it.
+this loop with a subagent per case. Where `/skill-doctor` is available (Claude Code v2.1.252 or
+later, in a session that fetches feature flags, run in the terminal rather than over Remote
+Control), it answers "does it activate" from usage data, not "is the output right". A
+`claude plugin eval` subcommand exists in the binary but is undocumented, so nothing here depends
+on it.
 
 When a rule is being missed, two fixes are on the table: directive wording ("MUST filter test
 accounts") and reasoning-based wording ("filter test accounts because they inflate every metric").
 The page offers the first; the runner's linked guidance prefers the second. The evals settle it.
 
-**Record.** Fresh-session baseline, skill-creator modes, `/skill-doctor`:
-<https://code.claude.com/docs/en/skills>, "Evaluate and iterate on a skill" and "Find unused
-skills". Eval file shape: <https://agentskills.io/skill-creation/evaluating-skills> and
-`plugins/skill-quality/reference/evals.schema.json`. The loop and the four signals: the page,
-"Evaluation and iteration". Verified 2026-09-10. Recheck: the Claude Code page documents
-`claude plugin eval`, or the runner changes its record shape.
+**Record.** Fresh-session baseline and skill-creator modes:
+<https://code.claude.com/docs/en/skills#evaluate-and-iterate-on-a-skill>; `/skill-doctor`, its
+version floor and feature-flag gate: <https://code.claude.com/docs/en/skills#find-unused-skills>
+(the CHANGELOG lists the command under 2.1.261, so treat the docs' 2.1.252 as "or later"). Eval
+file shape: <https://agentskills.io/skill-creation/evaluating-skills> and
+`plugins/skill-quality/reference/evals.schema.json`. The loop and the four signals:
+<https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices#evaluation-and-iteration>.
+Verified 2026-09-10. Recheck: the Claude Code page documents `claude plugin eval`, changes the
+`/skill-doctor` gate, or the runner changes its record shape.
 
 ## Model coverage
 
@@ -241,6 +270,7 @@ harness aliases (`haiku`, `sonnet`, `opus`, `fable`) the skill was exercised on.
 under a `model` override or inside a subagent has more than one target, and the attestation names
 them all or says which are untested.
 
-**Record.** Alias list: <https://code.claude.com/docs/en/sub-agents>, "Choose a model". The
-per-tier questions: the page, "Test with all models you plan to use". Verified 2026-09-10. Recheck:
-the alias list changes.
+**Record.** Alias list: <https://code.claude.com/docs/en/sub-agents#choose-a-model>. The per-tier
+questions:
+<https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices#test-with-all-models-you-plan-to-use>.
+Verified 2026-09-10. Recheck: the alias list changes.

--- a/plugins/playbooks/skills/skill-authoring/reference/authoring-guidance.md
+++ b/plugins/playbooks/skills/skill-authoring/reference/authoring-guidance.md
@@ -149,8 +149,9 @@ Dependencies: state the install command and check before use ("Install into the 
 environment with `pip install pypdf` inside its virtualenv; the script exits 2 with an install hint
 when it is missing"), never "use the pdf library". Claude Code skills have full network access and
 install packages on the user's machine, so there is no pre-installed list to verify against, and the
-install must stay local to the project (a virtualenv, a project `node_modules`, a `--user` install),
-never global, so the skill does not alter the user's computer. The other surfaces differ: the Claude
+install must stay local to the project (a project virtualenv, a project `node_modules`, an
+explicitly project-scoped target directory), never global and never the shared user site (a
+`pip install --user` persists across projects), so the skill does not alter the user's computer. The other surfaces differ: the Claude
 API sandbox has no network and no runtime installs, so a package must be on the code execution
 tool's pre-installed list, and claude.ai's network access varies with admin settings. That is why
 the page tells authors to list packages explicitly.

--- a/plugins/skill-quality/.claude-plugin/plugin.json
+++ b/plugins/skill-quality/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "skill-quality",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "description": "Skill-authoring QA tooling: a static contract checker that runs twenty-six deterministic checks over a Claude Code skill (frontmatter, explicit invocation mode, description/verb-contract polarity, per-skill listing-entry cap, trigger-keyword preservation, line caps, broken internal refs, markdownlint, gotchas surface, evals presence, precompute opportunity, completion-criteria signal, injection shell-declaration, fresh-eyes declaration conformance), a shared skill-listing budget reporter across a set of skills, and a bundled evals.json schema plus a deterministic eval-quality lint (duplicate case identities, missing fixtures, empty or vague grading criteria, set-coverage warnings). Runs against any repo's skills directory via the convention-resolution ladder \u2014 no baked layout.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/skill-quality/CHANGELOG.md
+++ b/plugins/skill-quality/CHANGELOG.md
@@ -3,6 +3,35 @@
 All notable changes to the `skill-quality` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.22.1]
+
+### Changed
+
+- **`check`: check 1's reserved-word limb is a WARN, with its basis corrected.** The 0.22.0 entry
+  attributed both name limbs to the Agent Skills specification and its `skills-ref` validator.
+  Only the 64-codepoint cap is the spec's; the reserved words `anthropic` and `claude` are a
+  Skills API upload requirement
+  (<https://platform.claude.com/docs/en/build-with-claude/skills-guide#creating-a-skill>, repeated
+  under "Limits and constraints", and the overview's `name` rules at
+  <https://platform.claude.com/docs/en/agents-and-tools/agent-skills/overview#skill-structure>),
+  which the best-practices page restates and `skills-ref` never checks. Claude Code loads such a
+  name and ships bundled skills named `claude-api` and `claude-in-chrome`, so a hard FAIL on it in
+  a checker whose consumers mostly never upload was over-broad: the limb now WARNs, naming the
+  upload surface that rejects the name, while the 64 limb stays a FAIL. The script comment, the
+  README, and the error text now name the correct source for each limb. Recheck trigger: the
+  spec's validator gaining a word list, the upload requirements changing, or a Claude Code release
+  rejecting either form.
+
+### Fixed
+
+- **`check`: "Claude Code loads it" is now measured, not assumed.** The check 1 and check 4 comment
+  blocks record a `--plugin-dir` load probe on Claude Code 2.1.263 (2026-09-11, `claude -p`): an
+  88-codepoint skill name containing `claude` and a 608-line SKILL.md both loaded and were invoked.
+  `claude plugin validate` exiting 0 had established only what validate inspects.
+- **`check`: check 4 and check 26 comments cite anchored URLs.** The best-practices page sections
+  are linked by anchor, the Claude Code Tip by its section anchor, and the skill-creator threshold
+  by its SKILL.md in the anthropics/skills repository, per the upstream-drift record form.
+
 ## [0.22.0]
 
 ### Added

--- a/plugins/skill-quality/README.md
+++ b/plugins/skill-quality/README.md
@@ -22,10 +22,13 @@ the reviewer to confirm the description still names that intent, or to restore t
 
 - Frontmatter parses; `description` present; a declared `name` is kebab-case and matches the skill
   directory (in a plugin skill it also WARNs as redundant, because the field defaults to the directory).
-  The effective name (the declared field, else the directory leaf) is at most 64 codepoints and
-  carries neither `anthropic` nor `claude` (FAIL). Both limits are the Agent Skills spec's and the
-  platform guidance's (<https://agentskills.io/specification>; verified 2026-09-10); Claude Code
-  itself enforces neither, so they are portability findings.
+  The effective name (the declared field, else the directory leaf) is at most 64 codepoints
+  (FAIL; the Agent Skills spec's `name` cap, <https://agentskills.io/specification>, enforced by
+  its `skills-ref` validator) and carries neither `anthropic` nor `claude` (WARN; a Skills API
+  upload requirement, <https://platform.claude.com/docs/en/build-with-claude/skills-guide#creating-a-skill>,
+  not a spec rule). Claude Code enforces neither and ships bundled skills named `claude-api` and
+  `claude-in-chrome`, so both are portability findings (verified 2026-09-10; recheck when the
+  spec's validator, the upload requirements, or a Claude Code release changes either rule).
 - `description` + `when_to_use` within the 1536-char **per-skill** listing-entry cap (overflow
   truncates that entry). A different, narrower limit from the shared budget below. The cap and the
   1% budget default are upstream's

--- a/plugins/skill-quality/scripts/check-skill.sh
+++ b/plugins/skill-quality/scripts/check-skill.sh
@@ -45,9 +45,10 @@
 # Checks:
 #   1. Frontmatter parses; description present; a declared name matches the dir
 #      (and, in a plugin skill, WARNs as redundant); the effective name (the
-#      declared field, else the directory) is at most 64 codepoints and carries
-#      neither "anthropic" nor "claude" (FAIL; Agent Skills spec portability,
-#      Claude Code itself enforces neither)
+#      declared field, else the directory) is at most 64 codepoints (FAIL;
+#      Agent Skills spec portability) and carries neither "anthropic" nor
+#      "claude" (WARN; Skills API upload portability). Claude Code itself
+#      enforces neither.
 #   2. description + when_to_use <= 1536 chars (per-skill listing-entry cap;
 #      counts the literal " - " joiner the harness inserts when when_to_use is
 #      populated)
@@ -270,16 +271,23 @@ DESC_FIELD_WARN_MARGIN=32
 DESC_FIELD_BASELINE="${CHECK_SKILL_DESC_FIELD_BASELINE:-}"
 # Agent Skills spec maximum for `name`: 64 characters, lowercase alphanumerics
 # and hyphens, matching the directory (https://agentskills.io/specification,
-# the "name" field). The platform best-practices page adds two reserved words,
-# "anthropic" and "claude"
-# (https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices#skill-structure).
-# Claude Code validates neither rule: measured 2026-09-10, `claude plugin
-# validate` (Claude Code 2.1.263) passes an over-long name containing "claude"
-# clean. Check 1's limbs on these are therefore PORTABILITY findings (a skill
-# that loads here and fails the spec's `skills-ref` validator on another
-# surface), not harness conformance. Both verified 2026-09-10. Recheck trigger:
-# the spec's validator or the page changing either rule re-derives this
-# constant and the word list.
+# the "name" field), enforced by the spec's `skills-ref` validator. The two
+# reserved words, "anthropic" and "claude", are NOT in the spec: they are a
+# Skills API upload requirement
+# (https://platform.claude.com/docs/en/build-with-claude/skills-guide#creating-a-skill,
+# repeated at #limits-and-constraints, and the overview's `name` rules at
+# https://platform.claude.com/docs/en/agents-and-tools/agent-skills/overview#skill-structure),
+# which the platform best-practices page restates. Claude Code enforces neither
+# rule, measured on Claude Code 2.1.263: `claude plugin validate` passes an
+# 88-codepoint name containing "claude" (2026-09-10), and a `--plugin-dir`
+# load probe (`claude -p`, 2026-09-11) loaded and invoked that same skill and a
+# 608-line SKILL.md; Claude Code also ships bundled skills named `claude-api`
+# and `claude-in-chrome`. So the 64 limb is a PORTABILITY FAIL (loads here,
+# fails the spec's validator elsewhere) and the reserved-word limb is a WARN
+# (loads here and everywhere except a Skills API upload). Recheck trigger: the
+# spec's validator gaining a word list, the upload requirements changing, or a
+# Claude Code release rejecting either form re-derives this constant, the word
+# list, and the severities.
 NAME_MAX_LEN=64
 NAME_RESERVED_WORDS='anthropic claude'
 LINE_HARD_CAP=500
@@ -287,9 +295,11 @@ LINE_SOFT_CAP=200
 SYNCED_MAX_AGE_DAYS=180
 # Check 26: a spoke file this long gets a table of contents. Two upstream
 # statements of the threshold: the bundled skill-creator says a TOC for
-# reference files over 300 lines; the platform best-practices page says over 100
-# (https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices,
-# the progressive-disclosure guidance). This check WARNs at the looser 300; the
+# reference files over 300 lines
+# (https://github.com/anthropics/skills/blob/main/skills/skill-creator/SKILL.md);
+# the platform best-practices page says over 100
+# (https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices#structure-longer-reference-files-with-table-of-contents).
+# This check WARNs at the looser 300; the
 # 100-to-300 band is judgment `docs-hygiene:audit-progressive-disclosure` owns
 # (its missing-toc finding). Both verified 2026-09-10. Recheck trigger: either
 # source moving its threshold re-derives this constant. The TOC heuristic below
@@ -440,7 +450,7 @@ else
   fi
   for reserved_word in $NAME_RESERVED_WORDS; do
     if [[ "$EFFECTIVE_NAME" == *"$reserved_word"* ]]; then
-      err "skill name '$EFFECTIVE_NAME' contains the reserved word '$reserved_word' (the platform Agent Skills guidance reserves 'anthropic' and 'claude'; Claude Code does not enforce it, so this is a portability finding); rename the $name_source"
+      warn "skill name '$EFFECTIVE_NAME' contains the word '$reserved_word', which a Skills API upload rejects ('anthropic' and 'claude' are reserved there; Claude Code loads it and ships bundled skills carrying the word); rename the $name_source if the skill will ever be uploaded"
     fi
   done
 fi
@@ -629,12 +639,15 @@ fi
 # Counted over the WHOLE file, frontmatter included (`grep -c ''`). The two
 # upstream statements of the 500 differ in scope: the platform best-practices
 # page applies it to the SKILL.md body
-# (https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices,
-# the progressive-disclosure guidance); the Claude Code skills page's Tip
-# applies it to the file (https://code.claude.com/docs/en/skills, "Keep SKILL.md
+# (https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices#progressive-disclosure-patterns);
+# the Claude Code skills page's Tip applies it to the file
+# (https://code.claude.com/docs/en/skills#add-supporting-files, "Keep SKILL.md
 # under 500 lines"). Whole-file is the stricter reading, so a skill that passes
-# here satisfies both, and it stays. Both verified 2026-09-10. Recheck trigger:
-# either page moving the number or its scope re-derives LINE_HARD_CAP.
+# here satisfies both, and it stays. Both verified 2026-09-10. Neither surface
+# enforces the number: a `--plugin-dir` load probe on Claude Code 2.1.263
+# (2026-09-11) loaded and invoked a 608-line SKILL.md. Recheck trigger: either
+# page moving the number or its scope, or a Claude Code release rejecting a
+# long file, re-derives LINE_HARD_CAP.
 
 LINE_COUNT="$(grep -c '' "$SKILL_MD")"
 if ((LINE_COUNT >= LINE_HARD_CAP)); then

--- a/plugins/skill-quality/scripts/check-skill.test.sh
+++ b/plugins/skill-quality/scripts/check-skill.test.sh
@@ -679,8 +679,9 @@ else
   fail "a 64-codepoint name should pass the length cap (rc=$rc): $out"
 fi
 
-# 17c. A reserved word anywhere in the effective name FAILs. Directory-leaf form:
-#      no declared name, the leaf carries "claude".
+# 17c. A reserved word anywhere in the effective name WARNs (a Skills API upload
+#      rejects it; Claude Code loads it). Directory-leaf form: no declared name,
+#      the leaf carries "claude".
 make_skill claude-helper '---
 description: "Reserved word in the leaf. Use when: '"'"'checking reserved names'"'"'."
 ---
@@ -695,10 +696,10 @@ None known.
 '
 out="$(run claude-helper 2>&1)"
 rc=$?
-if [[ $rc -eq 1 ]] && grep -q "contains the reserved word 'claude'" <<<"$out"; then
-  pass "a directory leaf containing 'claude' fails the reserved-word rule"
+if [[ $rc -eq 0 ]] && grep -q "WARN: skill name 'claude-helper' contains the word 'claude'" <<<"$out"; then
+  pass "a directory leaf containing 'claude' warns on the reserved-word rule and passes"
 else
-  fail "a leaf containing 'claude' should fail (rc=$rc): $out"
+  fail "a leaf containing 'claude' should warn and pass (rc=$rc): $out"
 fi
 
 # 17d. Declared-name form of 17c: the same rule reads the declared field when
@@ -718,12 +719,12 @@ None known.
 '
 out="$(run anthropic-notes 2>&1)"
 rc=$?
-if [[ $rc -eq 1 ]] &&
-  grep -q "contains the reserved word 'anthropic'" <<<"$out" &&
+if [[ $rc -eq 0 ]] &&
+  grep -q "WARN: skill name 'anthropic-notes' contains the word 'anthropic'" <<<"$out" &&
   grep -q 'rename the declared name' <<<"$out"; then
-  pass "a declared name containing 'anthropic' fails and names the declared field"
+  pass "a declared name containing 'anthropic' warns, passes, and names the declared field"
 else
-  fail "a declared name containing 'anthropic' should fail (rc=$rc): $out"
+  fail "a declared name containing 'anthropic' should warn and pass (rc=$rc): $out"
 fi
 
 # 18a. A fenced shell block of read-only context-gathering commands, with no `!`


### PR DESCRIPTION
No related issue: follow-up corrections to #4069 after an independent audit of its accepted decisions; no issue tracks them.

## Summary

Two fresh-context validators audited every decision behind #4069 against the official pages with the original rationale withheld. Nine rows were challenged, all on evidence that checks out against the platform Skills guide, the Agent Skills specification, the Claude Code skills page, and two load probes. This PR applies the resulting corrections. Nothing here adds a rule; it corrects where existing rules say they come from, downgrades one over-broad FAIL, and replaces an assumed harness claim with a measured one.

## Fix

- **skill-quality 0.22.1**
  - Check 1's reserved-word limb (`anthropic`, `claude`) is a Skills API upload requirement ([skills guide, "Creating a Skill"](https://platform.claude.com/docs/en/build-with-claude/skills-guide#creating-a-skill), repeated under "Limits and constraints"; [overview, "Skill structure"](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/overview#skill-structure)), not an Agent Skills spec rule: the spec's `skills-ref` validator has no word list. Claude Code loads such names and ships bundled skills named `claude-api` and `claude-in-chrome`. The limb is now a WARN naming the upload surface; the 64-codepoint cap stays a FAIL on the spec basis. The script comment, error text, README, and CHANGELOG name the correct source per limb (the 0.22.0 entry had attributed both to the spec).
  - "Claude Code loads it" in the check 1 and check 4 comments now rests on a recorded `--plugin-dir` load probe on Claude Code 2.1.263 (an 88-codepoint name containing `claude` and a 608-line SKILL.md both loaded and were invoked through `claude -p`), instead of on `claude plugin validate` exiting 0, which proves only what validate inspects.
  - Check 4 and check 26 comments cite anchored URLs and the skill-creator SKILL.md in anthropics/skills, per the upstream-drift record form.
  - Tests 17c and 17d expect the WARN and the exit 0.
- **playbooks 0.10.1** (`skill-authoring`)
  - The 1,024 description cap is stated as the spec's, enforced by `skills-ref` and stated as a Skills API upload requirement; the earlier "enforced on upload paths (claude.ai, the Skills API)" named claude.ai with no source. Eval case 3 follows.
  - The dependency paragraph carries the overview's second Claude Code bullet (installs stay local to the project, never global) and scopes its `pip install` example; the network sentence separates the Claude API sandbox (no network, no runtime installs) from claude.ai (varies with admin settings) instead of one "platform sandbox".
  - The `/skill-doctor` mention is presence-gated ("v2.1.252 or later, in a session that fetches feature flags, in the terminal") per the native-references convention; the Record notes the CHANGELOG lists it under 2.1.261.
  - The 500-line rule's "advisory on every surface" cites the load probe as well as the docs.
  - Every Record line cites an anchored URL instead of a quoted section name, and the spoke's intro says "anchor" rather than "anchor or section".
  - The pre-share checklist gains the presence-gated skill-creator row in its Testing group, which the decision placed there and the first change put only in the sibling spoke.

Review follow-up (`cf8b0171a`): Codex's one finding fixed. The project-local install examples no longer offer `pip install --user`, which writes to the shared user site; they name a project virtualenv, a project `node_modules`, or an explicitly project-scoped target, and say why the user site is excluded.

One audited row was reclassified to a human decision and is not changed here: whether third-person description voice applies to new skills only (current guidance), to the whole fleet through a voice sweep of 258 descriptions, or is recorded as a deliberate deviation like the gerund naming one.

## Verification

Run on Linux, branch head `995c9a2e2` (re-run on the one file `cf8b0171a` touches: `markdownlint-cli2` 0 issues, `typos` clean, no em dashes, `check-skill.sh --require-evals` PASS with the same 2 pre-existing WARNs):

- `bash plugins/skill-quality/scripts/check-skill.test.sh`: all assertions passed (17c and 17d updated: a leaf or declared name carrying a reserved word WARNs and exits 0).
- `shellcheck plugins/skill-quality/scripts/check-skill.sh`: clean.
- `check-skill.sh --require-evals` over `skill-quality/check` (PASS, 1 pre-existing WARN) and `playbooks/skill-authoring` (PASS, 2 pre-existing WARNs); `check-evals-quality.sh` PASS on the four cases.
- `markdownlint-cli2` over the five changed markdown files: 0 issues. `typos` over the diff: clean. `check-purged-em-dashes.sh`: no em dashes.
- `check-changelog-parity.sh --check`, `--check-bump origin/main`, `--check-order`: pass. `generate-catalog.mjs --check`: in sync (no description changed).
- Every new anchor was checked against the fetched page snapshots: the headings exist on the skills guide, the overview, the Claude Code skills, MCP, permissions, plugins-reference and sub-agents pages, and the best-practices page.
- `scripts/affected-tests.sh --run`: every selected suite passed except one, with 15 NOT RUN (Python and PowerShell suites the shell runner does not execute; CI's own lanes cover them). The one FAIL is `plugins/claude-ops/skills/plugins/scripts/cache-content-check.test.sh`, the process-budget trace probe that counts nothing in this container; it failed identically on #4069 and standalone, involves no file this PR touches, and is host-specific.
- CI on `995c9a2e2`: `ci-status` and every lane green on the draft run; Claude code-review and security-review lanes green with no findings after the ready flip.

## Related

- Follow-up to #4069; the audit verdicts and their resolution live in the untracked `.work/skill-authoring-best-practices/` memory tier of the authoring checkout (`AUDIT-ANSWERS-A.md`, `AUDIT-ANSWERS-B.md`, and the "Audit resolution" section of `INTERVIEW-ACCEPTED.md`).
- #4070 and #4071 remain the deferred follow-ups from #4069; nothing here changes their scope.
- `docs/conventions/upstream-drift/README.md` (record form) and `docs/conventions/native-references/README.md` (presence gate) are the conventions the corrections apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MSGD4WGhUXepHq3LTmpQML