### PR TITLE
fix(implementation): state the current subagent model resolution order

### DIFF
--- a/docs/PLUGIN-PHILOSOPHY.md
+++ b/docs/PLUGIN-PHILOSOPHY.md
@@ -936,12 +936,14 @@ above, never below; tedious or mechanical preparation may drop one tier.** The h
 explicit: an agent definition that omits `model` defaults to `inherit`, the main conversation's
 model ([subagents: model resolution](https://code.claude.com/docs/en/sub-agents#choose-a-model),
 verified 2026-08-10; frontmatter accepts `sonnet`, `opus`, `haiku`, `fable`, a full model ID, or
-`inherit`). Consumers hold one global override knob: `CLAUDE_CODE_SUBAGENT_MODEL`, set via the
-settings `env` map, which overrides both the per-invocation `model` parameter and frontmatter,
-except at the value `inherit`, which since v2.1.196 means normal resolution rather than forcing the
-session model, so the knob has an off position as well as an on one
-([model config: environment variables](https://code.claude.com/docs/en/model-config#environment-variables),
-verified 2026-08-10; `env` applies to every session and spawned subprocess,
+`inherit`). Consumers hold one global fallback knob: `CLAUDE_CODE_SUBAGENT_MODEL`, set via the
+settings `env` map. It ranks **third**, below the per-invocation `model` parameter and below
+frontmatter, so it decides only where neither is set; setting it to `inherit` is the same as leaving
+it unset. A structural frontmatter binding therefore holds against it, and the knob is a default for
+unbound subagents rather than an override
+([subagents: choose a model](https://code.claude.com/docs/en/sub-agents#choose-a-model),
+verified 2026-09-11, recheck when a release note touches subagent model selection;
+`env` applies to every session and spawned subprocess,
 [settings](https://code.claude.com/docs/en/settings), verified 2026-08-10). There is no per-plugin
 model surface, because plugin `userConfig` declares only generic typed options with no model semantics
 ([plugins reference: user configuration](https://code.claude.com/docs/en/plugins-reference#user-configuration),

--- a/plugins/implementation/.claude-plugin/plugin.json
+++ b/plugins/implementation/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "implementation",
-  "version": "0.16.5",
+  "version": "0.16.6",
   "description": "Disciplined implementation stage: execute approved plans inline (`/implementation:implement`) or via orchestrated worker subagents (`/implementation:implement-dispatch`) with incremental validation, TDD-by-default cadence, green-checkpoint commits, scope-fence drift detection, and divergence detection that routes back to planning. Build/test/lint, testing, and outcome verification live in the companion `toolchain`, `testing`, and `verification` plugins, invoked when installed.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/implementation/CHANGELOG.md
+++ b/plugins/implementation/CHANGELOG.md
@@ -3,6 +3,19 @@
 All notable changes to the `implementation` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.16.6]
+
+### Fixed
+
+- **`implement-dispatch` states the current subagent model resolution order.** The body ranked
+  `CLAUDE_CODE_SUBAGENT_MODEL` first and told orchestrated runs to keep it unset so it could not
+  undercut the frontmatter binding. Upstream reversed that order in v2.1.251: the per-invocation
+  `model` parameter ranks first, frontmatter second, the environment variable third, and the main
+  conversation's model last. The variable is a fallback for subagents that bind neither, so it
+  cannot undercut a frontmatter binding and the keep-it-unset instruction protected nothing. Both
+  the Step 2 parenthetical and the capability-tier gotcha now state the current order, dated, with a
+  recheck trigger.
+
 ## [0.16.5]
 
 ### Changed

--- a/plugins/implementation/skills/implement-dispatch/SKILL.md
+++ b/plugins/implementation/skills/implement-dispatch/SKILL.md
@@ -50,10 +50,11 @@ Because the orchestrator stays on the default branch, **every source-touching op
    frontier routing, dispatches at the frontier tier's current alias, and a run that cannot
    resolve that alias STOPs (autonomously: escalates) rather than dispatching lower, and a session
    whose own model resolves above the binding may pass that model. Never pass a `model` that
-   undercuts the frontmatter binding for source-editing work. (Model resolution order:
-   `CLAUDE_CODE_SUBAGENT_MODEL` when set to anything but `inherit`, then the per-invocation `model`
-   parameter, then the definition's `model` frontmatter, then the main conversation's model, per
-   <https://code.claude.com/docs/en/sub-agents>, verified 2026-08-10.)
+   undercuts the frontmatter binding for source-editing work. (Model resolution order: the
+   per-invocation `model` parameter, then the definition's `model` frontmatter, then
+   `CLAUDE_CODE_SUBAGENT_MODEL` when set to a model alias or id, then the main conversation's model,
+   per <https://code.claude.com/docs/en/sub-agents#choose-a-model>, verified 2026-09-11. Recheck when
+   a release note touches subagent model selection.)
    Dispatch a wave and keep working while it runs: verify returns from the same phase as they
    arrive, compose the next brief, and run the build/test gate on accepted returns. Intervene when
    a worker goes off track or is missing context. Do not block on the slowest worker before
@@ -121,5 +122,5 @@ The phase-boundary ritual and resume-prompt emission are the same either way. Re
 - **New shebang files need `chmod`, then `git add`, then `git update-index --chmod=+x`. In that order.** Brief every worker: `chmod +x <path>`, then `git add <path>` (a not-yet-tracked file fails `git update-index --chmod=+x` outright. It can't override the index mode of a path that isn't staged yet), then `git update-index --chmod=+x <path>` to force the index mode explicitly (skip symlinks, staged `120000`, they fail the same command), a shebang file staged non-executable trips the `exec-bit` check
 - **Push early, before the CI-poll tail. But never the PR.** Brief every worker to commit and push as early as practical rather than deferring until its fix-and-verify loop is done, so a mid-session death never orphans unpushed work. This is a source-only checkpoint commit. The phase-boundary plan-mark commit (Step 4) still runs separately, orchestrator-side, once the phase's acceptance criteria are verified. PR creation stays out of every worker brief. It happens in the orchestrator's post-verification flow (`/implementation:implement` Step 5) after every return is verified and the build/test gate passes
 - **Scope-fence drift applies to agent returns.** Every worker return is a decision boundary. Classify proposed follow-ups per `/implementation:implement` "Step 3.5: Scope-fence drift detector (run at every decision boundary)" before announcing them
-- **The capability-tier binding lives in agent frontmatter. Don't undercut it.** Workers dispatch as `implementation:implementer` and phase verifiers as `implementation:phase-verifier`; a generic subagent type inherits the orchestrator's model, which under a fast orchestrator root silently runs implementers at orchestrator strength. A per-invocation `model` routes only upward (frontier-alias for security-surface work, or the session's own higher tier); and a `CLAUDE_CODE_SUBAGENT_MODEL` environment variable set to anything but `inherit` outranks even the frontmatter binding. Keep it unset for orchestrated runs
+- **The capability-tier binding lives in agent frontmatter. Don't undercut it.** Workers dispatch as `implementation:implementer` and phase verifiers as `implementation:phase-verifier`; a generic subagent type inherits the orchestrator's model, which under a fast orchestrator root silently runs implementers at orchestrator strength. A per-invocation `model` routes only upward (frontier-alias for security-surface work, or the session's own higher tier). `CLAUDE_CODE_SUBAGENT_MODEL` ranks below both the per-invocation parameter and the frontmatter, so it cannot undercut the binding; it decides only where neither is set, which is the generic-subagent case this bullet already rules out
 - **An omitted `--wave-cap` keeps the internal 3–5. Never coerce an absent value into a number.** Only cap at `N` when the caller passed a real positive integer; a missing, empty, or unresolved-placeholder argument means "use the internal default," not `0` and not a hard `1`


### PR DESCRIPTION
No linked issue

## Summary

Two instruction surfaces state the subagent model resolution order that upstream
replaced in v2.1.251. Both rank `CLAUDE_CODE_SUBAGENT_MODEL` first, above the
per-invocation `model` parameter and above agent frontmatter. It now ranks third.

The consequence is not cosmetic. Both surfaces instruct orchestrated runs to keep
the variable unset so it cannot undercut the frontmatter capability-tier binding.
Ranked third, it never could: it decides only where neither a per-invocation
parameter nor frontmatter is set. The instruction guarded nothing, and it
understated how strong a frontmatter binding actually is, which is the opposite of
what a dispatch skill wants a reader to believe.

Found while adjudicating a model-alias question on #4023; out of that PR's scope,
so it is filed here on its own.

## Fix

- `docs/PLUGIN-PHILOSOPHY.md`, "Model tiers": the knob is described as a fallback
  for subagents that bind neither source, not as an override. States that it ranks
  third, that a structural frontmatter binding therefore holds against it, and that
  setting it to `inherit` is the same as leaving it unset.
- `plugins/implementation/skills/implement-dispatch/SKILL.md`, the Step 2
  parenthetical and the capability-tier gotcha: both now give the current
  four-step order. The gotcha drops the "keep it unset for orchestrated runs"
  instruction, which protected against an override that no longer exists.

Both citations are re-dated to 2026-09-11 and carry a recheck trigger on subagent
model selection, per `docs/conventions/upstream-drift/`.

`implementation` 0.16.5 to 0.16.6 with a changelog entry. No behavior change: this
is instruction text plus the version bump.

## Verification

Basis re-fetched live rather than taken from the report that surfaced it.
[Subagents, "Choose a model"](https://code.claude.com/docs/en/sub-agents#choose-a-model),
fetched 2026-09-11, gives the order as (1) the per-invocation `model` parameter,
(2) the definition's `model` frontmatter, (3) `CLAUDE_CODE_SUBAGENT_MODEL`,
(4) the main conversation's model, and states verbatim: "Before v2.1.251,
`CLAUDE_CODE_SUBAGENT_MODEL` came first in this order and overrode both the
per-invocation parameter and the frontmatter, including `model: inherit`."

Gates run locally against `origin/main`, all clean:

- `scripts/check-purged-em-dashes.sh`: 383 declared paths, 1194 files, no em dashes.
  `implement-dispatch/SKILL.md` is inside the purged set, so this one gates the edit.
- `scripts/check-changelog-parity.sh` in all four modes: `--check`, `--check-bump`,
  `--check-order` (93 changelogs), `--check-preserved`.
- `check-skill.sh implement-dispatch`: PASS, 0 errors, 0 warnings.
- `scripts/validate-plugin-contracts.mjs`: 54 setup skills, 3488 plugin files.
- `generate-catalog.mjs --check` and `generate-cheatsheet.mjs --check`: in sync.
- `markdownlint-cli2` over all three changed markdown files: 0 issues.
- `scripts/affected-tests.sh --run --base origin/main`: one suite failed,
  `plugins/claude-ops/skills/plugins/scripts/cache-content-check.test.sh`, on its two
  process-budget cases ("measured -1, the pid-stamped PS4 did not reach the traced
  shell"). Pre-existing and environmental, not this change: it reproduces identically
  at the merge base in a clean worktree, this PR touches neither the suite nor its
  subject, and the probe cannot instrument process creation in this container. CI runs
  it green.

## Related

Refs #4023, the PR whose alias adjudication surfaced this drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0162aXmqveac6hvBUeGXXAyn

---
_Generated by [Claude Code](https://claude.ai/code/session_0162aXmqveac6hvBUeGXXAyn)_