### PR TITLE
chore(code-metrics): exclude lockfiles and changelogs from this repo's audits

### DIFF
--- a/.claude/code-metrics.yaml
+++ b/.claude/code-metrics.yaml
@@ -1,6 +1,17 @@
 # Team layer for the code-metrics plugin (reference: plugins/code-metrics/reference/config.md).
 # Every key is optional; an absent key keeps the bundled default.
 scope:
+  # A closed list that replaces the bundled default whole, so the four bundled
+  # patterns are restated. The two added here are files nobody writes by hand
+  # or would ever split: npm lockfiles are generated, and a plugin changelog is
+  # an append-only record whose length is its history, not a size problem.
+  exclude:
+    - "**/node_modules/**"
+    - "**/vendor/**"
+    - "**/dist/**"
+    - "**/build/**"
+    - "**/package-lock.json"
+    - "**/CHANGELOG.md"
   # The files this repository vendors into several plugins on purpose. An audit
   # collapses their rows to one per function with a replica count instead of
   # counting each copy, and a clone across the copies is an exclusion, not debt.


### PR DESCRIPTION
No related issue: a one-file team-config follow-up to the audit-size findings in #4062, which #4063 closed; it changes what this repository's own reports show, not the plugin.

## Summary

With code-metrics 0.2.1 measuring every text file, a whole-tree `audit-size --all` on this repository puts the per-plugin changelogs and the npm lockfiles at the top of the Measures table: 23 of the 100 files over the 1000-line reference are one or the other, above the test suites and scripts a reader is actually looking for. Neither kind is written by hand or would ever be split.

## Fix

`.claude/code-metrics.yaml` (the tracked team layer) now sets `scope.exclude`. The list is a closed value that replaces the bundled default whole, so the four bundled patterns are restated and two are added: `**/package-lock.json` and `**/CHANGELOG.md`. The comment on the key says why. `scope.exclude` applies to every measure, and both kinds sit in the catch-all `other` lane where only `file_lines` is served, so no complexity, duplication, coverage, or type-debt row changes. The existing `registries` key and its comment are untouched.

## Verification

- `scripts/affected-tests.sh --run`: 8 shell suites green (`dispatch.test.sh`, `tool-free-path.test.sh`, every `audit-*.test.sh`, `setup-check.test.sh`), plus `test_resolve_config.py` (15) and `test_setup_apply.py` (6) OK from their lane.
- `setup-check.sh` on this tree: the team layer parses in the YAML subset and is tracked, 0 FAIL.
- `audit-size.sh --all` on this tree with the change: 3711 files in scope, 188 excluded (`**/package-lock.json` 6, `**/CHANGELOG.md` 93, the bundled three 90), 77 files over the reference, no changelog or lockfile rows; before the change 3809 in scope, 90 excluded, 100 over.

## Related

- #4062 (the audit-size findings) and #4063 (the 0.2.1 plugin release this config builds on).
- Reversible by deleting two lines; no ADR, no changelog entry (the plugin is unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CXW5ffit9v5fG15Wbr3xAN

---
_Generated by [Claude Code](https://claude.ai/code/session_01CXW5ffit9v5fG15Wbr3xAN)_