### PR TITLE
fix(instructions): add CLAUDE.md shims so three indexed AGENTS.md files load

### DIFF
--- a/plugins/playbooks/reference/model-adaptation/CLAUDE.md
+++ b/plugins/playbooks/reference/model-adaptation/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/plugins/provenance/skills/audit/CLAUDE.md
+++ b/plugins/provenance/skills/audit/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/plugins/work-items/skills/work-loop/CLAUDE.md
+++ b/plugins/work-items/skills/work-loop/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
Closes #4147

## Summary

The always-loaded rules index in `AGENTS.md` states that every surface it lists "enters context automatically when Claude reads a file it covers". Three of its five nested `AGENTS.md` rows had no `CLAUDE.md` shim beside them, so Claude Code never loaded those files on its own and the index's claim was false for them.

Nested `AGENTS.md` is not a surface Claude Code loads by itself; the repo's existing convention is a one-line `@AGENTS.md` shim, already present for `plugins/autonomy/` and `plugins/machine-health/skills/audit/`. The three rows below were missing it, so their subdirectory conventions sat on a surface nothing loaded.

## Fix

Added the one-line shim to each of:

- `plugins/playbooks/reference/model-adaptation/CLAUDE.md`
- `plugins/provenance/skills/audit/CLAUDE.md`
- `plugins/work-items/skills/work-loop/CLAUDE.md`

All three are byte-identical to the two shims that already exist (same sha256, 11 bytes). This makes the index's existing claim true rather than weakening the claim to match the code.

## Verification

| Check | Result |
|---|---|
| Shims match the existing convention | All 5 shims now share one sha256 (`336cc4fbf19b…`), 11 bytes each |
| `render-index.sh check --file AGENTS.md` | `IN-SYNC`, exit 0. The shims are skipped by `is_pure_shim`, so no index row changed |
| `scripts/affected-tests.sh --explain` | No suites selected; all three files fall in the recorded `*.md` no-suite class covered by the non-shell CI lane |
| `markdownlint-cli2` | 0 issues in 0 files |
| `editorconfig-checker` | exit 0 |
| Findings still live before the fix | Confirmed all three `CLAUDE.md` absent on 2026-09-12 |

## Related

- Closes #4147, the full findings list from the audit-pass run that produced this. This PR fixes findings `261c7fa5` (audit-instructions I12) and `4db22d56` (claude-memory C3), the only two corroborated by independent catalogs. The other 29 findings stay open there for a per-row judgment call; they are single-pass and unverified, since this host disables subagent nesting and no lane could dispatch its own verifier.
- #4132 carries improvements to the audit-pass skill itself, including a state-digest specification and a per-site finding split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVeftH9Gb7BrCo4Wb2Yk9q

---
_Generated by [Claude Code](https://claude.ai/code/session_01YVeftH9Gb7BrCo4Wb2Yk9q)_